### PR TITLE
Add entity evidence event store

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -59,6 +59,7 @@ from bnl_entity_activity_summary import (
     build_entity_activity_summary,
     format_entity_activity_summary_response,
     parse_entity_activity_summary_command,
+    refresh_entity_evidence_for_subject,
 )
 from bnl_source_file_lookup import (
     build_source_file_lookup_diagnostics,
@@ -3584,6 +3585,13 @@ def init_db():
     conn.commit()
     conn.close()
     ensure_community_presence_schema(DB_FILE)
+    from bnl_entity_evidence import ensure_entity_evidence_schema
+    evidence_conn = sqlite3.connect(DB_FILE)
+    try:
+        ensure_entity_evidence_schema(evidence_conn)
+        evidence_conn.commit()
+    finally:
+        evidence_conn.close()
     logging.info("✅ Database initialized successfully.")
 
 def _truncate_user_facts(user_id: int, guild_id: int, max_rows: int = MAX_FACTS_PER_USER):
@@ -4480,12 +4488,23 @@ async def maybe_handle_entity_activity_summary_command(message: discord.Message,
         await message.reply(f"Entity summary failed: {parse_error}")
         return True
 
+    refresh_result = None
+    if options.get("refreshEvidence"):
+        refresh_result = await asyncio.to_thread(
+            refresh_entity_evidence_for_subject,
+            DB_FILE,
+            options.get("subjectName", ""),
+            getattr(message.guild, "id", None),
+            200,
+        )
+
     summary = await asyncio.to_thread(
         build_entity_activity_summary,
         DB_FILE,
         options.get("subjectName", ""),
         getattr(message.guild, "id", None),
         [
+            "entity_evidence_events",
             "user_profiles",
             "user_memory_facts",
             "user_habits",
@@ -4494,13 +4513,27 @@ async def maybe_handle_entity_activity_summary_command(message: discord.Message,
             "memory_tiers",
             "conversations",
             "broadcast_memory",
+            "community_presence",
             "rd_context",
         ],
         "admin_internal",
         50,
         _current_rd_discovery_context(message),
     )
-    await message.reply(format_entity_activity_summary_response(summary))
+    response = format_entity_activity_summary_response(summary)
+    if refresh_result:
+        source_types = ", ".join(sorted((refresh_result.get("sourceTypes") or {}).keys())) or "none"
+        response = (
+            f"BNL Entity Evidence Refresh — {refresh_result.get('subjectName') or options.get('subjectName', '')}\n"
+            f"- created: `{int(refresh_result.get('createdCount') or 0)}`\n"
+            f"- updated: `{int(refresh_result.get('updatedCount') or 0)}`\n"
+            f"- unchanged: `{int(refresh_result.get('unchangedCount') or 0)}`\n"
+            f"- source types covered: `{source_types}`\n"
+            f"- review-only events touched: `{int(refresh_result.get('reviewOnlyCount') or 0)}`\n"
+            f"- public-safe candidates touched: `{int(refresh_result.get('publicSafeCandidateCount') or 0)}`\n\n"
+            f"{response}"
+        )
+    await message.reply(response)
     return True
 
 

--- a/bnl_entity_activity_summary.py
+++ b/bnl_entity_activity_summary.py
@@ -13,10 +13,17 @@ from collections import Counter
 from typing import Any
 
 from bnl_dossier_source_packets import normalize_subject_name, subject_key
+from bnl_entity_evidence import (
+    ENTITY_EVIDENCE_TABLE,
+    derive_entity_evidence_for_subject,
+    get_entity_evidence_for_subject,
+    table_exists as _evidence_table_exists,
+)
 
 DEFAULT_ENTITY_SUMMARY_LIMIT = 50
 MAX_ENTITY_SUMMARY_LIMIT = 200
 DEFAULT_ALLOWED_LANES = {
+    "entity_evidence_events",
     "user_profiles",
     "user_memory_facts",
     "user_habits",
@@ -49,16 +56,37 @@ _BNL_INTERACTION_PATTERN = re.compile(r"\b(bnl|bot|source files?|dossiers?|asked
 
 
 def parse_entity_activity_summary_command(content: str) -> tuple[bool, dict[str, Any] | None, str]:
-    """Parse `!bnl entity summary <subject>` operator readout commands."""
+    """Parse operator entity summary/evidence refresh readout commands."""
 
     text = (content or "").strip()
+    refresh_match = re.match(r"^!bnl\s+entity\s+evidence\s+refresh\s+(.+?)\s*$", text, flags=re.I | re.S)
+    if refresh_match:
+        subject = normalize_subject_name(refresh_match.group(1))
+        if not subject:
+            return True, None, "Use: `!bnl entity evidence refresh <subject>`"
+        return True, {"subjectName": subject, "refreshEvidence": True}, ""
     match = re.match(r"^!bnl\s+(?:entity\s+summary|source\s+summary)\s+(.+?)\s*$", text, flags=re.I | re.S)
     if not match:
         return False, None, "not_an_entity_activity_summary_command"
-    subject = normalize_subject_name(match.group(1))
+    subject_text = match.group(1)
+    refresh = False
+    parts = [piece.strip() for piece in subject_text.split("|") if piece.strip()]
+    if len(parts) > 1:
+        subject_text = parts[0]
+        for part in parts[1:]:
+            key_match = re.match(r"^([a-zA-Z_]+)\s*=\s*(.+)$", part)
+            if not key_match:
+                return True, None, "Use: `!bnl entity summary <subject> [| refresh=true]`"
+            key = key_match.group(1).strip().lower()
+            value = key_match.group(2).strip().lower()
+            if key == "refresh":
+                refresh = value in {"true", "1", "yes", "on"}
+            else:
+                return True, None, "Supported option: refresh."
+    subject = normalize_subject_name(subject_text)
     if not subject:
         return True, None, "Use: `!bnl entity summary <subject>`"
-    return True, {"subjectName": subject}, ""
+    return True, {"subjectName": subject, "refreshEvidence": refresh}, ""
 
 
 def compact_subject_text(value: str) -> str:
@@ -220,6 +248,100 @@ def _resolve_existing_enrichment_identity(db_path: str, subject: str, guild_id: 
         return {}
 
 
+
+def refresh_entity_evidence_for_subject(db_path: str, subject_name: str, guild_id: int | None = None, limit: int = MAX_ENTITY_SUMMARY_LIMIT) -> dict[str, Any]:
+    """Operator/source-path helper to derive structured evidence for one subject."""
+
+    return derive_entity_evidence_for_subject(db_path, subject_name, guild_id=guild_id, limit=limit)
+
+
+def _apply_structured_evidence(summary: dict[str, Any], rows: list[sqlite3.Row], topic_counts: Counter) -> None:
+    """Populate summary fields from entity_evidence_events rows."""
+
+    for row in rows:
+        data = dict(row)
+        source_table = str(data.get("source_table") or "entity_evidence_events")
+        source_label = str(data.get("source_label") or f"{source_table}/structured_evidence")
+        kind = str(data.get("evidence_kind") or "")
+        safe_summary = _safe_snippet(data.get("safe_summary") or "Structured entity evidence exists for owner review.")
+        relation = str(data.get("relation_to_subject") or "mentioned")
+        policy = str(data.get("channel_policy") or "unknown")
+        topic = str(data.get("topic") or "local context")
+        public_candidate = bool(data.get("public_safe_candidate"))
+        review_only = bool(data.get("review_only"))
+        channel_name = data.get("channel_name") if not review_only else None
+        channel_display = _channel_display_name(channel_name, policy) if channel_name else ("approved public-side channel" if public_candidate else "review-only channel")
+
+        summary["rawProvenance"]["sourceLabels"].append(source_label)
+        summary["rawProvenance"]["sourceCounts"][source_table] += 1
+        summary["rawProvenance"]["channelPolicies"][policy] += 1
+        summary["rawProvenance"]["rawFragments"].append({
+            "table": source_table,
+            "sourceLabel": source_label,
+            "sourceQuality": "structured_entity_evidence",
+            "evidenceKind": kind,
+            "rowId": data.get("source_row_id"),
+            "rawRefJson": data.get("raw_ref_json"),
+        })
+        if topic:
+            topic_counts[topic] += 1
+        _add_unique(summary["evidenceDetails"], safe_summary)
+
+        if kind == "profile_match":
+            _add_unique(summary["matchedNames"], normalize_subject_name(data.get("subject_name") or summary.get("subjectName") or ""))
+            _add_unique(summary["knownContext"], f"Local profile match found for {summary.get('subjectName')}." )
+            continue
+
+        if kind in {"authored_public_conversation", "mentioned_public_conversation"}:
+            _add_unique(summary["publicSafePossibilities"], "Public-side conversation context exists in approved Discord lanes and may support community/source-file wording after owner review.")
+            _add_unique(summary["publicUseCandidates"], "Possible community/source-file candidate based on approved public-side structured evidence, pending owner review.")
+            _add_unique(summary["observedChannels"], f"{channel_display} — approved public-side; subject {relation}.")
+            _add_unique(summary["channelActivity"], f"Appears in approved public-side structured conversation evidence as {relation} context.")
+            _add_unique(summary["conversationHighlights"], safe_summary)
+        elif "conversation" in kind:
+            _add_unique(summary["privateOnlyNotes"], "Non-public, unknown, internal, or sealed conversation context remains review-only.")
+            _add_unique(summary["reviewOnlyEvidence"], safe_summary)
+            _add_unique(summary["notPublicYet"], "Conversation context from unknown/internal/sealed lanes is not public-safe evidence.")
+            _add_unique(summary["observedChannels"], f"review-only channel — {policy}; subject {relation}.")
+            _add_unique(summary["channelActivity"], f"Seen in review-only structured conversation evidence as {relation} context.")
+            _add_unique(summary["conversationHighlights"], safe_summary)
+        elif kind == "relationship_context_review_only":
+            _add_unique(summary["relationshipSignals"], safe_summary)
+            _add_unique(summary["privateOnlyNotes"], "Relationship/context notes are private/internal and require owner review before any public wording.")
+            _add_unique(summary["reviewOnlyEvidence"], safe_summary)
+        elif kind == "source_blind_memory_review_only":
+            _add_unique(summary["privateOnlyNotes"], SOURCE_BLIND_REVIEW_NOTE)
+            _add_unique(summary["reviewOnlyEvidence"], safe_summary)
+            _add_unique(summary["notPublicYet"], "Source-blind memory cannot be used as a public fact without review.")
+        elif kind == "broadcast_memory_signal":
+            if public_candidate:
+                _add_unique(summary["publicSafePossibilities"], "Broadcast-memory context may support public wording after owner review.")
+                _add_unique(summary["publicUseCandidates"], "Active public-safe broadcast memory may support public wording after owner review.")
+                _add_unique(summary["observedChannels"], "broadcast memory — active/public-safe; owner review still required.")
+            else:
+                _add_unique(summary["privateOnlyNotes"], "Broadcast-memory context is not public-safe unless active and marked public-safe.")
+                _add_unique(summary["reviewOnlyEvidence"], safe_summary)
+        elif kind == "community_presence_signal":
+            _add_unique(summary["communitySignals"], safe_summary)
+            _add_unique(summary["publicUseCandidates"], "Community presence can inform a possible public role only after owner review confirms identity and wording.")
+            _add_unique(summary["publicSafePossibilities"], "Community presence may support public-safe wording after owner review; it is not a confirmed public fact by itself.")
+        elif review_only:
+            _add_unique(summary["reviewOnlyEvidence"], safe_summary)
+            _add_unique(summary["privateOnlyNotes"], safe_summary)
+
+        if data.get("music_signal"):
+            _add_unique(summary["musicSignals"], "Structured evidence connects this subject to music/radio/show context; queue identity still needs review.")
+        if data.get("community_signal"):
+            _add_unique(summary["communitySignals"], "Structured evidence places this subject in BARCODE/community context; owner review must confirm public wording.")
+        if data.get("bnl_interaction"):
+            _add_unique(summary["bnlInteractionSignals"], f"Structured evidence shows BNL-related interaction context; subject was {relation}.")
+
+
+def _structured_evidence_rows(conn: sqlite3.Connection, subject: str, guild_id: int | None, lanes: set[str], max_rows: int) -> list[sqlite3.Row]:
+    if "entity_evidence_events" not in lanes or not _evidence_table_exists(conn, ENTITY_EVIDENCE_TABLE):
+        return []
+    return get_entity_evidence_for_subject(conn, subject, guild_id=guild_id, limit=max_rows)
+
 def build_entity_activity_summary(
     db_path: str,
     subject_name: str,
@@ -291,6 +413,27 @@ def build_entity_activity_summary(
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     try:
+        structured_rows = _structured_evidence_rows(conn, subject, guild_id, lanes, max_rows)
+        if structured_rows:
+            _apply_structured_evidence(summary, structured_rows, topic_counts)
+            matched_user_ids.update(row["matched_user_id"] for row in structured_rows if "matched_user_id" in row.keys() and row["matched_user_id"] not in (None, ""))
+            for row in structured_rows:
+                if row["evidence_kind"] == "profile_match":
+                    clean_name = normalize_subject_name(row["subject_name"] or subject)
+                    _add_unique(summary["matchedNames"], clean_name)
+                    aliases.append(clean_name)
+            lanes = set(lanes) - {
+                "user_profiles",
+                "user_memory_facts",
+                "user_habits",
+                "relationship_state",
+                "relationship_journal",
+                "memory_tiers",
+                "conversations",
+                "broadcast_memory",
+                "community_presence",
+            }
+
         if "user_profiles" in lanes:
             for row in _fetch_rows(conn, "user_profiles", guild_id, max_rows):
                 data = dict(row)

--- a/bnl_entity_evidence.py
+++ b/bnl_entity_evidence.py
@@ -1,0 +1,553 @@
+"""Structured entity/source evidence events for BNL internal source workflows.
+
+This is a conservative evidence layer over existing local memory/source stores. It
+stores short review-safe summaries and provenance pointers; it does not create
+canonical profiles, website dossiers, Source Files, queue links, or public output.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Any
+
+from bnl_dossier_source_packets import normalize_subject_name, subject_key
+
+ENTITY_EVIDENCE_TABLE = "entity_evidence_events"
+PUBLIC_CONVERSATION_POLICIES = {"public_home", "public_context", "public_selective", "broadcast_memory"}
+QUEUE_NOT_CONNECTED_NOTE = "Queue/submission identity is not connected yet."
+MAX_SAFE_SUMMARY_LENGTH = 220
+MAX_REF_SNIPPET_LENGTH = 160
+
+ALLOWED_EVIDENCE_KINDS = {
+    "profile_match",
+    "authored_public_conversation",
+    "mentioned_public_conversation",
+    "authored_review_only_conversation",
+    "mentioned_review_only_conversation",
+    "music_or_show_signal",
+    "community_signal",
+    "bnl_interaction",
+    "relationship_context_review_only",
+    "source_blind_memory_review_only",
+    "broadcast_memory_signal",
+    "r_and_d_context_review_only",
+    "community_presence_signal",
+}
+
+_DISCORD_MENTION_PATTERN = re.compile(r"<[@#!&]?[0-9]{5,}>")
+_LONG_ID_PATTERN = re.compile(r"\b\d{15,22}\b")
+_URL_PATTERN = re.compile(r"https?://\S+", re.I)
+_WORD_PATTERN = re.compile(r"[a-z0-9]+")
+_MUSIC_PATTERN = re.compile(r"\b(artist|track|song|playlist|radio|show|performance|beat|demo|finished tracks?|wips?|collab(?:oration)?s?|music)\b", re.I)
+_COMMUNITY_PATTERN = re.compile(r"\b(community|server|barcode|member|public|conversation|channel|chat|finished tracks?|wips?)\b", re.I)
+_BNL_PATTERN = re.compile(r"\b(bnl|bot|source files?|dossiers?|owner review|public-safe|asked|question|help|review)\b", re.I)
+_TOPIC_PATTERNS = [
+    ("music/community context", _MUSIC_PATTERN),
+    ("source-file/dossier planning context", re.compile(r"\b(source files?|dossiers?|draft|candidate|owner review|public copy|public-safe)\b", re.I)),
+    ("community/event context", _COMMUNITY_PATTERN),
+    ("help/support requests", re.compile(r"\b(help|support|assist|fix|issue|question|request|need)\b", re.I)),
+]
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def safe_text(value: Any, max_length: int = MAX_REF_SNIPPET_LENGTH) -> str:
+    cleaned = _URL_PATTERN.sub("[redacted-url]", str(value or ""))
+    cleaned = _DISCORD_MENTION_PATTERN.sub("[redacted-mention]", cleaned)
+    cleaned = _LONG_ID_PATTERN.sub("[redacted-id]", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    if len(cleaned) <= max_length:
+        return cleaned
+    return cleaned[: max(0, max_length - 1)].rstrip() + "…"
+
+
+def compact_subject_text(value: str) -> str:
+    return "".join(_WORD_PATTERN.findall((value or "").lower()))
+
+
+def contains_subject_mention(text: str, subject: str, aliases: list[str] | None = None) -> bool:
+    candidates = [subject] + [alias for alias in (aliases or []) if alias]
+    haystack = text or ""
+    compact_haystack = compact_subject_text(haystack)
+    for candidate in candidates:
+        name = normalize_subject_name(candidate)
+        if not name:
+            continue
+        if re.search(rf"(?<![A-Za-z0-9]){re.escape(name)}(?![A-Za-z0-9])", haystack, flags=re.I):
+            return True
+        compact = compact_subject_text(name)
+        if compact and len(compact) >= 3 and compact in compact_haystack:
+            return True
+    return False
+
+
+def table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)).fetchone() is not None
+
+
+def columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    if not table_exists(conn, table):
+        return set()
+    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def ensure_entity_evidence_schema(conn: sqlite3.Connection) -> None:
+    """Create the v1 structured entity/source evidence table and indexes."""
+
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {ENTITY_EVIDENCE_TABLE} (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            guild_id INTEGER,
+            subject_key TEXT NOT NULL,
+            subject_name TEXT NOT NULL,
+            matched_user_id INTEGER,
+            source_type TEXT NOT NULL,
+            source_table TEXT NOT NULL,
+            source_row_id TEXT,
+            source_label TEXT NOT NULL,
+            channel_name TEXT,
+            channel_policy TEXT,
+            visibility TEXT NOT NULL,
+            authority TEXT NOT NULL,
+            confidence REAL NOT NULL DEFAULT 0.5,
+            relation_to_subject TEXT NOT NULL DEFAULT 'mentioned',
+            topic TEXT,
+            evidence_kind TEXT NOT NULL,
+            safe_summary TEXT NOT NULL,
+            public_safe_candidate INTEGER NOT NULL DEFAULT 0,
+            review_only INTEGER NOT NULL DEFAULT 1,
+            music_signal INTEGER NOT NULL DEFAULT 0,
+            community_signal INTEGER NOT NULL DEFAULT 0,
+            bnl_interaction INTEGER NOT NULL DEFAULT 0,
+            dossier_relevance TEXT,
+            raw_ref_json TEXT,
+            created_at TEXT NOT NULL,
+            observed_at TEXT,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_entity_evidence_unique_source
+        ON {ENTITY_EVIDENCE_TABLE} (
+            guild_id,
+            subject_key,
+            source_type,
+            source_table,
+            coalesce(source_row_id, ''),
+            evidence_kind,
+            relation_to_subject
+        )
+        """
+    )
+    conn.execute(f"CREATE INDEX IF NOT EXISTS idx_entity_evidence_subject ON {ENTITY_EVIDENCE_TABLE} (guild_id, subject_key, updated_at)")
+    conn.execute(f"CREATE INDEX IF NOT EXISTS idx_entity_evidence_kind ON {ENTITY_EVIDENCE_TABLE} (evidence_kind, review_only, public_safe_candidate)")
+
+
+def _coerce_bool(value: Any) -> int:
+    return 1 if bool(value) else 0
+
+
+def _clean_safe_summary(summary: str) -> str:
+    cleaned = safe_text(summary, MAX_SAFE_SUMMARY_LENGTH)
+    # Evidence summaries are labels, not transcript excerpts; remove accidental IDs.
+    return cleaned or "Structured entity evidence exists for owner review."
+
+
+def _raw_ref_json(raw_ref: dict[str, Any] | None) -> str:
+    safe_ref: dict[str, Any] = {}
+    for key, value in (raw_ref or {}).items():
+        if value is None:
+            continue
+        if key in {"snippet", "content", "summary", "raw_excerpt", "channel_name", "source_label"}:
+            safe_ref[key] = safe_text(value)
+        else:
+            safe_ref[key] = value
+    return json.dumps(safe_ref, sort_keys=True)
+
+
+def upsert_entity_evidence_event(conn: sqlite3.Connection, **event: Any) -> str:
+    """Insert/update one evidence event. Returns created, updated, or unchanged."""
+
+    ensure_entity_evidence_schema(conn)
+    subject = normalize_subject_name(event.get("subject_name") or event.get("subjectName") or "")
+    key = event.get("subject_key") or subject_key(subject)
+    evidence_kind = str(event.get("evidence_kind") or "").strip()
+    if evidence_kind not in ALLOWED_EVIDENCE_KINDS:
+        raise ValueError(f"Unsupported entity evidence kind: {evidence_kind}")
+    source_type = str(event.get("source_type") or event.get("source_table") or "unknown")[:80]
+    source_table = str(event.get("source_table") or source_type)[:80]
+    source_row_id = None if event.get("source_row_id") in (None, "") else str(event.get("source_row_id"))[:80]
+    relation = str(event.get("relation_to_subject") or "mentioned")[:80]
+    guild_id = event.get("guild_id")
+    now = now_iso()
+    values = {
+        "guild_id": guild_id,
+        "subject_key": key,
+        "subject_name": subject,
+        "matched_user_id": event.get("matched_user_id"),
+        "source_type": source_type,
+        "source_table": source_table,
+        "source_row_id": source_row_id,
+        "source_label": str(event.get("source_label") or f"{source_table}/structured_evidence")[:120],
+        "channel_name": event.get("channel_name") if event.get("channel_name") else None,
+        "channel_policy": str(event.get("channel_policy") or "unknown")[:80],
+        "visibility": str(event.get("visibility") or "review_only")[:80],
+        "authority": str(event.get("authority") or "local_observed")[:80],
+        "confidence": float(event.get("confidence") if event.get("confidence") is not None else 0.5),
+        "relation_to_subject": relation,
+        "topic": safe_text(event.get("topic") or "", 120) or None,
+        "evidence_kind": evidence_kind,
+        "safe_summary": _clean_safe_summary(str(event.get("safe_summary") or "")),
+        "public_safe_candidate": _coerce_bool(event.get("public_safe_candidate")),
+        "review_only": _coerce_bool(event.get("review_only", True)),
+        "music_signal": _coerce_bool(event.get("music_signal")),
+        "community_signal": _coerce_bool(event.get("community_signal")),
+        "bnl_interaction": _coerce_bool(event.get("bnl_interaction")),
+        "dossier_relevance": safe_text(event.get("dossier_relevance") or "", 120) or None,
+        "raw_ref_json": _raw_ref_json(event.get("raw_ref_json") or {}),
+        "observed_at": str(event.get("observed_at") or now)[:80],
+        "updated_at": now,
+    }
+    existing = conn.execute(
+        f"""
+        SELECT * FROM {ENTITY_EVIDENCE_TABLE}
+        WHERE (guild_id IS ? OR guild_id=?) AND subject_key=? AND source_type=? AND source_table=?
+          AND coalesce(source_row_id, '')=coalesce(?, '') AND evidence_kind=? AND relation_to_subject=?
+        LIMIT 1
+        """,
+        (guild_id, guild_id, key, source_type, source_table, source_row_id, evidence_kind, relation),
+    ).fetchone()
+    if existing is None:
+        insert_values = dict(values)
+        insert_values["created_at"] = now
+        columns_sql = ", ".join(insert_values.keys())
+        placeholders = ", ".join(["?"] * len(insert_values))
+        conn.execute(f"INSERT INTO {ENTITY_EVIDENCE_TABLE} ({columns_sql}) VALUES ({placeholders})", list(insert_values.values()))
+        return "created"
+    current = dict(existing) if isinstance(existing, sqlite3.Row) else {desc[0]: existing[idx] for idx, desc in enumerate(conn.execute(f"SELECT * FROM {ENTITY_EVIDENCE_TABLE} LIMIT 0").description or [])}
+    comparable = {k: v for k, v in values.items() if k != "updated_at"}
+    if all(str(current.get(k) or "") == str(v or "") for k, v in comparable.items()):
+        return "unchanged"
+    assignments = ", ".join(f"{k}=?" for k in values.keys())
+    conn.execute(f"UPDATE {ENTITY_EVIDENCE_TABLE} SET {assignments} WHERE id=?", [*values.values(), current["id"]])
+    return "updated"
+
+
+def _fetch_rows(conn: sqlite3.Connection, table: str, guild_id: int | None, limit: int) -> list[sqlite3.Row]:
+    cols = columns(conn, table)
+    if not cols:
+        return []
+    where = ""
+    params: list[Any] = []
+    if guild_id is not None and "guild_id" in cols:
+        where = " WHERE guild_id=?"
+        params.append(guild_id)
+    order = ""
+    for candidate in ("updated_at", "timestamp", "last_seen_at", "created_at", "id"):
+        if candidate in cols:
+            order = f" ORDER BY {candidate} DESC"
+            break
+    return list(conn.execute(f"SELECT * FROM {table}{where}{order} LIMIT ?", [*params, max(1, limit)]))
+
+
+def _row_text(row: sqlite3.Row, fields: list[str]) -> str:
+    data = dict(row)
+    return " ".join(str(data.get(field) or "") for field in fields if field in data)
+
+
+def _topic(text: str) -> str:
+    labels = [label for label, pattern in _TOPIC_PATTERNS if pattern.search(text or "")]
+    return labels[0] if labels else "local context"
+
+
+def _source_row_id(data: dict[str, Any]) -> str | None:
+    value = data.get("id")
+    return None if value in (None, "") else str(value)
+
+
+def derive_entity_evidence_from_conversation_row(
+    conn: sqlite3.Connection,
+    row: sqlite3.Row,
+    subject_name: str,
+    *,
+    guild_id: int | None = None,
+    matched_user_ids: set[Any] | None = None,
+    aliases: list[str] | None = None,
+) -> str | None:
+    """Derive one conservative conversation evidence event for a matched row."""
+
+    data = dict(row)
+    subject = normalize_subject_name(subject_name)
+    text = _row_text(row, ["content"])
+    haystack = _row_text(row, ["user_name", "content", "channel_name", "channel_policy"])
+    authored = data.get("user_id") in (matched_user_ids or set()) or contains_subject_mention(str(data.get("user_name") or ""), subject, aliases)
+    if not authored and not contains_subject_mention(haystack, subject, aliases):
+        return None
+    policy = str(data.get("channel_policy") or "unknown").strip().lower() or "unknown"
+    public = policy in PUBLIC_CONVERSATION_POLICIES
+    relation = "authored" if authored else "mentioned"
+    kind = f"{relation}_{'public' if public else 'review_only'}_conversation"
+    if public:
+        safe_summary = f"Subject {relation} approved public-side conversation about {_topic(text)}."
+        channel_name = safe_text(data.get("channel_name") or "", 80) or None
+    else:
+        safe_summary = f"Subject {relation} review-only conversation context; private/internal channel details require owner review."
+        channel_name = None
+    return upsert_entity_evidence_event(
+        conn,
+        guild_id=guild_id if guild_id is not None else data.get("guild_id"),
+        subject_name=subject,
+        matched_user_id=data.get("user_id") if authored else None,
+        source_type="conversation",
+        source_table="conversations",
+        source_row_id=_source_row_id(data),
+        source_label="conversations/public_discord_observed" if public else "conversations/internal_context_review_only",
+        channel_name=channel_name,
+        channel_policy=policy,
+        visibility="public_side" if public else "review_only",
+        authority="channel_policy_observed" if public else "internal_review_only",
+        confidence=0.72 if public else 0.5,
+        relation_to_subject=relation,
+        topic=_topic(text),
+        evidence_kind=kind,
+        safe_summary=safe_summary,
+        public_safe_candidate=public,
+        review_only=not public,
+        music_signal=bool(_MUSIC_PATTERN.search(text)),
+        community_signal=bool(_COMMUNITY_PATTERN.search(text)),
+        bnl_interaction=bool(_BNL_PATTERN.search(text)),
+        dossier_relevance="candidate_after_owner_review" if public else "review_only_context",
+        raw_ref_json={"table": "conversations", "row_id": data.get("id"), "channel_policy": policy, "channel_name": data.get("channel_name"), "snippet": text},
+        observed_at=data.get("timestamp"),
+    )
+
+
+def derive_entity_evidence_for_subject(db_path: str, subject_name: str, guild_id: int | None = None, limit: int = 200) -> dict[str, Any]:
+    """Derive/update evidence events for one subject from existing local stores only."""
+
+    subject = normalize_subject_name(subject_name)
+    key = subject_key(subject)
+    result = {"subjectName": subject, "subjectKey": key, "createdCount": 0, "updatedCount": 0, "unchangedCount": 0, "sourceTypes": Counter(), "reviewOnlyCount": 0, "publicSafeCandidateCount": 0, "status": "ok"}
+    if not subject:
+        result["status"] = "missing_subject"
+        result["sourceTypes"] = {}
+        return result
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        ensure_entity_evidence_schema(conn)
+        matched_user_ids: set[Any] = set()
+        aliases: list[str] = []
+
+        def note(status: str | None, source_type: str, review_only: bool, public_candidate: bool) -> None:
+            if not status:
+                return
+            result[f"{status}Count"] += 1
+            result["sourceTypes"][source_type] += 1
+            if review_only:
+                result["reviewOnlyCount"] += 1
+            if public_candidate:
+                result["publicSafeCandidateCount"] += 1
+
+        for row in _fetch_rows(conn, "user_profiles", guild_id, limit):
+            data = dict(row)
+            names = [data.get("display_name"), data.get("preferred_name")]
+            if not any(contains_subject_mention(str(name or ""), subject) or contains_subject_mention(subject, str(name or "")) for name in names if name):
+                continue
+            for name in names:
+                clean = normalize_subject_name(str(name or ""))
+                if clean:
+                    aliases.append(clean)
+            matched_user_ids.add(data.get("user_id"))
+            status = upsert_entity_evidence_event(
+                conn,
+                guild_id=data.get("guild_id", guild_id),
+                subject_name=subject,
+                matched_user_id=data.get("user_id"),
+                source_type="profile",
+                source_table="user_profiles",
+                source_row_id=str(data.get("user_id") or ""),
+                source_label="user_profiles/local_profile_observed",
+                channel_policy="none",
+                visibility="internal_identity_match",
+                authority="local_profile_label",
+                confidence=0.8,
+                relation_to_subject="profile_match",
+                topic="identity matching context",
+                evidence_kind="profile_match",
+                safe_summary="Local profile label matches this subject for internal identity review.",
+                public_safe_candidate=False,
+                review_only=True,
+                dossier_relevance="identity_match_review",
+                raw_ref_json={"table": "user_profiles", "user_id": data.get("user_id"), "display_name": data.get("display_name"), "preferred_name": data.get("preferred_name")},
+                observed_at=data.get("last_seen") or data.get("last_greeting_at"),
+            )
+            note(status, "profile", True, False)
+
+        aliases = list(dict.fromkeys([a for a in aliases if a and a.lower() != subject.lower()]))
+
+        def row_matches(row: sqlite3.Row, fields: list[str]) -> bool:
+            data = dict(row)
+            if data.get("user_id") in matched_user_ids:
+                return True
+            return contains_subject_mention(_row_text(row, fields), subject, aliases=aliases)
+
+        for row in _fetch_rows(conn, "conversations", guild_id, limit):
+            if not row_matches(row, ["user_name", "content", "channel_name", "channel_policy"]):
+                continue
+            data = dict(row)
+            status = derive_entity_evidence_from_conversation_row(conn, row, subject, guild_id=guild_id, matched_user_ids=matched_user_ids, aliases=aliases)
+            policy = str(data.get("channel_policy") or "unknown").strip().lower() or "unknown"
+            note(status, "conversation", policy not in PUBLIC_CONVERSATION_POLICIES, policy in PUBLIC_CONVERSATION_POLICIES)
+
+        for table in ("relationship_state", "relationship_journal"):
+            for row in _fetch_rows(conn, table, guild_id, limit):
+                if not row_matches(row, ["last_topic", "trust_stage", "social_stance", "summary", "entry_type"]):
+                    continue
+                data = dict(row)
+                text = _row_text(row, ["last_topic", "summary", "entry_type"])
+                status = upsert_entity_evidence_event(
+                    conn,
+                    guild_id=data.get("guild_id", guild_id),
+                    subject_name=subject,
+                    matched_user_id=data.get("user_id"),
+                    source_type="relationship_context",
+                    source_table=table,
+                    source_row_id=_source_row_id(data) or str(data.get("user_id") or ""),
+                    source_label=f"{table}/local_relationship_trace",
+                    channel_policy="source_blind_private",
+                    visibility="review_only",
+                    authority="private_relationship_context",
+                    confidence=0.45,
+                    relation_to_subject="relationship_context",
+                    topic=_topic(text),
+                    evidence_kind="relationship_context_review_only",
+                    safe_summary="Relationship/context notes exist but are private review-only.",
+                    public_safe_candidate=False,
+                    review_only=True,
+                    dossier_relevance="review_only_context",
+                    raw_ref_json={"table": table, "row_id": data.get("id"), "user_id": data.get("user_id"), "snippet": text},
+                    observed_at=data.get("updated_at") or data.get("timestamp"),
+                )
+                note(status, "relationship_context", True, False)
+
+        for row in _fetch_rows(conn, "memory_tiers", guild_id, limit):
+            if not row_matches(row, ["summary", "tier"]):
+                continue
+            data = dict(row)
+            text = _row_text(row, ["summary", "tier"])
+            status = upsert_entity_evidence_event(
+                conn,
+                guild_id=data.get("guild_id", guild_id),
+                subject_name=subject,
+                matched_user_id=data.get("user_id"),
+                source_type="source_blind_memory",
+                source_table="memory_tiers",
+                source_row_id=_source_row_id(data),
+                source_label="memory_tiers/source_blind_memory_trace",
+                channel_policy=str(data.get("source_channel_policy") or "source_blind"),
+                visibility="review_only",
+                authority="source_blind_legacy_memory",
+                confidence=0.35,
+                relation_to_subject="source_blind_memory",
+                topic=_topic(text),
+                evidence_kind="source_blind_memory_review_only",
+                safe_summary="Source-blind legacy memory exists and requires review.",
+                public_safe_candidate=False,
+                review_only=True,
+                music_signal=bool(_MUSIC_PATTERN.search(text)),
+                community_signal=bool(_COMMUNITY_PATTERN.search(text)),
+                dossier_relevance="requires_source_review",
+                raw_ref_json={"table": "memory_tiers", "row_id": data.get("id"), "snippet": text},
+                observed_at=data.get("updated_at"),
+            )
+            note(status, "source_blind_memory", True, False)
+
+        for row in _fetch_rows(conn, "broadcast_memory", guild_id, limit):
+            if not row_matches(row, ["cleaned_summary", "summary", "raw_note", "entry_type"]):
+                continue
+            data = dict(row)
+            text = _row_text(row, ["cleaned_summary", "summary", "raw_note", "entry_type"])
+            public_candidate = bool(data.get("public_safe")) and str(data.get("status") or "active") == "active"
+            status = upsert_entity_evidence_event(
+                conn,
+                guild_id=data.get("guild_id", guild_id),
+                subject_name=subject,
+                source_type="broadcast_memory",
+                source_table="broadcast_memory",
+                source_row_id=_source_row_id(data),
+                source_label="broadcast_memory/broadcast_memory_trace",
+                channel_policy="broadcast_memory",
+                visibility="public_safe_candidate" if public_candidate else "review_only",
+                authority="broadcast_memory_public_safe" if public_candidate else "broadcast_memory_review_only",
+                confidence=0.68 if public_candidate else 0.45,
+                relation_to_subject="broadcast_memory_context",
+                topic=_topic(text),
+                evidence_kind="broadcast_memory_signal",
+                safe_summary="Broadcast-memory context may support public wording after owner review." if public_candidate else "Broadcast-memory context exists but is review-only unless active and public-safe.",
+                public_safe_candidate=public_candidate,
+                review_only=not public_candidate,
+                music_signal=bool(_MUSIC_PATTERN.search(text)),
+                community_signal=True,
+                dossier_relevance="candidate_after_owner_review" if public_candidate else "review_only_context",
+                raw_ref_json={"table": "broadcast_memory", "row_id": data.get("id"), "status": data.get("status"), "public_safe": data.get("public_safe"), "snippet": text},
+                observed_at=data.get("episode_date"),
+            )
+            note(status, "broadcast_memory", not public_candidate, public_candidate)
+
+        for row in _fetch_rows(conn, "community_presence", guild_id, limit):
+            if not row_matches(row, ["subject_key", "display_name", "connection_notes", "evidence_snippets"]):
+                continue
+            data = dict(row)
+            text = _row_text(row, ["display_name", "connection_notes", "evidence_snippets"])
+            status = upsert_entity_evidence_event(
+                conn,
+                guild_id=data.get("guild_id", guild_id),
+                subject_name=subject,
+                source_type="community_presence",
+                source_table="community_presence",
+                source_row_id=str(data.get("subject_key") or key),
+                source_label="community_presence/community_presence_trace",
+                channel_policy="community_presence_approved_sources",
+                visibility="review_only",
+                authority="community_presence_trace",
+                confidence=0.62,
+                relation_to_subject="community_presence",
+                topic=_topic(text),
+                evidence_kind="community_presence_signal",
+                safe_summary="Community presence record exists and can inform public wording only after owner review.",
+                public_safe_candidate=False,
+                review_only=True,
+                community_signal=True,
+                dossier_relevance="candidate_after_owner_review",
+                raw_ref_json={"table": "community_presence", "subject_key": data.get("subject_key"), "mention_count": data.get("mention_count"), "direct_interaction_count": data.get("direct_interaction_count"), "snippet": text},
+                observed_at=data.get("last_seen_at"),
+            )
+            note(status, "community_presence", True, False)
+
+        conn.commit()
+    finally:
+        conn.close()
+    result["sourceTypes"] = dict(result["sourceTypes"])
+    return result
+
+
+def get_entity_evidence_for_subject(conn: sqlite3.Connection, subject_name: str, guild_id: int | None = None, limit: int = 200) -> list[sqlite3.Row]:
+    if not table_exists(conn, ENTITY_EVIDENCE_TABLE):
+        return []
+    key = subject_key(normalize_subject_name(subject_name))
+    where = "subject_key=?"
+    params: list[Any] = [key]
+    if guild_id is not None:
+        where += " AND guild_id=?"
+        params.append(guild_id)
+    return list(conn.execute(f"SELECT * FROM {ENTITY_EVIDENCE_TABLE} WHERE {where} ORDER BY updated_at DESC, id DESC LIMIT ?", [*params, max(1, limit)]))

--- a/tests/test_entity_activity_summary.py
+++ b/tests/test_entity_activity_summary.py
@@ -11,6 +11,7 @@ os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
 
 import bnl_entity_activity_summary as entity
+import bnl_entity_evidence as evidence
 import bnl01_bot
 
 
@@ -36,10 +37,82 @@ class EntityActivitySummaryBuilderTests(unittest.TestCase):
         c.execute("CREATE TABLE conversations (id INTEGER PRIMARY KEY, user_id INTEGER, user_name TEXT, guild_id INTEGER, channel_name TEXT, channel_policy TEXT, role TEXT, content TEXT, timestamp TEXT)")
         c.execute("CREATE TABLE memory_tiers (id INTEGER PRIMARY KEY, user_id INTEGER, guild_id INTEGER, tier TEXT, summary TEXT, salience REAL, mentions INTEGER, updated_at TEXT)")
         c.execute("CREATE TABLE broadcast_memory (id INTEGER PRIMARY KEY, guild_id INTEGER, episode_date TEXT, cleaned_summary TEXT, entry_type TEXT, public_safe INTEGER, usage_scope TEXT, status TEXT)")
+        c.execute("CREATE TABLE community_presence (guild_id INTEGER, subject_key TEXT, display_name TEXT, first_seen_at TEXT, last_seen_at TEXT, mention_count INTEGER, direct_interaction_count INTEGER, operator_mention_count INTEGER, connection_notes TEXT, evidence_snippets TEXT)")
         self.conn.commit()
 
     def _summary(self, subject="Crow"):
         return entity.build_entity_activity_summary(self.db, subject, guild_id=1)
+
+
+    def test_entity_evidence_schema_created_safely(self):
+        evidence.ensure_entity_evidence_schema(self.conn)
+        cols = {row[1] for row in self.conn.execute("PRAGMA table_info(entity_evidence_events)")}
+
+        self.assertIn("safe_summary", cols)
+        self.assertIn("raw_ref_json", cols)
+        self.assertIn("public_safe_candidate", cols)
+
+    def test_derives_structured_evidence_from_existing_sources_idempotently(self):
+        c = self.conn.cursor()
+        c.execute("INSERT INTO user_profiles VALUES (42,1,'Crow','Crow',NULL,NULL)")
+        c.execute("INSERT INTO conversations VALUES (1,42,'Crow',1,'finished-tracks','public_home','user','Can BNL explain dossier source-file behavior for my new track and radio show context?','2026-06-01')")
+        c.execute("INSERT INTO conversations VALUES (2,7,'Other',1,'barcode-bot','public_context','user','Crow was mentioned as a possible source-file candidate in community discussion.','2026-06-02')")
+        c.execute("INSERT INTO conversations VALUES (3,7,'Other',1,'research-and-development','internal_controlled','user','Crow appears in internal private notes with 123456789012345678.','2026-06-03')")
+        c.execute("INSERT INTO relationship_state VALUES (42,1,8,0.4,'known','steady','Crow discussed music support requests','now')")
+        c.execute("INSERT INTO relationship_journal VALUES (4,42,1,'note','Crow has review-only relationship context around help requests.','now')")
+        c.execute("INSERT INTO memory_tiers VALUES (5,42,1,'long','Crow source blind memory trace with EDGE_SESSION help_signal text.',0.9,1,'now')")
+        c.execute("INSERT INTO broadcast_memory VALUES (6,1,'2026-06-01','Crow appears in a public-safe broadcast music context.','show_note',1,'public','active')")
+        c.execute("INSERT INTO broadcast_memory VALUES (7,1,'2026-06-02','Crow appears in inactive broadcast context.','show_note',0,'internal','draft')")
+        c.execute("INSERT INTO community_presence VALUES (1,'crow','Crow','now','now',3,1,0,'Crow has community presence notes.','Crow appeared in approved public chat.')")
+        self.conn.commit()
+
+        first = evidence.derive_entity_evidence_for_subject(self.db, "Crow", guild_id=1)
+        second = evidence.derive_entity_evidence_for_subject(self.db, "Crow", guild_id=1)
+        rows = list(self.conn.execute("SELECT * FROM entity_evidence_events ORDER BY evidence_kind, source_row_id"))
+        kinds = {row[16] for row in rows}
+
+        self.assertGreaterEqual(first["createdCount"], 9)
+        self.assertEqual(second["createdCount"], 0)
+        self.assertIn("profile_match", kinds)
+        self.assertIn("authored_public_conversation", kinds)
+        self.assertIn("mentioned_public_conversation", kinds)
+        self.assertIn("mentioned_review_only_conversation", kinds)
+        self.assertIn("relationship_context_review_only", kinds)
+        self.assertIn("source_blind_memory_review_only", kinds)
+        self.assertIn("broadcast_memory_signal", kinds)
+        self.assertIn("community_presence_signal", kinds)
+        self.assertTrue(any(row[18] == 1 for row in rows))
+        self.assertTrue(any(row[19] == 1 for row in rows))
+        normal_safe_text = " ".join(row[17] or "" for row in rows)
+        self.assertNotIn("research-and-development", normal_safe_text)
+        self.assertNotIn("123456789012345678", normal_safe_text)
+        raw_refs = [row[0] or "" for row in self.conn.execute("SELECT raw_ref_json FROM entity_evidence_events")]
+        self.assertTrue(any("research-and-development" in raw_ref for raw_ref in raw_refs))
+
+    def test_entity_activity_summary_prefers_structured_evidence_events(self):
+        evidence.ensure_entity_evidence_schema(self.conn)
+        evidence.upsert_entity_evidence_event(
+            self.conn, guild_id=1, subject_name="Crow", source_type="conversation", source_table="conversations",
+            source_row_id="99", source_label="conversations/public_discord_observed", channel_name="finished-tracks",
+            channel_policy="public_home", visibility="public_side", authority="channel_policy_observed", confidence=0.7,
+            relation_to_subject="authored", topic="source-file/dossier planning context", evidence_kind="authored_public_conversation",
+            safe_summary="Subject authored approved public-side conversation about dossier/source-file behavior.",
+            public_safe_candidate=True, review_only=False, music_signal=True, community_signal=True, bnl_interaction=True,
+            dossier_relevance="candidate_after_owner_review", raw_ref_json={"table": "conversations", "row_id": 99, "content": "raw private-ish transcript 123456789012345678"},
+            observed_at="now",
+        )
+        self.conn.execute("INSERT INTO conversations VALUES (100,7,'Other',1,'general','public_home','user','Crow loose fallback text should not appear when structured evidence exists.','now')")
+        self.conn.commit()
+
+        summary = self._summary()
+        normal = dict(summary)
+        normal.pop("rawProvenance")
+
+        self.assertTrue(any("approved public-side conversation" in item for item in summary["conversationHighlights"]))
+        self.assertNotIn("loose fallback", json.dumps(normal))
+        self.assertIn("conversations/public_discord_observed", summary["rawProvenance"]["sourceLabels"])
+        self.assertTrue(any(fragment.get("rawRefJson") for fragment in summary["rawProvenance"]["rawFragments"]))
+        self.assertIn(entity.QUEUE_NOT_CONNECTED_NOTE, summary["notPublicYet"])
 
     def test_entity_summary_finds_local_profile_match(self):
         self.conn.execute("INSERT INTO user_profiles VALUES (42,1,'Crow','Crow',NULL,NULL)")
@@ -203,6 +276,10 @@ class EntityActivitySummaryCommandTests(unittest.TestCase):
         self.assertFalse(error)
         self.assertEqual(options["subjectName"], "Crow")
         self.assertTrue(entity.parse_entity_activity_summary_command("!bnl source summary Crow")[0])
+        matched, options, error = entity.parse_entity_activity_summary_command("!bnl entity evidence refresh Crow")
+        self.assertTrue(matched)
+        self.assertFalse(error)
+        self.assertTrue(options["refreshEvidence"])
 
     def test_command_is_owner_gated_and_uses_internal_channel_only(self):
         denied = FakeMessage("!bnl entity summary Crow", author_id=100, owner_id=99)
@@ -221,13 +298,37 @@ class EntityActivitySummaryCommandTests(unittest.TestCase):
         summary = entity.build_entity_activity_summary.__name__
         with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 99), \
              mock.patch.object(bnl01_bot, "build_entity_activity_summary", return_value={"subjectName": "Crow", "rawProvenance": {"rawFragments": []}, "missingInfo": []}) as builder, \
+             mock.patch.object(bnl01_bot, "refresh_entity_evidence_for_subject") as refresher, \
              mock.patch.object(bnl01_bot, "send_dossier_recommendation") as sender:
             handled = asyncio.run(bnl01_bot.maybe_handle_entity_activity_summary_command(allowed, allowed.content))
         self.assertTrue(handled)
         builder.assert_called_once()
         sender.assert_not_called()
+        refresher.assert_not_called()
         self.assertIn("BNL Entity Activity Summary", allowed.replies[0])
         self.assertEqual(summary, "build_entity_activity_summary")
+
+    def test_evidence_refresh_command_is_gated_internal_and_does_not_publish(self):
+        denied_public = FakeMessage("!bnl entity evidence refresh Crow", channel_name="general", author_id=99, owner_id=99)
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 99), \
+             mock.patch.object(bnl01_bot, "refresh_entity_evidence_for_subject") as refresher:
+            handled = asyncio.run(bnl01_bot.maybe_handle_entity_activity_summary_command(denied_public, denied_public.content))
+        self.assertTrue(handled)
+        self.assertIn("restricted", denied_public.replies[0])
+        refresher.assert_not_called()
+
+        allowed = FakeMessage("!bnl entity evidence refresh Crow", channel_name="research-and-development", author_id=99, owner_id=99)
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 99), \
+             mock.patch.object(bnl01_bot, "refresh_entity_evidence_for_subject", return_value={"subjectName": "Crow", "createdCount": 1, "updatedCount": 0, "unchangedCount": 0, "sourceTypes": {"profile": 1}, "reviewOnlyCount": 1, "publicSafeCandidateCount": 0}) as refresher, \
+             mock.patch.object(bnl01_bot, "build_entity_activity_summary", return_value={"subjectName": "Crow", "rawProvenance": {"rawFragments": []}, "missingInfo": [], "notPublicYet": [entity.QUEUE_NOT_CONNECTED_NOTE]}) as builder, \
+             mock.patch.object(bnl01_bot, "send_dossier_recommendation") as sender:
+            handled = asyncio.run(bnl01_bot.maybe_handle_entity_activity_summary_command(allowed, allowed.content))
+        self.assertTrue(handled)
+        refresher.assert_called_once()
+        builder.assert_called_once()
+        sender.assert_not_called()
+        self.assertIn("BNL Entity Evidence Refresh", allowed.replies[0])
+        self.assertIn("source types covered", allowed.replies[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Introduce a conservative, structured evidence layer to capture short, source-aware, review-safe evidence records so summaries and Source File packets can rely on organized provenance rather than re-inferring from loose legacy stores.
- Keep privacy, route, and channel-policy boundaries intact by marking internal/sealed/source-blind items as review-only and avoiding any automatic public publishing, website ingest, canonical profile creation, or queue/submission linkage.

### Description
- Add a new evidence table and helpers in `bnl_entity_evidence.py` implementing `ensure_entity_evidence_schema`, `upsert_entity_evidence_event`, `derive_entity_evidence_for_subject`, `derive_entity_evidence_from_conversation_row`, and `get_entity_evidence_for_subject`, with conservative `ALLOWED_EVIDENCE_KINDS`, safe `safe_summary` storage, and `raw_ref_json` for raw pointers.
- Integrate structured evidence into summaries by extending `bnl_entity_activity_summary.py` to prefer `entity_evidence_events` when present, via `_structured_evidence_rows`, `_apply_structured_evidence`, and a `refresh_entity_evidence_for_subject` wrapper.
- Add an operator-only refresh/readout path in `bnl01_bot.py` that calls `refresh_entity_evidence_for_subject` when `refresh=true` or via `!bnl entity evidence refresh <subject>`, restricted to internal operator channels and returning counts (created/updated/unchanged, source types, review-only/public-safe counts) without publishing or creating dossiers.
- Update tests in `tests/test_entity_activity_summary.py` to cover schema creation, idempotent derivation, public vs review-only handling, raw refs placement, structured-evidence preference, and gating of the evidence-refresh command.

### Testing
- Ran unit tests: `python -m unittest discover -s tests -v` and the full test suite passed (all tests succeeded) after changes.
- Verified syntax/compilation: `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py bnl_source_file_lookup.py bnl_source_file_enrichment.py bnl_source_knowledge_bridge.py bnl_entity_activity_summary.py bnl_community_scouting.py bnl_entity_evidence.py` succeeded with no errors.
- Ran repository checks: `git diff --check` returned no whitespace/format issues.

Notes: The change adds the structured internal evidence layer only and preserves existing stores and privacy boundaries; it does not add website ingest, publishing, canonical entity profiles, queue/payment links, artist account tables, or any ambient/autonomous scanning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2063c563e483218b3fc1f5f0a19304)