### PR TITLE
Add dynamic Friday show-day updates with per-guild dedupe and Gemini fallback

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -58,6 +58,7 @@ AMBIENT_AVOID_LAST = 12
 AMBIENT_MAX_CHARS = 280
 AMBIENT_RETRY_ON_SIMILAR = 1
 AMBIENT_FAIL_RESCHEDULE_MINUTES = 30
+SHOWDAY_WINDOW_MINUTES = 10
 
 # ======== GREETING COOLDOWN ========
 GREETING_COOLDOWN_MINUTES = 90
@@ -491,6 +492,20 @@ def init_db():
             guild_id INTEGER NOT NULL,
             message TEXT NOT NULL,
             timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS friday_show_updates (
+            guild_id INTEGER NOT NULL,
+            show_date TEXT NOT NULL,
+            phase_key TEXT NOT NULL,
+            discord_message TEXT,
+            website_message TEXT,
+            fired_at TEXT NOT NULL,
+            PRIMARY KEY (guild_id, show_date, phase_key)
         )
         """
     )
@@ -1206,6 +1221,59 @@ def get_recent_ambient(guild_id: int, limit: int = AMBIENT_AVOID_LAST):
     rows = cursor.fetchall()
     conn.close()
     return [r[0] for r in rows]
+
+def get_recent_signal_summary(guild_id: int, limit: int = 14) -> str:
+    conn = sqlite3.connect(DB_FILE)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT content
+        FROM conversations
+        WHERE guild_id = ? AND role = 'user'
+        ORDER BY id DESC
+        LIMIT ?
+        """,
+        (guild_id, limit),
+    )
+    rows = cursor.fetchall()
+    conn.close()
+    messages = [r[0].strip() for r in rows if r and r[0] and r[0].strip()]
+    if not messages:
+        return ""
+    avg_len = sum(len(m) for m in messages) / len(messages)
+    if len(messages) >= 10:
+        volume = "submission pressure is elevated"
+    elif len(messages) >= 6:
+        volume = "signal activity is steady"
+    else:
+        volume = "relay noise is light"
+    cadence = "short-burst chatter" if avg_len < 70 else "dense packet chatter"
+    return f"{volume}; {cadence}"
+
+def already_fired_show_update(guild_id: int, show_date: str, phase_key: str) -> bool:
+    conn = sqlite3.connect(DB_FILE)
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT 1 FROM friday_show_updates WHERE guild_id=? AND show_date=? AND phase_key=?",
+        (guild_id, show_date, phase_key),
+    )
+    row = cursor.fetchone()
+    conn.close()
+    return bool(row)
+
+def mark_show_update_fired(guild_id: int, show_date: str, phase_key: str, discord_message: str, website_message: str):
+    conn = sqlite3.connect(DB_FILE)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT OR REPLACE INTO friday_show_updates
+        (guild_id, show_date, phase_key, discord_message, website_message, fired_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (guild_id, show_date, phase_key, discord_message[:280], website_message[:240], datetime.now(PACIFIC_TZ).isoformat()),
+    )
+    conn.commit()
+    conn.close()
 
 def save_user_message(user_id: int, user_name: str, guild_id: int, content: str):
     conn = sqlite3.connect(DB_FILE)
@@ -2093,31 +2161,101 @@ async def ambient_message_task():
 QUEUE_CHANNEL_NAME = "general-chat"  # change if needed
 ENABLE_QUEUE_ANNOUNCEMENT = False
 
