### PR TITLE
Add deterministic restricted/internal recall boundary in public channels

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -1853,6 +1853,74 @@ def get_sealed_test_recall_guard_response(channel_policy: str, user_text: str, g
     )
     return sealed_test_recall_boundary_response()
 
+
+def _asks_recall_style_question(user_text: str) -> bool:
+    text = (user_text or "").strip().lower()
+    if not text:
+        return False
+    recall_tokens = (
+        "what did",
+        "what happened",
+        "what was said",
+        "what did i just say",
+        "what did i say",
+        "do you remember",
+        "recall",
+        "retrieve",
+        "quote",
+        "summarize",
+        "tell me what",
+    )
+    return any(token in text for token in recall_tokens)
+
+
+def _mentions_restricted_channel_target(user_text: str) -> bool:
+    text = (user_text or "").strip().lower()
+    if not text:
+        return False
+    restricted_tokens = (
+        "research-and-development",
+        "#research-and-development",
+        "important",
+        "#important",
+        "planning-and-coordination",
+        "#planning-and-coordination",
+        "mod-resources",
+        "#mod-resources",
+        "ai-avatar",
+        "#ai-avatar",
+        "internal_controlled",
+        "internal controlled",
+        "mod channel",
+        "mod channels",
+        "staff channel",
+        "internal channel",
+        "restricted channel",
+    )
+    return any(token in text for token in restricted_tokens)
+
+
+def restricted_channel_recall_boundary_response() -> str:
+    return (
+        "BNL-01 boundary notice: the channel you referenced is internal/restricted. "
+        "Its contents are not available for public recall from here, and I cannot "
+        "quote, summarize, retrieve, or invent those records in this channel."
+    )
+
+
+def get_restricted_channel_recall_guard_response(channel_policy: str, user_text: str, guild_id: int, channel_id: int) -> str:
+    if channel_policy in {"internal_controlled", "sealed_test"}:
+        return ""
+    if not _asks_recall_style_question(user_text):
+        return ""
+    if not _mentions_restricted_channel_target(user_text):
+        return ""
+    logging.info(
+        f"[conversation] guild_id={guild_id} channel_id={channel_id} reason=restricted_channel_recall_blocked"
+    )
+    return restricted_channel_recall_boundary_response()
+
+
 def try_repair_response(user_text: str) -> str:
     t = (user_text or "").lower().strip()
     if not t:
@@ -3622,6 +3690,17 @@ async def _flush_channel_buffer(channel: discord.TextChannel):
         await channel.send(sealed_recall_guard)
         _channel_last_reply_at[channel_id] = datetime.now(PACIFIC_TZ)
         return
+
+    restricted_recall_guard = get_restricted_channel_recall_guard_response(
+        channel_policy,
+        combined_text,
+        guild_id,
+        channel_id,
+    )
+    if restricted_recall_guard:
+        await channel.send(restricted_recall_guard)
+        _channel_last_reply_at[channel_id] = datetime.now(PACIFIC_TZ)
+        return
     if len(unique_user_ids) == 1:
         member = channel.guild.get_member(unique_user_ids[0])
         self_reflection = try_self_reflection_response(unique_user_ids[0], channel.guild.id, combined_text)
@@ -3949,6 +4028,16 @@ async def on_message(message: discord.Message):
             if sealed_recall_guard:
                 await message.reply(sealed_recall_guard)
                 return
+
+            restricted_recall_guard = get_restricted_channel_recall_guard_response(
+                channel_policy,
+                clean_content,
+                message.guild.id,
+                message.channel.id,
+            )
+            if restricted_recall_guard:
+                await message.reply(restricted_recall_guard)
+                return
             pending_count = len(_channel_buffers[message.channel.id])
             if pending_count:
                 _channel_buffers[message.channel.id].clear()
@@ -4042,6 +4131,16 @@ async def on_message(message: discord.Message):
             await message.reply(sealed_recall_guard)
             return
 
+        restricted_recall_guard = get_restricted_channel_recall_guard_response(
+            channel_policy,
+            clean_content,
+            message.guild.id,
+            message.channel.id,
+        )
+        if restricted_recall_guard:
+            await message.reply(restricted_recall_guard)
+            return
+
         if not is_sealed_test_channel:
             save_user_message(message.author.id, message.author.display_name, message.guild.id, clean_content, channel_name=getattr(message.channel, "name", ""), channel_policy=channel_policy)
 
@@ -4109,6 +4208,16 @@ async def on_message(message: discord.Message):
         )
         if sealed_recall_guard:
             await message.reply(sealed_recall_guard)
+            return
+
+        restricted_recall_guard = get_restricted_channel_recall_guard_response(
+            channel_policy,
+            clean_content,
+            message.guild.id,
+            message.channel.id,
+        )
+        if restricted_recall_guard:
+            await message.reply(restricted_recall_guard)
             return
 
         if not is_sealed_test_channel:


### PR DESCRIPTION
### Motivation
- Prevent the bot from quoting, summarizing, or inventing content from internal/mod/restricted channels when asked from public/non-internal channels by returning a deterministic boundary response instead. 
- Extend the existing sealed `#bnl-testing` recall guard to cover other internal/restricted references while preserving local internal behavior. 

### Description
- Added detection helpers ` _asks_recall_style_question`, `_mentions_restricted_channel_target`, `restricted_channel_recall_boundary_response`, and `get_restricted_channel_recall_guard_response` to detect recall-style prompts targeting internal/mod/restricted channels. 
- The restricted-target token set includes `research-and-development`, `#research-and-development`, `important`, `#important`, `planning-and-coordination`, `#planning-and-coordination`, `mod-resources`, `#mod-resources`, `ai-avatar`, `#ai-avatar`, `internal_controlled`, `internal controlled`, `mod channel`, `mod channels`, `staff channel`, `internal channel`, and `restricted channel`. 
- Wired the new guard into the main response paths before memory recall or Gemini generation: batched flush (`_flush_channel_buffer`) and the mention/reply handling paths inside `on_message`, so it short-circuits recall/generation with a deterministic BNL boundary message. 
- The guard is bypassed when the current channel policy is `internal_controlled` or `sealed_test` so normal local internal conversation remains unchanged, and the existing sealed `#bnl-testing` guard remains evaluated first. 
- Added safe logging on trigger with only `guild_id`, `channel_id`, and `reason=restricted_channel_recall_blocked` and no raw message content, while preserving website relay and memory capture behavior unchanged beyond interception. 

### Testing
- Compiled the module with `python3 -m py_compile bnl01_bot.py` and it passed successfully. 
- Static inspection and diff review confirm the new guard is evaluated before recall/generation and the sealed `#bnl-testing` behavior and other protected channels (e.g., `#welcome`, `#episode-tracker`) were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b45ff0d4832184e89c33507838c5)