### PR TITLE
Add meaning-first BNL source memory packets

### DIFF
--- a/bnl_dossier_recommendations.py
+++ b/bnl_dossier_recommendations.py
@@ -50,6 +50,15 @@ SUPPORTED_PAYLOAD_FIELDS = {
     "createdBy",
     "ingestKey",
     "ingestSource",
+    "knownContext",
+    "usefulEvidence",
+    "relationshipSignals",
+    "publicSafePossibilities",
+    "privateOnlyNotes",
+    "notPublicYet",
+    "recommendedAction",
+    "sourceAuthority",
+    "rawProvenance",
 }
 _SAFE_LANE_PATTERN = re.compile(r"[^a-z0-9_-]+")
 VALID_DOSSIER_CATEGORIES = {"Entity", "Personnel", "Sponsor", "Interface", "Production"}

--- a/bnl_dossier_source_packets.py
+++ b/bnl_dossier_source_packets.py
@@ -260,18 +260,46 @@ def build_dossier_recommendation_packet(
     if not actual_lanes:
         actual_lanes = ["rd_context"]
 
+    confidence = _confidence_for_evidence(actual_lanes, evidence)
+    known_context = [f"BNL has operator-provided review context for {subject_name}."]
+    useful_evidence = ["Operator supplied R&D context for review."]
+    public_safe_possibilities: list[str] = []
+    private_only_notes = ["Treat operator/R&D context as internal until owner review confirms public-safe wording."]
+    if any(item.get("lane") == "broadcast_memory" for item in evidence):
+        known_context.append(f"BNL found BARCODE Radio/show-history context connected to {subject_name}.")
+        useful_evidence.append("BARCODE Radio memory can support show-history review after owner approval.")
+        public_safe_possibilities.append("BARCODE Radio context may inform public wording only after owner review.")
+    if not public_safe_possibilities:
+        public_safe_possibilities.append("No public-safe fact is confirmed by this packet; owner review is required before public use.")
+    not_public_yet = ["Do not publish, merge identities, or expose private Discord identity from this packet without owner approval."]
+    raw_provenance = {
+        "sourceLabels": [f"{item.get('lane') or 'source'}/{item.get('label') or 'review'}" for item in evidence],
+        "sourceLaneMapping": {lane: lane for lane in actual_lanes},
+        "rawFragments": evidence,
+        "sourceCounts": {lane: sum(1 for item in evidence if item.get("lane") == lane) for lane in actual_lanes},
+    }
+
     packet = {
         "subjectName": subject_name,
         "subjectKey": subject_key(subject_name),
         "sourceLanes": actual_lanes,
         "reason": _safe_snippet(reason, 300),
         "evidenceSummary": _evidence_summary(evidence),
+        "knownContext": known_context,
+        "usefulEvidence": useful_evidence,
+        "relationshipSignals": [],
+        "publicSafePossibilities": public_safe_possibilities,
+        "privateOnlyNotes": private_only_notes,
         "missingInfo": list(DEFAULT_MISSING_INFO),
+        "notPublicYet": not_public_yet,
         "publicSafetyNotes": list(DEFAULT_PUBLIC_SAFETY_NOTES),
         "doNotSay": [],
         "recommendedTags": [],
-        "confidence": _confidence_for_evidence(actual_lanes, evidence),
+        "confidence": confidence,
+        "sourceAuthority": [{"source": "Operator R&D context", "boundary": "owner_review_required", "confidence": confidence}],
+        "rawProvenance": raw_provenance,
         "suggestedAction": DEFAULT_SUGGESTED_ACTION,
+        "recommendedAction": DEFAULT_SUGGESTED_ACTION,
         "evidence": evidence,
     }
     payload = build_dossier_recommendation_payload(
@@ -281,13 +309,22 @@ def build_dossier_recommendation_packet(
             "subjectKey": packet["subjectKey"],
             "reason": packet["reason"],
             "evidenceSummary": packet["evidenceSummary"],
+            "knownContext": packet["knownContext"],
+            "usefulEvidence": packet["usefulEvidence"],
+            "relationshipSignals": packet["relationshipSignals"],
+            "publicSafePossibilities": packet["publicSafePossibilities"],
+            "privateOnlyNotes": packet["privateOnlyNotes"],
             "missingInfo": packet["missingInfo"],
+            "notPublicYet": packet["notPublicYet"],
             "publicSafetyNotes": packet["publicSafetyNotes"],
             "doNotSay": packet["doNotSay"],
             "recommendedTags": packet["recommendedTags"],
             "confidence": packet["confidence"],
             "sourceLanes": packet["sourceLanes"],
+            "sourceAuthority": packet["sourceAuthority"],
+            "rawProvenance": packet["rawProvenance"],
             "suggestedAction": packet["suggestedAction"],
+            "recommendedAction": packet["recommendedAction"],
             "createdBy": "bnl",
         }
     )

--- a/bnl_source_knowledge_bridge.py
+++ b/bnl_source_knowledge_bridge.py
@@ -480,33 +480,205 @@ def _json_list(value: Any) -> list[str]:
 
 
 
+def _source_meaning(item: KnowledgeEvidence, display_name: str) -> tuple[str, str, str]:
+    """Return meaning-first source title, observation, and privacy boundary."""
+
+    name = _safe_snippet(display_name or item.subject_name, 80)
+    if item.source_type == "user_profiles":
+        return (
+            "Internal local profile",
+            f"BNL found an internal local profile match for {name}.",
+            "internal_only_owner_review_required",
+        )
+    if item.source_type in {"relationship_state", "relationship_journal"}:
+        return (
+            "Prior relationship/context notes",
+            f"BNL found prior relationship/context notes connected to {name}.",
+            "private_review_required_do_not_use_publicly",
+        )
+    if item.source_type == "conversations":
+        if "public_safe_candidate" in item.visibility_labels:
+            return (
+                "Approved public-side conversation context",
+                f"BNL found approved public-side conversation context connected to {name}.",
+                "public_safe_candidate_owner_review_required",
+            )
+        return (
+            "Internal conversation context",
+            f"BNL found conversation context connected to {name}, but its visibility is not public-safe without review.",
+            "internal_only_owner_review_required",
+        )
+    if item.source_type == "community_presence":
+        return (
+            "Community presence signal",
+            f"BNL found approved community presence signals connected to {name}.",
+            "public_safe_candidate_owner_review_required",
+        )
+    if item.source_type == "broadcast_memory":
+        return (
+            "BARCODE Radio memory",
+            f"BNL found BARCODE Radio/show-history context connected to {name}.",
+            "owner_review_required_before_public_use",
+        )
+    if item.source_type == "memory_tiers":
+        return (
+            "Source-blind memory trace",
+            f"BNL found older source-blind memory context connected to {name}.",
+            "source_blind_private_review_required",
+        )
+    if item.source_type == "user_memory_facts":
+        return (
+            "Internal memory fact",
+            f"BNL found an internal memory fact connected to {name}.",
+            "internal_only_owner_review_required",
+        )
+    if item.source_type == "user_habits":
+        return (
+            "Internal habit/topic signal",
+            f"BNL found internal topic/habit context connected to {name}.",
+            "internal_only_owner_review_required",
+        )
+    if item.source_type == "rd_context":
+        return (
+            "Operator R&D context",
+            f"BNL found operator-provided R&D context connected to {name}.",
+            "internal_only_owner_review_required",
+        )
+    return ("Internal review context", f"BNL found review-only context connected to {name}.", "owner_review_required")
+
+
+def _unique_preserve(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        clean = _safe_snippet(value, 240)
+        if not clean or clean in seen:
+            continue
+        seen.add(clean)
+        out.append(clean)
+    return out
+
+
+def _build_meaning_first_source_packet(
+    display_name: str,
+    evidence: list[KnowledgeEvidence],
+    source_types: list[str],
+    source_qualities: list[str],
+    visibility: list[str],
+    warnings: list[str],
+    confidence: str,
+    candidate_type: str,
+) -> dict[str, Any]:
+    """Build structured review context while keeping raw labels in rawProvenance."""
+
+    source_counts = Counter(item.source_type for item in evidence)
+    known_context: list[str] = []
+    useful_evidence: list[str] = []
+    relationship_signals: list[str] = []
+    public_safe: list[str] = []
+    private_notes: list[str] = []
+    not_public_yet: list[str] = []
+    source_authority: list[dict[str, str]] = []
+
+    for item in evidence:
+        title, observation, boundary = _source_meaning(item, display_name)
+        known_context.append(observation)
+        useful_evidence.append(observation)
+        source_authority.append({"source": title, "boundary": boundary, "confidence": confidence})
+        if item.source_type in {"relationship_state", "relationship_journal"}:
+            relationship_signals.append(observation + " Treat this as private relationship context, not a public fact.")
+            private_notes.append(observation + " Owner review must decide if any wording can be reused.")
+        if "public_safe_candidate" in item.visibility_labels:
+            public_safe.append(observation + " It may inform public wording only after owner review.")
+        else:
+            private_notes.append(observation + " Keep this internal until reviewed.")
+        if "owner_review_required" in item.visibility_labels or "public_use_not_allowed_until_review" in item.visibility_labels:
+            not_public_yet.append(observation + " Not public until owner review confirms safe use.")
+        if "source_blind_review_required" in item.visibility_labels:
+            private_notes.append("Source-blind memory requires source/visibility review before use.")
+
+    if candidate_type == "possible_connection_review":
+        connection = next((e.connected_subject for e in evidence if e.connected_subject), "another subject")
+        relationship_signals.insert(0, f"Possible connection to {_safe_snippet(connection, 80)} needs review; this is not an alias or identity match.")
+        not_public_yet.insert(0, "Do not present possible connections as confirmed identity, alias, or public fact.")
+    elif candidate_type == "identity_link":
+        private_notes.insert(0, "Alias/same-as language was found, but BNL must not merge aliases or identities without owner review.")
+        not_public_yet.insert(0, "Do not publish identity-link claims until owner review confirms them.")
+
+    if not public_safe:
+        public_safe.append("No public-safe fact is confirmed by this packet; owner review is required before any public use.")
+
+    return {
+        "knownContext": _unique_preserve(known_context)[:6],
+        "usefulEvidence": _unique_preserve(useful_evidence)[:6],
+        "relationshipSignals": _unique_preserve(relationship_signals)[:4],
+        "publicSafePossibilities": _unique_preserve(public_safe)[:4],
+        "privateOnlyNotes": _unique_preserve(private_notes)[:6],
+        "missingInfo": list(DEFAULT_MISSING_INFO),
+        "notPublicYet": _unique_preserve(not_public_yet)[:6],
+        "recommendedAction": "Keep as internal Source File review material until owner review decides what, if anything, can be public-safe.",
+        "confidence": confidence,
+        "sourceAuthority": source_authority[:8],
+        "rawProvenance": {
+            "sourceLabels": [f"{item.source_type}/{item.source_quality}" for item in evidence],
+            "sourceLaneMapping": {source: "unknown" for source in source_types},
+            "rawFragments": [
+                {
+                    "sourceLabel": f"{item.source_type}/{item.source_quality}",
+                    "visibilityLabels": list(item.visibility_labels),
+                    "warnings": list(item.warnings),
+                    "snippet": item.snippet,
+                }
+                for item in evidence
+            ],
+            "sourceCounts": dict(sorted(source_counts.items())),
+            "sourceTypes": list(source_types),
+            "sourceQualities": list(source_qualities),
+            "visibilityLabels": list(visibility),
+        },
+    }
+
+
+def _meaning_first_reason(display_name: str, packet: dict[str, Any], candidate_type: str) -> str:
+    contexts = list(packet.get("knownContext") or [])
+    relationship = list(packet.get("relationshipSignals") or [])
+    name = _safe_snippet(display_name, 80)
+    if candidate_type == "possible_connection_review":
+        prefix = f"BNL found review-only context for {name}, including a possible relationship/connection signal; this is not confirmed identity or alias."
+    elif candidate_type == "identity_link":
+        prefix = f"BNL found review-only identity/alias language for {name}."
+    else:
+        prefix = f"BNL found existing internal context for {name}."
+    details = []
+    for item in contexts + relationship:
+        if "local profile match" in item or "relationship/context notes" in item or "public-side conversation" in item or "community presence" in item or "BARCODE Radio" in item:
+            details.append(item)
+        if len(details) >= 2:
+            break
+    middle = " " + " ".join(details) if details else ""
+    return _safe_snippet(prefix + middle + " Keep this internal until owner review confirms what can be used publicly.", MAX_REASON_LENGTH)
+
+
 def _case_bridge_evidence_summary(display_name: str, evidence: list[KnowledgeEvidence], source_types: list[str], candidate_type: str) -> str:
     name = _safe_snippet(display_name, 80)
     if not evidence:
-        return f"{name} needs review, but BNL did not find enough supported local context to write a useful Source File note."
-    lead = f"{name} appears in existing BNL local knowledge stores ({', '.join(source_types)})."
+        return f"{name} needs owner review before BNL can write a useful Source File note."
+
+    observations = []
+    for item in evidence:
+        _title, observation, _boundary = _source_meaning(item, display_name)
+        observations.append(observation)
+
     if candidate_type == "possible_connection_review":
         connection = next((e.connected_subject for e in evidence if e.connected_subject), "another subject")
-        lead = f"{name} has a possible connection to {_safe_snippet(connection, 80)}; this is not a confirmed alias or identity match."
+        lead = f"BNL found review-only context for {name}, including a possible connection to {_safe_snippet(connection, 80)}; this is not a confirmed alias or identity match."
     elif candidate_type == "identity_link":
-        lead = f"{name} appears in alias/same-as language, but identity changes still need owner review before any merge or public use."
-    useful = []
-    for item in evidence[:4]:
-        snippet = _safe_snippet(item.snippet, 140)
-        if not snippet:
-            continue
-        if item.source_type == "memory_tiers":
-            useful.append(f"Review-only legacy memory mentions this subject: {snippet}")
-        elif item.source_type == "broadcast_memory":
-            useful.append(f"BARCODE Radio memory gives review context: {snippet}")
-        elif item.source_type == "community_presence":
-            useful.append(f"Community-side records show recurring activity around this subject: {snippet}")
-        elif item.source_type == "relationship_state":
-            useful.append(f"BNL has prior relationship context, but the public significance still needs confirmation: {snippet}")
-        else:
-            useful.append(f"Local review evidence: {snippet}")
-    tail = " ".join(useful[:3])
-    return _safe_snippet(f"{lead} {tail} Keep this as internal Source File review material until owner-approved public wording exists.", MAX_EVIDENCE_SUMMARY_LENGTH)
+        lead = f"BNL found review-only alias/same-as language for {name}; identity changes still need owner review before any merge or public use."
+    else:
+        lead = f"BNL found existing internal context for {name}."
+
+    detail = " ".join(_unique_preserve(observations)[:3])
+    return _safe_snippet(f"{lead} {detail} Keep this as internal Source File review material until owner-approved public wording exists.", MAX_EVIDENCE_SUMMARY_LENGTH)
 
 
 def collect_knowledge_bridge_candidates(db_path: str, guild_id: int | None = None, *, limit: int = DEFAULT_KNOWLEDGE_BRIDGE_LIMIT, rd_context: list[dict[str, Any]] | None = None) -> dict[str, Any]:
@@ -552,17 +724,18 @@ def collect_knowledge_bridge_candidates(db_path: str, guild_id: int | None = Non
         score = sum(e.confidence_points for e in acc.evidence)
         confidence = "high" if score >= 7 and len(source_types) > 1 else ("medium" if score >= 3 else "low")
         candidate_type = _candidate_type(acc.evidence)
-        evidence_summary = _case_bridge_evidence_summary(display_name, acc.evidence, source_types, candidate_type)
-        reason = _safe_snippet(
-            f"Knowledge bridge found {display_name} in existing BNL local knowledge stores ({', '.join(source_types)}). "
-            f"Source qualities: {', '.join(source_qualities)}. Visibility labels: {', '.join(visibility)}. Review-only Source File material; do not publish, draft, merge identities, or use publicly until owner review.",
-            MAX_REASON_LENGTH,
+        source_packet = _build_meaning_first_source_packet(
+            display_name,
+            acc.evidence,
+            source_types,
+            source_qualities,
+            visibility,
+            warnings,
+            confidence,
+            candidate_type,
         )
-        if candidate_type == "possible_connection_review":
-            connection = next((e.connected_subject for e in acc.evidence if e.connected_subject), "another subject")
-            reason = _safe_snippet(f"Knowledge bridge found {display_name} connected to {connection}. This is a possible connection review, not confirmed identity or alias. " + reason, MAX_REASON_LENGTH)
-        elif candidate_type == "identity_link":
-            reason = _safe_snippet(f"Knowledge bridge found explicit alias/same-as language for {display_name}. Review identity link before merging or public use. " + reason, MAX_REASON_LENGTH)
+        evidence_summary = _case_bridge_evidence_summary(display_name, acc.evidence, source_types, candidate_type)
+        reason = _meaning_first_reason(display_name, source_packet, candidate_type)
         evidence_hash = hashlib.sha256(f"{key}\n{candidate_type}\n{','.join(source_types)}".encode("utf-8")).hexdigest()[:10]
         payload = build_dossier_recommendation_payload(
             {
@@ -577,8 +750,17 @@ def collect_knowledge_bridge_candidates(db_path: str, guild_id: int | None = Non
                 "sourceQuality": source_qualities,
                 "visibilityLabels": visibility,
                 "safetyWarnings": warnings,
-                "suggestedAction": DEFAULT_SUGGESTED_ACTION,
-                "missingInfo": list(DEFAULT_MISSING_INFO),
+                "suggestedAction": source_packet["recommendedAction"],
+                "knownContext": source_packet["knownContext"],
+                "usefulEvidence": source_packet["usefulEvidence"],
+                "relationshipSignals": source_packet["relationshipSignals"],
+                "publicSafePossibilities": source_packet["publicSafePossibilities"],
+                "privateOnlyNotes": source_packet["privateOnlyNotes"],
+                "missingInfo": source_packet["missingInfo"],
+                "notPublicYet": source_packet["notPublicYet"],
+                "recommendedAction": source_packet["recommendedAction"],
+                "sourceAuthority": source_packet["sourceAuthority"],
+                "rawProvenance": source_packet["rawProvenance"],
                 "publicSafetyNotes": warnings + ["Internal BNL Source File recommendation only; proposed/public dossiers require separate owner review."],
                 "doNotSay": ["Do not expose raw private/internal notes, raw Discord IDs, or full transcripts publicly.", "Do not claim identity certainty or confirmed aliases unless owner review confirms it."],
                 "createdBy": "bnl",

--- a/tests/test_source_knowledge_bridge.py
+++ b/tests/test_source_knowledge_bridge.py
@@ -78,6 +78,55 @@ class SourceKnowledgeBridgeTests(unittest.TestCase):
         payload = self._payload_by_name(self._collect(), "Emerald")
         self.assertEqual(payload["type"], "identity_link")
 
+
+    def test_meaning_first_source_packet_separates_raw_provenance(self):
+        c = self.conn.cursor()
+        c.execute("INSERT INTO user_profiles VALUES (1,1,'Crow','Crow',NULL,NULL)")
+        c.execute("INSERT INTO relationship_journal VALUES (NULL,1,1,'note','help_signal: EDGE_SESSION Crow relationship_journal/local_relationship_trace raw detail','now')")
+        c.execute("INSERT INTO conversations VALUES (NULL,1,'Crow',1,'general','public_home','user','Crow is a recurring community subject candidate.','now')")
+        self.conn.commit()
+
+        payload = self._payload_by_name(self._collect(), "Crow")
+
+        self.assertIn("BNL found an internal local profile match for Crow.", payload["knownContext"])
+        self.assertTrue(any("prior relationship/context notes" in item for item in payload["relationshipSignals"]))
+        self.assertTrue(any("private relationship context" in item for item in payload["relationshipSignals"]))
+        self.assertTrue(any("approved public-side conversation context" in item for item in payload["publicSafePossibilities"]))
+        self.assertTrue(any("Keep this internal" in item or "Owner review" in item for item in payload["privateOnlyNotes"]))
+        self.assertEqual(payload["recommendedAction"], payload["suggestedAction"])
+        self.assertIn("sourceAuthority", payload)
+
+        normal_text = json.dumps({
+            "reason": payload.get("reason"),
+            "evidenceSummary": payload.get("evidenceSummary"),
+            "knownContext": payload.get("knownContext"),
+            "usefulEvidence": payload.get("usefulEvidence"),
+            "relationshipSignals": payload.get("relationshipSignals"),
+            "publicSafePossibilities": payload.get("publicSafePossibilities"),
+            "privateOnlyNotes": payload.get("privateOnlyNotes"),
+            "notPublicYet": payload.get("notPublicYet"),
+            "sourceAuthority": payload.get("sourceAuthority"),
+        })
+        for raw in (
+            "user_profiles/local_profile_observed",
+            "relationship_journal/local_relationship_trace",
+            "conversations/public_discord_observed",
+            "source lane mapping",
+            "Source lanes: unknown",
+            "unknown -> unknown",
+            "help_signal:",
+            "EDGE_SESSION",
+            "memory_tiers",
+        ):
+            self.assertNotIn(raw, normal_text)
+
+        provenance = payload["rawProvenance"]
+        self.assertIn("user_profiles/local_profile_observed", provenance["sourceLabels"])
+        self.assertIn("relationship_journal/local_relationship_trace", provenance["sourceLabels"])
+        self.assertIn("conversations/public_discord_observed", provenance["sourceLabels"])
+        self.assertEqual(provenance["sourceLaneMapping"].get("relationship_journal"), "unknown")
+        self.assertTrue(any("help_signal:" in fragment["snippet"] for fragment in provenance["rawFragments"]))
+
     def test_unknown_conversation_is_internal_review_not_public_safe(self):
         self.conn.execute("INSERT INTO conversations VALUES (NULL,1,'User',1,'mystery',NULL,'user','Hellcat is a recurring candidate from unknown policy.','now')")
         self.conn.commit()


### PR DESCRIPTION
### Motivation
- The bridge and packet builders were emitting backend-ish raw source fragments (e.g. `user_profiles/local_profile_observed`, `relationship_journal/local_relationship_trace`, `conversations/public_discord_observed`, `memory_tiers`, `help_signal`, `EDGE_SESSION`, and raw source-lane mappings) into normal `reason`/`evidenceSummary`/`knownFacts` fields, which exposed provenance details instead of meaning-first observations.
- The intent is for BNL to send structured, meaning-first source packets that summarize interpretation and preserve raw provenance only for audit/debugging while keeping strict privacy/source boundaries.
- Packets must provide compact, actionable recommendations and explicit privacy labels (owner review, internal-only, source-blind, public-safe candidate) rather than raw DB/table/source-path labels.
- This change keeps the existing review-only, operator-triggered model and does not add website, publishing, automatic scanning, or identity-merge behaviors.

### Description
- Added a set of structured, meaning-first fields to recommendation payloads and the payload allowlist: `knownContext`, `usefulEvidence`, `relationshipSignals`, `publicSafePossibilities`, `privateOnlyNotes`, `notPublicYet`, `recommendedAction`, `confidence`, `sourceAuthority`, and `rawProvenance` (files: `bnl_dossier_recommendations.py`, `bnl_dossier_source_packets.py`).
- Implemented interpretation helpers in the knowledge bridge that convert raw evidence types into human-meaningful observations and explicit privacy boundaries (e.g. local profile -> "Internal local profile", relationship journal/state -> "Prior relationship/context notes", public conversations -> "Approved public-side conversation context" when policy allows), and collect source authority entries (file: `bnl_source_knowledge_bridge.py`).
- Built `rawProvenance` as a separate audit structure containing `sourceLabels`, `sourceLaneMapping`, `rawFragments` (raw snippets/labels), `sourceCounts`, `sourceTypes`, `sourceQualities`, and `visibilityLabels`, and ensured raw source strings appear only in that field and not in normal `reason`/`evidenceSummary`/`knownFacts` text (file: `bnl_source_knowledge_bridge.py`).
- Updated the manual packet builder to include owner-review guidance, compact known-context bullets, public-safe possibility text, `sourceAuthority`, and a `rawProvenance` section for operator/R&D-origin packets (file: `bnl_dossier_source_packets.py`).

### Testing
- Ran the full test suite with `python -m unittest discover -s tests -v` and all tests passed (suite run completed successfully, existing and new tests OK).
- Compiled modified modules with `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py bnl_source_file_lookup.py bnl_source_file_enrichment.py bnl_source_knowledge_bridge.py` and compilation succeeded.
- Verified payload sanitization and `build_dossier_recommendation_payload` allowlist updated to include the new structured fields and confirmed `rawProvenance` contains raw labels/snippets while normal fields remain meaning-first (static checks performed, `git diff --check` clean).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd17703c48321b9ebe30f87818551)