### PR TITLE
Hotfix: Use get_bnl_control_flags in operations brief

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -2845,7 +2845,7 @@ def build_operations_brief_context(guild_id: int, user_text: str) -> str:
     else:
         lines.append("- Recent official broadcast memory: none available.")
 
-    flags = get_website_control_flags()
+    flags = get_bnl_control_flags()
     relay_enabled = bool(flags.get("websiteRelayEnabled", True)) if isinstance(flags, dict) else True
     bridge_configured = bool(BNL_STATUS_URL and BNL_API_KEY)
     lines.append(f"- Website relay flag: {'enabled' if relay_enabled else 'disabled'}")


### PR DESCRIPTION
### Motivation
- Replace nonexistent helper call in the operations brief with the correct `get_bnl_control_flags()` to sync GitHub with the working VPS hotfix and prevent crashes.

### Description
- Replace the single line `flags = get_website_control_flags()` with `flags = get_bnl_control_flags()` inside `build_operations_brief_context`, and do not alter internal prompts, the #research-and-development route, permission gating, memory behavior, website relay behavior, broadcast memory behavior, or payload/session timing.

### Testing
- Ran `python3 -m py_compile bnl01_bot.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a187d0db2288321bf343b07a3566bdd)