### PR TITLE
Loosen dynamic dossier discovery review thresholds

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -479,6 +479,11 @@ _last_candidate_discovery_first_failure_status = "none"
 _last_candidate_discovery_rejected_subjects_count = 0
 _last_candidate_discovery_source_lanes = []
 _last_candidate_discovery_mode = "none"
+_last_candidate_discovery_sendable_candidate_count = 0
+_last_candidate_discovery_withheld_reason_counts = {}
+_last_candidate_discovery_medium_confidence_count = 0
+_last_candidate_discovery_strong_confidence_count = 0
+_last_candidate_discovery_top_withheld_reason = "none"
 BNL_CONTROL_FLAGS_TTL_SECONDS = 300
 _bnl_control_flags_cache = None
 _bnl_control_flags_cached_at = None
@@ -3982,7 +3987,28 @@ def build_dossier_recommendation_diagnostics() -> dict:
         "candidate_discovery_last_rejected_subjects_count": _last_candidate_discovery_rejected_subjects_count,
         "candidate_discovery_last_source_lanes": list(_last_candidate_discovery_source_lanes),
         "candidate_discovery_last_mode": _last_candidate_discovery_mode,
+        "candidate_discovery_last_sendable_candidate_count": _last_candidate_discovery_sendable_candidate_count,
+        "candidate_discovery_last_withheld_reason_counts": dict(_last_candidate_discovery_withheld_reason_counts),
+        "candidate_discovery_last_medium_confidence_count": _last_candidate_discovery_medium_confidence_count,
+        "candidate_discovery_last_strong_confidence_count": _last_candidate_discovery_strong_confidence_count,
+        "candidate_discovery_last_top_withheld_reason": _last_candidate_discovery_top_withheld_reason,
     }
+
+
+def _humanize_discovery_reason(reason: str) -> str:
+    return str(reason or "unknown").replace("_", " ")
+
+
+def _format_withheld_reason_summary(reason_counts: dict, *, no_sent: bool = False) -> str:
+    counts = {str(k): int(v) for k, v in (reason_counts or {}).items() if int(v or 0) > 0}
+    if not counts:
+        return ""
+    ordered = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    if no_sent:
+        main = _humanize_discovery_reason(ordered[0][0])
+        return f" Main withheld reason: {main}. Try adding clearer source-file or recurring-entity notes to broadcast memory/R&D."
+    parts = [f"{count} {_humanize_discovery_reason(reason)}" for reason, count in ordered[:3]]
+    return f" Withheld: {', '.join(parts)}."
 
 
 def _safe_dossier_failure_reason(result: dict) -> str:
@@ -4010,6 +4036,9 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
     global _last_candidate_discovery_failed_count, _last_candidate_discovery_first_failure_status
     global _last_candidate_discovery_rejected_subjects_count, _last_candidate_discovery_error_status
     global _last_candidate_discovery_source_lanes, _last_candidate_discovery_mode
+    global _last_candidate_discovery_sendable_candidate_count, _last_candidate_discovery_withheld_reason_counts
+    global _last_candidate_discovery_medium_confidence_count, _last_candidate_discovery_strong_confidence_count
+    global _last_candidate_discovery_top_withheld_reason
 
     matched, options, parse_error = parse_dossier_discovery_command(clean_content)
     if not matched:
@@ -4038,6 +4067,11 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
     _last_candidate_discovery_error_status = "none"
     _last_candidate_discovery_first_failure_status = "none"
     _last_candidate_discovery_rejected_subjects_count = 0
