### PR TITLE
Bot PR #187 — Source File Context Injection v1

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -58,6 +58,13 @@ from bnl_source_file_lookup import (
     lookup_source_file,
     parse_source_file_lookup_command,
 )
+from bnl_source_context_injection import (
+    MAX_SOURCE_CONTEXT_SUBJECTS,
+    build_source_context_diagnostics,
+    build_source_context_for_subjects,
+    parse_source_context_subjects,
+    should_inject_source_context,
+)
 from bnl_source_knowledge_bridge import (
     KNOWLEDGE_BRIDGE_INGEST_SOURCE,
     format_source_knowledge_bridge_response,
@@ -3998,9 +4005,50 @@ def can_send_dossier_recommendation(user, member, guild) -> bool:
     return False
 
 
+def can_use_source_context_injection(user, member, guild) -> bool:
+    """Owner/admin/operator gate for automatic Source File context injection."""
+    return can_send_dossier_recommendation(user, member, guild)
+
+
+async def maybe_build_source_context_for_direct_message(
+    message: discord.Message,
+    direct_content: str,
+    channel_policy: str,
+    *,
+    route: str = "direct",
+) -> str:
+    """Build Source File prompt context only for approved direct operator routes."""
+
+    channel = getattr(message, "channel", None)
+    channel_name = getattr(channel, "name", "") or ""
+    guild = getattr(message, "guild", None)
+    member = message.author if isinstance(message.author, discord.Member) else (guild.get_member(message.author.id) if guild else None)
+    privileged = can_use_source_context_injection(message.author, member, guild)
+    if not should_inject_source_context(
+        channel_policy=channel_policy,
+        channel_name=channel_name,
+        privileged=privileged,
+        direct_interaction=True,
+        route=route,
+    ):
+        return ""
+
+    subjects = parse_source_context_subjects(direct_content)
+    if not subjects:
+        return ""
+
+    context_block, _results = await asyncio.to_thread(build_source_context_for_subjects, subjects, lookup_source_file)
+    if len(subjects) > MAX_SOURCE_CONTEXT_SUBJECTS:
+        logging.info("source_context_injection_narrowing_required subjects=%s", len(subjects))
+    elif context_block:
+        logging.info("source_context_injection_loaded subjects=%s", len(subjects))
+    return context_block
+
+
 def build_dossier_recommendation_diagnostics(guild_id=None) -> dict:
     """Safe configuration/status diagnostics for dossier recommendation ingest."""
     source_file_diag = build_source_file_lookup_diagnostics()
+    source_context_diag = build_source_context_diagnostics()
     return {
         "ingest_url_configured": bool(os.getenv("BNL_DOSSIER_INGEST_URL", "").strip()),
         "ingest_url_using_default": not bool(os.getenv("BNL_DOSSIER_INGEST_URL", "").strip()),
@@ -4018,6 +4066,13 @@ def build_dossier_recommendation_diagnostics(guild_id=None) -> dict:
         "source_file_last_lookup_subject": source_file_diag["last_lookup_subject"],
         "source_file_last_lookup_found": source_file_diag["last_lookup_found"],
         "source_file_last_lookup_error_status": source_file_diag["last_lookup_error_status"],
+        "source_context_injection_available": source_context_diag["available"],
+        "source_context_injection_enabled": source_context_diag["enabled"],
+        "source_context_last_status": source_context_diag["last_status"],
+        "source_context_last_subjects": source_context_diag["last_subjects"],
+        "source_context_last_found_count": source_context_diag["last_found_count"],
+        "source_context_last_match_kinds": source_context_diag["last_match_kinds"],
+        "source_context_last_error_status": source_context_diag["last_error_status"],
         "candidate_discovery_available": True,
         "candidate_discovery_enabled": False,
         "candidate_discovery_ingest_source": DISCOVERY_INGEST_SOURCE,
@@ -10348,7 +10403,8 @@ def build_user_aware_prompt(
     message_count: int = 1,
     privileged: bool = False,
     channel_policy: str = "unknown",
-    website_read_model_context: str = ""
+    website_read_model_context: str = "",
+    source_context_block: str = ""
 ) -> tuple:
     print("BNL DEBUG: build_user_aware_prompt start")
     display_name, preferred_name = get_user_profile(user_id, guild_id)
@@ -10387,6 +10443,10 @@ def build_user_aware_prompt(
     website_read_model_prompt_block = ""
     if website_read_model_context:
         website_read_model_prompt_block = f"{website_read_model_context}\n"
+
+    source_context_prompt_block = ""
+    if source_context_block:
+        source_context_prompt_block = f"{source_context_block}\n"
 
     room_prompt_block = ""
     if room_context:
@@ -10455,6 +10515,7 @@ def build_user_aware_prompt(
         f"{broadcast_prompt_block}"
         f"{show_state_prompt_block}"
         f"{website_read_model_prompt_block}"
+        f"{source_context_prompt_block}"
         f"User name to address (optional): {name_to_use}\n"
         f"User display name: {display_name or fallback_display_name}\n"
         f"User message: {clean_content}"
@@ -10769,6 +10830,12 @@ async def _generate_direct_payload_session(session_key, reason: str):
         route="direct_payload_session",
     )
     website_read_model_context = maybe_build_bnl_read_model_context(direct_content, session.get("channel_policy", "unknown"))
+    source_context_block = await maybe_build_source_context_for_direct_message(
+        anchor_message,
+        direct_content,
+        session.get("channel_policy", "unknown"),
+        route="direct_payload_session",
+    )
     prompt, allow_greeting, style_key = build_user_aware_prompt(
         session["requester_user_id"],
         session["guild_id"],
@@ -10780,6 +10847,7 @@ async def _generate_direct_payload_session(session_key, reason: str):
         privileged=is_privileged_member(session["requester_member"], session["guild"]),
         channel_policy=session.get("channel_policy", "unknown"),
         website_read_model_context=website_read_model_context,
+        source_context_block=source_context_block,
     )
     prompt = _build_direct_payload_prompt(prompt, direct_payload_items, direct_content)
     log_response_style(session["guild_id"], session["requester_user_id"], style_key)
@@ -11443,6 +11511,12 @@ async def on_message(message: discord.Message):
                 route="direct_active",
             )
             website_read_model_context = maybe_build_bnl_read_model_context(direct_content, channel_policy)
+            source_context_block = await maybe_build_source_context_for_direct_message(
+                message,
+                direct_content,
+                channel_policy,
+                route="direct_active",
+            )
             prompt, allow_greeting, style_key = build_user_aware_prompt(
                 message.author.id,
                 message.guild.id,
@@ -11455,6 +11529,7 @@ async def on_message(message: discord.Message):
                 privileged=is_privileged_member(message.author, message.guild),
                 channel_policy=channel_policy,
                 website_read_model_context=website_read_model_context,
+                source_context_block=source_context_block,
             )
             prompt = _build_direct_payload_prompt(prompt, direct_payload_items, direct_content)
             log_response_style(message.guild.id, message.author.id, style_key)
@@ -11609,6 +11684,12 @@ async def on_message(message: discord.Message):
             route="direct",
         )
         website_read_model_context = maybe_build_bnl_read_model_context(direct_content, channel_policy)
+        source_context_block = await maybe_build_source_context_for_direct_message(
+            message,
+            direct_content,
+            channel_policy,
+            route="direct",
+        )
         prompt, allow_greeting, style_key = build_user_aware_prompt(
             message.author.id,
             message.guild.id,
@@ -11621,6 +11702,7 @@ async def on_message(message: discord.Message):
             privileged=is_privileged_member(message.author, message.guild),
             channel_policy=channel_policy,
             website_read_model_context=website_read_model_context,
+            source_context_block=source_context_block,
         )
         prompt = _build_direct_payload_prompt(prompt, direct_payload_items, direct_content)
         log_response_style(message.guild.id, message.author.id, style_key)
@@ -11740,6 +11822,12 @@ async def on_message(message: discord.Message):
             route="direct",
         )
         website_read_model_context = maybe_build_bnl_read_model_context(direct_content, channel_policy)
