### PR TITLE
Add owner-only diagnostics and env-gated channel policy reporting

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -92,6 +92,14 @@ BNL_REACTIONS_GLITCH = ["🧿", "🫨", "⚠️", "❓", "🌀", "☢️", "📛
 BNL_REACTIONS_TECH = ["🧠", "⚙️", "💻", "🛰️", "🗜️", "📈", "🔧"]
 BNL_REACTIONS_VIBE = ["🫡", "👀", "🔥", "💯", "😵‍💫", "🧪", "🕶️"]
 
+PROTECTED_SYSTEM_CHANNELS = {"welcome", "episode-tracker"}
+PUBLIC_HOME_CHANNELS = {"barcode-bot"}
+PUBLIC_CONTEXT_CHANNELS = {"general-chat", "finished-tracks", "wips-and-demos", "collaboration-hub"}
+PUBLIC_SELECTIVE_CHANNELS = {"introductions", "social-links", "suggestions", "underground-nation", "hellcat-nz", "enter-data-ping-here", "daily-riddle"}
+REFERENCE_CANON_CHANNELS = {"announcements", "rules-and-guidelines", "faq", "resources", "roles"}
+INTERNAL_CONTROLLED_CHANNELS = {"research-and-development", "important", "planning-and-coordination", "mod-resources", "ai-avatar"}
+AI_IMAGE_TOOL_CHANNELS = {"ai-image-generator"}
+
 # ======== ADAPTIVE RESPONSE STYLE / MEMORY ========
 RECENT_STYLE_WINDOW = 6
 MAX_FACTS_PER_USER = 15
@@ -1579,34 +1587,44 @@ def resolve_channel_policy(channel: discord.abc.GuildChannel | None) -> str:
     if BNL_PRIMARY_GUILD_ID and guild_id and guild_id != BNL_PRIMARY_GUILD_ID:
         return "public_selective"
     name = ((getattr(channel, "name", "") or "").strip().lower())
-    exact_map = {
-        "welcome": "protected_system",
-        "episode-tracker": "protected_system",
-        "barcode-bot": "public_home",
-        "introductions": "public_selective",
-        "ai-image-generator": "ai_image_tool",
-    }
-    if name in exact_map:
-        return exact_map[name]
-    if name in {"reference-canon", "lore", "canon"}:
-        return "reference_canon"
-    if name in {"mod-chat", "admin", "staff", "ops"}:
-        return "internal_controlled"
-    if name in {"general", "chat", "lounge"}:
+    if name in PROTECTED_SYSTEM_CHANNELS:
+        return "protected_system"
+    if name in PUBLIC_HOME_CHANNELS:
+        return "public_home"
+    if name in PUBLIC_CONTEXT_CHANNELS:
         return "public_context"
-    if name in {"bot-commands", "commands"}:
+    if name in PUBLIC_SELECTIVE_CHANNELS:
         return "public_selective"
+    if name in REFERENCE_CANON_CHANNELS:
+        return "reference_canon"
+    if name in INTERNAL_CONTROLLED_CHANNELS:
+        return "internal_controlled"
+    if name in AI_IMAGE_TOOL_CHANNELS:
+        return "ai_image_tool"
     return "unknown"
 
 
 def website_relay_eligibility(policy: str) -> str:
-    if policy in {"public_home", "public_context", "reference_canon"}:
+    if policy in {"public_home", "public_context"}:
         return "yes"
-    if policy in {"public_selective", "ai_image_tool"}:
+    if policy == "public_selective":
         return "selective"
-    if policy in {"internal_controlled", "protected_system", "sealed_test"}:
-        return "no"
     return "no"
+
+
+def context_visibility_for_policy(policy: str) -> str:
+    mapping = {
+        "sealed_test": "test_only_no_public_relay",
+        "internal_controlled": "internal_no_passive_public_memory",
+        "protected_system": "protected_existing_behavior",
+        "reference_canon": "reference_only",
+        "ai_image_tool": "owner_approval_required",
+        "public_home": "public_context_allowed",
+        "public_context": "public_context_allowed",
+        "public_selective": "selective_public_context",
+        "unknown": "blocked_until_classified",
+    }
+    return mapping.get(policy, "blocked_until_classified")
 
 def try_repair_response(user_text: str) -> str:
     t = (user_text or "").lower().strip()
@@ -3856,7 +3874,7 @@ async def bnl_source_check(interaction: discord.Interaction):
         f"- testing_channel_id: `{BNL_TESTING_CHANNEL_ID or 'unset'}` ({testing_channel.mention if testing_channel else 'not found in this guild'})",
         f"- active_channel: {active_channel.mention if active_channel else 'none (mention/reply mode)'}",
         f"- current_channel: `{getattr(current_channel, 'name', 'unknown')}` (`{getattr(current_channel, 'id', 'n/a')}`)",
-        f"- context_visibility_category: `{policy}`",
+        f"- resolved_channel_policy: `{policy}`",
         f"- website_relay_eligibility: `{relay_eligibility}`",
         f"- primary_guild_match: `{primary_guild_match}`",
         f"- bnl_status_url_configured: `{bool(BNL_STATUS_URL)}`",
@@ -3892,13 +3910,14 @@ async def bnl_context_check(interaction: discord.Interaction):
     context_category = resolve_channel_policy(current_channel)
     relay_eligibility = website_relay_eligibility(context_category)
     primary_guild_match = bool(BNL_PRIMARY_GUILD_ID and guild.id == BNL_PRIMARY_GUILD_ID)
+    context_visibility = context_visibility_for_policy(context_category)
     lines = [
         "**BNL Context Diagnostic (report-only)**",
         f"- guild: `{guild.name}` (`{guild.id}`)",
         f"- resolved_channel_policy: `{context_category}`",
         f"- website_relay_eligibility: `{relay_eligibility}`",
         f"- primary_guild_match: `{primary_guild_match}`",
-        f"- context_visibility: `{context_category}`",
+        f"- context_visibility: `{context_visibility}`",
         f"- configured_active_channel: {active_channel.mention if active_channel else 'none'}",
         f"- configured_testing_channel: {testing_channel.mention if testing_channel else 'unset/not found'}",
         f"- current_channel: `{getattr(current_channel, 'name', 'unknown')}` (`{getattr(current_channel, 'id', 'n/a')}`)",

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -1568,10 +1568,38 @@ def has_mod_role(member: discord.Member) -> bool:
     return any(role.id == BNL_MOD_ROLE_ID for role in getattr(member, "roles", []))
 
 
-def diagnostics_channel_allowed(interaction: discord.Interaction) -> bool:
-    if not BNL_TESTING_CHANNEL_ID:
-        return True
-    return bool(interaction.channel_id) and interaction.channel_id == BNL_TESTING_CHANNEL_ID
+def resolve_channel_policy(channel: discord.abc.GuildChannel | None) -> str:
+    if not channel:
+        return "unknown"
+    name = (getattr(channel, "name", "") or "").lower()
+    cid = getattr(channel, "id", 0) or 0
+    if BNL_TESTING_CHANNEL_ID and cid == BNL_TESTING_CHANNEL_ID:
+        return "sealed_test"
+    if "welcome" in name or "introduc" in name or "new-member" in name:
+        return "public_home"
+    if "episode-tracker" in name or "episode_tracker" in name:
+        return "protected_system"
+    if "general" in name or "chat" in name or "lounge" in name:
+        return "public_context"
+    if "bot" in name or "command" in name:
+        return "public_selective"
+    if "canon" in name or "lore" in name or "reference" in name:
+        return "reference_canon"
+    if "mod" in name or "admin" in name or "staff" in name or "ops" in name:
+        return "internal_controlled"
+    if "image" in name or "art" in name or "media" in name:
+        return "ai_image_tool"
+    return "unknown"
+
+
+def website_relay_eligibility(policy: str) -> str:
+    if policy in {"internal_controlled", "protected_system", "sealed_test"}:
+        return "restricted"
+    if policy in {"public_home", "public_context", "public_selective", "reference_canon"}:
+        return "eligible"
+    if policy == "ai_image_tool":
+        return "limited"
+    return "unknown"
 
 def try_repair_response(user_text: str) -> str:
     t = (user_text or "").lower().strip()
@@ -3801,18 +3829,17 @@ async def bnl_source_check(interaction: discord.Interaction):
     if not is_owner_operator(interaction.user):
         await interaction.response.send_message("❌ Owner-only command.", ephemeral=True)
         return
-    if not diagnostics_channel_allowed(interaction):
-        await interaction.response.send_message(
-            f"❌ Diagnostics are restricted to <#{BNL_TESTING_CHANNEL_ID}>.",
-            ephemeral=True,
-        )
-        return
 
     guild = interaction.guild
     active_channel_id = guild.id and get_guild_config(guild.id) if guild else None
     active_channel = guild.get_channel(active_channel_id) if guild and active_channel_id else None
     testing_channel = guild.get_channel(BNL_TESTING_CHANNEL_ID) if guild and BNL_TESTING_CHANNEL_ID else None
     mod_role = guild.get_role(BNL_MOD_ROLE_ID) if guild and BNL_MOD_ROLE_ID else None
+    current_channel = interaction.channel if isinstance(interaction.channel, discord.abc.GuildChannel) else None
+    policy = resolve_channel_policy(current_channel)
+    relay_eligibility = website_relay_eligibility(policy)
+    primary_guild_match = bool(guild and BNL_PRIMARY_GUILD_ID and guild.id == BNL_PRIMARY_GUILD_ID)
+    flags_source = _bnl_control_flags_last_source_url or "none"
 
     lines = [
         "**BNL Source Diagnostic**",
@@ -3821,6 +3848,13 @@ async def bnl_source_check(interaction: discord.Interaction):
         f"- mod_role_id: `{BNL_MOD_ROLE_ID or 'unset'}` ({mod_role.mention if mod_role else 'not found in this guild'})",
         f"- testing_channel_id: `{BNL_TESTING_CHANNEL_ID or 'unset'}` ({testing_channel.mention if testing_channel else 'not found in this guild'})",
         f"- active_channel: {active_channel.mention if active_channel else 'none (mention/reply mode)'}",
+        f"- current_channel: `{getattr(current_channel, 'name', 'unknown')}` (`{getattr(current_channel, 'id', 'n/a')}`)",
+        f"- context_visibility_category: `{policy}`",
+        f"- website_relay_eligibility: `{relay_eligibility}`",
+        f"- primary_guild_match: `{primary_guild_match}`",
+        f"- bnl_status_url_configured: `{bool(BNL_STATUS_URL)}`",
+        f"- bnl_api_key_configured: `{bool(BNL_API_KEY)}`",
+        f"- _bnl_control_flags_last_source_url: `{flags_source}`",
         f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` every `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}` min",
     ]
     await interaction.response.send_message("\n".join(lines), ephemeral=True)
@@ -3837,12 +3871,6 @@ async def bnl_context_check(interaction: discord.Interaction):
     if not is_owner_operator(interaction.user):
         await interaction.response.send_message("❌ Owner-only command.", ephemeral=True)
         return
-    if not diagnostics_channel_allowed(interaction):
-        await interaction.response.send_message(
-            f"❌ Diagnostics are restricted to <#{BNL_TESTING_CHANNEL_ID}>.",
-            ephemeral=True,
-        )
-        return
 
     if not interaction.guild:
         await interaction.response.send_message("❌ This command can only be used in a server.", ephemeral=True)
@@ -3853,6 +3881,8 @@ async def bnl_context_check(interaction: discord.Interaction):
     active_channel_id = get_guild_config(guild.id)
     active_channel = guild.get_channel(active_channel_id) if active_channel_id else None
     testing_channel = guild.get_channel(BNL_TESTING_CHANNEL_ID) if BNL_TESTING_CHANNEL_ID else None
+    current_channel = interaction.channel if isinstance(interaction.channel, discord.abc.GuildChannel) else None
+    context_category = resolve_channel_policy(current_channel)
 
     channel_policy = "active-channel full reply mode + ping-only elsewhere" if active_channel else "mention/reply mode in all channels"
     lines = [
@@ -3861,6 +3891,8 @@ async def bnl_context_check(interaction: discord.Interaction):
         f"- channel_policy: {channel_policy}",
         f"- configured_active_channel: {active_channel.mention if active_channel else 'none'}",
         f"- configured_testing_channel: {testing_channel.mention if testing_channel else 'unset/not found'}",
+        f"- current_channel: `{getattr(current_channel, 'name', 'unknown')}` (`{getattr(current_channel, 'id', 'n/a')}`)",
+        f"- context_visibility_category: `{context_category}`",
         f"- invoker_is_owner: `{is_owner_operator(interaction.user)}`",
         f"- invoker_has_mod_role: `{has_mod_role(member)}`",
         "- behavior_changes_applied: `none` (reporting only)",

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -1571,24 +1571,31 @@ def has_mod_role(member: discord.Member) -> bool:
 def resolve_channel_policy(channel: discord.abc.GuildChannel | None) -> str:
     if not channel:
         return "unknown"
-    name = (getattr(channel, "name", "") or "").lower()
     cid = getattr(channel, "id", 0) or 0
+    guild_id = getattr(getattr(channel, "guild", None), "id", 0) or 0
+    active_channel_id = get_guild_config(guild_id) if guild_id else None
+
     if BNL_TESTING_CHANNEL_ID and cid == BNL_TESTING_CHANNEL_ID:
         return "sealed_test"
-    if "welcome" in name or "introduc" in name or "new-member" in name:
-        return "public_home"
-    if "episode-tracker" in name or "episode_tracker" in name:
-        return "protected_system"
-    if "general" in name or "chat" in name or "lounge" in name:
+    if active_channel_id and cid == active_channel_id:
         return "public_context"
-    if "bot" in name or "command" in name:
+    if BNL_PRIMARY_GUILD_ID and guild_id and guild_id != BNL_PRIMARY_GUILD_ID:
         return "public_selective"
+    name = (getattr(channel, "name", "") or "").lower()
+    if "episode-tracker" in name or "episode_tracker" in name or "ops" in name:
+        return "protected_system"
     if "canon" in name or "lore" in name or "reference" in name:
         return "reference_canon"
+    if "welcome" in name or "introduc" in name or "new-member" in name:
+        return "public_home"
     if "mod" in name or "admin" in name or "staff" in name or "ops" in name:
         return "internal_controlled"
     if "image" in name or "art" in name or "media" in name:
         return "ai_image_tool"
+    if "general" in name or "chat" in name or "lounge" in name:
+        return "public_context"
+    if "bot" in name or "command" in name:
+        return "public_selective"
     return "unknown"
 
 

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -1573,40 +1573,40 @@ def resolve_channel_policy(channel: discord.abc.GuildChannel | None) -> str:
         return "unknown"
     cid = getattr(channel, "id", 0) or 0
     guild_id = getattr(getattr(channel, "guild", None), "id", 0) or 0
-    active_channel_id = get_guild_config(guild_id) if guild_id else None
 
     if BNL_TESTING_CHANNEL_ID and cid == BNL_TESTING_CHANNEL_ID:
         return "sealed_test"
-    if active_channel_id and cid == active_channel_id:
-        return "public_context"
     if BNL_PRIMARY_GUILD_ID and guild_id and guild_id != BNL_PRIMARY_GUILD_ID:
         return "public_selective"
-    name = (getattr(channel, "name", "") or "").lower()
-    if "episode-tracker" in name or "episode_tracker" in name or "ops" in name:
-        return "protected_system"
-    if "canon" in name or "lore" in name or "reference" in name:
+    name = ((getattr(channel, "name", "") or "").strip().lower())
+    exact_map = {
+        "welcome": "protected_system",
+        "episode-tracker": "protected_system",
+        "barcode-bot": "public_home",
+        "introductions": "public_selective",
+        "ai-image-generator": "ai_image_tool",
+    }
+    if name in exact_map:
+        return exact_map[name]
+    if name in {"reference-canon", "lore", "canon"}:
         return "reference_canon"
-    if "welcome" in name or "introduc" in name or "new-member" in name:
-        return "public_home"
-    if "mod" in name or "admin" in name or "staff" in name or "ops" in name:
+    if name in {"mod-chat", "admin", "staff", "ops"}:
         return "internal_controlled"
-    if "image" in name or "art" in name or "media" in name:
-        return "ai_image_tool"
-    if "general" in name or "chat" in name or "lounge" in name:
+    if name in {"general", "chat", "lounge"}:
         return "public_context"
-    if "bot" in name or "command" in name:
+    if name in {"bot-commands", "commands"}:
         return "public_selective"
     return "unknown"
 
 
 def website_relay_eligibility(policy: str) -> str:
+    if policy in {"public_home", "public_context", "reference_canon"}:
+        return "yes"
+    if policy in {"public_selective", "ai_image_tool"}:
+        return "selective"
     if policy in {"internal_controlled", "protected_system", "sealed_test"}:
-        return "restricted"
-    if policy in {"public_home", "public_context", "public_selective", "reference_canon"}:
-        return "eligible"
-    if policy == "ai_image_tool":
-        return "limited"
-    return "unknown"
+        return "no"
+    return "no"
 
 def try_repair_response(user_text: str) -> str:
     t = (user_text or "").lower().strip()
@@ -3890,16 +3890,18 @@ async def bnl_context_check(interaction: discord.Interaction):
     testing_channel = guild.get_channel(BNL_TESTING_CHANNEL_ID) if BNL_TESTING_CHANNEL_ID else None
     current_channel = interaction.channel if isinstance(interaction.channel, discord.abc.GuildChannel) else None
     context_category = resolve_channel_policy(current_channel)
-
-    channel_policy = "active-channel full reply mode + ping-only elsewhere" if active_channel else "mention/reply mode in all channels"
+    relay_eligibility = website_relay_eligibility(context_category)
+    primary_guild_match = bool(BNL_PRIMARY_GUILD_ID and guild.id == BNL_PRIMARY_GUILD_ID)
     lines = [
         "**BNL Context Diagnostic (report-only)**",
         f"- guild: `{guild.name}` (`{guild.id}`)",
-        f"- channel_policy: {channel_policy}",
+        f"- resolved_channel_policy: `{context_category}`",
+        f"- website_relay_eligibility: `{relay_eligibility}`",
+        f"- primary_guild_match: `{primary_guild_match}`",
+        f"- context_visibility: `{context_category}`",
         f"- configured_active_channel: {active_channel.mention if active_channel else 'none'}",
         f"- configured_testing_channel: {testing_channel.mention if testing_channel else 'unset/not found'}",
         f"- current_channel: `{getattr(current_channel, 'name', 'unknown')}` (`{getattr(current_channel, 'id', 'n/a')}`)",
-        f"- context_visibility_category: `{context_category}`",
         f"- invoker_is_owner: `{is_owner_operator(interaction.user)}`",
         f"- invoker_has_mod_role: `{has_mod_role(member)}`",
         "- behavior_changes_applied: `none` (reporting only)",

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -46,6 +46,9 @@ BNL_WEBSITE_RELAY_INTERVAL_MINUTES = max(1, int(os.getenv("BNL_WEBSITE_RELAY_INT
 BNL_PRIMARY_GUILD_ID = int(os.getenv("BNL_PRIMARY_GUILD_ID", "0") or 0)
 BNL_FORCE_PULL_SHARED_SECRET = os.getenv("BNL_FORCE_PULL_SHARED_SECRET", "").strip()
 BNL_FORCE_PULL_PORT = int(os.getenv("BNL_FORCE_PULL_PORT", "8787") or 8787)
+BNL_OWNER_USER_ID = int(os.getenv("BNL_OWNER_USER_ID", "0") or 0)
+BNL_MOD_ROLE_ID = int(os.getenv("BNL_MOD_ROLE_ID", "0") or 0)
+BNL_TESTING_CHANNEL_ID = int(os.getenv("BNL_TESTING_CHANNEL_ID", "0") or 0)
 
 DAILY_TOKEN_LIMIT = 1_350_000
 PACIFIC_TZ = pytz.timezone("US/Pacific")
@@ -1553,6 +1556,16 @@ def is_privileged_member(member: discord.Member, guild: discord.Guild) -> bool:
         perms.kick_members,
         perms.ban_members,
     ])
+
+
+def is_owner_operator(user: discord.abc.User) -> bool:
+    return bool(BNL_OWNER_USER_ID) and bool(user) and user.id == BNL_OWNER_USER_ID
+
+
+def has_mod_role(member: discord.Member) -> bool:
+    if not member or not BNL_MOD_ROLE_ID:
+        return False
+    return any(role.id == BNL_MOD_ROLE_ID for role in getattr(member, "roles", []))
 
 def try_repair_response(user_text: str) -> str:
     t = (user_text or "").lower().strip()
@@ -3769,6 +3782,72 @@ async def about(interaction: discord.Interaction):
     )
     embed.set_footer(text="Use /setchannel to configure the liaison channel.")
     await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+@tree.command(name="bnl_source_check", description="Owner-only diagnostics for BNL source/config status.")
+async def bnl_source_check(interaction: discord.Interaction):
+    if not BNL_OWNER_USER_ID:
+        await interaction.response.send_message(
+            "❌ Owner diagnostics are disabled because `BNL_OWNER_USER_ID` is not configured.",
+            ephemeral=True,
+        )
+        return
+    if not is_owner_operator(interaction.user):
+        await interaction.response.send_message("❌ Owner-only command.", ephemeral=True)
+        return
+
+    guild = interaction.guild
+    active_channel_id = guild.id and get_guild_config(guild.id) if guild else None
+    active_channel = guild.get_channel(active_channel_id) if guild and active_channel_id else None
+    testing_channel = guild.get_channel(BNL_TESTING_CHANNEL_ID) if guild and BNL_TESTING_CHANNEL_ID else None
+    mod_role = guild.get_role(BNL_MOD_ROLE_ID) if guild and BNL_MOD_ROLE_ID else None
+
+    lines = [
+        "**BNL Source Diagnostic**",
+        f"- owner_user_id_configured: {'yes' if BNL_OWNER_USER_ID else 'no'}",
+        f"- owner_user_id: `{BNL_OWNER_USER_ID or 'unset'}`",
+        f"- mod_role_id: `{BNL_MOD_ROLE_ID or 'unset'}` ({mod_role.mention if mod_role else 'not found in this guild'})",
+        f"- testing_channel_id: `{BNL_TESTING_CHANNEL_ID or 'unset'}` ({testing_channel.mention if testing_channel else 'not found in this guild'})",
+        f"- active_channel: {active_channel.mention if active_channel else 'none (mention/reply mode)'}",
+        f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` every `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}` min",
+    ]
+    await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
+
+@tree.command(name="bnl_context_check", description="Owner-only diagnostics for channel policy reporting.")
+async def bnl_context_check(interaction: discord.Interaction):
+    if not BNL_OWNER_USER_ID:
+        await interaction.response.send_message(
+            "❌ Owner diagnostics are disabled because `BNL_OWNER_USER_ID` is not configured.",
+            ephemeral=True,
+        )
+        return
+    if not is_owner_operator(interaction.user):
+        await interaction.response.send_message("❌ Owner-only command.", ephemeral=True)
+        return
+
+    if not interaction.guild:
+        await interaction.response.send_message("❌ This command can only be used in a server.", ephemeral=True)
+        return
+
+    guild = interaction.guild
+    member = interaction.user if isinstance(interaction.user, discord.Member) else guild.get_member(interaction.user.id)
+    active_channel_id = get_guild_config(guild.id)
+    active_channel = guild.get_channel(active_channel_id) if active_channel_id else None
+    testing_channel = guild.get_channel(BNL_TESTING_CHANNEL_ID) if BNL_TESTING_CHANNEL_ID else None
+
+    channel_policy = "active-channel full reply mode + ping-only elsewhere" if active_channel else "mention/reply mode in all channels"
+    lines = [
+        "**BNL Context Diagnostic (report-only)**",
+        f"- guild: `{guild.name}` (`{guild.id}`)",
+        f"- channel_policy: {channel_policy}",
+        f"- configured_active_channel: {active_channel.mention if active_channel else 'none'}",
+        f"- configured_testing_channel: {testing_channel.mention if testing_channel else 'unset/not found'}",
+        f"- invoker_is_owner: `{is_owner_operator(interaction.user)}`",
+        f"- invoker_has_mod_role: `{has_mod_role(member)}`",
+        "- behavior_changes_applied: `none` (reporting only)",
+    ]
+    await interaction.response.send_message("\n".join(lines), ephemeral=True)
 
 @tree.command(name="showtest", description="Manually test Friday show-day update behavior.")
 @app_commands.describe(phase="Show-day phase to simulate")

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -1567,6 +1567,12 @@ def has_mod_role(member: discord.Member) -> bool:
         return False
     return any(role.id == BNL_MOD_ROLE_ID for role in getattr(member, "roles", []))
 
+
+def diagnostics_channel_allowed(interaction: discord.Interaction) -> bool:
+    if not BNL_TESTING_CHANNEL_ID:
+        return True
+    return bool(interaction.channel_id) and interaction.channel_id == BNL_TESTING_CHANNEL_ID
+
 def try_repair_response(user_text: str) -> str:
     t = (user_text or "").lower().strip()
     if not t:
@@ -3795,6 +3801,12 @@ async def bnl_source_check(interaction: discord.Interaction):
     if not is_owner_operator(interaction.user):
         await interaction.response.send_message("❌ Owner-only command.", ephemeral=True)
         return
+    if not diagnostics_channel_allowed(interaction):
+        await interaction.response.send_message(
+            f"❌ Diagnostics are restricted to <#{BNL_TESTING_CHANNEL_ID}>.",
+            ephemeral=True,
+        )
+        return
 
     guild = interaction.guild
     active_channel_id = guild.id and get_guild_config(guild.id) if guild else None
@@ -3824,6 +3836,12 @@ async def bnl_context_check(interaction: discord.Interaction):
         return
     if not is_owner_operator(interaction.user):
         await interaction.response.send_message("❌ Owner-only command.", ephemeral=True)
+        return
+    if not diagnostics_channel_allowed(interaction):
+        await interaction.response.send_message(
+            f"❌ Diagnostics are restricted to <#{BNL_TESTING_CHANNEL_ID}>.",
+            ephemeral=True,
+        )
         return
 
     if not interaction.guild:


### PR DESCRIPTION
### Motivation
- Provide owner-only diagnostics for source/config visibility and channel-policy reporting without changing runtime behavior.
- Gate sensitive diagnostics behind a configured owner id so owner-only commands fail closed when not configured.
- Expose small reporting hooks for operators to inspect `active`/`testing` channel and mod-role configuration without mutating state.

### Description
- Modified `bnl01_bot.py` (single-file change) to add three new environment variables: `BNL_OWNER_USER_ID`, `BNL_MOD_ROLE_ID`, and `BNL_TESTING_CHANNEL_ID` and parse them at startup.
- Added helper functions `is_owner_operator` and `has_mod_role` and two owner-only slash commands: `/bnl_source_check` (reports configured owner/mod/testing IDs and relay settings) and `/bnl_context_check` (report-only channel policy and invoker role/owner status); both commands fail closed if `BNL_OWNER_USER_ID` is unset.
- Owner-gating enforces that commands return an explicit disabled/fail-closed message when `BNL_OWNER_USER_ID` is not set and otherwise deny non-owner invokers, and the commands only report state and do not change posting, memory, relay, ambient, welcome, or episode-tracker behavior.
- Manual Discord test steps: deploy with `BNL_OWNER_USER_ID` unset and run `/bnl_source_check` and `/bnl_context_check` to confirm disabled messaging, then set `BNL_OWNER_USER_ID` to the owner id, restart, and as owner run `/bnl_source_check` and `/bnl_context_check` to confirm reported values while verifying non-owners are denied.

### Testing
- Ran `python3 -m py_compile bnl01_bot.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66f23890c832195a5f0fb74a9d535)