### PR TITLE
Fix repeat-after-commit timer loop only

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -5375,18 +5375,21 @@ async def _direct_session_timer(session_key):
             return
         now = datetime.now(timezone.utc)
         payload_lines = session.get("payload_lines", [])
+        payload_count = len(payload_lines)
+        last_committed_payload_count = int(session.get("last_committed_payload_count", 0))
+        has_uncommitted_payload = payload_count > last_committed_payload_count
         if not payload_lines and not session.get("last_bot_response_at") and not session.get("generating"):
             created_at = session.get("created_at") or now
             if (now - created_at).total_seconds() >= DIRECT_NO_PAYLOAD_TIMEOUT_SECONDS:
                 logging.info("direct_payload_session_expired payload_count=0 reason=no_payload_timeout")
                 _direct_payload_sessions.pop(session_key, None)
                 return
-        if now >= session["hard_deadline"]:
+        if has_uncommitted_payload and now >= session["hard_deadline"]:
             await _generate_direct_payload_session(session_key, "hard_cap")
             await asyncio.sleep(0.2)
             continue
         quiet_elapsed = (now - session["last_payload_at"]).total_seconds() if session.get("last_payload_at") else 0
-        if session.get("payload_lines") and len(session.get("payload_lines", [])) > int(session.get("last_committed_payload_count", 0)) and quiet_elapsed >= DIRECT_PAYLOAD_QUIET_SECONDS and not session.get("generating"):
+        if has_uncommitted_payload and quiet_elapsed >= DIRECT_PAYLOAD_QUIET_SECONDS and not session.get("generating"):
             await _generate_direct_payload_session(session_key, "quiet_timeout")
             await asyncio.sleep(0.2)
             continue


### PR DESCRIPTION
### Motivation
- Fix the runaway repeated-response loop where the direct/session timer could repeatedly trigger `hard_cap` (and `quiet_timeout`) and regenerate an already-committed payload snapshot.  This PR implements the intended invariant that generation only proceeds when there is new uncommitted user content. 
- This change is intentionally narrow: this PR fixes only the repeat-after-commit timer loop and preserves existing live-exchange behavior such as waiting/collecting/abort/rebuild/send once; it does not alter memory, relay, ambient, protected systems, routing, or add parallel state systems. 
- The accepted guard is that `len(payload_lines) > last_committed_payload_count` (or an equivalent existing session-state check) must hold before timed generation runs. 

### Description
- Compute `has_uncommitted_payload = len(payload_lines) > int(session.get("last_committed_payload_count", 0))` inside `_direct_session_timer`. 
- Gate both `hard_cap` (`now >= session["hard_deadline"]`) and `quiet_timeout` triggers on `has_uncommitted_payload` so timed generation only runs when there is new uncommitted payload. 
- No other behavior changes were made: `_generate_direct_payload_session` and the abort/rebuild/wait logic remain unchanged and no new routing, memory, or schema changes were introduced. 

### Testing
- `python3 -m py_compile bnl01_bot.py` succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9643ec3448321b3328a5a19332b5a)