### PR TITLE
Bot PR #179 — Dynamic Dossier Candidate Discovery v1

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -25,6 +25,12 @@ import urllib.error
 import urllib.parse
 import calendar
 
+from bnl_dossier_candidate_discovery import (
+    DEFAULT_DISCOVERY_LANES,
+    DISCOVERY_INGEST_SOURCE,
+    discover_candidate_recommendations,
+    parse_dossier_discovery_command,
+)
 from bnl_dossier_recommendations import (
     get_dossier_ingest_url,
     is_dossier_ingest_token_configured,
@@ -463,6 +469,13 @@ _missing_status_key_warned = False
 _last_dossier_recommendation_status = "never_sent"
 _last_dossier_packet_lane_count = 0
 _last_dossier_packet_subject = "none"
+_last_candidate_discovery_run_time = "never"
+_last_candidate_discovery_sent_count = 0
+_last_candidate_discovery_duplicate_count = 0
+_last_candidate_discovery_withheld_count = 0
+_last_candidate_discovery_error_status = "none"
+_last_candidate_discovery_source_lanes = []
+_last_candidate_discovery_mode = "none"
 BNL_CONTROL_FLAGS_TTL_SECONDS = 300
 _bnl_control_flags_cache = None
 _bnl_control_flags_cached_at = None
@@ -3952,6 +3965,17 @@ def build_dossier_recommendation_diagnostics() -> dict:
         "broadcast_memory_reader_available": is_broadcast_memory_reader_available(),
         "last_packet_lane_count": _last_dossier_packet_lane_count,
         "last_packet_subject": _last_dossier_packet_subject,
+        "candidate_discovery_available": True,
+        "candidate_discovery_enabled": False,
+        "candidate_discovery_ingest_source": DISCOVERY_INGEST_SOURCE,
+        "candidate_discovery_approved_lanes": list(DEFAULT_DISCOVERY_LANES),
+        "candidate_discovery_last_run_time": _last_candidate_discovery_run_time,
+        "candidate_discovery_last_sent_count": _last_candidate_discovery_sent_count,
+        "candidate_discovery_last_duplicate_count": _last_candidate_discovery_duplicate_count,
+        "candidate_discovery_last_withheld_count": _last_candidate_discovery_withheld_count,
+        "candidate_discovery_last_error_status": _last_candidate_discovery_error_status,
+        "candidate_discovery_last_source_lanes": list(_last_candidate_discovery_source_lanes),
+        "candidate_discovery_last_mode": _last_candidate_discovery_mode,
     }
 
 
@@ -3960,9 +3984,100 @@ def _safe_dossier_failure_reason(result: dict) -> str:
     return str(reason).replace("`", "'")[:140]
 
 
+def _current_rd_discovery_context(message: discord.Message) -> list[dict]:
+    """Return already-buffered R&D context for discovery without reading channel history."""
+
+    if not is_research_and_development_channel(message):
+        return []
+    combined: list[dict] = []
+    combined.extend(_get_recent_rd_ops_channel_context(message))
+    combined.extend(_get_recent_rd_ops_context(message))
+    return combined[-25:]
+
+
+async def maybe_handle_dossier_discovery_command(message: discord.Message, clean_content: str) -> bool:
+    """Handle operator-triggered dynamic dossier candidate discovery."""
+
+    global _last_dossier_recommendation_status
+    global _last_candidate_discovery_run_time, _last_candidate_discovery_sent_count
+    global _last_candidate_discovery_duplicate_count, _last_candidate_discovery_withheld_count
+    global _last_candidate_discovery_error_status, _last_candidate_discovery_source_lanes, _last_candidate_discovery_mode
+
+    matched, options, parse_error = parse_dossier_discovery_command(clean_content)
+    if not matched:
+        return False
+
+    member = message.author if isinstance(message.author, discord.Member) else message.guild.get_member(message.author.id)
+    if not can_send_dossier_recommendation(message.author, member, message.guild):
+        _last_candidate_discovery_error_status = "permission_denied"
+        _last_dossier_recommendation_status = "candidate_discovery_permission_denied"
+        logging.warning("dossier_candidate_discovery_denied reason=permission")
+        await message.reply("Dossier candidate discovery is operator-only.")
+        return True
+
+    if not options:
+        _last_candidate_discovery_error_status = "parse_rejected"
+        await message.reply(f"Dossier discovery failed: {parse_error}")
+        return True
+
+    dry_run = bool(options.get("dry_run"))
+    lanes = options.get("lanes") or list(DEFAULT_DISCOVERY_LANES)
+    limit = int(options.get("limit") or 10)
+    _last_candidate_discovery_run_time = datetime.now(timezone.utc).isoformat()
+    _last_candidate_discovery_source_lanes = list(lanes)
+    _last_candidate_discovery_mode = "dry_run" if dry_run else "command"
+    _last_candidate_discovery_error_status = "none"
+
+    discovery = discover_candidate_recommendations(
+        getattr(message.guild, "id", None),
+        lanes,
+        limit=limit,
+        broadcast_memory_reader=get_recent_broadcast_memory,
+        rd_context=_current_rd_discovery_context(message),
+    )
+    candidates = discovery.get("candidates") or []
+    withheld = int(discovery.get("withheldCount") or 0)
+    duplicate_count = int(discovery.get("duplicateCount") or 0)
+
+    if dry_run:
+        _last_candidate_discovery_sent_count = 0
+        _last_candidate_discovery_duplicate_count = duplicate_count
+        _last_candidate_discovery_withheld_count = withheld
+        names = [str(candidate.get("subjectName") or "subject")[:40] for candidate in candidates[:5]]
+        suffix = f" Top candidates: {', '.join(names)}." if names else ""
+        await message.reply(f"Dossier discovery dry run: {len(candidates)} candidates found.{suffix} Nothing sent.")
+        return True
+
+    sent_count = 0
+    send_duplicates = duplicate_count
+    first_error = "none"
+    for candidate in candidates:
+        payload = candidate.get("payload") or {}
+        result = await asyncio.to_thread(send_dossier_recommendation, payload)
+        if result.get("ok") and result.get("duplicate"):
+            send_duplicates += 1
+        elif result.get("ok"):
+            sent_count += 1
+        elif first_error == "none":
+            first_error = f"failed:{result.get('status') or 'no_status'}"
+
+    _last_candidate_discovery_sent_count = sent_count
+    _last_candidate_discovery_duplicate_count = send_duplicates
+    _last_candidate_discovery_withheld_count = withheld
+    _last_candidate_discovery_error_status = first_error
+    _last_dossier_recommendation_status = f"candidate_discovery_sent:{sent_count}:duplicates:{send_duplicates}:withheld:{withheld}" if first_error == "none" else first_error
+    await message.reply(
+        f"Dossier discovery complete: {sent_count} recommendations sent, "
+        f"{send_duplicates} duplicates skipped, {withheld} withheld for low confidence."
+    )
+    return True
+
+
 async def maybe_handle_dossier_recommendation_command(message: discord.Message, clean_content: str) -> bool:
-    """Handle the controlled `!bnl dossier recommend` packet/send command if present."""
+    """Handle controlled dossier recommendation/discovery commands if present."""
     global _last_dossier_recommendation_status, _last_dossier_packet_lane_count, _last_dossier_packet_subject
+    if await maybe_handle_dossier_discovery_command(message, clean_content):
+        return True
     matched, payload, parse_error = parse_manual_dossier_recommendation_command(clean_content)
     if not matched:
         return False
@@ -11657,6 +11772,16 @@ async def bnl_source_check(interaction: discord.Interaction):
         f"- dossier_broadcast_memory_reader_available: `{'yes' if dossier_diag['broadcast_memory_reader_available'] else 'no'}`",
         f"- dossier_last_packet_lane_count: `{dossier_diag['last_packet_lane_count']}`",
         f"- dossier_last_packet_subject: `{dossier_diag['last_packet_subject']}`",
+        f"- candidate_discovery_available: `{'yes' if dossier_diag['candidate_discovery_available'] else 'no'}`",
+        f"- candidate_discovery_enabled: `{'yes' if dossier_diag['candidate_discovery_enabled'] else 'no'}`",
+        f"- candidate_discovery_approved_lanes: `{','.join(dossier_diag['candidate_discovery_approved_lanes'])}`",
+        f"- candidate_discovery_last_run_time: `{dossier_diag['candidate_discovery_last_run_time']}`",
+        f"- candidate_discovery_last_sent_count: `{dossier_diag['candidate_discovery_last_sent_count']}`",
+        f"- candidate_discovery_last_duplicate_count: `{dossier_diag['candidate_discovery_last_duplicate_count']}`",
+        f"- candidate_discovery_last_withheld_count: `{dossier_diag['candidate_discovery_last_withheld_count']}`",
+        f"- candidate_discovery_last_error_status: `{dossier_diag['candidate_discovery_last_error_status']}`",
+        f"- candidate_discovery_last_source_lanes: `{','.join(dossier_diag['candidate_discovery_last_source_lanes']) or 'none'}`",
+        f"- candidate_discovery_last_mode: `{dossier_diag['candidate_discovery_last_mode']}`",
         f"- _bnl_control_flags_last_source_url: `{flags_source}`",
         f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` every `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}` min",
     ]
@@ -11878,6 +12003,16 @@ async def bnl_status(interaction: discord.Interaction):
         f"- dossier_broadcast_memory_reader_available: `{'yes' if dossier_diag['broadcast_memory_reader_available'] else 'no'}`",
         f"- dossier_last_packet_lane_count: `{dossier_diag['last_packet_lane_count']}`",
         f"- dossier_last_packet_subject: `{dossier_diag['last_packet_subject']}`",
+        f"- candidate_discovery_available: `{'yes' if dossier_diag['candidate_discovery_available'] else 'no'}`",
+        f"- candidate_discovery_enabled: `{'yes' if dossier_diag['candidate_discovery_enabled'] else 'no'}`",
+        f"- candidate_discovery_approved_lanes: `{','.join(dossier_diag['candidate_discovery_approved_lanes'])}`",
+        f"- candidate_discovery_last_run_time: `{dossier_diag['candidate_discovery_last_run_time']}`",
+        f"- candidate_discovery_last_sent_count: `{dossier_diag['candidate_discovery_last_sent_count']}`",
+        f"- candidate_discovery_last_duplicate_count: `{dossier_diag['candidate_discovery_last_duplicate_count']}`",
+        f"- candidate_discovery_last_withheld_count: `{dossier_diag['candidate_discovery_last_withheld_count']}`",
+        f"- candidate_discovery_last_error_status: `{dossier_diag['candidate_discovery_last_error_status']}`",
+        f"- candidate_discovery_last_source_lanes: `{','.join(dossier_diag['candidate_discovery_last_source_lanes']) or 'none'}`",
+        f"- candidate_discovery_last_mode: `{dossier_diag['candidate_discovery_last_mode']}`",
         f"- read_model_enabled: `{'yes' if read_model_diag.get('enabled') else 'no'}`",
         f"- read_model_url_configured: `{'yes' if read_model_diag.get('url_configured') else 'no'}`",
         f"- read_model_cache_present: `{'yes' if read_model_diag.get('cache_present') else 'no'}`",

--- a/bnl_dossier_candidate_discovery.py
+++ b/bnl_dossier_candidate_discovery.py
@@ -1,0 +1,375 @@
+"""Dynamic candidate discovery for review-only BNL dossier recommendations.
+
+The discovery layer is intentionally narrow: it only reads caller-supplied,
+approved source-safe lane material and returns ordinary dossier recommendation
+payloads for the existing website ingest pipeline. It does not scan Discord,
+create source files, create drafts, publish, merge identities, or confirm aliases.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from bnl_dossier_recommendations import build_dossier_recommendation_payload
+from bnl_dossier_source_packets import (
+    APPROVED_SOURCE_LANES,
+    DEFAULT_MISSING_INFO,
+    DEFAULT_PUBLIC_SAFETY_NOTES,
+    DEFAULT_SUGGESTED_ACTION,
+    MAX_EVIDENCE_SUMMARY_LENGTH,
+    MAX_SNIPPET_LENGTH,
+    normalize_source_lanes,
+    subject_key,
+)
+
+DISCOVERY_INGEST_SOURCE = "bnl_dynamic_candidate_discovery"
+DEFAULT_DISCOVERY_LANES = ["rd_context", "broadcast_memory"]
+MAX_DISCOVERY_LIMIT = 25
+DEFAULT_DISCOVERY_LIMIT = 10
+MIN_CANDIDATE_SCORE = 3
+MAX_REASON_LENGTH = 300
+_ALLOWED_DISCOVERY_LANES = set(DEFAULT_DISCOVERY_LANES) & set(APPROVED_SOURCE_LANES)
+_DISCORD_MENTION_PATTERN = re.compile(r"<[@#!&]?[0-9]{5,}>")
+_LONG_ID_PATTERN = re.compile(r"\b\d{15,22}\b")
+_SAFE_LANE_PATTERN = re.compile(r"[^a-z0-9_-]+")
+
+_STOP_PHRASES = {
+    "BNL",
+    "BNL 01",
+    "BARCODE",
+    "BARCODE Network",
+    "BARCODE Radio",
+    "Discord",
+    "R&D",
+    "Research Development",
+    "Source File",
+    "Source Files",
+    "Dossier",
+    "Dossiers",
+    "Broadcast Memory",
+    "Recommendation Inbox",
+    "Operator",
+    "Admin",
+    "Owner",
+    "Network",
+    "The Network",
+    "Do Not",
+    "Public Safe",
+}
+
+_CATEGORY_TERMS = (
+    ("identity_alias_review", re.compile(r"\b(alias|alternate name|aka|same as|duplicate|identity|connect(?:s|ed)? to)\b", re.I)),
+    ("system_concept_candidate", re.compile(r"\b(system|concept|protocol|workflow|lane|interface|program)\b", re.I)),
+    ("new_source_file_candidate", re.compile(r"\b(source file|dossier|candidate|review|track|recurring|sponsor|artist|collaborator|lore|character|entity)\b", re.I)),
+)
+
+@dataclass
+class DiscoverySourceItem:
+    lane: str
+    text: str
+    label: str = ""
+    source_ref: str = ""
+    weight: int = 1
+
+
+@dataclass
+class CandidateAccumulator:
+    subject_name: str
+    category: str = "new_source_file_candidate"
+    lanes: set[str] = field(default_factory=set)
+    evidence: list[dict[str, str]] = field(default_factory=list)
+    mentions: int = 0
+    explicit_hits: int = 0
+    score: int = 0
+
+
+def parse_dossier_discovery_command(content: str) -> tuple[bool, dict[str, Any] | None, str]:
+    """Parse `!bnl dossier discover candidates [| lanes=...] [| limit=...] [| dry_run=true]`."""
+
+    text = (content or "").strip()
+    match = re.match(r"^!bnl\s+dossier\s+discover\s+candidates(?:\s*(?:\|\s*)?(.*))?$", text, flags=re.I | re.S)
+    if not match:
+        return False, None, "not_a_dossier_discovery_command"
+
+    options_text = (match.group(1) or "").strip()
+    options: dict[str, Any] = {
+        "lanes": list(DEFAULT_DISCOVERY_LANES),
+        "limit": DEFAULT_DISCOVERY_LIMIT,
+        "dry_run": False,
+    }
+    if options_text:
+        for part in [piece.strip() for piece in options_text.split("|") if piece.strip()]:
+            key_match = re.match(r"^([a-zA-Z_]+)\s*=\s*(.+)$", part)
+            if not key_match:
+                return True, None, "Use: `!bnl dossier discover candidates [| lanes=rd_context,broadcast_memory] [| limit=10] [| dry_run=true]`"
+            key = key_match.group(1).strip().lower()
+            value = key_match.group(2).strip()
+            if key in {"lane", "lanes", "sourcelanes"}:
+                lanes = normalize_discovery_lanes(value)
+                if not lanes:
+                    return True, None, "No approved discovery lanes were requested. Approved lanes: rd_context,broadcast_memory."
+                options["lanes"] = lanes
+            elif key == "limit":
+                try:
+                    options["limit"] = max(1, min(int(value), MAX_DISCOVERY_LIMIT))
+                except ValueError:
+                    return True, None, "Discovery limit must be a number."
+            elif key in {"dry", "dryrun", "dry_run"}:
+                options["dry_run"] = value.lower() in {"1", "true", "yes", "y", "on"}
+            else:
+                return True, None, f"Unsupported discovery option: {key}."
+    return True, options, ""
+
+
+def normalize_discovery_lanes(lanes: Any) -> list[str]:
+    """Normalize to the approved v1 candidate-discovery lane subset only."""
+
+    normalized = normalize_source_lanes(lanes or DEFAULT_DISCOVERY_LANES)
+    return [lane for lane in normalized if lane in _ALLOWED_DISCOVERY_LANES]
+
+
+def _safe_snippet(text: str, max_length: int = MAX_SNIPPET_LENGTH) -> str:
+    cleaned = _DISCORD_MENTION_PATTERN.sub("[redacted-mention]", str(text or ""))
+    cleaned = _LONG_ID_PATTERN.sub("[redacted-id]", cleaned)
+    cleaned = re.sub(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", "[redacted-email]", cleaned, flags=re.I)
+    cleaned = re.sub(r"https?://\S+", "[redacted-url]", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    if len(cleaned) <= max_length:
+        return cleaned
+    return cleaned[: max(0, max_length - 1)].rstrip() + "…"
+
+
+def _row_text(row: Any) -> str:
+    if isinstance(row, dict):
+        return str(row.get("cleaned_summary") or row.get("summary") or row.get("text") or row.get("response_summary") or row.get("user_request") or "")
+    if isinstance(row, (list, tuple)):
+        if len(row) > 1 and row[1]:
+            return str(row[1])
+        return " ".join(str(part or "") for part in row)
+    return str(row or "")
+
+
+def _rd_entry_to_text(entry: Any) -> str:
+    if isinstance(entry, dict):
+        parts = [
+            entry.get("main_subject"),
+            entry.get("user_request"),
+            entry.get("response_summary"),
+            entry.get("suggested_lane"),
+            entry.get("detected_intent"),
+        ]
+        return " | ".join(str(part) for part in parts if str(part or "").strip())
+    return str(entry or "")
+
+
+def collect_discovery_source_items(
+    guild_id: int | None,
+    lanes: Any = None,
+    *,
+    broadcast_memory_reader: Callable[..., Any] | None = None,
+    rd_context_reader: Callable[..., Any] | None = None,
+    rd_context: list[Any] | None = None,
+    broadcast_limit: int = 500,
+) -> list[DiscoverySourceItem]:
+    """Collect approved source-safe lane text from explicit readers/context only."""
+
+    requested = normalize_discovery_lanes(lanes or DEFAULT_DISCOVERY_LANES)
+    items: list[DiscoverySourceItem] = []
+
+    if "rd_context" in requested:
+        rd_rows: list[Any] = list(rd_context or [])
+        if callable(rd_context_reader):
+            try:
+                rd_rows.extend(rd_context_reader() or [])
+            except Exception:
+                rd_rows.extend([])
+        for idx, entry in enumerate(rd_rows[-25:], start=1):
+            text = _safe_snippet(_rd_entry_to_text(entry), 500)
+            if text:
+                items.append(DiscoverySourceItem("rd_context", text, "R&D context", f"rd_context:{idx}", weight=1))
+
+    if "broadcast_memory" in requested and guild_id and callable(broadcast_memory_reader):
+        try:
+            rows = broadcast_memory_reader(guild_id, public_only=False, limit=max(1, min(int(broadcast_limit or 1), 500)))
+        except Exception:
+            rows = []
+        for idx, row in enumerate(rows or [], start=1):
+            text = _safe_snippet(_row_text(row), 500)
+            if text:
+                items.append(DiscoverySourceItem("broadcast_memory", text, "Broadcast memory", f"broadcast_memory:{idx}", weight=2))
+
+    return items
+
+
+def _explicit_subjects(text: str) -> list[str]:
+    subjects: list[str] = []
+    patterns = (
+        r"(?:source file|dossier|candidate|review|alias review|identity review)\s+(?:for|on|about)\s+([A-Z0-9][A-Za-z0-9'_-]*(?:\s+[A-Z0-9][A-Za-z0-9'_-]*){0,4})",
+        r"([A-Z0-9][A-Za-z0-9'_-]*(?:\s+[A-Z0-9][A-Za-z0-9'_-]*){0,4})\s+(?:needs|deserves|should have|should get|may need)\s+(?:a\s+)?(?:source file|dossier|alias review|identity review)",
+    )
+    for pattern in patterns:
+        for match in re.finditer(pattern, text or "", flags=re.I):
+            subjects.append(match.group(1))
+    return subjects
+
+
+def _title_subjects(text: str) -> list[str]:
+    candidates = re.findall(r"\b[A-Z][A-Za-z0-9'_-]*(?:\s+[A-Z0-9][A-Za-z0-9'_-]*){0,3}\b", text or "")
+    # Also catch compact/camel names like ShadowsPit when they start with a capital.
+    candidates.extend(re.findall(r"\b[A-Z][A-Za-z]+[A-Z][A-Za-z0-9]*\b", text or ""))
+    return candidates
+
+
+def _clean_subject(candidate: str) -> str:
+    cleaned = re.sub(r"\s+", " ", (candidate or "").strip(" .,:;!?()[]{}\"'"))
+    cleaned = re.sub(r"^(?:the|a|an)\s+", "", cleaned, flags=re.I).strip()
+    return cleaned[:80]
+
+
+def _valid_subject(candidate: str) -> bool:
+    subject = _clean_subject(candidate)
+    if not subject or len(subject) < 3 or subject in _STOP_PHRASES:
+        return False
+    if subject.lower() in {item.lower() for item in _STOP_PHRASES}:
+        return False
+    if re.fullmatch(r"\d+", subject):
+        return False
+    if subject.lower().startswith(("do not", "public safe", "source lane")):
+        return False
+    return bool(re.search(r"[A-Za-z]", subject))
+
+
+def _category_for_text(text: str) -> str:
+    for category, pattern in _CATEGORY_TERMS:
+        if pattern.search(text or ""):
+            return category
+    return "new_source_file_candidate"
+
+
+def _evidence_summary(evidence: list[dict[str, str]]) -> str:
+    pieces: list[str] = []
+    for item in evidence[:5]:
+        lane = item.get("lane") or "source"
+        summary = _safe_snippet(item.get("summary") or "", 160)
+        if summary:
+            pieces.append(f"{lane}: {summary}")
+    joined = " | ".join(pieces)
+    if len(joined) > MAX_EVIDENCE_SUMMARY_LENGTH:
+        return joined[: MAX_EVIDENCE_SUMMARY_LENGTH - 1].rstrip() + "…"
+    return joined
+
+
+def discover_candidate_recommendations(
+    guild_id: int | None,
+    lanes: Any = None,
+    *,
+    limit: int = DEFAULT_DISCOVERY_LIMIT,
+    broadcast_memory_reader: Callable[..., Any] | None = None,
+    rd_context_reader: Callable[..., Any] | None = None,
+    rd_context: list[Any] | None = None,
+) -> dict[str, Any]:
+    """Discover review candidates and return normal recommendation payloads plus safe counts."""
+
+    requested_lanes = normalize_discovery_lanes(lanes or DEFAULT_DISCOVERY_LANES)
+    max_candidates = max(1, min(int(limit or DEFAULT_DISCOVERY_LIMIT), MAX_DISCOVERY_LIMIT))
+    source_items = collect_discovery_source_items(
+        guild_id,
+        requested_lanes,
+        broadcast_memory_reader=broadcast_memory_reader,
+        rd_context_reader=rd_context_reader,
+        rd_context=rd_context,
+    )
+    accumulators: dict[str, CandidateAccumulator] = {}
+
+    for item in source_items:
+        text = item.text
+        explicit = {_clean_subject(subject) for subject in _explicit_subjects(text) if _valid_subject(subject)}
+        candidates = list(explicit)
+        candidates.extend(_clean_subject(subject) for subject in _title_subjects(text) if _valid_subject(subject))
+        seen_in_item: set[str] = set()
+        for subject in candidates:
+            key = subject_key(subject)
+            if key in seen_in_item:
+                continue
+            seen_in_item.add(key)
+            acc = accumulators.get(key)
+            if not acc:
+                acc = CandidateAccumulator(subject_name=subject)
+                accumulators[key] = acc
+            acc.mentions += 1
+            acc.lanes.add(item.lane)
+            if subject in explicit:
+                acc.explicit_hits += 1
+            category = _category_for_text(text)
+            if acc.category == "new_source_file_candidate" or category != "new_source_file_candidate":
+                acc.category = category
+            if len(acc.evidence) < 5:
+                acc.evidence.append({"lane": item.lane, "label": item.label, "summary": _safe_snippet(text), "sourceRef": item.source_ref})
+            acc.score += item.weight + (2 if subject in explicit else 0)
+            if re.search(r"\b(recurring|repeated|important|priority|source file|dossier|candidate|alias review|identity review)\b", text, flags=re.I):
+                acc.score += 1
+
+    candidates: list[dict[str, Any]] = []
+    withheld_count = 0
+    for acc in accumulators.values():
+        passed = acc.score >= MIN_CANDIDATE_SCORE and acc.evidence and acc.lanes
+        if not passed:
+            withheld_count += 1
+            continue
+        lane_list = [lane for lane in requested_lanes if lane in acc.lanes] or sorted(acc.lanes)
+        confidence = "high" if acc.score >= 7 and len(acc.lanes) > 1 else ("medium" if acc.score >= 4 else "low")
+        reason = _safe_snippet(
+            f"BNL dynamic candidate discovery found {acc.subject_name} in approved source-safe lanes "
+            f"({', '.join(lane_list)}) as {acc.category.replace('_', ' ')}. Review only; owner/admin must decide whether this becomes a source file, alias proposal, duplicate, or nothing.",
+            MAX_REASON_LENGTH,
+        )
+        evidence_summary = _evidence_summary(acc.evidence)
+        evidence_hash = hashlib.sha256(f"{reason}\n{evidence_summary}".encode("utf-8")).hexdigest()[:8]
+        payload = build_dossier_recommendation_payload(
+            {
+                "type": "new_subject",
+                "subjectName": acc.subject_name,
+                "subjectKey": subject_key(acc.subject_name),
+                "reason": reason,
+                "evidenceSummary": evidence_summary,
+                "sourceLanes": lane_list,
+                "suggestedAction": DEFAULT_SUGGESTED_ACTION,
+                "missingInfo": list(DEFAULT_MISSING_INFO),
+                "publicSafetyNotes": list(DEFAULT_PUBLIC_SAFETY_NOTES) + [
+                    "BNL dynamic discovery is review-only and does not confirm identity, aliases, or publication readiness."
+                ],
+                "recommendedCategory": acc.category,
+                "confidence": confidence,
+                "createdBy": "bnl",
+                "ingestSource": DISCOVERY_INGEST_SOURCE,
+                "ingestKey": f"bnl:dossier:{DISCOVERY_INGEST_SOURCE}:{acc.category}:{subject_key(acc.subject_name)}:{'-'.join(lane_list)}:{evidence_hash}",
+            }
+        )
+        candidates.append({"subjectName": acc.subject_name, "category": acc.category, "score": acc.score, "payload": payload})
+
+    candidates.sort(key=lambda row: (-int(row.get("score") or 0), str(row.get("subjectName") or "").lower()))
+    deduped: list[dict[str, Any]] = []
+    seen_keys: set[str] = set()
+    duplicate_count = 0
+    for candidate in candidates:
+        key = candidate["payload"]["ingestKey"]
+        if key in seen_keys:
+            duplicate_count += 1
+            continue
+        seen_keys.add(key)
+        deduped.append(candidate)
+        if len(deduped) >= max_candidates:
+            break
+
+    return {
+        "lanes": requested_lanes,
+        "sourceItemCount": len(source_items),
+        "candidateCount": len(deduped),
+        "withheldCount": withheld_count + max(0, len(candidates) - len(deduped) - duplicate_count),
+        "duplicateCount": duplicate_count,
+        "candidates": deduped,
+        "payloads": [candidate["payload"] for candidate in deduped],
+    }

--- a/bnl_dossier_recommendations.py
+++ b/bnl_dossier_recommendations.py
@@ -40,6 +40,7 @@ SUPPORTED_PAYLOAD_FIELDS = {
     "recommendedIdentityAuthority",
     "createdBy",
     "ingestKey",
+    "ingestSource",
 }
 _SAFE_LANE_PATTERN = re.compile(r"[^a-z0-9_-]+")
 

--- a/tests/test_dossier_recommendations.py
+++ b/tests/test_dossier_recommendations.py
@@ -1,11 +1,14 @@
+import asyncio
 import json
 import os
 import unittest
 import urllib.error
+from unittest import mock
 
 os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
 
+import bnl_dossier_candidate_discovery as discovery
 import bnl_dossier_recommendations as dossier
 import bnl_dossier_source_packets as packets
 import bnl01_bot
@@ -286,6 +289,175 @@ class DossierRecommendationPermissionTests(unittest.TestCase):
 
         mod = self.Member(102, roles=[self.Role(555)])
         self.assertTrue(bnl01_bot.can_send_dossier_recommendation(mod, mod, self.Guild()))
+
+
+
+class DossierCandidateDiscoveryTests(unittest.TestCase):
+    def test_discovers_candidate_subjects_from_approved_lane_text(self):
+        def broadcast_reader(guild_id, public_only=False, limit=500):
+            self.assertEqual(guild_id, 123)
+            self.assertFalse(public_only)
+            return [
+                ("2026-05-29", "Signal Witch came up as a recurring lore entity and source file candidate. Signal Witch should have a dossier review."),
+                ("2026-05-22", "Signal Witch returned as a priority signal in broadcast memory."),
+            ]
+
+        result = discovery.discover_candidate_recommendations(
+            123,
+            ["rd_context", "broadcast_memory"],
+            broadcast_memory_reader=broadcast_reader,
+            rd_context=[{"main_subject": "Priority Signal", "user_request": "Priority Signal deserves a source file."}],
+        )
+        names = [candidate["subjectName"] for candidate in result["candidates"]]
+        self.assertIn("Signal Witch", names)
+        payload = next(payload for payload in result["payloads"] if payload["subjectName"] == "Signal Witch")
+        self.assertEqual(payload["type"], "new_subject")
+        self.assertEqual(payload["createdBy"], "bnl")
+        self.assertEqual(payload["ingestSource"], discovery.DISCOVERY_INGEST_SOURCE)
+        self.assertIn("broadcast_memory", payload["sourceLanes"])
+        self.assertIn("review", payload["reason"].lower())
+
+    def test_discovery_parse_command_has_no_subject_argument(self):
+        matched, options, error = discovery.parse_dossier_discovery_command(
+            "!bnl dossier discover candidates | lanes=rd_context,broadcast_memory | limit=7 | dry_run=true"
+        )
+        self.assertTrue(matched)
+        self.assertFalse(error)
+        self.assertEqual(options["lanes"], ["rd_context", "broadcast_memory"])
+        self.assertEqual(options["limit"], 7)
+        self.assertTrue(options["dry_run"])
+
+    def test_deterministic_ingest_keys_and_dedupes_repeated_candidates(self):
+        rows = [
+            ("2026-05-29", "Signal Witch needs a source file. Signal Witch is a recurring candidate."),
+            ("2026-05-22", "Signal Witch needs a source file. Signal Witch is a recurring candidate."),
+        ]
+        first = discovery.discover_candidate_recommendations(123, ["broadcast_memory"], broadcast_memory_reader=lambda *a, **k: rows)
+        second = discovery.discover_candidate_recommendations(123, ["broadcast_memory"], broadcast_memory_reader=lambda *a, **k: rows)
+        signal_payloads = [payload for payload in first["payloads"] if payload["subjectName"] == "Signal Witch"]
+        self.assertEqual(len(signal_payloads), 1)
+        self.assertEqual(signal_payloads[0]["ingestKey"], next(payload for payload in second["payloads"] if payload["subjectName"] == "Signal Witch")["ingestKey"])
+        self.assertTrue(signal_payloads[0]["ingestKey"].startswith("bnl:dossier:bnl_dynamic_candidate_discovery:"))
+
+    def test_withholds_low_confidence_one_off_noise(self):
+        result = discovery.discover_candidate_recommendations(
+            123,
+            ["broadcast_memory"],
+            broadcast_memory_reader=lambda *a, **k: [("2026-05-29", "A one-off mention of Sheila happened once.")],
+        )
+        self.assertEqual(result["payloads"], [])
+        self.assertGreaterEqual(result["withheldCount"], 1)
+
+    def test_ignores_unsupported_lanes_and_does_not_scan_unapproved_sources(self):
+        result = discovery.discover_candidate_recommendations(
+            123,
+            ["member_activity_events", "memory_tiers", "broadcast_memory"],
+            broadcast_memory_reader=lambda *a, **k: [("2026-05-29", "ShadowsPit needs a source file. ShadowsPit is recurring.")],
+        )
+        self.assertEqual(result["lanes"], ["broadcast_memory"])
+        self.assertTrue(all(payload["sourceLanes"] == ["broadcast_memory"] for payload in result["payloads"]))
+
+    def test_evidence_snippets_are_capped_and_redacted(self):
+        raw = "Signal Witch needs a source file. " + "context " * 90 + "<@123456789012345678> 123456789012345678 https://private.example/path user@example.com"
+        result = discovery.discover_candidate_recommendations(
+            123,
+            ["broadcast_memory"],
+            broadcast_memory_reader=lambda *a, **k: [("2026-05-29", raw), ("2026-05-22", "Signal Witch recurring source file candidate.")],
+        )
+        payload = next(payload for payload in result["payloads"] if payload["subjectName"] == "Signal Witch")
+        self.assertLessEqual(len(payload["evidenceSummary"]), packets.MAX_EVIDENCE_SUMMARY_LENGTH)
+        self.assertNotIn("123456789012345678", payload["evidenceSummary"])
+        self.assertNotIn("private.example", payload["evidenceSummary"])
+        self.assertNotIn("user@example.com", payload["evidenceSummary"])
+
+    def test_discovery_module_has_no_separate_workflow_or_scanning_constructs(self):
+        with open("bnl_dossier_candidate_discovery.py", encoding="utf-8") as handle:
+            source = handle.read()
+        forbidden = [
+            "history(",
+            "member_activity_events",
+            "memory_tiers",
+            "create_source_file",
+            "create_draft",
+            "publish_dossier",
+            "auto_confirm",
+            "merge_source",
+            "send_dossier_recommendation",
+            "@tasks.loop",
+        ]
+        for token in forbidden:
+            self.assertNotIn(token, source)
+
+    def test_diagnostics_expose_safe_candidate_discovery_metadata(self):
+        diag = bnl01_bot.build_dossier_recommendation_diagnostics()
+        self.assertTrue(diag["candidate_discovery_available"])
+        self.assertFalse(diag["candidate_discovery_enabled"])
+        self.assertEqual(diag["candidate_discovery_approved_lanes"], ["rd_context", "broadcast_memory"])
+        self.assertNotIn("token", json.dumps(diag.get("candidate_discovery_last_source_lanes", [])).lower())
+
+
+class DossierDiscoveryRoutingTests(unittest.TestCase):
+    class Guild:
+        id = 123
+        owner_id = 100
+        def get_member(self, user_id):
+            return None
+
+    class Author:
+        def __init__(self, user_id):
+            self.id = user_id
+            self.guild_permissions = DossierRecommendationPermissionTests.Perms()
+            self.roles = []
+
+    class Channel:
+        id = 1369051635657084970
+        name = "research-and-development"
+
+    class Message:
+        def __init__(self, user_id=999):
+            self.author = DossierDiscoveryRoutingTests.Author(user_id)
+            self.guild = DossierDiscoveryRoutingTests.Guild()
+            self.channel = DossierDiscoveryRoutingTests.Channel()
+            self.replies = []
+        async def reply(self, text):
+            self.replies.append(text)
+
+    def test_unauthorized_users_cannot_run_discovery(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        message = self.Message(user_id=101)
+        handled = asyncio.run(bnl01_bot.maybe_handle_dossier_recommendation_command(message, "!bnl dossier discover candidates"))
+        self.assertTrue(handled)
+        self.assertIn("operator-only", message.replies[-1])
+
+    def test_dry_run_operator_trigger_does_not_send_recommendations(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        message = self.Message(user_id=999)
+        fake_discovery = {
+            "candidates": [{"subjectName": "Signal Witch", "category": "new_source_file_candidate", "payload": {"subjectName": "Signal Witch"}}],
+            "payloads": [{"subjectName": "Signal Witch"}],
+            "withheldCount": 0,
+            "duplicateCount": 0,
+        }
+        with mock.patch.object(bnl01_bot, "discover_candidate_recommendations", return_value=fake_discovery) as discover_mock, \
+             mock.patch.object(bnl01_bot, "send_dossier_recommendation") as send_mock:
+            handled = asyncio.run(bnl01_bot.maybe_handle_dossier_recommendation_command(message, "!bnl dossier discover candidates | dry_run=true"))
+        self.assertTrue(handled)
+        discover_mock.assert_called_once()
+        send_mock.assert_not_called()
+        self.assertIn("Nothing sent", message.replies[-1])
+
+    def test_command_sends_normal_review_only_recommendations_when_threshold_met(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        message = self.Message(user_id=999)
+        fake_payload = {"type": "new_subject", "subjectName": "Signal Witch", "reason": "Review only", "sourceLanes": ["broadcast_memory"]}
+        fake_discovery = {"candidates": [{"subjectName": "Signal Witch", "payload": fake_payload}], "payloads": [fake_payload], "withheldCount": 2, "duplicateCount": 0}
+        with mock.patch.object(bnl01_bot, "discover_candidate_recommendations", return_value=fake_discovery), \
+             mock.patch.object(bnl01_bot, "send_dossier_recommendation", return_value={"ok": True, "duplicate": False, "status": 200}) as send_mock:
+            handled = asyncio.run(bnl01_bot.maybe_handle_dossier_recommendation_command(message, "!bnl dossier discover candidates | limit=1"))
+        self.assertTrue(handled)
+        send_mock.assert_called_once_with(fake_payload)
+        self.assertIn("1 recommendations sent", message.replies[-1])
+        self.assertIn("2 withheld", message.replies[-1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Provide a safe, operator-triggered discovery layer so BNL can autonomously surface dossier/source-file candidates from approved source-safe lanes without creating new workflows or automatically publishing.
- Keep discovered candidates flowing into the existing review-only dossier recommendation pipeline so admins can review/attach/convert using the website inbox and existing BNL Source File process.
- Preserve strict safety boundaries by limiting sources, redacting evidence, withholding low-confidence noise, and exposing only non-sensitive diagnostics.

### Description

- Added `bnl_dossier_candidate_discovery.py`, a narrow discovery module that reads only approved v1 lanes (`rd_context`, `broadcast_memory`), extracts candidate subjects conservatively, caps/redacts snippets, scores/withholds low-confidence items, and builds normal dossier recommendation payloads with `ingestSource=bnl_dynamic_candidate_discovery` and deterministic `ingestKey` values.
- Implemented the operator command parser `parse_dossier_discovery_command` and the trigger `!bnl dossier discover candidates [| lanes=rd_context,broadcast_memory] [| limit=10] [| dry_run=true]` with a `dry_run` mode that reports counts/top names without sending recommendations.
- Wired discovery into the bot via `maybe_handle_dossier_discovery_command` and integrated it into `maybe_handle_dossier_recommendation_command` so discovered payloads are sent through the existing `send_dossier_recommendation` path (no new candidate lane or special records are created).
- Added safe diagnostics and state fields to `build_dossier_recommendation_diagnostics` and owner diagnostics output (availability, approved lanes, last run time, sent/duplicate/withheld counts, last mode), and extended `SUPPORTED_PAYLOAD_FIELDS` to allow non-sensitive `ingestSource` provenance.

### Testing

- Ran unit tests with `python -m unittest discover -s tests -v` and all tests (including new discovery tests) passed.
- Compiled runtime modules with `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py` with no syntax errors.
- Ran repository checks `git diff --check` with no whitespace/errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b51575e848321899613174750b575)