+    _last_candidate_discovery_sendable_candidate_count = 0
+    _last_candidate_discovery_withheld_reason_counts = {}
+    _last_candidate_discovery_medium_confidence_count = 0
+    _last_candidate_discovery_strong_confidence_count = 0
+    _last_candidate_discovery_top_withheld_reason = "none"
 
     discovery = discover_candidate_recommendations(
         getattr(message.guild, "id", None),
@@ -4049,6 +4083,16 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
     candidates = discovery.get("candidates") or []
     withheld = int(discovery.get("withheldCount") or 0)
     duplicate_count = int(discovery.get("duplicateCount") or 0)
+    reason_counts = dict(discovery.get("withheldReasonCounts") or {})
+    sendable_count = int(discovery.get("sendableCandidateCount") or len(candidates))
+    medium_count = int(discovery.get("mediumConfidenceCount") or 0)
+    strong_count = int(discovery.get("strongConfidenceCount") or 0)
+    top_reason = str(discovery.get("topWithheldReason") or "none")
+    _last_candidate_discovery_sendable_candidate_count = sendable_count
+    _last_candidate_discovery_withheld_reason_counts = reason_counts
+    _last_candidate_discovery_medium_confidence_count = medium_count
+    _last_candidate_discovery_strong_confidence_count = strong_count
+    _last_candidate_discovery_top_withheld_reason = top_reason
 
     if dry_run:
         _last_candidate_discovery_sent_count = 0
@@ -4056,8 +4100,9 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
         _last_candidate_discovery_withheld_count = withheld
         _last_candidate_discovery_rejected_subjects_count = withheld
         names = [str(candidate.get("subjectName") or "subject")[:40] for candidate in candidates[:5]]
-        suffix = f" Top candidates: {', '.join(names)}." if names else ""
-        await message.reply(f"Dossier discovery dry run: {len(candidates)} candidates found.{suffix} Nothing sent.")
+        sendable_suffix = f" Sendable: {', '.join(names)}." if names else ""
+        main_suffix = f" Main withheld reason: {_humanize_discovery_reason(top_reason)}." if withheld and top_reason != "none" else ""
+        await message.reply(f"Dry run: {sendable_count} sendable, {withheld} withheld.{sendable_suffix}{main_suffix}")
         return True
 
     sent_count = 0
@@ -4092,11 +4137,15 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
         else first_error
     )
     failure_suffix = f" First failure: {first_failure_status}." if failed_count and first_failure_status != "none" else ""
-    await message.reply(
-        f"Dossier discovery complete: {sent_count} recommendations sent, "
-        f"{send_duplicates} duplicates skipped, {withheld} withheld, {failed_count} failed."
-        f"{failure_suffix}"
-    )
+    reason_suffix = _format_withheld_reason_summary(reason_counts, no_sent=(sent_count == 0 and send_duplicates == 0))
+    if sent_count == 0 and send_duplicates == 0:
+        summary = f"Dossier discovery complete: 0 sent, 0 duplicates, {withheld} withheld, {failed_count} failed."
+    else:
+        summary = (
+            f"Dossier discovery complete: {sent_count} recommendations sent, "
+            f"{send_duplicates} duplicates skipped, {withheld} withheld, {failed_count} failed."
+        )
+    await message.reply(f"{summary}{reason_suffix}{failure_suffix}")
     return True
 
 
@@ -11812,6 +11861,11 @@ async def bnl_source_check(interaction: discord.Interaction):
         f"- candidate_discovery_last_rejected_subjects_count: `{dossier_diag['candidate_discovery_last_rejected_subjects_count']}`",
         f"- candidate_discovery_last_source_lanes: `{','.join(dossier_diag['candidate_discovery_last_source_lanes']) or 'none'}`",
         f"- candidate_discovery_last_mode: `{dossier_diag['candidate_discovery_last_mode']}`",
