### PR TITLE
Retarget internal operations route to #research-and-development

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -2792,16 +2792,16 @@ def context_visibility_for_policy(policy: str) -> str:
 def allow_passive_memory_for_policy(policy: str) -> bool:
     return policy in {"public_home", "public_context"}
 
-def is_planning_coordination_channel(message: discord.Message) -> bool:
+def is_research_and_development_channel(message: discord.Message) -> bool:
     if not message or not getattr(message, "channel", None):
         return False
     channel = message.channel
     channel_id = int(getattr(channel, "id", 0) or 0)
-    if channel_id == 1292010005180055627:
+    if channel_id == 1369051635657084970:
         return True
     name = (getattr(channel, "name", "") or "").strip().lower()
     normalized = re.sub(r"[^a-z0-9-]+", "-", name).strip("-")
-    return normalized == "planning-and-coordination"
+    return normalized == "research-and-development"
 
 
 def is_internal_operations_request(text: str) -> bool:
@@ -7633,7 +7633,7 @@ async def on_message(message: discord.Message):
         )
         return
 
-    if is_planning_coordination_channel(message):
+    if is_research_and_development_channel(message):
         if not real_direct_target:
             return
         member = message.author if isinstance(message.author, discord.Member) else message.guild.get_member(message.author.id)
@@ -7652,7 +7652,7 @@ async def on_message(message: discord.Message):
             "Use this structure: Current status / What matters / Suggested next actions / Optional Do not do yet.\n"
             "Do not write a lore monologue.\n"
             "Do not expose raw database rows, raw notes, or restricted internal details.\n"
-            "Do not convert planning discussion into canon.\n"
+            "Do not convert research-and-development operations discussion into canon.\n"
             "Do not imply website dossier, queue, or payment integrations are live unless explicitly stated in context.\n"
             "Do not publish or relay anything automatically.\n"
             f"{ops_context}\n"
@@ -7660,7 +7660,7 @@ async def on_message(message: discord.Message):
         )
         response = await get_gemini_response(ops_prompt, message.author.id, message.guild.id, route="internal_operations_brief")
         if not response:
-            response = "Current status: I can help with internal ops planning, but I hit a temporary sync issue. Please retry in a moment."
+            response = "Current status: I can help with internal operations, but I hit a temporary sync issue. Please retry in a moment."
         if len(response) <= 2000:
             await message.reply(response)
         else:


### PR DESCRIPTION
### Motivation
- Fix a miswired internal operations brief route that was triggering on the wrong Discord channel (#planning-and-coordination) and retarget it to the correct liaison channel (#research-and-development).
- Preserve all existing gated/safety behavior for internal operations while fixing the channel target.

### Description
- Renamed the channel helper from `is_planning_coordination_channel(...)` to `is_research_and_development_channel(...)` and updated its call sites.
- The helper now returns true when the channel ID equals `1369051635657084970` or the normalized channel name equals `research-and-development`, and the previous planning-channel ID `1292010005180055627` was removed from this route.
- Updated user-facing prompt text to reference research-and-development instead of planning-and-coordination and preserved the `internal_operations_brief` routing and gating logic.

### Testing
- `python3 -m py_compile bnl01_bot.py` completed successfully (passed).
- Static assertions and checks were executed to confirm the new helper name and ID are present, the old helper and old channel ID are not present, and that no `save_user_message`/`save_model_message` calls were introduced into the internal operations route (all checks passed).
- Basic grep/inspection validated the route now triggers on `#research-and-development` / `1369051635657084970` and no longer treats `#planning-and-coordination` / `1292010005180055627` as the internal ops liaison channel (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18788f7b688321a254273fa5508270)