### PR TITLE
Fix dynamic dossier discovery payload contract and tighten weak-subject extraction

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -473,7 +473,10 @@ _last_candidate_discovery_run_time = "never"
 _last_candidate_discovery_sent_count = 0
 _last_candidate_discovery_duplicate_count = 0
 _last_candidate_discovery_withheld_count = 0
+_last_candidate_discovery_failed_count = 0
 _last_candidate_discovery_error_status = "none"
+_last_candidate_discovery_first_failure_status = "none"
+_last_candidate_discovery_rejected_subjects_count = 0
 _last_candidate_discovery_source_lanes = []
 _last_candidate_discovery_mode = "none"
 BNL_CONTROL_FLAGS_TTL_SECONDS = 300
@@ -3973,7 +3976,10 @@ def build_dossier_recommendation_diagnostics() -> dict:
         "candidate_discovery_last_sent_count": _last_candidate_discovery_sent_count,
         "candidate_discovery_last_duplicate_count": _last_candidate_discovery_duplicate_count,
         "candidate_discovery_last_withheld_count": _last_candidate_discovery_withheld_count,
+        "candidate_discovery_last_failed_count": _last_candidate_discovery_failed_count,
         "candidate_discovery_last_error_status": _last_candidate_discovery_error_status,
+        "candidate_discovery_last_first_failure_status": _last_candidate_discovery_first_failure_status,
+        "candidate_discovery_last_rejected_subjects_count": _last_candidate_discovery_rejected_subjects_count,
         "candidate_discovery_last_source_lanes": list(_last_candidate_discovery_source_lanes),
         "candidate_discovery_last_mode": _last_candidate_discovery_mode,
     }
@@ -4001,7 +4007,9 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
     global _last_dossier_recommendation_status
     global _last_candidate_discovery_run_time, _last_candidate_discovery_sent_count
     global _last_candidate_discovery_duplicate_count, _last_candidate_discovery_withheld_count
-    global _last_candidate_discovery_error_status, _last_candidate_discovery_source_lanes, _last_candidate_discovery_mode
+    global _last_candidate_discovery_failed_count, _last_candidate_discovery_first_failure_status
+    global _last_candidate_discovery_rejected_subjects_count, _last_candidate_discovery_error_status
+    global _last_candidate_discovery_source_lanes, _last_candidate_discovery_mode
 
     matched, options, parse_error = parse_dossier_discovery_command(clean_content)
     if not matched:
@@ -4026,7 +4034,10 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
     _last_candidate_discovery_run_time = datetime.now(timezone.utc).isoformat()
     _last_candidate_discovery_source_lanes = list(lanes)
     _last_candidate_discovery_mode = "dry_run" if dry_run else "command"
+    _last_candidate_discovery_failed_count = 0
     _last_candidate_discovery_error_status = "none"
