### PR TITLE
Add typing-aware pre-send pause to active-channel batching

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -3612,6 +3612,7 @@ _channel_last_reply_at = defaultdict(lambda: datetime.min.replace(tzinfo=PACIFIC
 _channel_generating = defaultdict(bool)
 _channel_generation_id = defaultdict(int)
 _channel_preempted_generation_id = defaultdict(int)
+_channel_message_interrupt_generation_id = defaultdict(int)
 _channel_payload_wait_extended = defaultdict(bool)
 _channel_pending_request_intent = {}
 _channel_recent_typing_at = {}
@@ -4068,6 +4069,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel):
             if late_count > 0:
                 _log_batch_event(logging.INFO, "late_message_during_generation", guild_id, channel_id, late_count, "detected")
                 _channel_preempted_generation_id[channel_id] = local_generation_id
+                _channel_message_interrupt_generation_id[channel_id] = local_generation_id
                 _log_batch_event(logging.INFO, "stale_generation_interrupted", guild_id, channel_id, late_count, "late_message_arrived")
                 if (not regenerated_once) and datetime.now(PACIFIC_TZ) < cycle_deadline:
                     late_items = list(_channel_buffers[channel_id])
@@ -4077,6 +4079,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel):
                     items.extend(late_items)
                     regenerated_once = True
                     _channel_preempted_generation_id[channel_id] = 0
+                    _channel_message_interrupt_generation_id[channel_id] = 0
                     _log_batch_event(logging.INFO, "coalesced_late_messages", guild_id, channel_id, len(items), "merged")
                     _log_batch_event(logging.INFO, "generation_requeued_after_interruption", guild_id, channel_id, len(items), "regenerate_latest_cluster")
                     _log_batch_event(logging.INFO, "late_request_continuation", guild_id, channel_id, len(items), "regenerate_with_late_payload")
@@ -4109,8 +4112,10 @@ async def _flush_channel_buffer(channel: discord.TextChannel):
             break
 
         if _channel_preempted_generation_id.get(channel_id) == local_generation_id:
-            _log_batch_event(logging.INFO, "stale_response_discarded", guild_id, channel_id, len(items), "interrupted_preempted")
             pending_after_discard = len(_channel_buffers[channel_id])
+            interrupted_by_message = (_channel_message_interrupt_generation_id.get(channel_id) == local_generation_id)
+            if pending_after_discard > 0 or interrupted_by_message:
+                _log_batch_event(logging.INFO, "stale_response_discarded", guild_id, channel_id, len(items), "interrupted_preempted")
             if pending_after_discard > 0:
                 _log_batch_event(
                     logging.INFO,
@@ -4123,7 +4128,10 @@ async def _flush_channel_buffer(channel: discord.TextChannel):
                 pending_task = _channel_tasks.get(channel_id)
                 if not pending_task or pending_task.done():
                     _channel_tasks[channel_id] = asyncio.create_task(_schedule_flush(channel))
-            return
+                return
+            _log_batch_event(logging.INFO, "stale_preempt_cleared_no_pending", guild_id, channel_id, len(items), "no_pending_messages")
+            _channel_preempted_generation_id[channel_id] = 0
+            _channel_message_interrupt_generation_id[channel_id] = 0
 
         should_pause_for_typing, typing_reason = _should_pause_for_recent_typing(channel, items, local_generation_id)
         if should_pause_for_typing:
@@ -4140,6 +4148,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel):
             late_after_pause = len(_channel_buffers[channel_id])
             if late_after_pause > 0:
                 _channel_preempted_generation_id[channel_id] = local_generation_id
