### PR TITLE
Restore conversational default responses in allowed channels

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -3064,6 +3064,10 @@ def _extract_text_and_tokens(response):
         return "", None
 
 async def get_gemini_response(prompt: str, user_id: int, guild_id: int):
+    def _is_gemini_503(exc: Exception) -> bool:
+        msg = str(exc or "").lower()
+        return ("503" in msg and "unavailable" in msg) or "service unavailable" in msg
+
     try:
         if not check_quota_availability():
             tokens_used, _ = get_usage_stats()
@@ -3096,16 +3100,32 @@ async def get_gemini_response(prompt: str, user_id: int, guild_id: int):
         )
         print("BNL DEBUG: sending prompt to Gemini")
 
-        response = gemini_client.models.generate_content(
-            model="models/gemini-2.5-flash",
-            contents=f"""{BNL01_SYSTEM_PROMPT}
+        request_contents = f"""{BNL01_SYSTEM_PROMPT}
 
         Conversation history:
         {conversation_context}
 
         User: {prompt}
         BNL-01:"""
-        )
+        try:
+            response = gemini_client.models.generate_content(
+                model="models/gemini-2.5-flash",
+                contents=request_contents
+            )
+        except Exception as e:
+            if _is_gemini_503(e):
+                await asyncio.sleep(0.8)
+                try:
+                    response = gemini_client.models.generate_content(
+                        model="models/gemini-2.5-flash",
+                        contents=request_contents
+                    )
+                except Exception as retry_error:
+                    if _is_gemini_503(retry_error):
+                        logging.error("direct_generation_failed reason=gemini_503")
+                    raise
+            else:
+                raise
 
         text, tokens = _extract_text_and_tokens(response)
 
@@ -5202,6 +5222,17 @@ def _direct_session_key(message: discord.Message):
 
 
 _direct_payload_sessions = {}
+_recent_direct_response_window = {}
+DIRECT_FOLLOWUP_WINDOW_SECONDS = 45
+
+def _mark_recent_direct_response(channel_id: int, user_id: int):
+    _recent_direct_response_window[(channel_id, user_id)] = datetime.now(timezone.utc)
+
+def _is_recent_direct_followup(channel_id: int, user_id: int) -> bool:
+    ts = _recent_direct_response_window.get((channel_id, user_id))
+    if not ts:
+        return False
+    return (datetime.now(timezone.utc) - ts).total_seconds() <= DIRECT_FOLLOWUP_WINDOW_SECONDS
 
 
 async def _generate_direct_payload_session(session_key, reason: str):
@@ -5388,12 +5419,27 @@ async def on_message(message: discord.Message):
     )
 
     addressed_to_bot = bool(re.search(r"\b(bnl|bnl-01|barcode bot)\b", clean_content.lower())) if clean_content else False
-    direct_request = is_mention or is_reply or ((not BNL_ACTIVE_BATCHING_ENABLED) and addressed_to_bot)
+    conversational_channel_allowed = channel_policy in {"public_home", "public_context", "public_selective"} or is_active_channel
+    followup_candidate = _is_recent_direct_followup(message.channel.id, message.author.id) if clean_content else False
+    conversational_candidate = (
+        bool(clean_content)
+        and conversational_channel_allowed
+        and (not is_sealed_test_channel)
+        and (not getattr(message.author, "bot", False))
+    )
+    direct_request = is_mention or is_reply or ((not BNL_ACTIVE_BATCHING_ENABLED) and addressed_to_bot) or conversational_candidate or followup_candidate
+    if conversational_candidate and not (is_mention or is_reply or addressed_to_bot):
+        logging.info("conversational_response_candidate reason=allowed_channel")
+        if len(clean_content.split()) <= 2 and len(clean_content) <= 20:
+            logging.info("conversational_minimal_ack reason=low_detail")
+    if followup_candidate and not (is_mention or is_reply or addressed_to_bot):
+        logging.info("conversational_response_candidate reason=followup")
+        logging.info("conversational_continuation_detected reason=same_user_recent_response")
 
     session_key = _direct_session_key(message)
     active_direct_session = _direct_payload_sessions.get(session_key)
     if active_direct_session and not getattr(message.author, "bot", False):
-        if (not message.content.startswith("/")) and (not direct_request):
+        if (not message.content.startswith("/")) and (not (is_mention or is_reply or addressed_to_bot or conversational_candidate or followup_candidate)):
             line = (message.content or "").strip()
             if line:
                 active_direct_session["payload_lines"].append(line)
@@ -5588,6 +5634,7 @@ async def on_message(message: discord.Message):
                 await message.reply(chunks[0] + "...")
                 for chunk in chunks[1:]:
                     await message.channel.send("..." + chunk)
+            _mark_recent_direct_response(message.channel.id, message.author.id)
             return
 
         # Non-mention in active channel -> batch (kill-switched by env)
@@ -5727,6 +5774,7 @@ async def on_message(message: discord.Message):
             await message.reply(chunks[0] + "...")
             for chunk in chunks[1:]:
                 await message.channel.send("..." + chunk)
+        _mark_recent_direct_response(message.channel.id, message.author.id)
         return
 
     # ---------------- NO ACTIVE CHANNEL SET (RESPOND TO MENTIONS/REPLIES ANYWHERE) ----------------
@@ -5825,6 +5873,7 @@ async def on_message(message: discord.Message):
             set_last_greeting_at(message.author.id, message.guild.id, datetime.now(PACIFIC_TZ).isoformat())
 
         await message.reply(response if len(response) <= 2000 else response[:1900] + "...")
+        _mark_recent_direct_response(message.channel.id, message.author.id)
         return
 
 # ==================== SLASH COMMANDS ====================

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -5421,7 +5421,7 @@ async def on_message(message: discord.Message):
     plain_text_name_seen = bool(re.search(r"\b(bnl|bnl-01|barcode bot)\b", clean_content.lower())) if clean_content else False
     real_direct_target = bool(is_mention or is_reply)
     channel_allows_conversation = bool(
-        channel_policy in {"public_home", "public_context", "public_selective", "sealed_test"}
+        channel_policy in {"public_home", "sealed_test"}
         or is_active_channel
     )
     followup_candidate = _is_recent_direct_followup(message.channel.id, message.author.id) if clean_content else False

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -5418,28 +5418,21 @@ async def on_message(message: discord.Message):
         .strip()
     )
 
-    addressed_to_bot = bool(re.search(r"\b(bnl|bnl-01|barcode bot)\b", clean_content.lower())) if clean_content else False
-    conversational_channel_allowed = channel_policy in {"public_home", "public_context", "public_selective"} or is_active_channel
-    followup_candidate = _is_recent_direct_followup(message.channel.id, message.author.id) if clean_content else False
-    conversational_candidate = (
-        bool(clean_content)
-        and conversational_channel_allowed
-        and (not is_sealed_test_channel)
-        and (not getattr(message.author, "bot", False))
+    plain_text_name_seen = bool(re.search(r"\b(bnl|bnl-01|barcode bot)\b", clean_content.lower())) if clean_content else False
+    real_direct_target = bool(is_mention or is_reply)
+    channel_allows_conversation = bool(
+        channel_policy in {"public_home", "public_context", "public_selective", "sealed_test"}
+        or is_active_channel
     )
-    direct_request = is_mention or is_reply or ((not BNL_ACTIVE_BATCHING_ENABLED) and addressed_to_bot) or conversational_candidate or followup_candidate
-    if conversational_candidate and not (is_mention or is_reply or addressed_to_bot):
-        logging.info("conversational_response_candidate reason=allowed_channel")
-        if len(clean_content.split()) <= 2 and len(clean_content) <= 20:
-            logging.info("conversational_minimal_ack reason=low_detail")
-    if followup_candidate and not (is_mention or is_reply or addressed_to_bot):
-        logging.info("conversational_response_candidate reason=followup")
-        logging.info("conversational_continuation_detected reason=same_user_recent_response")
+    followup_candidate = _is_recent_direct_followup(message.channel.id, message.author.id) if clean_content else False
+    logging.info(f"response_route_channel_policy policy={channel_policy}")
+    logging.info(f"response_route_real_direct_target active={int(real_direct_target)}")
+    logging.info(f"response_route_plain_text_name_seen seen={int(plain_text_name_seen)}")
 
     session_key = _direct_session_key(message)
     active_direct_session = _direct_payload_sessions.get(session_key)
     if active_direct_session and not getattr(message.author, "bot", False):
-        explicit_new_direct_request = bool(is_mention or is_reply or addressed_to_bot)
+        explicit_new_direct_request = real_direct_target
         if explicit_new_direct_request:
             active_direct_session["completed"] = True
             _direct_payload_sessions.pop(session_key, None)
@@ -5456,7 +5449,25 @@ async def on_message(message: discord.Message):
                 logging.info(f"direct_payload_session_payload_added payload_count={len(active_direct_session['payload_lines'])}")
                 logging.info(f"direct_payload_session_timer_reset payload_count={len(active_direct_session['payload_lines'])}")
                 logging.info("conversational_continuation_detected reason=active_request")
+                logging.info("response_route_active_session active=1")
+                logging.info("response_route_decision route=active_session reason=direct_payload_continuation")
                 return
+
+    active_same_user_session = bool(_direct_payload_sessions.get(session_key))
+    message_should_enter_conversation = bool(clean_content and (channel_allows_conversation or real_direct_target or followup_candidate or active_same_user_session))
+    logging.info(f"response_route_active_session active={int(active_same_user_session)}")
+    if message_should_enter_conversation:
+        if channel_allows_conversation and not real_direct_target:
+            logging.info("response_route_decision route=conversation_allowed reason=channel_policy")
+            if len(clean_content.split()) <= 2 and len(clean_content) <= 20:
+                logging.info("conversational_minimal_ack reason=low_detail")
+        elif real_direct_target:
+            logging.info("response_route_decision route=real_direct_target reason=mention_or_reply")
+        elif followup_candidate:
+            logging.info("response_route_decision route=conversation_allowed reason=recent_followup_window")
+            logging.info("conversational_continuation_detected reason=same_user_recent_response")
+    else:
+        logging.info("response_route_decision route=policy_blocked reason=no_conversation_route")
 
     if clean_content and (should_handle_as_active_channel or is_mention or is_reply):
         if not is_sealed_test_channel:
@@ -5488,7 +5499,7 @@ async def on_message(message: discord.Message):
 
     # ---------------- ACTIVE CHANNEL ----------------
     if should_handle_as_active_channel:
-        if not clean_content and direct_request:
+        if not clean_content and message_should_enter_conversation:
             await message.reply("You pinged me. How may I assist with BARCODE operations?")
             return
         if not clean_content:
@@ -5498,7 +5509,7 @@ async def on_message(message: discord.Message):
             save_user_message(message.author.id, message.author.display_name, message.guild.id, clean_content, channel_name=getattr(message.channel, "name", ""), channel_policy=channel_policy)
 
         # Mentions/replies -> immediate response (not batched)
-        if direct_request:
+        if message_should_enter_conversation:
             direct_content, direct_payload_items = clean_content, _collect_inline_direct_payload_items(clean_content)
             sealed_recall_guard = get_sealed_test_recall_guard_response(
                 channel_policy,
@@ -5673,7 +5684,7 @@ async def on_message(message: discord.Message):
 
     # ---------------- OTHER CHANNELS (PING-ONLY IF ACTIVE CHANNEL SET) ----------------
     if active_channel_id is not None and not should_handle_as_active_channel:
-        if not direct_request:
+        if not real_direct_target:
             return
 
         if not clean_content:
@@ -5780,7 +5791,7 @@ async def on_message(message: discord.Message):
         return
 
     # ---------------- NO ACTIVE CHANNEL SET (RESPOND TO MENTIONS/REPLIES ANYWHERE) ----------------
-    if active_channel_id is None and direct_request:
+    if active_channel_id is None and message_should_enter_conversation:
         if not clean_content:
             await message.reply("You pinged me. How may I assist with BARCODE operations?")
             return

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -5439,7 +5439,12 @@ async def on_message(message: discord.Message):
     session_key = _direct_session_key(message)
     active_direct_session = _direct_payload_sessions.get(session_key)
     if active_direct_session and not getattr(message.author, "bot", False):
-        if (not message.content.startswith("/")) and (not (is_mention or is_reply or addressed_to_bot or conversational_candidate or followup_candidate)):
+        explicit_new_direct_request = bool(is_mention or is_reply or addressed_to_bot)
+        if explicit_new_direct_request:
+            active_direct_session["completed"] = True
+            _direct_payload_sessions.pop(session_key, None)
+            logging.info(f"direct_payload_session_expired payload_count={len(active_direct_session.get('payload_lines', []))} reason=new_direct_request")
+        elif not message.content.startswith("/"):
             line = (message.content or "").strip()
             if line:
                 active_direct_session["payload_lines"].append(line)
@@ -5450,11 +5455,8 @@ async def on_message(message: discord.Message):
                     logging.info(f"direct_payload_session_generation_invalidated payload_count={len(active_direct_session['payload_lines'])} reason=new_payload_during_generation")
                 logging.info(f"direct_payload_session_payload_added payload_count={len(active_direct_session['payload_lines'])}")
                 logging.info(f"direct_payload_session_timer_reset payload_count={len(active_direct_session['payload_lines'])}")
+                logging.info("conversational_continuation_detected reason=active_request")
                 return
-        if direct_request:
-            active_direct_session["completed"] = True
-            _direct_payload_sessions.pop(session_key, None)
-            logging.info(f"direct_payload_session_expired payload_count={len(active_direct_session.get('payload_lines', []))} reason=new_direct_request")
 
     if clean_content and (should_handle_as_active_channel or is_mention or is_reply):
         if not is_sealed_test_channel:


### PR DESCRIPTION
### Motivation
- Users expect BNL to behave conversationally in allowed channels without requiring the bot’s name or a reply, so route eligible no-name messages into the normal direct/session flow. 
- Keep the system simple and focused on coherence rather than building an aggressive “ignore” classifier or a parallel conversation-state system. 
- Preserve existing protections for protected/internal channels and keep batch/payload semantics and stale-generation safeguards intact.

### Description
- Add a short same-user same-channel follow-up window (`DIRECT_FOLLOWUP_WINDOW_SECONDS = 45`) with lightweight tracking (`_recent_direct_response_window`) and functions `
_mark_recent_direct_response` / `_is_recent_direct_followup` so late related continuations are treated as follow-ups. 
- Expand `direct_request` eligibility in `on_message` to include `conversational_candidate` for allowed channel policies (`public_home`, `public_context`, `public_selective`, or configured active channel) and `followup_candidate`, and log `conversational_response_candidate` / `conversational_continuation_detected` / `conversational_minimal_ack` without recording raw message content. 
- Route these conversational/no-name messages into the existing direct/session path and `_direct_payload_sessions` machinery (no new generation pipeline), preserve payload session invalidation/completion logic (`generation_invalidated`/completion/fallbacks), and do not introduce `_contextual_interaction_states`. 
- Add localized Gemini 503 handling inside `get_gemini_response`: detect 503/UNAVAILABLE exceptions, retry once after a short delay (0.8s), and log `direct_generation_failed reason=gemini_503` if the retry fails; keep the existing fallback reply `[NETWORK ERROR] Temporary synchronization issue. Try again.`. 

### Testing
- Successfully type-checked/compiled the module with `python3 -m py_compile bnl01_bot.py`. 
- Confirmed presence/absence of relevant code paths and guarantees using ripgrep (checks for `DIRECT_FOLLOWUP_WINDOW_SECONDS`, conversational logging keys, absence of `_contextual_interaction_states`, and that `pending_request_intent` / `pending_request_anchor` and `BNL_ACTIVE_BATCHING_ENABLED` behavior remain present). 
- Suggested VPS deploy/test commands (run locally before restart): `cd /workspace/BNL01-Bot`, `python3 -m py_compile bnl01_bot.py`, then restart the service as appropriate (example: `sudo systemctl restart bnl01-bot` and `sudo systemctl status bnl01-bot --no-pager -l`) and inspect logs with `journalctl -u bnl01-bot -n 200 --no-pager`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8bd4a08808321ae287e237cadeef8)