### PR TITLE
BNL Dossier Recommendation Sender v1

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -24,6 +24,14 @@ import urllib.request
 import urllib.error
 import urllib.parse
 import calendar
+
+from bnl_dossier_recommendations import (
+    build_dossier_recommendation_payload,
+    get_dossier_ingest_url,
+    is_dossier_ingest_token_configured,
+    parse_manual_dossier_recommendation_command,
+    send_dossier_recommendation,
+)
 from collections import defaultdict, deque
 from datetime import datetime, timedelta, timezone
 
@@ -448,6 +456,7 @@ _last_website_status_message = None
 _last_website_directive = None
 _last_website_status_at = None
 _missing_status_key_warned = False
+_last_dossier_recommendation_status = "never_sent"
 BNL_CONTROL_FLAGS_TTL_SECONDS = 300
 _bnl_control_flags_cache = None
 _bnl_control_flags_cached_at = None
@@ -3912,6 +3921,68 @@ def has_mod_role(member: discord.Member) -> bool:
     if not member or not BNL_MOD_ROLE_ID:
         return False
     return any(role.id == BNL_MOD_ROLE_ID for role in getattr(member, "roles", []))
+
+
+def can_send_dossier_recommendation(user, member, guild) -> bool:
+    """Owner/admin/operator gate for manual dossier recommendation sends."""
+    if is_owner_operator(user):
+        return True
+    if member and has_mod_role(member):
+        return True
+    if member and guild and is_privileged_member(member, guild):
+        return True
+    return False
+
+
+def build_dossier_recommendation_diagnostics() -> dict:
+    """Safe configuration/status diagnostics for dossier recommendation ingest."""
+    return {
+        "ingest_url_configured": bool(os.getenv("BNL_DOSSIER_INGEST_URL", "").strip()),
+        "ingest_url_using_default": not bool(os.getenv("BNL_DOSSIER_INGEST_URL", "").strip()),
+        "ingest_endpoint": get_dossier_ingest_url(),
+        "ingest_token_configured": is_dossier_ingest_token_configured(),
+        "last_send_status": _last_dossier_recommendation_status,
+    }
+
+
+def _safe_dossier_failure_reason(result: dict) -> str:
+    reason = (result or {}).get("error") or "send failed"
+    return str(reason).replace("`", "'")[:140]
+
+
+async def maybe_handle_dossier_recommendation_command(message: discord.Message, clean_content: str) -> bool:
+    """Handle the v1 manual `!bnl dossier recommend` command if present."""
+    global _last_dossier_recommendation_status
+    matched, payload, parse_error = parse_manual_dossier_recommendation_command(clean_content)
+    if not matched:
+        return False
+
+    member = message.author if isinstance(message.author, discord.Member) else message.guild.get_member(message.author.id)
+    if not can_send_dossier_recommendation(message.author, member, message.guild):
+        _last_dossier_recommendation_status = "permission_denied"
+        logging.warning("dossier_recommendation_command_denied reason=permission")
+        await message.reply("Dossier recommendation sender is operator-only.")
+        return True
+
+    if not payload:
+        _last_dossier_recommendation_status = "parse_rejected"
+        await message.reply(f"Recommendation failed: {parse_error}")
+        return True
+
+    safe_payload = build_dossier_recommendation_payload(payload)
+    subject = (safe_payload.get("subjectName") or "subject").strip()[:80]
+    result = await asyncio.to_thread(send_dossier_recommendation, safe_payload)
+    status = result.get("status")
+    if result.get("ok") and result.get("duplicate"):
+        _last_dossier_recommendation_status = f"duplicate:{status or 'ok'}"
+        await message.reply(f"Duplicate recommendation already exists: {subject}")
+    elif result.get("ok"):
+        _last_dossier_recommendation_status = f"sent:{status or 'ok'}"
+        await message.reply(f"Recommendation sent: {subject}")
+    else:
+        _last_dossier_recommendation_status = f"failed:{status or 'no_status'}"
+        await message.reply(f"Recommendation failed: {_safe_dossier_failure_reason(result)}")
+    return True
 
 
 def _resolve_channel_policy_without_parent(channel) -> str:
