### PR TITLE
Fix repeat-after-commit direct session timer loop

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -5256,6 +5256,10 @@ async def _generate_direct_payload_session(session_key, reason: str):
     anchor_message = session.get("anchor_message")
     payload_count = len(payload_lines)
     last_committed_payload_count = int(session.get("last_committed_payload_count", 0))
+    has_uncommitted_payload = payload_count > last_committed_payload_count
+    if not has_uncommitted_payload:
+        session["generating"] = False
+        return
     logging.info(f"direct_payload_session_generation_snapshot payload_count={payload_count} revision={generation_revision}")
 
     def _abort_if_invalidated(abort_reason: str):


### PR DESCRIPTION
### Motivation
- Based from `af7cdd9` / #117 behavior and preserves the #117 wait/collect/abort/rebuild behavior. 
- Fixes only the repeat-after-commit timer loop that could re-run generation after a response was already committed. 
- Generation is now gated to require uncommitted payloads before proceeding. 
- No routing, memory, website relay, ambient, or other protected systems were touched.

### Description
- Added an early invariant guard in `_generate_direct_payload_session` so generation returns immediately (and `session["generating"]` is reset to `False`) unless `len(payload_lines) > last_committed_payload_count`, preventing re-generation of already-committed payloads. 
- This guard enforces the uncommitted-payload requirement for both the `hard_cap` and `quiet_timeout` timer paths without changing the existing batching, abort, or rebuild logic. 
- No other subsystems, APIs, or routing behavior were modified.

### Testing
- `python3 -m py_compile bnl01_bot.py` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9677f1abc83218c8ccbe0983d5712)