+        source_context_block = await maybe_build_source_context_for_direct_message(
+            message,
+            direct_content,
+            channel_policy,
+            route="direct",
+        )
         prompt, allow_greeting, style_key = build_user_aware_prompt(
             message.author.id,
             message.guild.id,
@@ -11752,6 +11840,7 @@ async def on_message(message: discord.Message):
             privileged=is_privileged_member(message.author, message.guild),
             channel_policy=channel_policy,
             website_read_model_context=website_read_model_context,
+            source_context_block=source_context_block,
         )
         prompt = _build_direct_payload_prompt(prompt, direct_payload_items, direct_content)
         log_response_style(message.guild.id, message.author.id, style_key)
@@ -12058,6 +12147,13 @@ async def bnl_source_check(interaction: discord.Interaction):
         f"- source_file_last_lookup_subject: `{dossier_diag['source_file_last_lookup_subject']}`",
         f"- source_file_last_lookup_found: `{'yes' if dossier_diag['source_file_last_lookup_found'] else 'no'}`",
         f"- source_file_last_lookup_error_status: `{dossier_diag['source_file_last_lookup_error_status']}`",
+        f"- source_context_injection_available: `{'yes' if dossier_diag['source_context_injection_available'] else 'no'}`",
+        f"- source_context_injection_enabled: `{'yes' if dossier_diag['source_context_injection_enabled'] else 'no'}`",
+        f"- source_context_last_status: `{dossier_diag['source_context_last_status']}`",
+        f"- source_context_last_subjects: `{','.join(dossier_diag['source_context_last_subjects']) or 'none'}`",
+        f"- source_context_last_found_count: `{dossier_diag['source_context_last_found_count']}`",
+        f"- source_context_last_match_kinds: `{','.join(dossier_diag['source_context_last_match_kinds']) or 'none'}`",
+        f"- source_context_last_error_status: `{dossier_diag['source_context_last_error_status']}`",
         f"- candidate_discovery_available: `{'yes' if dossier_diag['candidate_discovery_available'] else 'no'}`",
         f"- candidate_discovery_enabled: `{'yes' if dossier_diag['candidate_discovery_enabled'] else 'no'}`",
         f"- candidate_discovery_approved_lanes: `{','.join(dossier_diag['candidate_discovery_approved_lanes'])}`",
@@ -12323,6 +12419,13 @@ async def bnl_status(interaction: discord.Interaction):
         f"- source_file_last_lookup_subject: `{dossier_diag['source_file_last_lookup_subject']}`",
         f"- source_file_last_lookup_found: `{'yes' if dossier_diag['source_file_last_lookup_found'] else 'no'}`",
         f"- source_file_last_lookup_error_status: `{dossier_diag['source_file_last_lookup_error_status']}`",
