### PR TITLE
Add safe mod-readable /bnl_status runtime status command

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -3998,6 +3998,49 @@ async def bnl_context_check(interaction: discord.Interaction):
     ]
     await interaction.response.send_message("\n".join(lines), ephemeral=True)
 
+
+@tree.command(name="bnl_status", description="Mod-readable runtime status snapshot (safe).")
+async def bnl_status(interaction: discord.Interaction):
+    if not interaction.guild:
+        await interaction.response.send_message("❌ This command can only be used in a server.", ephemeral=True)
+        return
+
+    guild = interaction.guild
+    member = interaction.user if isinstance(interaction.user, discord.Member) else guild.get_member(interaction.user.id)
+    is_owner = is_owner_operator(interaction.user)
+    has_named_admin_role = bool(member and any((getattr(role, "name", "") or "").strip() == "BARCODE_ADMIN" for role in member.roles))
+    is_mod = has_mod_role(member) or has_named_admin_role
+    if not is_owner and not is_mod:
+        await interaction.response.send_message("❌ You do not have permission to use this command.", ephemeral=True)
+        return
+
+    active_channel_id = get_guild_config(guild.id)
+    active_channel = guild.get_channel(active_channel_id) if active_channel_id else None
+    testing_channel = guild.get_channel(BNL_TESTING_CHANNEL_ID) if BNL_TESTING_CHANNEL_ID else None
+    current_channel = interaction.channel if isinstance(interaction.channel, discord.abc.GuildChannel) else None
+    policy = resolve_channel_policy(current_channel)
+    relay_eligibility = website_relay_eligibility(policy)
+    context_visibility = context_visibility_for_policy(policy)
+    flags_source_state = "available" if _bnl_control_flags_last_source_url else "not yet fetched"
+    website_bridge_configured = bool(BNL_STATUS_URL and BNL_API_KEY)
+
+    lines = [
+        "**BNL Runtime Status (safe)**",
+        "- online/command_responsive: `yes`",
+        f"- guild: `{guild.name}` (`{guild.id}`)",
+        f"- current_channel: `{getattr(current_channel, 'name', 'unknown')}` (`{getattr(current_channel, 'id', 'n/a')}`)",
+        f"- active_channel: {active_channel.mention if active_channel else 'none (mention/reply mode)'}",
+        f"- testing_channel: {testing_channel.mention if testing_channel else 'unset/not found'}",
+        f"- channel_policy: `{policy}`",
+        f"- relay_eligibility: `{relay_eligibility}`",
+        f"- context_visibility: `{context_visibility}`",
+        f"- ambient_throttle: cooldown=`{AMBIENT_POST_COOLDOWN_MINUTES}m` daily_cap=`{AMBIENT_DAILY_POST_CAP}` min_signal_messages=`{AMBIENT_MIN_SIGNAL_MESSAGES}` min_signal_users=`{AMBIENT_MIN_SIGNAL_UNIQUE_USERS}`",
+        f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` (interval `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}m`)",
+        f"- website_bridge_configured: `{'yes' if website_bridge_configured else 'no'}`",
+        f"- control_flags_source: `{flags_source_state}`",
+    ]
+    await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
 @tree.command(name="showtest", description="Manually test Friday show-day update behavior.")
 @app_commands.describe(phase="Show-day phase to simulate")
 @app_commands.choices(


### PR DESCRIPTION
### Motivation
- Provide moderators and the owner a quick, safe snapshot of the bot runtime state without exposing secrets or internal endpoints.
- Keep diagnostics scoped and non-invasive so owners/operators can triage runtime/relay/ambient settings without changing behavior.

### Description
- Added a new slash command `bnl_status` in `bnl01_bot.py` that reports a safe runtime snapshot including responsiveness, guild, current/active/testing channel, `resolve_channel_policy` output, `website_relay_eligibility`, `context_visibility_for_policy`, ambient throttle settings, website relay enabled state, website bridge configured yes/no, and control-flags source availability.
- Implemented access control that allows `is_owner_operator` or users who pass `has_mod_role` or have a role named `BARCODE_ADMIN`, and returns an ephemeral denial for others.
- Reused existing helpers `is_owner_operator`, `has_mod_role`, `resolve_channel_policy`, `website_relay_eligibility`, and `context_visibility_for_policy` to determine state and visibility.
- The command intentionally omits any secrets, API keys, `BNL_FORCE_PULL_SHARED_SECRET`, and full `BNL_STATUS_URL` values, and does not modify existing commands or relay/throttle plumbing.

### Testing
- Ran `python3 -m py_compile bnl01_bot.py` to verify syntax, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f68e1fb70c83219745b5e2a80b8992)