### PR TITLE
Stop direct session timer from regenerating already committed payloads

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -5381,12 +5381,19 @@ async def _direct_session_timer(session_key):
                 logging.info("direct_payload_session_expired payload_count=0 reason=no_payload_timeout")
                 _direct_payload_sessions.pop(session_key, None)
                 return
+        payload_count = len(payload_lines)
+        last_committed_payload_count = int(session.get("last_committed_payload_count", 0))
+        has_uncommitted_payload = payload_count > last_committed_payload_count
+
         if now >= session["hard_deadline"]:
-            await _generate_direct_payload_session(session_key, "hard_cap")
-            await asyncio.sleep(0.2)
-            continue
+            if has_uncommitted_payload and not session.get("generating"):
+                await _generate_direct_payload_session(session_key, "hard_cap")
+                await asyncio.sleep(0.2)
+                continue
+            if not has_uncommitted_payload:
+                logging.info(f"direct_session_timer_idle reason=no_uncommitted_payload payload_count={payload_count} last_committed_payload_count={last_committed_payload_count}")
         quiet_elapsed = (now - session["last_payload_at"]).total_seconds() if session.get("last_payload_at") else 0
-        if session.get("payload_lines") and len(session.get("payload_lines", [])) > int(session.get("last_committed_payload_count", 0)) and quiet_elapsed >= DIRECT_PAYLOAD_QUIET_SECONDS and not session.get("generating"):
+        if has_uncommitted_payload and quiet_elapsed >= DIRECT_PAYLOAD_QUIET_SECONDS and not session.get("generating"):
             await _generate_direct_payload_session(session_key, "quiet_timeout")
             await asyncio.sleep(0.2)
             continue


### PR DESCRIPTION
### Motivation
- The direct session timer could re-run generation after a response was committed because the `hard_cap` path did not check whether there were new uncommitted payload lines. 
- That caused repeated sends of the same committed snapshot while the session stayed open for follow-ups. 

### Description
- Compute `payload_count`, `last_committed_payload_count`, and `has_uncommitted_payload` once per `_direct_session_timer` loop. 
- Gate `hard_cap` generation so `_generate_direct_payload_session(..., "hard_cap")` only runs when `has_uncommitted_payload` is true and not currently generating. 
- Gate `quiet_timeout` generation on `has_uncommitted_payload` and preserve the existing `generating` guard. 
- Add an idle log `direct_session_timer_idle reason=no_uncommitted_payload payload_count=N last_committed_payload_count=N` when the timer reaches hard deadline but there is no uncommitted payload, and leave session follow-up/expiry lifecycles unchanged. 

### Testing
- Ran `python3 -m py_compile bnl01_bot.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f93ef5df588321a5677371c9aeccf8)