### PR TITLE
Bot PR #203 — Route First Acknowledgement Branch Through Media-Aware Resolver

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -8072,6 +8072,65 @@ def _free_speak_ack_resolution(decision: str, reason: str, items, channel_policy
     return "observe", "free_speak_canned_ack_suppressed", diagnostics
 
 
+def _batch_ack_resolution_details(original_decision: str, original_reason: str, resolved_decision: str, resolved_reason: str, diagnostics: dict, channel_policy: str) -> str:
+    conversation_surface = conversation_surface_for_channel_policy(channel_policy)
+    return (
+        f"original_decision={original_decision};original_reason={original_reason};"
+        f"resolved_decision={resolved_decision};resolved_reason={resolved_reason};"
+        f"canned_ack_suppressed={int(diagnostics.get('canned_ack_suppressed', False))};"
+        f"ack_converted_to_observe={int(diagnostics.get('ack_converted_to_observe', False))};"
+        f"ack_escalated_to_generation={int(diagnostics.get('ack_escalated_to_generation', False))};"
+        f"media_present={int(diagnostics.get('media_present', False))};"
+        f"media_context_included={int(diagnostics.get('media_context_included', False))};"
+        f"media_item_count={diagnostics.get('media_item_count', 0)};"
+        f"conversation_surface={conversation_surface};channel_policy={channel_policy}"
+    )
+
+
+def resolve_batch_acknowledgement_decision(
+    decision: str,
+    reason: str,
+    items,
+    channel_policy: str,
+    *,
+    payload_count: int = 0,
+    has_structured_intent: bool = False,
+    guild_id: int | None = None,
+    channel_id: int | None = None,
+    message_count: int | None = None,
+) -> tuple[str, str, dict]:
+    original_decision = decision
+    original_reason = reason
+    resolved_decision, resolved_reason, diagnostics = _free_speak_ack_resolution(
+        decision,
+        reason,
+        items,
+        channel_policy,
+        payload_count=payload_count,
+        has_structured_intent=has_structured_intent,
+    )
+    diagnostics.update({
+        "original_decision": original_decision,
+        "original_reason": original_reason,
+        "resolved_decision": resolved_decision,
+        "resolved_reason": resolved_reason,
+        "conversation_surface": conversation_surface_for_channel_policy(channel_policy),
+        "channel_policy": channel_policy,
+    })
+    if original_decision == "acknowledge" and diagnostics.get("canned_ack_suppressed") and guild_id is not None and channel_id is not None:
+        count = len(items or []) if message_count is None else message_count
+        details = _batch_ack_resolution_details(
+            original_decision,
+            original_reason,
+            resolved_decision,
+            resolved_reason,
+            diagnostics,
+            channel_policy,
+        )
+        _log_batch_event(logging.INFO, "free_speak_ack_resolution", guild_id, channel_id, count, details)
+        _log_batch_event(logging.INFO, "free_speak_canned_ack_suppressed", guild_id, channel_id, count, details)
+    return resolved_decision, resolved_reason, diagnostics
+
 def _extract_member_activity_event_from_text(text: str, source_author: str = "") -> dict:
     if not text:
         return {}
@@ -11625,6 +11684,20 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
         _log_batch_event(logging.INFO, "active_packet_collapsed_count", guild_id, channel_id, active_packet["collapsed_count"], f"collapsed_count={active_packet['collapsed_count']}")
         _log_batch_event(logging.INFO, "active_packet_built", guild_id, channel_id, active_packet["collapsed_count"], f"original_count={active_packet['original_count']};collapsed_count={active_packet['collapsed_count']};payload_count={payload_count};decision={decision};reason={reason}")
         _log_batch_event(logging.INFO, "active_packet_payload_items", guild_id, channel_id, active_packet["collapsed_count"], f"payload_count={payload_count}")
+        if decision == "acknowledge":
+            decision, reason, ack_diag = resolve_batch_acknowledgement_decision(
+                decision,
+                reason,
+                collapsed_items,
+                channel_policy,
+                payload_count=payload_count,
+                has_structured_intent=bool(active_packet.get("has_structured_intent")),
+                guild_id=guild_id,
+                channel_id=channel_id,
+                message_count=len(collapsed_items),
+            )
+        else:
+            ack_diag = {}
         if payload_count > 0 and decision != "answer":
             _log_batch_event(logging.INFO, "payload_items_force_answer", guild_id, channel_id, len(collapsed_items), f"message_count={len(collapsed_items)};payload_count={payload_count}")
             _log_batch_event(logging.INFO, "payload_force_answer_preserved_request_action", guild_id, channel_id, len(collapsed_items), f"payload_count={payload_count};request_action={active_packet.get('request_action','generic_request')}")
@@ -11644,7 +11717,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             _log_batch_event(logging.INFO, "request_intent_detected", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
         if reason.startswith("request_payload_expected:"):
             _log_batch_event(logging.INFO, "request_payload_phrase_detected", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
-        _log_batch_event(logging.INFO, "batch_engagement_decision", guild_id, channel_id, len(collapsed_items), f"decision={decision};reason={reason}")
+        _log_batch_event(logging.INFO, "batch_engagement_decision", guild_id, channel_id, len(collapsed_items), f"decision={decision};reason={reason};original_decision={ack_diag.get('original_decision', decision)};original_reason={ack_diag.get('original_reason', reason)};resolved_decision={ack_diag.get('resolved_decision', decision)};resolved_reason={ack_diag.get('resolved_reason', reason)};canned_ack_suppressed={int(ack_diag.get('canned_ack_suppressed', False))};ack_converted_to_observe={int(ack_diag.get('ack_converted_to_observe', False))};ack_escalated_to_generation={int(ack_diag.get('ack_escalated_to_generation', False))};media_present={int(ack_diag.get('media_present', active_packet.get('media_present', False)))};media_context_included={int(ack_diag.get('media_context_included', active_packet.get('media_context_included', False)))};media_item_count={ack_diag.get('media_item_count', active_packet.get('media_item_count', 0))};conversation_surface={conversation_surface_for_channel_policy(channel_policy)};channel_policy={channel_policy}")
         if decision in ("skip", "observe"):
             _log_batch_event(logging.INFO, "batch_response_skipped", guild_id, channel_id, len(collapsed_items), "no_response_needed")
             return
@@ -11704,6 +11777,20 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             _log_batch_event(logging.INFO, "active_packet_collapsed_count", guild_id, channel_id, active_packet["collapsed_count"], f"collapsed_count={active_packet['collapsed_count']}")
             _log_batch_event(logging.INFO, "active_packet_built", guild_id, channel_id, active_packet["collapsed_count"], f"original_count={active_packet['original_count']};collapsed_count={active_packet['collapsed_count']};payload_count={payload_count};decision={decision};reason={reason}")
             _log_batch_event(logging.INFO, "active_packet_payload_items", guild_id, channel_id, active_packet["collapsed_count"], f"payload_count={payload_count}")
+            if decision == "acknowledge":
+                decision, reason, ack_diag = resolve_batch_acknowledgement_decision(
+                    decision,
+                    reason,
+                    collapsed_items,
+                    channel_policy,
+                    payload_count=payload_count,
+                    has_structured_intent=bool(active_packet.get("has_structured_intent")),
+                    guild_id=guild_id,
+                    channel_id=channel_id,
+                    message_count=len(collapsed_items),
+                )
+            else:
+                ack_diag = {}
             if payload_count > 0 and decision != "answer":
                 _log_batch_event(logging.INFO, "payload_items_force_answer", guild_id, channel_id, len(collapsed_items), f"message_count={len(collapsed_items)};payload_count={payload_count}")
                 _log_batch_event(logging.INFO, "payload_force_answer_preserved_request_action", guild_id, channel_id, len(collapsed_items), f"payload_count={payload_count};request_action={active_packet.get('request_action','generic_request')}")
@@ -11725,25 +11812,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 _log_batch_event(logging.INFO, "request_intent_detected", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
             if reason.startswith("request_payload_expected:"):
                 _log_batch_event(logging.INFO, "request_payload_phrase_detected", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
-            ack_original_decision = decision
-            decision, reason, ack_diag = _free_speak_ack_resolution(
-                decision,
-                reason,
-                collapsed_items,
-                channel_policy,
-                payload_count=payload_count,
-                has_structured_intent=bool(active_packet.get("has_structured_intent")),
-            )
-            if ack_diag.get("canned_ack_suppressed"):
-                _log_batch_event(
-                    logging.INFO,
-                    "free_speak_canned_ack_suppressed",
-                    guild_id,
-                    channel_id,
-                    len(collapsed_items),
-                    f"ack_converted_to_observe={int(ack_diag.get('ack_converted_to_observe'))};ack_escalated_to_generation={int(ack_diag.get('ack_escalated_to_generation'))};media_present={int(ack_diag.get('media_present'))};media_context_included={int(ack_diag.get('media_context_included'))};media_item_count={ack_diag.get('media_item_count', 0)};reason={reason}",
-                )
-            _log_batch_event(logging.INFO, "batch_engagement_decision", guild_id, channel_id, len(collapsed_items), f"decision={decision};reason={reason};batch_ack_decision={ack_original_decision};canned_ack_suppressed={int(ack_diag.get('canned_ack_suppressed', False))};media_present={int(active_packet.get('media_present', False))};media_context_included={int(active_packet.get('media_context_included', False))};media_item_count={active_packet.get('media_item_count', 0)}")
+            _log_batch_event(logging.INFO, "batch_engagement_decision", guild_id, channel_id, len(collapsed_items), f"decision={decision};reason={reason};original_decision={ack_diag.get('original_decision', decision)};original_reason={ack_diag.get('original_reason', reason)};resolved_decision={ack_diag.get('resolved_decision', decision)};resolved_reason={ack_diag.get('resolved_reason', reason)};canned_ack_suppressed={int(ack_diag.get('canned_ack_suppressed', False))};ack_converted_to_observe={int(ack_diag.get('ack_converted_to_observe', False))};ack_escalated_to_generation={int(ack_diag.get('ack_escalated_to_generation', False))};media_present={int(ack_diag.get('media_present', active_packet.get('media_present', False)))};media_context_included={int(ack_diag.get('media_context_included', active_packet.get('media_context_included', False)))};media_item_count={ack_diag.get('media_item_count', active_packet.get('media_item_count', 0))};conversation_surface={conversation_surface_for_channel_policy(channel_policy)};channel_policy={channel_policy}")
             if decision in ("skip", "observe"):
                 _log_batch_event(logging.INFO, "batch_response_skipped", guild_id, channel_id, len(collapsed_items), "no_response_needed")
                 return

--- a/tests/test_route_memory_governance.py
+++ b/tests/test_route_memory_governance.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
@@ -669,6 +670,93 @@ class MediaAwareBatchAckTests(unittest.TestCase):
         self.assertEqual(resolved_decision, "answer")
         self.assertEqual(resolved_reason, "free_speak_media_context_generation")
         self.assertTrue(diag["ack_escalated_to_generation"])
+
+    def test_resolve_batch_acknowledgement_routes_first_free_speak_media_ack(self):
+        items = [(
+            "Crow",
+            bnl01_bot.append_media_context_to_text(
+                "",
+                {
+                    "items": ["gif embed (provider=Tenor; preview=yes)"],
+                    "prompt_text": "- gif embed (provider=Tenor; preview=yes)",
+                },
+            ),
+            101,
+        )]
+        decision, reason = bnl01_bot._classify_batch_engagement(items)
+        self.assertEqual(decision, "acknowledge")
+        with mock.patch.object(bnl01_bot, "_build_acknowledgement_response", wraps=bnl01_bot._build_acknowledgement_response) as ack_builder:
+            with mock.patch.object(bnl01_bot, "_log_batch_event") as batch_log:
+                resolved_decision, resolved_reason, diag = bnl01_bot.resolve_batch_acknowledgement_decision(
+                    decision,
+                    reason,
+                    items,
+                    "sealed_test",
+                    guild_id=1,
+                    channel_id=2,
+                    message_count=len(items),
+                )
+        self.assertEqual(resolved_decision, "observe")
+        self.assertEqual(resolved_reason, "free_speak_canned_ack_suppressed")
+        self.assertTrue(diag["canned_ack_suppressed"])
+        self.assertTrue(diag["ack_converted_to_observe"])
+        self.assertEqual(diag["original_decision"], "acknowledge")
+        self.assertEqual(diag["original_reason"], "light_media_reaction_cluster")
+        self.assertEqual(diag["resolved_decision"], "observe")
+        self.assertEqual(diag["conversation_surface"], bnl01_bot.CONVERSATION_SURFACE_FREE_SPEAK_SEALED_MIRROR)
+        ack_builder.assert_not_called()
+        logged_events = [call.args[1] for call in batch_log.call_args_list]
+        self.assertIn("free_speak_ack_resolution", logged_events)
+        self.assertIn("free_speak_canned_ack_suppressed", logged_events)
+        joined_details = " ".join(call.args[5] for call in batch_log.call_args_list)
+        self.assertIn("original_decision=acknowledge", joined_details)
+        self.assertIn("original_reason=light_media_reaction_cluster", joined_details)
+        self.assertIn("resolved_decision=observe", joined_details)
+        self.assertIn("ack_converted_to_observe=1", joined_details)
+        self.assertIn("media_present=1", joined_details)
+        self.assertIn("media_context_included=1", joined_details)
+        self.assertIn("channel_policy=sealed_test", joined_details)
+
+    def test_resolve_batch_acknowledgement_escalates_structured_free_speak_context(self):
+        items = [("Crow", "testing diagnostics with enough detail to require acknowledgement", 101)]
+        with mock.patch.object(bnl01_bot, "_log_batch_event") as batch_log:
+            resolved_decision, resolved_reason, diag = bnl01_bot.resolve_batch_acknowledgement_decision(
+                "acknowledge",
+                "light_fragment_or_test_cluster",
+                items,
+                "public_home",
+                has_structured_intent=True,
+                guild_id=1,
+                channel_id=2,
+                message_count=len(items),
+            )
+        self.assertEqual(resolved_decision, "answer")
+        self.assertEqual(resolved_reason, "free_speak_ack_structured_context_generation")
+        self.assertTrue(diag["canned_ack_suppressed"])
+        self.assertTrue(diag["ack_escalated_to_generation"])
+        self.assertFalse(diag["ack_converted_to_observe"])
+        joined_details = " ".join(call.args[5] for call in batch_log.call_args_list)
+        self.assertIn("resolved_decision=answer", joined_details)
+        self.assertIn("ack_escalated_to_generation=1", joined_details)
+        self.assertIn("conversation_surface=free_speak_public_home", joined_details)
+
+    def test_resolve_batch_acknowledgement_preserves_non_free_speak_received(self):
+        items = [("Ops", "testing diagnostics with enough detail to require acknowledgement from the utility path", 101), ("Ops", "second testing diagnostic line with enough detail", 101)]
+        with mock.patch.object(bnl01_bot, "_log_batch_event") as batch_log:
+            resolved_decision, resolved_reason, diag = bnl01_bot.resolve_batch_acknowledgement_decision(
+                "acknowledge",
+                "light_fragment_or_test_cluster",
+                items,
+                "internal_controlled",
+                guild_id=1,
+                channel_id=2,
+                message_count=len(items),
+            )
+        self.assertEqual(resolved_decision, "acknowledge")
+        self.assertEqual(resolved_reason, "light_fragment_or_test_cluster")
+        self.assertFalse(diag["canned_ack_suppressed"])
+        self.assertEqual(bnl01_bot._build_acknowledgement_response(items), "Received.")
+        batch_log.assert_not_called()
 
     def test_media_context_is_represented_in_batch_prompt_and_packet_metadata(self):
         media_text = bnl01_bot.append_media_context_to_text(


### PR DESCRIPTION
### Motivation
- Fix a control-flow bug where the early `acknowledge` branch in `_flush_channel_buffer(...)` could send or suppress a canned acknowledgement before the media-aware resolver from PR #202 ran. 
- Ensure every free-speak (`public_home` / `sealed_test`) `decision == "acknowledge"` path is evaluated by the media-aware resolver so media-only reactions are observed or escalated consistently.

### Description
- Introduced a centralized helper `resolve_batch_acknowledgement_decision(...)` that calls `_free_speak_ack_resolution(...)`, annotates diagnostics (original/resolved decision & reason, suppression flags, media stats, conversation surface and channel policy), and logs `free_speak_ack_resolution` / `free_speak_canned_ack_suppressed` events when appropriate in free-speak contexts (file: `bnl01_bot.py`).
- Routed the early acknowledgement branch in `_flush_channel_buffer(...)` through `resolve_batch_acknowledgement_decision(...)` before any call to `_build_acknowledgement_response(...)`, `generic_ack_suppressed`, `batch_response_acknowledge`, or any early return, preserving non-free-speak behavior.
- Reused the same helper in the later generation loop acknowledgement section so both acknowledgement sites share resolver semantics and consistent logging/diagnostics (file: `bnl01_bot.py`).
- Added targeted unit tests exercising the regression and helper behavior: media-only free-speak ack -> observe, media+text and structured free-speak -> escalate to generation, and non-free-speak `Received.` preservation (file: `tests/test_route_memory_governance.py`).

### Testing
- Ran full unit suite with `python -m unittest discover -s tests -v` and all tests passed (204 tests, all OK). 
- Verified Python compilation for main modules with `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py bnl_source_file_lookup.py bnl_community_scouting.py bnl_source_knowledge_bridge.py bnl_source_file_enrichment.py` (no syntax errors).
- Confirmed no whitespace/diff issues with `git diff --check` (no problems reported).
- New/updated tests added in `tests/test_route_memory_governance.py` and code changes in `bnl01_bot.py` passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cf062f70083218608234a446612dc)