### PR TITLE
Bot PR #188 — Source File Enrichment v1

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -71,6 +71,12 @@ from bnl_source_knowledge_bridge import (
     parse_source_knowledge_bridge_command,
     run_source_knowledge_bridge,
 )
+from bnl_source_file_enrichment import (
+    format_source_enrichment_response,
+    parse_source_enrichment_command,
+    run_source_file_enrichment,
+    source_enrichment_ingest_source,
+)
 from collections import defaultdict, deque
 from datetime import datetime, timedelta, timezone
 
@@ -527,6 +533,12 @@ _last_source_knowledge_bridge_failed_count = 0
 _last_source_knowledge_bridge_source_counts = {}
 _last_source_knowledge_bridge_warning_counts = {}
 _last_source_knowledge_bridge_error_status = "none"
+_source_enrichment_last_subject = "none"
+_source_enrichment_last_status = "never"
+_source_enrichment_last_match_kind = "none"
+_source_enrichment_last_source_counts = {}
+_source_enrichment_last_warning_counts = {}
+_source_enrichment_last_error_status = "none"
 BNL_CONTROL_FLAGS_TTL_SECONDS = 300
 _bnl_control_flags_cache = None
 _bnl_control_flags_cached_at = None
@@ -4102,6 +4114,14 @@ def build_dossier_recommendation_diagnostics(guild_id=None) -> dict:
         "source_knowledge_bridge_last_source_counts": dict(_last_source_knowledge_bridge_source_counts),
         "source_knowledge_bridge_last_warning_counts": dict(_last_source_knowledge_bridge_warning_counts),
         "source_knowledge_bridge_last_error_status": _last_source_knowledge_bridge_error_status,
+        "source_enrichment_available": True,
+        "source_enrichment_ingest_source": source_enrichment_ingest_source(os.environ),
+        "source_enrichment_last_subject": _source_enrichment_last_subject,
+        "source_enrichment_last_status": _source_enrichment_last_status,
+        "source_enrichment_last_match_kind": _source_enrichment_last_match_kind,
+        "source_enrichment_last_source_counts": dict(_source_enrichment_last_source_counts),
+        "source_enrichment_last_warning_counts": dict(_source_enrichment_last_warning_counts),
+        "source_enrichment_last_error_status": _source_enrichment_last_error_status,
         **build_community_presence_diagnostics(
             DB_FILE,
             guild_id=guild_id,
@@ -4367,6 +4387,70 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
         )
     lanes_suffix = f" Lanes: {', '.join(lanes)}."
     await message.reply(f"{summary}{reason_suffix}{failure_suffix}{lanes_suffix}")
+    return True
+
+
+
+async def maybe_handle_source_file_enrichment_command(message: discord.Message, clean_content: str) -> bool:
+    """Handle operator-triggered Source File enrichment commands."""
+
+    global _last_dossier_recommendation_status
+    global _source_enrichment_last_subject, _source_enrichment_last_status, _source_enrichment_last_match_kind
+    global _source_enrichment_last_source_counts, _source_enrichment_last_warning_counts, _source_enrichment_last_error_status
+
+    matched, options, parse_error = parse_source_enrichment_command(clean_content)
+    if not matched:
+        return False
+
+    member = message.author if isinstance(message.author, discord.Member) else message.guild.get_member(message.author.id)
+    if not can_send_dossier_recommendation(message.author, member, message.guild):
+        _source_enrichment_last_error_status = "permission_denied"
+        _source_enrichment_last_status = "permission_denied"
+        logging.warning("source_file_enrichment_denied reason=permission")
+        await message.reply("Source File enrichment is operator-only.")
+        return True
+
+    channel = getattr(message, "channel", None)
+    policy = resolve_channel_policy(channel)
+    channel_name = getattr(channel, "name", "") or ""
+    if is_public_prompt_context(policy) and not is_operator_authority_context(policy, channel_name):
+        _source_enrichment_last_error_status = "channel_restricted"
+        _source_enrichment_last_status = "channel_restricted"
+        await message.reply("Source File enrichment is restricted to approved internal/operator channels.")
+        return True
+
+    if not options:
+        _source_enrichment_last_error_status = "parse_rejected"
+        _source_enrichment_last_status = "parse_rejected"
+        await message.reply(f"Source enrichment failed: {parse_error}")
+        return True
+
+    subject = str(options.get("subject") or "").strip()
+    dry_run = bool(options.get("dry_run"))
+    result = await asyncio.to_thread(
+        run_source_file_enrichment,
+        DB_FILE,
+        getattr(message.guild, "id", None),
+        subject,
+        dry_run=dry_run,
+        rd_context=_current_rd_discovery_context(message),
+        lookup_func=lookup_source_file,
+        sender=send_dossier_recommendation,
+        environ=os.environ,
+    )
+    _source_enrichment_last_subject = str(result.get("subject") or subject or "none")[:90]
+    _source_enrichment_last_status = str(result.get("status") or "unknown")[:80]
+    _source_enrichment_last_match_kind = str(result.get("matchKind") or "none")[:80]
+    _source_enrichment_last_source_counts = dict(result.get("sourceCounts") or {})
+    _source_enrichment_last_warning_counts = dict(result.get("warningCounts") or {})
+    _source_enrichment_last_error_status = "none" if result.get("ok") else _source_enrichment_last_status
+    if dry_run:
+        _last_dossier_recommendation_status = "source_enrichment_dry_run"
+    elif result.get("sent"):
+        _last_dossier_recommendation_status = "source_enrichment_sent"
+    else:
+        _last_dossier_recommendation_status = f"source_enrichment_{_source_enrichment_last_status}"
+    await message.reply(format_source_enrichment_response(result))
     return True
 
 
@@ -11008,6 +11092,9 @@ async def on_message(message: discord.Message):
         .replace(f"<@{client.user.id}>", "")
         .strip()
     )
