### PR TITLE
Add `request_fresh_website_relay` helper and wire `/showtest relay` to website-only relay

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -514,6 +514,25 @@ async def generate_dynamic_website_relay(guild_id: int) -> tuple[str, str]:
 
     return mode, sanitize_website_status_message(generated, limit=240)
 
+async def request_fresh_website_relay(guild_id: int, *, force: bool = True) -> tuple[bool, str, str]:
+    """
+    Generate and post a fresh dynamic website relay update.
+    Website only: no Discord post side effects.
+    Returns (success, mode, sanitized_message).
+    """
+    try:
+        mode, relay_message = await generate_dynamic_website_relay(guild_id)
+        sanitized = sanitize_website_status_message(relay_message, limit=240)
+        ok = update_website_status_controlled(mode=mode, message=sanitized, status="ONLINE", force=force)
+        if ok:
+            logging.info(f"✅ Fresh website relay requested successfully (guild {guild_id}, mode {mode}).")
+        else:
+            logging.warning(f"⚠️ Fresh website relay request failed (guild {guild_id}, mode {mode}).")
+        return ok, mode, sanitized
+    except Exception as e:
+        logging.error(f"❌ Fresh website relay request crashed safely (guild {guild_id}): {e}")
+        return False, "OBSERVATION", ""
+
 # ==================== VALIDATION ====================
 
 if GEMINI_API_KEY in ("YOUR_GEMINI_API_KEY_HERE", "PASTE_YOUR_GEMINI_API_KEY_HERE", "", None):
@@ -3219,7 +3238,7 @@ async def showtest(interaction: discord.Interaction, phase: app_commands.Choice[
         return
 
     if phase_key == "relay":
-        mode, website_msg = await generate_dynamic_website_relay(interaction.guild.id)
+        website_ok, mode, website_msg = await request_fresh_website_relay(interaction.guild.id, force=True)
         discord_msg = ""
     else:
         discord_msg, website_msg = await generate_showday_messages(interaction.guild.id, phase_key)
@@ -3229,7 +3248,12 @@ async def showtest(interaction: discord.Interaction, phase: app_commands.Choice[
     logging.info(f"/showtest website bridge target URL: {BNL_STATUS_URL}")
     logging.info(f"/showtest BNL_API_KEY present: {bool(BNL_API_KEY)}")
     logging.info(f"/showtest BNL_API_KEY length: {key_len}")
-    website_ok = update_website_status_controlled(mode=mode, message=website_msg[:240], status="ONLINE", force=True)
+    website_ok = website_ok if phase_key == "relay" else update_website_status_controlled(
+        mode=mode,
+        message=website_msg[:240],
+        status="ONLINE",
+        force=True,
+    )
 
     if phase_key != "relay":
         target_channel = interaction.channel if isinstance(interaction.channel, discord.TextChannel) else None
@@ -3257,8 +3281,8 @@ async def showtest(interaction: discord.Interaction, phase: app_commands.Choice[
             user_msg = f"✅ Show-day test fired for `{phase.value}` (mapped to `{phase_key}`)."
     else:
         user_msg = (
-            f"⚠️ Show-day Discord test fired for `{phase.value}` (mapped to `{phase_key}`), "
-            "but website status update failed."
+            f"⚠️ Show-day {'website relay' if phase_key == 'relay' else 'Discord test'} fired for `{phase.value}` "
+            f"(mapped to `{phase_key}`), but website status update failed."
         )
     warnings = []
     if phase_key == "relay":


### PR DESCRIPTION
### Motivation
- Provide a safe, manual way for admins to trigger a fresh dynamic website relay without posting to Discord channels.
- Reuse existing dynamic relay generation and website bridge logic while enforcing message sanitization, length limits, and non-failure of the bot on errors.

### Description
- Added `async def request_fresh_website_relay(guild_id: int, *, force: bool = True) -> tuple[bool, str, str]` which calls `generate_dynamic_website_relay`, sanitizes the result with `sanitize_website_status_message`, posts only to the website bridge via `update_website_status_controlled`, logs success/failure, and catches exceptions to avoid crashes.
- The helper enforces the existing 240-character limit, strips label prefixes, and returns `(success, mode, sanitized_message)` for callers to inspect.
- Updated the `/showtest` command `relay` path to call `request_fresh_website_relay(...)` so the slash command performs a website-only relay and returns an ephemeral confirmation to the admin without sending a channel message or affecting show-day posting state.
- Preserved all other behavior: dynamic generation, cooldowns, token/persona/scheduling logic, and non-relay `/showtest` flows remain unchanged.

### Testing
- Ran `python -m py_compile bnl01_bot.py`, which completed successfully.
- Sanity-checked that `/showtest relay` now calls the new helper and that the helper logs success/failure and returns a stable tuple on error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46b617b688321bf02b70be3568bb1)