### PR TITLE
BNL blueprint P1: add VPS runtime requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+aiohttp
+discord.py
+google-genai
+pytz


### PR DESCRIPTION
## Summary
- Adds `requirements.txt` for the current single-file BNL bot runtime.
- Includes the packages already imported by `bnl01_bot.py`: `aiohttp`, `discord.py`, `google-genai`, and `pytz`.

## Blueprint classification
- Missing ops support.

## Acceptance checks
- VPS rebuilds can run `pip install -r requirements.txt` instead of guessing package names.
- No bot behavior changes are included in this PR.