### PR TITLE
Add post-generation capture grace to avoid send-boundary race in active batching

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -4332,6 +4332,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
 
         regenerated_once = False
         post_generation_capture_used = False
+        post_generation_regeneration_pending = None
         payload_completion_regenerated = False
         response = ""
         while True:
@@ -4408,6 +4409,19 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     "No long intro. No bracketed stage directions. No cinematic prose.\n"
                 )
                 _log_batch_event(logging.INFO, "simple_request_style_clamped", guild_id, channel_id, len(collapsed_items), f"payload_count={len(active_packet['payload_items'])}")
+            if post_generation_regeneration_pending:
+                _log_batch_event(
+                    logging.INFO,
+                    "post_generation_regeneration_started",
+                    guild_id,
+                    channel_id,
+                    post_generation_regeneration_pending["final_count"],
+                    "final_count={0};payload_count={1}".format(
+                        post_generation_regeneration_pending["final_count"],
+                        post_generation_regeneration_pending["payload_count"],
+                    ),
+                )
+                post_generation_regeneration_pending = None
 
             _log_batch_event(logging.INFO, "active_packet_generation_started", guild_id, channel_id, len(collapsed_items), f"payload_count={len(active_packet['payload_items'])};decision={decision};reason={reason}")
             generation_elapsed = max(0.0, (datetime.now(PACIFIC_TZ) - batch_start).total_seconds())
@@ -4517,6 +4531,23 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     _channel_message_interrupt_generation_id[channel_id] = local_generation_id
                     rebuilt_packet = _build_active_response_packet(channel_id, items, pending_state, bot_user=client.user)
                     rebuilt_payload_count = len(rebuilt_packet["payload_items"])
+                    rebuilt_collapsed_items = _collapse_consecutive_batch_fragments(items)
+                    rebuilt_msg_list = [(name, content) for (name, content, _uid) in rebuilt_collapsed_items]
+                    rebuilt_combined_text = " ".join([c for (_n, c, _u) in rebuilt_collapsed_items])
+                    rebuilt_first_uid = rebuilt_collapsed_items[0][2] if rebuilt_collapsed_items and rebuilt_collapsed_items[0][2] else 0
+                    rebuilt_style_key, rebuilt_style_rule = choose_response_style(channel.guild.id, rebuilt_first_uid, len(rebuilt_collapsed_items), rebuilt_combined_text)
+                    rebuilt_prompt = _format_batched_prompt(rebuilt_msg_list, rebuilt_style_key, rebuilt_style_rule)
+                    if rebuilt_packet["payload_items"]:
+                        rebuilt_prompt += "\n\nACTIVE REQUEST PAYLOAD ITEMS (respond to every unique item):\n"
+                        for i, item in enumerate(rebuilt_packet["payload_items"], start=1):
+                            rebuilt_prompt += f"{i}. {item}\n"
+                    if _is_simple_humor_or_list_request(rebuilt_combined_text, len(rebuilt_packet["payload_items"])):
+                        rebuilt_prompt += (
+                            "\nUse strict direct format for this response:\n"
+                            "Item Name: <brief response>\n"
+                            "No long intro. No bracketed stage directions. No cinematic prose.\n"
+                        )
+                    _ = rebuilt_prompt
                     _log_batch_event(
                         logging.INFO,
                         "post_generation_packet_rebuilt",
@@ -4531,6 +4562,10 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                         ),
                     )
                     regenerated_once = True
+                    post_generation_regeneration_pending = {
+                        "final_count": final_count,
+                        "payload_count": rebuilt_payload_count,
+                    }
                     _channel_preempted_generation_id[channel_id] = 0
                     _channel_message_interrupt_generation_id[channel_id] = 0
                     continue

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -3628,6 +3628,7 @@ TYPING_RECENT_WINDOW_SECONDS = 5
 TYPING_SEND_GRACE_SECONDS = 1.5
 HARD_INTERRUPT_REEVALUATE_PAUSE_MIN_SECONDS = 0.75
 HARD_INTERRUPT_REEVALUATE_PAUSE_MAX_SECONDS = 1.5
+POST_GENERATION_CAPTURE_GRACE_SECONDS = 0.5
 
 def _batch_max_wait_seconds(channel_id: int, selected_wait_seconds: float = None) -> float:
     if selected_wait_seconds is not None:
@@ -4330,6 +4331,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             return
 
         regenerated_once = False
+        post_generation_capture_used = False
         payload_completion_regenerated = False
         response = ""
         while True:
@@ -4451,6 +4453,87 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                         _log_batch_event(logging.INFO, "active_packet_completion_incomplete_after_retry", guild_id, channel_id, len(collapsed_items), f"payload_count={len(payload_items)};decision={decision};reason={reason}")
                 else:
                     _log_batch_event(logging.INFO, "active_packet_completion_passed", guild_id, channel_id, len(payload_items), "initial")
+
+            request_payload_expected = (
+                bool(active_packet["payload_items"])
+                or reason.startswith("request_payload_expected:")
+                or reason.startswith("request_intent:")
+                or reason in ("pending_request_payload_continuation", "pending_request_single_payload_continuation")
+                or bool(pending_state)
+                or _is_simple_humor_or_list_request(combined_text, len(active_packet["payload_items"]))
+            )
+            if (not post_generation_capture_used) and request_payload_expected and datetime.now(PACIFIC_TZ) < cycle_deadline:
+                post_generation_capture_used = True
+                payload_count = len(active_packet["payload_items"])
+                original_count = len(items)
+                _log_batch_event(
+                    logging.INFO,
+                    "post_generation_capture_wait",
+                    guild_id,
+                    channel_id,
+                    original_count,
+                    "original_count={0};added_count=0;final_count={0};payload_count={1};grace_seconds={2:.2f}".format(
+                        original_count,
+                        payload_count,
+                        POST_GENERATION_CAPTURE_GRACE_SECONDS,
+                    ),
+                )
+                await asyncio.sleep(POST_GENERATION_CAPTURE_GRACE_SECONDS)
+                late_after_generation = list(_channel_buffers[channel_id])
+                if late_after_generation:
+                    added_count = len(late_after_generation)
+                    _channel_buffers[channel_id].clear()
+                    _channel_first_seen.pop(channel_id, None)
+                    _channel_last_message_at.pop(channel_id, None)
+                    items.extend(late_after_generation)
+                    final_count = len(items)
+                    _log_batch_event(
+                        logging.INFO,
+                        "post_generation_buffer_drained",
+                        guild_id,
+                        channel_id,
+                        original_count,
+                        "original_count={0};added_count={1};final_count={2};payload_count={3}".format(
+                            original_count,
+                            added_count,
+                            final_count,
+                            payload_count,
+                        ),
+                    )
+                    _log_batch_event(
+                        logging.INFO,
+                        "stale_response_blocked_by_post_generation_capture",
+                        guild_id,
+                        channel_id,
+                        final_count,
+                        "original_count={0};added_count={1};final_count={2};payload_count={3}".format(
+                            original_count,
+                            added_count,
+                            final_count,
+                            payload_count,
+                        ),
+                    )
+                    _channel_preempted_generation_id[channel_id] = local_generation_id
+                    _channel_message_interrupt_generation_id[channel_id] = local_generation_id
+                    rebuilt_packet = _build_active_response_packet(channel_id, items, pending_state, bot_user=client.user)
+                    rebuilt_payload_count = len(rebuilt_packet["payload_items"])
+                    _log_batch_event(
+                        logging.INFO,
+                        "post_generation_packet_rebuilt",
+                        guild_id,
+                        channel_id,
+                        final_count,
+                        "original_count={0};added_count={1};final_count={2};payload_count={3}".format(
+                            original_count,
+                            added_count,
+                            final_count,
+                            rebuilt_payload_count,
+                        ),
+                    )
+                    regenerated_once = True
+                    _channel_preempted_generation_id[channel_id] = 0
+                    _channel_message_interrupt_generation_id[channel_id] = 0
+                    continue
 
             late_count = len(_channel_buffers[channel_id])
             if late_count > 0:

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -4421,6 +4421,17 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                         post_generation_regeneration_pending["payload_count"],
                     ),
                 )
+                _log_batch_event(
+                    logging.INFO,
+                    "post_generation_regeneration_prompt_ready",
+                    guild_id,
+                    channel_id,
+                    post_generation_regeneration_pending["final_count"],
+                    "final_count={0};payload_count={1}".format(
+                        post_generation_regeneration_pending["final_count"],
+                        post_generation_regeneration_pending["payload_count"],
+                    ),
+                )
                 post_generation_regeneration_pending = None
 
             _log_batch_event(logging.INFO, "active_packet_generation_started", guild_id, channel_id, len(collapsed_items), f"payload_count={len(active_packet['payload_items'])};decision={decision};reason={reason}")
@@ -4536,18 +4547,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     rebuilt_combined_text = " ".join([c for (_n, c, _u) in rebuilt_collapsed_items])
                     rebuilt_first_uid = rebuilt_collapsed_items[0][2] if rebuilt_collapsed_items and rebuilt_collapsed_items[0][2] else 0
                     rebuilt_style_key, rebuilt_style_rule = choose_response_style(channel.guild.id, rebuilt_first_uid, len(rebuilt_collapsed_items), rebuilt_combined_text)