+
+    if await maybe_handle_source_file_enrichment_command(message, clean_content):
+        return
 
     if await maybe_handle_source_file_lookup_command(message, clean_content):
         return

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -1,0 +1,514 @@
+"""Review-only Source File enrichment helpers for BNL.
+
+This module builds structured case-file notes from approved local BNL stores and
+optionally posts them through the existing review-only dossier recommendation
+endpoint. It never publishes, promotes, merges, or overwrites Source Files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from bnl_dossier_recommendations import build_dossier_recommendation_payload, send_dossier_recommendation
+from bnl_source_file_lookup import lookup_source_file
+
+ENRICHMENT_INGEST_SOURCE = "bnl_source_file_enrichment"
+FALLBACK_INGEST_SOURCE = "bnl_source_knowledge_bridge"
+SOURCE_BLIND_WARNING = "source-blind memory is review-only; do not treat as confirmed fact"
+SECTION_ORDER = [
+    "Subject Overview",
+    "Why This Subject Matters",
+    "Known Roles / Category",
+    "History With BARCODE / BNL / Discord / BARCODE Radio",
+    "Observed Patterns",
+    "Known Facts",
+    "Claimed or Inferred Notes",
+    "Possible Aliases / Connections",
+    "Public-Safe Notes",
+    "Internal-Only / Review-Only Notes",
+    "Missing Info",
+    "Do Not Say",
+    "Suggested Next Action",
+]
+_APPROVED_TABLES = {
+    "user_profiles",
+    "user_memory_facts",
+    "user_habits",
+    "relationship_state",
+    "relationship_journal",
+    "conversations",
+    "memory_tiers",
+    "broadcast_memory",
+    "community_presence",
+    "rd_context",
+    "source_file_lookup",
+}
+_DISCORD_MENTION_RE = re.compile(r"<@!?\d+>|<@&\d+>|<#\d+>")
+_LONG_ID_RE = re.compile(r"\b\d{15,22}\b")
+_URL_RE = re.compile(r"https?://\S+", re.I)
+_EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}\b")
+_WEAK_ALIAS_RE = re.compile(r"\b(?:alias|known as|aka|connection|connected to|via|through|introduced by)\b", re.I)
+
+
+def parse_source_enrichment_command(content: str) -> tuple[bool, dict[str, Any] | None, str]:
+    """Parse operator Source File enrichment commands."""
+
+    text = (content or "").strip()
+    match = re.match(
+        r"^!bnl\s+(?:(?:source\s+enrich)|(?:enrich\s+source)|(?:source\s+file\s+enrich))\s+(.+)$",
+        text,
+        flags=re.I | re.S,
+    )
+    if not match:
+        return False, None, "not_a_source_enrichment_command"
+    body = match.group(1).strip()
+    if not body:
+        return True, None, "Use: `!bnl source enrich <subject> [| dry_run=true]`"
+    parts = [part.strip() for part in body.split("|")]
+    subject = re.sub(r"\s+", " ", parts[0]).strip()
+    if not subject:
+        return True, None, "Subject is required."
+    options: dict[str, Any] = {"subject": subject, "dry_run": False}
+    for extra in parts[1:]:
+        if not extra:
+            continue
+        opt = re.match(r"^([A-Za-z_]+)\s*=\s*(.+)$", extra, flags=re.S)
+        if not opt:
+            return True, None, "Supported option: dry_run=true|false."
+        key = opt.group(1).strip().lower()
+        value = opt.group(2).strip().lower()
+        if key in {"dry_run", "dryrun"}:
+            options["dry_run"] = value in {"true", "1", "yes", "on"}
+        else:
+            return True, None, "Supported option: dry_run=true|false."
+    return True, options, ""
+
+
+def source_enrichment_ingest_source(environ: dict[str, str] | None = None) -> str:
+    """Return the safest ingestSource value for the current site contract."""
+
+    env = environ or {}
+    if str(env.get("BNL_SOURCE_ENRICHMENT_INGEST_SUPPORTED") or "").strip().lower() in {"1", "true", "yes", "on"}:
+        return ENRICHMENT_INGEST_SOURCE
+    return FALLBACK_INGEST_SOURCE
+
+
+def _subject_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", (value or "").strip().lower()).strip("-") or "unknown-subject"
+
+
+def _safe_text(value: Any, limit: int = 220) -> str:
+    text = str(value or "")
+    text = _DISCORD_MENTION_RE.sub("[redacted-mention]", text)
+    text = _LONG_ID_RE.sub("[redacted-id]", text)
+    text = _EMAIL_RE.sub("[redacted-email]", text)
+    text = _URL_RE.sub("[redacted-url]", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    if table not in _APPROVED_TABLES:
+        return False
+    return conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)).fetchone() is not None
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    if not _table_exists(conn, table):
+        return set()
+    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def _like_terms(subject: str) -> list[str]:
+    words = [w for w in re.findall(r"[A-Za-z0-9][A-Za-z0-9_-]*", subject or "") if len(w) >= 3]
+    terms = [subject.strip()] + words
+    out: list[str] = []
+    for term in terms:
+        lowered = term.lower()
+        if lowered not in {x.lower() for x in out}:
+            out.append(term[:80])
+    return out[:5]
+
+
+def _matches_subject(text: str, terms: list[str]) -> bool:
+    lower = str(text or "").lower()
+    return any(term.lower() in lower for term in terms if term)
+
+
+def _append_section(sections: dict[str, list[str]], name: str, value: str, *, limit: int = 5) -> None:
+    clean = _safe_text(value, 240)
+    if not clean:
+        return
+    bucket = sections.setdefault(name, [])
+    if clean not in bucket and len(bucket) < limit:
+        bucket.append(clean)
+
+
+def _source_file_obj(lookup_result: dict[str, Any]) -> dict[str, Any]:
+    data = lookup_result.get("data") if isinstance(lookup_result.get("data"), dict) else {}
+    for key in ("sourceFile", "source_file", "file", "candidate", "result", "dossier"):
+        if isinstance(data.get(key), dict):
+            return data[key]
+    return data if isinstance(data, dict) else {}
+
+
+def _first(obj: dict[str, Any], keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        if obj.get(key) not in (None, "", []):
+            return obj.get(key)
+    return None
+
+
+def classify_source_match(lookup_result: dict[str, Any]) -> tuple[str, str, dict[str, Any]]:
+    """Classify lookup result as active Source File, intake, existing dossier update, or none."""
+
+    if not lookup_result.get("ok"):
+        return "error", _safe_text(lookup_result.get("error") or "lookup failed", 140), {}
+    if not lookup_result.get("found"):
+        return "none", "No active Source File, Candidate Intake item, or existing dossier target was confirmed.", {}
+    obj = _source_file_obj(lookup_result)
+    data = lookup_result.get("data") if isinstance(lookup_result.get("data"), dict) else {}
+    raw = " ".join(str(x or "") for x in (
+        lookup_result.get("matchKind"), data.get("matchKind"), obj.get("status"), obj.get("state"), obj.get("reviewStatus"),
+        obj.get("kind"), obj.get("type"), obj.get("candidateType"), obj.get("sourceType"), obj.get("dossierStatus"),
+    )).lower()
+    if "candidate" in raw or "intake" in raw or "needs_review" in raw or "review" in raw:
+        return "candidate_intake", "Candidate Intake enrichment only — not active case-file fact.", obj
+    if "dossier" in raw or "public" in raw or obj.get("targetDossierId") or obj.get("dossierId"):
+        return "existing_dossier_update", "Existing Dossier Update material for admin review.", obj
+    return "active_source_file", "Active Source File enrichment target.", obj
+
+
+def _add_source_file_context(sections: dict[str, list[str]], source_file: dict[str, Any], subject: str) -> None:
+    if not source_file:
+        return
+    name = _first(source_file, ("name", "sourceFileName", "subject", "displayName", "title", "normalizedName")) or subject
+    _append_section(sections, "Subject Overview", f"Existing Source File target: {name}.")
+    _append_section(sections, "Known Roles / Category", _first(source_file, ("candidateType", "sourceType", "type", "kind", "recommendedCategory")) or "")
+    _append_section(sections, "Known Facts", _first(source_file, ("knownFacts", "facts", "evidenceSummary", "reason", "summary")) or "")
+    _append_section(sections, "Public-Safe Notes", _first(source_file, ("publicSafetyNotes", "safetyNotes", "publicUseNotes")) or "")
+    _append_section(sections, "Missing Info", _first(source_file, ("missingInfo", "missing")) or "")
+    _append_section(sections, "Do Not Say", _first(source_file, ("doNotSay", "do_not_say")) or "")
+    _append_section(sections, "Suggested Next Action", _first(source_file, ("nextRecommendedAction", "suggestedAction", "nextAction")) or "")
+    aliases = _first(source_file, ("aliases", "identityLinks", "identity_links", "possibleConnections"))
+    if aliases:
+        _append_section(sections, "Possible Aliases / Connections", f"Source File lists alias/connection material for review: {_safe_text(aliases, 180)}")
+
+
+def collect_source_enrichment_evidence(db_path: str, guild_id: int | None, subject: str, *, rd_context: list[dict[str, Any]] | None = None, lookup_result: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Collect bounded evidence from approved local stores only."""
+
+    terms = _like_terms(subject)
+    sections: dict[str, list[str]] = {name: [] for name in SECTION_ORDER}
+    source_counts: Counter[str] = Counter()
+    warning_counts: Counter[str] = Counter()
+    source_types: set[str] = set()
+    public_safe_candidates: list[str] = []
+    review_only_candidates: list[str] = []
+
+    if lookup_result:
+        match_kind, match_note, sf_obj = classify_source_match(lookup_result)
+        source_counts["source_file_lookup"] += 1
+        source_types.add("source_file_lookup")
+        _add_source_file_context(sections, sf_obj, subject)
+        _append_section(sections, "Internal-Only / Review-Only Notes", match_note)
+    else:
+        match_kind = "none"
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        if _table_exists(conn, "user_profiles"):
+            cols = _columns(conn, "user_profiles")
+            name_expr = "COALESCE(preferred_name, display_name, '')" if "preferred_name" in cols else "COALESCE(display_name, '')"
+            rows = conn.execute(f"SELECT user_id, display_name, {name_expr} AS name FROM user_profiles WHERE guild_id=?", (guild_id,)).fetchall()
+            matched_user_ids = []
+            for row in rows:
+                if _matches_subject(f"{row['display_name']} {row['name']}", terms):
+                    matched_user_ids.append(int(row["user_id"]))
+                    source_counts["user_profiles"] += 1
+                    source_types.add("user_profiles")
+                    _append_section(sections, "Subject Overview", f"Local profile/display-name match: {row['name'] or row['display_name']}.")
+                    _append_section(sections, "Known Roles / Category", "Discord community subject or participant (from local profile match).")
+            matched_user_ids = matched_user_ids[:8]
+        else:
+            matched_user_ids = []
+
+        if _table_exists(conn, "user_memory_facts"):
+            rows = conn.execute("SELECT user_id, fact_key, fact_value, confidence, is_core FROM user_memory_facts WHERE guild_id=? ORDER BY updated_at DESC LIMIT 500", (guild_id,)).fetchall()
+            for row in rows:
+                text = f"{row['fact_key']}: {row['fact_value']}"
+                if int(row["user_id"] or 0) in matched_user_ids or _matches_subject(text, terms):
+                    source_counts["user_memory_facts"] += 1
+                    source_types.add("user_memory_facts")
+                    conf = float(row["confidence"] or 0)
+                    target = "Known Facts" if conf >= 0.75 or int(row["is_core"] or 0) else "Claimed or Inferred Notes"
+                    _append_section(sections, target, f"{row['fact_key']}: {row['fact_value']} (confidence {conf:.2f}).")
+
+        if _table_exists(conn, "user_habits"):
+            rows = conn.execute("SELECT user_id, total_messages, question_messages, humor_messages, late_night_messages, last_topic FROM user_habits WHERE guild_id=?", (guild_id,)).fetchall()
+            for row in rows:
+                if int(row["user_id"] or 0) in matched_user_ids or _matches_subject(row["last_topic"], terms):
+                    source_counts["user_habits"] += 1
+                    source_types.add("user_habits")
+                    _append_section(sections, "Observed Patterns", f"Local habit summary: messages={row['total_messages']}, questions={row['question_messages']}, humor={row['humor_messages']}, late-night={row['late_night_messages']}, last topic={row['last_topic'] or 'unknown'}.")
+
+        if _table_exists(conn, "relationship_state"):
+            rows = conn.execute("SELECT user_id, interaction_count, trust_stage, social_stance, last_topic FROM relationship_state WHERE guild_id=?", (guild_id,)).fetchall()
+            for row in rows:
+                if int(row["user_id"] or 0) in matched_user_ids or _matches_subject(row["last_topic"], terms):
+                    source_counts["relationship_state"] += 1
+                    source_types.add("relationship_state")
+                    _append_section(sections, "History With BARCODE / BNL / Discord / BARCODE Radio", f"Relationship state: {row['interaction_count']} interactions; stage={row['trust_stage']}; stance={row['social_stance']}; last topic={row['last_topic'] or 'unknown'}.")
+
+        if _table_exists(conn, "relationship_journal"):
+            rows = conn.execute("SELECT user_id, entry_type, summary FROM relationship_journal WHERE guild_id=? ORDER BY timestamp DESC LIMIT 300", (guild_id,)).fetchall()
+            for row in rows:
+                if int(row["user_id"] or 0) in matched_user_ids or _matches_subject(row["summary"], terms):
+                    source_counts["relationship_journal"] += 1
+                    source_types.add("relationship_journal")
+                    _append_section(sections, "History With BARCODE / BNL / Discord / BARCODE Radio", f"Journal {row['entry_type']}: {row['summary']}.")
+
+        if _table_exists(conn, "conversations"):
+            rows = conn.execute("SELECT channel_name, channel_policy, role, content FROM conversations WHERE guild_id=? AND COALESCE(channel_policy,'') NOT IN ('dm','direct_message','private_dm') ORDER BY timestamp DESC LIMIT 600", (guild_id,)).fetchall()
+            for row in rows:
+                if row["role"] == "model":
+                    continue
+                if _matches_subject(row["content"], terms):
+                    source_counts["conversations"] += 1
+                    source_types.add("conversations")
+                    label = _safe_text(row["channel_policy"] or row["channel_name"] or "approved channel", 60)
+                    note = f"Mentioned in {label} context: {_safe_text(row['content'], 150)}"
+                    if _WEAK_ALIAS_RE.search(row["content"] or ""):
+                        _append_section(sections, "Possible Aliases / Connections", f"Possible connection only, not confirmed: {_safe_text(row['content'], 150)}")
+                    else:
+                        _append_section(sections, "Claimed or Inferred Notes", note)
+                    review_only_candidates.append(note)
+
+        if _table_exists(conn, "memory_tiers"):
+            cols = _columns(conn, "memory_tiers")
+            trust_col = "source_trust" if "source_trust" in cols else "'legacy_unknown'"
+            policy_col = "source_channel_policy" if "source_channel_policy" in cols else "'legacy_unknown'"
+            rows = conn.execute(f"SELECT tier, summary, salience, {trust_col} AS source_trust, {policy_col} AS source_channel_policy FROM memory_tiers WHERE guild_id=? ORDER BY salience DESC, updated_at DESC LIMIT 500", (guild_id,)).fetchall()
+            for row in rows:
+                if _matches_subject(row["summary"], terms):
+                    source_counts["memory_tiers"] += 1
+                    source_types.add("memory_tiers")
+                    trust = str(row["source_trust"] or "legacy_unknown")
+                    warning_counts["source_blind_memory"] += 1
+                    _append_section(sections, "Internal-Only / Review-Only Notes", f"Source-blind/legacy memory ({row['tier']}, trust={trust}): {_safe_text(row['summary'], 160)}")
+                    review_only_candidates.append(_safe_text(row["summary"], 160))
+
+        if _table_exists(conn, "broadcast_memory"):
+            rows = conn.execute("SELECT episode_date, cleaned_summary, entry_type, public_safe, usage_scope FROM broadcast_memory WHERE guild_id=? AND status='active' ORDER BY created_at DESC LIMIT 300", (guild_id,)).fetchall()
+            for row in rows:
+                text = row["cleaned_summary"]
+                if _matches_subject(text, terms):
+                    source_counts["broadcast_memory"] += 1
+                    source_types.add("broadcast_memory")
+                    note = f"Broadcast memory {row['episode_date']} ({row['entry_type']}): {text}"
+                    _append_section(sections, "History With BARCODE / BNL / Discord / BARCODE Radio", note)
+                    if int(row["public_safe"] or 0):
+                        _append_section(sections, "Public-Safe Notes", text)
+                        public_safe_candidates.append(_safe_text(text, 160))
+                    else:
+                        _append_section(sections, "Internal-Only / Review-Only Notes", note)
+
+        if _table_exists(conn, "community_presence"):
+            rows = conn.execute("SELECT display_name, source_lanes, approved_channel_labels, mention_count, direct_interaction_count, operator_mention_count, connection_notes, evidence_snippets, category FROM community_presence WHERE guild_id=?", (guild_id,)).fetchall()
+            for row in rows:
+                combined = " ".join(str(row[key] or "") for key in row.keys())
+                if _matches_subject(combined, terms):
+                    source_counts["community_presence"] += 1
+                    source_types.add("community_presence")
+                    _append_section(sections, "Observed Patterns", f"Community presence: {row['display_name']} has mention/direct/operator signals {row['mention_count']}/{row['direct_interaction_count']}/{row['operator_mention_count']}.")
+                    _append_section(sections, "Known Roles / Category", row["category"] or "community presence candidate")
+                    if row["connection_notes"]:
+                        _append_section(sections, "Possible Aliases / Connections", f"Community connection note, not confirmed identity: {row['connection_notes']}")
+    finally:
+        conn.close()
+
+    for item in rd_context or []:
+        text = " ".join(str(item.get(k) or "") for k in ("summary", "content", "text", "reason", "title")) if isinstance(item, dict) else str(item)
+        if _matches_subject(text, terms):
+            source_counts["rd_context"] += 1
+            source_types.add("rd_context")
+            _append_section(sections, "Why This Subject Matters", f"R&D context flags this subject for operator review: {_safe_text(text, 160)}")
+            review_only_candidates.append(_safe_text(text, 160))
+
+    if not sections["Why This Subject Matters"] and (sum(source_counts.values()) > source_counts.get("source_file_lookup", 0)):
+        _append_section(sections, "Why This Subject Matters", "BNL has local review signals for this subject; admins should decide what belongs in the Source File.")
+    if not sections["Subject Overview"]:
+        _append_section(sections, "Subject Overview", f"{subject} is known to this enrichment pass only through bounded local review signals; no confirmed overview is available yet.")
+    if not sections["Missing Info"]:
+        _append_section(sections, "Missing Info", "Confirmed public-safe summary, owner-approved role/category, and alias certainty are not fully established from supported sources.")
+    if not sections["Do Not Say"]:
+        _append_section(sections, "Do Not Say", "Do not present review-only memory, possible aliases, private identity, or source-blind notes as confirmed public fact.")
+    if not sections["Suggested Next Action"]:
+        _append_section(sections, "Suggested Next Action", "Admin should review these notes, confirm which items are public-safe, and attach only supported facts to the Source File.")
+
+    return {
+        "sections": {name: values for name, values in sections.items() if values},
+        "sourceCounts": dict(source_counts),
+        "warningCounts": dict(warning_counts),
+        "sourceTypes": sorted(source_types),
+        "warnings": ([SOURCE_BLIND_WARNING] if warning_counts.get("source_blind_memory") else []),
+        "publicSafeCandidates": public_safe_candidates[:5],
+        "reviewOnlyCandidates": review_only_candidates[:5],
+    }
+
+
+def _section_text(sections: dict[str, list[str]], name: str, *, limit: int = 4) -> str:
+    items = sections.get(name) or []
+    return "\n".join(f"- {_safe_text(item, 240)}" for item in items[:limit]) or "- currently unknown."
+
+
+def build_enrichment_markdown(packet: dict[str, Any]) -> str:
+    sections = packet.get("sections") or {}
+    lines: list[str] = []
+    for name in SECTION_ORDER:
+        if name in sections:
+            lines.append(f"## {name}\n{_section_text(sections, name)}")
+    return "\n\n".join(lines)
+
+
+def deterministic_enrichment_ingest_key(subject: str, match_kind: str, sections: dict[str, list[str]]) -> str:
+    material = json.dumps({"subject": _subject_key(subject), "matchKind": match_kind, "sections": sections}, sort_keys=True)
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:12]
+    return f"bnl:source-enrichment:{_subject_key(subject)}:{match_kind}:{digest}"
+
+
+def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: dict[str, str] | None = None) -> dict[str, Any]:
+    sections = packet.get("sections") or {}
+    subject = str(packet.get("subject") or "").strip()
+    match_kind = str(packet.get("matchKind") or "none")
+    source_file = packet.get("sourceFile") if isinstance(packet.get("sourceFile"), dict) else {}
+    target_candidate_id = _first(source_file, ("candidateId", "targetCandidateId", "id")) if match_kind in {"candidate_intake", "active_source_file"} else None
+    target_dossier_id = _first(source_file, ("targetDossierId", "dossierId", "publicDossierId")) if match_kind == "existing_dossier_update" else None
+    evidence = build_enrichment_markdown(packet)
+    payload = {
+        "type": "modify_existing_dossier" if match_kind in {"active_source_file", "existing_dossier_update", "candidate_intake"} else "new_subject",
+        "targetCandidateId": target_candidate_id,
+        "targetDossierId": target_dossier_id,
+        "subjectName": subject,
+        "reason": f"Review-only Source File enrichment generated by BNL. Match target: {match_kind}. No publishing, promotion, merge, or alias confirmation is requested.",
+        "evidenceSummary": evidence,
+        "publicSafetyNotes": _section_text(sections, "Public-Safe Notes", limit=5),
+        "doNotSay": _section_text(sections, "Do Not Say", limit=5),
+        "missingInfo": _section_text(sections, "Missing Info", limit=5),
+        "suggestedAction": _section_text(sections, "Suggested Next Action", limit=3),
+        "sourceLanes": ["source_file_enrichment"] + list(packet.get("sourceTypes") or []),
+        "sourceTypes": list(packet.get("sourceTypes") or []),
+        "safetyWarnings": list(packet.get("warnings") or []),
+        "visibilityLabels": ["internal_review_only", "admin_review_required"],
+        "confidence": "medium" if match_kind == "active_source_file" else "low",
+        "createdBy": "bnl",
+        "ingestSource": source_enrichment_ingest_source(environ),
+        "ingestKey": deterministic_enrichment_ingest_key(subject, match_kind, sections),
+    }
+    return build_dossier_recommendation_payload(payload)
+
+
+def run_source_file_enrichment(
+    db_path: str,
+    guild_id: int | None,
+    subject: str,
+    *,
+    dry_run: bool = False,
+    rd_context: list[dict[str, Any]] | None = None,
+    lookup_func: Callable[[dict[str, str]], dict[str, Any]] = lookup_source_file,
+    sender: Callable[[dict[str, Any]], dict[str, Any]] = send_dossier_recommendation,
+    environ: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    query = {"lookupKey": "subject", "lookupValue": subject, "subject": subject}
+    lookup_result = lookup_func(query)
+    match_kind, match_note, source_file = classify_source_match(lookup_result)
+    if match_kind in {"none", "error"}:
+        return {
+            "ok": match_kind != "error",
+            "dryRun": dry_run,
+            "subject": _safe_text(subject, 90),
+            "status": "no_target" if match_kind == "none" else "lookup_failed",
+            "matchKind": match_kind,
+            "matchNote": match_note,
+            "sections": {},
+            "sourceCounts": {},
+            "warningCounts": {},
+            "sourceTypes": [],
+            "warnings": [],
+            "sent": False,
+            "sendResult": {},
+            "runTime": datetime.now(timezone.utc).isoformat(),
+        }
+    evidence = collect_source_enrichment_evidence(db_path, guild_id, subject, rd_context=rd_context, lookup_result=lookup_result)
+    packet = {
+        "ok": True,
+        "dryRun": dry_run,
+        "subject": _safe_text(subject, 90),
+        "status": "dry_run" if dry_run else "ready_to_send",
+        "matchKind": match_kind,
+        "matchNote": match_note,
+        "sourceFile": source_file,
+        "sections": evidence["sections"],
+        "sourceCounts": evidence["sourceCounts"],
+        "warningCounts": evidence["warningCounts"],
+        "sourceTypes": evidence["sourceTypes"],
+        "warnings": evidence["warnings"],
+        "runTime": datetime.now(timezone.utc).isoformat(),
+    }
+    payload = build_enrichment_recommendation_payload(packet, environ=environ)
+    packet["payload"] = payload
+    packet["ingestKey"] = payload.get("ingestKey")
+    packet["ingestSource"] = payload.get("ingestSource")
+    if dry_run:
+        packet["sent"] = False
+        packet["sendResult"] = {}
+        return packet
+    send_result = sender(payload)
+    packet["sendResult"] = send_result
+    packet["sent"] = bool((send_result or {}).get("ok"))
+    packet["status"] = "sent" if packet["sent"] else "send_failed"
+    return packet
+
+
+def format_source_enrichment_response(result: dict[str, Any]) -> str:
+    subject = _safe_text(result.get("subject") or "subject", 90)
+    match_kind = _safe_text(result.get("matchKind") or "none", 80)
+    if result.get("status") == "no_target":
+        return (f"Source enrichment: no target found for “{subject}.”\n"
+                "Next: create/promote a Candidate Intake item first or run candidate bridge/discovery. No notes were sent.")
+    if result.get("status") == "lookup_failed":
+        return f"Source enrichment lookup failed for “{subject}”: {_safe_text(result.get('matchNote'), 140)}"
+    sections = result.get("sections") or {}
+    names = [name for name in SECTION_ORDER if name in sections][:6]
+    source_types = ", ".join(result.get("sourceTypes") or []) or "source_file_lookup"
+    warnings = result.get("warnings") or []
+    warning_text = "; ".join(_safe_text(w, 120) for w in warnings) or "none"
+    attach_label = {
+        "active_source_file": "active Source File",
+        "candidate_intake": "Candidate Intake (intake-only)",
+        "existing_dossier_update": "Existing Dossier Update",
+    }.get(match_kind, match_kind)
+    if result.get("dryRun"):
+        preview_lines = [
+            f"Dry run Source File enrichment for “{subject}.”",
+            f"Match: {match_kind} — {attach_label}.",
+            f"Would attach as: {attach_label}.",
+            f"Top sections: {', '.join(names) if names else 'none'}.",
+            f"Source types used: {source_types}.",
+            f"Warnings: {warning_text}.",
+            "No raw private transcripts were included; nothing was sent to the website.",
+        ]
+        return "\n".join(preview_lines)[:1900]
+    if result.get("sent"):
+        return f"Source enrichment sent for admin review: {subject}. Match: {match_kind}. Ingest key: {_safe_text(result.get('ingestKey'), 120)}."
+    err = (result.get("sendResult") or {}).get("error") or "site ingest did not accept the review-only payload"
+    return f"Source enrichment was built but not sent for “{subject}”: {_safe_text(err, 150)}"

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -1,0 +1,188 @@
+import asyncio
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from unittest import mock
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl_source_file_enrichment as enrich
+import bnl01_bot
+
+
+class SourceFileEnrichmentTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False)
+        self.tmp.close()
+        self.db = self.tmp.name
+        self.conn = sqlite3.connect(self.db)
+        self._schema()
+
+    def tearDown(self):
+        self.conn.close()
+        os.unlink(self.db)
+
+    def _schema(self):
+        c = self.conn.cursor()
+        c.execute("CREATE TABLE user_profiles (user_id INTEGER, guild_id INTEGER, display_name TEXT, preferred_name TEXT, last_seen TEXT, last_greeting_at TEXT)")
+        c.execute("CREATE TABLE user_memory_facts (id INTEGER PRIMARY KEY, user_id INTEGER, guild_id INTEGER, fact_key TEXT, fact_value TEXT, confidence REAL, is_core INTEGER, updated_at TEXT)")
+        c.execute("CREATE TABLE user_habits (user_id INTEGER, guild_id INTEGER, total_messages INTEGER, question_messages INTEGER, humor_messages INTEGER, late_night_messages INTEGER, avg_length REAL, last_topic TEXT, updated_at TEXT)")
+        c.execute("CREATE TABLE relationship_state (user_id INTEGER, guild_id INTEGER, interaction_count INTEGER, affinity_score REAL, trust_stage TEXT, social_stance TEXT, last_topic TEXT, updated_at TEXT)")
+        c.execute("CREATE TABLE relationship_journal (id INTEGER PRIMARY KEY, user_id INTEGER, guild_id INTEGER, entry_type TEXT, summary TEXT, timestamp TEXT)")
+        c.execute("CREATE TABLE conversations (id INTEGER PRIMARY KEY, user_id INTEGER, user_name TEXT, guild_id INTEGER, channel_name TEXT, channel_policy TEXT, role TEXT, content TEXT, timestamp TEXT)")
+        c.execute("CREATE TABLE memory_tiers (id INTEGER PRIMARY KEY, user_id INTEGER, guild_id INTEGER, tier TEXT, summary TEXT, salience REAL, mentions INTEGER, updated_at TEXT, source_trust TEXT, source_channel_policy TEXT)")
+        c.execute("CREATE TABLE broadcast_memory (id INTEGER PRIMARY KEY, guild_id INTEGER, episode_date TEXT, cleaned_summary TEXT, entry_type TEXT, public_safe INTEGER, usage_scope TEXT, status TEXT, created_at TEXT)")
+        c.execute("CREATE TABLE community_presence (guild_id INTEGER, subject_key TEXT, display_name TEXT, first_seen_at TEXT, last_seen_at TEXT, source_lanes TEXT, approved_channel_labels TEXT, mention_count INTEGER, direct_interaction_count INTEGER, operator_mention_count INTEGER, active_windows TEXT, connection_notes TEXT, evidence_snippets TEXT, category TEXT, last_error_status TEXT)")
+        self.conn.commit()
+
+    def _lookup(self, status="active"):
+        return lambda query: {
+            "ok": True,
+            "found": True,
+            "matchKind": "exact",
+            "data": {"sourceFile": {"id": "sf_1", "name": query["lookupValue"], "status": status, "candidateType": "entity"}},
+        }
+
+    def test_parses_source_enrich_dry_run(self):
+        matched, options, error = enrich.parse_source_enrichment_command("!bnl source enrich Hellcat | dry_run=true")
+        self.assertTrue(matched)
+        self.assertFalse(error)
+        self.assertEqual(options["subject"], "Hellcat")
+        self.assertTrue(options["dry_run"])
+        for command in ("!bnl enrich source Emerald", "!bnl source file enrich Mac Modem | dry_run=false"):
+            matched, options, error = enrich.parse_source_enrichment_command(command)
+            self.assertTrue(matched)
+            self.assertFalse(error)
+
+    def test_enriches_active_source_file_with_structured_sections(self):
+        c = self.conn.cursor()
+        c.execute("INSERT INTO user_profiles VALUES (10,1,'Hellcat','Hellcat',NULL,NULL)")
+        c.execute("INSERT INTO user_memory_facts VALUES (NULL,10,1,'role','Hellcat is a recurring artist candidate.',0.9,1,'now')")
+        c.execute("INSERT INTO broadcast_memory VALUES (NULL,1,'2026-05-30','Hellcat was referenced in a public-safe BARCODE Radio note.','show_note',1,'ambient,direct','active','now')")
+        self.conn.commit()
+        calls = []
+        result = enrich.run_source_file_enrichment(self.db, 1, "Hellcat", dry_run=False, lookup_func=self._lookup("active"), sender=lambda payload: calls.append(payload) or {"ok": True, "status": 200})
+        self.assertTrue(result["sent"])
+        self.assertEqual(result["matchKind"], "active_source_file")
+        self.assertIn("Subject Overview", result["sections"])
+        self.assertIn("Known Facts", result["sections"])
+        self.assertIn("Public-Safe Notes", result["sections"])
+        self.assertEqual(calls[0]["type"], "modify_existing_dossier")
+        self.assertIn("review-only", calls[0]["reason"].lower())
+
+    def test_candidate_intake_and_existing_dossier_are_labeled(self):
+        candidate = enrich.run_source_file_enrichment(self.db, 1, "Emerald", dry_run=True, lookup_func=self._lookup("candidate_intake"))
+        self.assertEqual(candidate["matchKind"], "candidate_intake")
+        self.assertIn("Candidate Intake", enrich.format_source_enrichment_response(candidate))
+        dossier_lookup = lambda query: {"ok": True, "found": True, "data": {"sourceFile": {"name": "Crow", "type": "public_dossier", "targetDossierId": "d1"}}}
+        dossier = enrich.run_source_file_enrichment(self.db, 1, "Crow", dry_run=True, lookup_func=dossier_lookup)
+        self.assertEqual(dossier["matchKind"], "existing_dossier_update")
+        self.assertIn("Existing Dossier Update", enrich.format_source_enrichment_response(dossier))
+
+    def test_no_match_returns_bounded_no_target_response(self):
+        result = enrich.run_source_file_enrichment(self.db, 1, "Unknown", dry_run=True, lookup_func=lambda query: {"ok": True, "found": False, "data": {}})
+        response = enrich.format_source_enrichment_response(result)
+        self.assertEqual(result["status"], "no_target")
+        self.assertIn("create/promote", response)
+        self.assertNotIn("payload", response.lower())
+
+    def test_source_blind_memory_review_only_and_alias_not_confirmed(self):
+        c = self.conn.cursor()
+        c.execute("INSERT INTO memory_tiers VALUES (NULL,10,1,'long','Hellcat may be connected to Emerald in old source-blind memory.',0.9,1,'now','legacy_unknown','legacy_unknown')")
+        c.execute("INSERT INTO conversations VALUES (NULL,10,'User',1,'general','public_home','user','Hellcat aka Emerald is a possible connection review, not confirmed identity. 123456789012345678','now')")
+        self.conn.commit()
+        result = enrich.run_source_file_enrichment(self.db, 1, "Hellcat", dry_run=True, lookup_func=self._lookup("active"))
+        self.assertIn(enrich.SOURCE_BLIND_WARNING, result["warnings"])
+        self.assertIn("Internal-Only / Review-Only Notes", result["sections"])
+        alias_text = json.dumps(result["sections"].get("Possible Aliases / Connections", []))
+        self.assertIn("not confirmed", alias_text.lower())
+        response = enrich.format_source_enrichment_response(result)
+        self.assertNotIn("123456789012345678", response)
+        self.assertNotIn("payload", response.lower())
+
+    def test_dry_run_does_not_send_and_ingest_key_is_deterministic(self):
+        calls = []
+        first = enrich.run_source_file_enrichment(self.db, 1, "Hellcat", dry_run=True, lookup_func=self._lookup("active"), sender=lambda payload: calls.append(payload) or {"ok": True})
+        second = enrich.run_source_file_enrichment(self.db, 1, "Hellcat", dry_run=True, lookup_func=self._lookup("active"), sender=lambda payload: calls.append(payload) or {"ok": True})
+        self.assertEqual(calls, [])
+        self.assertEqual(first["ingestKey"], second["ingestKey"])
+        self.assertEqual(first["ingestSource"], enrich.FALLBACK_INGEST_SOURCE)
+
+    def test_does_not_invent_unsupported_sections(self):
+        result = enrich.run_source_file_enrichment(self.db, 1, "Mac Modem", dry_run=True, lookup_func=self._lookup("active"))
+        self.assertNotIn("Observed Patterns", result["sections"])
+        self.assertIn("Missing Info", result["sections"])
+
+
+class SourceFileEnrichmentBotTests(unittest.TestCase):
+    class Perms:
+        administrator = False
+        manage_guild = False
+        manage_messages = False
+        kick_members = False
+        ban_members = False
+
+    class User:
+        def __init__(self, user_id):
+            self.id = user_id
+            self.guild_permissions = SourceFileEnrichmentBotTests.Perms()
+            self.roles = []
+
+    class Guild:
+        id = 1
+        owner_id = 999
+        def get_member(self, user_id):
+            return None
+
+    class Channel:
+        id = 10
+        parent = None
+        def __init__(self, name):
+            self.name = name
+
+    class Message:
+        def __init__(self, user_id=999, channel_name="research-and-development"):
+            self.author = SourceFileEnrichmentBotTests.User(user_id)
+            self.guild = SourceFileEnrichmentBotTests.Guild()
+            self.channel = SourceFileEnrichmentBotTests.Channel(channel_name)
+            self.replies = []
+        async def reply(self, text):
+            self.replies.append(text)
+
+    def test_rejects_unauthorized_user(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        message = self.Message(user_id=111)
+        with mock.patch.object(bnl01_bot, "run_source_file_enrichment") as run_mock:
+            handled = asyncio.run(bnl01_bot.maybe_handle_source_file_enrichment_command(message, "!bnl source enrich Hellcat | dry_run=true"))
+        self.assertTrue(handled)
+        run_mock.assert_not_called()
+        self.assertIn("operator-only", message.replies[-1])
+
+    def test_rejects_public_channel_use(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        message = self.Message(user_id=999, channel_name="general")
+        with mock.patch.object(bnl01_bot, "resolve_channel_policy", return_value="public_home"), mock.patch.object(bnl01_bot, "run_source_file_enrichment") as run_mock:
+            handled = asyncio.run(bnl01_bot.maybe_handle_source_file_enrichment_command(message, "!bnl source enrich Hellcat | dry_run=true"))
+        self.assertTrue(handled)
+        run_mock.assert_not_called()
+        self.assertIn("restricted", message.replies[-1])
+
+    def test_real_run_reports_send_failure_safely_and_diagnostics_update(self):
+        bnl01_bot.BNL_OWNER_USER_ID = 999
+        message = self.Message(user_id=999)
+        fake = {"ok": True, "dryRun": False, "subject": "Hellcat", "status": "send_failed", "matchKind": "active_source_file", "sections": {"Subject Overview": ["x"]}, "sourceCounts": {"source_file_lookup": 1}, "warningCounts": {}, "sourceTypes": ["source_file_lookup"], "warnings": [], "sent": False, "sendResult": {"error": "site support missing"}}
+        with mock.patch.object(bnl01_bot, "run_source_file_enrichment", return_value=fake):
+            handled = asyncio.run(bnl01_bot.maybe_handle_source_file_enrichment_command(message, "!bnl source enrich Hellcat"))
+        self.assertTrue(handled)
+        self.assertIn("not sent", message.replies[-1])
+        diag = bnl01_bot.build_dossier_recommendation_diagnostics(1)
+        self.assertTrue(diag["source_enrichment_available"])
+        self.assertEqual(diag["source_enrichment_last_subject"], "Hellcat")
+        self.assertEqual(diag["source_enrichment_last_match_kind"], "active_source_file")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Source Files were thin and lacked operator-friendly, structured enrichment; operators need a safe way to gather BNL local knowledge into a review-only enrichment packet for admin review. 
- The feature must be operator-triggered, preserve public/internal safety boundaries, avoid publishing/promoting/merging, and never use private/account/payment/DM data. 
- Enrichment should reuse existing review-only dossier ingest behavior and fall back safely if the site has not added a first-class `bnl_source_file_enrichment` ingest source.

### Description
- Added a new review-only enrichment module `bnl_source_file_enrichment.py` that looks up the subject, gathers bounded evidence from approved local stores, builds sectioned case-file notes, and creates a deterministic review-only recommendation payload. 
- Implemented the `!bnl source enrich <subject> [| dry_run=true]` parser and aliases and wired a new handler into `bnl01_bot.py` that enforces operator/admin/mod gating and internal/operator-channel restrictions. 
- The enrichment packet includes the ordered case-file sections (Subject Overview; Why This Subject Matters; Known Roles/Category; History; Observed Patterns; Known Facts; Claimed/Inferred Notes; Possible Aliases/Connections; Public-Safe Notes; Internal-Only Notes; Missing Info; Do Not Say; Suggested Next Action) and marks source-blind memory as review-only. 
- Built safe payload generation (`modify_existing_dossier` when targeting active/candidate/dossier matches) with deterministic `ingestKey`, `ingestSource` selection (opt-in `bnl_source_file_enrichment` or fallback to existing bridge), redaction/sanitization of IDs/URLs/emails, and clear “no publish/promote/merge/confirm alias” language. 
- Integrated diagnostics keys and runtime state into `build_dossier_recommendation_diagnostics` for safe visibility (`source_enrichment_available`, `source_enrichment_last_subject`, `source_enrichment_last_status`, `source_enrichment_last_match_kind`, etc.).

### Testing
- Ran the full unit test suite with `python -m unittest discover -s tests -v` and all tests (including new `tests/test_source_file_enrichment.py`) passed. 
- Compiled the changed modules with `python -m py_compile` for `bnl01_bot.py`, recommendation/sender/packet modules, the bridge, and the new enrichment module with no syntax errors. 
- Ran repository checks (`git diff --check`) and code integration smoke checks; diagnostics and safe-routing behavior verified by unit tests (dry-run preview, permission/channel rejection, send-failure reporting, deterministic ingest keys, and separation of public-safe vs internal notes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b9449805483218438ea594eb72b8e)