+        f"- source_context_injection_available: `{'yes' if dossier_diag['source_context_injection_available'] else 'no'}`",
+        f"- source_context_injection_enabled: `{'yes' if dossier_diag['source_context_injection_enabled'] else 'no'}`",
+        f"- source_context_last_status: `{dossier_diag['source_context_last_status']}`",
+        f"- source_context_last_subjects: `{','.join(dossier_diag['source_context_last_subjects']) or 'none'}`",
+        f"- source_context_last_found_count: `{dossier_diag['source_context_last_found_count']}`",
+        f"- source_context_last_match_kinds: `{','.join(dossier_diag['source_context_last_match_kinds']) or 'none'}`",
+        f"- source_context_last_error_status: `{dossier_diag['source_context_last_error_status']}`",
         f"- candidate_discovery_available: `{'yes' if dossier_diag['candidate_discovery_available'] else 'no'}`",
         f"- candidate_discovery_enabled: `{'yes' if dossier_diag['candidate_discovery_enabled'] else 'no'}`",
         f"- candidate_discovery_approved_lanes: `{','.join(dossier_diag['candidate_discovery_approved_lanes'])}`",

--- a/bnl_source_context_injection.py
+++ b/bnl_source_context_injection.py
@@ -1,0 +1,341 @@
+"""Conservative Source File context injection helpers for operator-only answers.
+
+This module builds compact prompt context from the existing protected Source File
+read client. It does not mutate Source Files, dossiers, recommendations, memory,
+or website state.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Callable
+
+MAX_SOURCE_CONTEXT_SUBJECTS = 2
+_SOURCE_CONTEXT_DEFAULT_ENABLED = "true"
+
+_CONTEXTUAL_VERBS_RE = re.compile(
+    r"\b(?:what\s+do\s+we\s+know|what(?:'|’)?s\s+missing|summari[sz]e|review|next\s+with|do\s+next|connected\s+to|source\s+file|case\s+file|dossier)\b",
+    re.IGNORECASE,
+)
+_STOP_TRAILING_RE = re.compile(
+    r"\s+(?:source\s+file|case\s+file|dossier|for\s+internal\s+review|internal\s+review|please|pls|now|today)\b.*$",
+    re.IGNORECASE,
+)
+_BAD_SUBJECTS = {
+    "a", "an", "and", "any", "anything", "case", "connected", "dossier", "file", "info",
+    "internal", "it", "me", "missing", "next", "review", "source", "that", "the", "them",
+    "there", "this", "us", "we", "what", "who", "you",
+}
+
+_last_status = "idle"
+_last_subjects: list[str] = []
+_last_found_count = 0
+_last_match_kinds: list[str] = []
+_last_error_status = "none"
+
+
+def is_source_context_injection_enabled(environ: dict[str, str] | None = None) -> bool:
+    env = environ if environ is not None else os.environ
+    return (env.get("BNL_SOURCE_CONTEXT_INJECTION_ENABLED", _SOURCE_CONTEXT_DEFAULT_ENABLED) or "").strip().lower() not in {"false", "0", "off", "no"}
+
+
+def _compact(value: Any, limit: int = 180) -> str:
+    if value is None:
+        return ""
+    text = re.sub(r"\s+", " ", str(value)).strip().replace("`", "'")
+    if not text:
+        return ""
+    return text if len(text) <= limit else text[: max(1, limit - 1)].rstrip() + "…"
+
+
+def _clean_subject(raw: str) -> str:
+    text = re.sub(r"<@!?\d+>", " ", raw or "")
+    text = re.sub(r"\s+", " ", text).strip(" \t\r\n'\"“”‘’.,!?;:()[]{}")
+    text = _STOP_TRAILING_RE.sub("", text).strip(" \t\r\n'\"“”‘’.,!?;:()[]{}")
+    text = re.sub(r"^(?:the|a|an|summari[sz]e)\s+", "", text, flags=re.IGNORECASE).strip()
+    text = re.sub(r"(?:'|’)?s$", "", text).strip()
+    # Stop before request continuations that are not part of names.
+    text = re.split(r"\b(?:if|and\s+what|but|because|with\s+the)\b", text, maxsplit=1, flags=re.IGNORECASE)[0].strip(" ,")
+    return _compact(text, 80)
+
+
+def _subject_like(subject: str) -> bool:
+    text = (subject or "").strip()
+    if not (2 <= len(text) <= 80):
+        return False
+    if text.lower() in _BAD_SUBJECTS:
+        return False
+    if re.search(r"https?://|@everyone|@here|\n", text, re.IGNORECASE):
+        return False
+    tokens = re.findall(r"[A-Za-z0-9][A-Za-z0-9'_-]*", text)
+    if not tokens or len(tokens) > 5:
+        return False
+    if all(tok.lower() in _BAD_SUBJECTS for tok in tokens):
+        return False
+    # Conservative v1: quoted names may be arbitrary; unquoted names should look like entity/title wording.
+    titleish = any(tok[:1].isupper() or re.search(r"\d", tok) for tok in tokens)
+    multiword = len(tokens) >= 2 and not all(tok.islower() for tok in tokens)
+    return bool(titleish or multiword)
+
+
+def _add_subject(subjects: list[str], raw: str) -> None:
+    subject = _clean_subject(raw)
+    if not _subject_like(subject):
+        return
+    key = subject.casefold()
+    if key not in {s.casefold() for s in subjects}:
+        subjects.append(subject)
+
+
+def parse_source_context_subjects(message_text: str) -> list[str]:
+    """Extract up to a small number of likely Source File subjects from an operator prompt.
+
+    This intentionally recognizes direct case-file/source-file wording only; it is
+    not broad named-entity extraction and should reject casual conversation.
+    """
+
+    text = re.sub(r"<@!?\d+>", " ", message_text or "")
+    text = re.sub(r"\s+", " ", text).strip()
+    if not text or text.startswith("!bnl "):
+        return []
+    if not _CONTEXTUAL_VERBS_RE.search(text):
+        return []
+
+    subjects: list[str] = []
+
+    for quoted in re.findall(r"[\"“‘']([^\"”’']{2,80})[\"”’']", text):
+        _add_subject(subjects, quoted)
+
+    patterns = [
+        r"\bwhat\s+do\s+we\s+know\s+about\s+(.+?)(?:[?.!]|$)",
+        r"\bwhat(?:'|’)?s\s+missing\s+from\s+(.+?)(?:[?.!]|$)",
+        r"\bsummari[sz]e\s+(.+?\s+(?:source\s+file|case\s+file|dossier))(?:[?.!]|$)",
+        r"\bwhat\s+should\s+we\s+do\s+next\s+with\s+(.+?)(?:[?.!]|$)",
+        r"\b(?:about|for)\s+(.+?)\s+(?:source\s+file|case\s+file|dossier)\b",
+        r"\b([A-Z][A-Za-z0-9'_-]*(?:\s+[A-Z][A-Za-z0-9'_-]*){0,4})\s+(?:source\s+file|case\s+file|dossier)\b",
+    ]
+    for pattern in patterns:
+        for match in re.finditer(pattern, text, flags=re.IGNORECASE):
+            _add_subject(subjects, match.group(1))
+
+    for match in re.finditer(
+        r"\bis\s+(.+?)\s+connected\s+to\s+(.+?)(?:[?.!]|$)", text, flags=re.IGNORECASE
+    ):
+        _add_subject(subjects, match.group(1))
+        _add_subject(subjects, match.group(2))
+
+    return subjects
+
+
+def should_inject_source_context(
+    *,
+    channel_policy: str,
+    channel_name: str = "",
+    privileged: bool = False,
+    direct_interaction: bool = False,
+    route: str = "direct",
+    environ: dict[str, str] | None = None,
+) -> bool:
+    """Return True only for privileged direct/operator routes in approved internal contexts."""
+
+    if not is_source_context_injection_enabled(environ):
+        return False
+    if not privileged or not direct_interaction:
+        return False
+    policy = (channel_policy or "unknown").strip().lower()
+    name = re.sub(r"[^a-z0-9-]+", "-", (channel_name or "").strip().lower()).strip("-")
+    if policy in {"public_home", "public_context", "public_selective", "protected_system", "broadcast_memory", "reference_canon", "ai_image_tool", "unknown"}:
+        return False
+    if name in {"welcome", "episode-tracker", "bnl-broadcast-memory"}:
+        return False
+    if route in {"website_relay", "ambient", "passive", "queue", "payment", "dm", "broadcast_memory_intake"}:
+        return False
+    if policy == "sealed_test" or name == "bnl-testing":
+        return True
+    if policy == "internal_controlled" and name == "research-and-development":
+        return True
+    return False
+
+
+def _lookup_path(data: dict[str, Any], paths: list[tuple[str, ...]]) -> Any:
+    for path in paths:
+        cur: Any = data
+        for key in path:
+            if not isinstance(cur, dict) or key not in cur:
+                cur = None
+                break
+            cur = cur.get(key)
+        if cur not in (None, "", [], {}):
+            return cur
+    return None
+
+
+def _source_file_object(data: dict[str, Any]) -> dict[str, Any]:
+    for key in ("sourceFile", "source_file", "file", "candidate", "result"):
+        value = data.get(key)
+        if isinstance(value, dict):
+            return value
+    return data if isinstance(data, dict) else {}
+
+
+def _list_text(value: Any, *, limit: int = 4, item_limit: int = 130) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, dict):
+        iterable = value.values()
+    elif isinstance(value, (list, tuple, set)):
+        iterable = value
+    else:
+        iterable = [value]
+    parts: list[str] = []
+    for item in iterable:
+        if isinstance(item, dict):
+            item = item.get("summary") or item.get("text") or item.get("note") or item.get("name") or item.get("label") or item.get("reason") or item.get("value") or item.get("status")
+        safe = _compact(item, item_limit)
+        if safe:
+            parts.append(safe)
+        if len(parts) >= limit:
+            break
+    return "; ".join(parts)
+
+
+def _append_section(lines: list[str], label: str, value: Any, fallback: str = "") -> None:
+    text = _list_text(value) if isinstance(value, (list, tuple, set, dict)) else _compact(value, 220)
+    if not text:
+        text = fallback
+    if text:
+        lines.append(f"{label}: {text}")
+
+
+def _alias_review(source_file: dict[str, Any], data: dict[str, Any], match_kind: str, requested: str) -> str:
+    aliases = _lookup_path(source_file, [("aliases",), ("identityLinks",), ("identity_links",)])
+    matched = _lookup_path(data, [("matchedAlias",), ("alias",), ("match", "alias")]) or requested
+    if "alias" in (match_kind or "").lower():
+        if "confirm" in (match_kind or "").lower():
+            return f"Requested subject matched confirmed alias '{_compact(matched, 70)}'. Treat as internal routing/context only; do not present as a public identity claim unless the Source File explicitly says public-safe."
+        return f"Requested subject appears to be an alias-style match ('{_compact(matched, 70)}'); keep identity/connection language review-only."
+    if isinstance(aliases, dict):
+        proposed = len(aliases.get("proposed") or aliases.get("proposedAliases") or [])
+        confirmed = len(aliases.get("confirmed") or aliases.get("confirmedAliases") or [])
+        return f"Aliases on file: {confirmed} confirmed, {proposed} proposed; proposed aliases remain review-only."
+    if aliases:
+        return _list_text(aliases, limit=3, item_limit=70)
+    return "No confirmed alias instruction surfaced in the compact read result."
+
+
+def build_source_context_block(result: dict[str, Any], original_subject: str = "") -> str:
+    """Build a bounded internal prompt block from one Source File lookup result."""
+
+    requested = _compact(original_subject or (result.get("query") or {}).get("lookupValue") or "that subject", 90)
+    if not result.get("ok"):
+        return (
+            "SOURCE FILE / INTERNAL CASE FILE CONTEXT:\n"
+            f"Subject requested: {requested}\n"
+            f"Lookup status: unavailable ({_compact(result.get('kind') or result.get('error') or 'error', 120)})\n"
+            "Boundary: Do not hallucinate a case file. Say the Source File read is unavailable and keep any answer uncertain."
+        )
+
+    data = result.get("data") if isinstance(result.get("data"), dict) else {}
+    match_kind = _compact(result.get("matchKind") or data.get("matchKind") or data.get("match_kind") or "none", 70) or "none"
+    if not result.get("found"):
+        possible = data.get("possibleMatches") or data.get("possible_matches") or data.get("matches")
+        possible_text = _list_text(possible, limit=3, item_limit=80)
+        lines = [
+            "SOURCE FILE / INTERNAL CASE FILE CONTEXT:",
+            f"Subject requested: {requested}",
+            "Match kind: none",
+            "Case file status: no Source File found by the protected read endpoint.",
+        ]
+        if possible_text:
+            lines.append(f"Possible matches: {possible_text} (review-only; not confirmed)")
+        lines.append("Boundary: Do not hallucinate a case file. Say BNL does not see a Source File yet and suggest creating/reviewing one if relevant.")
+        return "\n".join(lines)
+
+    source_file = _source_file_object(data)
+    subject = _lookup_path(source_file, [("name",), ("sourceFileName",), ("source_file_name",), ("subject",), ("displayName",), ("title",), ("normalizedName",)]) or requested
+    lines = [
+        "SOURCE FILE / INTERNAL CASE FILE CONTEXT:",
+        f"Subject: {_compact(subject, 90)}",
+        f"Requested subject: {requested}",
+        f"Match kind: {match_kind}",
+        "Case file status: internal working case file, not public dossier",
+    ]
+    _append_section(lines, "Known facts", _lookup_path(source_file, [("knownFacts",), ("facts",), ("evidenceSummary",), ("summary",), ("reason",)]), "not surfaced in compact read result")
+    _append_section(lines, "Warnings", _lookup_path(source_file, [("warnings",), ("safetyWarnings",), ("sourceWarnings",), ("duplicateWarnings",), ("duplicateWarning",)]), "none surfaced")
+    _append_section(lines, "Public-safety notes", _lookup_path(source_file, [("publicSafetyNotes",), ("safetyNotes",), ("publicUseNotes",), ("safety",)]), "internal-only until reviewed for public use")
+    _append_section(lines, "Missing info", _lookup_path(source_file, [("missingInfo",), ("missing",), ("openQuestions",)]), "not surfaced in compact read result")
+    _append_section(lines, "Identity/alias review", _alias_review(source_file, data, match_kind, requested))
+    _append_section(lines, "Review-only/internal notes", _lookup_path(source_file, [("reviewNotes",), ("internalNotes",), ("ownerReview",), ("ownerReviewState",), ("draft",), ("activeDraft",)]), "do not frame review-only notes as public-safe facts")
+    _append_section(lines, "Recommended next action", _lookup_path(source_file, [("nextRecommendedAction",), ("suggestedAction",), ("nextAction",)]), "review source notes before drafting or public use")
+    lines.append("Boundary: Use this as internal case-file context. Do not present review-only, source-blind, or internal-only material as confirmed public fact. Do not call this a public dossier unless public dossier status is explicitly present.")
+    return "\n".join(lines[:16])
+
+
+def inject_source_context_into_prompt(base_prompt: str, context_block: str) -> str:
+    if not context_block:
+        return base_prompt or ""
+    return f"{base_prompt or ''}\n\n{context_block}\n"
+
+
+def record_source_context_attempt(subjects: list[str] | None, results: list[dict[str, Any]] | None = None, *, status: str = "idle", error_status: str = "none") -> None:
+    global _last_status, _last_subjects, _last_found_count, _last_match_kinds, _last_error_status
+    _last_status = _compact(status, 80) or "idle"
+    _last_subjects = [_compact(s, 80) for s in (subjects or []) if _compact(s, 80)][:MAX_SOURCE_CONTEXT_SUBJECTS + 1]
+    found = 0
+    kinds: list[str] = []
+    for result in results or []:
+        if result.get("found"):
+            found += 1
+        kind = _compact(result.get("matchKind") or ((result.get("data") or {}) if isinstance(result.get("data"), dict) else {}).get("matchKind") or "none", 60)
+        kinds.append(kind or "none")
+    _last_found_count = found
+    _last_match_kinds = kinds[:MAX_SOURCE_CONTEXT_SUBJECTS]
+    _last_error_status = _compact(error_status, 80) or "none"
+
+
+def build_source_context_diagnostics(environ: dict[str, str] | None = None) -> dict[str, Any]:
+    return {
+        "available": True,
+        "enabled": is_source_context_injection_enabled(environ),
+        "last_status": _last_status,
+        "last_subjects": list(_last_subjects),
+        "last_found_count": _last_found_count,
+        "last_match_kinds": list(_last_match_kinds),
+        "last_error_status": _last_error_status,
+    }
+
+
+def build_source_context_for_subjects(subjects: list[str], lookup_func: Callable[[dict[str, str]], dict[str, Any]]) -> tuple[str, list[dict[str, Any]]]:
+    """Lookup up to two subjects and return a combined compact context block."""
+
+    clean_subjects = []
+    for subject in subjects or []:
+        cleaned = _clean_subject(subject)
+        if cleaned and cleaned.casefold() not in {s.casefold() for s in clean_subjects}:
+            clean_subjects.append(cleaned)
+    if len(clean_subjects) > MAX_SOURCE_CONTEXT_SUBJECTS:
+        record_source_context_attempt(clean_subjects, [], status="too_many_subjects")
+        return (
+            "SOURCE FILE / INTERNAL CASE FILE CONTEXT:\n"
+            f"Subject candidates: {', '.join(clean_subjects[:4])}\n"
+            "Lookup status: not run; more than two likely subjects were detected.\n"
+            "Boundary: Ask the operator to narrow the request to one or two Source Files before using case-file context.",
+            [],
+        )
+
+    blocks: list[str] = []
+    results: list[dict[str, Any]] = []
+    for subject in clean_subjects:
+        result = lookup_func({"lookupKey": "subject", "lookupValue": subject, "subject": subject})
+        results.append(result)
+        blocks.append(build_source_context_block(result, subject))
+    status = "loaded" if blocks else "no_subjects"
+    error_status = "none"
+    for result in results:
+        if not result.get("ok"):
+            error_status = _compact(result.get("kind") or result.get("error") or "error", 80)
+            status = "lookup_error"
+            break
+    record_source_context_attempt(clean_subjects, results, status=status, error_status=error_status)
+    return "\n\n".join(blocks), results

--- a/tests/test_source_context_injection.py
+++ b/tests/test_source_context_injection.py
@@ -1,0 +1,177 @@
+import asyncio
+import json
+import os
+import unittest
+from unittest import mock
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl_source_context_injection as sci
+import bnl01_bot
+
+
+class SourceContextSubjectParserTests(unittest.TestCase):
+    def test_detects_what_do_we_know_about_subject(self):
+        self.assertEqual(sci.parse_source_context_subjects("@BNL-01 what do we know about Hellcat?"), ["Hellcat"])
+
+    def test_detects_source_file_phrase(self):
+        self.assertEqual(sci.parse_source_context_subjects("Emerald source file"), ["Emerald"])
+
+    def test_detects_connection_pair(self):
+        self.assertEqual(sci.parse_source_context_subjects("is Crow connected to Orion?"), ["Crow", "Orion"])
+
+    def test_detects_case_file_review(self):
+        self.assertEqual(sci.parse_source_context_subjects("summarize Mac Modem's case file for internal review."), ["Mac Modem"])
+
+    def test_rejects_generic_casual_messages(self):
+        for text in ("that was funny", "what are we doing today", "tell me a joke about pizza", "thanks BNL"):
+            self.assertEqual(sci.parse_source_context_subjects(text), [])
+
+
+class SourceContextPolicyTests(unittest.TestCase):
+    def test_allows_privileged_direct_rd_and_sealed_test(self):
+        self.assertTrue(sci.should_inject_source_context(channel_policy="internal_controlled", channel_name="research-and-development", privileged=True, direct_interaction=True))
+        self.assertTrue(sci.should_inject_source_context(channel_policy="sealed_test", channel_name="bnl-testing", privileged=True, direct_interaction=True))
+
+    def test_rejects_public_channel_injection(self):
+        for policy in ("public_home", "public_context", "public_selective"):
+            self.assertFalse(sci.should_inject_source_context(channel_policy=policy, channel_name="general-chat", privileged=True, direct_interaction=True))
+
+    def test_rejects_unauthorized_user_injection(self):
+        self.assertFalse(sci.should_inject_source_context(channel_policy="internal_controlled", channel_name="research-and-development", privileged=False, direct_interaction=True))
+
+    def test_rejects_protected_channels(self):
+        self.assertFalse(sci.should_inject_source_context(channel_policy="protected_system", channel_name="welcome", privileged=True, direct_interaction=True))
+        self.assertFalse(sci.should_inject_source_context(channel_policy="protected_system", channel_name="episode-tracker", privileged=True, direct_interaction=True))
+
+    def test_rejects_website_relay_and_ambient_paths(self):
+        self.assertFalse(sci.should_inject_source_context(channel_policy="internal_controlled", channel_name="research-and-development", privileged=True, direct_interaction=True, route="website_relay"))
+        self.assertFalse(sci.should_inject_source_context(channel_policy="sealed_test", channel_name="bnl-testing", privileged=True, direct_interaction=True, route="ambient"))
+
+
+class SourceContextBlockTests(unittest.TestCase):
+    def test_source_file_found_adds_compact_context_block(self):
+        result = {
+            "ok": True,
+            "found": True,
+            "matchKind": "exact",
+            "data": {"sourceFile": {"name": "Hellcat", "knownFacts": ["recurring approved-lane entity"], "missingInfo": ["confirm public-safe role"], "publicSafetyNotes": "internal-only until reviewed", "nextRecommendedAction": "review source notes"}},
+        }
+        block = sci.build_source_context_block(result, "Hellcat")
+        self.assertIn("SOURCE FILE / INTERNAL CASE FILE CONTEXT", block)
+        self.assertIn("Subject: Hellcat", block)
+        self.assertIn("Case file status: internal working case file, not public dossier", block)
+        self.assertIn("Known facts: recurring approved-lane entity", block)
+        self.assertNotIn("{", block)
+
+    def test_no_source_file_found_gives_bounded_no_file_context(self):
+        block = sci.build_source_context_block({"ok": True, "found": False, "data": {"found": False}}, "Unknown")
+        self.assertIn("no Source File found", block)
+        self.assertIn("Do not hallucinate a case file", block)
+
+    def test_confirmed_alias_is_alias_match_not_public_identity_claim(self):
+        result = {"ok": True, "found": True, "matchKind": "confirmed alias", "data": {"matchedAlias": "ShadowsPit", "sourceFile": {"name": "Deadite Ash"}}}
+        block = sci.build_source_context_block(result, "ShadowsPit")
+        self.assertIn("Match kind: confirmed alias", block)
+        self.assertIn("internal routing/context only", block)
+        self.assertNotIn("public identity proof", block.lower())
+
+    def test_source_blind_warning_remains_warning_not_fact(self):
+        result = {"ok": True, "found": True, "matchKind": "exact", "data": {"sourceFile": {"name": "Emerald", "knownFacts": ["approved-lane mention"], "warnings": ["source-blind memory support only"]}}}
+        block = sci.build_source_context_block(result, "Emerald")
+        self.assertIn("Known facts: approved-lane mention", block)
+        self.assertIn("Warnings: source-blind memory support only", block)
+
+    def test_internal_only_note_is_not_framed_as_public_safe(self):
+        result = {"ok": True, "found": True, "matchKind": "exact", "data": {"sourceFile": {"name": "Shortbabe", "internalNotes": "operator review only"}}}
+        block = sci.build_source_context_block(result, "Shortbabe")
+        self.assertIn("Review-only/internal notes: operator review only", block)
+        self.assertIn("Do not present review-only", block)
+
+    def test_lookup_limit_asks_to_narrow_beyond_two_subjects(self):
+        calls = []
+        block, results = sci.build_source_context_for_subjects(["Hellcat", "Emerald", "Crow"], lambda query: calls.append(query) or {})
+        self.assertEqual(calls, [])
+        self.assertEqual(results, [])
+        self.assertIn("more than two", block)
+
+
+class SourceContextBotIntegrationTests(unittest.TestCase):
+    class Perms:
+        administrator = False
+        manage_guild = False
+        manage_messages = False
+        kick_members = False
+        ban_members = False
+
+    class User:
+        def __init__(self, user_id, perms=None):
+            self.id = user_id
+            self.guild_permissions = perms or SourceContextBotIntegrationTests.Perms()
+            self.roles = []
+            self.display_name = "Operator"
+            self.bot = False
+
+    class Guild:
+        id = 123
+        owner_id = 999
+        name = "Guild"
+        def get_member(self, user_id):
+            return None
+
+    class Channel:
+        id = 456
+        name = "research-and-development"
+        parent = None
+        def __init__(self, guild):
+            self.guild = guild
+
+    class Message:
+        def __init__(self, user_id=999, channel_name="research-and-development"):
+            self.author = SourceContextBotIntegrationTests.User(user_id)
+            self.guild = SourceContextBotIntegrationTests.Guild()
+            self.channel = SourceContextBotIntegrationTests.Channel(self.guild)
+            self.channel.name = channel_name
+
+    def test_bot_helper_loads_context_for_authorized_rd_direct_question(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        fake_result = {"ok": True, "found": True, "matchKind": "exact", "data": {"sourceFile": {"name": "Hellcat", "knownFacts": ["fact"]}}}
+        with mock.patch.object(bnl01_bot, "lookup_source_file", return_value=fake_result) as lookup_mock:
+            block = asyncio.run(bnl01_bot.maybe_build_source_context_for_direct_message(self.Message(), "what do we know about Hellcat?", "internal_controlled"))
+        lookup_mock.assert_called_once()
+        self.assertIn("Subject: Hellcat", block)
+
+    def test_bot_helper_rejects_public_channel(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        with mock.patch.object(bnl01_bot, "lookup_source_file") as lookup_mock:
+            block = asyncio.run(bnl01_bot.maybe_build_source_context_for_direct_message(self.Message(channel_name="general-chat"), "what do we know about Hellcat?", "public_context"))
+        lookup_mock.assert_not_called()
+        self.assertEqual(block, "")
+
+    def test_bot_helper_rejects_unauthorized_user(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        with mock.patch.object(bnl01_bot, "lookup_source_file") as lookup_mock:
+            block = asyncio.run(bnl01_bot.maybe_build_source_context_for_direct_message(self.Message(user_id=111), "what do we know about Hellcat?", "internal_controlled"))
+        lookup_mock.assert_not_called()
+        self.assertEqual(block, "")
+
+    def test_prompt_accepts_source_context_without_breaking_existing_args(self):
+        with mock.patch.object(bnl01_bot, "get_user_profile", return_value=("Operator", None)), \
+             mock.patch.object(bnl01_bot, "should_allow_greeting", return_value=False), \
+             mock.patch.object(bnl01_bot, "choose_response_style", return_value=("concise", "style rule")), \
+             mock.patch.object(bnl01_bot, "build_user_memory_context", return_value="No durable memory."), \
+             mock.patch.object(bnl01_bot, "build_broadcast_memory_context", return_value=""):
+            prompt, _allow, _style = bnl01_bot.build_user_aware_prompt(1, 1, "Operator", "what do we know about Hellcat?", channel_name="research-and-development", privileged=True, channel_policy="internal_controlled", source_context_block="SOURCE FILE / INTERNAL CASE FILE CONTEXT:\nSubject: Hellcat")
+        self.assertIn("SOURCE FILE / INTERNAL CASE FILE CONTEXT", prompt)
+        self.assertIn("Prompt operator authority: approved_operator_context", prompt)
+
+    def test_diagnostics_include_source_context_safe_metadata(self):
+        diag = bnl01_bot.build_dossier_recommendation_diagnostics()
+        for key in ("source_context_injection_available", "source_context_injection_enabled", "source_context_last_status", "source_context_last_subjects", "source_context_last_found_count", "source_context_last_match_kinds", "source_context_last_error_status"):
+            self.assertIn(key, diag)
+        self.assertNotIn("secret", json.dumps(diag).lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_source_file_lookup.py
+++ b/tests/test_source_file_lookup.py
@@ -272,7 +272,19 @@ class SourceFileLookupBotTests(unittest.TestCase):
         self.assertTrue(diag["source_file_read_token_configured"])
         self.assertTrue(diag["source_file_read_url_configured"])
         self.assertIn("source_file_last_lookup_status", diag)
+        self.assertIn("source_context_injection_available", diag)
+        self.assertIn("source_context_injection_enabled", diag)
         self.assertNotIn("secret-token", json.dumps(diag))
+
+    def test_existing_source_lookup_command_still_works(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        message = self.Message(999)
+        fake_result = {"ok": True, "found": True, "matchKind": "exact", "data": {"sourceFile": {"name": "Hellcat"}}}
+        with mock.patch.object(bnl01_bot, "lookup_source_file", return_value=fake_result) as lookup_mock:
+            handled = asyncio.run(bnl01_bot.maybe_handle_source_file_lookup_command(message, "!bnl source lookup Hellcat"))
+        self.assertTrue(handled)
+        lookup_mock.assert_called_once()
+        self.assertIn("Source File: Hellcat", message.replies[-1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Provide a conservative v1 helper to allow BNL to use internal Source File / case-file context in operator-only answers without requiring explicit `!bnl source lookup` commands.
- Keep public/private boundaries strict and re-use the existing protected Source File read client rather than adding any mutation or new website endpoints.
- Limit automatic injection to privileged operator contexts and a small, conservative subject-detection surface to avoid over-eager or public leaks.

### Description
- Added a new helper module `bnl_source_context_injection.py` that implements subject parsing (`parse_source_context_subjects`), injection gating (`should_inject_source_context`), Source File prompt block builders (`build_source_context_block`, `build_source_context_for_subjects`), diagnostics (`build_source_context_diagnostics`), and prompt injection helpers (`inject_source_context_into_prompt`).
- Integrated the helper into `bnl01_bot.py` for operator/direct routes by adding `maybe_build_source_context_for_direct_message` and wiring `source_context_block` into `build_user_aware_prompt` and the direct response generation paths (direct active replies, direct payload sessions, other direct routes) while leaving explicit `!bnl source lookup` handling unchanged.
- Permission gating reuses existing owner/mod/operator helpers via `can_use_source_context_injection` which delegates to `can_send_dossier_recommendation`, ensuring only privileged users can trigger injection automatically.
- Conservative subject-detection recognizes patterns like `what do we know about X`, `X source file`, `is A connected to B`, quoted names, and supports up to two subjects; if >2 subjects are detected the helper asks the operator to narrow the request.
- Prompt boundaries and content rules ensure the injected block is compact, review-only, and clearly labeled as internal case-file context with explicit directives not to treat review-only items as public facts.
- Diagnostics extended in `bnl01_bot.build_dossier_recommendation_diagnostics`, `/bnl_source_check`, and `/bnl_status` to expose `source_context_injection_*` fields (available/enabled/last status/subjects/found count/match kinds/error status) without leaking secrets.
- Added `tests/test_source_context_injection.py` to verify subject parsing, policy gating, context block formatting, integration helper behavior, and diagnostics; updated `tests/test_source_file_lookup.py` to include an integration sanity test that the explicit `!bnl source lookup` command still works.

### Testing
- Ran the full test suite with `python -m unittest discover -s tests -v` and all tests passed (107 tests run, OK). 
- Compiled the modified modules with `python -m py_compile` and the compile check succeeded without syntax errors. 
- Performed automated diagnostics checks (`git diff --check` and local lint-like checks) and confirmed no check failures. 
- Existing tests exercised: source-file lookup, source-knowledge bridge, dossier discovery/recommendations, community scouting, routing/direct reply behavior, and the new source-context parsing/integration tests; all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b885db468832184aacf3b2e1e16b9)