@@ -10453,6 +10524,9 @@ async def on_message(message: discord.Message):
         .strip()
     )
 
+    if await maybe_handle_dossier_recommendation_command(message, clean_content):
+        return
+
     plain_text_name_seen = bool(re.search(r"\b(bnl|bnl-01|barcode bot)\b", clean_content.lower())) if clean_content else False
     channel_allows_conversation = bool(
         channel_policy in {"public_home", "sealed_test"}
@@ -11533,6 +11607,7 @@ async def bnl_source_check(interaction: discord.Interaction):
     relay_eligibility = website_relay_eligibility(policy)
     primary_guild_match = bool(guild and BNL_PRIMARY_GUILD_ID and guild.id == BNL_PRIMARY_GUILD_ID)
     flags_source = _bnl_control_flags_last_source_url or "none"
+    dossier_diag = build_dossier_recommendation_diagnostics()
 
     lines = [
         "**BNL Source Diagnostic**",
@@ -11547,6 +11622,9 @@ async def bnl_source_check(interaction: discord.Interaction):
         f"- primary_guild_match: `{primary_guild_match}`",
         f"- bnl_status_url_configured: `{bool(BNL_STATUS_URL)}`",
         f"- bnl_api_key_configured: `{bool(BNL_API_KEY)}`",
+        f"- dossier_ingest_url_configured: `{'yes' if dossier_diag['ingest_url_configured'] else 'no_using_default'}`",
+        f"- dossier_ingest_token_configured: `{'yes' if dossier_diag['ingest_token_configured'] else 'no'}`",
+        f"- dossier_last_send_status: `{dossier_diag['last_send_status']}`",
         f"- _bnl_control_flags_last_source_url: `{flags_source}`",
         f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` every `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}` min",
     ]
@@ -11735,6 +11813,7 @@ async def bnl_status(interaction: discord.Interaction):
     flags_source_state = "available" if _bnl_control_flags_last_source_url else "not yet fetched"
     website_bridge_configured = bool(BNL_STATUS_URL and BNL_API_KEY)
     read_model_diag = get_bnl_read_model_diagnostic_state()
+    dossier_diag = build_dossier_recommendation_diagnostics()
     broadcast_channel = guild.get_channel(BNL_BROADCAST_MEMORY_CHANNEL_ID) if BNL_BROADCAST_MEMORY_CHANNEL_ID else None
     broadcast_count = len(get_recent_broadcast_memory(guild.id, public_only=False, limit=500))
     latest_written_episode_date, latest_show_episode_date = get_broadcast_memory_diagnostic_dates(guild.id)
@@ -11760,6 +11839,9 @@ async def bnl_status(interaction: discord.Interaction):
         f"- last_ambient_skip_reason: `{ambient_runtime.get('last_skip_reason', 'unknown')}`",
         f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` (interval `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}m`)",
         f"- website_bridge_configured: `{'yes' if website_bridge_configured else 'no'}`",
+        f"- dossier_ingest_url_configured: `{'yes' if dossier_diag['ingest_url_configured'] else 'no_using_default'}`",
+        f"- dossier_ingest_token_configured: `{'yes' if dossier_diag['ingest_token_configured'] else 'no'}`",
+        f"- dossier_last_send_status: `{dossier_diag['last_send_status']}`",
         f"- read_model_enabled: `{'yes' if read_model_diag.get('enabled') else 'no'}`",
         f"- read_model_url_configured: `{'yes' if read_model_diag.get('url_configured') else 'no'}`",
         f"- read_model_cache_present: `{'yes' if read_model_diag.get('cache_present') else 'no'}`",

--- a/bnl_dossier_recommendations.py
+++ b/bnl_dossier_recommendations.py
@@ -1,0 +1,251 @@
+"""Safe sender for BNL dossier recommendation ingest.
+
+This module is intentionally isolated from Discord runtime state. It builds a
+review-only recommendation payload and sends it to the BARCODE Network site
+endpoint when explicitly called by an operator-controlled bot path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import socket
+import urllib.error
+import urllib.request
+from typing import Any
+
+DEFAULT_DOSSIER_INGEST_URL = "https://www.barcode-network.com/api/bnl/dossier-recommendations"
+DOSSIER_INGEST_TIMEOUT_SECONDS = 10
+SUPPORTED_PAYLOAD_FIELDS = {
+    "type",
+    "subjectName",
+    "subjectKey",
+    "targetCandidateId",
+    "targetDossierId",
+    "reason",
+    "evidenceSummary",
+    "confidence",
+    "sourceLanes",
+    "suggestedAction",
+    "missingInfo",
+    "publicSafetyNotes",
+    "doNotSay",
+    "recommendedTags",
+    "recommendedCategory",
+    "recommendedKind",
+    "recommendedEcosystemLane",
+    "recommendedIdentityAuthority",
+    "createdBy",
+    "ingestKey",
+}
+_SAFE_LANE_PATTERN = re.compile(r"[^a-z0-9_-]+")
+
+
+def get_dossier_ingest_url(environ: dict[str, str] | None = None) -> str:
+    """Return configured ingest URL or the production endpoint fallback."""
+
+    env = environ if environ is not None else os.environ
+    configured = (env.get("BNL_DOSSIER_INGEST_URL") or "").strip()
+    return configured or DEFAULT_DOSSIER_INGEST_URL
+
+
+def is_dossier_ingest_token_configured(environ: dict[str, str] | None = None) -> bool:
+    """Return whether the ingest token exists without exposing its value."""
+
+    env = environ if environ is not None else os.environ
+    return bool((env.get("BNL_DOSSIER_INGEST_TOKEN") or "").strip())
+
+
+def _normalize_subject_key(subject_name: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", (subject_name or "").strip().lower())
+    return normalized.strip("-") or "unknown-subject"
+
+
+def _normalize_source_lanes(source_lanes: Any) -> list[str]:
+    if isinstance(source_lanes, str):
+        raw_lanes = re.split(r"[,\s]+", source_lanes)
+    elif isinstance(source_lanes, (list, tuple, set)):
+        raw_lanes = list(source_lanes)
+    else:
+        raw_lanes = []
+
+    lanes: list[str] = []
+    seen = set()
+    for lane in raw_lanes:
+        normalized = _SAFE_LANE_PATTERN.sub("_", str(lane or "").strip().lower()).strip("_")
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        lanes.append(normalized[:48])
+    return lanes or ["unknown"]
+
+
+def generate_dossier_ingest_key(payload: dict[str, Any]) -> str:
+    """Create a deterministic non-sensitive ingest key for deduplication."""
+
+    recommendation_type = re.sub(r"[^a-z0-9_-]+", "_", str(payload.get("type") or "new_subject").strip().lower()).strip("_") or "new_subject"
+    subject_key = _normalize_subject_key(str(payload.get("subjectName") or payload.get("subjectKey") or ""))
+    source_lanes = _normalize_source_lanes(payload.get("sourceLanes"))
+    lane_part = "-".join(source_lanes)
+    reason_material = "\n".join(
+        str(payload.get(key) or "")
+        for key in ("reason", "evidenceSummary")
+        if str(payload.get(key) or "").strip()
+    )
+    reason_hash = hashlib.sha256(reason_material.strip().encode("utf-8")).hexdigest()[:8] if reason_material.strip() else "no-reason"
+    return f"bnl:dossier:{recommendation_type}:{subject_key}:{lane_part}:{reason_hash}"
+
+
+def build_dossier_recommendation_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a sanitized recommendation payload with safe defaults."""
+
+    cleaned = {key: value for key, value in (payload or {}).items() if key in SUPPORTED_PAYLOAD_FIELDS and value is not None}
+    cleaned["type"] = str(cleaned.get("type") or "new_subject").strip() or "new_subject"
+    cleaned["createdBy"] = str(cleaned.get("createdBy") or "bnl").strip() or "bnl"
+    cleaned["confidence"] = str(cleaned.get("confidence") or "medium").strip() or "medium"
+    cleaned["sourceLanes"] = _normalize_source_lanes(cleaned.get("sourceLanes"))
+
+    if cleaned.get("subjectName") is not None:
+        cleaned["subjectName"] = str(cleaned.get("subjectName") or "").strip()
+    if not cleaned.get("subjectKey") and cleaned.get("subjectName"):
+        cleaned["subjectKey"] = _normalize_subject_key(str(cleaned["subjectName"]))
+    if not cleaned.get("ingestKey"):
+        cleaned["ingestKey"] = generate_dossier_ingest_key(cleaned)
+    return cleaned
+
+
+def build_manual_dossier_recommendation(subject: str, reason: str, source_lanes: Any = None) -> dict[str, Any]:
+    """Build the v1 operator/manual recommendation payload."""
+
+    return build_dossier_recommendation_payload(
+        {
+            "type": "new_subject",
+            "subjectName": (subject or "").strip(),
+            "reason": (reason or "").strip(),
+            "evidenceSummary": (reason or "").strip(),
+            "sourceLanes": source_lanes or ["rd_context"],
+            "suggestedAction": "review_for_future_dossier",
+            "createdBy": "bnl",
+            "confidence": "medium",
+        }
+    )
+
+
+def parse_manual_dossier_recommendation_command(content: str) -> tuple[bool, dict[str, Any] | None, str]:
+    """Parse `!bnl dossier recommend <subject> | <reason> [| lanes=a,b]`."""
+
+    text = (content or "").strip()
+    match = re.match(r"^!bnl\s+dossier\s+recommend\s+(.+)$", text, flags=re.IGNORECASE | re.DOTALL)
+    if not match:
+        return False, None, "not_a_dossier_recommendation_command"
+
+    body = match.group(1).strip()
+    parts = [part.strip() for part in body.split("|")]
+    if len(parts) < 2:
+        return True, None, "Use: `!bnl dossier recommend Subject | Reason`"
+
+    subject, reason = parts[0], parts[1]
+    if not subject:
+        return True, None, "Subject is required."
+    if not reason:
+        return True, None, "Reason is required."
+
+    lanes = ["rd_context"]
+    for extra in parts[2:]:
+        lane_match = re.match(r"^(?:lanes?|sourceLanes)\s*=\s*(.+)$", extra, flags=re.IGNORECASE)
+        if lane_match:
+            lanes = _normalize_source_lanes(lane_match.group(1))
+    payload = build_manual_dossier_recommendation(subject, reason, lanes)
+    return True, payload, ""
+
+
+def _extract_recommendation_id(response_json: dict[str, Any]) -> Any:
+    for key in ("recommendationId", "recommendation_id", "id"):
+        if response_json.get(key) is not None:
+            return response_json.get(key)
+    recommendation = response_json.get("recommendation")
+    if isinstance(recommendation, dict):
+        return recommendation.get("id") or recommendation.get("recommendationId")
+    return None
+
+
+def _safe_failure(error: str, status: int | None = None, duplicate: bool = False) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "duplicate": duplicate,
+        "recommendationId": None,
+        "error": error,
+        "status": status,
+    }
+
+
+def send_dossier_recommendation(payload: dict[str, Any], *, environ: dict[str, str] | None = None, opener=None) -> dict[str, Any]:
+    """POST a dossier recommendation to the configured site ingest endpoint."""
+
+    env = environ if environ is not None else os.environ
+    token = (env.get("BNL_DOSSIER_INGEST_TOKEN") or "").strip()
+    if not token:
+        logging.warning("dossier_recommendation_send_failed reason=missing_ingest_token")
+        return _safe_failure("Dossier ingest token is not configured.")
+
+    url = get_dossier_ingest_url(env)
+    safe_payload = build_dossier_recommendation_payload(payload or {})
+    logging.info(
+        "dossier_recommendation_send_attempted "
+        f"endpoint_configured={bool(url)} subject_key={safe_payload.get('subjectKey', 'unknown')}"
+    )
+
+    body = json.dumps(safe_payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+        method="POST",
+    )
+    urlopen = opener.open if opener is not None else urllib.request.urlopen
+
+    try:
+        with urlopen(request, timeout=DOSSIER_INGEST_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", None) or response.getcode()
+            raw = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        logging.warning(f"dossier_recommendation_send_failed status={status}")
+        return _safe_failure("Dossier recommendation endpoint rejected the request.", status=status)
+    except (urllib.error.URLError, TimeoutError, socket.timeout):
+        logging.warning("dossier_recommendation_send_failed reason=network_or_timeout")
+        return _safe_failure("Dossier recommendation endpoint was unreachable or timed out.")
+    except Exception:
+        logging.warning("dossier_recommendation_send_failed reason=unexpected_error")
+        return _safe_failure("Dossier recommendation send failed unexpectedly.")
+
+    try:
+        parsed = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        logging.warning(f"dossier_recommendation_send_failed status={status} reason=invalid_json")
+        return _safe_failure("Dossier recommendation endpoint returned invalid JSON.", status=status)
+
+    ok = bool(parsed.get("ok")) and 200 <= int(status or 0) < 300
+    duplicate = bool(parsed.get("duplicate"))
+    recommendation_id = _extract_recommendation_id(parsed)
+    if ok:
+        if duplicate:
+            logging.info(f"dossier_recommendation_duplicate status={status} recommendation_id={recommendation_id or 'none'}")
+        else:
+            logging.info(f"dossier_recommendation_send_succeeded status={status} recommendation_id={recommendation_id or 'none'}")
+        return {
+            "ok": True,
+            "duplicate": duplicate,
+            "recommendationId": recommendation_id,
+            "error": "",
+            "status": status,
+        }
+
+    logging.warning(f"dossier_recommendation_send_failed status={status}")
+    return _safe_failure("Dossier recommendation endpoint returned a failure.", status=status, duplicate=duplicate)

--- a/tests/test_dossier_recommendations.py
+++ b/tests/test_dossier_recommendations.py
@@ -1,0 +1,191 @@
+import json
+import os
+import unittest
+import urllib.error
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl_dossier_recommendations as dossier
+import bnl01_bot
+
+
+class FakeResponse:
+    def __init__(self, status, body):
+        self.status = status
+        self._body = body.encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._body
+
+    def getcode(self):
+        return self.status
+
+
+class FakeOpener:
+    def __init__(self, response=None, error=None):
+        self.response = response
+        self.error = error
+        self.requests = []
+
+    def open(self, request, timeout=None):
+        self.requests.append((request, timeout))
+        if self.error:
+            raise self.error
+        return self.response
+
+
+class DossierRecommendationPayloadTests(unittest.TestCase):
+    def test_payload_defaults_and_deterministic_ingest_key(self):
+        payload = dossier.build_manual_dossier_recommendation(
+            "Signal Witch",
+            "Mentioned in R&D and should be reviewed for a future dossier.",
+            ["rd_context"],
+        )
+        again = dossier.build_manual_dossier_recommendation(
+            "Signal Witch",
+            "Mentioned in R&D and should be reviewed for a future dossier.",
+            ["rd_context"],
+        )
+
+        self.assertEqual(payload["createdBy"], "bnl")
+        self.assertEqual(payload["confidence"], "medium")
+        self.assertEqual(payload["sourceLanes"], ["rd_context"])
+        self.assertEqual(payload["type"], "new_subject")
+        self.assertEqual(payload["subjectKey"], "signal-witch")
+        self.assertEqual(payload["ingestKey"], again["ingestKey"])
+        self.assertTrue(payload["ingestKey"].startswith("bnl:dossier:new_subject:signal-witch:rd_context:"))
+        self.assertNotIn("BNL_DOSSIER_INGEST_TOKEN", payload)
+
+    def test_parse_command_subject_reason_and_lanes(self):
+        matched, payload, error = dossier.parse_manual_dossier_recommendation_command(
+            "!bnl dossier recommend Signal Witch | Review for future dossier. | lanes=rd_context,broadcast_memory"
+        )
+        self.assertTrue(matched)
+        self.assertFalse(error)
+        self.assertEqual(payload["subjectName"], "Signal Witch")
+        self.assertEqual(payload["reason"], "Review for future dossier.")
+        self.assertEqual(payload["sourceLanes"], ["rd_context", "broadcast_memory"])
+
+    def test_parse_command_rejects_empty_reason(self):
+        matched, payload, error = dossier.parse_manual_dossier_recommendation_command(
+            "!bnl dossier recommend Signal Witch |   "
+        )
+        self.assertTrue(matched)
+        self.assertIsNone(payload)
+        self.assertIn("Reason", error)
+
+
+class DossierRecommendationSenderTests(unittest.TestCase):
+    def test_missing_token_fails_safely(self):
+        result = dossier.send_dossier_recommendation(
+            {"subjectName": "Signal Witch", "reason": "Review", "sourceLanes": ["rd_context"]},
+            environ={},
+        )
+        self.assertFalse(result["ok"])
+        self.assertIsNone(result["status"])
+        self.assertNotIn("secret", json.dumps(result).lower())
+
+    def test_token_is_used_in_authorization_header(self):
+        opener = FakeOpener(FakeResponse(200, '{"ok": true, "duplicate": false, "recommendationId": "rec_1"}'))
+        result = dossier.send_dossier_recommendation(
+            {"subjectName": "Signal Witch", "reason": "Review", "sourceLanes": ["rd_context"]},
+            environ={"BNL_DOSSIER_INGEST_TOKEN": "secret-token", "BNL_DOSSIER_INGEST_URL": "https://example.test/ingest"},
+            opener=opener,
+        )
+        request, timeout = opener.requests[0]
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["recommendationId"], "rec_1")
+        self.assertEqual(timeout, dossier.DOSSIER_INGEST_TIMEOUT_SECONDS)
+        self.assertEqual(request.get_header("Authorization"), "Bearer secret-token")
+        self.assertNotIn("secret-token", json.dumps(result))
+
+    def test_duplicate_response_returns_duplicate_true(self):
+        opener = FakeOpener(FakeResponse(200, '{"ok": true, "duplicate": true, "id": "rec_1"}'))
+        result = dossier.send_dossier_recommendation(
+            {"subjectName": "Signal Witch", "reason": "Review", "sourceLanes": ["rd_context"]},
+            environ={"BNL_DOSSIER_INGEST_TOKEN": "secret-token"},
+            opener=opener,
+        )
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["duplicate"])
+
+    def test_401_response_returns_safe_failure(self):
+        http_error = urllib.error.HTTPError("https://example.test", 401, "Unauthorized", hdrs=None, fp=None)
+        opener = FakeOpener(error=http_error)
+        result = dossier.send_dossier_recommendation(
+            {"subjectName": "Signal Witch", "reason": "Review", "sourceLanes": ["rd_context"]},
+            environ={"BNL_DOSSIER_INGEST_TOKEN": "secret-token"},
+            opener=opener,
+        )
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["status"], 401)
+        self.assertNotIn("secret-token", json.dumps(result))
+
+    def test_network_error_returns_safe_failure(self):
+        opener = FakeOpener(error=urllib.error.URLError("timed out"))
+        result = dossier.send_dossier_recommendation(
+            {"subjectName": "Signal Witch", "reason": "Review", "sourceLanes": ["rd_context"]},
+            environ={"BNL_DOSSIER_INGEST_TOKEN": "secret-token"},
+            opener=opener,
+        )
+        self.assertFalse(result["ok"])
+        self.assertIsNone(result["status"])
+        self.assertIn("unreachable", result["error"])
+
+
+class DossierRecommendationPermissionTests(unittest.TestCase):
+    class Perms:
+        administrator = False
+        manage_guild = False
+        manage_messages = False
+        kick_members = False
+        ban_members = False
+
+    class User:
+        def __init__(self, user_id):
+            self.id = user_id
+
+    class Role:
+        def __init__(self, role_id):
+            self.id = role_id
+
+    class Member(User):
+        def __init__(self, user_id, perms=None, roles=None):
+            super().__init__(user_id)
+            self.guild_permissions = perms or DossierRecommendationPermissionTests.Perms()
+            self.roles = roles or []
+
+    class Guild:
+        owner_id = 100
+
+    def test_non_admin_cannot_send_recommendation(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        bnl01_bot.BNL_MOD_ROLE_ID = 555
+        member = self.Member(101)
+        self.assertFalse(bnl01_bot.can_send_dossier_recommendation(member, member, self.Guild()))
+
+    def test_admin_owner_or_operator_can_send_recommendation(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        bnl01_bot.BNL_MOD_ROLE_ID = 555
+
+        owner_user = self.Member(999)
+        self.assertTrue(bnl01_bot.can_send_dossier_recommendation(owner_user, owner_user, self.Guild()))
+
+        admin_perms = self.Perms()
+        admin_perms.administrator = True
+        admin = self.Member(101, perms=admin_perms)
+        self.assertTrue(bnl01_bot.can_send_dossier_recommendation(admin, admin, self.Guild()))
+
+        mod = self.Member(102, roles=[self.Role(555)])
+        self.assertTrue(bnl01_bot.can_send_dossier_recommendation(mod, mod, self.Guild()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Add a safe, isolated sender so BNL operators can submit dossier recommendations to the BARCODE website without changing site code or enabling any automatic scanning or publishing.
- Provide a minimal, operator-controlled manual trigger path for v1 that uses existing owner/mod/admin permission checks and keeps secrets out of logs and Discord.

### Description
- Added a new isolated helper module `bnl_dossier_recommendations.py` implementing payload builders, deterministic `ingestKey` generation, a parser for the manual command, and `send_dossier_recommendation(payload)` which POSTs JSON with `Authorization: Bearer <token>` and a 10s timeout to the ingest endpoint (fallback `https://www.barcode-network.com/api/bnl/dossier-recommendations`).
- Wired a single manual operator trigger into the bot runtime: `!bnl dossier recommend <subject> | <reason> [| lanes=...]` handled in `bnl01_bot.py` via `maybe_handle_dossier_recommendation_command`; the command defaults `sourceLanes` to `['rd_context']` for manual sends.
- Permission gate reuses existing checks: owner via `BNL_OWNER_USER_ID`, mod role via `BNL_MOD_ROLE_ID`, or privileged guild admin perms (`administrator`, `manage_guild`, `manage_messages`, `kick_members`, `ban_members`, or guild owner). Non-authorized users receive a short denial and no send is attempted.
- Deterministic `ingestKey` format for dedupe: `bnl:dossier:<type>:<normalized-subject>:<source-lanes-list>:<short-reason-hash>` (subject normalized, lanes normalized, short SHA256 of reason/evidence); designed to avoid including raw private text or tokens.
- Diagnostics: safe, non-sensitive diagnostics exposed in existing owner/mod commands (`/bnl_source_check` and `/bnl_status`) showing `dossier_ingest_url_configured`, `dossier_ingest_token_configured` (yes/no only), and `dossier_last_send_status` without exposing token values or payload contents.
- Safety boundaries enforced: no automatic scanning, no broadcast-memory auto-submit, no dossier generation, no file/draft creation, no publishing, and no website repo changes in this PR.
- Files added/modified: `bnl_dossier_recommendations.py` (new), `bnl01_bot.py` (imports + command handler + diagnostics), `tests/test_dossier_recommendations.py` (new unit tests).

### Testing
- Ran the unit test suite: `python -m unittest discover -s tests -v` (new tests plus existing read-model tests), all tests passed (12 tests, OK).
- Performed syntax checks: compiled with `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py tests/test_dossier_recommendations.py tests/test_read_model_relevance.py`, and compilation succeeded.
- Confirmed HTTP/send behavior in tests using a fake opener and simulated HTTP errors; tests validated authorization header usage, duplicate handling, 401 and network error handling, and that the token is never leaked in returned results.
- Summary of test results: unit tests passed and static compile checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b30395fd08321bb8fe9f7e409d4cd)