### PR TITLE
Bot PR #183 — Community Candidate Scouting v1

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -28,8 +28,18 @@ import calendar
 from bnl_dossier_candidate_discovery import (
     DEFAULT_DISCOVERY_LANES,
     DISCOVERY_INGEST_SOURCE,
+    COMMUNITY_DISCOVERY_LANE,
     discover_candidate_recommendations,
     parse_dossier_discovery_command,
+)
+from bnl_community_scouting import (
+    build_community_presence_diagnostics,
+    community_min_signals,
+    community_scouting_enabled,
+    ensure_community_presence_schema,
+    get_community_presence_candidates,
+    is_community_presence_channel_allowed,
+    record_community_presence_event,
 )
 from bnl_dossier_recommendations import (
     get_dossier_ingest_url,
@@ -84,6 +94,8 @@ BNL_OWNER_USER_ID = int(os.getenv("BNL_OWNER_USER_ID", "0") or 0)
 BNL_MOD_ROLE_ID = int(os.getenv("BNL_MOD_ROLE_ID", "0") or 0)
 BNL_TESTING_CHANNEL_ID = int(os.getenv("BNL_TESTING_CHANNEL_ID", "0") or 0)
 BNL_BROADCAST_MEMORY_CHANNEL_ID = int(os.getenv("BNL_BROADCAST_MEMORY_CHANNEL_ID", "1509384896554995752") or 0)
+BNL_COMMUNITY_SCOUTING_ENABLED = community_scouting_enabled()
+BNL_COMMUNITY_SCOUTING_MIN_SIGNALS = community_min_signals()
 
 DAILY_TOKEN_LIMIT = 1_350_000
 PACIFIC_TZ = pytz.timezone("US/Pacific")
@@ -490,6 +502,10 @@ _last_candidate_discovery_withheld_reason_counts = {}
 _last_candidate_discovery_medium_confidence_count = 0
 _last_candidate_discovery_strong_confidence_count = 0
 _last_candidate_discovery_top_withheld_reason = "none"
+_last_community_presence_candidate_count = 0
+_last_community_presence_withheld_count = 0
+_last_community_presence_top_withheld_reason = "none"
+_last_community_presence_error_status = "none"
 BNL_CONTROL_FLAGS_TTL_SECONDS = 300
 _bnl_control_flags_cache = None
 _bnl_control_flags_cached_at = None
@@ -3304,6 +3320,7 @@ def init_db():
 
     conn.commit()
     conn.close()
+    ensure_community_presence_schema(DB_FILE)
     logging.info("✅ Database initialized successfully.")
 
 def _truncate_user_facts(user_id: int, guild_id: int, max_rows: int = MAX_FACTS_PER_USER):
@@ -3967,7 +3984,7 @@ def can_send_dossier_recommendation(user, member, guild) -> bool:
     return False
 
 
-def build_dossier_recommendation_diagnostics() -> dict:
+def build_dossier_recommendation_diagnostics(guild_id: int | None = None) -> dict:
     """Safe configuration/status diagnostics for dossier recommendation ingest."""
     source_file_diag = build_source_file_lookup_diagnostics()
     return {
@@ -3990,7 +4007,7 @@ def build_dossier_recommendation_diagnostics() -> dict:
         "candidate_discovery_available": True,
         "candidate_discovery_enabled": False,
         "candidate_discovery_ingest_source": DISCOVERY_INGEST_SOURCE,
-        "candidate_discovery_approved_lanes": list(DEFAULT_DISCOVERY_LANES),
+        "candidate_discovery_approved_lanes": list(DEFAULT_DISCOVERY_LANES) + [COMMUNITY_DISCOVERY_LANE],
         "candidate_discovery_last_run_time": _last_candidate_discovery_run_time,
         "candidate_discovery_last_sent_count": _last_candidate_discovery_sent_count,
         "candidate_discovery_last_duplicate_count": _last_candidate_discovery_duplicate_count,
@@ -4006,6 +4023,15 @@ def build_dossier_recommendation_diagnostics() -> dict:
         "candidate_discovery_last_medium_confidence_count": _last_candidate_discovery_medium_confidence_count,
         "candidate_discovery_last_strong_confidence_count": _last_candidate_discovery_strong_confidence_count,
         "candidate_discovery_last_top_withheld_reason": _last_candidate_discovery_top_withheld_reason,
+        **build_community_presence_diagnostics(
+            DB_FILE,
+            guild_id=guild_id,
+            environ=os.environ,
+            last_candidate_count=_last_community_presence_candidate_count,
+            last_withheld_count=_last_community_presence_withheld_count,
+            last_top_withheld_reason=_last_community_presence_top_withheld_reason,
+            last_error_status=_last_community_presence_error_status,
+        ),
     }
 
 
@@ -4041,6 +4067,40 @@ def _current_rd_discovery_context(message: discord.Message) -> list[dict]:
     return combined[-25:]
 
 
+def read_community_presence_candidates_for_discovery(guild_id: int | None, limit: int = 500):
+    """Return sanitized community-presence rows for the discovery lane without Discord IDs or raw transcripts."""
+    if not community_scouting_enabled():
+        return []
+    return get_community_presence_candidates(DB_FILE, guild_id, limit=limit, min_signals=community_min_signals())
+
+
+def maybe_record_live_community_presence(message: discord.Message, clean_content: str, channel_policy: str, direct_interaction: bool) -> None:
+    """Record minimal live community presence from approved channels only; never reads history."""
+    global _last_community_presence_error_status
+    if not community_scouting_enabled():
+        _last_community_presence_error_status = "disabled"
+        return
+    channel = getattr(message, "channel", None)
+    channel_id = int(getattr(channel, "id", 0) or 0)
+    if not is_community_presence_channel_allowed(channel_id, channel_policy):
+        _last_community_presence_error_status = "channel_not_approved"
+        return
+    member = message.author if isinstance(message.author, discord.Member) else message.guild.get_member(message.author.id)
+    operator_mention = bool(member and can_send_dossier_recommendation(message.author, member, message.guild))
+    result = record_community_presence_event(
+        DB_FILE,
+        getattr(message.guild, "id", 0),
+        getattr(message.author, "display_name", "") or getattr(message.author, "name", ""),
+        clean_content,
+        channel_id=channel_id,
+        channel_name=getattr(channel, "name", ""),
+        channel_policy=channel_policy,
+        direct_interaction=direct_interaction,
+        operator_mention=operator_mention,
+    )
+    _last_community_presence_error_status = str(result.get("status") or "none")[:80]
+
+
 async def maybe_handle_dossier_discovery_command(message: discord.Message, clean_content: str) -> bool:
     """Handle operator-triggered dynamic dossier candidate discovery."""
 
@@ -4053,6 +4113,8 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
     global _last_candidate_discovery_sendable_candidate_count, _last_candidate_discovery_withheld_reason_counts
     global _last_candidate_discovery_medium_confidence_count, _last_candidate_discovery_strong_confidence_count
     global _last_candidate_discovery_top_withheld_reason
+    global _last_community_presence_candidate_count, _last_community_presence_withheld_count
+    global _last_community_presence_top_withheld_reason, _last_community_presence_error_status
 
     matched, options, parse_error = parse_dossier_discovery_command(clean_content)
     if not matched:
@@ -4093,6 +4155,7 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
         limit=limit,
         broadcast_memory_reader=get_recent_broadcast_memory,
         rd_context=_current_rd_discovery_context(message),
+        community_presence_reader=read_community_presence_candidates_for_discovery,
     )
     candidates = discovery.get("candidates") or []
     withheld = int(discovery.get("withheldCount") or 0)
@@ -4107,6 +4170,11 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
     _last_candidate_discovery_medium_confidence_count = medium_count
     _last_candidate_discovery_strong_confidence_count = strong_count
     _last_candidate_discovery_top_withheld_reason = top_reason
