### PR TITLE
Add owner/mod role config, channel policy classification, and owner diagnostics

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -23,6 +23,7 @@ import urllib.error
 import urllib.parse
 from collections import defaultdict, deque
 from datetime import datetime, timedelta
+from typing import Optional, Set
 
 import pytz
 import discord
@@ -46,6 +47,24 @@ BNL_WEBSITE_RELAY_INTERVAL_MINUTES = max(1, int(os.getenv("BNL_WEBSITE_RELAY_INT
 BNL_PRIMARY_GUILD_ID = int(os.getenv("BNL_PRIMARY_GUILD_ID", "0") or 0)
 BNL_FORCE_PULL_SHARED_SECRET = os.getenv("BNL_FORCE_PULL_SHARED_SECRET", "").strip()
 BNL_FORCE_PULL_PORT = int(os.getenv("BNL_FORCE_PULL_PORT", "8787") or 8787)
+BNL_OWNER_USER_ID = int(os.getenv("BNL_OWNER_USER_ID", "0") or 0)
+BNL_MOD_ROLE_ID = int(os.getenv("BNL_MOD_ROLE_ID", "0") or 0)
+_BNL_MOD_ROLE_IDS_RAW = os.getenv("BNL_MOD_ROLE_IDS", "")
+BNL_TESTING_CHANNEL_ID = int(os.getenv("BNL_TESTING_CHANNEL_ID", "0") or 0)
+
+
+def _parse_role_ids(raw_value: str) -> Set[int]:
+    parsed: Set[int] = set()
+    for chunk in (raw_value or "").split(","):
+        token = chunk.strip()
+        if not token:
+            continue
+        if token.isdigit():
+            parsed.add(int(token))
+    return parsed
+
+
+BNL_MOD_ROLE_IDS = _parse_role_ids(_BNL_MOD_ROLE_IDS_RAW)
 
 DAILY_TOKEN_LIMIT = 1_350_000
 PACIFIC_TZ = pytz.timezone("US/Pacific")
@@ -88,6 +107,14 @@ BNL_REACTIONS_BROADCAST = ["📻", "🎚️", "🎛️", "🔊", "🎤", "📡",
 BNL_REACTIONS_GLITCH = ["🧿", "🫨", "⚠️", "❓", "🌀", "☢️", "📛"]
 BNL_REACTIONS_TECH = ["🧠", "⚙️", "💻", "🛰️", "🗜️", "📈", "🔧"]
 BNL_REACTIONS_VIBE = ["🫡", "👀", "🔥", "💯", "😵‍💫", "🧪", "🕶️"]
+
+PROTECTED_SYSTEM_CHANNELS = {"welcome", "episode-tracker"}
+PUBLIC_HOME_CHANNELS = {"barcode-bot"}
+PUBLIC_CONTEXT_CHANNELS = {"general-chat", "finished-tracks", "wips-and-demos", "collaboration-hub"}
+PUBLIC_SELECTIVE_CHANNELS = {"introductions", "social-links", "suggestions", "underground-nation", "hellcat-nz", "enter-data-ping-here", "daily-riddle"}
+REFERENCE_CANON_CHANNELS = {"announcements", "rules-and-guidelines", "faq", "resources", "roles"}
+INTERNAL_CONTROLLED_CHANNELS = {"research-and-development", "important", "planning-and-coordination", "mod-resources", "ai-avatar"}
+AI_IMAGE_TOOL_CHANNELS = {"ai-image-generator"}
 
 # ======== ADAPTIVE RESPONSE STYLE / MEMORY ========
 RECENT_STYLE_WINDOW = 6
@@ -819,7 +846,7 @@ async def request_fresh_website_relay(guild_id: int, *, force: bool = True) -> t
         return False, "OBSERVATION", "", ""
 
 
-def _resolve_force_pull_guild() -> int | None:
+def _resolve_force_pull_guild() -> Optional[int]:
     if BNL_PRIMARY_GUILD_ID:
         return BNL_PRIMARY_GUILD_ID
     if client.guilds:
@@ -1553,6 +1580,73 @@ def is_privileged_member(member: discord.Member, guild: discord.Guild) -> bool:
         perms.kick_members,
         perms.ban_members,
     ])
+
+
+def is_owner_operator(user: discord.abc.User) -> bool:
+    return bool(BNL_OWNER_USER_ID) and bool(user) and user.id == BNL_OWNER_USER_ID
+
+
+def has_mod_role(member: discord.Member) -> bool:
+    if not member:
+        return False
+    configured_ids = set(BNL_MOD_ROLE_IDS)
+    if BNL_MOD_ROLE_ID:
+        configured_ids.add(BNL_MOD_ROLE_ID)
+    if not configured_ids:
+        return False
+    member_role_ids = {role.id for role in getattr(member, "roles", [])}
+    return bool(member_role_ids.intersection(configured_ids))
+
+
+def resolve_channel_policy(channel: Optional[discord.abc.GuildChannel]) -> str:
+    if not channel:
+        return "unknown"
+    cid = getattr(channel, "id", 0) or 0
+    guild_id = getattr(getattr(channel, "guild", None), "id", 0) or 0
+
+    if BNL_TESTING_CHANNEL_ID and cid == BNL_TESTING_CHANNEL_ID:
+        return "sealed_test"
+    if BNL_PRIMARY_GUILD_ID and guild_id and guild_id != BNL_PRIMARY_GUILD_ID:
+        return "public_selective"
+    name = ((getattr(channel, "name", "") or "").strip().lower())
+    if name in PROTECTED_SYSTEM_CHANNELS:
+        return "protected_system"
+    if name in PUBLIC_HOME_CHANNELS:
+        return "public_home"
+    if name in PUBLIC_CONTEXT_CHANNELS:
+        return "public_context"
+    if name in PUBLIC_SELECTIVE_CHANNELS:
+        return "public_selective"
+    if name in REFERENCE_CANON_CHANNELS:
+        return "reference_canon"
+    if name in INTERNAL_CONTROLLED_CHANNELS:
+        return "internal_controlled"
+    if name in AI_IMAGE_TOOL_CHANNELS:
+        return "ai_image_tool"
+    return "unknown"
+
+
+def website_relay_eligibility(policy: str) -> str:
+    if policy in {"public_home", "public_context"}:
+        return "yes"
+    if policy == "public_selective":
+        return "selective"
+    return "no"
+
+
+def context_visibility_for_policy(policy: str) -> str:
+    mapping = {
+        "sealed_test": "test_only_no_public_relay",
+        "internal_controlled": "internal_no_passive_public_memory",
+        "protected_system": "protected_existing_behavior",
+        "reference_canon": "reference_only",
+        "ai_image_tool": "owner_approval_required",
+        "public_home": "public_context_allowed",
+        "public_context": "public_context_allowed",
+        "public_selective": "selective_public_context",
+        "unknown": "blocked_until_classified",
+    }
+    return mapping.get(policy, "blocked_until_classified")
 
 def try_repair_response(user_text: str) -> str:
     t = (user_text or "").lower().strip()
@@ -3769,6 +3863,97 @@ async def about(interaction: discord.Interaction):
     )
     embed.set_footer(text="Use /setchannel to configure the liaison channel.")
     await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+@tree.command(name="bnl_source_check", description="Owner-only diagnostics for BNL source/config status.")
+async def bnl_source_check(interaction: discord.Interaction):
+    if not BNL_OWNER_USER_ID:
+        await interaction.response.send_message(
+            "❌ Owner diagnostics are disabled because `BNL_OWNER_USER_ID` is not configured.",
+            ephemeral=True,
+        )
+        return
+    if not is_owner_operator(interaction.user):
+        await interaction.response.send_message("❌ Owner-only command.", ephemeral=True)
+        return
+
+    guild = interaction.guild
+    active_channel_id = guild.id and get_guild_config(guild.id) if guild else None
+    active_channel = guild.get_channel(active_channel_id) if guild and active_channel_id else None
+    testing_channel = guild.get_channel(BNL_TESTING_CHANNEL_ID) if guild and BNL_TESTING_CHANNEL_ID else None
+    mod_role = guild.get_role(BNL_MOD_ROLE_ID) if guild and BNL_MOD_ROLE_ID else None
+    configured_mod_role_ids = set(BNL_MOD_ROLE_IDS)
+    if BNL_MOD_ROLE_ID:
+        configured_mod_role_ids.add(BNL_MOD_ROLE_ID)
+    found_mod_role_ids = {rid for rid in configured_mod_role_ids if guild and guild.get_role(rid)}
+    current_channel = interaction.channel if isinstance(interaction.channel, discord.abc.GuildChannel) else None
+    policy = resolve_channel_policy(current_channel)
+    relay_eligibility = website_relay_eligibility(policy)
+    primary_guild_match = bool(guild and BNL_PRIMARY_GUILD_ID and guild.id == BNL_PRIMARY_GUILD_ID)
+    flags_source = _bnl_control_flags_last_source_url or "none"
+
+    lines = [
+        "**BNL Source Diagnostic**",
+        f"- owner_user_id_configured: {'yes' if BNL_OWNER_USER_ID else 'no'}",
+        f"- owner_user_id: `{BNL_OWNER_USER_ID or 'unset'}`",
+        f"- mod_role_id: `{BNL_MOD_ROLE_ID or 'unset'}` ({mod_role.mention if mod_role else 'not found in this guild'})",
+        f"- mod_role_ids_count: `{len(BNL_MOD_ROLE_IDS)}`",
+        f"- configured_mod_roles_found_in_guild: `{bool(found_mod_role_ids)}` ({len(found_mod_role_ids)}/{len(configured_mod_role_ids)})",
+        f"- testing_channel_id: `{BNL_TESTING_CHANNEL_ID or 'unset'}` ({testing_channel.mention if testing_channel else 'not found in this guild'})",
+        f"- active_channel: {active_channel.mention if active_channel else 'none (mention/reply mode)'}",
+        f"- current_channel: `{getattr(current_channel, 'name', 'unknown')}` (`{getattr(current_channel, 'id', 'n/a')}`)",
+        f"- resolved_channel_policy: `{policy}`",
+        f"- website_relay_eligibility: `{relay_eligibility}`",
+        f"- primary_guild_match: `{primary_guild_match}`",
+        f"- bnl_status_url_configured: `{bool(BNL_STATUS_URL)}`",
+        f"- bnl_api_key_configured: `{bool(BNL_API_KEY)}`",
+        f"- _bnl_control_flags_last_source_url: `{flags_source}`",
+        f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` every `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}` min",
+    ]
+    await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
+
+@tree.command(name="bnl_context_check", description="Owner-only diagnostics for channel policy reporting.")
+async def bnl_context_check(interaction: discord.Interaction):
+    if not BNL_OWNER_USER_ID:
+        await interaction.response.send_message(
+            "❌ Owner diagnostics are disabled because `BNL_OWNER_USER_ID` is not configured.",
+            ephemeral=True,
+        )
+        return
+    if not is_owner_operator(interaction.user):
+        await interaction.response.send_message("❌ Owner-only command.", ephemeral=True)
+        return
+
+    if not interaction.guild:
+        await interaction.response.send_message("❌ This command can only be used in a server.", ephemeral=True)
+        return
+
+    guild = interaction.guild
+    member = interaction.user if isinstance(interaction.user, discord.Member) else guild.get_member(interaction.user.id)
+    active_channel_id = get_guild_config(guild.id)
+    active_channel = guild.get_channel(active_channel_id) if active_channel_id else None
+    testing_channel = guild.get_channel(BNL_TESTING_CHANNEL_ID) if BNL_TESTING_CHANNEL_ID else None
+    current_channel = interaction.channel if isinstance(interaction.channel, discord.abc.GuildChannel) else None
+    context_category = resolve_channel_policy(current_channel)
+    relay_eligibility = website_relay_eligibility(context_category)
+    primary_guild_match = bool(BNL_PRIMARY_GUILD_ID and guild.id == BNL_PRIMARY_GUILD_ID)
+    context_visibility = context_visibility_for_policy(context_category)
+    lines = [
+        "**BNL Context Diagnostic (report-only)**",
+        f"- guild: `{guild.name}` (`{guild.id}`)",
+        f"- resolved_channel_policy: `{context_category}`",
+        f"- website_relay_eligibility: `{relay_eligibility}`",
+        f"- primary_guild_match: `{primary_guild_match}`",
+        f"- context_visibility: `{context_visibility}`",
+        f"- configured_active_channel: {active_channel.mention if active_channel else 'none'}",
+        f"- configured_testing_channel: {testing_channel.mention if testing_channel else 'unset/not found'}",
+        f"- current_channel: `{getattr(current_channel, 'name', 'unknown')}` (`{getattr(current_channel, 'id', 'n/a')}`)",
+        f"- invoker_is_owner: `{is_owner_operator(interaction.user)}`",
+        f"- invoker_has_mod_role: `{has_mod_role(member)}`",
+        "- behavior_changes_applied: `none` (reporting only)",
+    ]
+    await interaction.response.send_message("\n".join(lines), ephemeral=True)
 
 @tree.command(name="showtest", description="Manually test Friday show-day update behavior.")
 @app_commands.describe(phase="Show-day phase to simulate")


### PR DESCRIPTION
### Motivation

- Expose owner and moderator configuration via environment variables and enable programmatic checks for privileged operators. 
- Classify channels into policy buckets to control website relay and context visibility decisions for different channel types. 
- Provide owner-only diagnostic commands to inspect runtime configuration and channel-policy resolution to aid debugging and safe rollout.

### Description

- Added new environment-driven configuration keys `BNL_OWNER_USER_ID`, `BNL_MOD_ROLE_ID`, `BNL_MOD_ROLE_IDS`, and `BNL_TESTING_CHANNEL_ID` and a parser `_parse_role_ids` for comma-separated role IDs. 
- Introduced channel classification sets (`PROTECTED_SYSTEM_CHANNELS`, `PUBLIC_HOME_CHANNELS`, `PUBLIC_CONTEXT_CHANNELS`, `PUBLIC_SELECTIVE_CHANNELS`, `REFERENCE_CANON_CHANNELS`, `INTERNAL_CONTROLLED_CHANNELS`, `AI_IMAGE_TOOL_CHANNELS`) and the resolver `resolve_channel_policy`. 
- Implemented privilege helpers `is_owner_operator` and `has_mod_role` and policy helpers `website_relay_eligibility` and `context_visibility_for_policy`, plus changed `_resolve_force_pull_guild` type hint to return `Optional[int]`. 
- Added two owner-only slash commands `bnl_source_check` and `bnl_context_check` to report configuration, resolved channel policy, relay eligibility, and other diagnostic details to the invoker.

### Testing

- Performed an automated Python syntax/compile check with `python -m py_compile bnl01_bot.py`, which passed. 
- No automated unit test suite was modified or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66f23890c832195a5f0fb74a9d535)