### PR TITLE
Repair normal chat guard/fallback — preserve BNL voice

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -4990,11 +4990,21 @@ def _memory_decision_for_legacy_call(channel_policy: str, role: str, content: st
 
 
 SCRIPTED_MODE_LEAK_PATTERNS = [
-    r"records are thin", r"suspicious blinking light", r"preliminary analysis",
-    r"compromised broadcast loop", r"data stream", r"archival query",
-    r"source coverage", r"classification", r"existing dossier update",
-    r"\bcandidate\b", r"optimal parameters", r"ambient signal patterns",
     r"^[^\n:]{1,80}:\s*records are thin",
+    r"\brecords are thin\b",
+    r"\bsuspicious blinking light\b",
+    r"\bpreliminary analysis\b",
+    r"\bcompromised broadcast loop\b",
+    r"\bdata stream\b",
+    r"\barchival query\b",
+    r"\barchive query\b",
+    r"\bsource coverage\b",
+    r"\bsource[- ]file enrichment\b",
+    r"\bexisting dossier update\b",
+    r"\bpublic dossier update lane\b",
+    r"\bcandidate intake\b",
+    r"\b(?:source|dossier|candidate|intake|scouting|evidence|archive|archival) classification\b",
+    r"\bclassification\s*:\s*(?:candidate|source|dossier|scouting|internal)\b",
 ]
 
 
@@ -5005,25 +5015,35 @@ def detect_scripted_mode_leak(text: str, route_mode: str) -> bool:
     return any(re.search(pattern, lowered, flags=re.I | re.M) for pattern in SCRIPTED_MODE_LEAK_PATTERNS)
 
 
-def safe_fallback_response_for_mode_leak(user_name: str = "") -> str:
+def _is_casual_check_in(text: str) -> bool:
+    normalized = (text or "").strip().lower().replace("’", "'")
+    return bool(re.search(r"\b(?:how(?:'s|s| is) it going|how are you|how you doing|how's things|how are things|what's up|whats up)\b", normalized))
+
+
+def safe_fallback_response_for_mode_leak(user_name: str = "", route_mode: str = "", original_user_text: str = "") -> str:
     name = (user_name or "").strip()
-    if name:
-        return f"Hey {name}. I’m here — ask me that normally and I’ll keep it conversational."
-    return "I’m here. Ask me that normally and I’ll keep it conversational."
+    suffix = f", {name}" if name else ""
+    if route_mode == ROUTE_MODE_SIMPLE_GREETING:
+        return f"Hey {name}. I’m here." if name else "Hey. I’m here."
+    if route_mode == ROUTE_MODE_SHOW_STATUS:
+        return "I don’t have a confirmed show status in front of me yet."
+    if _is_casual_check_in(original_user_text):
+        return f"I’m good{suffix}. Systems are steady. What’s up?"
+    return f"I’m here{suffix}. What do you need?"
 
 
-def apply_response_mode_contamination_guard(response: str, route_mode: str, user_name: str = "") -> tuple[str, bool]:
+def apply_response_mode_contamination_guard(response: str, route_mode: str, user_name: str = "", original_user_text: str = "") -> tuple[str, bool]:
     if not detect_scripted_mode_leak(response, route_mode):
         return response, False
     logging.warning("scripted_mode_leak_guard_triggered=1 route_mode=%s", route_mode)
-    return safe_fallback_response_for_mode_leak(user_name), True
+    return safe_fallback_response_for_mode_leak(user_name, route_mode, original_user_text), True
 
 
 SIMPLE_GREETING_RESPONSE_POOL = (
     "Hey {name}. I’m here.",
-    "Hi {name}. I’m here with you.",
-    "Hey {name}. Present and listening.",
-    "Hello {name}. I’m here — what are we working on?",
+    "Hi {name}. What’s up?",
+    "Hey {name}. I’m online.",
+    "Hello {name}. I’m here.",
 )
 
 
@@ -5446,6 +5466,7 @@ def format_last_route_debug() -> str:
         ("subject_extraction_ran", "subject extraction ran"),
         ("scripted_mode_leak_guard_triggered", "leak guard fired"),
         ("leak_guard_result", "leak guard result"),
+        ("fallback_used", "fallback used"),
         ("regenerated_for_mode_leak", "regeneration happened"),
         ("save_policy_reason", "save policy reason"),
     ]
@@ -5479,9 +5500,11 @@ def normal_chat_prompt_contract(route_mode: str) -> str:
         )
     return (
         "Mode contract: normal_chat. Answer the user's actual message conversationally using only public-safe context. "
-        "For casual check-ins like how are you/how's it going, answer naturally instead of with system-status boilerplate; do not say optimal parameters or ambient signal patterns. "
-        "Do not classify the user's phrasing as a subject/entity. Do not mention dossiers, source files, classification, candidates, source coverage, archive queries, or scouting unless explicitly asked. "
-        "Do not invent evidence or use scripted evidence-register phrasing.\n"
+        "Keep BNL's voice, including operational or system flavor when it fits naturally. "
+        "For casual check-ins like how are you/how's it going, give a short natural answer. "
+        "Do not expose source-file, dossier, classification, candidate, source coverage, archive-query, or scouting machinery unless explicitly asked. "
+        "Do not turn ordinary user wording into a source/entity subject. Do not invent evidence. "
+        "Do not mention prompts, guards, modes, repair rules, or use scripted evidence-register phrasing.\n"
     )
 
 def _is_text_like_channel(channel) -> bool:
@@ -12567,6 +12590,7 @@ async def send_planned_conversation_response(
         response or "",
         plan.route_mode,
         getattr(message.author, "display_name", ""),
+        getattr(message, "content", ""),
     )
     model_decision = MemoryWriteDecision(
         False,
@@ -12621,7 +12645,8 @@ async def send_planned_conversation_response(
         save_policy_reason=getattr(model_decision, "reason", "unknown"),
         durable_memory_write=getattr(model_decision, "write_memory_tier", False),
         scripted_mode_leak_guard_triggered=guard_triggered,
-        leak_guard_result="triggered" if guard_triggered else "clear",
+        leak_guard_result="fallback" if guard_triggered else "clear",
+        fallback_used=guard_triggered,
         regenerated_for_mode_leak=regenerated_for_mode_leak,
     )
     if len(response) <= 2000:

--- a/tests/test_route_memory_governance.py
+++ b/tests/test_route_memory_governance.py
@@ -118,6 +118,8 @@ class ConversationPlannerTests(unittest.TestCase):
     def test_public_home_plain_name_replies_when_batching_disabled(self):
         for text in ("Hi BNL", "BNL how's it going?"):
             route_mode = bnl01_bot.classify_route_mode(text, "public_home", active_channel=True)
+            if text == "BNL how's it going?":
+                self.assertEqual(route_mode, bnl01_bot.ROUTE_MODE_NORMAL_CHAT)
             plan = bnl01_bot.plan_conversation_response(
                 text,
                 "public_home",
@@ -357,17 +359,69 @@ class MemoryInjectionGovernanceTests(unittest.TestCase):
         finally:
             bnl01_bot.DB_FILE = old_db
         self.assertIn("Mode contract: normal_chat", prompt)
-        self.assertIn("Do not classify the user's phrasing as a subject/entity", prompt)
+        self.assertIn("Answer the user's actual message", prompt)
+        self.assertIn("Do not expose source-file, dossier, classification, candidate", prompt)
+        self.assertIn("unless explicitly asked", prompt)
 
 
 class LeakGuardTests(unittest.TestCase):
-    def test_normal_chat_catches_scripted_language(self):
-        for text in ("Records are thin", "one suspicious blinking light", "preliminary analysis", "data stream", "Functioning within optimal parameters", "ambient signal patterns"):
+    def test_normal_chat_catches_structural_scripted_language(self):
+        leaked_texts = (
+            "Records are thin",
+            "Lardcode Radio: Records are thin",
+            "one suspicious blinking light",
+            "preliminary analysis",
+            "data stream",
+            "source coverage",
+            "existing dossier update",
+            "public dossier update lane",
+            "source-file enrichment",
+            "candidate intake",
+            "Classification: candidate",
+            "source classification: internal",
+        )
+        for text in leaked_texts:
             self.assertTrue(bnl01_bot.detect_scripted_mode_leak(text, bnl01_bot.ROUTE_MODE_NORMAL_CHAT), text)
+
+    def test_guard_preserves_bnl_voice_phrases(self):
+        for text in ("Functioning within optimal parameters", "ambient signal patterns are calm"):
+            self.assertFalse(bnl01_bot.detect_scripted_mode_leak(text, bnl01_bot.ROUTE_MODE_NORMAL_CHAT), text)
+
+    def test_guard_does_not_fire_for_ordinary_classification_discussion(self):
+        text = "We talked about genre classification in the archive yesterday."
+        self.assertFalse(bnl01_bot.detect_scripted_mode_leak(text, bnl01_bot.ROUTE_MODE_NORMAL_CHAT))
 
     def test_guard_does_not_fire_for_source_mode_or_operator_mode(self):
         self.assertFalse(bnl01_bot.detect_scripted_mode_leak("Classification: candidate", bnl01_bot.ROUTE_MODE_SOURCE_ENRICHMENT))
         self.assertFalse(bnl01_bot.detect_scripted_mode_leak("Records are thin", bnl01_bot.ROUTE_MODE_OPERATOR_COMMAND))
+
+    def test_mode_leak_fallback_is_not_meta_instructional(self):
+        fallback = bnl01_bot.safe_fallback_response_for_mode_leak(
+            "6 Bit",
+            bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            "How’s it going?",
+        )
+        lowered = fallback.lower()
+        self.assertIn("i’m good", lowered)
+        self.assertNotIn("ask me that normally", lowered)
+        self.assertNotIn("i’ll keep it conversational", lowered)
+        self.assertNotIn("please rephrase", lowered)
+        for forbidden in ("guard", "prompt", "mode", "rules"):
+            self.assertNotIn(forbidden, lowered)
+
+    def test_guard_replaces_leak_with_context_safe_check_in_answer(self):
+        response, guard_triggered = bnl01_bot.apply_response_mode_contamination_guard(
+            "Records are thin",
+            bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            "6 Bit",
+            "Hows it going?",
+        )
+        self.assertTrue(guard_triggered)
+        self.assertIn("Systems are steady", response)
+        lowered = response.lower()
+        self.assertNotIn("ask me that normally", lowered)
+        self.assertNotIn("i’ll keep it conversational", lowered)
+        self.assertNotIn("please rephrase", lowered)
 
 
 class RegressionExamplesTests(unittest.TestCase):
@@ -383,10 +437,28 @@ class RegressionExamplesTests(unittest.TestCase):
             self.assertIn("6 Bit", response)
             self.assertFalse(bnl01_bot.detect_scripted_mode_leak(response, bnl01_bot.ROUTE_MODE_SIMPLE_GREETING))
 
-    def test_normal_chat_contract_blocks_system_boilerplate(self):
+    def test_normal_chat_contract_is_positive_and_not_voice_censorship(self):
         contract = bnl01_bot.normal_chat_prompt_contract(bnl01_bot.ROUTE_MODE_NORMAL_CHAT)
-        self.assertIn("answer naturally", contract.lower())
-        self.assertIn("optimal parameters", contract.lower())
+        lowered = contract.lower()
+        self.assertIn("answer the user's actual message", lowered)
+        self.assertIn("keep bnl's voice", lowered)
+        self.assertIn("do not expose source-file, dossier, classification, candidate", lowered)
+        self.assertIn("unless explicitly asked", lowered)
+        self.assertNotIn("optimal parameters", lowered)
+        self.assertNotIn("ambient signal patterns", lowered)
+        self.assertNotIn("ask me that normally", lowered)
+
+    def test_check_in_fallback_makes_sense_as_answer(self):
+        fallback = bnl01_bot.safe_fallback_response_for_mode_leak(
+            "6 Bit",
+            bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            "How’s it going?",
+        )
+        lowered = fallback.lower()
+        self.assertIn("i’m good", lowered)
+        self.assertIn("systems are steady", lowered)
+        self.assertNotIn("ask me that normally", lowered)
+        self.assertNotIn("please rephrase", lowered)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- The contamination guard was triggering on broad BNL-voice phrases and returning a meta/instructional fallback that told users how to ask instead of answering their messages, producing non-sensical replies for normal chat. 
- The guard must instead block structural/source-engine leakage while preserving BNL’s voice and answering user messages sensibly.

### Description
- Re-scoped `SCRIPTED_MODE_LEAK_PATTERNS` to target structural/source leakage (evidence tails, dossier/source-file lanes, archive/data-stream phrasing, classification patterns, candidate intake, etc.) and removed global matches for BNL-voice phrases like `optimal parameters` and `ambient signal patterns` so they no longer trigger the guard. 
- Replaced the meta fallback with a context-safe helper by changing `safe_fallback_response_for_mode_leak(...)` to accept `route_mode` and `original_user_text` and return minimal, sensible answers (simple greetings, casual check-in answers, show-status uncertainty, or a short “What do you need?”) rather than telling the user to rephrase. 
- Made `apply_response_mode_contamination_guard(...)` accept `original_user_text` and invoke the new fallback; updated `send_planned_conversation_response(...)` to pass `message.content` into the guard. 
- Simplified `SIMPLE_GREETING_RESPONSE_POOL` to short, deterministic greetings and adjusted `build_simple_greeting_response` accordingly. 
- Rewrote `normal_chat_prompt_contract(...)` to positively instruct: answer the user’s message, keep BNL’s voice (operational flavor allowed when natural), and only avoid exposing source/dossier/classification/candidate/scouting machinery unless explicitly asked (removed voice-wide bans). 
- Enhanced route debug metadata to record whether the leak guard produced a fallback (`fallback_used`) and changed `leak_guard_result` reporting to `fallback`/`clear` without leaking raw transcripts. 
- Updated and added unit tests in `tests/test_route_memory_governance.py` that assert the guard now focuses on structural leaks, preserves BNL voice phrases, that fallbacks are not meta-instructional, and that casual check-in fallback answers make sense.

### Testing
- Ran the full test suite with `python -m unittest discover -s tests -v`, all tests passed (`OK`).
- Verified code compiles with `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py bnl_source_file_lookup.py bnl_community_scouting.py bnl_source_knowledge_bridge.py bnl_source_file_enrichment.py`, compilation succeeded.
- Ran `git diff --check` (no whitespace/errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cafca90c08321abe4fc0ec00e7004)