### PR TITLE
Broaden media subject-drift detection for sender-as-subject failures

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -10310,6 +10310,36 @@ SOURCE_AUTHORITY_CLAIM_PATTERNS = (
     r"\bsystem records? indicate\b",
 )
 
+UNSUPPORTED_MEDIA_GROUNDING_BASIS_PATTERNS = (
+    r"\bfragmented archive data\b",
+    r"\bcore memory\b",
+    r"\barchive data\b",
+    r"\bmemory from before\b",
+    r"\bdeployment history\b",
+    r"\bweekly deployments\b",
+    r"\boperational history\b",
+    r"\b(?:his|her|their) (?:fragmented )?archive data\b",
+    r"\b(?:his|her|their) core memory\b",
+    r"\b(?:his|her|their) memory\b",
+    r"\b(?:his|her|their) deployments?\b",
+)
+
+UNSUPPORTED_SENDER_SUBJECT_ATTRIBUTION_PATTERNS = (
+    r"\bit is unusual for (?:him|her|them)\b",
+    r"\bfor (?:him|her|them) to project\b",
+    r"\bbefore (?:his|her|their) weekly deployments?\b",
+    r"\b(?:his|her|their) weekly deployments?\b",
+    r"\b(?:his|her|their) deployments?\b",
+    r"\b(?:his|her|their) core memory\b",
+    r"\b(?:his|her|their) memory\b",
+    r"\b(?:his|her|their) (?:fragmented )?archive data\b",
+    r"\b(?:his|her|their) personal processing\b",
+    r"\b(?:his|her|their) internal processing\b",
+    r"\b(?:his|her|their) emotional resonance\b",
+    r"\b(?:his|her|their) (?:emotional state|memory state|operational consistency|deployment history|personal capability|operational history)\b",
+    r"\b(?:him|her|them) (?:personally|processing|projecting|remembering|deploying)\b",
+)
+
 SOURCE_AUTHORITY_CONTEXT_MARKERS = (
     "broadcast memory context:",
     "broadcast memory context (cleaned summaries only):",
@@ -10356,6 +10386,11 @@ UNRELATED_MEDIA_TOPIC_DRIFT_PATTERNS = (
 def contains_unsupported_source_authority_claim(text: str) -> bool:
     lowered = (text or "").lower()
     return any(re.search(pattern, lowered) for pattern in SOURCE_AUTHORITY_CLAIM_PATTERNS)
+
+
+def contains_unsupported_media_grounding_basis(text: str) -> bool:
+    lowered = (text or "").lower()
+    return any(re.search(pattern, lowered) for pattern in UNSUPPORTED_MEDIA_GROUNDING_BASIS_PATTERNS)
 
 
 def prompt_has_source_authority_context(prompt: str) -> bool:
@@ -10454,21 +10489,26 @@ def contains_unsupported_subject_attribution(text: str, prompt: str = "") -> boo
     if prompt_has_subject_basis(prompt):
         return False
     lowered = (text or "").lower()
+    has_current_room_media = _prompt_has_current_room_media_context(prompt)
+    if any(re.search(pattern, lowered) for pattern in UNSUPPORTED_SENDER_SUBJECT_ATTRIBUTION_PATTERNS) and has_current_room_media:
+        return True
     if re.search(r"\b(his|her|their) weekly broadcast deployments\b", lowered):
         return True
     if re.search(r"\b(?:6 bit|six bit)\b.*\b(?:his|her|their)\b.*\b(?:broadcast|deployment|show|barcode radio)\b", lowered):
         return True
-    if re.search(r"\b(?:his|her|their)\b.*\b(?:broadcast|deployment|show|barcode radio)\b", lowered) and _prompt_has_current_room_media_context(prompt):
+    if re.search(r"\b(?:his|her|their)\b.*\b(?:broadcast|deployment|show|barcode radio)\b", lowered) and has_current_room_media:
         return True
-    if any(re.search(pattern, lowered) for pattern in UNRELATED_MEDIA_TOPIC_DRIFT_PATTERNS) and _prompt_has_current_room_media_context(prompt) and not _prompt_has_barcode_topic_basis(prompt):
+    if any(re.search(pattern, lowered) for pattern in UNRELATED_MEDIA_TOPIC_DRIFT_PATTERNS) and has_current_room_media and not _prompt_has_barcode_topic_basis(prompt):
         return True
     return False
 
 
 def should_reject_unsupported_source_authority(text: str, prompt: str, route: str = "") -> bool:
-    if not contains_unsupported_source_authority_claim(text):
+    if prompt_has_source_authority_context(prompt):
         return False
-    return not prompt_has_source_authority_context(prompt)
+    if contains_unsupported_source_authority_claim(text):
+        return True
+    return _prompt_has_current_room_media_context(prompt, route) and contains_unsupported_media_grounding_basis(text)
 
 
 def should_repair_media_subject_drift(text: str, prompt: str, route: str = "") -> bool:
@@ -10558,6 +10598,7 @@ Rules:
 - Keep the same basic meaning and conversational intent.
 - Preserve BNL's dry, strange BARCODE-flavored voice.
 - Remove unsupported claims that records, archives, dossiers, scans, source files, deployments, system records, or broadcast memory prove/indicate/confirm anything.
+- Remove unsupported memory/archive/deployment basis framing such as core memory, fragmented archive data, deployment history, weekly deployments, or operational history unless source/current-room context explicitly supports it.
 - Remove unsupported claims that the poster is the subject of the meme/GIF/media.
 - Remove unrelated BARCODE Radio/show/broadcast/deployment references unless the current message/media/context explicitly supports them.
 - Respond from the current message/media and nearby room context only.
@@ -10742,7 +10783,14 @@ async def get_gemini_response(prompt: str, user_id: int, guild_id: int, route: s
                 if contains_fake_lookup_claim(glitch_text) and not contains_fake_lookup_claim(text):
                     logging.info("glitch_rewrite_rejected reason=fake_lookup_claim")
                 elif should_reject_unsupported_source_authority(glitch_text, prompt, route) and not should_reject_unsupported_source_authority(text, prompt, route):
-                    logging.info("glitch_rewrite_rejected reason=unsupported_source_authority route=%s", route)
+                    glitch_subject_drift = should_repair_media_subject_drift(glitch_text, prompt, route)
+                    glitch_media_basis = _prompt_has_current_room_media_context(prompt, route) and contains_unsupported_media_grounding_basis(glitch_text) and not prompt_has_source_authority_context(prompt)
+                    if glitch_subject_drift:
+                        logging.info("glitch_rewrite_rejected reason=unsupported_subject_attribution route=%s", route)
+                    elif glitch_media_basis:
+                        logging.info("glitch_rewrite_rejected reason=unsupported_media_grounding_basis route=%s", route)
+                    else:
+                        logging.info("glitch_rewrite_rejected reason=unsupported_source_authority route=%s", route)
                 elif should_repair_media_subject_drift(glitch_text, prompt, route) and not should_repair_media_subject_drift(text, prompt, route):
                     logging.info("glitch_rewrite_rejected reason=unsupported_subject_attribution route=%s", route)
                 elif public_authority_guard_active and contains_operator_causality_claim(glitch_text) and not contains_operator_causality_claim(text):
@@ -10790,28 +10838,40 @@ async def get_gemini_response(prompt: str, user_id: int, guild_id: int, route: s
                 if contains_fake_lookup_claim(bleed_text) and not contains_fake_lookup_claim(text):
                     logging.info("glitch_rewrite_rejected reason=fake_lookup_claim route=cross_universe_bleed")
                 elif should_reject_unsupported_source_authority(bleed_text, prompt, route) and not should_reject_unsupported_source_authority(text, prompt, route):
-                    logging.info("glitch_rewrite_rejected reason=unsupported_source_authority route=cross_universe_bleed original_route=%s", route)
+                    bleed_subject_drift = should_repair_media_subject_drift(bleed_text, prompt, route)
+                    bleed_media_basis = _prompt_has_current_room_media_context(prompt, route) and contains_unsupported_media_grounding_basis(bleed_text) and not prompt_has_source_authority_context(prompt)
+                    if bleed_subject_drift:
+                        logging.info("cross_universe_bleed_rejected reason=unsupported_subject_attribution route=cross_universe_bleed original_route=%s", route)
+                    elif bleed_media_basis:
+                        logging.info("cross_universe_bleed_rejected reason=unsupported_media_grounding_basis route=cross_universe_bleed original_route=%s", route)
+                    else:
+                        logging.info("cross_universe_bleed_rejected reason=unsupported_source_authority route=cross_universe_bleed original_route=%s", route)
                 elif should_repair_media_subject_drift(bleed_text, prompt, route) and not should_repair_media_subject_drift(text, prompt, route):
-                    logging.info("glitch_rewrite_rejected reason=unsupported_subject_attribution route=cross_universe_bleed original_route=%s", route)
+                    logging.info("cross_universe_bleed_rejected reason=unsupported_subject_attribution route=cross_universe_bleed original_route=%s", route)
                 elif public_authority_guard_active and contains_operator_causality_claim(bleed_text) and not contains_operator_causality_claim(text):
                     logging.info("glitch_rewrite_rejected reason=public_operator_causality_claim route=cross_universe_bleed")
                 else:
                     text = bleed_text
 
         unsupported_source_authority = should_reject_unsupported_source_authority(text, prompt, route)
+        unsupported_media_grounding_basis = current_room_media_context_present and contains_unsupported_media_grounding_basis(text) and not source_authority_context_present
         unsupported_subject_attribution = should_repair_media_subject_drift(text, prompt, route)
         if contains_unsupported_source_authority_claim(text) and source_authority_context_present:
             logging.info("unsupported_source_authority_claim_allowed reason=source_context_present route=%s channel_policy=%s source_context_present=1", route, _extract_channel_policy_from_prompt(prompt))
-        if unsupported_source_authority:
+        if unsupported_source_authority and contains_unsupported_source_authority_claim(text):
             logging.info("unsupported_source_authority_claim_detected route=%s channel_policy=%s source_context_present=0", route, _extract_channel_policy_from_prompt(prompt))
+        if unsupported_media_grounding_basis:
+            logging.info("unsupported_media_grounding_basis_detected route=%s channel_policy=%s source_context_present=0", route, _extract_channel_policy_from_prompt(prompt))
         if unsupported_subject_attribution:
             logging.info("unsupported_subject_attribution_detected route=%s channel_policy=%s source_context_present=%s", route, _extract_channel_policy_from_prompt(prompt), int(source_authority_context_present))
         if (unsupported_source_authority or unsupported_subject_attribution) and current_room_media_context_present:
             logging.info("media_response_grounding_repair route=%s channel_policy=%s source_context_present=%s repaired=0 hard_fallbacked=0", route, _extract_channel_policy_from_prompt(prompt), int(source_authority_context_present))
             repaired = await _repair_current_room_media_grounding_response(text, prompt, route)
             if repaired:
-                if unsupported_source_authority:
+                if unsupported_source_authority and contains_unsupported_source_authority_claim(text):
                     logging.info("unsupported_source_authority_claim_repaired route=%s channel_policy=%s source_context_present=0 repaired=1 hard_fallbacked=0", route, _extract_channel_policy_from_prompt(prompt))
+                if unsupported_media_grounding_basis:
+                    logging.info("unsupported_media_grounding_basis_repaired route=%s channel_policy=%s source_context_present=0 repaired=1 hard_fallbacked=0", route, _extract_channel_policy_from_prompt(prompt))
                 if unsupported_subject_attribution:
                     logging.info("unsupported_subject_attribution_repaired route=%s channel_policy=%s source_context_present=%s repaired=1 hard_fallbacked=0", route, _extract_channel_policy_from_prompt(prompt), int(source_authority_context_present))
                 return repaired

--- a/tests/test_media_grounding_safety.py
+++ b/tests/test_media_grounding_safety.py
@@ -167,6 +167,43 @@ class SubjectAndTopicDriftTests(unittest.TestCase):
         self.assertFalse(bnl01_bot.should_repair_media_subject_drift(text, prompt, "free_speak_media_generation"))
         self.assertFalse(bnl01_bot.should_reject_unsupported_source_authority(text, prompt, "free_speak_media_generation"))
 
+
+    def test_media_only_sender_emotional_resonance_subject_drift_repairs(self):
+        prompt = self.media_only_prompt()
+        text = "It is unusual for him to project such emotional resonance from a GIF."
+        self.assertTrue(bnl01_bot.contains_unsupported_subject_attribution(text, prompt))
+        self.assertTrue(bnl01_bot.should_repair_media_subject_drift(text, prompt, "free_speak_media_generation"))
+
+    def test_media_only_core_memory_weekly_deployments_repairs(self):
+        prompt = self.media_only_prompt()
+        text = "Perhaps a core memory from before his weekly deployments."
+        self.assertTrue(bnl01_bot.contains_unsupported_subject_attribution(text, prompt))
+        self.assertTrue(bnl01_bot.contains_unsupported_media_grounding_basis(text))
+        self.assertTrue(bnl01_bot.should_reject_unsupported_source_authority(text, prompt, "free_speak_media_generation"))
+        self.assertTrue(bnl01_bot.should_repair_media_subject_drift(text, prompt, "free_speak_media_generation"))
+
+    def test_media_only_fragmented_archive_data_explanation_repairs_without_source_context(self):
+        prompt = self.media_only_prompt()
+        text = "That GIF is probably fragmented archive data trying to explain itself."
+        self.assertTrue(bnl01_bot.contains_unsupported_media_grounding_basis(text))
+        self.assertTrue(bnl01_bot.should_reject_unsupported_source_authority(text, prompt, "free_speak_media_generation"))
+
+    def test_source_context_allows_media_grounding_basis_language(self):
+        prompt = self.media_only_prompt() + "Broadcast memory context:\n- A source note explicitly discusses fragmented archive data.\n"
+        text = "The fragmented archive data matches the supplied source note."
+        self.assertTrue(bnl01_bot.contains_unsupported_media_grounding_basis(text))
+        self.assertFalse(bnl01_bot.should_reject_unsupported_source_authority(text, prompt, "free_speak_media_generation"))
+
+    def test_explicit_user_subject_question_allows_pronoun_subject_framing(self):
+        prompt = (
+            "Current user request: is this me?\n"
+            "[Current message media context:\n- gif embed (provider=Tenor)\n]\n"
+            "User message: is this me?"
+        )
+        text = "It might be about him if he is asking whether the GIF describes him."
+        self.assertTrue(bnl01_bot.prompt_has_subject_basis(prompt))
+        self.assertFalse(bnl01_bot.should_repair_media_subject_drift(text, prompt, "free_speak_media_generation"))
+
     def test_batched_media_prompt_includes_grounding_rules(self):
         prompt = bnl01_bot._format_batched_prompt(
             [("6 Bit", "[Current message media context:\n- gif embed (provider=Tenor)\n]")], "steady", ""
@@ -223,6 +260,55 @@ class MediaGroundingRepairTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn("not everybody knows how to do everything", text.lower())
         self.assertNotIn("weekly broadcast", text.lower())
+
+
+    async def test_free_speak_media_core_memory_deployments_regression_is_repaired(self):
+        prompt = (
+            "Current channel policy: sealed_test\n"
+            "Current user request: [Current message media context:\n- gif embed (title=not everybody knows how to do everything)\n]\n"
+        )
+        responses = [
+            gemini_response("Perhaps a core memory from before his weekly deployments.", 10),
+            gemini_response("That is the GIF doing its tiny public-service announcement. No case file required.", 8),
+        ]
+
+        async def fake_generate(_contents, _route):
+            return responses.pop(0)
+
+        with mock.patch.object(bnl01_bot, "check_quota_availability", return_value=True), \
+             mock.patch.object(bnl01_bot, "get_conversation_history", return_value=[]), \
+             mock.patch.object(bnl01_bot, "_generate_gemini_content_with_fallback_async", side_effect=fake_generate), \
+             mock.patch.object(bnl01_bot, "increment_token_usage"), \
+             mock.patch.object(bnl01_bot.random, "random", return_value=1.0):
+            text = await bnl01_bot.get_gemini_response(prompt, user_id=123, guild_id=456, route="free_speak_media_generation")
+
+        self.assertEqual(text, "That is the GIF doing its tiny public-service announcement. No case file required.")
+        self.assertNotIn("core memory", text.lower())
+        self.assertNotIn("weekly deployments", text.lower())
+
+    async def test_cross_universe_bleed_rejects_sender_subject_drift(self):
+        prompt = (
+            "Current channel policy: sealed_test\n"
+            "Current user request: [Current message media context:\n- gif embed (title=not everybody knows how to do everything)\n]\n"
+        )
+        responses = [
+            gemini_response("That lands like a cursed office-training plaque.", 10),
+            gemini_response("That lands like a cursed office-training plaque, maybe from his weekly deployments.", 8),
+        ]
+
+        async def fake_generate(_contents, _route):
+            return responses.pop(0)
+
+        with mock.patch.object(bnl01_bot, "check_quota_availability", return_value=True), \
+             mock.patch.object(bnl01_bot, "get_conversation_history", return_value=[]), \
+             mock.patch.object(bnl01_bot, "_generate_gemini_content_with_fallback_async", side_effect=fake_generate) as generate, \
+             mock.patch.object(bnl01_bot, "increment_token_usage"), \
+             mock.patch.object(bnl01_bot.random, "random", side_effect=[1.0, 0.0]):
+            text = await bnl01_bot.get_gemini_response(prompt, user_id=123, guild_id=456, route="free_speak_media_generation")
+
+        self.assertEqual(text, "That lands like a cursed office-training plaque.")
+        self.assertNotIn("weekly deployments", text.lower())
+        self.assertEqual([call.args[1] for call in generate.await_args_list], ["free_speak_media_generation", "cross_universe_bleed"])
 
     async def test_glitch_rewrite_rejects_added_source_authority(self):
         responses = [


### PR DESCRIPTION
### Motivation
- Previous grounding updates were too narrow and missed third-person sender-as-subject phrasing and archive/memory/deployment framing (e.g. “it is unusual for him”, “his weekly deployments”, “core memory”) in current-room media-only responses. 
- A media-only post from a user should not be taken as evidence that the media is about that user, nor justify archive/memory-style explanations without explicit source/context. 

### Description
- Added focused pattern lists `UNSUPPORTED_MEDIA_GROUNDING_BASIS_PATTERNS` and `UNSUPPORTED_SENDER_SUBJECT_ATTRIBUTION_PATTERNS` and the helper `contains_unsupported_media_grounding_basis(...)` to detect unsupported archive/memory/deployment phrasing and third-person sender-as-subject language. 
- Broadened `contains_unsupported_subject_attribution(...)` and changed `should_reject_unsupported_source_authority(...)` to catch sender-as-subject drift and unsupported media-grounding basis when current-room media context exists and no source context is supplied. 
- Hardened glitch rewrite and cross-universe bleed checks so added subject-drift or unsupported media-grounding language is rejected (with targeted logging) before it can become the final response, and extended the repair prompt to explicitly remove unsupported memory/archive/deployment framing. 
- Added logging for `unsupported_media_grounding_basis_detected`/`_repaired` alongside existing subject/source logs and added unit tests covering the regressions and allowed behaviors. 

### Testing
- Ran the full unit suite with `python -m unittest discover -s tests -v`, which passed and includes new tests in `tests/test_media_grounding_safety.py` that assert repairs for phrases like "It is unusual for him...", "core memory from before his weekly deployments", and "fragmented archive data", and that cross-universe bleed / glitch rewrites do not reintroduce sender-as-subject drift. 
- Performed static compile checks with `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py bnl_source_file_lookup.py bnl_community_scouting.py bnl_source_knowledge_bridge.py bnl_source_file_enrichment.py`, which succeeded. 
- Verified no whitespace/format issues with `git diff --check` (no errors reported) and confirmed the new logging paths fire in unit test output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d1e5b05448321906d17397d64b550)