### PR TITLE
Enforce collected direct payload items before send

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -5176,6 +5176,7 @@ async def _collect_direct_payload_lines(anchor_message: discord.Message, clean_c
         return clean_content, []
 
     collected = [clean_content]
+    follow_up_lines = []
     logging.info("direct_payload_wait_started")
     deadline = datetime.now(PACIFIC_TZ) + timedelta(seconds=4)
     while datetime.now(PACIFIC_TZ) < deadline:
@@ -5198,12 +5199,41 @@ async def _collect_direct_payload_lines(anchor_message: discord.Message, clean_c
         if not line or line.startswith("/"):
             continue
         collected.append(line)
-    payload_items = _collect_request_payload_items([("user", line) for line in collected])
+        follow_up_lines.append(line)
+
+    def _dedupe_payload_items(items):
+        unique = []
+        seen = set()
+        for raw_item in items:
+            key = _normalize_payload_item_key(raw_item)
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            unique.append(raw_item.strip())
+        return unique
+
+    if follow_up_lines:
+        payload_items = _dedupe_payload_items(follow_up_lines)
+    else:
+        payload_items = []
+        multiline = _extract_multiline_request_payload(clean_content)
+        if multiline:
+            payload_items.extend(multiline.get("payload_items", []))
+        if not payload_items:
+            inline_match = re.search(r"\b(?:about|for)\s+(.+)$", clean_content, re.IGNORECASE)
+            if inline_match:
+                candidate_text = inline_match.group(1).strip().rstrip(".!?")
+                candidate_text = re.sub(r"^\b(?:these|the|those)\s+(?:people|names|items)\b\s*", "", candidate_text, flags=re.IGNORECASE).strip()
+                candidate_text = re.sub(r"\b(?:please|thanks?)\b$", "", candidate_text, flags=re.IGNORECASE).strip(" ,")
+                if candidate_text:
+                    parts = [p.strip(" .,!?:;") for p in re.split(r",|\band\b", candidate_text, flags=re.IGNORECASE)]
+                    payload_items.extend([p for p in parts if _is_single_payload_like_item(p)])
+        payload_items = _dedupe_payload_items(payload_items)
     logging.info(f"direct_payload_items_collected payload_count={len(payload_items)}")
     return "\n".join(collected), payload_items
 
 
-def _build_direct_payload_prompt(base_prompt: str, payload_items) -> str:
+def _build_direct_payload_prompt(base_prompt: str, payload_items, request_text: str) -> str:
     if not payload_items:
         return base_prompt
     lines = ["", "DIRECT REQUEST PAYLOAD ITEMS:"]
@@ -5212,7 +5242,7 @@ def _build_direct_payload_prompt(base_prompt: str, payload_items) -> str:
     lines.append("")
     lines.append("Instruction:")
     lines.append("Respond to every required payload item by name. Do not omit any item.")
-    if _is_simple_humor_or_list_request(" ".join(payload_items), len(payload_items)):
+    if _is_simple_humor_or_list_request(request_text, len(payload_items)):
         lines.append("For simple joke/list requests, prefer per-item format like `Name: <answer>`.")
     return base_prompt + "\n" + "\n".join(lines)
 
@@ -5356,7 +5386,7 @@ async def on_message(message: discord.Message):
                 message_count=1,
                 privileged=is_privileged_member(message.author, message.guild)
             )
-            prompt = _build_direct_payload_prompt(prompt, direct_payload_items)
+            prompt = _build_direct_payload_prompt(prompt, direct_payload_items, direct_content)
             log_response_style(message.guild.id, message.author.id, style_key)
 
             async with message.channel.typing():
@@ -5494,7 +5524,7 @@ async def on_message(message: discord.Message):
             message_count=1,
             privileged=is_privileged_member(message.author, message.guild)
         )
-        prompt = _build_direct_payload_prompt(prompt, direct_payload_items)
+        prompt = _build_direct_payload_prompt(prompt, direct_payload_items, direct_content)
         log_response_style(message.guild.id, message.author.id, style_key)
 
         async with message.channel.typing():
