### PR TITLE
Add aiohttp force-pull webhook to trigger website relay updates

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -26,6 +26,7 @@ from datetime import datetime, timedelta
 
 import pytz
 import discord
+from aiohttp import web
 from discord import app_commands
 from discord.ext import tasks
 from google import genai
@@ -43,6 +44,8 @@ BNL_STATUS_URL = os.getenv("BNL_STATUS_URL")
 BNL_WEBSITE_RELAY_ENABLED = os.getenv("BNL_WEBSITE_RELAY_ENABLED", "true").strip().lower() not in {"false", "0", "off"}
 BNL_WEBSITE_RELAY_INTERVAL_MINUTES = max(1, int(os.getenv("BNL_WEBSITE_RELAY_INTERVAL_MINUTES", "20")))
 BNL_PRIMARY_GUILD_ID = int(os.getenv("BNL_PRIMARY_GUILD_ID", "0") or 0)
+BNL_FORCE_PULL_SHARED_SECRET = os.getenv("BNL_FORCE_PULL_SHARED_SECRET", "").strip()
+BNL_FORCE_PULL_PORT = int(os.getenv("BNL_FORCE_PULL_PORT", "8787") or 8787)
 
 DAILY_TOKEN_LIMIT = 1_350_000
 PACIFIC_TZ = pytz.timezone("US/Pacific")
@@ -492,6 +495,7 @@ STALE_RELAY_PHRASES = (
     "broadcast-side movement",
 )
 _recent_relay_messages: dict[int, list[str]] = {}
+force_pull_runner = None
 
 
 def _website_relay_mode_from_context(messages: list[str], now_pt: datetime) -> str:
@@ -698,6 +702,59 @@ async def request_fresh_website_relay(guild_id: int, *, force: bool = True) -> t
     except Exception as e:
         logging.error(f"❌ Fresh website relay request crashed safely (guild {guild_id}): {e}")
         return False, "OBSERVATION", "", ""
+
+
+def _resolve_force_pull_guild() -> int | None:
+    if BNL_PRIMARY_GUILD_ID:
+        return BNL_PRIMARY_GUILD_ID
+    if client.guilds:
+        return client.guilds[0].id
+    return None
+
+
+async def _handle_force_pull(request: web.Request) -> web.Response:
+    if BNL_FORCE_PULL_SHARED_SECRET:
+        provided_secret = (request.headers.get("x-bnl-secret") or "").strip()
+        if provided_secret != BNL_FORCE_PULL_SHARED_SECRET:
+            logging.warning("Invalid force-pull secret rejected")
+            return web.json_response({"ok": False, "error": "unauthorized"}, status=401)
+
+    guild_id = _resolve_force_pull_guild()
+    if not guild_id:
+        return web.json_response({"ok": False, "error": "no_guild_available"}, status=503)
+
+    logging.info("Force-pull received")
+    try:
+        mode, relay_message, directive = await generate_dynamic_website_relay(guild_id)
+        ok = update_website_status_controlled(
+            mode=mode,
+            message=relay_message,
+            status="ONLINE",
+            force=True,
+            current_directive=directive,
+            source="forcePull",
+        )
+        if ok:
+            logging.info("Force-pull relay update succeeded")
+            return web.json_response({"ok": True, "mode": mode, "message": relay_message, "directive": directive})
+        logging.warning("Force-pull relay update failed")
+        return web.json_response({"ok": False, "error": "relay_update_failed"}, status=502)
+    except Exception as e:
+        logging.error(f"Force-pull relay update failed: {e}")
+        return web.json_response({"ok": False, "error": "internal_error"}, status=500)
+
+
+async def start_force_pull_listener():
+    global force_pull_runner
+    if force_pull_runner is not None:
+        return
+    app = web.Application()
+    app.router.add_post("/force-pull", _handle_force_pull)
+    force_pull_runner = web.AppRunner(app)
+    await force_pull_runner.setup()
+    site = web.TCPSite(force_pull_runner, host="0.0.0.0", port=BNL_FORCE_PULL_PORT)
+    await site.start()
+    logging.info(f"Force-pull webhook listening on port {BNL_FORCE_PULL_PORT}")
 
 # ==================== VALIDATION ====================
 
@@ -2899,6 +2956,7 @@ def log_admin_controls_connection_check():
 @client.event
 async def on_ready():
     init_db()
+    await start_force_pull_listener()
 
     try:
         synced = await tree.sync()


### PR DESCRIPTION
### Motivation
- Expose a lightweight HTTP endpoint so operators can remotely trigger an immediate website relay/status update when the bot is running on the VPS. 
- The VPS test showed the bot was not listening on port `8787`, so a non-blocking listener is required to accept `POST /force-pull` requests without blocking the Discord client. 

### Description
- Added aiohttp import and two new env vars: `BNL_FORCE_PULL_SHARED_SECRET` and `BNL_FORCE_PULL_PORT` (default `8787`).
- Implemented `POST /force-pull` handler that requires header `x-bnl-secret` when `BNL_FORCE_PULL_SHARED_SECRET` is set and returns JSON responses with appropriate HTTP status codes for success, unauthorized, no-guild, relay-failure, and internal errors.
- The handler resolves the target guild using `BNL_PRIMARY_GUILD_ID` if set or the first connected guild otherwise, then triggers the existing relay path by calling `generate_dynamic_website_relay(...)` and `update_website_status_controlled(..., force=True, source="forcePull")`.
- Started the aiohttp server inside the bot startup flow by calling `start_force_pull_listener()` from `on_ready()` using `web.AppRunner`/`web.TCPSite`, so the HTTP listener runs concurrently with the Discord client; added clear logs for listener startup, request receipt, invalid secret rejection, and relay update success/failure.

### Testing
- `python -m py_compile bnl01_bot.py` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52491836083219afd31b465e4de1d)