### PR TITLE
Fix payload packets being suppressed as light fragments

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -4463,6 +4463,8 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 if payload_count > 0:
                     decision, reason = "answer", "payload_items_present"
                     _log_batch_event(logging.INFO, "payload_items_force_answer", guild_id, channel_id, len(collapsed_items), f"message_count={len(collapsed_items)};payload_count={payload_count}")
+                if decision == "answer":
+                    continue
                 ack = _build_acknowledgement_response(collapsed_items)
                 if not ack:
                     if _hard_interrupt_active_for_generation(channel_id, local_generation_id):
@@ -4477,14 +4479,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     if (pending_state or pending_anchor) and _is_payload_like_cluster(collapsed_items):
                         decision, reason = "answer", "pending_request_payload_continuation"
                         _log_batch_event(logging.INFO, "payload_continuation_not_suppressed", guild_id, channel_id, len(collapsed_items), "override_ack_suppression_to_answer")
-                    elif payload_count > 0:
-                        decision, reason = "answer", "payload_items_present"
-                        _log_batch_event(logging.INFO, "payload_items_force_answer", guild_id, channel_id, len(collapsed_items), f"message_count={len(collapsed_items)};payload_count={payload_count}")
-                    else:
-                        _log_batch_event(logging.INFO, "generic_ack_suppressed", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
-                        return
-                if decision == "answer":
-                    continue
+                        continue
+                    _log_batch_event(logging.INFO, "generic_ack_suppressed", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
+                    return
                 await channel.send(ack, allowed_mentions=safe_mentions)
                 _log_batch_event(logging.INFO, "batch_response_acknowledge", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
                 _channel_last_reply_at[channel_id] = datetime.now(PACIFIC_TZ)

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -4354,10 +4354,14 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 return
         active_packet = _build_active_response_packet(channel_id, items, pending_state, pending_anchor=pending_anchor, bot_user=client.user)
         decision, reason = active_packet["decision"], active_packet["reason"]
+        payload_count = len(active_packet["payload_items"])
         _log_batch_event(logging.INFO, "active_packet_original_count", guild_id, channel_id, active_packet["original_count"], f"original_count={active_packet['original_count']}")
         _log_batch_event(logging.INFO, "active_packet_collapsed_count", guild_id, channel_id, active_packet["collapsed_count"], f"collapsed_count={active_packet['collapsed_count']}")
-        _log_batch_event(logging.INFO, "active_packet_built", guild_id, channel_id, active_packet["collapsed_count"], f"original_count={active_packet['original_count']};collapsed_count={active_packet['collapsed_count']};payload_count={len(active_packet['payload_items'])};decision={decision};reason={reason}")
-        _log_batch_event(logging.INFO, "active_packet_payload_items", guild_id, channel_id, active_packet["collapsed_count"], f"payload_count={len(active_packet['payload_items'])}")
+        _log_batch_event(logging.INFO, "active_packet_built", guild_id, channel_id, active_packet["collapsed_count"], f"original_count={active_packet['original_count']};collapsed_count={active_packet['collapsed_count']};payload_count={payload_count};decision={decision};reason={reason}")
+        _log_batch_event(logging.INFO, "active_packet_payload_items", guild_id, channel_id, active_packet["collapsed_count"], f"payload_count={payload_count}")
+        if payload_count > 0 and decision != "answer":
+            _log_batch_event(logging.INFO, "payload_items_force_answer", guild_id, channel_id, len(collapsed_items), f"message_count={len(collapsed_items)};payload_count={payload_count}")
+            decision, reason = "answer", "payload_items_present"
         _log_batch_event(logging.INFO, "active_packet_decision", guild_id, channel_id, active_packet["collapsed_count"], f"decision={decision};reason={reason}")
         answer_intent_locked = decision == "answer"
         if (pending_state or pending_anchor) and reason in ("pending_request_payload_continuation", "pending_request_single_payload_continuation"):
@@ -4379,23 +4383,29 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             _log_batch_event(logging.INFO, "pending_request_intent_used", guild_id, channel_id, len(collapsed_items), "override_acknowledge")
             _log_batch_event(logging.INFO, "continuation_not_suppressed", guild_id, channel_id, len(collapsed_items), "override_acknowledge_to_answer")
         if decision == "acknowledge":
-            ack = _build_acknowledgement_response(collapsed_items)
-            if not ack:
-                if _hard_interrupt_active_for_generation(channel_id, local_generation_id):
-                    _log_batch_event(logging.INFO, "interrupted_buffer_requeued", guild_id, channel_id, len(collapsed_items), f"reason=ack_suppression_blocked:{reason}")
-                    if channel_id not in _channel_first_seen:
-                        _channel_first_seen[channel_id] = datetime.now(PACIFIC_TZ)
-                    _channel_last_message_at[channel_id] = datetime.now(PACIFIC_TZ)
-                    pending_task = _channel_tasks.get(channel_id)
-                    if not pending_task or pending_task.done():
-                        _channel_tasks[channel_id] = asyncio.create_task(_schedule_flush(channel))
+            if payload_count > 0:
+                decision, reason = "answer", "payload_items_present"
+                _log_batch_event(logging.INFO, "payload_items_force_answer", guild_id, channel_id, len(collapsed_items), f"message_count={len(collapsed_items)};payload_count={payload_count}")
+            if decision == "answer":
+                answer_intent_locked = True
+            else:
+                ack = _build_acknowledgement_response(collapsed_items)
+                if not ack:
+                    if _hard_interrupt_active_for_generation(channel_id, local_generation_id):
+                        _log_batch_event(logging.INFO, "interrupted_buffer_requeued", guild_id, channel_id, len(collapsed_items), f"reason=ack_suppression_blocked:{reason}")
+                        if channel_id not in _channel_first_seen:
+                            _channel_first_seen[channel_id] = datetime.now(PACIFIC_TZ)
+                        _channel_last_message_at[channel_id] = datetime.now(PACIFIC_TZ)
+                        pending_task = _channel_tasks.get(channel_id)
+                        if not pending_task or pending_task.done():
+                            _channel_tasks[channel_id] = asyncio.create_task(_schedule_flush(channel))
+                        return
+                    _log_batch_event(logging.INFO, "generic_ack_suppressed", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
                     return
-                _log_batch_event(logging.INFO, "generic_ack_suppressed", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
+                await channel.send(ack)
+                _log_batch_event(logging.INFO, "batch_response_acknowledge", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
+                _channel_last_reply_at[channel_id] = datetime.now(PACIFIC_TZ)
                 return
-            await channel.send(ack)
-            _log_batch_event(logging.INFO, "batch_response_acknowledge", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
-            _channel_last_reply_at[channel_id] = datetime.now(PACIFIC_TZ)
-            return
 
         regenerated_once = False
         post_generation_capture_used = False
@@ -4419,10 +4429,14 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             unique_user_ids = sorted({uid for (_n, _c, uid) in collapsed_items if uid})
             active_packet = _build_active_response_packet(channel_id, items, pending_state, pending_anchor=pending_anchor, bot_user=client.user)
             decision, reason = active_packet["decision"], active_packet["reason"]
+            payload_count = len(active_packet["payload_items"])
             _log_batch_event(logging.INFO, "active_packet_original_count", guild_id, channel_id, active_packet["original_count"], f"original_count={active_packet['original_count']}")
             _log_batch_event(logging.INFO, "active_packet_collapsed_count", guild_id, channel_id, active_packet["collapsed_count"], f"collapsed_count={active_packet['collapsed_count']}")
-            _log_batch_event(logging.INFO, "active_packet_built", guild_id, channel_id, active_packet["collapsed_count"], f"original_count={active_packet['original_count']};collapsed_count={active_packet['collapsed_count']};payload_count={len(active_packet['payload_items'])};decision={decision};reason={reason}")
-            _log_batch_event(logging.INFO, "active_packet_payload_items", guild_id, channel_id, active_packet["collapsed_count"], f"payload_count={len(active_packet['payload_items'])}")
+            _log_batch_event(logging.INFO, "active_packet_built", guild_id, channel_id, active_packet["collapsed_count"], f"original_count={active_packet['original_count']};collapsed_count={active_packet['collapsed_count']};payload_count={payload_count};decision={decision};reason={reason}")
+            _log_batch_event(logging.INFO, "active_packet_payload_items", guild_id, channel_id, active_packet["collapsed_count"], f"payload_count={payload_count}")
+            if payload_count > 0 and decision != "answer":
+                _log_batch_event(logging.INFO, "payload_items_force_answer", guild_id, channel_id, len(collapsed_items), f"message_count={len(collapsed_items)};payload_count={payload_count}")
+                decision, reason = "answer", "payload_items_present"
             _log_batch_event(logging.INFO, "active_packet_decision", guild_id, channel_id, active_packet["collapsed_count"], f"decision={decision};reason={reason}")
             if answer_intent_locked and decision != "answer":
                 _log_batch_event(logging.INFO, "request_intent_preserved", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
@@ -4446,6 +4460,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 _log_batch_event(logging.INFO, "pending_request_intent_used", guild_id, channel_id, len(collapsed_items), "override_acknowledge")
                 _log_batch_event(logging.INFO, "continuation_not_suppressed", guild_id, channel_id, len(collapsed_items), "override_acknowledge_to_answer")
             if decision == "acknowledge":
+                if payload_count > 0:
+                    decision, reason = "answer", "payload_items_present"
+                    _log_batch_event(logging.INFO, "payload_items_force_answer", guild_id, channel_id, len(collapsed_items), f"message_count={len(collapsed_items)};payload_count={payload_count}")
                 ack = _build_acknowledgement_response(collapsed_items)
                 if not ack:
                     if _hard_interrupt_active_for_generation(channel_id, local_generation_id):
@@ -4460,6 +4477,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     if (pending_state or pending_anchor) and _is_payload_like_cluster(collapsed_items):
                         decision, reason = "answer", "pending_request_payload_continuation"
                         _log_batch_event(logging.INFO, "payload_continuation_not_suppressed", guild_id, channel_id, len(collapsed_items), "override_ack_suppression_to_answer")
+                    elif payload_count > 0:
+                        decision, reason = "answer", "payload_items_present"
+                        _log_batch_event(logging.INFO, "payload_items_force_answer", guild_id, channel_id, len(collapsed_items), f"message_count={len(collapsed_items)};payload_count={payload_count}")
                     else:
                         _log_batch_event(logging.INFO, "generic_ack_suppressed", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
                         return


### PR DESCRIPTION
### Motivation
- After recent changes some packets that contained collected payload items were still classified as light fragments and suppressed instead of answered. 
- The intent is that any `active_packet` with non-empty `payload_items` must be treated as answerable and not be suppressed by generic ack logic.

### Description
- In `bnl01_bot.py` after building `active_packet` we compute `payload_count = len(active_packet["payload_items"])` and, if `payload_count > 0` and `decision != "answer"`, force `decision = "answer"` and `reason = "payload_items_present"` before downstream handling. 
- Added a safe log event `payload_items_force_answer` (no raw payload text) that records `guild_id`, `channel_id`, `message_count`, and `payload_count`. 
- Applied the same override in both the initial pre-loop pass and the regeneration loop so the decision is forced before `batch_engagement_decision`, generic ack suppression, ack send path, simple joke/list clamp, and prompt construction. 
- Adjusted acknowledge suppression branches to ensure packets with `payload_count > 0` do not trigger `generic_ack_suppressed` and instead proceed into normal answer generation while preserving existing continuation/anchor logic.

### Testing
- Ran `python3 -m py_compile bnl01_bot.py` and it completed successfully. 
- Verified the change is localized to `_flush_channel_buffer` and does not refactor the batching system or alter other preserved behaviors such as pending anchors, post-generation capture, adaptive timing, payload completion enforcement, simple-style clamp, allowed-mention safety, hard interruption, and typing diagnostic behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f81e2fc6d48321bdacc68ff9fc6082)