@@ -5596,7 +5626,7 @@ async def on_message(message: discord.Message):
             message_count=1,
             privileged=is_privileged_member(message.author, message.guild)
         )
-        prompt = _build_direct_payload_prompt(prompt, direct_payload_items)
+        prompt = _build_direct_payload_prompt(prompt, direct_payload_items, direct_content)
         log_response_style(message.guild.id, message.author.id, style_key)
 
         async with message.channel.typing():

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -5170,12 +5170,13 @@ async def on_typing(channel, user, when):
     _log_batch_event(logging.DEBUG, "typing_signal_observed", channel.guild.id, channel.id, len(_channel_buffers[channel.id]), "reason=active_generation")
 
 
-async def _collect_direct_payload_lines(anchor_message: discord.Message, clean_content: str, is_direct_request: bool) -> str:
+async def _collect_direct_payload_lines(anchor_message: discord.Message, clean_content: str, is_direct_request: bool):
     payload_expected, _ = _detect_request_payload_expectation(clean_content)
     if (not is_direct_request) or (not payload_expected):
-        return clean_content
+        return clean_content, []
 
     collected = [clean_content]
+    logging.info("direct_payload_wait_started")
     deadline = datetime.now(PACIFIC_TZ) + timedelta(seconds=4)
     while datetime.now(PACIFIC_TZ) < deadline:
         timeout = (deadline - datetime.now(PACIFIC_TZ)).total_seconds()
