### PR TITLE
Python 3.9 compatibility: fix PEP 604 annotations in bnl01_bot.py

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -3984,7 +3984,7 @@ def can_send_dossier_recommendation(user, member, guild) -> bool:
     return False
 
 
-def build_dossier_recommendation_diagnostics(guild_id: int | None = None) -> dict:
+def build_dossier_recommendation_diagnostics(guild_id=None) -> dict:
     """Safe configuration/status diagnostics for dossier recommendation ingest."""
     source_file_diag = build_source_file_lookup_diagnostics()
     return {
@@ -4067,7 +4067,7 @@ def _current_rd_discovery_context(message: discord.Message) -> list[dict]:
     return combined[-25:]
 
 
-def read_community_presence_candidates_for_discovery(guild_id: int | None, limit: int = 500):
+def read_community_presence_candidates_for_discovery(guild_id, limit: int = 500):
     """Return sanitized community-presence rows for the discovery lane without Discord IDs or raw transcripts."""
     if not community_scouting_enabled():
         return []


### PR DESCRIPTION
### Motivation
- Fix the Python 3.9 VPS crash `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` caused by evaluated PEP 604 union annotations (e.g. `int | None`) in runtime-loaded bot code so the bot can run under Python 3.9 without behavioral changes.

### Description
- Replace PEP 604 annotations in runtime-loaded `bnl01_bot.py` with Python 3.9-safe forms by changing `def build_dossier_recommendation_diagnostics(guild_id: int | None = None) -> dict:` to `def build_dossier_recommendation_diagnostics(guild_id=None) -> dict:` and `def read_community_presence_candidates_for_discovery(guild_id: int | None, limit: int = 500):` to `def read_community_presence_candidates_for_discovery(guild_id, limit: int = 500):`, touching only `bnl01_bot.py` and making no logic or behavior changes to community scouting, source-file lookup, dossier discovery, queue, relay, welcome, ambient, or permissions.

### Testing
- Ran `python3 -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py bnl_source_file_lookup.py bnl_community_scouting.py` which completed successfully.
- Ran `python -m unittest discover -s tests -v` which passed (70 tests, OK).
- Ran `git diff --check` with no issues.
- Manual VPS verification command: `python3 -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py bnl_source_file_lookup.py bnl_community_scouting.py && python -m unittest discover -s tests -v`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b719cd8bc8321bcb8bd95e466b4de)