+    if COMMUNITY_DISCOVERY_LANE in lanes:
+        _last_community_presence_candidate_count = sendable_count
+        _last_community_presence_withheld_count = withheld
+        _last_community_presence_top_withheld_reason = top_reason
+        _last_community_presence_error_status = "none"
 
     if dry_run:
         _last_candidate_discovery_sent_count = 0
@@ -4116,7 +4184,8 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
         names = [str(candidate.get("subjectName") or "subject")[:40] for candidate in candidates[:5]]
         sendable_suffix = f" Sendable: {', '.join(names)}." if names else ""
         main_suffix = f" Main withheld reason: {_humanize_discovery_reason(top_reason)}." if withheld and top_reason != "none" else ""
-        await message.reply(f"Dry run: {sendable_count} sendable, {withheld} withheld.{sendable_suffix}{main_suffix}")
+        lanes_suffix = f" Lanes: {', '.join(lanes)}."
+        await message.reply(f"Dry run: {sendable_count} sendable, {withheld} withheld.{sendable_suffix}{main_suffix}{lanes_suffix}")
         return True
 
     sent_count = 0
@@ -4159,7 +4228,8 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
             f"Dossier discovery complete: {sent_count} recommendations sent, "
             f"{send_duplicates} duplicates skipped, {withheld} withheld, {failed_count} failed."
         )
-    await message.reply(f"{summary}{reason_suffix}{failure_suffix}")
+    lanes_suffix = f" Lanes: {', '.join(lanes)}."
+    await message.reply(f"{summary}{reason_suffix}{failure_suffix}{lanes_suffix}")
     return True
 
 
@@ -10793,6 +10863,8 @@ async def on_message(message: discord.Message):
     if await maybe_handle_dossier_recommendation_command(message, clean_content):
         return
 
