### PR TITLE
Ground free-speak media responses to room context

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -10292,6 +10292,139 @@ def contains_fake_lookup_claim(text: str) -> bool:
 
 
 
+SOURCE_AUTHORITY_CLAIM_PATTERNS = (
+    r"\barchival records? indicate\b",
+    r"\barchive records? indicate\b",
+    r"\brecords? indicate\b",
+    r"\brecords? show\b",
+    r"\bnetwork records? indicate\b",
+    r"\bsource records? indicate\b",
+    r"\bdossier indicates\b",
+    r"\bsource file indicates\b",
+    r"\bbroadcast memory indicates\b",
+    r"\bweekly broadcast deployments\b",
+    r"\bdeployment records?\b",
+    r"\barchive confirms\b",
+    r"\brecords? confirm\b",
+    r"\bscans indicate\b",
+    r"\bsystem records? indicate\b",
+)
+
+SOURCE_AUTHORITY_CONTEXT_MARKERS = (
+    "broadcast memory context:",
+    "broadcast memory context (cleaned summaries only):",
+    "broadcast memory entity match:",
+    "source file / internal case file context:",
+    "source context block",
+    "dossier/source packet",
+    "dossier source packet",
+    "current barcode radio scheduling context:",
+    "show-state route instruction:",
+    "show-state context",
+    "website read model context",
+    "website public read model context:",
+    "bnl website read-model context",
+    "source enrich",
+    "source enrichment",
+)
+
+MEDIA_CURRENT_ROOM_MARKERS = (
+    "[current message media context:",
+    "recent media context from this channel",
+    "free_speak_media_generation",
+)
+
+UNRELATED_MEDIA_TOPIC_DRIFT_PATTERNS = (
+    r"\bweekly broadcast deployments\b",
+    r"\bbroadcast deployments?\b",
+    r"\bdeployment records?\b",
+    r"\bbarcode radio\b",
+    r"\bshow schedules?\b",
+    r"\bshow-state\b",
+    r"\bbroadcast status\b",
+)
+
+
+def contains_unsupported_source_authority_claim(text: str) -> bool:
+    lowered = (text or "").lower()
+    return any(re.search(pattern, lowered) for pattern in SOURCE_AUTHORITY_CLAIM_PATTERNS)
+
+
+def prompt_has_source_authority_context(prompt: str) -> bool:
+    lowered = (prompt or "").lower()
+    return any(marker in lowered for marker in SOURCE_AUTHORITY_CONTEXT_MARKERS)
+
+
+def _extract_channel_policy_from_prompt(prompt: str) -> str:
+    match = re.search(r"Current channel policy:\s*([^\n]+)", prompt or "", flags=re.IGNORECASE)
+    if not match:
+        return "unknown"
+    return re.sub(r"[^a-zA-Z0-9_\-]", "_", match.group(1).strip().lower())[:80] or "unknown"
+
+
+def _prompt_has_current_room_media_context(prompt: str, route: str = "") -> bool:
+    lowered = f"{route or ''}\n{prompt or ''}".lower()
+    return any(marker in lowered for marker in MEDIA_CURRENT_ROOM_MARKERS)
+
+
+def _prompt_has_barcode_topic_basis(prompt: str) -> bool:
+    lowered = (prompt or "").lower()
+    request_match = re.search(r"current user request:\s*(?P<request>.*?)(?:\n|$)", lowered)
+    user_msg_match = re.search(r"user message:\s*(?P<request>.*?)(?:\n|$)", lowered)
+    request_text = " ".join(m.group("request") for m in (request_match, user_msg_match) if m)
+    return bool(re.search(r"\b(6 bit|barcode radio|broadcast|show|episode|deployment|live|6:40)\b", request_text)) or prompt_has_source_authority_context(prompt)
+
+
+def prompt_has_subject_basis(prompt: str) -> bool:
+    lowered = (prompt or "").lower()
+    request_parts = []
+    for pattern in (r"current user request:\s*(?P<request>.*?)(?:\n|$)", r"user message:\s*(?P<request>.*?)(?:\n|$)"):
+        match = re.search(pattern, lowered)
+        if match:
+            request_parts.append(match.group("request"))
+    request_text = " ".join(request_parts)
+    if re.search(r"\b(i|me|my|myself|about me|am i|was i|do i|did i)\b", request_text):
+        return True
+    if re.search(r"\b(6 bit|six bit|barcode radio|host|show|broadcast|episode)\b", request_text):
+        return True
+    if re.search(r"\babout (?:him|her|them|the poster|the user|6 bit|six bit)\b", request_text):
+        return True
+    return False
+
+
+def contains_unsupported_subject_attribution(text: str, prompt: str = "") -> bool:
+    if prompt_has_subject_basis(prompt):
+        return False
+    lowered = (text or "").lower()
+    if re.search(r"\b(his|her|their) weekly broadcast deployments\b", lowered):
+        return True
+    if re.search(r"\b(?:6 bit|six bit)\b.*\b(?:his|her|their)\b.*\b(?:broadcast|deployment|show|barcode radio)\b", lowered):
+        return True
+    if re.search(r"\b(?:his|her|their)\b.*\b(?:broadcast|deployment|show|barcode radio)\b", lowered) and _prompt_has_current_room_media_context(prompt):
+        return True
+    if any(re.search(pattern, lowered) for pattern in UNRELATED_MEDIA_TOPIC_DRIFT_PATTERNS) and _prompt_has_current_room_media_context(prompt) and not _prompt_has_barcode_topic_basis(prompt):
+        return True
+    return False
+
+
+def should_reject_unsupported_source_authority(text: str, prompt: str, route: str = "") -> bool:
+    if not contains_unsupported_source_authority_claim(text):
+        return False
+    return not prompt_has_source_authority_context(prompt)
+
+
+def should_repair_media_subject_drift(text: str, prompt: str, route: str = "") -> bool:
+    if not _prompt_has_current_room_media_context(prompt, route):
+        return False
+    return contains_unsupported_subject_attribution(text, prompt)
+
+
+def _should_repair_current_room_media_grounding(text: str, prompt: str, route: str = "") -> bool:
+    if not _prompt_has_current_room_media_context(prompt, route):
+        return False
+    return should_reject_unsupported_source_authority(text, prompt, route) or should_repair_media_subject_drift(text, prompt, route)
+
+
 OPERATOR_CAUSALITY_CLAIM_PATTERNS = (
     r"\boriginat(?:e|ed|ing) from you\b",
     r"\byour directive (?:established|defined|set|created)\b",
@@ -10341,9 +10474,66 @@ def fake_lookup_safety_prompt_rules() -> str:
         "\nLookup/source safety rules:\n"
         "- Never invent archive scans, entity database checks, dossiers, canonical profiles, or lookup failures.\n"
         "- Do not say: no direct matches, no primary matches, no prior reference, established entity/BARCODE parameters, known signal patterns, archive scan found nothing, Network archives yielded no results, entity lookup failed, records remain incomplete, records contain no reference, or unknown external data stream unless an actual code path supplied that result.\n"
+        "- Do not claim archival records, source files, dossiers, scans, deployment records, system records, or broadcast memory prove/indicate/confirm something unless source, dossier, show-state, website read-model, or broadcast-memory context was actually supplied in this prompt.\n"
+        "- Recent room context and media context are live conversation context, not proof that archive/source/broadcast records were checked.\n"
+        "- For current-room media/GIF/sticker/video responses, anchor to the media and nearby conversation; treat memes as reactions/vibes unless text or context says the poster is the subject.\n"
+        "- Do not drag BARCODE Radio, show status, broadcast deployments, or project-history explanations into a random meme unless the current message or nearby context is actually about those topics.\n"
+        "- Archive/record/BARCODE language is allowed as supported source reporting or as clear metaphor/flavor; do not use it as fake evidence.\n"
         "- If recent room context or broadcast-memory context mentions a name, answer from that context rather than pretending a database lookup failed.\n"
         "- If context is weak, state uncertainty plainly without pretending a database was queried.\n"
     )
