### PR TITLE
Feed Entity Activity Summary into BNL source packets

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -4841,7 +4841,11 @@ async def maybe_handle_dossier_recommendation_command(message: discord.Message, 
         payload.get("reason", ""),
         payload.get("sourceLanes") or ["rd_context"],
         guild_id=getattr(message.guild, "id", None),
-        options={"broadcast_memory_reader": get_recent_broadcast_memory},
+        options={
+            "broadcast_memory_reader": get_recent_broadcast_memory,
+            "db_path": DB_FILE,
+            "rd_context": _current_rd_discovery_context(message),
+        },
     )
     safe_payload = packet_result["payload"]
     subject = (safe_payload.get("subjectName") or "subject").strip()[:80]

--- a/bnl_dossier_source_packets.py
+++ b/bnl_dossier_source_packets.py
@@ -33,6 +33,19 @@ _DISCORD_MENTION_PATTERN = re.compile(r"<[@#!&]?[0-9]{5,}>")
 _LONG_ID_PATTERN = re.compile(r"\b\d{15,22}\b")
 _broadcast_memory_reader: Callable[..., Any] | None = None
 
+_RAW_NORMAL_FIELD_MARKERS = (
+    "user_profiles/local_profile_observed",
+    "relationship_journal/local_relationship_trace",
+    "relationship_state/local_relationship_trace",
+    "conversations/public_discord_observed",
+    "memory_tiers/source_blind_memory_trace",
+    "source lane mapping",
+    "unknown -> unknown",
+    "help_signal",
+    "EDGE_SESSION",
+)
+MAX_ENTITY_RAW_FRAGMENTS = 8
+
 
 def set_broadcast_memory_reader(reader: Callable[..., Any] | None) -> None:
     """Register the existing bot broadcast-memory reader, if available."""