-                    rebuilt_prompt = _format_batched_prompt(rebuilt_msg_list, rebuilt_style_key, rebuilt_style_rule)
-                    if rebuilt_packet["payload_items"]:
-                        rebuilt_prompt += "\n\nACTIVE REQUEST PAYLOAD ITEMS (respond to every unique item):\n"
-                        for i, item in enumerate(rebuilt_packet["payload_items"], start=1):
-                            rebuilt_prompt += f"{i}. {item}\n"
-                    if _is_simple_humor_or_list_request(rebuilt_combined_text, len(rebuilt_packet["payload_items"])):
-                        rebuilt_prompt += (
-                            "\nUse strict direct format for this response:\n"
-                            "Item Name: <brief response>\n"
-                            "No long intro. No bracketed stage directions. No cinematic prose.\n"
-                        )
-                    _ = rebuilt_prompt
+                    _format_batched_prompt(rebuilt_msg_list, rebuilt_style_key, rebuilt_style_rule)
                     _log_batch_event(
                         logging.INFO,
                         "post_generation_packet_rebuilt",

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -4540,14 +4540,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     )
                     _channel_preempted_generation_id[channel_id] = local_generation_id
                     _channel_message_interrupt_generation_id[channel_id] = local_generation_id
-                    rebuilt_packet = _build_active_response_packet(channel_id, items, pending_state, bot_user=client.user)
-                    rebuilt_payload_count = len(rebuilt_packet["payload_items"])
-                    rebuilt_collapsed_items = _collapse_consecutive_batch_fragments(items)
-                    rebuilt_msg_list = [(name, content) for (name, content, _uid) in rebuilt_collapsed_items]
-                    rebuilt_combined_text = " ".join([c for (_n, c, _u) in rebuilt_collapsed_items])
-                    rebuilt_first_uid = rebuilt_collapsed_items[0][2] if rebuilt_collapsed_items and rebuilt_collapsed_items[0][2] else 0
-                    rebuilt_style_key, rebuilt_style_rule = choose_response_style(channel.guild.id, rebuilt_first_uid, len(rebuilt_collapsed_items), rebuilt_combined_text)
-                    _format_batched_prompt(rebuilt_msg_list, rebuilt_style_key, rebuilt_style_rule)
+                    rebuilt_payload_count = len(
+                        _build_active_response_packet(channel_id, items, pending_state, bot_user=client.user)["payload_items"]
+                    )
                     _log_batch_event(
                         logging.INFO,
                         "post_generation_packet_rebuilt",


### PR DESCRIPTION
### Motivation
- There is a send-boundary race in active-channel batching where late payload messages arriving after generation begins can cause the bot to send a stale single-item response and then handle the late message as a separate continuation, which is undesirable for request/list flows.  
- The change aims to respect the rule that actual sent messages are the source of truth while avoiding unnecessary separate continuations for closely-timed payload items.  
- The fix must be bounded, preserve adaptive timing and interruption semantics, and only apply when request/list-style payloads are expected.

### Description
- Added a small constant `POST_GENERATION_CAPTURE_GRACE_SECONDS = 0.5` as the capture grace window.  
- Implemented a one-time post-generation / pre-send capture path inside `_flush_channel_buffer` that activates only when request/list-relevant conditions are detected (payload items present, request/payload reason markers, pending request state, or simple humor/list clamp).  
- During the grace the code waits briefly, checks ` _channel_buffers[channel_id]` and if new real messages arrived it drains them, merges them into `items`, rebuilds the active packet via `_build_active_response_packet`, logs safe diagnostics, and forces one regeneration of the response before proceeding to the final pre-send checks.  
- The path is bounded to a single capture/regeneration per flush cycle, leaves post-commit semantics unchanged (messages arriving after `response_send_commit_start` / `response_send_commit_complete` remain continuation flow), and adds safe logs (`post_generation_capture_wait`, `post_generation_buffer_drained`, `post_generation_packet_rebuilt`, `stale_response_blocked_by_post_generation_capture`) that include counts and payload metadata but no raw content.

### Testing
- Ran Python static compilation with `python3 -m py_compile bnl01_bot.py` which succeeded.  
- Verified that the change is limited to `_flush_channel_buffer` and supporting logic and preserves existing adaptive/wait/interruption behavior by inspection of the modified code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f81457c3bc8321b19aff561c783fe3)