+        f"- candidate_discovery_last_sendable_candidate_count: `{dossier_diag['candidate_discovery_last_sendable_candidate_count']}`",
+        f"- candidate_discovery_last_withheld_reason_counts: `{json.dumps(dossier_diag['candidate_discovery_last_withheld_reason_counts'], sort_keys=True)}`",
+        f"- candidate_discovery_last_medium_confidence_count: `{dossier_diag['candidate_discovery_last_medium_confidence_count']}`",
+        f"- candidate_discovery_last_strong_confidence_count: `{dossier_diag['candidate_discovery_last_strong_confidence_count']}`",
+        f"- candidate_discovery_last_top_withheld_reason: `{dossier_diag['candidate_discovery_last_top_withheld_reason']}`",
         f"- _bnl_control_flags_last_source_url: `{flags_source}`",
         f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` every `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}` min",
     ]
@@ -12046,6 +12100,11 @@ async def bnl_status(interaction: discord.Interaction):
         f"- candidate_discovery_last_rejected_subjects_count: `{dossier_diag['candidate_discovery_last_rejected_subjects_count']}`",
         f"- candidate_discovery_last_source_lanes: `{','.join(dossier_diag['candidate_discovery_last_source_lanes']) or 'none'}`",
         f"- candidate_discovery_last_mode: `{dossier_diag['candidate_discovery_last_mode']}`",
+        f"- candidate_discovery_last_sendable_candidate_count: `{dossier_diag['candidate_discovery_last_sendable_candidate_count']}`",
+        f"- candidate_discovery_last_withheld_reason_counts: `{json.dumps(dossier_diag['candidate_discovery_last_withheld_reason_counts'], sort_keys=True)}`",
+        f"- candidate_discovery_last_medium_confidence_count: `{dossier_diag['candidate_discovery_last_medium_confidence_count']}`",
+        f"- candidate_discovery_last_strong_confidence_count: `{dossier_diag['candidate_discovery_last_strong_confidence_count']}`",
+        f"- candidate_discovery_last_top_withheld_reason: `{dossier_diag['candidate_discovery_last_top_withheld_reason']}`",
         f"- read_model_enabled: `{'yes' if read_model_diag.get('enabled') else 'no'}`",
         f"- read_model_url_configured: `{'yes' if read_model_diag.get('url_configured') else 'no'}`",
         f"- read_model_cache_present: `{'yes' if read_model_diag.get('cache_present') else 'no'}`",

--- a/bnl_dossier_candidate_discovery.py
+++ b/bnl_dossier_candidate_discovery.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import re
 from dataclasses import dataclass, field
+from collections import Counter
 from typing import Any, Callable
 
 from bnl_dossier_recommendations import VALID_DOSSIER_CATEGORIES, build_dossier_recommendation_payload
@@ -31,6 +32,7 @@ MAX_DISCOVERY_LIMIT = 25
 DEFAULT_DISCOVERY_LIMIT = 10
 MIN_CANDIDATE_SCORE = 3
 TITLE_ONLY_MIN_SCORE = 5
+MEDIUM_CONTEXT_MIN_SCORE = 2
 MAX_REASON_LENGTH = 300
 _ALLOWED_DISCOVERY_LANES = set(DEFAULT_DISCOVERY_LANES) & set(APPROVED_SOURCE_LANES)
 _DISCORD_MENTION_PATTERN = re.compile(r"<[@#!&]?[0-9]{5,}>")
@@ -120,6 +122,7 @@ class CandidateAccumulator:
     mentions: int = 0
     explicit_hits: int = 0
     title_hits: int = 0
+    contextual_hits: int = 0
     score: int = 0
 
 
@@ -267,25 +270,40 @@ def _clean_subject(candidate: str) -> str:
     return cleaned[:80]
 
 
-def _valid_subject(candidate: str) -> bool:
+def _subject_rejection_reason(candidate: str) -> str:
     subject = _clean_subject(candidate)
     normalized = subject.lower()
-    if not subject or len(subject) < 3 or subject in _STOP_PHRASES:
-        return False
-    if normalized in {item.lower() for item in _STOP_PHRASES}:
-        return False
+    if not subject or len(subject) < 3:
+        return "invalid_subject_shape"
+    if subject in _STOP_PHRASES or normalized in {item.lower() for item in _STOP_PHRASES}:
+        return "weak_generic_subject"
     if normalized in _WEAK_SUBJECT_TERMS:
-        return False
+        return "weak_generic_subject"
     words = re.findall(r"[A-Za-z0-9]+", normalized)
     if words and all(word in _WEAK_SUBJECT_TERMS for word in words):
-        return False
+        return "weak_generic_subject"
+    if words and words[0] in _WEAK_SUBJECT_TERMS and words[0] not in {"signal"}:
+        return "weak_generic_subject"
     if normalized in {"barcode", "barcode radio", "barcode network"}:
-        return False
+        return "weak_generic_subject"
     if re.fullmatch(r"\d+", subject):
-        return False
+        return "invalid_subject_shape"
     if subject.lower().startswith(("do not", "public safe", "source lane", "in ", "on ", "at ", "for ", "with ")):
-        return False
-    return bool(re.search(r"[A-Za-z]", subject))
+        return "invalid_subject_shape"
+    if not re.search(r"[A-Za-z]", subject):
+        return "invalid_subject_shape"
+    return ""
+
+
+def _valid_subject(candidate: str) -> bool:
+    return not _subject_rejection_reason(candidate)
+
+
+def _has_contextual_evidence(acc: CandidateAccumulator) -> bool:
+    return acc.contextual_hits > 0 or any(
+        re.search(r"\b(recurring|repeated|priority|source file|dossier|candidate|alias review|identity review|entity|character|lore|track|review)\b", item.get("summary") or "", flags=re.I)
+        for item in acc.evidence
+    )
 
 
 def _has_strong_evidence(acc: CandidateAccumulator) -> bool:
@@ -296,10 +314,32 @@ def _has_strong_evidence(acc: CandidateAccumulator) -> bool:
         return False
     if acc.mentions < 2 or acc.score < TITLE_ONLY_MIN_SCORE:
         return False
-    return any(
-        re.search(r"\b(recurring|repeated|priority|source file|dossier|candidate|alias review|identity review)\b", item.get("summary") or "", flags=re.I)
-        for item in acc.evidence
-    )
+    return _has_contextual_evidence(acc)
+
+
+def _has_medium_evidence(acc: CandidateAccumulator) -> bool:
+    if not acc.evidence or not acc.lanes:
+        return False
+    normalized = acc.subject_name.lower()
+    if len(acc.subject_name.split()) == 1 and normalized not in _KNOWN_ONE_WORD_SUBJECTS:
+        return False
+    if acc.score < MEDIUM_CONTEXT_MIN_SCORE:
+        return False
+    return acc.mentions >= 2 or _has_contextual_evidence(acc)
+
+
+def _withheld_reason(acc: CandidateAccumulator) -> str:
+    if not _valid_subject(acc.subject_name):
+        return _subject_rejection_reason(acc.subject_name) or "invalid_subject_shape"
+    if not acc.lanes:
+        return "unsupported_lane"
+    if not acc.evidence:
+        return "insufficient_source_context"
+    if acc.title_hits and not acc.explicit_hits and not _has_contextual_evidence(acc):
+        return "title_only_low_evidence"
+    if acc.mentions < 2 and not _has_contextual_evidence(acc):
+        return "insufficient_source_context"
+    return "below_minimum_score"
 
 
 def _payload_taxonomy(acc: CandidateAccumulator) -> dict[str, Any]:
@@ -361,12 +401,26 @@ def discover_candidate_recommendations(
         rd_context=rd_context,
     )
     accumulators: dict[str, CandidateAccumulator] = {}
+    withheld_reasons: Counter[str] = Counter()
+
+    if not requested_lanes:
+        withheld_reasons["unsupported_lane"] += 1
 
     for item in source_items:
         text = item.text
-        explicit = {_clean_subject(subject) for subject in _explicit_subjects(text) if _valid_subject(subject)}
-        candidate_sources: list[tuple[str, bool]] = [(subject, True) for subject in explicit]
-        candidate_sources.extend((_clean_subject(subject), False) for subject in _title_subjects(text) if _valid_subject(subject))
+        candidate_sources: list[tuple[str, bool]] = []
+        for subject in _explicit_subjects(text):
+            reason = _subject_rejection_reason(subject)
+            if reason:
+                withheld_reasons[reason] += 1
+                continue
+            candidate_sources.append((_clean_subject(subject), True))
+        for subject in _title_subjects(text):
+            reason = _subject_rejection_reason(subject)
+            if reason:
+                withheld_reasons[reason] += 1
+                continue
+            candidate_sources.append((_clean_subject(subject), False))
         seen_in_item: set[str] = set()
         for subject, is_explicit in candidate_sources:
             key = subject_key(subject)
@@ -389,18 +443,25 @@ def discover_candidate_recommendations(
             if len(acc.evidence) < 5:
                 acc.evidence.append({"lane": item.lane, "label": item.label, "summary": _safe_snippet(text), "sourceRef": item.source_ref})
             acc.score += item.weight + (2 if is_explicit else 0)
-            if re.search(r"\b(recurring|repeated|important|priority|source file|dossier|candidate|alias review|identity review)\b", text, flags=re.I):
+            if re.search(r"\b(recurring|repeated|important|priority|source file|dossier|candidate|alias review|identity review|entity|character|lore|track|review)\b", text, flags=re.I):
+                acc.contextual_hits += 1
                 acc.score += 1
 
     candidates: list[dict[str, Any]] = []
-    withheld_count = 0
+    strong_count = 0
+    medium_count = 0
     for acc in accumulators.values():
-        passed = acc.score >= MIN_CANDIDATE_SCORE and acc.evidence and acc.lanes and _has_strong_evidence(acc)
-        if not passed:
-            withheld_count += 1
+        is_strong = acc.score >= MIN_CANDIDATE_SCORE and _has_strong_evidence(acc)
+        is_medium = not is_strong and _has_medium_evidence(acc)
+        if not (is_strong or is_medium):
+            withheld_reasons[_withheld_reason(acc)] += 1
             continue
+        if is_strong:
+            strong_count += 1
+        else:
+            medium_count += 1
         lane_list = [lane for lane in requested_lanes if lane in acc.lanes] or sorted(acc.lanes)
-        confidence = "high" if acc.score >= 7 and len(acc.lanes) > 1 else ("medium" if acc.score >= 4 else "low")
+        confidence = "high" if is_strong and acc.score >= 7 and len(acc.lanes) > 1 else ("medium" if acc.score >= 4 else "low")
         reason = _safe_snippet(
             f"BNL dynamic candidate discovery found {acc.subject_name} in approved source-safe lanes "
             f"({', '.join(lane_list)}) as {acc.category.replace('_', ' ')}. Review only; owner/admin must decide whether this becomes a source file, alias proposal, duplicate, or nothing.",
@@ -421,8 +482,10 @@ def discover_candidate_recommendations(
                 "missingInfo": list(DEFAULT_MISSING_INFO),
                 "publicSafetyNotes": list(DEFAULT_PUBLIC_SAFETY_NOTES) + [
                     f"Internal discovery classification: {acc.category}.",
-                    "BNL dynamic discovery is review-only and does not confirm identity, aliases, or publication readiness."
-                ],
+                    "BNL dynamic discovery is review-only and does not confirm identity, aliases, or publication readiness.",
+                ] + ([
+                    "Medium-confidence BNL discovery. Review before converting, merging, aliasing, drafting, or publishing."
+                ] if is_medium else []),
                 "confidence": confidence,
                 "createdBy": "bnl",
                 "ingestSource": DISCOVERY_INGEST_SOURCE,
@@ -431,7 +494,7 @@ def discover_candidate_recommendations(
         )
         if payload.get("recommendedCategory") and payload.get("recommendedCategory") not in VALID_DOSSIER_CATEGORIES:
             payload.pop("recommendedCategory", None)
-        candidates.append({"subjectName": acc.subject_name, "category": acc.category, "score": acc.score, "payload": payload})
+        candidates.append({"subjectName": acc.subject_name, "category": acc.category, "score": acc.score, "confidenceTier": "strong" if is_strong else "medium", "payload": payload})
 
     candidates.sort(key=lambda row: (-int(row.get("score") or 0), str(row.get("subjectName") or "").lower()))
     deduped: list[dict[str, Any]] = []
@@ -441,17 +504,31 @@ def discover_candidate_recommendations(
         key = candidate["payload"]["ingestKey"]
         if key in seen_keys:
             duplicate_count += 1
+            withheld_reasons["duplicate_internal_candidate"] += 1
             continue
         seen_keys.add(key)
         deduped.append(candidate)
         if len(deduped) >= max_candidates:
             break
 
+    limited_count = max(0, len(candidates) - len(deduped) - duplicate_count)
+    if limited_count:
+        withheld_reasons["below_minimum_score"] += limited_count
+    reason_counts = dict(sorted(withheld_reasons.items()))
+    top_withheld_reason = "none"
+    if withheld_reasons:
+        top_withheld_reason = sorted(withheld_reasons.items(), key=lambda item: (-item[1], item[0]))[0][0]
+
     return {
         "lanes": requested_lanes,
         "sourceItemCount": len(source_items),
         "candidateCount": len(deduped),
-        "withheldCount": withheld_count + max(0, len(candidates) - len(deduped) - duplicate_count),
+        "sendableCandidateCount": len(deduped),
+        "withheldCount": sum(withheld_reasons.values()),
+        "withheldReasonCounts": reason_counts,
+        "topWithheldReason": top_withheld_reason,
+        "mediumConfidenceCount": sum(1 for candidate in deduped if candidate.get("confidenceTier") == "medium"),
+        "strongConfidenceCount": sum(1 for candidate in deduped if candidate.get("confidenceTier") == "strong"),
         "duplicateCount": duplicate_count,
         "candidates": deduped,
         "payloads": [candidate["payload"] for candidate in deduped],

--- a/tests/test_dossier_recommendations.py
+++ b/tests/test_dossier_recommendations.py
@@ -318,6 +318,56 @@ class DossierCandidateDiscoveryTests(unittest.TestCase):
         self.assertIn("review", payload["reason"].lower())
 
 
+
+    def test_medium_confidence_non_generic_candidate_is_sent_review_only(self):
+        result = discovery.discover_candidate_recommendations(
+            123,
+            ["broadcast_memory"],
+            broadcast_memory_reader=lambda *a, **k: [("2026-05-29", "Anita Cable surfaced as a dossier candidate for source-file review.")],
+        )
+        payload = next(payload for payload in result["payloads"] if payload["subjectName"] == "Anita Cable")
+
+        self.assertEqual(payload["type"], "new_subject")
+        self.assertIn(payload["confidence"], {"low", "medium"})
+        self.assertEqual(payload.get("recommendedCategory"), "Entity")
+        self.assertIn("Medium-confidence BNL discovery. Review before converting, merging, aliasing, drafting, or publishing.", " ".join(payload["publicSafetyNotes"]))
+        self.assertEqual(result["mediumConfidenceCount"], 1)
+
+    def test_bare_title_case_one_off_remains_withheld_with_reason(self):
+        result = discovery.discover_candidate_recommendations(
+            123,
+            ["broadcast_memory"],
+            broadcast_memory_reader=lambda *a, **k: [("2026-05-29", "Anita Cable appeared once during a quiet recap.")],
+        )
+
+        self.assertEqual(result["payloads"], [])
+        self.assertGreaterEqual(result["withheldReasonCounts"].get("title_only_low_evidence", 0), 1)
+
+    def test_repeated_contextual_subject_passes_as_medium_confidence(self):
+        result = discovery.discover_candidate_recommendations(
+            None,
+            ["rd_context"],
+            rd_context=[
+                {"main_subject": "Signal Witch", "user_request": "Signal Witch noted in dossier context for source-lane review."},
+                {"main_subject": "Signal Witch", "user_request": "Signal Witch returned in entity context for later review."},
+            ],
+        )
+        payload = next(payload for payload in result["payloads"] if payload["subjectName"] == "Signal Witch")
+
+        self.assertEqual(payload["confidence"], "medium")
+        self.assertEqual(result["mediumConfidenceCount"], 1)
+
+    def test_weak_generic_subject_reasons_are_tracked(self):
+        result = discovery.discover_candidate_recommendations(
+            123,
+            ["broadcast_memory"],
+            broadcast_memory_reader=lambda *a, **k: [("2026-05-29", "Source file for next. Add needs a source file. Owner deserves a dossier.")],
+        )
+
+        self.assertEqual(result["payloads"], [])
+        self.assertGreaterEqual(result["withheldReasonCounts"].get("weak_generic_subject", 0), 3)
+        self.assertNotIn("evidence", json.dumps(result["withheldReasonCounts"]).lower())
+
     def test_dynamic_discovery_payload_uses_valid_website_taxonomy(self):
         rows = [("2026-05-29", "Anita Cable needs a source file. Anita Cable is a recurring entity.")]
         result = discovery.discover_candidate_recommendations(123, ["broadcast_memory"], broadcast_memory_reader=lambda *a, **k: rows)
@@ -520,7 +570,8 @@ class DossierDiscoveryRoutingTests(unittest.TestCase):
         self.assertTrue(handled)
         discover_mock.assert_called_once()
         send_mock.assert_not_called()
-        self.assertIn("Nothing sent", message.replies[-1])
+        self.assertIn("Dry run: 1 sendable, 0 withheld", message.replies[-1])
+        self.assertIn("Sendable: Signal Witch", message.replies[-1])
 
     def test_command_sends_normal_review_only_recommendations_when_threshold_met(self):
         bnl01_bot.BNL_OWNER_USER_ID = 999
@@ -534,6 +585,82 @@ class DossierDiscoveryRoutingTests(unittest.TestCase):
         send_mock.assert_called_once_with(fake_payload)
         self.assertIn("1 recommendations sent", message.replies[-1])
         self.assertIn("2 withheld", message.replies[-1])
+
+
+    def test_dry_run_reports_sendable_and_withheld_counts(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        message = self.Message(user_id=999)
+        fake_discovery = {
+            "candidates": [{"subjectName": "Anita Cable", "payload": {"subjectName": "Anita Cable"}}],
+            "payloads": [{"subjectName": "Anita Cable"}],
+            "withheldCount": 6,
+            "duplicateCount": 0,
+            "sendableCandidateCount": 1,
+            "withheldReasonCounts": {"title_only_low_evidence": 6},
+            "topWithheldReason": "title_only_low_evidence",
+            "mediumConfidenceCount": 1,
+            "strongConfidenceCount": 0,
+        }
+        with mock.patch.object(bnl01_bot, "discover_candidate_recommendations", return_value=fake_discovery), \
+             mock.patch.object(bnl01_bot, "send_dossier_recommendation"):
+            handled = asyncio.run(bnl01_bot.maybe_handle_dossier_recommendation_command(message, "!bnl dossier discover candidates | dry_run=true"))
+
+        self.assertTrue(handled)
+        self.assertIn("Dry run: 1 sendable, 6 withheld", message.replies[-1])
+        self.assertIn("Sendable: Anita Cable", message.replies[-1])
+        self.assertIn("Main withheld reason: title only low evidence", message.replies[-1])
+
+    def test_command_reply_reports_withheld_reason_summary_and_diagnostics(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        message = self.Message(user_id=999)
+        fake_payload = {"type": "new_subject", "subjectName": "Signal Witch", "reason": "Review only", "sourceLanes": ["broadcast_memory"]}
+        fake_discovery = {
+            "candidates": [{"subjectName": "Signal Witch", "payload": fake_payload}],
+            "payloads": [fake_payload],
+            "withheldCount": 6,
+            "duplicateCount": 0,
+            "sendableCandidateCount": 1,
+            "withheldReasonCounts": {"title_only_low_evidence": 4, "weak_generic_subject": 2},
+            "topWithheldReason": "title_only_low_evidence",
+            "mediumConfidenceCount": 1,
+            "strongConfidenceCount": 0,
+        }
+        with mock.patch.object(bnl01_bot, "discover_candidate_recommendations", return_value=fake_discovery), \
+             mock.patch.object(bnl01_bot, "send_dossier_recommendation", return_value={"ok": True, "duplicate": False, "status": 200}):
+            handled = asyncio.run(bnl01_bot.maybe_handle_dossier_recommendation_command(message, "!bnl dossier discover candidates | limit=1"))
+
+        self.assertTrue(handled)
+        self.assertIn("Withheld: 4 title only low evidence, 2 weak generic subject", message.replies[-1])
+        diag = bnl01_bot.build_dossier_recommendation_diagnostics()
+        self.assertEqual(diag["candidate_discovery_last_sendable_candidate_count"], 1)
+        self.assertEqual(diag["candidate_discovery_last_withheld_reason_counts"], {"title_only_low_evidence": 4, "weak_generic_subject": 2})
+        self.assertEqual(diag["candidate_discovery_last_medium_confidence_count"], 1)
+        self.assertEqual(diag["candidate_discovery_last_strong_confidence_count"], 0)
+        self.assertEqual(diag["candidate_discovery_last_top_withheld_reason"], "title_only_low_evidence")
+        self.assertNotIn("Anita Cable", json.dumps(diag["candidate_discovery_last_withheld_reason_counts"]))
+
+    def test_no_send_reply_uses_main_withheld_reason_guidance(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        message = self.Message(user_id=999)
+        fake_discovery = {
+            "candidates": [],
+            "payloads": [],
+            "withheldCount": 9,
+            "duplicateCount": 0,
+            "sendableCandidateCount": 0,
+            "withheldReasonCounts": {"title_only_low_evidence": 9},
+            "topWithheldReason": "title_only_low_evidence",
+            "mediumConfidenceCount": 0,
+            "strongConfidenceCount": 0,
+        }
+        with mock.patch.object(bnl01_bot, "discover_candidate_recommendations", return_value=fake_discovery), \
+             mock.patch.object(bnl01_bot, "send_dossier_recommendation"):
+            handled = asyncio.run(bnl01_bot.maybe_handle_dossier_recommendation_command(message, "!bnl dossier discover candidates"))
+
+        self.assertTrue(handled)
+        self.assertIn("Dossier discovery complete: 0 sent, 0 duplicates, 9 withheld, 0 failed", message.replies[-1])
+        self.assertIn("Main withheld reason: title only low evidence", message.replies[-1])
+        self.assertIn("Try adding clearer source-file or recurring-entity notes", message.replies[-1])
 
     def test_failed_dynamic_sends_are_counted_in_operator_reply(self):
         bnl01_bot.BNL_OWNER_USER_ID = 999
@@ -553,7 +680,7 @@ class DossierDiscoveryRoutingTests(unittest.TestCase):
             handled = asyncio.run(bnl01_bot.maybe_handle_dossier_recommendation_command(message, "!bnl dossier discover candidates | limit=2"))
 
         self.assertTrue(handled)
-        self.assertIn("0 recommendations sent", message.replies[-1])
+        self.assertIn("0 sent", message.replies[-1])
         self.assertIn("4 withheld", message.replies[-1])
         self.assertIn("2 failed", message.replies[-1])
         self.assertIn("First failure: HTTP 400", message.replies[-1])


### PR DESCRIPTION
### Motivation
- Dynamic discovery was withholding all candidates after recent fixes, preventing useful review-only recommendations from reaching operators. 
- The goal is to permit medium-confidence, source-safe candidates into the admin review workflow while still blocking obvious junk and preserving safety boundaries.

### Description
- Added a medium-confidence tier in `bnl_dossier_candidate_discovery.py` that allows valid non-generic subjects with approved source-lane evidence and contextual or repeated mentions to be sent as review-only recommendations. 
- Introduced subject rejection reasoning and withheld reason tracking (`weak_generic_subject`, `title_only_low_evidence`, `insufficient_source_context`, `unsupported_lane`, `duplicate_internal_candidate`, `invalid_subject_shape`, `below_minimum_score`) and surfaced counts/top reason in the discovery result. 
- Adjusted payloads so medium candidates use `confidence` = `low`/`medium`, `type` = `new_subject` (unless `identity_alias_review`), include the safety note "Medium-confidence BNL discovery. Review before converting, merging, aliasing, drafting, or publishing.", and maintain valid website taxonomy. 
- Updated `bnl01_bot.py` to summarize dry-run results (`Dry run: X sendable, Y withheld...`) and command completion replies with a concise withheld-reason summary and guidance when nothing is sent, and to expose safe diagnostics (`candidate_discovery_last_sendable_candidate_count`, `candidate_discovery_last_withheld_reason_counts`, `candidate_discovery_last_medium_confidence_count`, `candidate_discovery_last_strong_confidence_count`, `candidate_discovery_last_top_withheld_reason`). 
- Added and adjusted unit tests in `tests/test_dossier_recommendations.py` to exercise medium-confidence sends, withheld reason tracking, dry-run summaries, command reply summaries, and diagnostics while preserving existing taxonomy and safety tests.

### Testing
- Ran unit tests with `python -m unittest discover -s tests -v`, which passed (all tests executed successfully). 
- Confirmed Python compilation with `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py` succeeded. 
- Ran static check `git diff --check` with no issues detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b5e26ca008321a7634a4df107af42)