+    maybe_record_live_community_presence(message, clean_content, channel_policy, real_direct_target)
+
     plain_text_name_seen = bool(re.search(r"\b(bnl|bnl-01|barcode bot)\b", clean_content.lower())) if clean_content else False
     channel_allows_conversation = bool(
         channel_policy in {"public_home", "sealed_test"}
@@ -11873,7 +11945,7 @@ async def bnl_source_check(interaction: discord.Interaction):
     relay_eligibility = website_relay_eligibility(policy)
     primary_guild_match = bool(guild and BNL_PRIMARY_GUILD_ID and guild.id == BNL_PRIMARY_GUILD_ID)
     flags_source = _bnl_control_flags_last_source_url or "none"
-    dossier_diag = build_dossier_recommendation_diagnostics()
+    dossier_diag = build_dossier_recommendation_diagnostics(guild.id)
 
     lines = [
         "**BNL Source Diagnostic**",
@@ -11920,6 +11992,16 @@ async def bnl_source_check(interaction: discord.Interaction):
         f"- candidate_discovery_last_medium_confidence_count: `{dossier_diag['candidate_discovery_last_medium_confidence_count']}`",
         f"- candidate_discovery_last_strong_confidence_count: `{dossier_diag['candidate_discovery_last_strong_confidence_count']}`",
         f"- candidate_discovery_last_top_withheld_reason: `{dossier_diag['candidate_discovery_last_top_withheld_reason']}`",
+        f"- community_scouting_available: `{'yes' if dossier_diag['community_scouting_available'] else 'no'}`",
+        f"- community_scouting_enabled: `{'yes' if dossier_diag['community_scouting_enabled'] else 'no'}`",
+        f"- community_scouting_allowed_channels_configured: `{'yes' if dossier_diag['community_scouting_allowed_channels_configured'] else 'no'}`",
+        f"- community_presence_item_count: `{dossier_diag['community_presence_item_count']}`",
+        f"- community_presence_last_seen_at: `{dossier_diag['community_presence_last_seen_at']}`",
+        f"- community_presence_candidate_count: `{dossier_diag['community_presence_candidate_count']}`",
+        f"- community_presence_last_candidate_count: `{dossier_diag['community_presence_last_candidate_count']}`",
+        f"- community_presence_last_withheld_count: `{dossier_diag['community_presence_last_withheld_count']}`",
+        f"- community_presence_last_top_withheld_reason: `{dossier_diag['community_presence_last_top_withheld_reason']}`",
+        f"- community_presence_last_error_status: `{dossier_diag['community_presence_last_error_status']}`",
         f"- _bnl_control_flags_last_source_url: `{flags_source}`",
         f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` every `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}` min",
     ]
@@ -12108,7 +12190,7 @@ async def bnl_status(interaction: discord.Interaction):
     flags_source_state = "available" if _bnl_control_flags_last_source_url else "not yet fetched"
     website_bridge_configured = bool(BNL_STATUS_URL and BNL_API_KEY)
     read_model_diag = get_bnl_read_model_diagnostic_state()
-    dossier_diag = build_dossier_recommendation_diagnostics()
+    dossier_diag = build_dossier_recommendation_diagnostics(guild.id)
     broadcast_channel = guild.get_channel(BNL_BROADCAST_MEMORY_CHANNEL_ID) if BNL_BROADCAST_MEMORY_CHANNEL_ID else None
     broadcast_count = len(get_recent_broadcast_memory(guild.id, public_only=False, limit=500))
     latest_written_episode_date, latest_show_episode_date = get_broadcast_memory_diagnostic_dates(guild.id)
@@ -12166,6 +12248,16 @@ async def bnl_status(interaction: discord.Interaction):
         f"- candidate_discovery_last_medium_confidence_count: `{dossier_diag['candidate_discovery_last_medium_confidence_count']}`",
         f"- candidate_discovery_last_strong_confidence_count: `{dossier_diag['candidate_discovery_last_strong_confidence_count']}`",
         f"- candidate_discovery_last_top_withheld_reason: `{dossier_diag['candidate_discovery_last_top_withheld_reason']}`",
+        f"- community_scouting_available: `{'yes' if dossier_diag['community_scouting_available'] else 'no'}`",
+        f"- community_scouting_enabled: `{'yes' if dossier_diag['community_scouting_enabled'] else 'no'}`",
+        f"- community_scouting_allowed_channels_configured: `{'yes' if dossier_diag['community_scouting_allowed_channels_configured'] else 'no'}`",
+        f"- community_presence_item_count: `{dossier_diag['community_presence_item_count']}`",
+        f"- community_presence_last_seen_at: `{dossier_diag['community_presence_last_seen_at']}`",
+        f"- community_presence_candidate_count: `{dossier_diag['community_presence_candidate_count']}`",
+        f"- community_presence_last_candidate_count: `{dossier_diag['community_presence_last_candidate_count']}`",
+        f"- community_presence_last_withheld_count: `{dossier_diag['community_presence_last_withheld_count']}`",
+        f"- community_presence_last_top_withheld_reason: `{dossier_diag['community_presence_last_top_withheld_reason']}`",
+        f"- community_presence_last_error_status: `{dossier_diag['community_presence_last_error_status']}`",
         f"- read_model_enabled: `{'yes' if read_model_diag.get('enabled') else 'no'}`",
         f"- read_model_url_configured: `{'yes' if read_model_diag.get('url_configured') else 'no'}`",
         f"- read_model_cache_present: `{'yes' if read_model_diag.get('cache_present') else 'no'}`",

--- a/bnl_community_scouting.py
+++ b/bnl_community_scouting.py
@@ -1,0 +1,447 @@
+"""Safe community-presence scouting helpers for BNL dossier discovery.
+
+This module only handles lightweight, review-only signals from approved live
+community contexts supplied by the bot. It does not fetch Discord history, read
+DMs, merge identities, infer real-world identity, create drafts, publish, or
+send recommendations by itself.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any
+
+from bnl_dossier_source_packets import MAX_SNIPPET_LENGTH, subject_key
+
+COMMUNITY_PRESENCE_LANE = "community_presence"
+COMMUNITY_SCOUTING_MIN_SIGNALS_DEFAULT = 2
+MAX_COMMUNITY_EVIDENCE_SNIPPETS = 3
+MAX_CONNECTION_NOTES = 4
+MAX_CHANNEL_LABELS = 6
+_DISCORD_MENTION_PATTERN = re.compile(r"<[@#!&]?[0-9]{5,}>")
+_LONG_ID_PATTERN = re.compile(r"\b\d{15,22}\b")
+_EMAIL_PATTERN = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I)
+_URL_PATTERN = re.compile(r"https?://\S+", re.I)
+_SUBJECT_WORD = r"[A-Z0-9][A-Za-z0-9'_-]*"
+_SUBJECT_PHRASE = rf"{_SUBJECT_WORD}(?:\s+{_SUBJECT_WORD}){{0,3}}"
+WEAK_COMMUNITY_TERMS = {
+    "everyone", "somebody", "someone", "anyone", "today", "tonight", "yesterday", "tomorrow",
+    "chat", "thread", "post", "comment", "reply", "song", "track", "live", "show", "server", "discord",
+    "message", "channel", "admin", "operator", "owner", "mod", "bot", "user", "member", "people",
+    "thing", "stuff", "voice", "role", "rules", "welcome", "announcement", "question", "answer",
+}
+
+
+def community_scouting_enabled(environ: dict[str, str] | None = None) -> bool:
+    env = environ if environ is not None else os.environ
+    return (env.get("BNL_COMMUNITY_SCOUTING_ENABLED") or "false").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def configured_channel_ids(environ: dict[str, str] | None = None) -> set[int]:
+    env = environ if environ is not None else os.environ
+    ids: set[int] = set()
+    for part in re.split(r"[,\s]+", (env.get("BNL_COMMUNITY_SCOUTING_CHANNEL_IDS") or "").strip()):
+        if not part:
+            continue
+        try:
+            ids.add(int(part))
+        except ValueError:
+            continue
+    return ids
+
+
+def community_min_signals(environ: dict[str, str] | None = None) -> int:
+    env = environ if environ is not None else os.environ
+    try:
+        return max(1, min(int(env.get("BNL_COMMUNITY_SCOUTING_MIN_SIGNALS") or COMMUNITY_SCOUTING_MIN_SIGNALS_DEFAULT), 10))
+    except ValueError:
+        return COMMUNITY_SCOUTING_MIN_SIGNALS_DEFAULT
+
+
+def is_community_presence_channel_allowed(channel_id: int | None, channel_policy: str, environ: dict[str, str] | None = None) -> bool:
+    configured = configured_channel_ids(environ)
+    if configured:
+        return bool(channel_id and int(channel_id) in configured)
+    return (channel_policy or "").strip().lower() in {"public_home", "public_context", "public_selective"}
+
+
+def safe_community_snippet(text: str, max_length: int = MAX_SNIPPET_LENGTH) -> str:
+    cleaned = _DISCORD_MENTION_PATTERN.sub("[redacted-mention]", str(text or ""))
+    cleaned = _LONG_ID_PATTERN.sub("[redacted-id]", cleaned)
+    cleaned = _EMAIL_PATTERN.sub("[redacted-email]", cleaned)
+    cleaned = _URL_PATTERN.sub("[redacted-url]", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    if len(cleaned) <= max_length:
+        return cleaned
+    return cleaned[: max(0, max_length - 1)].rstrip() + "…"
+
+
+def clean_subject_name(candidate: str) -> str:
+    cleaned = re.sub(r"\s+", " ", (candidate or "").strip(" .,:;!?()[]{}\"'"))
+    cleaned = re.sub(r"^(?:the|a|an)\s+", "", cleaned, flags=re.I).strip()
+    return cleaned[:80]
+
+
+def is_weak_community_subject(candidate: str) -> bool:
+    subject = clean_subject_name(candidate)
+    normalized = subject.lower()
+    if not subject or len(subject) < 3:
+        return True
+    if re.fullmatch(r"\d+", subject) or not re.search(r"[A-Za-z]", subject):
+        return True
+    words = re.findall(r"[A-Za-z0-9]+", normalized)
+    if normalized in WEAK_COMMUNITY_TERMS:
+        return True
+    if words and all(word in WEAK_COMMUNITY_TERMS for word in words):
+        return True
+    if words and words[0] in WEAK_COMMUNITY_TERMS:
+        return True
+    if normalized in {"bnl", "bnl 01", "barcode", "barcode network", "barcode radio"}:
+        return True
+    return False
+
+
+def _json_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if not value:
+        return []
+    try:
+        parsed = json.loads(value)
+    except Exception:
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def _append_unique(items: list[Any], value: Any, limit: int) -> list[Any]:
+    if value in (None, "", []):
+        return items[:limit]
+    if value not in items:
+        items.append(value)
+    return items[-limit:]
+
+
+def ensure_community_presence_schema(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS community_presence (
+            guild_id INTEGER NOT NULL,
+            subject_key TEXT NOT NULL,
+            display_name TEXT NOT NULL,
+            first_seen_at TEXT NOT NULL,
+            last_seen_at TEXT NOT NULL,
+            source_lanes TEXT DEFAULT '["community_presence"]',
+            approved_channel_labels TEXT DEFAULT '[]',
+            mention_count INTEGER DEFAULT 0,
+            direct_interaction_count INTEGER DEFAULT 0,
+            operator_mention_count INTEGER DEFAULT 0,
+            active_windows TEXT DEFAULT '[]',
+            connection_notes TEXT DEFAULT '[]',
+            evidence_snippets TEXT DEFAULT '[]',
+            category TEXT DEFAULT 'community_regular_candidate',
+            last_error_status TEXT DEFAULT 'none',
+            PRIMARY KEY (guild_id, subject_key)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _extract_connection_subjects(content: str) -> list[tuple[str, str, str]]:
+    rows: list[tuple[str, str, str]] = []
+    patterns = (
+        rf"\b({_SUBJECT_PHRASE})\s+(?:via|through|introduced\s+through|introduced\s+by)\s+({_SUBJECT_PHRASE})\b",
+        rf"\b(?:introduced|introducing|mention(?:ed)?|brought\s+up)\s+({_SUBJECT_PHRASE})\s+(?:via|through|by)\s+({_SUBJECT_PHRASE})\b",
+    )
+    for pattern in patterns:
+        for match in re.finditer(pattern, content or ""):
+            subject = clean_subject_name(match.group(1))
+            connector = clean_subject_name(match.group(2))
+            if subject and connector and not is_weak_community_subject(subject) and not is_weak_community_subject(connector):
+                rows.append((subject, connector, f"mentioned through {connector}"))
+    return rows
+
+
+def extract_community_subjects(content: str) -> list[str]:
+    subjects: list[str] = []
+    explicit_patterns = (
+        rf"\b(?:source file|dossier|community candidate|community subject|review)\s+(?:for|on|about)\s+({_SUBJECT_PHRASE})\b",
+        rf"\b({_SUBJECT_PHRASE})\s+(?:is|was|seems like|feels like)\s+(?:a\s+)?(?:regular|recurring|community|artist|collaborator|moderator|mod|support|participant|candidate)\b",
+        rf"\b(?:artist|collaborator|regular|participant|moderator|mod)\s+({_SUBJECT_PHRASE})\b",
+    )
+    for pattern in explicit_patterns:
+        for match in re.finditer(pattern, content or "", flags=re.I):
+            subject = clean_subject_name(match.group(1))
+            if subject and not is_weak_community_subject(subject):
+                subjects.append(subject)
+    for subject, _connector, _note in _extract_connection_subjects(content):
+        subjects.append(subject)
+    deduped: list[str] = []
+    for subject in subjects:
+        key = subject_key(subject)
+        if key not in {subject_key(item) for item in deduped}:
+            deduped.append(subject)
+    return deduped
+
+
+def _category_for_signal(subject: str, content: str, *, connection_note: str = "", operator_mention: bool = False) -> str:
+    text = f"{subject} {content} {connection_note}".lower()
+    if re.search(r"\b(alias|aka|same as|duplicate|identity link|identity review)\b", text):
+        return "possible_alias_review"
+    if connection_note or re.search(r"\b(via|through|introduced by|introduced through|connected to)\b", text):
+        return "introduced_subject_candidate"
+    if re.search(r"\b(mod|moderator|support|staff)\b", text) and operator_mention:
+        return "mod_support_candidate"
+    if re.search(r"\b(artist|collaborator|producer|dj|vocalist|musician)\b", text):
+        return "artist_or_collaborator_candidate"
+    return "community_regular_candidate"
+
+
+def upsert_community_presence_subject(
+    db_path: str,
+    guild_id: int,
+    subject_name: str,
+    *,
+    channel_label: str = "approved community channel",
+    mention_increment: int = 1,
+    direct_interaction_increment: int = 0,
+    operator_mention_increment: int = 0,
+    connection_note: str = "",
+    evidence_snippet: str = "",
+    category: str = "community_regular_candidate",
+    now: datetime | None = None,
+) -> bool:
+    subject = clean_subject_name(subject_name)
+    if is_weak_community_subject(subject):
+        return False
+    ensure_community_presence_schema(db_path)
+    now_dt = now or datetime.now(timezone.utc)
+    now_text = now_dt.isoformat()
+    day = now_dt.date().isoformat()
+    key = subject_key(subject)
+    lane = COMMUNITY_PRESENCE_LANE
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM community_presence WHERE guild_id=? AND subject_key=?", (guild_id, key))
+    row = cur.fetchone()
+    columns = [desc[0] for desc in cur.description] if cur.description else []
+    existing = dict(zip(columns, row)) if row else {}
+    if existing:
+        channels = _append_unique(_json_list(existing.get("approved_channel_labels")), channel_label, MAX_CHANNEL_LABELS)
+        windows = _append_unique(_json_list(existing.get("active_windows")), day, 30)
+        notes = _append_unique(_json_list(existing.get("connection_notes")), safe_community_snippet(connection_note, 120), MAX_CONNECTION_NOTES) if connection_note else _json_list(existing.get("connection_notes"))[:MAX_CONNECTION_NOTES]
+        snippets = _append_unique(_json_list(existing.get("evidence_snippets")), safe_community_snippet(evidence_snippet, 160), MAX_COMMUNITY_EVIDENCE_SNIPPETS) if evidence_snippet else _json_list(existing.get("evidence_snippets"))[:MAX_COMMUNITY_EVIDENCE_SNIPPETS]
+        old_category = existing.get("category") or "community_regular_candidate"
+        new_category = category if old_category == "community_regular_candidate" or category != "community_regular_candidate" else old_category
+        cur.execute(
+            """
+            UPDATE community_presence
+            SET display_name=?, last_seen_at=?, source_lanes=?, approved_channel_labels=?,
+                mention_count=mention_count+?, direct_interaction_count=direct_interaction_count+?,
+                operator_mention_count=operator_mention_count+?, active_windows=?, connection_notes=?,
+                evidence_snippets=?, category=?, last_error_status='none'
+            WHERE guild_id=? AND subject_key=?
+            """,
+            (
+                subject, now_text, json.dumps([lane]), json.dumps(channels), int(mention_increment),
+                int(direct_interaction_increment), int(operator_mention_increment), json.dumps(windows),
+                json.dumps(notes), json.dumps(snippets), new_category, guild_id, key,
+            ),
+        )
+    else:
+        cur.execute(
+            """
+            INSERT INTO community_presence (
+                guild_id, subject_key, display_name, first_seen_at, last_seen_at, source_lanes,
+                approved_channel_labels, mention_count, direct_interaction_count, operator_mention_count,
+                active_windows, connection_notes, evidence_snippets, category, last_error_status
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'none')
+            """,
+            (
+                guild_id, key, subject, now_text, now_text, json.dumps([lane]),
+                json.dumps([channel_label] if channel_label else []), int(mention_increment),
+                int(direct_interaction_increment), int(operator_mention_increment), json.dumps([day]),
+                json.dumps([safe_community_snippet(connection_note, 120)] if connection_note else []),
+                json.dumps([safe_community_snippet(evidence_snippet, 160)] if evidence_snippet else []),
+                category,
+            ),
+        )
+    conn.commit()
+    conn.close()
+    return True
+
+
+def record_community_presence_event(
+    db_path: str,
+    guild_id: int,
+    author_display_name: str,
+    content: str,
+    *,
+    channel_id: int | None = None,
+    channel_name: str = "",
+    channel_policy: str = "unknown",
+    direct_interaction: bool = False,
+    operator_mention: bool = False,
+    environ: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    if not community_scouting_enabled(environ):
+        return {"ok": False, "status": "disabled", "stored": 0}
+    if not is_community_presence_channel_allowed(channel_id, channel_policy, environ):
+        return {"ok": False, "status": "channel_not_approved", "stored": 0}
+    if not guild_id:
+        return {"ok": False, "status": "missing_guild", "stored": 0}
+
+    channel_label = (channel_policy or "approved community channel").strip()[:40]
+    safe_snippet = safe_community_snippet(content, 160)
+    stored = 0
+
+    if author_display_name and upsert_community_presence_subject(
+        db_path,
+        guild_id,
+        author_display_name,
+        channel_label=channel_label,
+        mention_increment=1,
+        direct_interaction_increment=1 if direct_interaction else 0,
+        operator_mention_increment=0,
+        evidence_snippet="direct BNL interaction in approved community context" if direct_interaction else "approved-channel presence",
+        category="community_regular_candidate",
+    ):
+        stored += 1
+
+    connection_subjects = _extract_connection_subjects(content)
+    connection_keys = {subject_key(subject) for subject, _connector, _note in connection_subjects}
+    for subject, _connector, note in connection_subjects:
+        category = _category_for_signal(subject, content, connection_note=note, operator_mention=operator_mention)
+        if upsert_community_presence_subject(
+            db_path,
+            guild_id,
+            subject,
+            channel_label=channel_label,
+            mention_increment=1,
+            operator_mention_increment=1 if operator_mention else 0,
+            connection_note=note,
+            evidence_snippet=f"connection phrase: {note}",
+            category=category,
+        ):
+            stored += 1
+
+    for subject in extract_community_subjects(content):
+        if subject_key(subject) in connection_keys:
+            continue
+        category = _category_for_signal(subject, content, operator_mention=operator_mention)
+        if upsert_community_presence_subject(
+            db_path,
+            guild_id,
+            subject,
+            channel_label=channel_label,
+            mention_increment=1,
+            operator_mention_increment=1 if operator_mention else 0,
+            evidence_snippet=("operator/mod mention in approved community context" if operator_mention else safe_snippet),
+            category=category,
+        ):
+            stored += 1
+    return {"ok": True, "status": "ok", "stored": stored}
+
+
+def get_community_presence_candidates(db_path: str, guild_id: int | None, *, limit: int = 500, min_signals: int | None = None) -> list[dict[str, Any]]:
+    if not guild_id:
+        return []
+    ensure_community_presence_schema(db_path)
+    min_required = max(1, int(min_signals or community_min_signals()))
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT * FROM community_presence
+        WHERE guild_id=?
+        ORDER BY (mention_count + direct_interaction_count + operator_mention_count) DESC, last_seen_at DESC
+        LIMIT ?
+        """,
+        (guild_id, max(1, min(int(limit or 500), 500))),
+    )
+    rows = cur.fetchall()
+    conn.close()
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        item = dict(row)
+        signals = int(item.get("mention_count") or 0) + int(item.get("direct_interaction_count") or 0) + int(item.get("operator_mention_count") or 0) + len(_json_list(item.get("active_windows"))) - 1
+        if signals < min_required and not int(item.get("operator_mention_count") or 0) and not int(item.get("direct_interaction_count") or 0):
+            continue
+        results.append(
+            {
+                "subjectName": item.get("display_name") or item.get("subject_key") or "unknown subject",
+                "subjectKey": item.get("subject_key") or subject_key(item.get("display_name") or "unknown subject"),
+                "firstSeenAt": item.get("first_seen_at"),
+                "lastSeenAt": item.get("last_seen_at"),
+                "sourceLanes": _json_list(item.get("source_lanes")) or [COMMUNITY_PRESENCE_LANE],
+                "approvedChannelLabels": _json_list(item.get("approved_channel_labels")),
+                "mentionCount": int(item.get("mention_count") or 0),
+                "directInteractionCount": int(item.get("direct_interaction_count") or 0),
+                "operatorMentionCount": int(item.get("operator_mention_count") or 0),
+                "daysActive": len(_json_list(item.get("active_windows"))),
+                "connectionNotes": _json_list(item.get("connection_notes"))[:MAX_CONNECTION_NOTES],
+                "evidenceSnippets": _json_list(item.get("evidence_snippets"))[:MAX_COMMUNITY_EVIDENCE_SNIPPETS],
+                "category": item.get("category") or "community_regular_candidate",
+                "signalCount": signals,
+            }
+        )
+    return results
+
+
+def build_community_presence_diagnostics(db_path: str, guild_id: int | None = None, environ: dict[str, str] | None = None, *, last_candidate_count: int = 0, last_withheld_count: int = 0, last_top_withheld_reason: str = "none", last_error_status: str = "none") -> dict[str, Any]:
+    enabled = community_scouting_enabled(environ)
+    configured = bool(configured_channel_ids(environ))
+    item_count = 0
+    last_seen = "none"
+    candidate_count = 0
+    try:
+        ensure_community_presence_schema(db_path)
+        conn = sqlite3.connect(db_path)
+        cur = conn.cursor()
+        if guild_id:
+            cur.execute("SELECT COUNT(*), MAX(last_seen_at) FROM community_presence WHERE guild_id=?", (guild_id,))
+            row = cur.fetchone()
+            item_count = int(row[0] or 0) if row else 0
+            last_seen = str(row[1] or "none") if row else "none"
+            candidate_count = len(get_community_presence_candidates(db_path, guild_id, min_signals=community_min_signals(environ)))
+        else:
+            cur.execute("SELECT COUNT(*), MAX(last_seen_at) FROM community_presence")
+            row = cur.fetchone()
+            item_count = int(row[0] or 0) if row else 0
+            last_seen = str(row[1] or "none") if row else "none"
+        conn.close()
+    except Exception:
+        last_error_status = "diagnostic_error"
+    return {
+        "community_scouting_available": True,
+        "community_scouting_enabled": enabled,
+        "community_scouting_allowed_channels_configured": configured,
+        "community_presence_item_count": item_count,
+        "community_presence_last_seen_at": last_seen,
+        "community_presence_candidate_count": candidate_count,
+        "community_presence_last_candidate_count": int(last_candidate_count or 0),
+        "community_presence_last_withheld_count": int(last_withheld_count or 0),
+        "community_presence_last_top_withheld_reason": str(last_top_withheld_reason or "none")[:80],
+        "community_presence_last_error_status": str(last_error_status or "none")[:80],
+    }
+
+
+def community_category_taxonomy(category: str) -> dict[str, Any]:
+    cat = category or "community_regular_candidate"
+    if cat == "possible_alias_review":
+        return {"type": "identity_link"}
+    if cat == "artist_or_collaborator_candidate":
+        return {"type": "new_subject", "recommendedCategory": "Personnel", "recommendedKind": "collaborator", "recommendedIdentityAuthority": "mixed_or_unclear"}
+    if cat == "mod_support_candidate":
+        return {"type": "new_subject", "recommendedCategory": "Personnel", "recommendedKind": "moderator", "recommendedIdentityAuthority": "community_owned"}
+    if cat in {"introduced_subject_candidate", "possible_connection_review"}:
+        return {"type": "new_subject", "recommendedCategory": "Personnel", "recommendedIdentityAuthority": "mixed_or_unclear"}
+    return {"type": "new_subject", "recommendedCategory": "Personnel", "recommendedKind": "community_member", "recommendedIdentityAuthority": "community_owned"}

--- a/bnl_dossier_candidate_discovery.py
+++ b/bnl_dossier_candidate_discovery.py
@@ -15,6 +15,7 @@ from collections import Counter
 from typing import Any, Callable
 
 from bnl_dossier_recommendations import VALID_DOSSIER_CATEGORIES, build_dossier_recommendation_payload
+from bnl_community_scouting import COMMUNITY_PRESENCE_LANE, community_category_taxonomy
 from bnl_dossier_source_packets import (
     APPROVED_SOURCE_LANES,
     DEFAULT_MISSING_INFO,
@@ -28,13 +29,14 @@ from bnl_dossier_source_packets import (
 
 DISCOVERY_INGEST_SOURCE = "bnl_dynamic_candidate_discovery"
 DEFAULT_DISCOVERY_LANES = ["rd_context", "broadcast_memory"]
+COMMUNITY_DISCOVERY_LANE = COMMUNITY_PRESENCE_LANE
 MAX_DISCOVERY_LIMIT = 25
 DEFAULT_DISCOVERY_LIMIT = 10
 MIN_CANDIDATE_SCORE = 3
 TITLE_ONLY_MIN_SCORE = 5
 MEDIUM_CONTEXT_MIN_SCORE = 2
 MAX_REASON_LENGTH = 300
-_ALLOWED_DISCOVERY_LANES = set(DEFAULT_DISCOVERY_LANES) & set(APPROVED_SOURCE_LANES)
+_ALLOWED_DISCOVERY_LANES = (set(DEFAULT_DISCOVERY_LANES) | {COMMUNITY_DISCOVERY_LANE}) & set(APPROVED_SOURCE_LANES)
 _DISCORD_MENTION_PATTERN = re.compile(r"<[@#!&]?[0-9]{5,}>")
 _LONG_ID_PATTERN = re.compile(r"\b\d{15,22}\b")
 _SAFE_LANE_PATTERN = re.compile(r"[^a-z0-9_-]+")
@@ -91,6 +93,25 @@ _WEAK_SUBJECT_TERMS = {
     "user",
     "channel",
     "message",
+    "everyone",
+    "somebody",
+    "someone",
+    "anyone",
+    "today",
+    "tonight",
+    "yesterday",
+    "tomorrow",
+    "chat",
+    "thread",
+    "post",
+    "comment",
+    "reply",
+    "song",
+    "track",
+    "live",
+    "show",
+    "server",
+    "discord",
 }
 
 _KNOWN_ONE_WORD_SUBJECTS = {"cliff", "sheila", "shadowspit"}
@@ -111,6 +132,7 @@ class DiscoverySourceItem:
     label: str = ""
     source_ref: str = ""
     weight: int = 1
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -124,6 +146,11 @@ class CandidateAccumulator:
     title_hits: int = 0
     contextual_hits: int = 0
     score: int = 0
+    community_signal_count: int = 0
+    direct_interaction_count: int = 0
+    operator_mention_count: int = 0
+    days_active: int = 0
+    connection_notes: list[str] = field(default_factory=list)
 
 
 def parse_dossier_discovery_command(content: str) -> tuple[bool, dict[str, Any] | None, str]:
@@ -131,12 +158,15 @@ def parse_dossier_discovery_command(content: str) -> tuple[bool, dict[str, Any] 
 
     text = (content or "").strip()
     match = re.match(r"^!bnl\s+dossier\s+discover\s+candidates(?:\s*(?:\|\s*)?(.*))?$", text, flags=re.I | re.S)
-    if not match:
+    alias_match = None if match else re.match(r"^!bnl\s+community\s+scout\s+candidates(?:\s*(?:\|\s*)?(.*))?$", text, flags=re.I | re.S)
+    if not match and not alias_match:
         return False, None, "not_a_dossier_discovery_command"
+    if alias_match:
+        match = alias_match
 
     options_text = (match.group(1) or "").strip()
     options: dict[str, Any] = {
-        "lanes": list(DEFAULT_DISCOVERY_LANES),
+        "lanes": [COMMUNITY_DISCOVERY_LANE] if alias_match else list(DEFAULT_DISCOVERY_LANES),
         "limit": DEFAULT_DISCOVERY_LIMIT,
         "dry_run": False,
     }
@@ -144,13 +174,13 @@ def parse_dossier_discovery_command(content: str) -> tuple[bool, dict[str, Any] 
         for part in [piece.strip() for piece in options_text.split("|") if piece.strip()]:
             key_match = re.match(r"^([a-zA-Z_]+)\s*=\s*(.+)$", part)
             if not key_match:
-                return True, None, "Use: `!bnl dossier discover candidates [| lanes=rd_context,broadcast_memory] [| limit=10] [| dry_run=true]`"
+                return True, None, "Use: `!bnl dossier discover candidates [| lanes=rd_context,broadcast_memory,community_presence] [| limit=10] [| dry_run=true]`"
             key = key_match.group(1).strip().lower()
             value = key_match.group(2).strip()
             if key in {"lane", "lanes", "sourcelanes"}:
                 lanes = normalize_discovery_lanes(value)
                 if not lanes:
-                    return True, None, "No approved discovery lanes were requested. Approved lanes: rd_context,broadcast_memory."
+                    return True, None, "No approved discovery lanes were requested. Approved lanes: rd_context,broadcast_memory,community_presence."
                 options["lanes"] = lanes
             elif key == "limit":
                 try:
@@ -213,6 +243,7 @@ def collect_discovery_source_items(
     rd_context_reader: Callable[..., Any] | None = None,
     rd_context: list[Any] | None = None,
     broadcast_limit: int = 500,
+    community_presence_reader: Callable[..., Any] | None = None,
 ) -> list[DiscoverySourceItem]:
     """Collect approved source-safe lane text from explicit readers/context only."""
 
@@ -230,6 +261,43 @@ def collect_discovery_source_items(
             text = _safe_snippet(_rd_entry_to_text(entry), 500)
             if text:
                 items.append(DiscoverySourceItem("rd_context", text, "R&D context", f"rd_context:{idx}", weight=1))
+
+    if COMMUNITY_DISCOVERY_LANE in requested and guild_id and callable(community_presence_reader):
+        try:
+            rows = community_presence_reader(guild_id, limit=max(1, min(int(broadcast_limit or 1), 500)))
+        except Exception:
+            rows = []
+        for idx, row in enumerate(rows or [], start=1):
+            if not isinstance(row, dict):
+                continue
+            subject = _clean_subject(str(row.get("subjectName") or row.get("displayName") or ""))
+            reason = _subject_rejection_reason(subject)
+            if reason:
+                continue
+            mentions = int(row.get("mentionCount") or 0)
+            direct = int(row.get("directInteractionCount") or 0)
+            operator = int(row.get("operatorMentionCount") or 0)
+            days = int(row.get("daysActive") or 0)
+            notes = [str(note) for note in (row.get("connectionNotes") or []) if str(note or "").strip()][:3]
+            category = str(row.get("category") or "community_regular_candidate")
+            context = "recurring approved-channel participant"
+            if category == "introduced_subject_candidate" and notes:
+                context = notes[0]
+            elif operator:
+                context = "operator/mod-mentioned community subject"
+            elif direct:
+                context = "direct BNL interaction in approved community context"
+            text = _safe_snippet(
+                f"Community presence candidate for {subject}: {context}. "
+                f"Signals: mentions {mentions}, direct interactions {direct}, operator mentions {operator}, active windows {days}. "
+                "Review only; no identity, alias, relationship, draft, or public dossier is confirmed.",
+                500,
+            )
+            items.append(DiscoverySourceItem(
+                COMMUNITY_DISCOVERY_LANE, text, "Community presence", f"community_presence:{idx}",
+                weight=2 + min(3, direct + operator),
+                metadata={**row, "subjectName": subject, "category": category},
+            ))
 
     if "broadcast_memory" in requested and guild_id and callable(broadcast_memory_reader):
         try:
@@ -310,7 +378,7 @@ def _has_strong_evidence(acc: CandidateAccumulator) -> bool:
     if acc.explicit_hits > 0:
         return True
     normalized = acc.subject_name.lower()
-    if len(acc.subject_name.split()) == 1 and normalized not in _KNOWN_ONE_WORD_SUBJECTS:
+    if len(acc.subject_name.split()) == 1 and normalized not in _KNOWN_ONE_WORD_SUBJECTS and not acc.community_signal_count:
         return False
     if acc.mentions < 2 or acc.score < TITLE_ONLY_MIN_SCORE:
         return False
@@ -321,11 +389,11 @@ def _has_medium_evidence(acc: CandidateAccumulator) -> bool:
     if not acc.evidence or not acc.lanes:
         return False
     normalized = acc.subject_name.lower()
-    if len(acc.subject_name.split()) == 1 and normalized not in _KNOWN_ONE_WORD_SUBJECTS:
+    if len(acc.subject_name.split()) == 1 and normalized not in _KNOWN_ONE_WORD_SUBJECTS and not acc.community_signal_count:
         return False
     if acc.score < MEDIUM_CONTEXT_MIN_SCORE:
         return False
-    return acc.mentions >= 2 or _has_contextual_evidence(acc)
+    return acc.mentions >= 2 or _has_contextual_evidence(acc) or acc.community_signal_count >= 1 or acc.direct_interaction_count or acc.operator_mention_count
 
 
 def _withheld_reason(acc: CandidateAccumulator) -> str:
@@ -343,6 +411,8 @@ def _withheld_reason(acc: CandidateAccumulator) -> str:
 
 
 def _payload_taxonomy(acc: CandidateAccumulator) -> dict[str, Any]:
+    if acc.category in {"community_regular_candidate", "artist_or_collaborator_candidate", "mod_support_candidate", "introduced_subject_candidate", "possible_connection_review", "possible_alias_review"}:
+        return community_category_taxonomy(acc.category)
     if acc.category == "identity_alias_review":
         return {"type": "identity_link"}
     if acc.category == "system_concept_candidate":
@@ -388,6 +458,7 @@ def discover_candidate_recommendations(
     broadcast_memory_reader: Callable[..., Any] | None = None,
     rd_context_reader: Callable[..., Any] | None = None,
     rd_context: list[Any] | None = None,
+    community_presence_reader: Callable[..., Any] | None = None,
 ) -> dict[str, Any]:
     """Discover review candidates and return normal recommendation payloads plus safe counts."""
 
@@ -399,6 +470,7 @@ def discover_candidate_recommendations(
         broadcast_memory_reader=broadcast_memory_reader,
         rd_context_reader=rd_context_reader,
         rd_context=rd_context,
+        community_presence_reader=community_presence_reader,
     )
     accumulators: dict[str, CandidateAccumulator] = {}
     withheld_reasons: Counter[str] = Counter()
@@ -409,13 +481,15 @@ def discover_candidate_recommendations(
     for item in source_items:
         text = item.text
         candidate_sources: list[tuple[str, bool]] = []
-        for subject in _explicit_subjects(text):
+        if item.lane == COMMUNITY_DISCOVERY_LANE and item.metadata.get("subjectName"):
+            candidate_sources.append((_clean_subject(str(item.metadata.get("subjectName") or "")), True))
+        for subject in ([] if item.lane == COMMUNITY_DISCOVERY_LANE else _explicit_subjects(text)):
             reason = _subject_rejection_reason(subject)
             if reason:
                 withheld_reasons[reason] += 1
                 continue
             candidate_sources.append((_clean_subject(subject), True))
-        for subject in _title_subjects(text):
+        for subject in ([] if item.lane == COMMUNITY_DISCOVERY_LANE else _title_subjects(text)):
             reason = _subject_rejection_reason(subject)
             if reason:
                 withheld_reasons[reason] += 1
@@ -437,12 +511,23 @@ def discover_candidate_recommendations(
                 acc.explicit_hits += 1
             else:
                 acc.title_hits += 1
-            category = _category_for_text(text)
+            category = str(item.metadata.get("category") or _category_for_text(text))
             if acc.category == "new_source_file_candidate" or category != "new_source_file_candidate":
                 acc.category = category
             if len(acc.evidence) < 5:
                 acc.evidence.append({"lane": item.lane, "label": item.label, "summary": _safe_snippet(text), "sourceRef": item.source_ref})
             acc.score += item.weight + (2 if is_explicit else 0)
+            if item.lane == COMMUNITY_DISCOVERY_LANE:
+                acc.community_signal_count += int(item.metadata.get("signalCount") or item.metadata.get("mentionCount") or 0)
+                acc.direct_interaction_count += int(item.metadata.get("directInteractionCount") or 0)
+                acc.operator_mention_count += int(item.metadata.get("operatorMentionCount") or 0)
+                acc.days_active = max(acc.days_active, int(item.metadata.get("daysActive") or 0))
+                for note in item.metadata.get("connectionNotes") or []:
+                    note_text = _safe_snippet(str(note), 120)
+                    if note_text and note_text not in acc.connection_notes:
+                        acc.connection_notes.append(note_text)
+                acc.contextual_hits += 1
+                acc.score += min(4, acc.community_signal_count + acc.direct_interaction_count + acc.operator_mention_count + max(0, acc.days_active - 1))
             if re.search(r"\b(recurring|repeated|important|priority|source file|dossier|candidate|alias review|identity review|entity|character|lore|track|review)\b", text, flags=re.I):
                 acc.contextual_hits += 1
                 acc.score += 1
@@ -462,11 +547,23 @@ def discover_candidate_recommendations(
             medium_count += 1
         lane_list = [lane for lane in requested_lanes if lane in acc.lanes] or sorted(acc.lanes)
         confidence = "high" if is_strong and acc.score >= 7 and len(acc.lanes) > 1 else ("medium" if acc.score >= 4 else "low")
-        reason = _safe_snippet(
-            f"BNL dynamic candidate discovery found {acc.subject_name} in approved source-safe lanes "
-            f"({', '.join(lane_list)}) as {acc.category.replace('_', ' ')}. Review only; owner/admin must decide whether this becomes a source file, alias proposal, duplicate, or nothing.",
-            MAX_REASON_LENGTH,
-        )
+        if COMMUNITY_DISCOVERY_LANE in acc.lanes:
+            if acc.category == "introduced_subject_candidate" and acc.connection_notes:
+                reason_text = (
+                    f"BNL community scouting found {acc.subject_name} as a subject {acc.connection_notes[0]} in approved community context. "
+                    "This is a possible connection, not confirmed identity. Review before creating relationships, aliases, drafts, or public dossiers."
+                )
+            else:
+                reason_text = (
+                    f"BNL community scouting found {acc.subject_name} as a recurring approved-channel participant with repeated community presence. "
+                    "Review only; owner/admin must decide whether this becomes a Source File, alias proposal, duplicate, or nothing. No public identity or private account claim is made."
+                )
+        else:
+            reason_text = (
+                f"BNL dynamic candidate discovery found {acc.subject_name} in approved source-safe lanes "
+                f"({', '.join(lane_list)}) as {acc.category.replace('_', ' ')}. Review only; owner/admin must decide whether this becomes a source file, alias proposal, duplicate, or nothing."
+            )
+        reason = _safe_snippet(reason_text, MAX_REASON_LENGTH)
         evidence_summary = _evidence_summary(acc.evidence)
         evidence_hash = hashlib.sha256(f"{reason}\n{evidence_summary}".encode("utf-8")).hexdigest()[:8]
         taxonomy = _payload_taxonomy(acc)

--- a/bnl_dossier_source_packets.py
+++ b/bnl_dossier_source_packets.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 
 from bnl_dossier_recommendations import build_dossier_recommendation_payload
 
-APPROVED_SOURCE_LANES = {"rd_context", "broadcast_memory"}
+APPROVED_SOURCE_LANES = {"rd_context", "broadcast_memory", "community_presence"}
 FUTURE_SOURCE_LANES = {"read_model", "public_read_model", "safe_rd_notes"}
 DEFAULT_MISSING_INFO = [
     "preferred display name",

--- a/tests/test_dossier_recommendations.py
+++ b/tests/test_dossier_recommendations.py
@@ -518,7 +518,7 @@ class DossierCandidateDiscoveryTests(unittest.TestCase):
         diag = bnl01_bot.build_dossier_recommendation_diagnostics()
         self.assertTrue(diag["candidate_discovery_available"])
         self.assertFalse(diag["candidate_discovery_enabled"])
-        self.assertEqual(diag["candidate_discovery_approved_lanes"], ["rd_context", "broadcast_memory"])
+        self.assertEqual(diag["candidate_discovery_approved_lanes"], ["rd_context", "broadcast_memory", "community_presence"])
         self.assertNotIn("token", json.dumps(diag.get("candidate_discovery_last_source_lanes", [])).lower())
 
 
@@ -687,6 +687,166 @@ class DossierDiscoveryRoutingTests(unittest.TestCase):
         diag = bnl01_bot.build_dossier_recommendation_diagnostics()
         self.assertEqual(diag["candidate_discovery_last_failed_count"], 2)
         self.assertEqual(diag["candidate_discovery_last_first_failure_status"], "HTTP 400")
+
+
+class CommunityCandidateScoutingTests(unittest.TestCase):
+    def community_rows(self):
+        return [
+            {
+                "subjectName": "Emerald",
+                "mentionCount": 3,
+                "directInteractionCount": 1,
+                "operatorMentionCount": 0,
+                "daysActive": 2,
+                "connectionNotes": [],
+                "category": "community_regular_candidate",
+                "signalCount": 5,
+            },
+            {
+                "subjectName": "Orion",
+                "mentionCount": 1,
+                "directInteractionCount": 0,
+                "operatorMentionCount": 1,
+                "daysActive": 1,
+                "connectionNotes": ["mentioned through Crow"],
+                "category": "introduced_subject_candidate",
+                "signalCount": 2,
+            },
+        ]
+
+    def test_community_presence_lane_is_accepted_when_requested(self):
+        matched, options, error = discovery.parse_dossier_discovery_command(
+            "!bnl dossier discover candidates | lanes=rd_context,broadcast_memory,community_presence | limit=10"
+        )
+        self.assertTrue(matched)
+        self.assertFalse(error)
+        self.assertEqual(options["lanes"], ["rd_context", "broadcast_memory", "community_presence"])
+
+    def test_community_scout_alias_wraps_discovery_pipeline(self):
+        matched, options, error = discovery.parse_dossier_discovery_command("!bnl community scout candidates | limit=5")
+        self.assertTrue(matched)
+        self.assertFalse(error)
+        self.assertEqual(options["lanes"], ["community_presence"])
+        self.assertEqual(options["limit"], 5)
+
+    def test_community_presence_ignored_when_no_reader_available(self):
+        result = discovery.discover_candidate_recommendations(123, ["community_presence"])
+        self.assertEqual(result["payloads"], [])
+        self.assertEqual(result["sourceItemCount"], 0)
+
+    def test_recurring_community_subject_becomes_review_candidate(self):
+        result = discovery.discover_candidate_recommendations(
+            123,
+            ["community_presence"],
+            community_presence_reader=lambda *a, **k: self.community_rows(),
+        )
+        payload = next(payload for payload in result["payloads"] if payload["subjectName"] == "Emerald")
+        self.assertEqual(payload["type"], "new_subject")
+        self.assertEqual(payload.get("recommendedCategory"), "Personnel")
+        self.assertEqual(payload.get("recommendedKind"), "community_member")
+        self.assertIn("community scouting found Emerald", payload["reason"])
+        self.assertIn("community_presence", payload["sourceLanes"])
+        self.assertNotRegex(json.dumps(payload), r"\b\d{15,22}\b")
+
+    def test_operator_mentioned_subject_and_direct_interaction_score(self):
+        rows = [
+            {"subjectName": "Hellcat", "mentionCount": 1, "directInteractionCount": 0, "operatorMentionCount": 1, "daysActive": 1, "category": "community_regular_candidate", "signalCount": 2},
+            {"subjectName": "Crow", "mentionCount": 1, "directInteractionCount": 1, "operatorMentionCount": 0, "daysActive": 1, "category": "community_regular_candidate", "signalCount": 2},
+        ]
+        result = discovery.discover_candidate_recommendations(123, ["community_presence"], community_presence_reader=lambda *a, **k: rows)
+        names = {payload["subjectName"] for payload in result["payloads"]}
+        self.assertIn("Hellcat", names)
+        self.assertIn("Crow", names)
+
+    def test_orion_via_crow_is_possible_connection_not_confirmed_identity(self):
+        result = discovery.discover_candidate_recommendations(
+            123,
+            ["community_presence"],
+            community_presence_reader=lambda *a, **k: self.community_rows(),
+        )
+        payload = next(payload for payload in result["payloads"] if payload["subjectName"] == "Orion")
+        self.assertEqual(payload["type"], "new_subject")
+        self.assertEqual(payload.get("recommendedCategory"), "Personnel")
+        self.assertIn("mentioned through Crow", payload["reason"])
+        self.assertIn("not confirmed identity", payload["reason"])
+        self.assertNotIn("relationship", payload.get("recommendedKind", ""))
+
+    def test_community_weak_terms_and_one_off_title_words_withheld(self):
+        rows = [
+            {"subjectName": "everyone", "mentionCount": 5, "directInteractionCount": 0, "operatorMentionCount": 0, "daysActive": 4, "category": "community_regular_candidate", "signalCount": 5},
+            {"subjectName": "today", "mentionCount": 3, "directInteractionCount": 0, "operatorMentionCount": 0, "daysActive": 2, "category": "community_regular_candidate", "signalCount": 4},
+            {"subjectName": "Signal", "mentionCount": 1, "directInteractionCount": 0, "operatorMentionCount": 0, "daysActive": 1, "category": "community_regular_candidate", "signalCount": 1},
+        ]
+        result = discovery.discover_candidate_recommendations(123, ["community_presence"], community_presence_reader=lambda *a, **k: rows)
+        self.assertEqual(result["payloads"], [])
+
+    def test_community_payload_does_not_store_raw_transcript_or_invalid_taxonomy(self):
+        rows = [{"subjectName": "Emerald", "mentionCount": 3, "directInteractionCount": 1, "operatorMentionCount": 0, "daysActive": 2, "category": "community_regular_candidate", "signalCount": 5, "evidenceSnippets": ["raw message body should not appear 123456789012345678"]}]
+        result = discovery.discover_candidate_recommendations(123, ["community_presence"], community_presence_reader=lambda *a, **k: rows)
+        payload = result["payloads"][0]
+        self.assertIn(payload.get("recommendedCategory"), {"Entity", "Personnel", "Sponsor", "Interface", "Production"})
+        self.assertNotIn("raw message body", json.dumps(payload))
+        self.assertNotRegex(json.dumps(payload), r"\b\d{15,22}\b")
+
+    def test_alias_language_maps_to_identity_link_only_when_explicit(self):
+        alias_rows = [{"subjectName": "Emerald", "mentionCount": 2, "directInteractionCount": 0, "operatorMentionCount": 1, "daysActive": 1, "category": "possible_alias_review", "signalCount": 3}]
+        regular_rows = [{"subjectName": "Hellcat", "mentionCount": 2, "directInteractionCount": 1, "operatorMentionCount": 0, "daysActive": 1, "category": "community_regular_candidate", "signalCount": 3}]
+        alias_result = discovery.discover_candidate_recommendations(123, ["community_presence"], community_presence_reader=lambda *a, **k: alias_rows)
+        regular_result = discovery.discover_candidate_recommendations(123, ["community_presence"], community_presence_reader=lambda *a, **k: regular_rows)
+        self.assertEqual(alias_result["payloads"][0]["type"], "identity_link")
+        self.assertEqual(regular_result["payloads"][0]["type"], "new_subject")
+
+
+class CommunityPresenceStoreTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path = "test_community_presence.db"
+        try:
+            os.remove(self.db_path)
+        except FileNotFoundError:
+            pass
+
+    def tearDown(self):
+        try:
+            os.remove(self.db_path)
+        except FileNotFoundError:
+            pass
+
+    def test_live_store_minimal_fields_no_raw_ids(self):
+        import bnl_community_scouting as scouting
+        result = scouting.record_community_presence_event(
+            self.db_path,
+            123,
+            "Emerald",
+            "Orion via Crow should be reviewed <@123456789012345678> with https://secret.example/path",
+            channel_id=456,
+            channel_policy="public_context",
+            direct_interaction=True,
+            operator_mention=True,
+            environ={"BNL_COMMUNITY_SCOUTING_ENABLED": "true"},
+        )
+        self.assertTrue(result["ok"])
+        rows = scouting.get_community_presence_candidates(self.db_path, 123, min_signals=1)
+        names = {row["subjectName"] for row in rows}
+        self.assertIn("Emerald", names)
+        self.assertIn("Orion", names)
+        blob = json.dumps(rows)
+        self.assertNotIn("123456789012345678", blob)
+        self.assertNotIn("https://secret.example", blob)
+        self.assertIn("mentioned through Crow", blob)
+
+    def test_disabled_store_is_safely_unavailable(self):
+        import bnl_community_scouting as scouting
+        result = scouting.record_community_presence_event(
+            self.db_path,
+            123,
+            "Emerald",
+            "Emerald is around",
+            channel_id=456,
+            channel_policy="public_context",
+            environ={"BNL_COMMUNITY_SCOUTING_ENABLED": "false"},
+        )
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["status"], "disabled")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Expand BNL's safe candidate scouting to surface recurring community subjects (e.g., Emerald, Hellcat, Crow, Orion via Crow) into the existing review-only Source File recommendation pipeline. 
- Keep the collector conservative and privacy-preserving: no history backfills, no DMs, no identity merges, no public profiles, and no raw transcripts in outputs.

### Description
- Add a new safe helper module `bnl_community_scouting.py` that implements an opt-in community presence store and lightweight APIs for recording and querying minimal community signals (subject key, display name, firstSeenAt/lastSeenAt, channel labels, mention/direct/operator counts, active windows, capped connection notes, sanitized evidence snippets, category). 
- Register `community_presence` as an approved source lane and wire it into the existing discovery pipeline by updating `bnl_dossier_source_packets.py` and `bnl_dossier_candidate_discovery.py`; discovery now accepts `community_presence` rows (via a caller-supplied reader) and scores candidates using mentions, direct interactions, operator mentions, days active, and safe connection phrases. 
- Add a `!bnl community scout candidates | limit=...` alias and extend `!bnl dossier discover candidates` to accept `lanes=...` including `community_presence`; discovery remains disabled by default unless requested or enabled via config. 
- Hook a minimal live recorder `maybe_record_live_community_presence` into `on_message` so BNL can log approved live signals (only when `BNL_COMMUNITY_SCOUTING_ENABLED` and channel-policy/config permit); the recorder never reads history and only stores sanitized snippets and counts. 
- Map internal community categories to website-safe taxonomy via `community_category_taxonomy` (e.g., community_regular_candidate → Personnel/community_member, possible_alias_review → identity_link) and ensure invalid taxonomy fields are omitted. 
- Add safe diagnostics and runtime state keys for community scouting availability, enabled flag, configured channels, item/candidate counts, last seen, withheld counts/top reason, and last error status; these are merged into existing dossier diagnostics. 
- Tests and small test harness updates: new unit tests for the community lane and store were added and an existing discovery-lane approved-lane expectation was updated.

### Testing
- Ran the full unit test suite: `python -m unittest discover -s tests -v` (70 tests) and all tests passed. 
- Ran static compile checks: `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py bnl_source_file_lookup.py bnl_community_scouting.py` with no errors. 
- Ran repository checks: `git diff --check` (no issues).
- Manual/QA notes: tests include community-presence reader scenarios (Emerald/Orion/Hellcat/Crow), disabled-store behavior, weak-term withholding, alias-to-identity_link mapping, and safety checks ensuring no raw Discord IDs or raw transcripts appear in outgoing payloads.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b6bcbb738832189b76530651f54fe)