### PR TITLE
Source enrichment: handle possible matches, add lookup modes and diagnostics

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -539,6 +539,10 @@ _source_enrichment_last_match_kind = "none"
 _source_enrichment_last_source_counts = {}
 _source_enrichment_last_warning_counts = {}
 _source_enrichment_last_error_status = "none"
+_source_enrichment_last_lookup_found = False
+_source_enrichment_last_possible_match_count = 0
+_source_enrichment_last_possible_match_names = []
+_source_enrichment_last_resolution_mode = "none"
 BNL_CONTROL_FLAGS_TTL_SECONDS = 300
 _bnl_control_flags_cache = None
 _bnl_control_flags_cached_at = None
@@ -4121,6 +4125,10 @@ def build_dossier_recommendation_diagnostics(guild_id=None) -> dict:
         "source_enrichment_last_match_kind": _source_enrichment_last_match_kind,
         "source_enrichment_last_source_counts": dict(_source_enrichment_last_source_counts),
         "source_enrichment_last_warning_counts": dict(_source_enrichment_last_warning_counts),
+        "source_enrichment_last_lookup_found": _source_enrichment_last_lookup_found,
+        "source_enrichment_last_possible_match_count": _source_enrichment_last_possible_match_count,
+        "source_enrichment_last_possible_match_names": list(_source_enrichment_last_possible_match_names),
+        "source_enrichment_last_resolution_mode": _source_enrichment_last_resolution_mode,
         "source_enrichment_last_error_status": _source_enrichment_last_error_status,
         **build_community_presence_diagnostics(
             DB_FILE,
@@ -4397,6 +4405,7 @@ async def maybe_handle_source_file_enrichment_command(message: discord.Message, 
     global _last_dossier_recommendation_status
     global _source_enrichment_last_subject, _source_enrichment_last_status, _source_enrichment_last_match_kind
     global _source_enrichment_last_source_counts, _source_enrichment_last_warning_counts, _source_enrichment_last_error_status
+    global _source_enrichment_last_lookup_found, _source_enrichment_last_possible_match_count, _source_enrichment_last_possible_match_names, _source_enrichment_last_resolution_mode
 
     matched, options, parse_error = parse_source_enrichment_command(clean_content)
     if not matched:
@@ -4426,6 +4435,8 @@ async def maybe_handle_source_file_enrichment_command(message: discord.Message, 
         return True
 
     subject = str(options.get("subject") or "").strip()
+    lookup_key = str(options.get("lookupKey") or "subject")
+    lookup_value = str(options.get("lookupValue") or subject).strip()
     dry_run = bool(options.get("dry_run"))
     result = await asyncio.to_thread(
         run_source_file_enrichment,
@@ -4437,12 +4448,18 @@ async def maybe_handle_source_file_enrichment_command(message: discord.Message, 
         lookup_func=lookup_source_file,
         sender=send_dossier_recommendation,
         environ=os.environ,
+        lookup_key=lookup_key,
+        lookup_value=lookup_value,
     )
     _source_enrichment_last_subject = str(result.get("subject") or subject or "none")[:90]
     _source_enrichment_last_status = str(result.get("status") or "unknown")[:80]
     _source_enrichment_last_match_kind = str(result.get("matchKind") or "none")[:80]
     _source_enrichment_last_source_counts = dict(result.get("sourceCounts") or {})
     _source_enrichment_last_warning_counts = dict(result.get("warningCounts") or {})
+    _source_enrichment_last_lookup_found = result.get("status") not in {"no_target", "possible_match_review", "lookup_failed"}
+    _source_enrichment_last_possible_match_count = int(result.get("possibleMatchCount") or 0)
+    _source_enrichment_last_possible_match_names = list(result.get("possibleMatchNames") or [])[:5]
+    _source_enrichment_last_resolution_mode = str(result.get("resolutionMode") or "none")[:80]
     _source_enrichment_last_error_status = "none" if result.get("ok") else _source_enrichment_last_status
     if dry_run:
         _last_dossier_recommendation_status = "source_enrichment_dry_run"

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -56,6 +56,16 @@ _EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}\b")
 _WEAK_ALIAS_RE = re.compile(r"\b(?:alias|known as|aka|connection|connected to|via|through|introduced by)\b", re.I)
 
 
+_ENRICHMENT_QUERY_KEYS = {
+    "alias": "alias",
+    "candidateid": "candidateId",
+    "candidate_id": "candidateId",
+    "normalizedname": "normalizedName",
+    "normalized_name": "normalizedName",
+    "subject": "subject",
+}
+
+
 def parse_source_enrichment_command(content: str) -> tuple[bool, dict[str, Any] | None, str]:
     """Parse operator Source File enrichment commands."""
 
@@ -71,10 +81,30 @@ def parse_source_enrichment_command(content: str) -> tuple[bool, dict[str, Any] 
     if not body:
         return True, None, "Use: `!bnl source enrich <subject> [| dry_run=true]`"
     parts = [part.strip() for part in body.split("|")]
-    subject = re.sub(r"\s+", " ", parts[0]).strip()
-    if not subject:
+    raw_target = re.sub(r"\s+", " ", parts[0]).strip()
+    if not raw_target:
         return True, None, "Subject is required."
-    options: dict[str, Any] = {"subject": subject, "dry_run": False}
+
+    lookup_key = "subject"
+    lookup_value = raw_target
+    key_match = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+)$", raw_target, flags=re.S)
+    if key_match:
+        requested_key = key_match.group(1).strip().lower()
+        canonical_key = _ENRICHMENT_QUERY_KEYS.get(requested_key)
+        if not canonical_key:
+            return True, None, "Enrichment target must be subject, alias, candidateId, or normalizedName."
+        lookup_key = canonical_key
+        lookup_value = re.sub(r"\s+", " ", key_match.group(2).strip())
+        if not lookup_value:
+            return True, None, f"Lookup value for `{canonical_key}` is required."
+
+    options: dict[str, Any] = {
+        "subject": lookup_value,
+        "lookupKey": lookup_key,
+        "lookupValue": lookup_value,
+        lookup_key: lookup_value,
+        "dry_run": False,
+    }
     for extra in parts[1:]:
         if not extra:
             continue
@@ -82,9 +112,9 @@ def parse_source_enrichment_command(content: str) -> tuple[bool, dict[str, Any] 
         if not opt:
             return True, None, "Supported option: dry_run=true|false."
         key = opt.group(1).strip().lower()
-        value = opt.group(2).strip().lower()
+        value = opt.group(2).strip()
         if key in {"dry_run", "dryrun"}:
-            options["dry_run"] = value in {"true", "1", "yes", "on"}
+            options["dry_run"] = value.lower() in {"true", "1", "yes", "on"}
         else:
             return True, None, "Supported option: dry_run=true|false."
     return True, options, ""
@@ -165,6 +195,71 @@ def _first(obj: dict[str, Any], keys: tuple[str, ...]) -> Any:
         if obj.get(key) not in (None, "", []):
             return obj.get(key)
     return None
+
+
+def _possible_match_items(lookup_result: dict[str, Any]) -> list[dict[str, str]]:
+    data = lookup_result.get("data") if isinstance(lookup_result.get("data"), dict) else {}
+    raw = data.get("possibleMatches") or data.get("possible_matches") or data.get("matches") or []
+    if isinstance(raw, dict):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        return []
+    items: list[dict[str, str]] = []
+    for item in raw[:10]:
+        if isinstance(item, dict):
+            name = _safe_text(_first(item, ("name", "sourceFileName", "source_file_name", "subject", "displayName", "title", "normalizedName", "alias")), 90)
+            kind = _safe_text(_first(item, ("matchKind", "match_kind", "kind", "reason", "status")) or "possible_match", 80)
+            candidate_id = _safe_text(_first(item, ("candidateId", "candidate_id", "id", "sourceFileId", "source_file_id")), 90)
+        else:
+            name = _safe_text(item, 90)
+            kind = "possible_match"
+            candidate_id = ""
+        if name:
+            items.append({"name": name, "matchKind": kind, "candidateId": candidate_id})
+    return items
+
+
+def _is_confirmed_alias_lookup(lookup_result: dict[str, Any]) -> bool:
+    data = lookup_result.get("data") if isinstance(lookup_result.get("data"), dict) else {}
+    match_text = " ".join(str(x or "") for x in (
+        lookup_result.get("matchKind"), data.get("matchKind"), data.get("match_kind"), data.get("aliasStatus"), data.get("alias_status"),
+    )).lower()
+    return "alias" in match_text and "confirm" in match_text
+
+
+def _simple_expansion_note(subject: str, matches: list[dict[str, str]]) -> str:
+    compact_subject = re.sub(r"[^a-z0-9]", "", (subject or "").lower())
+    if not compact_subject:
+        return ""
+    for item in matches:
+        compact_name = re.sub(r"[^a-z0-9]", "", item.get("name", "").lower())
+        if compact_name and compact_name != compact_subject and (compact_name.startswith(compact_subject) or compact_name.endswith(compact_subject)):
+            return f"This looks like a simple prefix/suffix expansion of “{_safe_text(subject, 60)}”, but it still needs candidateId or exact-name targeting before notes are sent."
+    return ""
+
+
+def _possible_match_review_result(subject: str, lookup_result: dict[str, Any], *, dry_run: bool, resolution_mode: str, match_note: str = "") -> dict[str, Any]:
+    matches = _possible_match_items(lookup_result)
+    return {
+        "ok": True,
+        "dryRun": dry_run,
+        "subject": _safe_text(subject, 90),
+        "status": "possible_match_review",
+        "matchKind": "possible_match",
+        "matchNote": match_note or "Possible match found, but enrichment needs an exact active Source File target.",
+        "possibleMatches": matches,
+        "possibleMatchCount": len(matches),
+        "possibleMatchNames": [m["name"] for m in matches[:5]],
+        "resolutionMode": resolution_mode,
+        "sections": {},
+        "sourceCounts": {},
+        "warningCounts": {},
+        "sourceTypes": [],
+        "warnings": [],
+        "sent": False,
+        "sendResult": {},
+        "runTime": datetime.now(timezone.utc).isoformat(),
+    }
 
 
 def classify_source_match(lookup_result: dict[str, Any]) -> tuple[str, str, dict[str, Any]]:
@@ -427,18 +522,37 @@ def run_source_file_enrichment(
     lookup_func: Callable[[dict[str, str]], dict[str, Any]] = lookup_source_file,
     sender: Callable[[dict[str, Any]], dict[str, Any]] = send_dossier_recommendation,
     environ: dict[str, str] | None = None,
+    lookup_key: str = "subject",
+    lookup_value: str | None = None,
 ) -> dict[str, Any]:
-    query = {"lookupKey": "subject", "lookupValue": subject, "subject": subject}
+    canonical_key = lookup_key if lookup_key in {"subject", "alias", "candidateId", "normalizedName"} else "subject"
+    target_value = (lookup_value if lookup_value is not None else subject) or ""
+    query = {"lookupKey": canonical_key, "lookupValue": target_value, canonical_key: target_value}
     lookup_result = lookup_func(query)
     match_kind, match_note, source_file = classify_source_match(lookup_result)
-    if match_kind in {"none", "error"}:
+    resolution_mode = {"subject": "exact", "candidateId": "candidateId", "alias": "alias", "normalizedName": "exact"}.get(canonical_key, "exact")
+
+    if match_kind == "none":
+        possible_matches = _possible_match_items(lookup_result)
+        if possible_matches:
+            note = "Possible match found, but enrichment needs an exact active Source File target."
+            if canonical_key == "alias":
+                note = "Alias lookup only returned unconfirmed possible matches; use candidateId after review."
+            expansion_note = _simple_expansion_note(target_value, possible_matches)
+            if expansion_note:
+                note = f"{note} {expansion_note}"
+            return _possible_match_review_result(target_value, lookup_result, dry_run=dry_run, resolution_mode="possible_match_review", match_note=note)
         return {
-            "ok": match_kind != "error",
+            "ok": True,
             "dryRun": dry_run,
-            "subject": _safe_text(subject, 90),
-            "status": "no_target" if match_kind == "none" else "lookup_failed",
+            "subject": _safe_text(target_value, 90),
+            "status": "no_target",
             "matchKind": match_kind,
             "matchNote": match_note,
+            "possibleMatches": [],
+            "possibleMatchCount": 0,
+            "possibleMatchNames": [],
+            "resolutionMode": "no_target",
             "sections": {},
             "sourceCounts": {},
             "warningCounts": {},
@@ -448,15 +562,51 @@ def run_source_file_enrichment(
             "sendResult": {},
             "runTime": datetime.now(timezone.utc).isoformat(),
         }
-    evidence = collect_source_enrichment_evidence(db_path, guild_id, subject, rd_context=rd_context, lookup_result=lookup_result)
+    if match_kind == "error":
+        return {
+            "ok": False,
+            "dryRun": dry_run,
+            "subject": _safe_text(target_value, 90),
+            "status": "lookup_failed",
+            "matchKind": match_kind,
+            "matchNote": match_note,
+            "possibleMatches": [],
+            "possibleMatchCount": 0,
+            "possibleMatchNames": [],
+            "resolutionMode": "no_target",
+            "sections": {},
+            "sourceCounts": {},
+            "warningCounts": {},
+            "sourceTypes": [],
+            "warnings": [],
+            "sent": False,
+            "sendResult": {},
+            "runTime": datetime.now(timezone.utc).isoformat(),
+        }
+
+    if canonical_key == "alias" and not _is_confirmed_alias_lookup(lookup_result):
+        possible_result = dict(lookup_result)
+        data = possible_result.get("data") if isinstance(possible_result.get("data"), dict) else {}
+        source_name = _first(_source_file_obj(possible_result), ("name", "sourceFileName", "subject", "displayName", "title", "normalizedName"))
+        data = dict(data)
+        data["possibleMatches"] = data.get("possibleMatches") or [{"name": source_name or target_value, "matchKind": lookup_result.get("matchKind") or "unconfirmed_alias", "candidateId": _first(_source_file_obj(possible_result), ("candidateId", "candidate_id", "id"))}]
+        possible_result["data"] = data
+        return _possible_match_review_result(target_value, possible_result, dry_run=dry_run, resolution_mode="possible_match_review", match_note="Alias lookup was not a confirmed alias match; use candidateId after review.")
+
+    effective_subject = _first(source_file, ("name", "sourceFileName", "subject", "displayName", "title", "normalizedName")) or target_value
+    evidence = collect_source_enrichment_evidence(db_path, guild_id, str(effective_subject), rd_context=rd_context, lookup_result=lookup_result)
     packet = {
         "ok": True,
         "dryRun": dry_run,
-        "subject": _safe_text(subject, 90),
+        "subject": _safe_text(effective_subject, 90),
         "status": "dry_run" if dry_run else "ready_to_send",
         "matchKind": match_kind,
         "matchNote": match_note,
         "sourceFile": source_file,
+        "possibleMatches": [],
+        "possibleMatchCount": 0,
+        "possibleMatchNames": [],
+        "resolutionMode": resolution_mode,
         "sections": evidence["sections"],
         "sourceCounts": evidence["sourceCounts"],
         "warningCounts": evidence["warningCounts"],
@@ -482,8 +632,34 @@ def run_source_file_enrichment(
 def format_source_enrichment_response(result: dict[str, Any]) -> str:
     subject = _safe_text(result.get("subject") or "subject", 90)
     match_kind = _safe_text(result.get("matchKind") or "none", 80)
+    if result.get("status") == "possible_match_review":
+        matches = result.get("possibleMatches") or []
+        lines = [
+            f"Source enrichment: No confirmed target found for “{subject}.”",
+            "Possible match found, but enrichment needs an exact active Source File target.",
+        ]
+        if len(matches) == 1:
+            item = matches[0]
+            candidate = _safe_text(item.get("candidateId"), 90)
+            lines.append(f"Possible match found: {_safe_text(item.get('name'), 90)}")
+            lines.append(f"Match kind: {_safe_text(item.get('matchKind') or 'possible_match', 80)}")
+            target_hint = "Use " + (f"candidateId={candidate} or " if candidate else "") + "exact name to target it."
+            lines.append(target_hint)
+        elif matches:
+            lines.append("Possible matches (narrow with exact name or candidateId):")
+            for item in matches[:5]:
+                candidate = _safe_text(item.get("candidateId"), 90)
+                suffix = f" — candidateId={candidate}" if candidate else ""
+                lines.append(f"* {_safe_text(item.get('name'), 90)} — {_safe_text(item.get('matchKind') or 'possible_match', 80)}{suffix}")
+        note = _safe_text(result.get("matchNote"), 220)
+        if note and note not in lines:
+            lines.append(note)
+        lines.append("No notes were sent.")
+        if len(matches) != 1:
+            lines.append("Use exact name or candidateId=<id> to target one active Source File.")
+        return "\n".join(lines)[:1900]
     if result.get("status") == "no_target":
-        return (f"Source enrichment: no target found for “{subject}.”\n"
+        return (f"Source enrichment: No confirmed target found for “{subject}.”\n"
                 "Next: create/promote a Candidate Intake item first or run candidate bridge/discovery. No notes were sent.")
     if result.get("status") == "lookup_failed":
         return f"Source enrichment lookup failed for “{subject}”: {_safe_text(result.get('matchNote'), 140)}"

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -57,6 +57,137 @@ class SourceFileEnrichmentTests(unittest.TestCase):
             self.assertTrue(matched)
             self.assertFalse(error)
 
+
+    def test_parses_enrich_lookup_modes(self):
+        cases = (
+            ("!bnl source enrich candidateId=sf_123 | dry_run=true", "candidateId", "sf_123"),
+            ("!bnl source enrich alias=Hellcat | dry_run=true", "alias", "Hellcat"),
+            ("!bnl source enrich normalizedName=hellcatnz | dry_run=true", "normalizedName", "hellcatnz"),
+            ("!bnl source enrich subject=Hellcat | dry_run=true", "subject", "Hellcat"),
+        )
+        for command, key, value in cases:
+            matched, options, error = enrich.parse_source_enrichment_command(command)
+            self.assertTrue(matched)
+            self.assertFalse(error)
+            self.assertEqual(options["lookupKey"], key)
+            self.assertEqual(options["lookupValue"], value)
+            self.assertTrue(options["dry_run"])
+
+    def test_possible_single_match_is_review_only_and_does_not_send(self):
+        calls = []
+        result = enrich.run_source_file_enrichment(
+            self.db,
+            1,
+            "Hellcat",
+            dry_run=True,
+            lookup_func=lambda query: {
+                "ok": True,
+                "found": False,
+                "data": {"possibleMatches": [{"name": "HellcatNZ", "matchKind": "partial_name", "candidateId": "sf_hellcatnz"}]},
+            },
+            sender=lambda payload: calls.append(payload) or {"ok": True},
+        )
+        response = enrich.format_source_enrichment_response(result)
+        self.assertEqual(result["status"], "possible_match_review")
+        self.assertEqual(result["resolutionMode"], "possible_match_review")
+        self.assertEqual(result["possibleMatchCount"], 1)
+        self.assertFalse(result["sent"])
+        self.assertEqual(calls, [])
+        self.assertIn("Possible match found: HellcatNZ", response)
+        self.assertIn("Match kind: partial_name", response)
+        self.assertIn("Use candidateId=sf_hellcatnz or exact name", response)
+        self.assertIn("No notes were sent", response)
+        self.assertNotIn("no target found", response.lower())
+
+    def test_multiple_possible_matches_asks_operator_to_narrow(self):
+        result = enrich.run_source_file_enrichment(
+            self.db,
+            1,
+            "Modem",
+            dry_run=True,
+            lookup_func=lambda query: {
+                "ok": True,
+                "found": False,
+                "data": {
+                    "possibleMatches": [
+                        {"name": "Mac Modem", "matchKind": "partial_name", "candidateId": "sf_mac_modem"},
+                        {"name": "Modem Ghost", "matchKind": "compact_name", "candidateId": "sf_modem_ghost"},
+                    ]
+                },
+            },
+        )
+        response = enrich.format_source_enrichment_response(result)
+        self.assertEqual(result["status"], "possible_match_review")
+        self.assertIn("Possible matches (narrow", response)
+        self.assertIn("Mac Modem — partial_name — candidateId=sf_mac_modem", response)
+        self.assertIn("Use exact name or candidateId", response)
+        self.assertFalse(result["sent"])
+
+    def test_candidate_id_lookup_proceeds_with_enrichment(self):
+        queries = []
+        result = enrich.run_source_file_enrichment(
+            self.db,
+            1,
+            "sf_hellcatnz",
+            dry_run=True,
+            lookup_key="candidateId",
+            lookup_value="sf_hellcatnz",
+            lookup_func=lambda query: queries.append(query) or {
+                "ok": True,
+                "found": True,
+                "matchKind": "candidateId",
+                "data": {"sourceFile": {"id": "sf_hellcatnz", "name": "HellcatNZ", "status": "active"}},
+            },
+        )
+        self.assertEqual(queries[0]["lookupKey"], "candidateId")
+        self.assertEqual(result["status"], "dry_run")
+        self.assertEqual(result["resolutionMode"], "candidateId")
+        self.assertEqual(result["subject"], "HellcatNZ")
+
+    def test_alias_confirmed_proceeds_but_unconfirmed_alias_is_review_only(self):
+        confirmed = enrich.run_source_file_enrichment(
+            self.db,
+            1,
+            "Hellcat",
+            dry_run=True,
+            lookup_key="alias",
+            lookup_value="Hellcat",
+            lookup_func=lambda query: {
+                "ok": True,
+                "found": True,
+                "matchKind": "confirmed alias",
+                "data": {"matchedAlias": "Hellcat", "sourceFile": {"name": "HellcatNZ", "status": "active"}},
+            },
+        )
+        self.assertEqual(confirmed["status"], "dry_run")
+        self.assertEqual(confirmed["resolutionMode"], "alias")
+
+        calls = []
+        unconfirmed = enrich.run_source_file_enrichment(
+            self.db,
+            1,
+            "Hellcat",
+            dry_run=False,
+            lookup_key="alias",
+            lookup_value="Hellcat",
+            lookup_func=lambda query: {
+                "ok": True,
+                "found": False,
+                "data": {"possibleMatches": [{"name": "HellcatNZ", "matchKind": "unconfirmed_alias", "candidateId": "sf_hellcatnz"}]},
+            },
+            sender=lambda payload: calls.append(payload) or {"ok": True},
+        )
+        response = enrich.format_source_enrichment_response(unconfirmed)
+        self.assertEqual(unconfirmed["status"], "possible_match_review")
+        self.assertEqual(calls, [])
+        self.assertIn("Use candidateId=sf_hellcatnz", response)
+
+    def test_exact_name_lookup_still_proceeds_with_enrichment(self):
+        result = enrich.run_source_file_enrichment(self.db, 1, "HellcatNZ", dry_run=True, lookup_func=self._lookup("active"))
+        self.assertEqual(result["status"], "dry_run")
+        self.assertEqual(result["matchKind"], "active_source_file")
+        self.assertEqual(result["resolutionMode"], "exact")
+
     def test_enriches_active_source_file_with_structured_sections(self):
         c = self.conn.cursor()
         c.execute("INSERT INTO user_profiles VALUES (10,1,'Hellcat','Hellcat',NULL,NULL)")
@@ -182,6 +313,10 @@ class SourceFileEnrichmentBotTests(unittest.TestCase):
         self.assertTrue(diag["source_enrichment_available"])
         self.assertEqual(diag["source_enrichment_last_subject"], "Hellcat")
         self.assertEqual(diag["source_enrichment_last_match_kind"], "active_source_file")
+        self.assertIn("source_enrichment_last_lookup_found", diag)
+        self.assertIn("source_enrichment_last_possible_match_count", diag)
+        self.assertIn("source_enrichment_last_possible_match_names", diag)
+        self.assertIn("source_enrichment_last_resolution_mode", diag)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Operators running `!bnl source enrich Hellcat` got a misleading “no target found” even when the website returned possible matches like `HellcatNZ`; the enrichment flow stopped too early. 
- The enrichment command needed support for admin/operator targeting via `candidateId`, `alias`, and `normalizedName` while keeping `subject` positional lookups and preserving dry-run safety.
- Improve operator-facing copy and internal diagnostics so matches and possible-match review states are visible without sending notes or confirming aliases.

### Description

- Added explicit enrichment lookup-mode parsing in `bnl_source_file_enrichment.py` to accept `candidateId=`, `alias=`, `normalizedName=`, and `subject=` as well as the original positional `subject` form and exposed `lookupKey`/`lookupValue` in the parsed options.
- Implemented possible-match extraction and review-only resolution paths: when the website returns `found=false` but includes `possibleMatches`, enrichment now returns a `possible_match_review` result (safe, non-sending) containing up to 5 safe match summaries including `name`, `matchKind`, and `candidateId` where available, plus a hint when the match looks like a simple prefix/suffix expansion (e.g., `Hellcat` → `HellcatNZ`).
- Enrichment execution now supports targeted runs by `candidateId`/`alias`/`normalizedName` (via new `lookup_key`/`lookup_value` parameters passed from `bnl01_bot.py`) and treats confirmed alias matches as normal targets while treating unconfirmed alias responses as review-only and asking for `candidateId`/exact name before sending notes.
- Kept `dry_run` safety: review-only possible matches never cause notes to be sent; only exact/candidateId/confirmed-alias targets proceed to evidence collection and (non-dry) sends.
- Improved operator-facing response text in `format_source_enrichment_response` to clearly show “No confirmed target found.”, list one or multiple possible matches safely, include match kind and candidateId hints, and always state “No notes were sent.” for review-only outcomes.
- Added diagnostics fields in `bnl01_bot.py` to expose lookup metadata: `source_enrichment_last_lookup_found`, `source_enrichment_last_possible_match_count`, `source_enrichment_last_possible_match_names`, and `source_enrichment_last_resolution_mode`, and wired the command handler to pass parsed lookup modes into the enrichment runner.
- Files changed: `bnl_source_file_enrichment.py`, `bnl01_bot.py`, and tests updated/extended in `tests/test_source_file_enrichment.py`.

### Testing

- Ran the full test suite with `python -m unittest discover -s tests -v` and observed all tests pass (existing tests plus new coverage for lookup modes, single/multiple possible matches, candidateId targeting, alias confirmed/unconfirmed behavior, and diagnostics exposure). 
- Performed static checks with `python -m py_compile` on modified modules to ensure syntax validity; compilation succeeded. 
- Verified safe behavior via unit tests ensuring `dry_run=true` never sends notes and possible-match review responses contain the expected guidance and safe fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b997a36e883218124a2a3fd80055e)