### PR TITLE
Safe truncation for website relays; preserve full sentences/words

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -126,21 +126,59 @@ WEBSITE_STATUS_LABEL_RE = re.compile(
 )
 
 
-def sanitize_website_status_message(message: str, limit: int = 240) -> str:
-    """Remove leading label wrappers and return plain website status text."""
+def _safe_boundary_truncate(text: str, limit: int, min_chars: int = 0, use_ellipsis: bool = True) -> str:
+    """Trim text at sentence/word boundaries and append ellipsis only when clipping is necessary."""
+    raw = (text or "").strip()
+    if not raw or limit <= 0:
+        return ""
+    if len(raw) <= limit:
+        return raw
+
+    sentence_boundaries = [m.end() for m in re.finditer(r"[.!?](?:\s+|$)", raw)]
+    best_sentence = 0
+    for idx in sentence_boundaries:
+        if idx <= limit:
+            best_sentence = idx
+        else:
+            break
+
+    min_target = min_chars if min_chars and min_chars < limit else 0
+    if best_sentence and (best_sentence >= min_target or min_target == 0):
+        clipped = raw[:best_sentence].strip()
+        return clipped
+
+    hard_limit = limit - 1 if use_ellipsis and limit > 1 else limit
+    fragment = raw[:hard_limit].rstrip()
+    if not fragment:
+        return "..." if use_ellipsis else ""
+
+    space_idx = fragment.rfind(" ")
+    if space_idx >= max(1, min_target):
+        fragment = fragment[:space_idx].rstrip()
+
+    if not fragment:
+        fragment = raw[:hard_limit].rstrip()
+
+    if use_ellipsis and len(fragment) < len(raw):
+        return fragment + "..."
+    return fragment
+
+
+def sanitize_website_status_message(message: str, limit: int = 240, min_chars: int = 0) -> str:
+    """Remove label wrappers and return website-safe text without mid-word clipping."""
     cleaned = (message or "").strip()
     while cleaned:
         updated = WEBSITE_STATUS_LABEL_RE.sub("", cleaned, count=1).strip()
         if updated == cleaned:
             break
         cleaned = updated
-    return cleaned[:limit]
+    return _safe_boundary_truncate(cleaned, limit=limit, min_chars=min_chars, use_ellipsis=True)
 
 
 def build_admin_note(mode: str, message: str, current_directive: str = "", source: str = "relay", compact: bool = False) -> str:
     """Build a compact admin-only operator note for website relay payloads."""