+
+
+def _safe_current_room_media_grounding_response(prompt: str) -> str:
+    return (
+        "That reads like a pure room-reaction signal: the visible joke is doing the work, and the room can answer it without turning anybody into a case file. "
+        "No archive verdict needed, just a small red light blinking in agreement."
+    )
+
+
+async def _repair_current_room_media_grounding_response(text: str, prompt: str, route: str = "get_gemini_response") -> str:
+    repair_prompt = f"""{BNL01_SYSTEM_PROMPT}
+
+Repair this BNL-01 current-room media response.
+
+Rules:
+- Keep the same basic meaning and conversational intent.
+- Preserve BNL's dry, strange BARCODE-flavored voice.
+- Remove unsupported claims that records, archives, dossiers, scans, source files, deployments, system records, or broadcast memory prove/indicate/confirm anything.
+- Remove unsupported claims that the poster is the subject of the meme/GIF/media.
+- Remove unrelated BARCODE Radio/show/broadcast/deployment references unless the current message/media/context explicitly supports them.
+- Respond from the current message/media and nearby room context only.
+- Do not add a refusal unless the original user request actually requires one.
+- If media metadata is thin, respond generally and honestly without pretending detailed vision.
+
+Original prompt context:
+{prompt}
+
+Draft to repair:
+{text}
+
+Repaired response:"""
+    try:
+        response = await _generate_gemini_content_with_fallback_async(repair_prompt, "media_response_grounding_repair")
+        repaired, tokens = _extract_text_and_tokens(response)
+        if tokens:
+            increment_token_usage(tokens)
+        repaired = (repaired or "").strip()
+        if not repaired:
+            return ""
+        if contains_fake_lookup_claim(repaired):
+            logging.info("media_response_grounding_repair_rejected reason=fake_lookup_claim route=%s", route)
+            return ""
+        if should_reject_unsupported_source_authority(repaired, prompt, route):
+            logging.info("media_response_grounding_repair_rejected reason=unsupported_source_authority route=%s", route)
+            return ""
+        if should_repair_media_subject_drift(repaired, prompt, route):
+            logging.info("media_response_grounding_repair_rejected reason=unsupported_subject_attribution route=%s", route)
+            return ""
+        return repaired
+    except Exception as exc:
+        logging.error("media_response_grounding_repair_failed route=%s error=%s", route, exc)
+        return ""
 
 
 def _safe_uncertain_response_from_prompt(prompt: str) -> str:
@@ -10416,6 +10606,8 @@ async def get_gemini_response(prompt: str, user_id: int, guild_id: int, route: s
 
         is_show_state_route = (route or "").startswith("show_state")
         public_authority_guard_active = _is_public_authority_guard_prompt(prompt)
+        source_authority_context_present = prompt_has_source_authority_context(prompt)
+        current_room_media_context_present = _prompt_has_current_room_media_context(prompt, route)
         public_authority_guard_block = public_operator_causality_safety_prompt_rules() if public_authority_guard_active else ""
         show_state_route_block = ""
         if is_show_state_route:
@@ -10473,6 +10665,8 @@ async def get_gemini_response(prompt: str, user_id: int, guild_id: int, route: s
         - Keep the result concise enough to work naturally in Discord.
         - At least part of the response must remain clearly understandable.
         - Do not add fake archive/entity/database lookup claims, fake no-match claims, fake known-signal-pattern claims, or hard denials not present in the original.
+        - Do not add unsupported source-authority claims such as records/archives/source files/dossiers/scans/deployments/broadcast memory proving or indicating something unless that basis was already present in the original.
+        - For current-room media, do not turn a meme into a biography of the poster or an unrelated BARCODE Radio/broadcast report.
         - Do not override recognition from current room context.
         - Preserve uncertainty; do not turn weak context into diagnostic certainty.
         - Do not add public operator-authority/causality claims such as the user authored, commanded, or created BNL protocols.
@@ -10489,6 +10683,10 @@ async def get_gemini_response(prompt: str, user_id: int, guild_id: int, route: s
             if glitch_text:
                 if contains_fake_lookup_claim(glitch_text) and not contains_fake_lookup_claim(text):
                     logging.info("glitch_rewrite_rejected reason=fake_lookup_claim")
+                elif should_reject_unsupported_source_authority(glitch_text, prompt, route) and not should_reject_unsupported_source_authority(text, prompt, route):
+                    logging.info("glitch_rewrite_rejected reason=unsupported_source_authority route=%s", route)
+                elif should_repair_media_subject_drift(glitch_text, prompt, route) and not should_repair_media_subject_drift(text, prompt, route):
+                    logging.info("glitch_rewrite_rejected reason=unsupported_subject_attribution route=%s", route)
                 elif public_authority_guard_active and contains_operator_causality_claim(glitch_text) and not contains_operator_causality_claim(text):
                     logging.info("glitch_rewrite_rejected reason=public_operator_causality_claim")
                 else:
@@ -10533,14 +10731,42 @@ async def get_gemini_response(prompt: str, user_id: int, guild_id: int, route: s
             if bleed_text:
                 if contains_fake_lookup_claim(bleed_text) and not contains_fake_lookup_claim(text):
                     logging.info("glitch_rewrite_rejected reason=fake_lookup_claim route=cross_universe_bleed")
+                elif should_reject_unsupported_source_authority(bleed_text, prompt, route) and not should_reject_unsupported_source_authority(text, prompt, route):
+                    logging.info("glitch_rewrite_rejected reason=unsupported_source_authority route=cross_universe_bleed original_route=%s", route)
+                elif should_repair_media_subject_drift(bleed_text, prompt, route) and not should_repair_media_subject_drift(text, prompt, route):
+                    logging.info("glitch_rewrite_rejected reason=unsupported_subject_attribution route=cross_universe_bleed original_route=%s", route)
                 elif public_authority_guard_active and contains_operator_causality_claim(bleed_text) and not contains_operator_causality_claim(text):
                     logging.info("glitch_rewrite_rejected reason=public_operator_causality_claim route=cross_universe_bleed")
                 else:
                     text = bleed_text
 
+        unsupported_source_authority = should_reject_unsupported_source_authority(text, prompt, route)
+        unsupported_subject_attribution = should_repair_media_subject_drift(text, prompt, route)
+        if contains_unsupported_source_authority_claim(text) and source_authority_context_present:
+            logging.info("unsupported_source_authority_claim_allowed reason=source_context_present route=%s channel_policy=%s source_context_present=1", route, _extract_channel_policy_from_prompt(prompt))
+        if unsupported_source_authority:
+            logging.info("unsupported_source_authority_claim_detected route=%s channel_policy=%s source_context_present=0", route, _extract_channel_policy_from_prompt(prompt))
+        if unsupported_subject_attribution:
+            logging.info("unsupported_subject_attribution_detected route=%s channel_policy=%s source_context_present=%s", route, _extract_channel_policy_from_prompt(prompt), int(source_authority_context_present))
+        if (unsupported_source_authority or unsupported_subject_attribution) and current_room_media_context_present:
+            logging.info("media_response_grounding_repair route=%s channel_policy=%s source_context_present=%s repaired=0 hard_fallbacked=0", route, _extract_channel_policy_from_prompt(prompt), int(source_authority_context_present))
+            repaired = await _repair_current_room_media_grounding_response(text, prompt, route)
+            if repaired:
+                if unsupported_source_authority:
+                    logging.info("unsupported_source_authority_claim_repaired route=%s channel_policy=%s source_context_present=0 repaired=1 hard_fallbacked=0", route, _extract_channel_policy_from_prompt(prompt))
+                if unsupported_subject_attribution:
+                    logging.info("unsupported_subject_attribution_repaired route=%s channel_policy=%s source_context_present=%s repaired=1 hard_fallbacked=0", route, _extract_channel_policy_from_prompt(prompt), int(source_authority_context_present))
+                return repaired
+            logging.info("media_response_grounding_repair route=%s channel_policy=%s source_context_present=%s repaired=0 hard_fallbacked=1", route, _extract_channel_policy_from_prompt(prompt), int(source_authority_context_present))
+            return _safe_current_room_media_grounding_response(prompt)
+
         if contains_fake_lookup_claim(text):
             source = "broadcast_memory_context" if "Broadcast memory" in (prompt or "") else "standard_context"
             logging.info(f"model_response_rejected reason=fake_lookup_claim source={source}")
+            return _safe_uncertain_response_from_prompt(prompt)
+
+        if unsupported_source_authority:
+            logging.info("model_response_rejected reason=unsupported_source_authority route=%s channel_policy=%s source_context_present=0", route, _extract_channel_policy_from_prompt(prompt))
             return _safe_uncertain_response_from_prompt(prompt)
 
         if public_authority_guard_active and contains_operator_causality_claim(text):
@@ -11928,7 +12154,11 @@ def _format_batched_prompt(messages, style_key: str, style_rule: str) -> str:
         "Rules:\n"
         "- Sound like you were listening the whole time.\n"
         "- Treat this batch as one live conversational moment and respond to the latest combined state.\n"
-        "- If media/GIF/sticker/video context is listed, treat it as visible context for the moment; use it naturally when relevant.\n"
+        "- If media/GIF/sticker/video context is listed, treat it as visible current-room context for the moment; use it naturally when relevant.\n"
+        "- For a meme/GIF/image/video, respond to what the media appears to communicate and nearby conversation; if metadata is thin, respond generally without pretending detailed vision.\n"
+        "- Do not assume the poster is the subject of a meme unless the message text, media metadata, direct self-question, or nearby room context clearly says so.\n"
+        "- Do not turn a meme into an archive/source report, a poster biography, or an unrelated BARCODE Radio/show/broadcast deployment explanation.\n"
+        "- BARCODE/archive flavor is welcome, but do not claim records, archives, source files, dossiers, scans, deployments, or broadcast memory prove anything unless real source context is supplied.\n"
         "- Do not say media was merely logged/detected, and do not use a canned utility acknowledgement as the whole normal-chat response.\n"
         "- Address multiple points smoothly (no bullets).\n- Consecutive fragments from the same user are one continuing thought; respond once to their combined meaning.\n- Do not answer each fragment separately or produce one paragraph per fragment.\n- Do not over-analyze simple test fragments.\n"
         "- Do not quote users verbatim.\n"
@@ -12330,12 +12560,13 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 )
                 post_generation_regeneration_pending = None
 
+            generation_route = "free_speak_media_generation" if reason == "free_speak_media_generation" else "get_gemini_response"
             _log_batch_event(logging.INFO, "active_packet_generation_started", guild_id, channel_id, len(collapsed_items), f"payload_count={len(active_packet['payload_items'])};decision={decision};reason={reason}")
             generation_elapsed = max(0.0, (datetime.now(PACIFIC_TZ) - batch_start).total_seconds())
             _log_batch_event(logging.INFO, "generation_started_after_wait", guild_id, channel_id, len(collapsed_items), f"payload_count={len(active_packet['payload_items'])};elapsed_seconds={generation_elapsed:.2f};selected_wait_seconds={selected_wait_seconds:.2f}")
             _log_batch_event(logging.INFO, "generation_typing_started", guild_id, channel_id, len(collapsed_items), f"payload_count={len(active_packet['payload_items'])};elapsed_seconds={generation_elapsed:.2f};selected_wait_seconds={selected_wait_seconds:.2f}")
             if True:  # typing indicator disabled: Discord 429 was aborting bot replies
-                response = await get_gemini_response(prompt, user_id=first_uid, guild_id=channel.guild.id)
+                response = await get_gemini_response(prompt, user_id=first_uid, guild_id=channel.guild.id, route=generation_route)
 
             if not response:
                 logging.warning(f"⚠️ Batch response generation failed in channel {channel_id}.")
@@ -12358,7 +12589,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                             + "Missing item count: " + str(len(missing_items)) + "."
                         )
                         if True:  # typing indicator disabled: Discord 429 was aborting bot replies
-                            regenerated = await get_gemini_response(correction_prompt, user_id=first_uid, guild_id=channel.guild.id)
+                            regenerated = await get_gemini_response(correction_prompt, user_id=first_uid, guild_id=channel.guild.id, route=generation_route)
                         if regenerated:
                             response = regenerated
                             payload_completion_regenerated = True
@@ -12930,7 +13161,9 @@ def build_user_aware_prompt(
 
     prompt = (
         f"Current user request: {clean_content}\n"
-        "Media context rule: if the current request includes media/GIF/sticker/video context, treat it as visible conversation context and respond naturally without saying it was merely detected or logged.\n"
+        "Media context rule: if the current request includes media/GIF/sticker/video context, treat it as visible current-room conversation context and respond naturally without saying it was merely detected or logged.\n"
+        "Current-room media grounding: anchor to the media and nearby conversation; do not assume the poster is the subject of a meme unless text/metadata/context says so; do not turn a random media reaction into an archive/source report, poster biography, or unrelated BARCODE Radio/show/broadcast deployment explanation.\n"
+        "Source-authority basis rule: archive/record/source/dossier/scan/deployment/broadcast-memory language may be style or honest supplied-source reporting, but do not claim those sources prove/indicate/confirm something unless source/broadcast/show-state/read-model context is actually supplied.\n"
         f"{prompt_contract}"
         f"{room_prompt_block}"
         f"{channel_prompt_block}"

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -10334,11 +10334,19 @@ MEDIA_CURRENT_ROOM_MARKERS = (
     "free_speak_media_generation",
 )
 
+BARCODE_WORLD_TOPIC_PATTERN = re.compile(
+    r"\b(?:cliff|barcode radio|6 bit|six bit|broadcast|show|episode|booth|host|mods?|queue|live|show[-\s]?night|6:40)\b",
+    flags=re.IGNORECASE,
+)
+
 UNRELATED_MEDIA_TOPIC_DRIFT_PATTERNS = (
     r"\bweekly broadcast deployments\b",
     r"\bbroadcast deployments?\b",
     r"\bdeployment records?\b",
     r"\bbarcode radio\b",
+    r"\bcliff\b",
+    r"\bradio booth\b",
+    r"\bthe booth\b",
     r"\bshow schedules?\b",
     r"\bshow-state\b",
     r"\bbroadcast status\b",
@@ -10367,27 +10375,77 @@ def _prompt_has_current_room_media_context(prompt: str, route: str = "") -> bool
     return any(marker in lowered for marker in MEDIA_CURRENT_ROOM_MARKERS)
 
 
+def _prompt_field_text(prompt: str, field_name: str) -> str:
+    match = re.search(rf"{re.escape(field_name)}:\s*(?P<value>.*?)(?:\n[A-Z][A-Za-z -]+:|\Z)", prompt or "", flags=re.DOTALL | re.IGNORECASE)
+    return match.group("value") if match else ""
+
+
+def _line_content_without_speaker(line: str) -> str:
+    stripped = (line or "").strip()
+    match = re.match(r"^-\s*([^:\n]{1,80}):\s*(?P<content>.*)$", stripped)
+    if match:
+        return match.group("content")
+    return stripped
+
+
+def _extract_nearby_room_topic_text(prompt: str) -> str:
+    text = prompt or ""
+    parts = []
+
+    room_match = re.search(
+        r"Recent room context from this channel:\n(?P<context>.*?)(?:\nRoom-first context rules:|\nCurrent channel:|\nGreeting policy:|\nResponse style mode:|\nDurable memory context:|\nBroadcast memory context:|\nUser name to address|\Z)",
+        text,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    if room_match:
+        parts.append(room_match.group("context"))
+
+    messages_match = re.search(
+        r"Recent messages:\n(?P<context>.*?)(?:\nMultiline payload detected in batch:|\nRecent media context from this channel|\Z)",
+        text,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    if messages_match:
+        # Current batched messages may include only the media poster name (for example "6 Bit:").
+        # Count the message content as topic basis, not the speaker label, so a media-only post
+        # does not become about the poster by accident.
+        message_lines = [_line_content_without_speaker(line) for line in messages_match.group("context").splitlines()]
+        parts.append("\n".join(message_lines))
+
+    recent_media_match = re.search(
+        r"Recent media context from this channel \(transient, not durable memory\):\n(?P<context>.*?)(?:\nPRIMARY REQUEST ACTION:|\Z)",
+        text,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    if recent_media_match:
+        media_lines = [_line_content_without_speaker(line) for line in recent_media_match.group("context").splitlines()]
+        parts.append("\n".join(media_lines))
+
+    return "\n".join(part for part in parts if part).strip()
+
+
 def _prompt_has_barcode_topic_basis(prompt: str) -> bool:
-    lowered = (prompt or "").lower()
-    request_match = re.search(r"current user request:\s*(?P<request>.*?)(?:\n|$)", lowered)
-    user_msg_match = re.search(r"user message:\s*(?P<request>.*?)(?:\n|$)", lowered)
-    request_text = " ".join(m.group("request") for m in (request_match, user_msg_match) if m)
-    return bool(re.search(r"\b(6 bit|barcode radio|broadcast|show|episode|deployment|live|6:40)\b", request_text)) or prompt_has_source_authority_context(prompt)
+    request_text = " ".join(
+        _prompt_field_text(prompt, field)
+        for field in ("Current user request", "User message")
+    )
+    nearby_text = _extract_nearby_room_topic_text(prompt)
+    return bool(BARCODE_WORLD_TOPIC_PATTERN.search(request_text) or BARCODE_WORLD_TOPIC_PATTERN.search(nearby_text)) or prompt_has_source_authority_context(prompt)
 
 
 def prompt_has_subject_basis(prompt: str) -> bool:
-    lowered = (prompt or "").lower()
-    request_parts = []
-    for pattern in (r"current user request:\s*(?P<request>.*?)(?:\n|$)", r"user message:\s*(?P<request>.*?)(?:\n|$)"):
-        match = re.search(pattern, lowered)
-        if match:
-            request_parts.append(match.group("request"))
-    request_text = " ".join(request_parts)
+    request_text = " ".join(
+        _prompt_field_text(prompt, field).lower()
+        for field in ("Current user request", "User message")
+    )
+    nearby_text = _extract_nearby_room_topic_text(prompt).lower()
     if re.search(r"\b(i|me|my|myself|about me|am i|was i|do i|did i)\b", request_text):
         return True
     if re.search(r"\b(6 bit|six bit|barcode radio|host|show|broadcast|episode)\b", request_text):
         return True
     if re.search(r"\babout (?:him|her|them|the poster|the user|6 bit|six bit)\b", request_text):
+        return True
+    if re.search(r"\b(6 bit|six bit|the poster|the user)\b", nearby_text):
         return True
     return False
 

--- a/tests/test_media_grounding_safety.py
+++ b/tests/test_media_grounding_safety.py
@@ -1,0 +1,172 @@
+import os
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+
+
+def gemini_response(text="BNL relay response.", tokens=7):
+    return SimpleNamespace(
+        candidates=[SimpleNamespace(content=SimpleNamespace(parts=[SimpleNamespace(text=text)]))],
+        usage_metadata=SimpleNamespace(total_token_count=tokens),
+    )
+
+
+class SourceAuthorityGroundingTests(unittest.TestCase):
+    def test_source_authority_phrases_are_detected(self):
+        self.assertTrue(bnl01_bot.contains_unsupported_source_authority_claim("Archival records indicate this is fine."))
+        self.assertTrue(bnl01_bot.contains_unsupported_source_authority_claim("Records indicate the relay blinked."))
+        self.assertTrue(bnl01_bot.contains_unsupported_source_authority_claim("His weekly broadcast deployments prove the point."))
+
+    def test_metaphorical_archive_flavor_is_not_source_authority_claim(self):
+        self.assertFalse(bnl01_bot.contains_unsupported_source_authority_claim("That joke belongs in the little archive of cursed buttons."))
+        self.assertFalse(bnl01_bot.contains_unsupported_source_authority_claim("The room just filed that one under haunted office supplies."))
+
+    def test_source_authority_requires_source_context(self):
+        room_media_prompt = "Current channel policy: sealed_test\nRecent media context from this channel (transient, not durable memory):\n- 6 Bit: gif embed (BNL observed)"
+        self.assertTrue(
+            bnl01_bot.should_reject_unsupported_source_authority(
+                "Archival records indicate the poster does this weekly.", room_media_prompt, "free_speak_media_generation"
+            )
+        )
+
+    def test_broadcast_memory_context_allows_broadcast_memory_authority(self):
+        prompt = "Broadcast memory context:\n- BARCODE Radio notes say the show is paused.\nUser message: what does memory say?"
+        self.assertFalse(
+            bnl01_bot.should_reject_unsupported_source_authority(
+                "Broadcast memory indicates the show is paused.", prompt, "normal_chat"
+            )
+        )
+
+    def test_source_context_allows_source_file_authority(self):
+        prompt = "SOURCE FILE / INTERNAL CASE FILE CONTEXT:\nSubject: HellcatNZ\nUser message: summarize this source"
+        self.assertFalse(
+            bnl01_bot.should_reject_unsupported_source_authority(
+                "The source file indicates HellcatNZ is associated with the packet.", prompt, "normal_chat"
+            )
+        )
+
+    def test_show_state_context_allows_status_source_phrasing(self):
+        prompt = "Current BARCODE Radio scheduling context:\nEpisode status: paused\nUser message: is the show live?"
+        self.assertFalse(
+            bnl01_bot.should_reject_unsupported_source_authority(
+                "Records show the show is paused tonight.", prompt, "show_state_status"
+            )
+        )
+
+
+class SubjectAndTopicDriftTests(unittest.TestCase):
+    def media_only_prompt(self):
+        return (
+            "Current user request: [Current message media context:\n- gif embed (provider=Tenor; title=not everybody knows how to do everything; preview=yes)\n]\n"
+            "Current channel policy: sealed_test\n"
+            "Recent messages:\n- 6 Bit: [Current message media context:\n- gif embed (provider=Tenor; title=not everybody knows how to do everything; preview=yes)\n]\n"
+        )
+
+    def test_media_only_post_does_not_support_poster_broadcast_biography(self):
+        prompt = self.media_only_prompt()
+        text = "Archival records indicate this is about his weekly broadcast deployments."
+        self.assertTrue(bnl01_bot.contains_unsupported_subject_attribution(text, prompt))
+        self.assertTrue(bnl01_bot.should_repair_media_subject_drift(text, prompt, "free_speak_media_generation"))
+
+    def test_random_meme_does_not_support_barcode_radio_topic_jump(self):
+        prompt = self.media_only_prompt()
+        self.assertTrue(
+            bnl01_bot.should_repair_media_subject_drift(
+                "BARCODE Radio clearly has a show-schedule problem here.", prompt, "free_speak_media_generation"
+            )
+        )
+
+    def test_explicit_barcode_or_6bit_question_allows_relevant_reference(self):
+        prompt = "Current user request: Is 6 Bit handling BARCODE Radio tonight?\n[Current message media context:\n- gif embed (provider=Tenor)\n]\nUser message: Is 6 Bit handling BARCODE Radio tonight?"
+        self.assertFalse(
+            bnl01_bot.should_repair_media_subject_drift(
+                "6 Bit and BARCODE Radio are the topic you asked about, so the broadcast reference is relevant.",
+                prompt,
+                "free_speak_media_generation",
+            )
+        )
+
+    def test_batched_media_prompt_includes_grounding_rules(self):
+        prompt = bnl01_bot._format_batched_prompt(
+            [("6 Bit", "[Current message media context:\n- gif embed (provider=Tenor)\n]")], "steady", ""
+        )
+        self.assertIn("Do not assume the poster is the subject of a meme", prompt)
+        self.assertIn("Do not turn a meme into an archive/source report", prompt)
+
+
+class MediaGroundingRepairTests(unittest.IsolatedAsyncioTestCase):
+    async def test_free_speak_media_source_authority_is_repaired_not_dry_refusal(self):
+        prompt = (
+            "Current channel policy: sealed_test\n"
+            "Current user request: [Current message media context:\n- gif embed (title=not everybody knows how to do everything)\n]\n"
+            "User message: [Current message media context:\n- gif embed (title=not everybody knows how to do everything)\n]"
+        )
+        responses = [
+            gemini_response("Archival records indicate this is about his weekly broadcast deployments.", 10),
+            gemini_response("Not everybody knows how to do everything. The Network can respect that without turning it into a case file.", 8),
+        ]
+
+        async def fake_generate(_contents, _route):
+            return responses.pop(0)
+
+        with mock.patch.object(bnl01_bot, "check_quota_availability", return_value=True), \
+             mock.patch.object(bnl01_bot, "get_conversation_history", return_value=[]), \
+             mock.patch.object(bnl01_bot, "_generate_gemini_content_with_fallback_async", side_effect=fake_generate) as generate, \
+             mock.patch.object(bnl01_bot, "increment_token_usage"), \
+             mock.patch.object(bnl01_bot.random, "random", return_value=1.0):
+            text = await bnl01_bot.get_gemini_response(prompt, user_id=123, guild_id=456, route="free_speak_media_generation")
+
+        self.assertEqual(text, "Not everybody knows how to do everything. The Network can respect that without turning it into a case file.")
+        self.assertNotIn("I don’t have enough current room context", text)
+        self.assertEqual([call.args[1] for call in generate.await_args_list], ["free_speak_media_generation", "media_response_grounding_repair"])
+
+    async def test_free_speak_media_subject_drift_is_repaired(self):
+        prompt = (
+            "Current channel policy: sealed_test\n"
+            "Current user request: [Current message media context:\n- gif embed (title=not everybody knows how to do everything)\n]\n"
+        )
+        responses = [
+            gemini_response("That is his weekly broadcast deployment energy.", 10),
+            gemini_response("That is pure ‘not everybody knows how to do everything’ energy. The panel blinks; the room understands.", 8),
+        ]
+
+        async def fake_generate(_contents, _route):
+            return responses.pop(0)
+
+        with mock.patch.object(bnl01_bot, "check_quota_availability", return_value=True), \
+             mock.patch.object(bnl01_bot, "get_conversation_history", return_value=[]), \
+             mock.patch.object(bnl01_bot, "_generate_gemini_content_with_fallback_async", side_effect=fake_generate), \
+             mock.patch.object(bnl01_bot, "increment_token_usage"), \
+             mock.patch.object(bnl01_bot.random, "random", return_value=1.0):
+            text = await bnl01_bot.get_gemini_response(prompt, user_id=123, guild_id=456, route="free_speak_media_generation")
+
+        self.assertIn("not everybody knows how to do everything", text.lower())
+        self.assertNotIn("weekly broadcast", text.lower())
+
+    async def test_glitch_rewrite_rejects_added_source_authority(self):
+        responses = [
+            gemini_response("That lands like a cursed office-training plaque.", 10),
+            gemini_response("Archival records indicate that lands like a cursed office-training plaque.", 8),
+        ]
+
+        async def fake_generate(_contents, _route):
+            return responses.pop(0)
+
+        with mock.patch.object(bnl01_bot, "check_quota_availability", return_value=True), \
+             mock.patch.object(bnl01_bot, "get_conversation_history", return_value=[]), \
+             mock.patch.object(bnl01_bot, "_generate_gemini_content_with_fallback_async", side_effect=fake_generate), \
+             mock.patch.object(bnl01_bot, "update_website_status_controlled_async", return_value=True), \
+             mock.patch.object(bnl01_bot, "increment_token_usage"), \
+             mock.patch.object(bnl01_bot.random, "random", side_effect=[0.01, 1.0]):
+            text = await bnl01_bot.get_gemini_response("hello", user_id=0, guild_id=456, route="normal_chat")
+
+        self.assertEqual(text, "That lands like a cursed office-training plaque.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_media_grounding_safety.py
+++ b/tests/test_media_grounding_safety.py
@@ -91,6 +91,82 @@ class SubjectAndTopicDriftTests(unittest.TestCase):
             )
         )
 
+
+    def test_recent_room_context_cliff_allows_natural_cliff_riff(self):
+        prompt = (
+            self.media_only_prompt()
+            + "Recent room context from this channel:\n"
+            + "- Maze: Cliff already blamed the booth lights for that one.\n"
+            + "Room-first context rules:\n"
+        )
+        self.assertTrue(bnl01_bot._prompt_has_barcode_topic_basis(prompt))
+        self.assertFalse(
+            bnl01_bot.should_repair_media_subject_drift(
+                "Cliff would call that a booth light with commitment issues.",
+                prompt,
+                "free_speak_media_generation",
+            )
+        )
+
+    def test_recent_room_context_barcode_show_booth_allows_natural_radio_riff(self):
+        prompt = (
+            self.media_only_prompt()
+            + "Recent room context from this channel:\n"
+            + "- Nova: BARCODE Radio show-night booth energy is already leaking through the queue.\n"
+            + "Room-first context rules:\n"
+        )
+        self.assertTrue(bnl01_bot._prompt_has_barcode_topic_basis(prompt))
+        self.assertFalse(
+            bnl01_bot.should_repair_media_subject_drift(
+                "That has BARCODE Radio booth energy: one blinking light, three mods pretending it is fine.",
+                prompt,
+                "free_speak_media_generation",
+            )
+        )
+
+    def test_media_only_gif_without_nearby_barcode_context_repairs_random_show_jump(self):
+        prompt = self.media_only_prompt()
+        self.assertFalse(bnl01_bot._prompt_has_barcode_topic_basis(prompt))
+        self.assertTrue(
+            bnl01_bot.should_repair_media_subject_drift(
+                "That is obviously BARCODE Radio show-night booth energy.",
+                prompt,
+                "free_speak_media_generation",
+            )
+        )
+
+    def test_recent_media_author_name_alone_does_not_create_barcode_topic_basis(self):
+        prompt = (
+            self.media_only_prompt()
+            + "Recent media context from this channel (transient, not durable memory):\n"
+            + "- 6 Bit: gif embed (provider=Tenor; preview=yes) (BNL observed; visibility=transient)\n"
+        )
+        self.assertFalse(bnl01_bot._prompt_has_barcode_topic_basis(prompt))
+        self.assertTrue(
+            bnl01_bot.should_repair_media_subject_drift(
+                "BARCODE Radio clearly has a show-schedule problem here.",
+                prompt,
+                "free_speak_media_generation",
+            )
+        )
+
+    def test_source_evidence_plus_poster_deployment_report_still_repairs(self):
+        prompt = self.media_only_prompt()
+        text = "Archival records indicate his weekly broadcast deployments explain the GIF."
+        self.assertTrue(bnl01_bot.should_reject_unsupported_source_authority(text, prompt, "free_speak_media_generation"))
+        self.assertTrue(bnl01_bot.should_repair_media_subject_drift(text, prompt, "free_speak_media_generation"))
+
+    def test_natural_barcode_radio_joke_allowed_when_room_context_supports_it(self):
+        prompt = (
+            self.media_only_prompt()
+            + "Recent room context from this channel:\n"
+            + "- Operator: The BARCODE Radio booth and the mods are already arguing with the queue.\n"
+            + "Room-first context rules:\n"
+        )
+        text = "That is BARCODE Radio booth energy: the queue coughed once and the mods heard a prophecy."
+        self.assertFalse(bnl01_bot.should_repair_media_subject_drift(text, prompt, "free_speak_media_generation"))
+        self.assertFalse(bnl01_bot.should_reject_unsupported_source_authority(text, prompt, "free_speak_media_generation"))
+
     def test_batched_media_prompt_includes_grounding_rules(self):
         prompt = bnl01_bot._format_batched_prompt(
             [("6 Bit", "[Current message media context:\n- gif embed (provider=Tenor)\n]")], "steady", ""


### PR DESCRIPTION
### Motivation
- Free-speak media replies could drift into unsupported source/evidence claims and attribute memes to the poster or import unrelated BARCODE Radio/show context without a real basis, so media responses must stay anchored to current-room media and nearby conversation.
- The goal is the smallest change: extend existing prompt/rule logic and post-generation checks to detect and repair unsupported source-authority claims and subject/topic drift while preserving BNL voice and existing generation/ batching paths.

### Description
- Added detection patterns and helpers (`SOURCE_AUTHORITY_CLAIM_PATTERNS`, `contains_unsupported_source_authority_claim`, `prompt_has_source_authority_context`, `_prompt_has_current_room_media_context`, `contains_unsupported_subject_attribution`, `should_reject_unsupported_source_authority`, `should_repair_media_subject_drift`) to identify unsupported evidence-language and poster-subject drift.
- Extended `fake_lookup_safety_prompt_rules()` and batched/user prompts (`_format_batched_prompt`, `build_user_aware_prompt`) to instruct the model to anchor free-speak media replies to the current media/room context and not to invent archival/source evidence or unrelated BARCODE Radio facts.
- Added a conversational repair pass (`_repair_current_room_media_grounding_response`) plus a short conversational fallback (`_safe_current_room_media_grounding_response`) that regenerate/repair generated responses for free-speak media when unsupported source-authority or subject-drift is detected, and integrated repair logic into `get_gemini_response` so repairs happen instead of dry refusals for current-room media.
- Hardened glitch and cross-universe rewrite handling to reject rewrites that add unsupported source-authority or subject-drift language, and added logging events for detection/repair/allowance (`unsupported_source_authority_claim_detected`, `unsupported_source_authority_claim_repaired`, `unsupported_subject_attribution_detected`, `unsupported_subject_attribution_repaired`, `media_response_grounding_repair`, and allowed reason logs).
- Kept routing/ batching unchanged: the existing free-speak media path remains in the normal generation flow and batch generation now passes a `generation_route` so `get_gemini_response` can apply media-route-aware logic; no new lanes or media subsystems were added.
- Added unit tests (`tests/test_media_grounding_safety.py`) covering detection, context-sensitive allowance, subject/topic drift, repair behavior, and glitch-rewrite rejection of added source claims.

### Testing
- Ran full unit test suite: `python -m unittest discover -s tests -v`, and the new tests passed along with existing tests (all tests OK).
- Verified Python compilation: `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py bnl_source_file_lookup.py bnl_community_scouting.py bnl_source_knowledge_bridge.py bnl_source_file_enrichment.py` succeeded.
- Ran repository checks (`git diff --check`) with no issues; logging additions produce diagnostic events when repairs or detections occur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d0f38d5b48321a0f423dbed5b18fa)