@@ -5197,7 +5198,23 @@ async def _collect_direct_payload_lines(anchor_message: discord.Message, clean_c
         if not line or line.startswith("/"):
             continue
         collected.append(line)
-    return "\n".join(collected)
+    payload_items = _collect_request_payload_items([("user", line) for line in collected])
+    logging.info(f"direct_payload_items_collected payload_count={len(payload_items)}")
+    return "\n".join(collected), payload_items
+
+
+def _build_direct_payload_prompt(base_prompt: str, payload_items) -> str:
+    if not payload_items:
+        return base_prompt
+    lines = ["", "DIRECT REQUEST PAYLOAD ITEMS:"]
+    for idx, item in enumerate(payload_items, start=1):
+        lines.append(f"{idx}. {item}")
+    lines.append("")
+    lines.append("Instruction:")
+    lines.append("Respond to every required payload item by name. Do not omit any item.")
+    if _is_simple_humor_or_list_request(" ".join(payload_items), len(payload_items)):
+        lines.append("For simple joke/list requests, prefer per-item format like `Name: <answer>`.")
+    return base_prompt + "\n" + "\n".join(lines)
 
 @client.event
 async def on_message(message: discord.Message):
@@ -5275,7 +5292,7 @@ async def on_message(message: discord.Message):
 
         # Mentions/replies -> immediate response (not batched)
         if direct_request:
-            direct_content = await _collect_direct_payload_lines(message, clean_content, direct_request)
+            direct_content, direct_payload_items = await _collect_direct_payload_lines(message, clean_content, direct_request)
             sealed_recall_guard = get_sealed_test_recall_guard_response(
                 channel_policy,
                 direct_content,
@@ -5339,10 +5356,32 @@ async def on_message(message: discord.Message):
                 message_count=1,
                 privileged=is_privileged_member(message.author, message.guild)
             )
+            prompt = _build_direct_payload_prompt(prompt, direct_payload_items)
             log_response_style(message.guild.id, message.author.id, style_key)
 
             async with message.channel.typing():
+                logging.info(f"direct_payload_generation_started payload_count={len(direct_payload_items)}")
                 response = await get_gemini_response(prompt, message.author.id, message.guild.id)
+            if response and direct_payload_items:
+                missing_items = _missing_request_payload_items(direct_payload_items, response)
+                logging.info(f"direct_payload_completion_check missing_count={len(missing_items)}")
+                if missing_items:
+                    correction_prompt = (
+                        prompt
+                        + "\n\nCORRECTION REQUIRED: Regenerate and include every required payload item explicitly by name.\n"
+                        + "Missing required payload items: " + ", ".join(missing_items) + "."
+                    )
+                    async with message.channel.typing():
+                        response = await get_gemini_response(correction_prompt, message.author.id, message.guild.id)
+                    missing_items = _missing_request_payload_items(direct_payload_items, response or "")
+                    logging.info(f"direct_payload_completion_regenerated missing_count={len(missing_items)}")
+                    if missing_items:
+                        response = (response or "").strip()
+                        fallback_lines = _build_payload_fallback_lines(missing_items)
+                        if fallback_lines:
+                            response = (response + "\n\n" + fallback_lines).strip() if response else fallback_lines
+                            logging.info(f"direct_payload_completion_fallback_appended missing_count={len(missing_items)}")
+            logging.info(f"direct_payload_generation_complete payload_count={len(direct_payload_items)}")
 
             if not response:
                 await message.reply("[NETWORK ERROR] Temporary synchronization issue. Try again.")
@@ -5403,7 +5442,7 @@ async def on_message(message: discord.Message):
         if not clean_content:
             await message.reply("I monitor this channel passively. My active operations are in the designated liaison channel.")
             return
-        direct_content = await _collect_direct_payload_lines(message, clean_content, direct_request)
+        direct_content, direct_payload_items = await _collect_direct_payload_lines(message, clean_content, direct_request)
         sealed_recall_guard = get_sealed_test_recall_guard_response(
             channel_policy,
             direct_content,
@@ -5455,10 +5494,32 @@ async def on_message(message: discord.Message):
             message_count=1,
             privileged=is_privileged_member(message.author, message.guild)
         )
+        prompt = _build_direct_payload_prompt(prompt, direct_payload_items)
         log_response_style(message.guild.id, message.author.id, style_key)
 
         async with message.channel.typing():
+            logging.info(f"direct_payload_generation_started payload_count={len(direct_payload_items)}")
             response = await get_gemini_response(prompt, message.author.id, message.guild.id)
+        if response and direct_payload_items:
+            missing_items = _missing_request_payload_items(direct_payload_items, response)
+            logging.info(f"direct_payload_completion_check missing_count={len(missing_items)}")
+            if missing_items:
+                correction_prompt = (
+                    prompt
+                    + "\n\nCORRECTION REQUIRED: Regenerate and include every required payload item explicitly by name.\n"
+                    + "Missing required payload items: " + ", ".join(missing_items) + "."
+                )
+                async with message.channel.typing():
+                    response = await get_gemini_response(correction_prompt, message.author.id, message.guild.id)
+                missing_items = _missing_request_payload_items(direct_payload_items, response or "")
+                logging.info(f"direct_payload_completion_regenerated missing_count={len(missing_items)}")
+                if missing_items:
+                    response = (response or "").strip()
+                    fallback_lines = _build_payload_fallback_lines(missing_items)
+                    if fallback_lines:
+                        response = (response + "\n\n" + fallback_lines).strip() if response else fallback_lines
+                        logging.info(f"direct_payload_completion_fallback_appended missing_count={len(missing_items)}")
+        logging.info(f"direct_payload_generation_complete payload_count={len(direct_payload_items)}")
 
         if not response:
             await message.reply("[NETWORK ERROR] Temporary synchronization issue. Try again.")
@@ -5483,7 +5544,7 @@ async def on_message(message: discord.Message):
         if not clean_content:
             await message.reply("You pinged me. How may I assist with BARCODE operations?")
             return
-        direct_content = await _collect_direct_payload_lines(message, clean_content, direct_request)
+        direct_content, direct_payload_items = await _collect_direct_payload_lines(message, clean_content, direct_request)
         sealed_recall_guard = get_sealed_test_recall_guard_response(
             channel_policy,
             direct_content,
@@ -5535,10 +5596,32 @@ async def on_message(message: discord.Message):
             message_count=1,
             privileged=is_privileged_member(message.author, message.guild)
         )
+        prompt = _build_direct_payload_prompt(prompt, direct_payload_items)
         log_response_style(message.guild.id, message.author.id, style_key)
 
         async with message.channel.typing():
+            logging.info(f"direct_payload_generation_started payload_count={len(direct_payload_items)}")
             response = await get_gemini_response(prompt, message.author.id, message.guild.id)
+        if response and direct_payload_items:
+            missing_items = _missing_request_payload_items(direct_payload_items, response)
+            logging.info(f"direct_payload_completion_check missing_count={len(missing_items)}")
+            if missing_items:
+                correction_prompt = (
+                    prompt
+                    + "\n\nCORRECTION REQUIRED: Regenerate and include every required payload item explicitly by name.\n"
+                    + "Missing required payload items: " + ", ".join(missing_items) + "."
+                )
+                async with message.channel.typing():
+                    response = await get_gemini_response(correction_prompt, message.author.id, message.guild.id)
+                missing_items = _missing_request_payload_items(direct_payload_items, response or "")
+                logging.info(f"direct_payload_completion_regenerated missing_count={len(missing_items)}")
+                if missing_items:
+                    response = (response or "").strip()
+                    fallback_lines = _build_payload_fallback_lines(missing_items)
+                    if fallback_lines:
+                        response = (response + "\n\n" + fallback_lines).strip() if response else fallback_lines
+                        logging.info(f"direct_payload_completion_fallback_appended missing_count={len(missing_items)}")
+        logging.info(f"direct_payload_generation_complete payload_count={len(direct_payload_items)}")
 
         if not response:
             await message.reply("[NETWORK ERROR] Temporary synchronization issue. Try again.")


### PR DESCRIPTION
### Motivation
- Fix the multi-line direct-payload failure where follow-up lines were not reliably treated as required payload items, causing items after the first to be omitted from replies. 
- Ensure directly addressed/tagged/replied requests that expect a list of payload items always produce replies mentioning every collected item by name.
- Preserve existing batching/intent semantics and avoid re-introducing pending-request state changes while making the direct path explicitly enforce payload completion.

### Description
- Updated direct payload capture to return both the merged direct text and explicit `payload_items` metadata from `bnl01_bot.py` via the updated `_collect_direct_payload_lines` signature. 
- Added safe lifecycle logs without raw content: `direct_payload_wait_started`, `direct_payload_items_collected payload_count=N`, `direct_payload_generation_started payload_count=N`, `direct_payload_completion_check missing_count=N`, `direct_payload_completion_regenerated missing_count=N`, `direct_payload_completion_fallback_appended missing_count=N`, and `direct_payload_generation_complete payload_count=N`.
- Added `_build_direct_payload_prompt` to augment the model prompt with a `DIRECT REQUEST PAYLOAD ITEMS:` section and an explicit instruction to respond to every required payload item (with per-item formatting guidance for simple joke/list requests). 
- Enforced completion in all direct-response paths by checking the initial generation for missing payload items, regenerating once with a correction prompt if items are missing, and appending concise fallback lines for any still-missing items; this is applied to active-channel direct replies, non-active ping-direct replies, and the no-active-channel direct path.
- Did not re-enable passive active-channel batching, did not set/restore `pending_request_intent` or `pending_request_anchor`, and made no unrelated changes to website relay, `#welcome`, `#episode-tracker`, force-pull, control flags, or `/showtest` behavior; implementation remains Python 3.9-compatible.

### Testing
- Ran `python3 -m py_compile bnl01_bot.py` and compilation succeeded. 
- No other automated tests exist in this PR; runtime behavior should be validated in integration/live testing to confirm multi-message payload scenarios meet the acceptance criteria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f83e7ce2408321a6fa3cb427081dcd)