+FRIDAY_SHOW_PHASES = [
+    {"key": "submissions_open", "hour": 18, "minute": 40, "window_min": SHOWDAY_WINDOW_MINUTES},
+    {"key": "show_live", "hour": 19, "minute": 0, "window_min": SHOWDAY_WINDOW_MINUTES},
+    {"key": "sponsor_window", "hour": 21, "minute": 0, "window_min": SHOWDAY_WINDOW_MINUTES},
+]
+
+SHOWDAY_FALLBACKS = {
+    "submissions_open": [
+        "📡 Intake corridor open. Auxchord routing is active; submission pressure can now be transmitted.",
+        "Signal intake has commenced. BNL-01 is routing inbound track traffic through the Friday relay.",
+        "Auxchord channels are now accepting payloads. Submit while the pre-broadcast gate is stable.",
+    ],
+    "show_live": [
+        "🎛️ Broadcast deployment confirmed. BARCODE Radio is now active and 6 Bit is on-air.",
+        "Carrier lock acquired. Friday transmission is live; 6 Bit has entered broadcast posture.",
+        "BARCODE Radio is now transmitting. Signal integrity is nominal and the host stack is online.",
+    ],
+    "sponsor_window": [
+        "📼 Sponsor relay window is active. Commercial packets require 6 Bit for compliant execution.",
+        "Funding cycle check: sponsor transmissions are due, and the host channel must process them.",
+        "Network obligations are now in rotation. Sponsor payloads should be run through 6 Bit’s lane.",
+    ],
+}
+
+def _pick_varied_fallback(phase_key: str, avoid: str = "") -> str:
+    options = SHOWDAY_FALLBACKS.get(phase_key, [])
+    if not options:
+        return "Signal update acknowledged."
+    random.shuffle(options)
+    for msg in options:
+        if avoid and msg.strip().lower() == avoid.strip().lower():
+            continue
+        return msg
+    return options[0]
+
+async def generate_showday_messages(guild_id: int, phase_key: str):
+    signal_context = get_recent_signal_summary(guild_id)
+    phase_desc = {
+        "submissions_open": "Friday 6:40 PM Pacific intake window opens for submissions",
+        "show_live": "Friday 7:00 PM Pacific live broadcast begins",
+        "sponsor_window": "around Friday 9:00 PM Pacific sponsor/commercial obligations window",
+    }.get(phase_key, phase_key)
+
+    prompt = (
+        "You are BNL-01. Generate exactly two lines.\n"
+        "Line 1: Discord update under 280 chars.\n"
+        "Line 2: Website status message under 240 chars.\n"
+        "Voice: concise, corporate, lightly sinister, signal-analysis.\n"
+        f"Event: {phase_desc}.\n"
+        f"Room context (optional): {signal_context or 'none'}.\n"
+        "Do not quote users. No usernames. No emojis except optional one at start.\n"
+        "Do not repeat generic stock wording. Keep it fresh.\n"
+    )
+    text = (await get_gemini_response(prompt, user_id=0, guild_id=guild_id) or "").strip()
+    lines = [ln.strip(" -•\t") for ln in text.splitlines() if ln.strip()]
+    if len(lines) >= 2:
+        discord_msg = lines[0][:280]
+        website_msg = lines[1][:240]
+        if discord_msg and website_msg:
+            return discord_msg, website_msg
+    fallback = _pick_varied_fallback(phase_key)
+    return fallback[:280], fallback[:240]
+
 @tasks.loop(minutes=1)
 async def barcode_radio_queue_task():
-    if not ENABLE_QUEUE_ANNOUNCEMENT:
+    now = datetime.now(PACIFIC_TZ)
+    if now.weekday() != 4:
         return
 
-    now = datetime.now(PACIFIC_TZ)
-
-    # Friday = weekday 4
-    if now.weekday() == 4 and now.hour == 18 and now.minute == 40:
-
+    show_date = now.date().isoformat()
+    for phase in FRIDAY_SHOW_PHASES:
+        scheduled = now.replace(hour=phase["hour"], minute=phase["minute"], second=0, microsecond=0)
+        age_min = (now - scheduled).total_seconds() / 60.0
+        if age_min < 0 or age_min > phase["window_min"]:
+            continue
+        phase_key = phase["key"]
         for guild in client.guilds:
-
-            channel = discord.utils.get(guild.text_channels, name=QUEUE_CHANNEL_NAME)
-
-            if not channel:
+            if already_fired_show_update(guild.id, show_date, phase_key):
                 continue
