### PR TITLE
Sanitize website status messages, harden website bridge, and improve `/showtest` feedback

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -90,6 +90,22 @@ MAX_CONVERSATION_ROWS_PER_USER = 260
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
+WEBSITE_STATUS_LABEL_RE = re.compile(
+    r"^\s*(?:\*\*|__)?\s*(?:website\s+status|website\s+message|discord\s+message|status)\s*:\s*(?:\*\*|__)?\s*",
+    re.IGNORECASE,
+)
+
+
+def sanitize_website_status_message(message: str, limit: int = 240) -> str:
+    """Remove leading label wrappers and return plain website status text."""
+    cleaned = (message or "").strip()
+    while cleaned:
+        updated = WEBSITE_STATUS_LABEL_RE.sub("", cleaned, count=1).strip()
+        if updated == cleaned:
+            break
+        cleaned = updated
+    return cleaned[:limit]
+
 
 def update_website_status(status: str, mode: str, message: str) -> bool:
     """
@@ -100,7 +116,8 @@ def update_website_status(status: str, mode: str, message: str) -> bool:
         logging.warning("⚠️ BNL_API_KEY is missing; skipping website status update.")
         return False
 
-    payload = {"status": status, "mode": mode, "message": message}
+    sanitized_message = sanitize_website_status_message(message, limit=240)
+    payload = {"status": status, "mode": mode, "message": sanitized_message}
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
         BNL_STATUS_URL,
@@ -255,7 +272,7 @@ _last_website_status_message = None
 _last_website_status_at = None
 _missing_status_key_warned = False
 
-def update_website_status_controlled(mode: str, message: str, status: str = "ONLINE", force: bool = False):
+def update_website_status_controlled(mode: str, message: str, status: str = "ONLINE", force: bool = False) -> bool:
     global _last_website_status_mode, _last_website_status_message, _last_website_status_at, _missing_status_key_warned
 
     now = datetime.now(PACIFIC_TZ)
@@ -263,43 +280,37 @@ def update_website_status_controlled(mode: str, message: str, status: str = "ONL
         if not _missing_status_key_warned:
             logging.warning("⚠️ BNL_API_KEY missing. Website status bridge disabled.")
             _missing_status_key_warned = True
-        return
+        return False
 
     if not BNL_STATUS_URL:
         logging.warning("⚠️ BNL_STATUS_URL missing. Cannot post website status updates.")
-        return
+        return False
 
-    same_payload = (_last_website_status_mode == mode and _last_website_status_message == message)
+    sanitized_message = sanitize_website_status_message(message, limit=240)
+    same_payload = (_last_website_status_mode == mode and _last_website_status_message == sanitized_message)
     if same_payload and not force:
-        return
+        return True
 
     if _last_website_status_at and not force and _last_website_status_mode == mode:
         elapsed = (now - _last_website_status_at).total_seconds()
         if elapsed < STATUS_UPDATE_COOLDOWN_SECONDS:
-            return
-
-    payload = {"status": status, "mode": mode, "message": message}
-    req = urllib.request.Request(
-        BNL_STATUS_URL,
-        data=json.dumps(payload).encode("utf-8"),
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {BNL_API_KEY}",
-        },
-        method="POST",
-    )
+            return True
 
     try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            resp.read()
+        ok = update_website_status(status=status, mode=mode, message=sanitized_message)
+        if not ok:
+            return False
         _last_website_status_mode = mode
-        _last_website_status_message = message
+        _last_website_status_message = sanitized_message
         _last_website_status_at = now
         logging.info(f"🌐 Website status updated: {mode}")
+        return True
     except urllib.error.URLError as e:
         logging.warning(f"⚠️ Website status update failed: {e}")
+        return False
     except Exception as e:
         logging.warning(f"⚠️ Unexpected website status bridge failure: {e}")
+        return False
 
 def maybe_update_broadcast_status_from_text(text: str):
     t = (text or "").lower()
@@ -2975,14 +2986,16 @@ async def about(interaction: discord.Interaction):
     ]
 )
 async def showtest(interaction: discord.Interaction, phase: app_commands.Choice[str]):
+    await interaction.response.defer(ephemeral=True)
+
     if not interaction.guild:
-        await interaction.response.send_message("❌ This command can only be used in a server.", ephemeral=True)
+        await interaction.followup.send("❌ This command can only be used in a server.", ephemeral=True)
         return
 
     member = interaction.user if isinstance(interaction.user, discord.Member) else interaction.guild.get_member(interaction.user.id)
     perms = member.guild_permissions if member else None
     if not perms or (not perms.manage_guild and not perms.administrator):
-        await interaction.response.send_message("❌ You need Manage Server or Administrator permissions.", ephemeral=True)
+        await interaction.followup.send("❌ You need Manage Server or Administrator permissions.", ephemeral=True)
         return
 
     phase_map = {
@@ -2992,12 +3005,16 @@ async def showtest(interaction: discord.Interaction, phase: app_commands.Choice[
     }
     phase_key = phase_map.get(phase.value)
     if not phase_key:
-        await interaction.response.send_message("❌ Invalid phase.", ephemeral=True)
+        await interaction.followup.send("❌ Invalid phase.", ephemeral=True)
         return
 
     discord_msg, website_msg = await generate_showday_messages(interaction.guild.id, phase_key)
     mode = "RESTRICTED" if phase_key == "sponsor_window" else "ACTIVE_LIAISON"
-    update_website_status_controlled(mode=mode, message=website_msg[:240], status="ONLINE", force=True)
+    key_len = len(BNL_API_KEY) if BNL_API_KEY else 0
+    logging.info(f"/showtest website bridge target URL: {BNL_STATUS_URL}")
+    logging.info(f"/showtest BNL_API_KEY present: {bool(BNL_API_KEY)}")
+    logging.info(f"/showtest BNL_API_KEY length: {key_len}")
+    website_ok = update_website_status_controlled(mode=mode, message=website_msg[:240], status="ONLINE", force=True)
 
     target_channel = interaction.channel if isinstance(interaction.channel, discord.TextChannel) else None
     if not target_channel:
@@ -3010,16 +3027,25 @@ async def showtest(interaction: discord.Interaction, phase: app_commands.Choice[
             log_ambient(interaction.guild.id, discord_msg)
         except Exception as e:
             logging.error(f"Show-test Discord update failed (guild {interaction.guild.id}, {phase_key}): {e}")
-            await interaction.response.send_message(
-                "⚠️ Website status updated, but test message could not be posted to the target channel.",
+            await interaction.followup.send(
+                "⚠️ Test message could not be posted to the target channel. "
+                + ("Website status updated." if website_ok else "Website status update also failed."),
                 ephemeral=True,
             )
             return
 
-    await interaction.response.send_message(
-        f"✅ Show-day test fired for `{phase.value}` (mapped to `{phase_key}`).",
-        ephemeral=True,
-    )
+    if website_ok:
+        user_msg = f"✅ Show-day test fired for `{phase.value}` (mapped to `{phase_key}`)."
+    else:
+        user_msg = (
+            f"⚠️ Show-day Discord test fired for `{phase.value}` (mapped to `{phase_key}`), "
+            "but website status update failed."
+        )
+
+    try:
+        await interaction.followup.send(user_msg, ephemeral=True)
+    except Exception as e:
+        logging.error(f"/showtest followup.send failed (guild {getattr(interaction.guild, 'id', 'n/a')}): {e}")
 
 # ==================== ERROR HANDLER ====================
 


### PR DESCRIPTION
### Motivation
- Prevent labeled or formatted status text from being posted to the website bridge and enforce a length limit. 
- Avoid redundant or rapid duplicate website updates by normalizing messages before comparison. 
- Make the website bridge more resilient by surfacing success/failure as boolean returns and handling missing configuration explicitly. 
- Improve `/showtest` command UX and diagnostics so operators can see whether the website update succeeded and why it may have failed.

### Description
- Add `WEBSITE_STATUS_LABEL_RE` and `sanitize_website_status_message(message, limit=240)` to strip leading labels/wrappers and truncate website messages. 
- Update `update_website_status` to send the sanitized message payload. 
- Refactor `update_website_status_controlled` to return `bool`, compare against the sanitized message for deduplication, delegate the actual POST to `update_website_status`, and return explicit success/failure values while updating internal timestamp/state. 
- Improve error handling to return `False` on URL/other errors and log warnings, and change early returns to boolean values when configuration is missing. 
- Modify the `showtest` command to `defer` the interaction, use `followup.send` for later responses, add logging about `BNL_API_KEY` presence/length and target URL, capture the website update result in `website_ok`, present clearer messages to the user based on that result, and guard followup sends with a `try/except`.

### Testing
- No automated tests were added or executed for this change. 
- Static/behavioral verification was limited to code inspection and logging-driven runtime checks during manual invocation (no CI test results to report).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4213edb4c8321b95002ed38fb88c8)