@@ -227,6 +240,153 @@ def _confidence_for_evidence(actual_lanes: list[str], evidence: list[dict[str, A
     return "low"
 
 
+def _normal_text_key(value: Any) -> str:
+    text = re.sub(r"[^a-z0-9]+", " ", str(value or "").lower()).strip()
+    replacements = {
+        "local profile match found for": "bnl found an internal local profile match for",
+        "review only relationship context signal exists for this subject": "bnl found prior relationship context notes connected to subject",
+        "public side conversation context exists but owner review is needed before stating it as public fact": "bnl found approved public side conversation context connected to subject",
+    }
+    for old, new in replacements.items():
+        text = text.replace(old, new)
+    return re.sub(r"\s+", " ", text)
+
+
+def _looks_like_raw_label(value: Any) -> bool:
+    text = str(value or "")
+    lowered = text.lower()
+    if any(marker.lower() in lowered for marker in _RAW_NORMAL_FIELD_MARKERS):
+        return True
+    if re.search(r"\b[a-z]+(?:_[a-z]+)+/[a-z]+(?:_[a-z]+)+\b", text):
+        return True
+    if re.search(r"\b\d{15,22}\b", text):
+        return True
+    return False
+
+
+def _merge_unique(target: list[Any], values: Any, *, limit: int | None = None) -> None:
+    if not isinstance(values, list):
+        return
+    seen = {_normal_text_key(item) for item in target}
+    for value in values:
+        if isinstance(value, dict):
+            marker = _normal_text_key(value)
+            if marker and marker not in seen:
+                target.append(value)
+                seen.add(marker)
+        else:
+            clean = _safe_snippet(str(value or ""), 260)
+            key = _normal_text_key(clean)
+            if not clean or _looks_like_raw_label(clean) or key in seen:
+                continue
+            target.append(clean)
+            seen.add(key)
+        if limit and len(target) >= limit:
+            break
+
+
+def _dedupe_same_observation(values: list[Any]) -> list[Any]:
+    seen: set[str] = set()
+    out: list[Any] = []
+    for value in values:
+        if isinstance(value, dict):
+            key = _normal_text_key(value)
+        else:
+            text = str(value or "")
+            observation = re.split(r"\b(?:Keep this internal|Owner review|Not public|Treat this as|It may inform|Source-blind memory requires)\b", text, maxsplit=1)[0]
+            key = _normal_text_key(observation or text)
+        if key and key in seen:
+            continue
+        if key:
+            seen.add(key)
+        out.append(value)
+    return out
+
+
+def _has_entity_evidence(entity_summary: dict[str, Any] | None) -> bool:
+    raw = (entity_summary or {}).get("rawProvenance") or {}
+    return bool(raw.get("rawFragments"))
+
+
+def _entity_source_authority_items(entity_summary: dict[str, Any], confidence: str) -> list[dict[str, str]]:
+    items: list[dict[str, str]] = []
+    for value in entity_summary.get("sourceAuthority") or []:
+        if not value or _looks_like_raw_label(value):
+            continue
+        items.append({"source": "Entity Activity Summary", "boundary": _safe_snippet(str(value), 160), "confidence": confidence})
+    return items
+
+
+def merge_entity_activity_summary_into_packet(packet: dict[str, Any], entity_summary: dict[str, Any] | None) -> dict[str, Any]:
+    """Merge shared entity-summary context into a source packet without changing privacy boundaries."""
+
+    if not _has_entity_evidence(entity_summary):
+        return packet
+
+    summary = entity_summary or {}
+    confidence = str(packet.get("confidence") or summary.get("confidence") or "low")
+    _merge_unique(packet.setdefault("knownContext", []), summary.get("knownContext"), limit=8)
+    useful_from_summary: list[str] = []
+    useful_from_summary.extend(summary.get("activitySignals") or [])
+    useful_from_summary.extend(summary.get("channelActivity") or [])
+    useful_from_summary.extend(summary.get("recurringTopics") or [])
+    if summary.get("matchedNames"):
+        useful_from_summary.insert(0, f"BNL found an internal local profile match for {packet.get('subjectName') or summary.get('subjectName') or 'this subject'}.")
+    _merge_unique(packet.setdefault("usefulEvidence", []), useful_from_summary, limit=8)
+    _merge_unique(packet.setdefault("relationshipSignals", []), summary.get("relationshipSignals"), limit=6)
+
+    current_public = packet.setdefault("publicSafePossibilities", [])
+    summary_public = [
+        item for item in (summary.get("publicSafePossibilities") or [])
+        if item != "No public-safe facts confirmed yet." or not any("public-safe" not in str(existing).lower() for existing in current_public)
+    ]
+    if any(item != "No public-safe facts confirmed yet." for item in summary_public):
+        current_public[:] = [item for item in current_public if item != "No public-safe fact is confirmed by this packet; owner review is required before public use."]
+    _merge_unique(current_public, summary_public, limit=6)
+    if not current_public:
+        current_public.append("No public-safe fact is confirmed by this packet; owner review is required before public use.")
+
+    _merge_unique(packet.setdefault("privateOnlyNotes", []), summary.get("privateOnlyNotes"), limit=8)
+    packet["privateOnlyNotes"] = _dedupe_same_observation(packet.get("privateOnlyNotes") or [])[:8]
+    _merge_unique(packet.setdefault("notPublicYet", []), summary.get("notPublicYet"), limit=8)
+    packet["notPublicYet"] = _dedupe_same_observation(packet.get("notPublicYet") or [])[:8]
+    _merge_unique(packet.setdefault("missingInfo", []), summary.get("missingInfo"), limit=8)
+    _merge_unique(packet.setdefault("sourceAuthority", []), _entity_source_authority_items(summary, confidence), limit=10)
+
+    summary_confidence = str(summary.get("confidence") or "none")
+    if packet.get("confidence") == "low" and summary_confidence in {"medium", "high"}:
+        packet["confidence"] = "medium" if summary_confidence == "medium" else "high"
+
+    if packet.get("relationshipSignals") or any("relationship" in str(item).lower() for item in packet.get("privateOnlyNotes") or []):
+        action = "Separate private relationship/context notes from any public-safe community description before drafting; queue/submission identity is not connected yet."
+    elif any(item != "No public-safe facts confirmed yet." and "no public-safe fact" not in str(item).lower() for item in packet.get("publicSafePossibilities") or []):
+        action = "Review this subject as a possible community/source-file candidate; owner review must confirm public-safe identity, role, and wording before any public use."
+    else:
+        action = "Keep this as internal Source File review material until an owner confirms public-safe identity, role, and wording; queue/submission identity is not connected yet."
+    packet["recommendedAction"] = action
+    packet["suggestedAction"] = action
+
+    raw = packet.setdefault("rawProvenance", {})
+    entity_raw = summary.get("rawProvenance") or {}
+    direct_labels = list(raw.get("sourceLabels") or [])
+    entity_labels = list(entity_raw.get("sourceLabels") or [])
+    raw["sourceLabels"] = list(dict.fromkeys(direct_labels + entity_labels))
+    raw["sourceCounts"] = dict(raw.get("sourceCounts") or {})
+    raw["entitySourceCounts"] = dict(entity_raw.get("sourceCounts") or {})
+    if entity_raw.get("channelPolicies"):
+        raw["channelPolicyCounts"] = dict(entity_raw.get("channelPolicies") or {})
+    raw["entitySourceAuthority"] = list(summary.get("sourceAuthority") or [])[:5]
+    fragments = list(raw.get("rawFragments") or [])
+    for fragment in list(entity_raw.get("rawFragments") or [])[:MAX_ENTITY_RAW_FRAGMENTS]:
+        if isinstance(fragment, dict):
+            merged = {"origin": "entity_activity_summary", **fragment}
+        else:
+            merged = {"origin": "entity_activity_summary", "snippet": _safe_snippet(str(fragment))}
+        fragments.append(merged)
+    raw["rawFragments"] = fragments[: MAX_EVIDENCE_MATCHES + MAX_ENTITY_RAW_FRAGMENTS]
+    packet["entityActivitySummaryIncluded"] = True
+    return packet
+
 def build_dossier_recommendation_packet(
     subject: str,
     reason: str,
@@ -251,6 +411,34 @@ def build_dossier_recommendation_packet(
                 aliases=aliases,
             )
         )
+
+    entity_summary = opts.get("entity_activity_summary") if isinstance(opts.get("entity_activity_summary"), dict) else None
+    db_path = opts.get("db_path") or opts.get("entity_db_path")
+    if entity_summary is None and db_path:
+        try:
+            from bnl_entity_activity_summary import build_entity_activity_summary
+
+            entity_summary = build_entity_activity_summary(
+                str(db_path),
+                subject_name,
+                guild_id,
+                [
+                    "user_profiles",
+                    "user_memory_facts",
+                    "user_habits",
+                    "relationship_state",
+                    "relationship_journal",
+                    "memory_tiers",
+                    "conversations",
+                    "broadcast_memory",
+                    "rd_context",
+                ],
+                "admin_internal",
+                50,
+                opts.get("rd_context"),
+            )
+        except Exception:
+            entity_summary = None
 
     actual_lanes: list[str] = []
     for item in evidence:
@@ -302,6 +490,7 @@ def build_dossier_recommendation_packet(
         "recommendedAction": DEFAULT_SUGGESTED_ACTION,
         "evidence": evidence,
     }
+    merge_entity_activity_summary_into_packet(packet, entity_summary)
     payload = build_dossier_recommendation_payload(
         {
             "type": "new_subject",

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 from bnl_dossier_recommendations import build_dossier_recommendation_payload, send_dossier_recommendation
+from bnl_entity_activity_summary import build_entity_activity_summary
 from bnl_source_file_lookup import lookup_source_file
 
 ENRICHMENT_INGEST_SOURCE = "bnl_source_file_enrichment"
@@ -718,6 +719,34 @@ def _summarize_channel_activity(subject: str, rows: list[sqlite3.Row]) -> str:
     return f"{lead}. review-only internal context; internal source context, not public dossier copy. no specific public-safe role has been confirmed yet. No meaningful repeated theme has been extracted yet.{channel_text}"
 
 
+def _entity_summary_has_evidence(summary: dict[str, Any] | None) -> bool:
+    return bool(((summary or {}).get("rawProvenance") or {}).get("rawFragments"))
+
+
+def _append_entity_summary_sections(sections: dict[str, list[str]], summary: dict[str, Any]) -> None:
+    for item in (summary.get("knownContext") or [])[:2]:
+        if "No approved local" not in str(item):
+            _append_section(sections, "Subject Overview", str(item), limit=5)
+    for item in (summary.get("activitySignals") or [])[:2] + (summary.get("channelActivity") or [])[:2] + (summary.get("recurringTopics") or [])[:2]:
+        _append_section(sections, "Observed Patterns", str(item), limit=8)
+    for item in (summary.get("publicSafePossibilities") or [])[:3]:
+        if str(item) != "No public-safe facts confirmed yet.":
+            safe_item = re.sub(r"owner review", "human review", str(item), flags=re.I)
+            _append_section(sections, "Public-Safe Notes", safe_item, limit=6)
+    review_items = list(summary.get("relationshipSignals") or []) + list(summary.get("privateOnlyNotes") or []) + list(summary.get("notPublicYet") or [])
+    for item in review_items[:5]:
+        _append_section(sections, "Internal-Only / Review-Only Notes", str(item), limit=10)
+    for item in (summary.get("missingInfo") or [])[:4]:
+        _append_section(sections, "Missing Info", str(item), limit=8)
+    if summary.get("recommendedAction"):
+        _append_section(
+            sections,
+            "Suggested Next Action",
+            "Keep this as internal Source File review material until an owner confirms public-safe identity, role, and wording; queue/submission identity is not connected yet.",
+            limit=4,
+        )
+
+
 def _append_section(sections: dict[str, list[str]], name: str, value: str, *, limit: int = 5) -> None:
     clean = _safe_text(value, 240)
     if not clean:
@@ -1295,6 +1324,34 @@ def collect_source_enrichment_evidence(db_path: str, guild_id: int | None, subje
     if "rd_context" not in source_statuses:
         _source_status(source_statuses, "rd_context", "no_match" if rd_context else "not_provided")
 
+    entity_summary = build_entity_activity_summary(
+        db_path,
+        subject,
+        guild_id,
+        [
+            "user_profiles",
+            "user_memory_facts",
+            "user_habits",
+            "relationship_state",
+            "relationship_journal",
+            "memory_tiers",
+            "conversations",
+            "broadcast_memory",
+            "rd_context",
+        ],
+        "admin_internal",
+        50,
+        rd_context,
+    )
+    raw_provenance = entity_summary.get("rawProvenance") if _entity_summary_has_evidence(entity_summary) else {}
+    if raw_provenance:
+        _append_entity_summary_sections(sections, entity_summary)
+        source_counts["entity_activity_summary"] += len(raw_provenance.get("rawFragments") or [])
+        source_types.add("entity_activity_summary")
+        _source_status(source_statuses, "entity_activity_summary", "yes")
+    else:
+        _source_status(source_statuses, "entity_activity_summary", "no_match")
+
     if not sections["Why This Subject Matters"] and (sum(source_counts.values()) > source_counts.get("source_file_lookup", 0)):
         _append_section(sections, "Why This Subject Matters", "BNL has enough local review signals to keep this subject in the working record; admins should decide what, if anything, belongs in a public-safe Source File summary.")
     if not sections["Subject Overview"]:
@@ -1357,6 +1414,19 @@ def collect_source_enrichment_evidence(db_path: str, guild_id: int | None, subje
         "subjectIdentity": safe_identity,
         "diagnostics": diagnostics,
         "classification": classification,
+        "knownContext": list(entity_summary.get("knownContext") or [])[:6] if raw_provenance else [],
+        "relationshipSignals": list(entity_summary.get("relationshipSignals") or [])[:4] if raw_provenance else [],
+        "publicSafePossibilities": list(entity_summary.get("publicSafePossibilities") or [])[:4] if raw_provenance else [],
+        "privateOnlyNotes": list(entity_summary.get("privateOnlyNotes") or [])[:6] if raw_provenance else [],
+        "notPublicYet": list(entity_summary.get("notPublicYet") or [])[:6] if raw_provenance else [],
+        "sourceAuthority": list(entity_summary.get("sourceAuthority") or [])[:5] if raw_provenance else [],
+        "rawProvenance": {
+            "sourceLabels": list(raw_provenance.get("sourceLabels") or []),
+            "sourceCounts": dict(raw_provenance.get("sourceCounts") or {}),
+            "rawFragments": list(raw_provenance.get("rawFragments") or [])[:8],
+            "channelPolicyCounts": dict(raw_provenance.get("channelPolicies") or {}),
+            "sourceAuthority": list(entity_summary.get("sourceAuthority") or [])[:5],
+        } if raw_provenance else {},
     }
 
 def _section_text(sections: dict[str, list[str]], name: str, *, limit: int = 4) -> str:
@@ -1422,6 +1492,13 @@ def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: 
         "sourceCoverage": dict(packet.get("sourceTypesChecked") or {}),
         "identityDiagnostics": dict(packet.get("diagnostics") or {}),
         "internalClassification": dict(packet.get("classification") or {}),
+        "knownContext": list(packet.get("knownContext") or []),
+        "relationshipSignals": list(packet.get("relationshipSignals") or []),
+        "publicSafePossibilities": list(packet.get("publicSafePossibilities") or []),
+        "privateOnlyNotes": list(packet.get("privateOnlyNotes") or []),
+        "notPublicYet": list(packet.get("notPublicYet") or []),
+        "sourceAuthority": list(packet.get("sourceAuthority") or []),
+        "rawProvenance": dict(packet.get("rawProvenance") or {}),
         "visibilityLabels": ["internal_review_only", "admin_review_required"],
         "confidence": "low" if packet.get("qualityStatus") in {"too_thin", "forced_low_confidence"} else ("medium" if match_kind == "active_source_file" else "low"),
         "createdBy": "bnl",

--- a/bnl_source_knowledge_bridge.py
+++ b/bnl_source_knowledge_bridge.py
@@ -18,7 +18,8 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 from bnl_dossier_recommendations import build_dossier_recommendation_payload, send_dossier_recommendation
-from bnl_dossier_source_packets import DEFAULT_MISSING_INFO, DEFAULT_SUGGESTED_ACTION, subject_key
+from bnl_entity_activity_summary import build_entity_activity_summary
+from bnl_dossier_source_packets import DEFAULT_MISSING_INFO, DEFAULT_SUGGESTED_ACTION, merge_entity_activity_summary_into_packet, subject_key
 
 KNOWLEDGE_BRIDGE_INGEST_SOURCE = "bnl_source_knowledge_bridge"
 DEFAULT_KNOWLEDGE_BRIDGE_LIMIT = 20
@@ -734,6 +735,27 @@ def collect_knowledge_bridge_candidates(db_path: str, guild_id: int | None = Non
             confidence,
             candidate_type,
         )
+        entity_summary = build_entity_activity_summary(
+            db_path,
+            display_name,
+            guild_id,
+            [
+                "user_profiles",
+                "user_memory_facts",
+                "user_habits",
+                "relationship_state",
+                "relationship_journal",
+                "memory_tiers",
+                "conversations",
+                "broadcast_memory",
+                "rd_context",
+            ],
+            "admin_internal",
+            50,
+            rd_context,
+        )
+        merge_entity_activity_summary_into_packet(source_packet, entity_summary)
+        confidence = str(source_packet.get("confidence") or confidence)
         evidence_summary = _case_bridge_evidence_summary(display_name, acc.evidence, source_types, candidate_type)
         reason = _meaning_first_reason(display_name, source_packet, candidate_type)
         evidence_hash = hashlib.sha256(f"{key}\n{candidate_type}\n{','.join(source_types)}".encode("utf-8")).hexdigest()[:10]

--- a/tests/test_dossier_recommendations.py
+++ b/tests/test_dossier_recommendations.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 import os
+import sqlite3
+import tempfile
 import unittest
 import urllib.error
 from unittest import mock
@@ -175,6 +177,46 @@ class DossierSourcePacketTests(unittest.TestCase):
         self.assertEqual(payload["confidence"], "medium")
         self.assertLessEqual(len(payload["evidenceSummary"]), packets.MAX_EVIDENCE_SUMMARY_LENGTH)
         self.assertEqual(payload["ingestKey"], second["payload"]["ingestKey"])
+
+
+    def test_manual_packet_can_include_entity_summary_context_when_local_memory_exists(self):
+        tmp = tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False)
+        tmp.close()
+        conn = sqlite3.connect(tmp.name)
+        try:
+            conn.execute("CREATE TABLE user_profiles (user_id INTEGER, guild_id INTEGER, display_name TEXT, preferred_name TEXT, last_seen TEXT, last_greeting_at TEXT)")
+            conn.execute("CREATE TABLE relationship_journal (id INTEGER PRIMARY KEY, user_id INTEGER, guild_id INTEGER, entry_type TEXT, summary TEXT, timestamp TEXT)")
+            conn.execute("INSERT INTO user_profiles VALUES (1,123,'Signal Witch','Signal Witch',NULL,NULL)")
+            conn.execute("INSERT INTO relationship_journal VALUES (NULL,1,123,'note','Signal Witch private relationship/context note for owner review.','now')")
+            conn.commit()
+
+            result = packets.build_dossier_recommendation_packet(
+                "Signal Witch",
+                "Operator says Signal Witch should be reviewed.",
+                ["rd_context"],
+                guild_id=123,
+                options={"db_path": tmp.name},
+            )
+            payload = result["payload"]
+
+            self.assertTrue(any("Local profile match found for Signal Witch" in item for item in payload["knownContext"]))
+            self.assertTrue(any("relationship/context" in item for item in payload["relationshipSignals"]))
+            self.assertFalse(any("relationship" in item.lower() for item in payload["publicSafePossibilities"]))
+            self.assertIn("queue/submission identity is not connected yet", payload["recommendedAction"])
+            normal_text = json.dumps({
+                "knownContext": payload.get("knownContext"),
+                "relationshipSignals": payload.get("relationshipSignals"),
+                "publicSafePossibilities": payload.get("publicSafePossibilities"),
+                "privateOnlyNotes": payload.get("privateOnlyNotes"),
+                "notPublicYet": payload.get("notPublicYet"),
+            })
+            self.assertNotIn("user_profiles/local_profile_observed", normal_text)
+            self.assertIn("rd_context/R&D/operator note", payload["rawProvenance"]["sourceLabels"])
+            self.assertIn("user_profiles/local_profile_observed", payload["rawProvenance"]["sourceLabels"])
+            self.assertIn("relationship_journal/local_relationship_trace", payload["rawProvenance"]["sourceLabels"])
+        finally:
+            conn.close()
+            os.unlink(tmp.name)
 
     def test_no_automatic_scanning_constructs_in_packet_module(self):
         with open("bnl_dossier_source_packets.py", encoding="utf-8") as handle:

--- a/tests/test_source_knowledge_bridge.py
+++ b/tests/test_source_knowledge_bridge.py
@@ -127,6 +127,59 @@ class SourceKnowledgeBridgeTests(unittest.TestCase):
         self.assertEqual(provenance["sourceLaneMapping"].get("relationship_journal"), "unknown")
         self.assertTrue(any("help_signal:" in fragment["snippet"] for fragment in provenance["rawFragments"]))
 
+
+    def test_entity_summary_enriches_bridge_packet_with_privacy_boundaries_and_provenance(self):
+        c = self.conn.cursor()
+        c.execute("INSERT INTO user_profiles VALUES (1,1,'Crow','Crow',NULL,NULL)")
+        c.execute("INSERT INTO relationship_journal VALUES (NULL,1,1,'note','help_signal: EDGE_SESSION Crow relationship_journal/local_relationship_trace private note','now')")
+        c.execute("INSERT INTO conversations VALUES (NULL,1,'Crow',1,'general','public_home','user','Crow is a recurring community subject candidate.','now')")
+        c.execute("INSERT INTO memory_tiers VALUES (NULL,1,1,'long','Crow source-blind legacy memory trace.',0.9,1,'now')")
+        self.conn.commit()
+
+        payload = self._payload_by_name(self._collect(), "Crow")
+
+        self.assertIn("BNL found an internal local profile match for Crow.", payload["knownContext"])
+        self.assertEqual(payload["knownContext"].count("BNL found an internal local profile match for Crow."), 1)
+        self.assertTrue(any("relationship/context" in item for item in payload["relationshipSignals"]))
+        self.assertTrue(any("prior relationship/context notes" in item for item in payload["privateOnlyNotes"]))
+        self.assertEqual(sum(1 for item in payload["privateOnlyNotes"] if "prior relationship/context notes" in item), 1)
+        self.assertFalse(any("relationship" in item.lower() for item in payload["publicSafePossibilities"]))
+        self.assertTrue(any("Public-side conversation context exists" in item for item in payload["publicSafePossibilities"]))
+        self.assertTrue(any("Source-blind legacy memory exists" in item for item in payload["privateOnlyNotes"]))
+        self.assertTrue(any("Source-blind memory cannot" in item for item in payload["notPublicYet"]))
+        self.assertNotEqual(payload["recommendedAction"], "Review source context.")
+        self.assertIn("queue/submission identity is not connected yet", payload["recommendedAction"])
+
+        normal_text = json.dumps({
+            "knownContext": payload.get("knownContext"),
+            "usefulEvidence": payload.get("usefulEvidence"),
+            "relationshipSignals": payload.get("relationshipSignals"),
+            "publicSafePossibilities": payload.get("publicSafePossibilities"),
+            "privateOnlyNotes": payload.get("privateOnlyNotes"),
+            "notPublicYet": payload.get("notPublicYet"),
+            "recommendedAction": payload.get("recommendedAction"),
+            "sourceAuthority": payload.get("sourceAuthority"),
+        })
+        for raw in (
+            "user_profiles/local_profile_observed",
+            "relationship_journal/local_relationship_trace",
+            "conversations/public_discord_observed",
+            "memory_tiers/source_blind_memory_trace",
+            "help_signal",
+            "EDGE_SESSION",
+            "unknown -> unknown",
+        ):
+            self.assertNotIn(raw, normal_text)
+
+        provenance = payload["rawProvenance"]
+        self.assertIn("user_profiles/local_profile_observed", provenance["sourceLabels"])
+        self.assertIn("conversations/public_discord_observed", provenance["sourceLabels"])
+        self.assertIn("memory_tiers/source_blind_memory_trace", provenance["sourceLabels"])
+        self.assertIn("relationship_journal", provenance["sourceCounts"])
+        self.assertIn("relationship_journal", provenance["entitySourceCounts"])
+        self.assertEqual(provenance["channelPolicyCounts"].get("public_home"), 1)
+        self.assertTrue(any(fragment.get("origin") == "entity_activity_summary" for fragment in provenance["rawFragments"] if isinstance(fragment, dict)))
+
     def test_unknown_conversation_is_internal_review_not_public_safe(self):
         self.conn.execute("INSERT INTO conversations VALUES (NULL,1,'User',1,'mystery',NULL,'user','Hellcat is a recurring candidate from unknown policy.','now')")
         self.conn.commit()


### PR DESCRIPTION
### Motivation

- Make the shared `Entity Activity Summary` layer reusable across BNL source/recommendation packets so dossier/source-file recommendations use consistent, meaning-first summary context instead of only raw fragments. 
- Enrich packet fields like `knownContext`, `usefulEvidence`, `relationshipSignals`, `publicSafePossibilities`, `privateOnlyNotes`, `notPublicYet`, `missingInfo`, `sourceAuthority`, `confidence`, and `recommendedAction` with privacy boundaries preserved. 
- Keep raw labels/IDs/snippets out of normal packet fields and keep them bounded and auditable inside `rawProvenance`. 

### Description

- Added a merge helper `merge_entity_activity_summary_into_packet(...)` and supporting meaning-first helpers (`_merge_unique`, `_normal_text_key`, `_looks_like_raw_label`, `_dedupe_same_observation`, etc.) in `bnl_dossier_source_packets.py` to combine entity summaries into source packets without leaking raw provenance into normal fields. 
- Wired `build_entity_activity_summary(...)` into the knowledge bridge and manual packet paths so `collect_knowledge_bridge_candidates(...)` and `build_dossier_recommendation_packet(...)` call the summary builder and merge its structured fields into the packet before payload assembly. 
- Extended source-file enrichment (`bnl_source_file_enrichment.py`) to optionally include lightweight entity-summary sections and bounded `rawProvenance` when entity summary evidence exists, while keeping enrichment review-only. 
- Updated the manual operator recommendation path in `bnl01_bot.py` to pass `DB_FILE` and current R&D context into packet construction so manual recommendations can include entity summary context when available. 
- Preserved existing packet behavior and raw provenance by appending entity provenance labels/fragments into `rawProvenance`, de-duplicating overlapping observations, and preferring summary meaning in normal fields. 
- Added/updated tests to assert enrichment, privacy boundaries, de-duplication, raw provenance merging, and recommendedAction improvements (see `tests/test_source_knowledge_bridge.py` and `tests/test_dossier_recommendations.py`). 

### Testing

- Ran the full unit test suite with `python -m unittest discover -s tests -v` and all tests passed, including the new/updated assertions for entity-summary enrichment and manual packet inclusion. 
- Compiled the changed modules with `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py bnl_source_file_lookup.py bnl_source_file_enrichment.py bnl_source_knowledge_bridge.py bnl_entity_activity_summary.py` and the compile step succeeded. 
- Verified static checks with `git diff --check` produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a204cfae8688321ae5ba5a6ccbf29bb)