-
-            try:
-                await channel.send(
-                    "📡 **BARCODE Radio Transmission Incoming**\n\n"
-                    "The music queue is now open.\n"
-                    "Submit your signal for tonight’s broadcast."
-                )
-            except Exception as e:
-                logging.error(f"Queue announcement failed: {e}")
+            channel_id = get_guild_config(guild.id)
+            channel = guild.get_channel(channel_id) if channel_id else None
+            last_ambient = (get_recent_ambient(guild.id, limit=1) or [""])[0]
+            discord_msg, website_msg = await generate_showday_messages(guild.id, phase_key)
+            if last_ambient and discord_msg.strip().lower() == last_ambient.strip().lower():
+                discord_msg = _pick_varied_fallback(phase_key, avoid=discord_msg)[:280]
+            if channel:
+                try:
+                    await channel.send(discord_msg)
+                except Exception as e:
+                    logging.error(f"Show-day Discord update failed (guild {guild.id}, {phase_key}): {e}")
+                    continue
+            mode = "RESTRICTED" if phase_key == "sponsor_window" else "ACTIVE_LIAISON"
+            update_website_status_controlled(mode=mode, message=website_msg[:240], status="ONLINE", force=True)
+            log_ambient(guild.id, discord_msg)
+            mark_show_update_fired(guild.id, show_date, phase_key, discord_msg, website_msg)
 
 # ==================== BATCHED REPLY SYSTEM (ACTIVE CHANNEL ONLY) ====================
 
@@ -2268,7 +2406,7 @@ async def on_ready():
     if not ambient_message_task.is_running():
         ambient_message_task.start()
 
-    if ENABLE_QUEUE_ANNOUNCEMENT and not barcode_radio_queue_task.is_running():
+    if not barcode_radio_queue_task.is_running():
         barcode_radio_queue_task.start()
 
     logging.info(f"🎯 BNL-01 online as {client.user.name} ({client.user.id})")


### PR DESCRIPTION
### Motivation
- Provide Friday show-day updates tied to BARCODE Radio schedule and surface those states to the existing website bridge without changing the bridge itself.
- Keep updates concise, dynamic, and in BNL-01 voice while avoiding repeated verbatim lines and protecting user privacy.
- Ensure each scheduled announcement fires once per guild per Friday and survives restarts.

### Description
- Added a per-guild, persisted duplicate-prevention table `friday_show_updates` and helper functions `already_fired_show_update(...)` and `mark_show_update_fired(...)` to record which phase has fired for a given guild/date.
- Introduced `FRIDAY_SHOW_PHASES` and `SHOWDAY_WINDOW_MINUTES` with three phases: `submissions_open` (6:40 PM PT), `show_live` (7:00 PM PT), and `sponsor_window` (~9:00 PM PT), and repurposed the existing `barcode_radio_queue_task` to run the Friday schedule per-minute on Fridays and evaluate each phase window.
- Added dynamic message generation via `generate_showday_messages(...)` which prefers Gemini (`get_gemini_response`) and falls back to randomized local templates (`SHOWDAY_FALLBACKS`) when generation fails, and enforces length caps (Discord ≤280 chars, website ≤240 chars).
- Added contextual summarization via `get_recent_signal_summary(...)` to include safe, high-level room context (e.g., “submission pressure is elevated”, “relay noise is light”) without quoting or exposing user data.
- When a phase fires the bot posts to the configured active channel (if present), calls the existing status bridge wrapper `update_website_status_controlled(...)` (using `ACTIVE_LIAISON` for intake/live and `RESTRICTED` for sponsor-phase), logs the ambient message with `log_ambient(...)`, and records the fired row to prevent duplicates.
- Avoids immediate repeats by comparing the generated Discord text to the last ambient/show message and selecting an alternate randomized fallback if identical, and forces website updates through the controlled wrapper while preserving existing bridge behavior.

### Testing
- Ran `python -m py_compile bnl01_bot.py` with no syntax errors (success).
- The code was committed after local validation; no automated runtime tests were run beyond byte-compile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f417a19b9483218ecea1a4daec6a13)