### PR TITLE
Prevent website relay Gemini calls from blocking Discord event loop

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -26,6 +26,7 @@ import urllib.request
 import urllib.error
 import urllib.parse
 import calendar
+import time
 
 from bnl_dossier_candidate_discovery import (
     DEFAULT_DISCOVERY_LANES,
@@ -109,6 +110,7 @@ BNL_ACTIVE_BATCHING_ENABLED = os.getenv("BNL_ACTIVE_BATCHING_ENABLED", "false").
 BNL_TYPING_INDICATOR_ENABLED = os.getenv("BNL_TYPING_INDICATOR_ENABLED", "false").strip().lower() in {"true", "1", "on"}
 BNL_TYPING_INDICATOR_COOLDOWN_SECONDS = max(8, int(os.getenv("BNL_TYPING_INDICATOR_COOLDOWN_SECONDS", "12") or 12))
 BNL_WEBSITE_RELAY_INTERVAL_MINUTES = max(1, int(os.getenv("BNL_WEBSITE_RELAY_INTERVAL_MINUTES", "20")))
+BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS = max(1.0, float(os.getenv("BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS", "25") or 25))
 BNL_PRIMARY_GUILD_ID = int(os.getenv("BNL_PRIMARY_GUILD_ID", "0") or 0)
 BNL_FORCE_PULL_SHARED_SECRET = os.getenv("BNL_FORCE_PULL_SHARED_SECRET", "").strip()
 BNL_FORCE_PULL_PORT = int(os.getenv("BNL_FORCE_PULL_PORT", "8787") or 8787)
@@ -2011,6 +2013,20 @@ def build_website_read_model_intent_response(intent: str, request_text: str) -> 
         return build_website_public_safe_candidate_response(read_model, request_text)
     return build_website_read_model_classifier_response(read_model, request_text)
 
+async def update_website_status_controlled_async(mode: str, message: str, status: str = "ONLINE", force: bool = False, current_directive: str = "", source: str = "relay", admin_note: str = "") -> bool:
+    logging.info(f"website_status_push_offloaded source={source} mode={mode}")
+    return await asyncio.to_thread(
+        update_website_status_controlled,
+        mode=mode,
+        message=message,
+        status=status,
+        force=force,
+        current_directive=current_directive,
+        source=source,
+        admin_note=admin_note,
+    )
+
+
 def update_website_status_controlled(mode: str, message: str, status: str = "ONLINE", force: bool = False, current_directive: str = "", source: str = "relay", admin_note: str = "") -> bool:
     global _last_website_status_mode, _last_website_status_message, _last_website_directive, _last_website_status_at, _missing_status_key_warned
 
@@ -2150,6 +2166,7 @@ _recent_weak_context_modes: dict[int, list[str]] = {}
 _last_relay_lane_by_guild: dict[int, str] = {}
 _recent_relay_lanes_by_guild = defaultdict(lambda: deque(maxlen=8))
 _last_relay_metadata_by_guild: dict[int, dict] = {}
+_website_relay_generation_tasks_by_guild: dict[int, asyncio.Task] = {}
 RELAY_ANGLE_ROTATION = [
     "whisper",
     "wonder",
@@ -2207,7 +2224,7 @@ async def _run_force_pull_relay_update(guild_id: int, request_id: str = ""):
     logging.info(f"Force-pull background relay update started guild={guild_id}{tag}")
     try:
         mode, relay_message, directive, _relay_meta = await generate_dynamic_website_relay(guild_id)
-        ok = update_website_status_controlled(
+        ok = await update_website_status_controlled_async(
             mode=mode,
             message=relay_message,
             status="ONLINE",
@@ -3213,7 +3230,7 @@ async def request_fresh_website_relay(guild_id: int, *, force: bool = True) -> t
         sanitized = fit_complete_statement(relay_message, limit=360, min_chars=0, fallback=_weak_context_relay_message(target_guild_id, signal_summary="", relay_context=""))
         sanitized_directive = fit_complete_statement(directive, limit=220, min_chars=120, fallback=random.choice(RELAY_DIRECTIVE_FALLBACKS))
         admin_note = build_admin_note(mode=mode, message=sanitized, current_directive=sanitized_directive, source="relay", compact=not force) if force else ""
-        ok = update_website_status_controlled(
+        ok = await update_website_status_controlled_async(
             mode=mode,
             message=sanitized,
             status="ONLINE",
@@ -10201,6 +10218,16 @@ def _gemini_model_resource_name(model_name: str) -> str:
         return model_name
     return f"models/{model_name}"
 
+async def _generate_gemini_content_with_fallback_async(contents: str, route: str):
+    started = time.monotonic()
+    logging.info(f"gemini_generation_offloaded route={route}")
+    try:
+        return await asyncio.to_thread(_generate_gemini_content_with_fallback, contents, route)
+    finally:
+        elapsed = time.monotonic() - started
+        logging.info(f"gemini_generation_completed route={route} elapsed_seconds={elapsed:.3f}")
+
+
 def _generate_gemini_content_with_fallback(contents: str, route: str):
     logging.info(f"gemini_model_attempt model={GEMINI_MODEL} route={route}")
     try:
@@ -10413,7 +10440,7 @@ async def get_gemini_response(prompt: str, user_id: int, guild_id: int, route: s
 
         User: {prompt}
         BNL-01:"""
-        response = _generate_gemini_content_with_fallback(request_contents, route)
+        response = await _generate_gemini_content_with_fallback_async(request_contents, route)
 
         text, tokens = _extract_text_and_tokens(response)
 
@@ -10455,7 +10482,7 @@ async def get_gemini_response(prompt: str, user_id: int, guild_id: int, route: s
         {text}
         """
 
-            glitch_response = _generate_gemini_content_with_fallback(glitch_prompt, "glitch_rewrite")
+            glitch_response = await _generate_gemini_content_with_fallback_async(glitch_prompt, "glitch_rewrite")
 
             glitch_text, _ = _extract_text_and_tokens(glitch_response)
 
@@ -10466,7 +10493,7 @@ async def get_gemini_response(prompt: str, user_id: int, guild_id: int, route: s
                     logging.info("glitch_rewrite_rejected reason=public_operator_causality_claim")
                 else:
                     text = glitch_text
-                    update_website_status_controlled(
+                    await update_website_status_controlled_async(
                         mode="SIGNAL_DEGRADATION",
                         message="Signal degradation detected. Liaison output may fluctuate.",
                         status="ONLINE",
@@ -10501,7 +10528,7 @@ async def get_gemini_response(prompt: str, user_id: int, guild_id: int, route: s
         {text}
         """
 
-            bleed_response = _generate_gemini_content_with_fallback(bleed_prompt, "cross_universe_bleed")
+            bleed_response = await _generate_gemini_content_with_fallback_async(bleed_prompt, "cross_universe_bleed")
             bleed_text, _ = _extract_text_and_tokens(bleed_response)
             if bleed_text:
                 if contains_fake_lookup_claim(bleed_text) and not contains_fake_lookup_claim(text):
@@ -11026,8 +11053,92 @@ async def barcode_radio_queue_task():
                     logging.error(f"Show-day Discord update failed (guild {guild.id}, {phase_key}): {e}")
             mode = "RESTRICTED" if phase_key == "sponsor_window" else "ACTIVE_LIAISON"
             if flags.get("websiteRelayEnabled", True):
-                update_website_status_controlled(mode=mode, message=fit_complete_statement(website_msg, limit=360, min_chars=220, fallback=_pick_varied_fallback(phase_key)), status="ONLINE", force=True)
+                await update_website_status_controlled_async(mode=mode, message=fit_complete_statement(website_msg, limit=360, min_chars=220, fallback=_pick_varied_fallback(phase_key)), status="ONLINE", force=True)
             mark_show_update_fired(guild.id, show_date, phase_key, discord_sent, website_msg)
+
+def _build_website_relay_timeout_fallback(guild_id: int) -> tuple[str, str, str, dict]:
+    relay_message = fit_complete_statement(
+        _pick_varied_relay_fallback(_last_website_status_message),
+        limit=360,
+        min_chars=0,
+        fallback=RELAY_WEAK_CONTEXT_STANDBY_MESSAGE,
+    )
+    directive = fit_complete_statement(
+        RELAY_WEAK_CONTEXT_STANDBY_DIRECTIVE,
+        limit=220,
+        min_chars=120,
+        fallback=RELAY_WEAK_CONTEXT_STANDBY_DIRECTIVE,
+    )
+    metadata = {
+        "context_is_strong": False,
+        "reason": "relay_generation_timeout",
+        "has_specific_context": False,
+        "source_message_count": 0,
+        "source_speaker_count": 0,
+        "source_channel_count": 0,
+        "attribution_context_format": "timeout_fallback",
+        "eligible_policies": [],
+        "relay_lane": "network_posture",
+        "relay_lane_reason": "relay_generation_timeout",
+        "dormant_signal_enabled": False,
+        "is_weak_fallback": True,
+        "is_low_signal_dynamic": False,
+    }
+    _last_relay_metadata_by_guild[guild_id] = dict(metadata)
+    return "OBSERVATION", relay_message, directive, metadata
+
+
+async def _generate_website_relay_guarded(guild_id: int) -> tuple[str, str, str, dict] | None:
+    existing = _website_relay_generation_tasks_by_guild.get(guild_id)
+    if existing and not existing.done():
+        logging.info(f"website_relay_generation_skipped_inflight guild={guild_id}")
+        return None
+    if existing and existing.done():
+        _website_relay_generation_tasks_by_guild.pop(guild_id, None)
+
+    started = time.monotonic()
+    state = {"timed_out": False}
+    task = asyncio.create_task(generate_dynamic_website_relay(guild_id))
+    _website_relay_generation_tasks_by_guild[guild_id] = task
+    logging.info(f"website_relay_generation_started guild={guild_id}")
+
+    def _clear_inflight(done_task: asyncio.Task, done_guild_id: int = guild_id) -> None:
+        if _website_relay_generation_tasks_by_guild.get(done_guild_id) is done_task:
+            _website_relay_generation_tasks_by_guild.pop(done_guild_id, None)
+        try:
+            exc = done_task.exception()
+        except asyncio.CancelledError:
+            exc = None
+        if state["timed_out"]:
+            elapsed = time.monotonic() - started
+            if exc:
+                logging.warning(f"website_relay_generation_completed guild={done_guild_id} elapsed_seconds={elapsed:.3f} status=late_after_timeout error={exc}")
+            else:
+                logging.info(f"website_relay_generation_completed guild={done_guild_id} elapsed_seconds={elapsed:.3f} status=late_after_timeout")
+
+    task.add_done_callback(_clear_inflight)
+
+    try:
+        result = await asyncio.wait_for(
+            asyncio.shield(task),
+            timeout=BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS,
+        )
+        elapsed = time.monotonic() - started
+        logging.info(f"website_relay_generation_completed guild={guild_id} elapsed_seconds={elapsed:.3f}")
+        return result
+    except asyncio.TimeoutError:
+        state["timed_out"] = True
+        elapsed = time.monotonic() - started
+        logging.warning(
+            f"website_relay_generation_timeout guild={guild_id} elapsed_seconds={elapsed:.3f} "
+            f"timeout_seconds={BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS:.1f}"
+        )
+        return _build_website_relay_timeout_fallback(guild_id)
+    except Exception as e:
+        elapsed = time.monotonic() - started
+        logging.warning(f"website_relay_generation_completed guild={guild_id} elapsed_seconds={elapsed:.3f} status=failed error={e}")
+        return _build_website_relay_timeout_fallback(guild_id)
+
 
 @tasks.loop(minutes=1)
 async def website_relay_task():
@@ -11054,7 +11165,10 @@ async def website_relay_task():
         if relay_eligibility == "no":
             continue
         logging.info(f"⏲️ website_relay_task tick guild={guild.id} active_channel={active_channel_id}.")
-        mode, relay_message, directive, relay_meta = await generate_dynamic_website_relay(guild.id)
+        guarded_result = await _generate_website_relay_guarded(guild.id)
+        if guarded_result is None:
+            continue
+        mode, relay_message, directive, relay_meta = guarded_result
         logging.info(f"📤 website_relay_task prepared mode={mode} preview={relay_message[:120]!r}")
         elapsed = (datetime.now(PACIFIC_TZ) - _last_website_status_at).total_seconds() if _last_website_status_at else 0.0
         weak_quiet = (
@@ -11076,7 +11190,7 @@ async def website_relay_task():
                 f"source_channel_count={relay_meta.get('source_channel_count', 0)}"
             )
             continue
-        update_website_status_controlled(mode=mode, message=relay_message, status="ONLINE", current_directive=directive, source="relay")
+        await update_website_status_controlled_async(mode=mode, message=relay_message, status="ONLINE", current_directive=directive, source="relay")
 
 # ==================== BATCHED REPLY SYSTEM (ACTIVE CHANNEL ONLY) ====================
 

--- a/tests/test_async_relay_offload.py
+++ b/tests/test_async_relay_offload.py
@@ -1,0 +1,171 @@
+import asyncio
+import os
+import threading
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+
+
+def gemini_response(text="BNL relay response.", tokens=17):
+    return SimpleNamespace(
+        candidates=[SimpleNamespace(content=SimpleNamespace(parts=[SimpleNamespace(text=text)]))],
+        usage_metadata=SimpleNamespace(total_token_count=tokens),
+    )
+
+
+class GeminiOffloadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_async_gemini_helper_offloads_sync_generation(self):
+        loop_thread = threading.get_ident()
+        called_threads = []
+
+        def fake_sync(contents, route):
+            called_threads.append(threading.get_ident())
+            self.assertEqual(contents, "prompt")
+            self.assertEqual(route, "website_relay_generation")
+            return gemini_response("offloaded", 3)
+
+        with mock.patch.object(bnl01_bot, "_generate_gemini_content_with_fallback", side_effect=fake_sync):
+            with self.assertLogs(level="INFO") as logs:
+                response = await bnl01_bot._generate_gemini_content_with_fallback_async("prompt", "website_relay_generation")
+
+        self.assertEqual(bnl01_bot._extract_text_and_tokens(response), ("offloaded", 3))
+        self.assertTrue(called_threads)
+        self.assertNotEqual(called_threads[0], loop_thread)
+        joined = "\n".join(logs.output)
+        self.assertIn("gemini_generation_offloaded route=website_relay_generation", joined)
+        self.assertIn("gemini_generation_completed route=website_relay_generation", joined)
+
+    async def test_async_gemini_helper_preserves_fallback_model_behavior(self):
+        calls = []
+
+        def fake_generate_content(model, contents):
+            calls.append((model, contents))
+            if len(calls) == 1:
+                raise Exception("503 service unavailable")
+            return gemini_response("fallback ok", 5)
+
+        with mock.patch.object(bnl01_bot.gemini_client.models, "generate_content", side_effect=fake_generate_content):
+            response = await bnl01_bot._generate_gemini_content_with_fallback_async("contents", "fallback_route")
+
+        self.assertEqual(bnl01_bot._extract_text_and_tokens(response), ("fallback ok", 5))
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][0], bnl01_bot._gemini_model_resource_name(bnl01_bot.GEMINI_MODEL))
+        self.assertEqual(calls[1][0], bnl01_bot._gemini_model_resource_name(bnl01_bot.GEMINI_FALLBACK_MODEL))
+
+    async def test_get_gemini_response_keeps_token_accounting(self):
+        with mock.patch.object(bnl01_bot, "check_quota_availability", return_value=True), \
+             mock.patch.object(bnl01_bot, "get_conversation_history", return_value=[]), \
+             mock.patch.object(bnl01_bot, "_generate_gemini_content_with_fallback_async", return_value=gemini_response("token text", 42)), \
+             mock.patch.object(bnl01_bot, "increment_token_usage") as inc, \
+             mock.patch.object(bnl01_bot.random, "random", return_value=1.0):
+            text = await bnl01_bot.get_gemini_response("hello", user_id=123, guild_id=456, route="normal_chat")
+
+        self.assertEqual(text, "token text")
+        inc.assert_called_once_with(42)
+
+    async def test_get_gemini_response_keeps_quota_handling_without_generation(self):
+        with mock.patch.object(bnl01_bot, "check_quota_availability", return_value=False), \
+             mock.patch.object(bnl01_bot, "get_usage_stats", return_value=(bnl01_bot.DAILY_TOKEN_LIMIT, "today")), \
+             mock.patch.object(bnl01_bot, "_generate_gemini_content_with_fallback_async") as generate:
+            text = await bnl01_bot.get_gemini_response("hello", user_id=123, guild_id=456)
+
+        self.assertIn("Daily quota exhausted", text)
+        generate.assert_not_called()
+
+    async def test_glitch_rewrite_uses_offloaded_generation(self):
+        responses = [gemini_response("base text", 11), gemini_response("glitched text", 2)]
+
+        async def fake_async(contents, route):
+            return responses.pop(0)
+
+        with mock.patch.object(bnl01_bot, "check_quota_availability", return_value=True), \
+             mock.patch.object(bnl01_bot, "get_conversation_history", return_value=[]), \
+             mock.patch.object(bnl01_bot, "_generate_gemini_content_with_fallback_async", side_effect=fake_async) as generate, \
+             mock.patch.object(bnl01_bot, "update_website_status_controlled_async", return_value=True), \
+             mock.patch.object(bnl01_bot, "increment_token_usage"), \
+             mock.patch.object(bnl01_bot.random, "random", side_effect=[0.01, 1.0]):
+            text = await bnl01_bot.get_gemini_response("hello", user_id=0, guild_id=456)
+
+        self.assertEqual(text, "glitched text")
+        self.assertEqual([call.args[1] for call in generate.await_args_list], ["get_gemini_response", "glitch_rewrite"])
+
+
+class WebsiteRelayGuardTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        bnl01_bot._website_relay_generation_tasks_by_guild.clear()
+
+    async def asyncTearDown(self):
+        for task in list(bnl01_bot._website_relay_generation_tasks_by_guild.values()):
+            task.cancel()
+        await asyncio.sleep(0)
+        bnl01_bot._website_relay_generation_tasks_by_guild.clear()
+
+    async def test_slow_relay_generation_times_out_safely_and_logs(self):
+        original_timeout = bnl01_bot.BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS
+        release = asyncio.Event()
+
+        async def slow_generation(guild_id):
+            await release.wait()
+            return ("OBSERVATION", "late", "directive", {})
+
+        bnl01_bot.BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS = 0.01
+        try:
+            with mock.patch.object(bnl01_bot, "generate_dynamic_website_relay", side_effect=slow_generation):
+                with self.assertLogs(level="WARNING") as logs:
+                    mode, message, directive, meta = await bnl01_bot._generate_website_relay_guarded(99)
+                self.assertEqual(mode, "OBSERVATION")
+                self.assertTrue(message)
+                self.assertEqual(meta["reason"], "relay_generation_timeout")
+                self.assertIn("website_relay_generation_timeout", "\n".join(logs.output))
+        finally:
+            release.set()
+            await asyncio.sleep(0.02)
+            bnl01_bot.BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS = original_timeout
+
+    async def test_inflight_relay_generation_skips_second_tick_and_clears_after_success(self):
+        release = asyncio.Event()
+
+        async def slow_generation(guild_id):
+            await release.wait()
+            return ("OBSERVATION", "message", "directive", {"reason": "ok"})
+
+        with mock.patch.object(bnl01_bot, "generate_dynamic_website_relay", side_effect=slow_generation):
+            first = asyncio.create_task(bnl01_bot._generate_website_relay_guarded(123))
+            await asyncio.sleep(0)
+            with self.assertLogs(level="INFO") as logs:
+                skipped = await bnl01_bot._generate_website_relay_guarded(123)
+            self.assertIsNone(skipped)
+            self.assertIn("website_relay_generation_skipped_inflight", "\n".join(logs.output))
+            release.set()
+            result = await first
+
+        self.assertEqual(result[1], "message")
+        await asyncio.sleep(0)
+        self.assertNotIn(123, bnl01_bot._website_relay_generation_tasks_by_guild)
+
+    async def test_status_push_wrapper_offloads_sync_status_update(self):
+        loop_thread = threading.get_ident()
+        called_threads = []
+
+        def fake_status(**kwargs):
+            called_threads.append(threading.get_ident())
+            self.assertEqual(kwargs["mode"], "OBSERVATION")
+            return True
+
+        with mock.patch.object(bnl01_bot, "update_website_status_controlled", side_effect=fake_status):
+            with self.assertLogs(level="INFO") as logs:
+                ok = await bnl01_bot.update_website_status_controlled_async(mode="OBSERVATION", message="msg")
+
+        self.assertTrue(ok)
+        self.assertTrue(called_threads)
+        self.assertNotEqual(called_threads[0], loop_thread)
+        self.assertIn("website_status_push_offloaded", "\n".join(logs.output))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- The website relay sometimes blocked the Discord heartbeat because synchronous Gemini generation ran on the event loop during `website_relay_task` (notably during `glitch_rewrite`), so offload and guard relay generation to keep Discord responsive.
- The change must be minimal: keep existing Gemini helpers, preserve fallback behavior and payload shapes, and prevent overlapping relay runs per guild.

### Description
- Added an async offload wrapper `_generate_gemini_content_with_fallback_async(...)` that uses `asyncio.to_thread(...)` to run the existing synchronous `_generate_gemini_content_with_fallback(...)` off the event loop and logs `gemini_generation_offloaded` / `gemini_generation_completed` with elapsed time.
- Updated `get_gemini_response(...)` to await the async wrapper for main generation, `glitch_rewrite`, and cross-universe bleed, and preserved token accounting, fallback-model behavior, and safety checks without changing prompts or response text shape.
- Introduced per-guild in-flight protection and timeout via `_generate_website_relay_guarded(...)` with `BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS` (default 25s) that logs `website_relay_generation_started`, `website_relay_generation_completed`, `website_relay_generation_timeout`, and `website_relay_generation_skipped_inflight`, and returns a safe relay fallback on timeout.
- Audited status push I/O and added `update_website_status_controlled_async(...)` which offloads the existing synchronous `update_website_status_controlled(...)` via `asyncio.to_thread(...)` and logs `website_status_push_offloaded`; relay and show paths now call the async wrapper while payload fields remain unchanged.

### Testing
- Added unit tests `tests/test_async_relay_offload.py` covering Gemini offload helper, fallback-model preservation, token accounting, glitch-rewrite offload, relay timeout fallback and logging, in-flight guard skip/cleanup, and status-push offload; these tests passed locally. (`python -m unittest tests.test_async_relay_offload -v` ✅)
- Ran the full test suite and static checks: `python -m unittest discover -s tests -v` (all tests passed) and `python -m py_compile ...` (modules compiled) and `git diff --check` (no issues); all succeeded. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d020b787c8321b8724822531e577f)