+    _last_candidate_discovery_first_failure_status = "none"
+    _last_candidate_discovery_rejected_subjects_count = 0
 
     discovery = discover_candidate_recommendations(
         getattr(message.guild, "id", None),
@@ -4043,14 +4054,17 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
         _last_candidate_discovery_sent_count = 0
         _last_candidate_discovery_duplicate_count = duplicate_count
         _last_candidate_discovery_withheld_count = withheld
+        _last_candidate_discovery_rejected_subjects_count = withheld
         names = [str(candidate.get("subjectName") or "subject")[:40] for candidate in candidates[:5]]
         suffix = f" Top candidates: {', '.join(names)}." if names else ""
         await message.reply(f"Dossier discovery dry run: {len(candidates)} candidates found.{suffix} Nothing sent.")
         return True
 
     sent_count = 0
+    failed_count = 0
     send_duplicates = duplicate_count
     first_error = "none"
+    first_failure_status = "none"
     for candidate in candidates:
         payload = candidate.get("payload") or {}
         result = await asyncio.to_thread(send_dossier_recommendation, payload)
@@ -4058,17 +4072,30 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
             send_duplicates += 1
         elif result.get("ok"):
             sent_count += 1
-        elif first_error == "none":
-            first_error = f"failed:{result.get('status') or 'no_status'}"
+        else:
+            failed_count += 1
+            status = result.get("status") or "no_status"
+            if first_error == "none":
+                first_error = f"failed:{status}"
+                first_failure_status = f"HTTP {status}" if status != "no_status" else "no_status"
 
     _last_candidate_discovery_sent_count = sent_count
+    _last_candidate_discovery_failed_count = failed_count
     _last_candidate_discovery_duplicate_count = send_duplicates
     _last_candidate_discovery_withheld_count = withheld
+    _last_candidate_discovery_rejected_subjects_count = withheld
     _last_candidate_discovery_error_status = first_error
-    _last_dossier_recommendation_status = f"candidate_discovery_sent:{sent_count}:duplicates:{send_duplicates}:withheld:{withheld}" if first_error == "none" else first_error
+    _last_candidate_discovery_first_failure_status = first_failure_status
+    _last_dossier_recommendation_status = (
+        f"candidate_discovery_sent:{sent_count}:duplicates:{send_duplicates}:withheld:{withheld}:failed:{failed_count}"
+        if first_error == "none"
+        else first_error
+    )
+    failure_suffix = f" First failure: {first_failure_status}." if failed_count and first_failure_status != "none" else ""
     await message.reply(
         f"Dossier discovery complete: {sent_count} recommendations sent, "
-        f"{send_duplicates} duplicates skipped, {withheld} withheld for low confidence."
+        f"{send_duplicates} duplicates skipped, {withheld} withheld, {failed_count} failed."
+        f"{failure_suffix}"
     )
     return True
 
@@ -11779,7 +11806,10 @@ async def bnl_source_check(interaction: discord.Interaction):
         f"- candidate_discovery_last_sent_count: `{dossier_diag['candidate_discovery_last_sent_count']}`",
         f"- candidate_discovery_last_duplicate_count: `{dossier_diag['candidate_discovery_last_duplicate_count']}`",
         f"- candidate_discovery_last_withheld_count: `{dossier_diag['candidate_discovery_last_withheld_count']}`",
+        f"- candidate_discovery_last_failed_count: `{dossier_diag['candidate_discovery_last_failed_count']}`",
         f"- candidate_discovery_last_error_status: `{dossier_diag['candidate_discovery_last_error_status']}`",
+        f"- candidate_discovery_last_first_failure_status: `{dossier_diag['candidate_discovery_last_first_failure_status']}`",
+        f"- candidate_discovery_last_rejected_subjects_count: `{dossier_diag['candidate_discovery_last_rejected_subjects_count']}`",
         f"- candidate_discovery_last_source_lanes: `{','.join(dossier_diag['candidate_discovery_last_source_lanes']) or 'none'}`",
         f"- candidate_discovery_last_mode: `{dossier_diag['candidate_discovery_last_mode']}`",
         f"- _bnl_control_flags_last_source_url: `{flags_source}`",
@@ -12010,7 +12040,10 @@ async def bnl_status(interaction: discord.Interaction):
         f"- candidate_discovery_last_sent_count: `{dossier_diag['candidate_discovery_last_sent_count']}`",
         f"- candidate_discovery_last_duplicate_count: `{dossier_diag['candidate_discovery_last_duplicate_count']}`",
         f"- candidate_discovery_last_withheld_count: `{dossier_diag['candidate_discovery_last_withheld_count']}`",
+        f"- candidate_discovery_last_failed_count: `{dossier_diag['candidate_discovery_last_failed_count']}`",
         f"- candidate_discovery_last_error_status: `{dossier_diag['candidate_discovery_last_error_status']}`",
+        f"- candidate_discovery_last_first_failure_status: `{dossier_diag['candidate_discovery_last_first_failure_status']}`",
+        f"- candidate_discovery_last_rejected_subjects_count: `{dossier_diag['candidate_discovery_last_rejected_subjects_count']}`",
         f"- candidate_discovery_last_source_lanes: `{','.join(dossier_diag['candidate_discovery_last_source_lanes']) or 'none'}`",
         f"- candidate_discovery_last_mode: `{dossier_diag['candidate_discovery_last_mode']}`",
         f"- read_model_enabled: `{'yes' if read_model_diag.get('enabled') else 'no'}`",

--- a/bnl_dossier_candidate_discovery.py
+++ b/bnl_dossier_candidate_discovery.py
@@ -13,7 +13,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
-from bnl_dossier_recommendations import build_dossier_recommendation_payload
+from bnl_dossier_recommendations import VALID_DOSSIER_CATEGORIES, build_dossier_recommendation_payload
 from bnl_dossier_source_packets import (
     APPROVED_SOURCE_LANES,
     DEFAULT_MISSING_INFO,
@@ -30,6 +30,7 @@ DEFAULT_DISCOVERY_LANES = ["rd_context", "broadcast_memory"]
 MAX_DISCOVERY_LIMIT = 25
 DEFAULT_DISCOVERY_LIMIT = 10
 MIN_CANDIDATE_SCORE = 3
+TITLE_ONLY_MIN_SCORE = 5
 MAX_REASON_LENGTH = 300
 _ALLOWED_DISCOVERY_LANES = set(DEFAULT_DISCOVERY_LANES) & set(APPROVED_SOURCE_LANES)
 _DISCORD_MENTION_PATTERN = re.compile(r"<[@#!&]?[0-9]{5,}>")
@@ -60,6 +61,41 @@ _STOP_PHRASES = {
     "Public Safe",
 }
 
+_WEAK_SUBJECT_TERMS = {
+    "next",
+    "add",
+    "origin",
+    "bit",
+    "signal",
+    "source",
+    "file",
+    "candidate",
+    "review",
+    "lane",
+    "memory",
+    "public",
+    "private",
+    "context",
+    "system",
+    "entity",
+    "recommendation",
+    "inbox",
+    "subject",
+    "name",
+    "admin",
+    "owner",
+    "operator",
+    "mod",
+    "user",
+    "channel",
+    "message",
+}
+
+_KNOWN_ONE_WORD_SUBJECTS = {"cliff", "sheila", "shadowspit"}
+_SUBJECT_WORD = r"[A-Z0-9][A-Za-z0-9'_-]*"
+_SUBJECT_PHRASE = rf"{_SUBJECT_WORD}(?:\s+{_SUBJECT_WORD}){{0,4}}"
+_EXPLICIT_SUBJECT_BOUNDARY = r"(?=$|[.?!,;:]|\s+(?:because|and|with|from|in|as|that|so|when|while|but|for review)\b)"
+
 _CATEGORY_TERMS = (
     ("identity_alias_review", re.compile(r"\b(alias|alternate name|aka|same as|duplicate|identity|connect(?:s|ed)? to)\b", re.I)),
     ("system_concept_candidate", re.compile(r"\b(system|concept|protocol|workflow|lane|interface|program)\b", re.I)),
@@ -83,6 +119,7 @@ class CandidateAccumulator:
     evidence: list[dict[str, str]] = field(default_factory=list)
     mentions: int = 0
     explicit_hits: int = 0
+    title_hits: int = 0
     score: int = 0
 
 
@@ -207,8 +244,9 @@ def collect_discovery_source_items(
 def _explicit_subjects(text: str) -> list[str]:
     subjects: list[str] = []
     patterns = (
-        r"(?:source file|dossier|candidate|review|alias review|identity review)\s+(?:for|on|about)\s+([A-Z0-9][A-Za-z0-9'_-]*(?:\s+[A-Z0-9][A-Za-z0-9'_-]*){0,4})",
-        r"([A-Z0-9][A-Za-z0-9'_-]*(?:\s+[A-Z0-9][A-Za-z0-9'_-]*){0,4})\s+(?:needs|deserves|should have|should get|may need)\s+(?:a\s+)?(?:source file|dossier|alias review|identity review)",
+        rf"\b(?:source file|dossier|alias review|identity review)\s+(?:for|on|about)\s+({_SUBJECT_PHRASE}){_EXPLICIT_SUBJECT_BOUNDARY}",
+        rf"\b({_SUBJECT_PHRASE})\s+(?:needs|deserves|should have|should get|may need)\s+(?:a\s+)?(?:source file|dossier|alias review|identity review)\b",
+        rf"\b({_SUBJECT_PHRASE})\s+is\s+(?:an?\s+)?(?:recurring|repeated|priority)\s+(?:entity|character|candidate|subject)\b",
     )
     for pattern in patterns:
         for match in re.finditer(pattern, text or "", flags=re.I):
@@ -231,15 +269,55 @@ def _clean_subject(candidate: str) -> str:
 
 def _valid_subject(candidate: str) -> bool:
     subject = _clean_subject(candidate)
+    normalized = subject.lower()
     if not subject or len(subject) < 3 or subject in _STOP_PHRASES:
         return False
-    if subject.lower() in {item.lower() for item in _STOP_PHRASES}:
+    if normalized in {item.lower() for item in _STOP_PHRASES}:
+        return False
+    if normalized in _WEAK_SUBJECT_TERMS:
+        return False
+    words = re.findall(r"[A-Za-z0-9]+", normalized)
+    if words and all(word in _WEAK_SUBJECT_TERMS for word in words):
+        return False
+    if normalized in {"barcode", "barcode radio", "barcode network"}:
         return False
     if re.fullmatch(r"\d+", subject):
         return False
-    if subject.lower().startswith(("do not", "public safe", "source lane")):
+    if subject.lower().startswith(("do not", "public safe", "source lane", "in ", "on ", "at ", "for ", "with ")):
         return False
     return bool(re.search(r"[A-Za-z]", subject))
+
+
+def _has_strong_evidence(acc: CandidateAccumulator) -> bool:
+    if acc.explicit_hits > 0:
+        return True
+    normalized = acc.subject_name.lower()
+    if len(acc.subject_name.split()) == 1 and normalized not in _KNOWN_ONE_WORD_SUBJECTS:
+        return False
+    if acc.mentions < 2 or acc.score < TITLE_ONLY_MIN_SCORE:
+        return False
+    return any(
+        re.search(r"\b(recurring|repeated|priority|source file|dossier|candidate|alias review|identity review)\b", item.get("summary") or "", flags=re.I)
+        for item in acc.evidence
+    )
+
+
+def _payload_taxonomy(acc: CandidateAccumulator) -> dict[str, Any]:
+    if acc.category == "identity_alias_review":
+        return {"type": "identity_link"}
+    if acc.category == "system_concept_candidate":
+        return {
+            "type": "new_subject",
+            "recommendedCategory": "Interface",
+            "recommendedKind": "system",
+            "recommendedEcosystemLane": "infrastructure",
+            "recommendedIdentityAuthority": "mixed_or_unclear",
+        }
+    return {
+        "type": "new_subject",
+        "recommendedCategory": "Entity",
+        "recommendedIdentityAuthority": "mixed_or_unclear",
+    }
 
 
 def _category_for_text(text: str) -> str:
@@ -287,10 +365,10 @@ def discover_candidate_recommendations(
     for item in source_items:
         text = item.text
         explicit = {_clean_subject(subject) for subject in _explicit_subjects(text) if _valid_subject(subject)}
-        candidates = list(explicit)
-        candidates.extend(_clean_subject(subject) for subject in _title_subjects(text) if _valid_subject(subject))
+        candidate_sources: list[tuple[str, bool]] = [(subject, True) for subject in explicit]
+        candidate_sources.extend((_clean_subject(subject), False) for subject in _title_subjects(text) if _valid_subject(subject))
         seen_in_item: set[str] = set()
-        for subject in candidates:
+        for subject, is_explicit in candidate_sources:
             key = subject_key(subject)
             if key in seen_in_item:
                 continue
@@ -301,21 +379,23 @@ def discover_candidate_recommendations(
                 accumulators[key] = acc
             acc.mentions += 1
             acc.lanes.add(item.lane)
-            if subject in explicit:
+            if is_explicit:
                 acc.explicit_hits += 1
+            else:
+                acc.title_hits += 1
             category = _category_for_text(text)
             if acc.category == "new_source_file_candidate" or category != "new_source_file_candidate":
                 acc.category = category
             if len(acc.evidence) < 5:
                 acc.evidence.append({"lane": item.lane, "label": item.label, "summary": _safe_snippet(text), "sourceRef": item.source_ref})
-            acc.score += item.weight + (2 if subject in explicit else 0)
+            acc.score += item.weight + (2 if is_explicit else 0)
             if re.search(r"\b(recurring|repeated|important|priority|source file|dossier|candidate|alias review|identity review)\b", text, flags=re.I):
                 acc.score += 1
 
     candidates: list[dict[str, Any]] = []
     withheld_count = 0
     for acc in accumulators.values():
-        passed = acc.score >= MIN_CANDIDATE_SCORE and acc.evidence and acc.lanes
+        passed = acc.score >= MIN_CANDIDATE_SCORE and acc.evidence and acc.lanes and _has_strong_evidence(acc)
         if not passed:
             withheld_count += 1
             continue
@@ -328,9 +408,10 @@ def discover_candidate_recommendations(
         )
         evidence_summary = _evidence_summary(acc.evidence)
         evidence_hash = hashlib.sha256(f"{reason}\n{evidence_summary}".encode("utf-8")).hexdigest()[:8]
+        taxonomy = _payload_taxonomy(acc)
         payload = build_dossier_recommendation_payload(
             {
-                "type": "new_subject",
+                **taxonomy,
                 "subjectName": acc.subject_name,
                 "subjectKey": subject_key(acc.subject_name),
                 "reason": reason,
@@ -339,15 +420,17 @@ def discover_candidate_recommendations(
                 "suggestedAction": DEFAULT_SUGGESTED_ACTION,
                 "missingInfo": list(DEFAULT_MISSING_INFO),
                 "publicSafetyNotes": list(DEFAULT_PUBLIC_SAFETY_NOTES) + [
+                    f"Internal discovery classification: {acc.category}.",
                     "BNL dynamic discovery is review-only and does not confirm identity, aliases, or publication readiness."
                 ],
-                "recommendedCategory": acc.category,
                 "confidence": confidence,
                 "createdBy": "bnl",
                 "ingestSource": DISCOVERY_INGEST_SOURCE,
                 "ingestKey": f"bnl:dossier:{DISCOVERY_INGEST_SOURCE}:{acc.category}:{subject_key(acc.subject_name)}:{'-'.join(lane_list)}:{evidence_hash}",
             }
         )
+        if payload.get("recommendedCategory") and payload.get("recommendedCategory") not in VALID_DOSSIER_CATEGORIES:
+            payload.pop("recommendedCategory", None)
         candidates.append({"subjectName": acc.subject_name, "category": acc.category, "score": acc.score, "payload": payload})
 
     candidates.sort(key=lambda row: (-int(row.get("score") or 0), str(row.get("subjectName") or "").lower()))

--- a/bnl_dossier_recommendations.py
+++ b/bnl_dossier_recommendations.py
@@ -43,6 +43,8 @@ SUPPORTED_PAYLOAD_FIELDS = {
     "ingestSource",
 }
 _SAFE_LANE_PATTERN = re.compile(r"[^a-z0-9_-]+")
+VALID_DOSSIER_CATEGORIES = {"Entity", "Personnel", "Sponsor", "Interface", "Production"}
+
 
 
 def get_dossier_ingest_url(environ: dict[str, str] | None = None) -> str:
@@ -108,6 +110,8 @@ def build_dossier_recommendation_payload(payload: dict[str, Any]) -> dict[str, A
     cleaned["createdBy"] = str(cleaned.get("createdBy") or "bnl").strip() or "bnl"
     cleaned["confidence"] = str(cleaned.get("confidence") or "medium").strip() or "medium"
     cleaned["sourceLanes"] = _normalize_source_lanes(cleaned.get("sourceLanes"))
+    if cleaned.get("recommendedCategory") not in VALID_DOSSIER_CATEGORIES:
+        cleaned.pop("recommendedCategory", None)
 
     if cleaned.get("subjectName") is not None:
         cleaned["subjectName"] = str(cleaned.get("subjectName") or "").strip()

--- a/tests/test_dossier_recommendations.py
+++ b/tests/test_dossier_recommendations.py
@@ -317,6 +317,82 @@ class DossierCandidateDiscoveryTests(unittest.TestCase):
         self.assertIn("broadcast_memory", payload["sourceLanes"])
         self.assertIn("review", payload["reason"].lower())
 
+
+    def test_dynamic_discovery_payload_uses_valid_website_taxonomy(self):
+        rows = [("2026-05-29", "Anita Cable needs a source file. Anita Cable is a recurring entity.")]
+        result = discovery.discover_candidate_recommendations(123, ["broadcast_memory"], broadcast_memory_reader=lambda *a, **k: rows)
+        payload = next(payload for payload in result["payloads"] if payload["subjectName"] == "Anita Cable")
+
+        self.assertEqual(payload["type"], "new_subject")
+        self.assertEqual(payload["ingestSource"], discovery.DISCOVERY_INGEST_SOURCE)
+        self.assertEqual(payload.get("recommendedCategory"), "Entity")
+        self.assertNotIn(payload.get("recommendedCategory"), {"new_source_file_candidate", "system_concept_candidate", "identity_alias_review"})
+        self.assertIn("Internal discovery classification: new_source_file_candidate", " ".join(payload["publicSafetyNotes"]))
+
+    def test_system_concept_candidate_uses_interface_taxonomy(self):
+        result = discovery.discover_candidate_recommendations(
+            123,
+            ["broadcast_memory"],
+            broadcast_memory_reader=lambda *a, **k: [("2026-05-29", "Source file for Mac Modem. Mac Modem is a recurring interface system concept.")],
+        )
+        payload = next(payload for payload in result["payloads"] if payload["subjectName"] == "Mac Modem")
+
+        self.assertEqual(payload["type"], "new_subject")
+        self.assertEqual(payload.get("recommendedCategory"), "Interface")
+        self.assertEqual(payload.get("recommendedKind"), "system")
+        self.assertEqual(payload.get("recommendedEcosystemLane"), "infrastructure")
+        self.assertNotIn(payload.get("recommendedCategory"), {"new_source_file_candidate", "system_concept_candidate", "identity_alias_review"})
+
+    def test_identity_alias_review_is_review_only_identity_link(self):
+        result = discovery.discover_candidate_recommendations(
+            123,
+            ["broadcast_memory"],
+            broadcast_memory_reader=lambda *a, **k: [("2026-05-29", "Identity review for Anita Cable. Anita Cable may be an alias and needs identity review.")],
+        )
+        payload = next(payload for payload in result["payloads"] if payload["subjectName"] == "Anita Cable")
+
+        self.assertEqual(payload["type"], "identity_link")
+        self.assertNotIn("recommendedCategory", payload)
+        self.assertNotIn("recommendedKind", payload)
+        self.assertIn("Internal discovery classification: identity_alias_review", " ".join(payload["publicSafetyNotes"]))
+
+    def test_payload_builder_drops_invalid_recommended_category(self):
+        payload = dossier.build_dossier_recommendation_payload(
+            {
+                "type": "new_subject",
+                "subjectName": "Signal Witch",
+                "reason": "Review.",
+                "sourceLanes": ["rd_context"],
+                "recommendedCategory": "new_source_file_candidate",
+            }
+        )
+
+        self.assertNotIn("recommendedCategory", payload)
+
+    def test_weak_generic_subjects_are_withheld(self):
+        result = discovery.discover_candidate_recommendations(
+            123,
+            ["broadcast_memory"],
+            broadcast_memory_reader=lambda *a, **k: [
+                ("2026-05-29", "Source file for next. Add needs a source file. Origin deserves a dossier. Bit needs a source file."),
+                ("2026-05-22", "Next is a recurring entity. Origin needs a source file. Bit deserves a dossier."),
+            ],
+        )
+
+        self.assertEqual(result["payloads"], [])
+        self.assertGreaterEqual(result["withheldCount"], 0)
+
+    def test_explicit_legitimate_subjects_pass_with_strong_evidence(self):
+        rows = [
+            ("2026-05-29", "Anita Cable needs a source file. Anita Cable is a recurring entity."),
+            ("2026-05-22", "Source file for Signal Witch. Signal Witch deserves a dossier."),
+        ]
+        result = discovery.discover_candidate_recommendations(123, ["broadcast_memory"], broadcast_memory_reader=lambda *a, **k: rows)
+        names = {payload["subjectName"] for payload in result["payloads"]}
+
+        self.assertIn("Anita Cable", names)
+        self.assertIn("Signal Witch", names)
+
     def test_discovery_parse_command_has_no_subject_argument(self):
         matched, options, error = discovery.parse_dossier_discovery_command(
             "!bnl dossier discover candidates | lanes=rd_context,broadcast_memory | limit=7 | dry_run=true"
@@ -458,6 +534,32 @@ class DossierDiscoveryRoutingTests(unittest.TestCase):
         send_mock.assert_called_once_with(fake_payload)
         self.assertIn("1 recommendations sent", message.replies[-1])
         self.assertIn("2 withheld", message.replies[-1])
+
+    def test_failed_dynamic_sends_are_counted_in_operator_reply(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        message = self.Message(user_id=999)
+        payloads = [
+            {"type": "new_subject", "subjectName": "Anita Cable", "reason": "Review only", "sourceLanes": ["broadcast_memory"]},
+            {"type": "new_subject", "subjectName": "Signal Witch", "reason": "Review only", "sourceLanes": ["broadcast_memory"]},
+        ]
+        fake_discovery = {
+            "candidates": [{"subjectName": payload["subjectName"], "payload": payload} for payload in payloads],
+            "payloads": payloads,
+            "withheldCount": 4,
+            "duplicateCount": 0,
+        }
+        with mock.patch.object(bnl01_bot, "discover_candidate_recommendations", return_value=fake_discovery), \
+             mock.patch.object(bnl01_bot, "send_dossier_recommendation", return_value={"ok": False, "duplicate": False, "status": 400}):
+            handled = asyncio.run(bnl01_bot.maybe_handle_dossier_recommendation_command(message, "!bnl dossier discover candidates | limit=2"))
+
+        self.assertTrue(handled)
+        self.assertIn("0 recommendations sent", message.replies[-1])
+        self.assertIn("4 withheld", message.replies[-1])
+        self.assertIn("2 failed", message.replies[-1])
+        self.assertIn("First failure: HTTP 400", message.replies[-1])
+        diag = bnl01_bot.build_dossier_recommendation_diagnostics()
+        self.assertEqual(diag["candidate_discovery_last_failed_count"], 2)
+        self.assertEqual(diag["candidate_discovery_last_first_failure_status"], "HTTP 400")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Dynamic discovery sends internal labels as `recommendedCategory` which the website rejects, causing HTTP 400 failures. The discovery layer must emit website-safe taxonomy while preserving internal classification as safe metadata. 
- Discovery was extracting weak/generic one-word subjects and returning low-confidence recommendations; subject extraction rules need to be stricter to avoid noisy sends.

### Description
- Map internal discovery categories to website-safe recommendation payloads and avoid shipping internal labels as `recommendedCategory`: `new_source_file_candidate` -> `type=new_subject` + `recommendedCategory=Entity` (plus `recommendedIdentityAuthority=mixed_or_unclear`), `system_concept_candidate` -> `type=new_subject` + `recommendedCategory=Interface` + `recommendedKind=system` + `recommendedEcosystemLane=infrastructure` + `recommendedIdentityAuthority=mixed_or_unclear`, `identity_alias_review` -> `type=identity_link` (omits `recommendedCategory`/`recommendedKind`).
- Add an allowlist in the shared payload builder (`VALID_DOSSIER_CATEGORIES`) and drop any invalid `recommendedCategory` values before sending; keep `ingestSource = bnl_dynamic_candidate_discovery` and deterministic `ingestKey` behavior unchanged.
- Tighten subject extraction and evidence thresholds: prefer explicit phrases (e.g., "source file for X", "X needs a source file", "identity review for X"), block a list of weak/generic one-word subjects, require stronger evidence for bare title-case matches (title-only candidates need repeated/clear evidence), and require explicit hits or higher title-only score before releasing a candidate.
- Preserve internal discovery classification as safe metadata in `publicSafetyNotes` instead of using it for `recommendedCategory` so website ingest receives only safe taxonomy values.
- Improve operator feedback and diagnostics: discovery run Discord reply now reports sent/duplicates/withheld/failed counts and includes a safe first failure status (e.g., `First failure: HTTP 400`), and diagnostics expose `candidate_discovery_last_failed_count`, `candidate_discovery_last_first_failure_status`, and `candidate_discovery_last_rejected_subjects_count`.
- Files changed: `bnl_dossier_candidate_discovery.py`, `bnl_dossier_recommendations.py`, `bnl01_bot.py`, `tests/test_dossier_recommendations.py`.

### Testing
- Ran unit tests: `python -m unittest discover -s tests -v`; all tests passed (37 tests, OK).
- Ran static checks/compilation: `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py`; success.
- Ran `git diff --check` to ensure no whitespace/errors; no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b5a76e6608321bbf4bb8a10e8cfc6)