### PR TITLE
Patch relay lane thin-signal validation

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -1047,10 +1047,12 @@ def _sanitize_relay_temporal_claims(
 
 def _validate_relay_lane_adherence(message: str, lane: str, context_is_strong: bool, guild_id: int) -> tuple[bool, str]:
     safe_lane = lane if lane in RELAY_LANES else "carrier_trace"
-    lowered = (message or "").lower()
+    normalized = re.sub(
+        r"\s+",
+        " ",
+        (message or "").replace("–", "-").replace("—", "-").lower(),
+    ).strip()
     thin_signal_markers = (
-        "public signal is thin",
-        "signal is thin",
         "public signal is quiet",
         "public channels are quiet",
         "public corridor is quiet",
@@ -1061,15 +1063,30 @@ def _validate_relay_lane_adherence(message: str, lane: str, context_is_strong: b
         "weak signal",
         "thin signal",
         "quiet public",
+        "holding a stable listening window",
+        "stable listening window",
+        "clearer discord-side movement",
+        "clearer public movement",
+        "until clearer movement",
+        "until clearer discord-side movement can",
+        "until clearer discord-side movement returns",
+        "until clearer public signal returns",
+    )
+    thin_signal_patterns = (
+        r"\bpublic signal\s+(?:is\s+(?:currently\s+)?|remains\s+)thin\b",
+        r"\bsignal\s+is\s+(?:currently\s+)?thin\b",
     )
     if safe_lane == "current_signal":
         if not context_is_strong:
             logging.info(f"website_relay_lane_mismatch guild={guild_id} lane={safe_lane} reason=weak_context")
             return False, "weak_context"
-        if any(marker in lowered for marker in thin_signal_markers):
+        has_thin_signal_text = any(marker in normalized for marker in thin_signal_markers) or any(
+            re.search(pattern, normalized) for pattern in thin_signal_patterns
+        )
+        if has_thin_signal_text:
             logging.info(f"website_relay_lane_mismatch guild={guild_id} lane={safe_lane} reason=thin_signal_text")
             return False, "thin_signal_text"
-    if safe_lane == "residual_echo" and not any(marker in lowered for marker in ("residue", "echo", "afterimage", "archive", "still on", "recent")):
+    if safe_lane == "residual_echo" and not any(marker in normalized for marker in ("residue", "echo", "afterimage", "archive", "still on", "recent")):
         logging.info(f"website_relay_lane_mismatch guild={guild_id} lane={safe_lane} reason=missing_residual_anchor")
         return False, "missing_residual_anchor"
     return True, ""


### PR DESCRIPTION
### Motivation
- The `current_signal` lane validator was missing some low-signal / fallback phrasings (e.g., “public signal is currently thin” and stable-listening-window language) which allowed semantically-fallback text to be published as `current_signal`.
- This change is a focused fix to ensure thin/fallback wording is detected and triggers the existing retry/reroute logic without touching unrelated subsystems.

### Description
- Normalize relay text (collapse whitespace, normalize dashes, lowercase, and trim) before matching so small formatting differences do not bypass detection.
- Expand the thin/fallback marker set to include stable-listening-window and clearer-movement phrases and add regex patterns to catch variants like `public signal is currently thin` and `public signal remains thin`.
- Use the normalized text and regexes to reject thin/fallback language for the `current_signal` lane and preserve the existing `thin_signal_text` mismatch reason that drives the retry/reroute path.
- File changed: `bnl01_bot.py` (only `_validate_relay_lane_adherence()` logic was modified).

### Testing
- Ran syntax check with `python3 -m py_compile bnl01_bot.py` and it passed successfully.
- Ran a helper-level assertion: `from bnl01_bot import _validate_relay_lane_adherence` then called `_validate_relay_lane_adherence("Public signal is currently thin, so BNL-01 is holding a stable listening window until clearer Discord-side movement can return.", "current_signal", True, 123)` and it returned `(False, "thin_signal_text")`, which passed.
- Ran a batch check over the required phrases with `GEMINI_API_KEY=dummy DISCORD_BOT_TOKEN=dummy python3 - <<'PY' ...` asserting each phrase is rejected with reason `thin_signal_text`, and all 12 phrases succeeded.
- All automated checks listed above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc11323dd08321977a0e5395f6414f)