### PR TITLE
Remove low-signal website relay cadence gate

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -431,14 +431,10 @@ You are BNL-01. The BARCODE Network is watching. You are functioning as intended
 
 # ======== WEBSITE STATUS BRIDGE GUARDRAILS ========
 STATUS_UPDATE_COOLDOWN_SECONDS = 300
-LOW_SIGNAL_RELAY_MIN_PUBLISH_MINUTES = 45
 _last_website_status_mode = None
 _last_website_status_message = None
 _last_website_directive = None
 _last_website_status_at = None
-_last_low_signal_relay_published_at = None
-_last_low_signal_relay_message = None
-_low_signal_relay_quiet_streak_active = False
 _missing_status_key_warned = False
 BNL_CONTROL_FLAGS_TTL_SECONDS = 300
 _bnl_control_flags_cache = None
@@ -943,38 +939,6 @@ def _is_weak_context_fallback(message: str) -> bool:
         "nothing fresh has cleared",
     )
     return any(marker in normalized for marker in low_signal_markers)
-
-
-def _low_signal_publish_gate(now: datetime, mode: str, relay_meta: dict) -> tuple[bool, float, float]:
-    if mode != "OBSERVATION":
-        return True, 0.0, LOW_SIGNAL_RELAY_MIN_PUBLISH_MINUTES * 60
-    if relay_meta.get("context_is_strong"):
-        return True, 0.0, LOW_SIGNAL_RELAY_MIN_PUBLISH_MINUTES * 60
-    if not relay_meta.get("is_low_signal_dynamic"):
-        return True, 0.0, LOW_SIGNAL_RELAY_MIN_PUBLISH_MINUTES * 60
-    if not _low_signal_relay_quiet_streak_active or not _last_low_signal_relay_published_at:
-        return True, 0.0, LOW_SIGNAL_RELAY_MIN_PUBLISH_MINUTES * 60
-
-    elapsed = (now - _last_low_signal_relay_published_at).total_seconds()
-    min_seconds = LOW_SIGNAL_RELAY_MIN_PUBLISH_MINUTES * 60
-    return elapsed >= min_seconds, elapsed, min_seconds
-
-
-def _remember_low_signal_publish_state(now: datetime, mode: str, message: str, relay_meta: dict):
-    global _last_low_signal_relay_published_at, _last_low_signal_relay_message, _low_signal_relay_quiet_streak_active
-
-    low_signal_observation = (
-        mode == "OBSERVATION"
-        and relay_meta.get("is_low_signal_dynamic")
-        and not relay_meta.get("context_is_strong")
-    )
-    if low_signal_observation:
-        _last_low_signal_relay_published_at = now
-        _last_low_signal_relay_message = sanitize_website_status_message(message, limit=360, min_chars=0)
-        _low_signal_relay_quiet_streak_active = True
-        return
-
-    _low_signal_relay_quiet_streak_active = False
 
 
 def _contains_stale_phrase(text: str) -> bool:
@@ -3933,17 +3897,7 @@ async def website_relay_task():
                 f"source_channel_count={relay_meta.get('source_channel_count', 0)}"
             )
             continue
-        cadence_allowed, low_signal_elapsed, low_signal_min_seconds = _low_signal_publish_gate(datetime.now(PACIFIC_TZ), mode, relay_meta)
-        if not cadence_allowed:
-            logging.info(
-                f"website_relay_low_signal_cadence_skip mode={mode} reason={relay_meta.get('reason')} "
-                f"elapsed_seconds={low_signal_elapsed:.1f} min_seconds={low_signal_min_seconds:.1f} "
-                f"source_channel_count={relay_meta.get('source_channel_count', 0)}"
-            )
-            continue
-        update_ok = update_website_status_controlled(mode=mode, message=relay_message, status="ONLINE", current_directive=directive, source="relay")
-        if update_ok:
-            _remember_low_signal_publish_state(datetime.now(PACIFIC_TZ), mode, relay_message, relay_meta)
+        update_website_status_controlled(mode=mode, message=relay_message, status="ONLINE", current_directive=directive, source="relay")
 
 # ==================== BATCHED REPLY SYSTEM (ACTIVE CHANNEL ONLY) ====================
 


### PR DESCRIPTION
### Motivation
- The 45-minute low-signal cadence gate was preventing valid different low-signal relay messages from publishing on the normal scheduled website relay interval. 
- The intent is to allow every scheduled relay tick to publish when the generated website payload differs from the previous payload while keeping duplicate protection and other bridge behavior intact.

### Description
- Removed the low-signal cadence globals and helpers: `LOW_SIGNAL_RELAY_MIN_PUBLISH_MINUTES`, `_last_low_signal_relay_published_at`, `_last_low_signal_relay_message`, `_low_signal_relay_quiet_streak_active`, `_low_signal_publish_gate`, and `_remember_low_signal_publish_state` from `bnl01_bot.py`.
- Removed the cadence-gate call and `website_relay_low_signal_cadence_skip` logging path from the active `website_relay_task` so eligible generated low-signal messages flow into `update_website_status_controlled(...)` on the normal scheduled interval.
- Left dynamic low-signal generation (`build_low_signal_relay_message` and Gemini routing), exact duplicate protection, website API payload shape, force-pull behavior, control-flag handling, direct payload/session timing, and other relay subsystems unchanged.
- Cleaned up the now-unused globals/helpers so no active references to the cadence gate remain in the active relay path.

### Testing
- Ran `python3 -m py_compile bnl01_bot.py` which passed successfully.
- Searched the codebase for the cadence symbols and helper names to confirm they no longer appear in the active path. The grep checks for `website_relay_low_signal_cadence_skip`, `LOW_SIGNAL_RELAY_MIN_PUBLISH_MINUTES`, `_low_signal_publish_gate`, `_remember_low_signal_publish_state`, `_last_low_signal_relay_published_at`, `_last_low_signal_relay_message`, and `_low_signal_relay_quiet_streak_active` returned no active usage in the relay path.
- Verified that `update_website_status_controlled` still enforces exact duplicate skipping and `STATUS_UPDATE_COOLDOWN_SECONDS` behavior, and that `build_low_signal_relay_message` / fallback logic and Gemini routing remain intact.

What changed: Removed the 45-minute low-signal cadence gate and its supporting state/helpers from `bnl01_bot.py` so scheduled relay ticks may publish different dynamically-generated low-signal messages.
Cadence gate removed from active path: Yes, the active `website_relay_task` no longer invokes the cadence gate or logs `website_relay_low_signal_cadence_skip`.
Files changed: `bnl01_bot.py`.
`py_compile` result: Passed.
Remaining risks: No live website POSTs were executed in testing due to runtime credential/environment dependencies, so integration with the website endpoint should be smoke-tested in staging; removal of gating state is localized but warrants monitoring to ensure the site receives expected 20-minute varied updates and that no subtle duplicate or cooldown interactions emerge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbda0b45388321b330d61eba80cf1f)