### PR TITLE
Fix Python 3.9 annotation startup crash

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -11,6 +11,8 @@
 # - Greeting cooldown: 90 minutes (greeting allowed occasionally)
 # - Length variety policy (responses won’t all be the same length)
 
+from __future__ import annotations
+
 import os
 import re
 import asyncio


### PR DESCRIPTION
### Motivation
- Prevent the Python 3.9 startup `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` caused by PEP 604 union annotations introduced in PR #192 (for example `policy: str | None`) by postponing annotation evaluation.

### Description
- Add `from __future__ import annotations` as the first non-comment import in `bnl01_bot.py` (only `bnl01_bot.py` was changed) to defer evaluation of Python 3.10-style union annotations and avoid the runtime crash on Python 3.9.

### Testing
- Ran `python -m unittest discover -s tests -v` which executed 142 tests and returned `OK`; ran `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py bnl_source_file_lookup.py bnl_community_scouting.py bnl_source_knowledge_bridge.py bnl_source_file_enrichment.py` which completed successfully; and ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bba9738648321bcbb8dc62d731e83)