### PR TITLE
Approved source-lane reader + dossier recommendation packet builder (v1)

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -26,11 +26,15 @@ import urllib.parse
 import calendar
 
 from bnl_dossier_recommendations import (
-    build_dossier_recommendation_payload,
     get_dossier_ingest_url,
     is_dossier_ingest_token_configured,
     parse_manual_dossier_recommendation_command,
     send_dossier_recommendation,
+)
+from bnl_dossier_source_packets import (
+    build_dossier_recommendation_packet,
+    is_broadcast_memory_reader_available,
+    set_broadcast_memory_reader,
 )
 from collections import defaultdict, deque
 from datetime import datetime, timedelta, timezone
@@ -457,6 +461,8 @@ _last_website_directive = None
 _last_website_status_at = None
 _missing_status_key_warned = False
 _last_dossier_recommendation_status = "never_sent"
+_last_dossier_packet_lane_count = 0
+_last_dossier_packet_subject = "none"
 BNL_CONTROL_FLAGS_TTL_SECONDS = 300
 _bnl_control_flags_cache = None
 _bnl_control_flags_cached_at = None
@@ -3942,6 +3948,10 @@ def build_dossier_recommendation_diagnostics() -> dict:
         "ingest_endpoint": get_dossier_ingest_url(),
         "ingest_token_configured": is_dossier_ingest_token_configured(),
         "last_send_status": _last_dossier_recommendation_status,
+        "approved_packet_lanes_available": True,
+        "broadcast_memory_reader_available": is_broadcast_memory_reader_available(),
+        "last_packet_lane_count": _last_dossier_packet_lane_count,
+        "last_packet_subject": _last_dossier_packet_subject,
     }
 
 
@@ -3951,8 +3961,8 @@ def _safe_dossier_failure_reason(result: dict) -> str:
 
 
 async def maybe_handle_dossier_recommendation_command(message: discord.Message, clean_content: str) -> bool:
-    """Handle the v1 manual `!bnl dossier recommend` command if present."""
-    global _last_dossier_recommendation_status
+    """Handle the controlled `!bnl dossier recommend` packet/send command if present."""
+    global _last_dossier_recommendation_status, _last_dossier_packet_lane_count, _last_dossier_packet_subject
     matched, payload, parse_error = parse_manual_dossier_recommendation_command(clean_content)
     if not matched:
         return False