+                _channel_message_interrupt_generation_id[channel_id] = local_generation_id
                 _log_batch_event(
                     logging.INFO,
                     "typing_pause_message_arrived",
@@ -4152,13 +4161,18 @@ async def _flush_channel_buffer(channel: discord.TextChannel):
                 _log_batch_event(logging.INFO, "typing_pause_expired_no_message", guild_id, channel_id, len(items), "send_proceed")
 
         if _channel_preempted_generation_id.get(channel_id) == local_generation_id:
-            _log_batch_event(logging.INFO, "stale_response_discarded", guild_id, channel_id, len(items), "typing_pause_preempted")
             pending_after_pause = len(_channel_buffers[channel_id])
+            interrupted_by_message_after_pause = (_channel_message_interrupt_generation_id.get(channel_id) == local_generation_id)
+            if pending_after_pause > 0 or interrupted_by_message_after_pause:
+                _log_batch_event(logging.INFO, "stale_response_discarded", guild_id, channel_id, len(items), "typing_pause_preempted")
             if pending_after_pause > 0:
                 pending_task = _channel_tasks.get(channel_id)
                 if not pending_task or pending_task.done():
                     _channel_tasks[channel_id] = asyncio.create_task(_schedule_flush(channel))
-            return
+                return
+            _log_batch_event(logging.INFO, "typing_preempt_cleared_no_pending", guild_id, channel_id, len(items), "typing_only_no_message")
+            _channel_preempted_generation_id[channel_id] = 0
+            _channel_message_interrupt_generation_id[channel_id] = 0
 
         if reason.startswith("request_payload_expected:") or reason in ("pending_request_payload_continuation", "pending_request_single_payload_continuation"):
             _log_batch_event(logging.INFO, "request_payload_items_preserved", guild_id, channel_id, len(collapsed_items), "list_items_included_in_prompt")
@@ -4501,6 +4515,7 @@ async def on_message(message: discord.Message):
                 return
             if _channel_generating[message.channel.id]:
                 _channel_preempted_generation_id[message.channel.id] = _channel_generation_id[message.channel.id]
+                _channel_message_interrupt_generation_id[message.channel.id] = _channel_generation_id[message.channel.id]
                 _log_batch_event(logging.INFO, "stale_response_discarded", message.guild.id, message.channel.id, len(_channel_buffers[message.channel.id]), "direct_reply_preempted_generation")
             pending_count = len(_channel_buffers[message.channel.id])
             if pending_count:
@@ -4571,6 +4586,7 @@ async def on_message(message: discord.Message):
             logging.info(f"[conversation] guild_id={message.guild.id} channel_id={message.channel.id} reason=sealed_test_free_speak")
         if _channel_generating[message.channel.id]:
             _channel_preempted_generation_id[message.channel.id] = _channel_generation_id[message.channel.id]
+            _channel_message_interrupt_generation_id[message.channel.id] = _channel_generation_id[message.channel.id]
             _log_batch_event(
                 logging.INFO,
                 "stale_generation_interrupted",

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -3662,8 +3662,10 @@ def _should_pause_for_recent_typing(channel: discord.TextChannel, items, generat
         return False, "typing_user_invalid"
 
     channel_policy = resolve_channel_policy(channel)
-    if channel_policy not in ("active", "free_speak", "sealed_test"):
-        return False, "channel_not_active_policy"
+    active_channel_id = get_guild_config(channel.guild.id) if channel.guild else None
+    is_active_scope = (active_channel_id is not None and channel_id == active_channel_id) or (channel_policy == "sealed_test")
+    if not is_active_scope:
+        return False, "channel_not_active_scope"
 
     recent_speakers = {uid for (_n, _c, uid) in items if uid}
     if recent_speakers and typing_user_id in recent_speakers:

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -3335,6 +3335,7 @@ intents.messages = True
 intents.message_content = True
 intents.guilds = True
 intents.members = True
+intents.typing = True
 
 client = discord.Client(intents=intents)
 tree = app_commands.CommandTree(client)
@@ -3613,6 +3614,12 @@ _channel_generation_id = defaultdict(int)
 _channel_preempted_generation_id = defaultdict(int)
 _channel_payload_wait_extended = defaultdict(bool)
 _channel_pending_request_intent = {}
+_channel_recent_typing_at = {}
+_channel_recent_typing_user_id = {}
+_channel_generation_typing_pause_used = defaultdict(bool)
+
+TYPING_RECENT_WINDOW_SECONDS = 5
+TYPING_SEND_GRACE_SECONDS = 1.5
 
 def _batch_max_wait_seconds(channel_id: int) -> int:
     return BATCH_REQUEST_PAYLOAD_MAX_WAIT_SECONDS if _channel_payload_wait_extended.get(channel_id) else BATCH_MAX_WAIT_SECONDS
@@ -3627,6 +3634,42 @@ def _log_batch_event(level: int, event: str, guild_id: int, channel_id: int, mes
 def _clear_generation_state(channel_id: int, generation_id: int):
     if _channel_generation_id[channel_id] == generation_id:
         _channel_generating[channel_id] = False
+        _channel_generation_typing_pause_used[channel_id] = False
+
+
+def _typing_signal_is_recent(channel_id: int, now: datetime):
+    typed_at = _channel_recent_typing_at.get(channel_id)
+    if not typed_at:
+        return False
+    return (now - typed_at).total_seconds() <= TYPING_RECENT_WINDOW_SECONDS
+
+
+def _should_pause_for_recent_typing(channel: discord.TextChannel, items, generation_id: int):
+    channel_id = channel.id
+    now = datetime.now(PACIFIC_TZ)
+    if _channel_generation_typing_pause_used.get(channel_id):
+        return False, "already_paused_once"
+    if not _channel_generating.get(channel_id):
+        return False, "not_generating"
+    if _channel_generation_id.get(channel_id) != generation_id:
+        return False, "generation_changed"
+    if not _typing_signal_is_recent(channel_id, now):
+        return False, "typing_not_recent"
+
+    typing_user_id = _channel_recent_typing_user_id.get(channel_id)
+    if not typing_user_id or typing_user_id == client.user.id:
+        return False, "typing_user_invalid"
+
+    channel_policy = resolve_channel_policy(channel)
+    if channel_policy not in ("active", "free_speak", "sealed_test"):
+        return False, "channel_not_active_policy"
+
+    recent_speakers = {uid for (_n, _c, uid) in items if uid}
+    if recent_speakers and typing_user_id in recent_speakers:
+        return True, "recent_speaker_typing"
+    if len(recent_speakers) >= 2:
+        return True, "active_conversation_typing"
+    return False, "typing_user_not_relevant"
 
 
 def _collapse_consecutive_batch_fragments(items):
@@ -4082,6 +4125,41 @@ async def _flush_channel_buffer(channel: discord.TextChannel):
                     _channel_tasks[channel_id] = asyncio.create_task(_schedule_flush(channel))
             return
 
+        should_pause_for_typing, typing_reason = _should_pause_for_recent_typing(channel, items, local_generation_id)
+        if should_pause_for_typing:
+            _channel_generation_typing_pause_used[channel_id] = True
+            _log_batch_event(
+                logging.INFO,
+                "typing_pause_before_send",
+                guild_id,
+                channel_id,
+                len(items),
+                f"reason={typing_reason};grace_seconds={TYPING_SEND_GRACE_SECONDS}",
+            )
+            await asyncio.sleep(TYPING_SEND_GRACE_SECONDS)
+            late_after_pause = len(_channel_buffers[channel_id])
+            if late_after_pause > 0:
+                _channel_preempted_generation_id[channel_id] = local_generation_id
+                _log_batch_event(
+                    logging.INFO,
+                    "typing_pause_message_arrived",
+                    guild_id,
+                    channel_id,
+                    late_after_pause,
+                    "message_after_typing_pause",
+                )
+            else:
+                _log_batch_event(logging.INFO, "typing_pause_expired_no_message", guild_id, channel_id, len(items), "send_proceed")
+
+        if _channel_preempted_generation_id.get(channel_id) == local_generation_id:
+            _log_batch_event(logging.INFO, "stale_response_discarded", guild_id, channel_id, len(items), "typing_pause_preempted")
+            pending_after_pause = len(_channel_buffers[channel_id])
+            if pending_after_pause > 0:
+                pending_task = _channel_tasks.get(channel_id)
+                if not pending_task or pending_task.done():
+                    _channel_tasks[channel_id] = asyncio.create_task(_schedule_flush(channel))
+            return
+
         if reason.startswith("request_payload_expected:") or reason in ("pending_request_payload_continuation", "pending_request_single_payload_continuation"):
             _log_batch_event(logging.INFO, "request_payload_items_preserved", guild_id, channel_id, len(collapsed_items), "list_items_included_in_prompt")
 
@@ -4308,6 +4386,26 @@ Rules:
         greeting = f"{username} has entered the BARCODE Network."
 
     await welcome_channel.send(f"{greeting}\n\nWelcome {member.mention}")
+
+@client.event
+async def on_typing(channel, user, when):
+    if not user or user == client.user:
+        return
+    if not isinstance(channel, discord.TextChannel):
+        return
+    if not channel.guild:
+        return
+    active_channel_id = get_guild_config(channel.guild.id)
+    channel_policy = resolve_channel_policy(channel)
+    is_active_scope = (active_channel_id is not None and channel.id == active_channel_id) or (channel_policy == "sealed_test")
+    if not is_active_scope:
+        return
+    if not _channel_generating.get(channel.id):
+        return
+
+    _channel_recent_typing_at[channel.id] = datetime.now(PACIFIC_TZ)
+    _channel_recent_typing_user_id[channel.id] = user.id
+    _log_batch_event(logging.INFO, "typing_signal_observed", channel.guild.id, channel.id, len(_channel_buffers[channel.id]), f"user_id={user.id};reason=active_generation")
 
 @client.event
 async def on_message(message: discord.Message):


### PR DESCRIPTION
### Motivation
- Audited active-channel paths and state: `on_message`, `_flush_channel_buffer`, `_schedule_flush`, generation/preemption state, late-message coalescing, and active-channel batching to locate where a typing-aware checkpoint is appropriate.
- Improve conversational feel so BNL treats in-progress generations as potentially stale when a relevant user begins typing, without breaking existing batching/coalescing guarantees.
- Keep behavior bounded and selective so typing only briefly delays sends in relevant contexts and cannot silence the bot indefinitely.

### Description
- Enabled typing intent (`intents.typing = True`) and added an `on_typing` handler that records a short-lived typing signal for the active/free-speak/sealed_test scope while generation is in progress.
- Added in-memory typing state and controls: `_channel_recent_typing_at`, `_channel_recent_typing_user_id`, `_channel_generation_typing_pause_used`, plus `TYPING_RECENT_WINDOW_SECONDS` and `TYPING_SEND_GRACE_SECONDS`.
- Implemented `_should_pause_for_recent_typing` which enforces relevance rules (recent signal, same generation, not the bot, active/free-speak/sealed_test channels, and recent speaker or multi-user activity).
- Integrated a one-time, bounded pre-send pause in `_flush_channel_buffer` that logs `typing_pause_before_send`, sleeps a short grace period, and then re-checks for late arrivals to trigger the existing preempt/requeue path or proceed; `_clear_generation_state` resets the pause flag.

### Testing
- Verified `python3 -m py_compile bnl01_bot.py` succeeds with the changes.
- Confirmed the change is Python 3.9-compatible and uses only existing dependencies and the discord.py typing event guarded by `intents.typing`.
- Performed a code-level audit of the modified functions to ensure existing batching, payload-wait, coalescing, and preemption paths are preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6d38748008321bf584c0dbdb0aae5)