### PR TITLE
Fix stale-batch cutoff for extended request payload flushes

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -3614,6 +3614,9 @@ _channel_preempted_generation_id = defaultdict(int)
 _channel_payload_wait_extended = defaultdict(bool)
 _channel_pending_request_intent = {}
 
+def _batch_max_wait_seconds(channel_id: int) -> int:
+    return BATCH_REQUEST_PAYLOAD_MAX_WAIT_SECONDS if _channel_payload_wait_extended.get(channel_id) else BATCH_MAX_WAIT_SECONDS
+
 
 def _log_batch_event(level: int, event: str, guild_id: int, channel_id: int, message_count: int, reason: str):
     logging.log(
@@ -3841,16 +3844,19 @@ async def _flush_channel_buffer(channel: discord.TextChannel):
         _log_batch_event(logging.INFO, "skip", guild_id, channel_id, message_count, "reply_cooldown")
         return
 
+    batch_max_wait = _batch_max_wait_seconds(channel_id)
     last_msg_at = _channel_last_message_at.get(channel_id)
-    if last_msg_at and (now - last_msg_at).total_seconds() > BATCH_MAX_WAIT_SECONDS:
+    if last_msg_at and (now - last_msg_at).total_seconds() > batch_max_wait:
+        stale_reason = "extended_payload_stale_batch" if _channel_payload_wait_extended.get(channel_id) else "stale_batch"
+        _log_batch_event(logging.INFO, "stale_batch_allowed_extended_payload", guild_id, channel_id, message_count, f"extended={int(_channel_payload_wait_extended.get(channel_id))};max_wait={batch_max_wait}")
         buf.clear()
         _channel_first_seen.pop(channel_id, None)
         _channel_last_message_at.pop(channel_id, None)
-        _log_batch_event(logging.INFO, "skip", guild_id, channel_id, message_count, "stale_batch")
+        _log_batch_event(logging.INFO, "skip", guild_id, channel_id, message_count, stale_reason)
         return
 
     batch_start = _channel_first_seen.get(channel_id, now)
-    cycle_deadline = batch_start + timedelta(seconds=BATCH_REQUEST_PAYLOAD_MAX_WAIT_SECONDS)
+    cycle_deadline = batch_start + timedelta(seconds=batch_max_wait)
     items = list(buf)
     pending_state = _consume_pending_request_intent(channel_id, now)
     if pending_state == "expired":
@@ -4080,7 +4086,7 @@ async def _schedule_flush(channel: discord.TextChannel):
     """
     channel_id = channel.id
     start = _channel_first_seen.get(channel_id, datetime.now(PACIFIC_TZ))
-    hard_wait = BATCH_REQUEST_PAYLOAD_MAX_WAIT_SECONDS if _channel_payload_wait_extended.get(channel_id) else BATCH_MAX_WAIT_SECONDS
+    hard_wait = _batch_max_wait_seconds(channel_id)
     deadline = start + timedelta(seconds=hard_wait)
     guild_id = channel.guild.id
 


### PR DESCRIPTION
### Motivation
- Recent batching changes extended the quiet window for request/list payload collection but left the stale-batch cutoff in `_flush_channel_buffer` using the old hard-deadline, causing intentionally-extended batches to be discarded as `stale_batch` after `quiet_window_extended` flushes.
- This produced mismatched behavior where `_schedule_flush` would wait the longer extended horizon but `_flush_channel_buffer` still applied the shorter stale cutoff.
- The goal is to ensure flush and stale-check use a single hard-deadline source so request-payload-extended batches are honored (within bounded limits).

### Description
- Add helper `_batch_max_wait_seconds(channel_id)` to centralize the hard-deadline selection and return `BATCH_REQUEST_PAYLOAD_MAX_WAIT_SECONDS` when payload extension is active, otherwise `BATCH_MAX_WAIT_SECONDS`.
- Use `_batch_max_wait_seconds(channel_id)` in both `_schedule_flush` and `_flush_channel_buffer`, and compute `cycle_deadline` from that value so scheduler and flusher share the same deadline logic.
- Update the stale-check in `_flush_channel_buffer` to compare against the computed `batch_max_wait` and emit safer diagnostic logs `stale_batch_allowed_extended_payload` and `extended_payload_stale_batch` (or `stale_batch`) without including raw message content.
- Preserve lifecycle of `_channel_payload_wait_extended[channel_id]` so the extension flag is available during stale evaluation and is only cleared in the existing `finally` block after flush completion, and keep all existing bounded waits.

### Testing
- `python3 -m py_compile bnl01_bot.py` ran and passed successfully.
- Repository search (`rg`) confirms the new helper and log events (`_batch_max_wait_seconds`, `stale_batch_allowed_extended_payload`, `extended_payload_stale_batch`) are present in `bnl01_bot.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6cde502188321a447d95c0083f5a0)