@@ -3969,8 +3979,19 @@ async def maybe_handle_dossier_recommendation_command(message: discord.Message, 
         await message.reply(f"Recommendation failed: {parse_error}")
         return True
 
-    safe_payload = build_dossier_recommendation_payload(payload)
+    packet_result = build_dossier_recommendation_packet(
+        payload.get("subjectName", ""),
+        payload.get("reason", ""),
+        payload.get("sourceLanes") or ["rd_context"],
+        guild_id=getattr(message.guild, "id", None),
+        options={"broadcast_memory_reader": get_recent_broadcast_memory},
+    )
+    safe_payload = packet_result["payload"]
     subject = (safe_payload.get("subjectName") or "subject").strip()[:80]
+    _last_dossier_packet_lane_count = len(safe_payload.get("sourceLanes") or [])
+    _last_dossier_packet_subject = subject
+    if "broadcast_memory" in (payload.get("sourceLanes") or []) and "broadcast_memory" not in (safe_payload.get("sourceLanes") or []):
+        logging.warning("dossier_packet_broadcast_memory_unavailable_or_no_match")
     result = await asyncio.to_thread(send_dossier_recommendation, safe_payload)
     status = result.get("status")
     if result.get("ok") and result.get("duplicate"):
@@ -3978,7 +3999,10 @@ async def maybe_handle_dossier_recommendation_command(message: discord.Message, 
         await message.reply(f"Duplicate recommendation already exists: {subject}")
     elif result.get("ok"):
         _last_dossier_recommendation_status = f"sent:{status or 'ok'}"
-        await message.reply(f"Recommendation sent: {subject}")
+        if safe_payload.get("sourceLanes") == ["rd_context"]:
+            await message.reply(f"Recommendation sent from manual/R&D context only: {subject}")
+        else:
+            await message.reply(f"Recommendation sent: {subject}")
     else:
         _last_dossier_recommendation_status = f"failed:{status or 'no_status'}"
         await message.reply(f"Recommendation failed: {_safe_dossier_failure_reason(result)}")
@@ -6073,6 +6097,10 @@ def get_recent_broadcast_memory(guild_id: int, public_only: bool = False, limit:
     rows = cursor.fetchall()
     conn.close()
     return rows
+
+
+
+set_broadcast_memory_reader(get_recent_broadcast_memory)
 
 def get_latest_broadcast_episode_date(guild_id: int, public_only: bool = False, usage_scope: str = ""):
     conn = sqlite3.connect(DB_FILE)
@@ -11625,6 +11653,10 @@ async def bnl_source_check(interaction: discord.Interaction):
         f"- dossier_ingest_url_configured: `{'yes' if dossier_diag['ingest_url_configured'] else 'no_using_default'}`",
         f"- dossier_ingest_token_configured: `{'yes' if dossier_diag['ingest_token_configured'] else 'no'}`",
         f"- dossier_last_send_status: `{dossier_diag['last_send_status']}`",
+        f"- dossier_packet_lanes_available: `{'yes' if dossier_diag['approved_packet_lanes_available'] else 'no'}`",
+        f"- dossier_broadcast_memory_reader_available: `{'yes' if dossier_diag['broadcast_memory_reader_available'] else 'no'}`",
+        f"- dossier_last_packet_lane_count: `{dossier_diag['last_packet_lane_count']}`",
+        f"- dossier_last_packet_subject: `{dossier_diag['last_packet_subject']}`",
         f"- _bnl_control_flags_last_source_url: `{flags_source}`",
         f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` every `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}` min",
     ]
@@ -11842,6 +11874,10 @@ async def bnl_status(interaction: discord.Interaction):
         f"- dossier_ingest_url_configured: `{'yes' if dossier_diag['ingest_url_configured'] else 'no_using_default'}`",
         f"- dossier_ingest_token_configured: `{'yes' if dossier_diag['ingest_token_configured'] else 'no'}`",
         f"- dossier_last_send_status: `{dossier_diag['last_send_status']}`",
+        f"- dossier_packet_lanes_available: `{'yes' if dossier_diag['approved_packet_lanes_available'] else 'no'}`",
+        f"- dossier_broadcast_memory_reader_available: `{'yes' if dossier_diag['broadcast_memory_reader_available'] else 'no'}`",
+        f"- dossier_last_packet_lane_count: `{dossier_diag['last_packet_lane_count']}`",
+        f"- dossier_last_packet_subject: `{dossier_diag['last_packet_subject']}`",
         f"- read_model_enabled: `{'yes' if read_model_diag.get('enabled') else 'no'}`",
         f"- read_model_url_configured: `{'yes' if read_model_diag.get('url_configured') else 'no'}`",
         f"- read_model_cache_present: `{'yes' if read_model_diag.get('cache_present') else 'no'}`",

--- a/bnl_dossier_source_packets.py
+++ b/bnl_dossier_source_packets.py
@@ -1,0 +1,289 @@
+"""Approved source-lane packet builder for BNL dossier recommendations.
+
+This module is deliberately deterministic and bot-internal. It does not scan
+Discord history, create public content, or submit recommendations by itself; it
+only builds a sanitized packet/payload for an explicitly-triggered operator path.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable
+
+from bnl_dossier_recommendations import build_dossier_recommendation_payload
+
+APPROVED_SOURCE_LANES = {"rd_context", "broadcast_memory"}
+FUTURE_SOURCE_LANES = {"read_model", "public_read_model", "safe_rd_notes"}
+DEFAULT_MISSING_INFO = [
+    "preferred display name",
+    "public link",
+    "public-safe role/description",
+]
+DEFAULT_PUBLIC_SAFETY_NOTES = [
+    "Do not expose private Discord identity without owner approval.",
+    "Verify public-safe wording before publishing.",
+]
+DEFAULT_SUGGESTED_ACTION = "Review source context and decide whether to attach or convert into a BNL Source File."
+MAX_EVIDENCE_MATCHES = 5
+MAX_SNIPPET_LENGTH = 220
+MAX_EVIDENCE_SUMMARY_LENGTH = 700
+_SAFE_LANE_PATTERN = re.compile(r"[^a-z0-9_-]+")
+_WORD_PATTERN = re.compile(r"[a-z0-9]+")
+_DISCORD_MENTION_PATTERN = re.compile(r"<[@#!&]?[0-9]{5,}>")
+_LONG_ID_PATTERN = re.compile(r"\b\d{15,22}\b")
+_broadcast_memory_reader: Callable[..., Any] | None = None
+
+
+def set_broadcast_memory_reader(reader: Callable[..., Any] | None) -> None:
+    """Register the existing bot broadcast-memory reader, if available."""
+
+    global _broadcast_memory_reader
+    _broadcast_memory_reader = reader
+
+
+def is_broadcast_memory_reader_available() -> bool:
+    """Return whether the packet builder has a reader for existing memory."""
+
+    return callable(_broadcast_memory_reader)
+
+
+def normalize_subject_name(subject_name: str) -> str:
+    """Normalize display whitespace without guessing identity aliases."""
+
+    return re.sub(r"\s+", " ", (subject_name or "").strip())
+
+
+def subject_key(subject_name: str) -> str:
+    """Return the stable subject key used by dossier ingest payloads."""
+
+    normalized = re.sub(r"[^a-z0-9]+", "-", normalize_subject_name(subject_name).lower())
+    return normalized.strip("-") or "unknown-subject"
+
+
+def compact_subject_text(value: str) -> str:
+    """Return compact lowercase alphanumeric text for conservative matching."""
+
+    return "".join(_WORD_PATTERN.findall((value or "").lower()))
+
+
+def contains_exact_subject_mention(text: str, subject_name: str) -> bool:
+    """Case-insensitive exact phrase match with non-word boundaries."""
+
+    subject = normalize_subject_name(subject_name)
+    if not subject:
+        return False
+    pattern = re.compile(rf"(?<![A-Za-z0-9]){re.escape(subject)}(?![A-Za-z0-9])", re.IGNORECASE)
+    return bool(pattern.search(text or ""))
+
+
+def contains_compact_subject_mention(text: str, subject_name: str) -> bool:
+    """Match spacing/punctuation variants only; no broad fuzzy matching."""
+
+    compact_subject = compact_subject_text(subject_name)
+    if not compact_subject or len(compact_subject) < 3:
+        return False
+    compact_text = compact_subject_text(text)
+    return compact_subject in compact_text
+
+
+def contains_subject_mention(text: str, subject_name: str, aliases: list[str] | None = None) -> bool:
+    """Return true for conservative subject/explicit-alias mention matches."""
+
+    candidates = [subject_name] + [alias for alias in (aliases or []) if alias]
+    return any(
+        contains_exact_subject_mention(text, candidate) or contains_compact_subject_mention(text, candidate)
+        for candidate in candidates
+    )
+
+
+def normalize_source_lanes(lanes: Any) -> list[str]:
+    """Normalize and allow only approved v1 lanes for packet collection."""
+
+    if isinstance(lanes, str):
+        raw_lanes = re.split(r"[,\s]+", lanes)
+    elif isinstance(lanes, (list, tuple, set)):
+        raw_lanes = list(lanes)
+    else:
+        raw_lanes = []
+
+    normalized: list[str] = []
+    seen = set()
+    for lane in raw_lanes:
+        clean = _SAFE_LANE_PATTERN.sub("_", str(lane or "").strip().lower()).strip("_")
+        if clean in {"manual", "operator", "manual_operator", "r_d", "rnd", "rd"}:
+            clean = "rd_context"
+        if clean not in APPROVED_SOURCE_LANES or clean in seen:
+            continue
+        seen.add(clean)
+        normalized.append(clean)
+    return normalized or ["rd_context"]
+
+
+def _safe_snippet(text: str, max_length: int = MAX_SNIPPET_LENGTH) -> str:
+    cleaned = _DISCORD_MENTION_PATTERN.sub("[redacted-mention]", str(text or ""))
+    cleaned = _LONG_ID_PATTERN.sub("[redacted-id]", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    if len(cleaned) <= max_length:
+        return cleaned
+    return cleaned[: max(0, max_length - 1)].rstrip() + "…"
+
+
+def _broadcast_row_to_text(row: Any) -> str:
+    if isinstance(row, dict):
+        return str(row.get("cleaned_summary") or row.get("summary") or row.get("text") or row.get("raw_note") or "")
+    if isinstance(row, (list, tuple)):
+        # get_recent_broadcast_memory returns cleaned_summary at index 1.
+        if len(row) > 1 and row[1]:
+            return str(row[1])
+        return " ".join(str(part or "") for part in row)
+    return str(row or "")
+
+
+def _broadcast_row_episode(row: Any) -> str:
+    if isinstance(row, dict):
+        return str(row.get("episode_date") or row.get("created_at") or "unknown-date")
+    if isinstance(row, (list, tuple)) and row:
+        return str(row[0] or "unknown-date")
+    return "unknown-date"
+
+
+def build_manual_operator_evidence(subject: str, reason: str, source_lanes: Any = None) -> dict[str, Any]:
+    """Build explicit operator/R&D evidence from the command reason."""
+
+    # The command reason is always an explicit operator/R&D note, even when
+    # additional lanes are requested for lookup.
+    return {
+        "lane": "rd_context",
+        "label": "R&D/operator note",
+        "summary": _safe_snippet(reason, MAX_SNIPPET_LENGTH),
+        "subjectName": normalize_subject_name(subject),
+    }
+
+
+def collect_broadcast_memory_evidence(
+    guild_id: int | None,
+    subject_name: str,
+    limit: int = 500,
+    *,
+    reader: Callable[..., Any] | None = None,
+    aliases: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Collect small labeled snippets from existing broadcast memory records."""
+
+    memory_reader = reader or _broadcast_memory_reader
+    if not guild_id or not callable(memory_reader):
+        return []
+
+    try:
+        rows = memory_reader(guild_id, public_only=False, limit=max(1, min(int(limit or 1), 500)))
+    except Exception:
+        return []
+
+    evidence: list[dict[str, Any]] = []
+    for row in rows or []:
+        text = _broadcast_row_to_text(row)
+        if not contains_subject_mention(text, subject_name, aliases=aliases):
+            continue
+        snippet = _safe_snippet(text)
+        if not snippet:
+            continue
+        evidence.append(
+            {
+                "lane": "broadcast_memory",
+                "label": "Broadcast memory",
+                "summary": snippet,
+                "episodeDate": _broadcast_row_episode(row),
+            }
+        )
+        if len(evidence) >= MAX_EVIDENCE_MATCHES:
+            break
+    return evidence
+
+
+def _evidence_summary(evidence: list[dict[str, Any]]) -> str:
+    pieces = []
+    for item in evidence:
+        lane = item.get("lane") or "source"
+        summary = _safe_snippet(item.get("summary") or "", 180)
+        if summary:
+            pieces.append(f"{lane}: {summary}")
+    joined = " | ".join(pieces)
+    if len(joined) > MAX_EVIDENCE_SUMMARY_LENGTH:
+        return joined[: MAX_EVIDENCE_SUMMARY_LENGTH - 1].rstrip() + "…"
+    return joined
+
+
+def _confidence_for_evidence(actual_lanes: list[str], evidence: list[dict[str, Any]]) -> str:
+    non_manual_lanes = {item.get("lane") for item in evidence if item.get("lane") != "rd_context"}
+    if len(non_manual_lanes) >= 2 and len(evidence) >= 3:
+        return "high"
+    if non_manual_lanes or len(actual_lanes) > 1:
+        return "medium"
+    return "low"
+
+
+def build_dossier_recommendation_packet(
+    subject: str,
+    reason: str,
+    lanes: Any = None,
+    guild_id: int | None = None,
+    options: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build an internal source packet and sender-compatible payload."""
+
+    opts = options or {}
+    subject_name = normalize_subject_name(subject)
+    requested_lanes = normalize_source_lanes(lanes or ["rd_context"])
+    aliases = opts.get("aliases") if isinstance(opts.get("aliases"), list) else None
+
+    evidence = [build_manual_operator_evidence(subject_name, reason, requested_lanes)]
+    if "broadcast_memory" in requested_lanes:
+        evidence.extend(
+            collect_broadcast_memory_evidence(
+                guild_id,
+                subject_name,
+                reader=opts.get("broadcast_memory_reader"),
+                aliases=aliases,
+            )
+        )
+
+    actual_lanes: list[str] = []
+    for item in evidence:
+        lane = item.get("lane")
+        if lane and lane not in actual_lanes:
+            actual_lanes.append(lane)
+    if not actual_lanes:
+        actual_lanes = ["rd_context"]
+
+    packet = {
+        "subjectName": subject_name,
+        "subjectKey": subject_key(subject_name),
+        "sourceLanes": actual_lanes,
+        "reason": _safe_snippet(reason, 300),
+        "evidenceSummary": _evidence_summary(evidence),
+        "missingInfo": list(DEFAULT_MISSING_INFO),
+        "publicSafetyNotes": list(DEFAULT_PUBLIC_SAFETY_NOTES),
+        "doNotSay": [],
+        "recommendedTags": [],
+        "confidence": _confidence_for_evidence(actual_lanes, evidence),
+        "suggestedAction": DEFAULT_SUGGESTED_ACTION,
+        "evidence": evidence,
+    }
+    payload = build_dossier_recommendation_payload(
+        {
+            "type": "new_subject",
+            "subjectName": packet["subjectName"],
+            "subjectKey": packet["subjectKey"],
+            "reason": packet["reason"],
+            "evidenceSummary": packet["evidenceSummary"],
+            "missingInfo": packet["missingInfo"],
+            "publicSafetyNotes": packet["publicSafetyNotes"],
+            "doNotSay": packet["doNotSay"],
+            "recommendedTags": packet["recommendedTags"],
+            "confidence": packet["confidence"],
+            "sourceLanes": packet["sourceLanes"],
+            "suggestedAction": packet["suggestedAction"],
+            "createdBy": "bnl",
+        }
+    )
+    return {"packet": packet, "payload": payload}

--- a/tests/test_dossier_recommendations.py
+++ b/tests/test_dossier_recommendations.py
@@ -7,6 +7,7 @@ os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
 
 import bnl_dossier_recommendations as dossier
+import bnl_dossier_source_packets as packets
 import bnl01_bot
 
 
@@ -73,6 +74,29 @@ class DossierRecommendationPayloadTests(unittest.TestCase):
         self.assertEqual(payload["reason"], "Review for future dossier.")
         self.assertEqual(payload["sourceLanes"], ["rd_context", "broadcast_memory"])
 
+    def test_parse_command_ignores_unsupported_lanes_in_packet_builder(self):
+        matched, payload, error = dossier.parse_manual_dossier_recommendation_command(
+            "!bnl dossier recommend Signal Witch | Review. | lanes=bogus,broadcast_memory"
+        )
+        self.assertTrue(matched)
+        self.assertFalse(error)
+        packet_result = packets.build_dossier_recommendation_packet(
+            payload["subjectName"],
+            payload["reason"],
+            payload["sourceLanes"],
+            guild_id=123,
+            options={"broadcast_memory_reader": lambda *a, **k: []},
+        )
+        self.assertEqual(packet_result["payload"]["sourceLanes"], ["rd_context"])
+
+    def test_parse_command_rejects_empty_subject(self):
+        matched, payload, error = dossier.parse_manual_dossier_recommendation_command(
+            "!bnl dossier recommend   | Reason"
+        )
+        self.assertTrue(matched)
+        self.assertIsNone(payload)
+        self.assertIn("Subject", error)
+
     def test_parse_command_rejects_empty_reason(self):
         matched, payload, error = dossier.parse_manual_dossier_recommendation_command(
             "!bnl dossier recommend Signal Witch |   "
@@ -80,6 +104,83 @@ class DossierRecommendationPayloadTests(unittest.TestCase):
         self.assertTrue(matched)
         self.assertIsNone(payload)
         self.assertIn("Reason", error)
+
+
+class DossierSourcePacketTests(unittest.TestCase):
+    def test_subject_matching_is_conservative(self):
+        self.assertEqual(packets.normalize_subject_name("  Signal   Witch "), "Signal Witch")
+        self.assertTrue(packets.contains_exact_subject_mention("Signal Witch should be reviewed.", "signal witch"))
+        self.assertTrue(packets.contains_compact_subject_mention("Signal-Witch should be reviewed.", "Signal Witch"))
+        self.assertFalse(packets.contains_subject_mention("Signal is noisy but unrelated.", "Signal Witch"))
+        self.assertFalse(packets.contains_subject_mention("Witch signal is reversed.", "Signal Witch"))
+
+    def test_manual_packet_defaults_and_no_token(self):
+        result = packets.build_dossier_recommendation_packet(
+            "Signal Witch",
+            "Operator says Signal Witch should be reviewed.",
+            ["rd_context"],
+        )
+        packet = result["packet"]
+        payload = result["payload"]
+        self.assertEqual(packet["sourceLanes"], ["rd_context"])
+        self.assertEqual(packet["confidence"], "low")
+        self.assertIn("preferred display name", packet["missingInfo"])
+        self.assertIn("Verify public-safe wording before publishing.", packet["publicSafetyNotes"])
+        self.assertNotIn("BNL_DOSSIER_INGEST_TOKEN", json.dumps(packet))
+        self.assertNotIn("Authorization", json.dumps(payload))
+
+    def test_broadcast_memory_collection_matches_and_caps_snippets(self):
+        long_summary = "Signal Witch " + ("context " * 80) + "123456789012345678"
+
+        def fake_reader(guild_id, public_only=False, limit=500):
+            self.assertEqual(guild_id, 123)
+            self.assertFalse(public_only)
+            self.assertLessEqual(limit, 500)
+            return [
+                ("2026-05-29", long_summary, "notable_moment", "medium", 0, 0, "internal", None, None, 1, 0),
+                ("2026-05-22", "Unrelated artist note.", "notable_moment", "medium", 0, 0, "internal", None, None, 1, 0),
+            ]
+
+        evidence = packets.collect_broadcast_memory_evidence(123, "Signal Witch", reader=fake_reader)
+        self.assertEqual(len(evidence), 1)
+        self.assertEqual(evidence[0]["lane"], "broadcast_memory")
+        self.assertLessEqual(len(evidence[0]["summary"]), packets.MAX_SNIPPET_LENGTH)
+        self.assertNotIn("123456789012345678", evidence[0]["summary"])
+        self.assertEqual(packets.collect_broadcast_memory_evidence(None, "Signal Witch", reader=fake_reader), [])
+        self.assertEqual(packets.collect_broadcast_memory_evidence(123, "Signal Witch", reader=lambda *a, **k: (_ for _ in ()).throw(RuntimeError())), [])
+
+    def test_packet_builder_manual_plus_broadcast_and_stable_ingest_key(self):
+        def fake_reader(guild_id, public_only=False, limit=500):
+            return [("2026-05-29", "Signal-Witch came up in broadcast memory as a recurring source candidate.")]
+
+        first = packets.build_dossier_recommendation_packet(
+            "Signal Witch",
+            "Testing source packet builder.",
+            ["rd_context", "broadcast_memory", "unsupported_lane"],
+            guild_id=123,
+            options={"broadcast_memory_reader": fake_reader},
+        )
+        second = packets.build_dossier_recommendation_packet(
+            "Signal Witch",
+            "Testing source packet builder.",
+            ["rd_context", "broadcast_memory"],
+            guild_id=123,
+            options={"broadcast_memory_reader": fake_reader},
+        )
+        payload = first["payload"]
+        self.assertEqual(payload["sourceLanes"], ["rd_context", "broadcast_memory"])
+        self.assertEqual(payload["confidence"], "medium")
+        self.assertLessEqual(len(payload["evidenceSummary"]), packets.MAX_EVIDENCE_SUMMARY_LENGTH)
+        self.assertEqual(payload["ingestKey"], second["payload"]["ingestKey"])
+
+    def test_no_automatic_scanning_constructs_in_packet_module(self):
+        with open("bnl_dossier_source_packets.py", encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertNotIn("@tasks.loop", source)
+        self.assertNotIn("history(", source)
+        self.assertNotIn("create_source_file", source)
+        self.assertNotIn("create_draft", source)
+        self.assertNotIn("send_dossier_recommendation", source)
 
 
 class DossierRecommendationSenderTests(unittest.TestCase):


### PR DESCRIPTION
### Motivation
- Provide a controlled, operator-triggered way to assemble a small, labeled source packet for a named subject from approved lanes so the bot can send richer dossier recommendations without broad scanning or new memory architectures.
- Use only tightly-approved v1 lanes (`rd_context`, `broadcast_memory`) and existing bot helpers to keep packet building deterministic, admin-only, and privacy-safe.

### Description
- Added `bnl_dossier_source_packets.py` which implements a deterministic internal packet model, subject normalization/matching (`normalize_subject_name`, `contains_exact_subject_mention`, `contains_compact_subject_mention`), safe snippet redaction/capping, approved-lane normalization, broadcast-memory evidence collection (`collect_broadcast_memory_evidence`) and packet assembly (`build_dossier_recommendation_packet`).
- Integrated the packet builder into the existing command path by updating `maybe_handle_dossier_recommendation_command` to call `build_dossier_recommendation_packet` and then send the sanitized payload via the existing `send_dossier_recommendation` sender, preserving permission gating and short Discord replies.
- Wired the packet builder to the bot’s existing broadcast-memory reader by registering `set_broadcast_memory_reader(get_recent_broadcast_memory)` so `broadcast_memory` evidence uses `get_recent_broadcast_memory(...)` safely and only when explicitly requested.
- Added lightweight diagnostics and metadata fields to `build_dossier_recommendation_diagnostics()` exposing non-sensitive info: approved-packet lanes availability, whether a broadcast-memory reader is available, last packet lane count, and last packet subject; no evidence or tokens are exposed.
- Tests updated: extended `tests/test_dossier_recommendations.py` with `DossierSourcePacketTests` covering subject matching, manual-packet defaults, broadcast-memory evidence collection/capping, packet building and ingest-key stability, unsupported-lane handling, and a check that the new module contains no background scanning or publish behavior.
- Safety boundaries preserved: no new DB writes, no creation of source files/drafts/publishing, no broad Discord history scraping, no private message ingestion, and no automatic or background submission tasks.

### Testing
- Ran unit tests: `python -m unittest discover -s tests -v` and all tests passed (19 tests OK).
- Performed static checks/compilation: `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py tests/test_dossier_recommendations.py` and compilation succeeded.
- Ran repository checks: `git diff --check` with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b3756b9288321a8d931c5a8019150)