### PR TITLE
Prevent idle hard-cap direct-session regeneration

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -5382,6 +5382,19 @@ async def _direct_session_timer(session_key):
                 _direct_payload_sessions.pop(session_key, None)
                 return
         if now >= session["hard_deadline"]:
+            payload_count = len(payload_lines)
+            last_committed_payload_count = int(session.get("last_committed_payload_count", 0))
+            revision = int(session.get("revision", 0))
+            last_committed_revision = int(session.get("last_committed_revision", 0))
+            if (
+                session.get("last_bot_response_at")
+                and payload_count == last_committed_payload_count
+                and revision == last_committed_revision
+            ):
+                logging.info("direct_session_timer_idle_committed_snapshot")
+                session["hard_deadline"] = now + timedelta(seconds=DIRECT_PAYLOAD_HARD_CAP_SECONDS)
+                await asyncio.sleep(0.2)
+                continue
             await _generate_direct_payload_session(session_key, "hard_cap")
             await asyncio.sleep(0.2)
             continue


### PR DESCRIPTION
### Motivation

- Preserve the direct-session behavior introduced in #117 while fixing a bug where the hard-cap timer could re-trigger a generation/Gemini call and send after a session was already committed with no new payloads. 
- Ensure sessions that already have a committed snapshot (fields like `original_request_text`, `last_committed_revision`, `last_committed_payload_count`, `last_bot_response_at`, and `generation_invalidated`) are not regenerated by the hard-cap path unless new payloads arrive.

### Description

- Add an idle-committed snapshot guard to `_direct_session_timer` that checks `payload_count == last_committed_payload_count` and `revision == last_committed_revision` while `last_bot_response_at` exists, and when true logs `direct_session_timer_idle_committed_snapshot`, rolls the `hard_deadline` forward, and skips calling `_generate_direct_payload_session` (thereby avoiding Gemini/call/send). 
- The guard uses the session fields `last_committed_payload_count`, `last_committed_revision`, `revision`, and `last_bot_response_at` and performs a short sleep/continue to keep the session alive for real follow-up deltas. 
- No changes were made to payload collection, quiet-timeout generation, `generation_invalidated` handling, pre-send grace, prompts, routing, memory, relay, ambient, `#welcome`, or `#episode-tracker` behavior; delta continuation still uses only new payload lines as before.

### Testing

- Confirmed presence of the snapshot and delta-related fields via source scans for `original_request_text`, `last_committed_revision`, `last_committed_payload_count`, `last_bot_response_at`, and `generation_invalidated`. 
- Ran `git diff --check` to validate basic repository hygiene and static checks with no reported issues. 
- Ran `python3 -m py_compile bnl01_bot.py` and the file compiled successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf518e1288321a4a9bbfd2e9c28ba)