-    msg = sanitize_website_status_message(message, limit=240)
-    directive = sanitize_website_status_message(current_directive, limit=160)
+    msg = sanitize_website_status_message(message, limit=360, min_chars=220)
+    directive = sanitize_website_status_message(current_directive, limit=220, min_chars=120)
     summary = msg[:120] if msg else "No public relay text was generated."
     if compact:
         return sanitize_website_status_message(
@@ -165,8 +203,8 @@ def update_website_status(status: str, mode: str, message: str, current_directiv
         logging.warning("⚠️ BNL_API_KEY is missing; skipping website status update.")
         return False
 
-    sanitized_message = sanitize_website_status_message(message, limit=240)
-    sanitized_directive = sanitize_website_status_message(current_directive, limit=160)
+    sanitized_message = sanitize_website_status_message(message, limit=360, min_chars=220)
+    sanitized_directive = sanitize_website_status_message(current_directive, limit=220, min_chars=120)
     payload = {"status": status, "mode": mode, "message": sanitized_message, "currentDirective": sanitized_directive, "source": (source or "relay")[:32]}
     sanitized_admin_note = (admin_note or "").strip()
     if sanitized_admin_note:
@@ -454,8 +492,8 @@ def update_website_status_controlled(mode: str, message: str, status: str = "ONL
         logging.warning("⚠️ BNL_STATUS_URL missing. Cannot post website status updates.")
         return False
 
-    sanitized_message = sanitize_website_status_message(message, limit=240)
-    sanitized_directive = sanitize_website_status_message(current_directive, limit=160)
+    sanitized_message = sanitize_website_status_message(message, limit=360, min_chars=220)
+    sanitized_directive = sanitize_website_status_message(current_directive, limit=220, min_chars=120)
     same_payload = (_last_website_status_mode == mode and _last_website_status_message == sanitized_message and _last_website_directive == sanitized_directive)
     if same_payload and not force:
         logging.info(
@@ -730,8 +768,8 @@ async def generate_dynamic_website_relay(guild_id: int) -> tuple[str, str, str]:
         prompt = (
             "You are BNL-01 generating a website-only relay ticker line.\n"
             "Return exactly two plain-text lines.\n"
-            "Line 1: message under 240 chars.\n"
-            "Line 2: current directive under 160 chars.\n"
+            "Line 1: message about 220-360 chars, complete sentence(s), never cut mid-word or mid-sentence.\n"
+            "Line 2: current directive about 120-220 chars, complete sentence, never cut mid-word or mid-sentence.\n"
             "No markdown labels.\n"
             "Public line must be 1-2 compact sentences max.\n"
             "Use concrete Discord-side observations when present: recurring display names, channels, topics, jokes, questions, updates, or patterns.\n"
@@ -767,9 +805,9 @@ async def generate_dynamic_website_relay(guild_id: int) -> tuple[str, str, str]:
     if generated:
         lines = [ln.strip() for ln in generated.splitlines() if ln.strip()]
         if lines:
-            relay_message = sanitize_website_status_message(lines[0], limit=240)
+            relay_message = sanitize_website_status_message(lines[0], limit=360, min_chars=220)
         if len(lines) > 1:
-            current_directive = sanitize_website_status_message(lines[1], limit=160)
+            current_directive = sanitize_website_status_message(lines[1], limit=220, min_chars=120)
 
     if not relay_message or _contains_stale_phrase(relay_message):
         relay_message = _pick_varied_relay_fallback(_last_website_status_message)
@@ -786,14 +824,14 @@ async def generate_dynamic_website_relay(guild_id: int) -> tuple[str, str, str]:
         if options:
             current_directive = random.choice(options)
 
-    relay_message = sanitize_website_status_message(relay_message, limit=240)
+    relay_message = sanitize_website_status_message(relay_message, limit=360, min_chars=220)
     logging.info(
         f"📝 Relay generated guild={guild_id} preview={relay_message[:120]!r} "
         f"context_used={bool(relay_context.strip())}"
     )
     _remember_relay_message(guild_id, relay_message)
     _remember_relay_topic(guild_id, relay_message)
-    return mode, relay_message, sanitize_website_status_message(current_directive, limit=160)
+    return mode, relay_message, sanitize_website_status_message(current_directive, limit=220, min_chars=120)
 
 
 def resolve_network_guild_id(requested_guild_id: int) -> int:
@@ -816,8 +854,8 @@ async def request_fresh_website_relay(guild_id: int, *, force: bool = True) -> t
         target_guild_id = resolve_network_guild_id(guild_id)
         logging.info(f"📨 Fresh website relay requested guild={guild_id} target_guild={target_guild_id} force={force}.")
         mode, relay_message, directive = await generate_dynamic_website_relay(target_guild_id)
-        sanitized = sanitize_website_status_message(relay_message, limit=240)
-        sanitized_directive = sanitize_website_status_message(directive, limit=160)
+        sanitized = sanitize_website_status_message(relay_message, limit=360, min_chars=220)
+        sanitized_directive = sanitize_website_status_message(directive, limit=220, min_chars=120)
         admin_note = build_admin_note(mode=mode, message=sanitized, current_directive=sanitized_directive, source="relay", compact=not force) if force else ""
         ok = update_website_status_controlled(
             mode=mode,
@@ -3125,7 +3163,7 @@ async def generate_showday_messages(guild_id: int, phase_key: str):
     prompt = (
         "You are BNL-01. Generate exactly two lines.\n"
         "Line 1: Discord update under 320 chars.\n"
-        "Line 2: Website status message under 240 chars.\n"
+        "Line 2: Website status message about 220-360 chars, complete sentence(s), no mid-word or mid-sentence cuts.\n"
         "Voice: concise, corporate, lightly sinister, signal-analysis.\n"
         f"Event: {phase_desc}.\n"
         f"Room context (optional): {signal_context or 'none'}.\n"
@@ -3136,11 +3174,11 @@ async def generate_showday_messages(guild_id: int, phase_key: str):
     lines = [ln.strip(" -•\t") for ln in text.splitlines() if ln.strip()]
     if len(lines) >= 2:
         discord_msg = lines[0][:320]
-        website_msg = lines[1][:240]
+        website_msg = sanitize_website_status_message(lines[1], limit=360, min_chars=220)
         if discord_msg and website_msg:
             return discord_msg, website_msg
     fallback = _pick_varied_fallback(phase_key)
-    return fallback[:320], fallback[:240]
+    return fallback[:320], sanitize_website_status_message(fallback, limit=360, min_chars=220)
 
 
 def iter_managed_guilds():
@@ -3205,7 +3243,7 @@ async def barcode_radio_queue_task():
                     logging.error(f"Show-day Discord update failed (guild {guild.id}, {phase_key}): {e}")
             mode = "RESTRICTED" if phase_key == "sponsor_window" else "ACTIVE_LIAISON"
             if flags.get("websiteRelayEnabled", True):
-                update_website_status_controlled(mode=mode, message=website_msg[:240], status="ONLINE", force=True)
+                update_website_status_controlled(mode=mode, message=sanitize_website_status_message(website_msg, limit=360, min_chars=220), status="ONLINE", force=True)
             mark_show_update_fired(guild.id, show_date, phase_key, discord_sent, website_msg)
 
 @tasks.loop(minutes=1)
@@ -4093,7 +4131,7 @@ async def showtest(interaction: discord.Interaction, phase: app_commands.Choice[
     logging.info(f"/showtest BNL_API_KEY length: {key_len}")
     website_ok = website_ok if phase_key == "relay" else update_website_status_controlled(
         mode=mode,
-        message=website_msg[:240],
+        message=sanitize_website_status_message(website_msg, limit=360, min_chars=220),
         status="ONLINE",
         force=True,
         source="relay",


### PR DESCRIPTION
### Motivation
- Website-facing relay and status lines were sometimes cut mid-word or mid-sentence, producing awkward or incomplete public text.
- Public-facing messages should prefer short, complete statements instead of chopped longer lines and must fit target ranges for readability.
- Provide a robust helper to truncate at sentence/word boundaries and only append ellipsis when necessary.

### Description
- Added a `_safe_boundary_truncate` helper and routed `sanitize_website_status_message` through it so website text is trimmed at sentence/word boundaries rather than hard-sliced.
- Updated website-facing flows to use boundary-safe truncation, including `update_website_status`, `update_website_status_controlled`, `generate_dynamic_website_relay`, `request_fresh_website_relay`, `generate_showday_messages`, admin-note construction, and showday/showtest website update paths.
- Adjusted generation prompts and limits so public relay/status targets roughly `220–360` chars and directive text targets roughly `120–220` chars, and replaced remaining `[:240]`/`[:160]` slices with `sanitize_website_status_message(..., limit=..., min_chars=...)` calls.
- Preserved all Discord behavior and excluded the listed non-goals, while keeping code compatible with Python 3.9.

### Testing
- Ran `python3 -m py_compile bnl01_bot.py` and the file compiled successfully without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f693296e3483219c937ade753b789f)