### PR TITLE
Entity evidence ranking + best-evidence review queue for summaries

### DIFF
--- a/bnl_entity_activity_summary.py
+++ b/bnl_entity_activity_summary.py
@@ -255,9 +255,42 @@ def refresh_entity_evidence_for_subject(db_path: str, subject_name: str, guild_i
     return derive_entity_evidence_for_subject(db_path, subject_name, guild_id=guild_id, limit=limit)
 
 
-def _apply_structured_evidence(summary: dict[str, Any], rows: list[sqlite3.Row], topic_counts: Counter) -> None:
-    """Populate summary fields from entity_evidence_events rows."""
+def _evidence_review_label(data: dict[str, Any], channel_display: str, safe_summary: str) -> str:
+    kind = str(data.get("evidence_kind") or "structured_evidence")
+    source_type = str(data.get("source_type") or "structured")
+    relation = str(data.get("relation_to_subject") or "mentioned")
+    topic = str(data.get("topic") or "local context")
+    public_candidate = bool(data.get("public_safe_candidate"))
+    channel_part = f" in {channel_display}" if public_candidate and channel_display and channel_display != "review-only channel" else ""
+    return _safe_snippet(f"{source_type}: {kind} ({relation}, {topic}){channel_part} — {safe_summary}", 220)
 
+
+def _append_best_evidence(summary: dict[str, Any], data: dict[str, Any], channel_display: str, safe_summary: str) -> None:
+    if len(summary.setdefault("bestEvidenceToReview", [])) >= 8:
+        return
+    # Raw refs/transcripts/IDs stay in rawProvenance; this queue uses only sanitized labels and summaries.
+    _add_unique(summary["bestEvidenceToReview"], _evidence_review_label(data, channel_display, safe_summary))
+
+
+def _cap_review_only_evidence(summary: dict[str, Any], source_blind_limit: int = 2, total_limit: int = 8) -> None:
+    capped: list[str] = []
+    source_blind_seen = 0
+    for item in summary.get("reviewOnlyEvidence") or []:
+        is_source_blind = "source-blind" in item.lower() or "source blind" in item.lower()
+        if is_source_blind:
+            source_blind_seen += 1
+            if source_blind_seen > source_blind_limit:
+                continue
+        _add_unique(capped, item)
+        if len(capped) >= total_limit:
+            break
+    summary["reviewOnlyEvidence"] = capped
+
+
+def _apply_structured_evidence(summary: dict[str, Any], rows: list[sqlite3.Row], topic_counts: Counter) -> None:
+    """Populate summary fields from ranked entity_evidence_events rows."""
+
+    source_blind_review_added = 0
     for row in rows:
         data = dict(row)
         source_table = str(data.get("source_table") or "entity_evidence_events")
@@ -286,6 +319,8 @@ def _apply_structured_evidence(summary: dict[str, Any], rows: list[sqlite3.Row],
         if topic:
             topic_counts[topic] += 1
         _add_unique(summary["evidenceDetails"], safe_summary)
+        if kind != "source_blind_memory_review_only":
+            _append_best_evidence(summary, data, channel_display, safe_summary)
 
         if kind == "profile_match":
             _add_unique(summary["matchedNames"], normalize_subject_name(data.get("subject_name") or summary.get("subjectName") or ""))
@@ -311,7 +346,9 @@ def _apply_structured_evidence(summary: dict[str, Any], rows: list[sqlite3.Row],
             _add_unique(summary["reviewOnlyEvidence"], safe_summary)
         elif kind == "source_blind_memory_review_only":
             _add_unique(summary["privateOnlyNotes"], SOURCE_BLIND_REVIEW_NOTE)
-            _add_unique(summary["reviewOnlyEvidence"], safe_summary)
+            if source_blind_review_added < 2:
+                _add_unique(summary["reviewOnlyEvidence"], safe_summary)
+                source_blind_review_added += 1
             _add_unique(summary["notPublicYet"], "Source-blind memory cannot be used as a public fact without review.")
         elif kind == "broadcast_memory_signal":
             if public_candidate:
@@ -375,6 +412,7 @@ def build_entity_activity_summary(
         "communitySignals": [],
         "sourceCoverage": [],
         "evidenceDetails": [],
+        "bestEvidenceToReview": [],
         "relationshipSignals": [],
         "publicSafePossibilities": [],
         "publicUseCandidates": [],
@@ -383,7 +421,7 @@ def build_entity_activity_summary(
         "notPublicYet": [],
         "missingInfo": ["public role", "public links", "confirmed display name", "queue/submission identity"],
         "sourceAuthority": [],
-        "recommendedAction": "Keep internal and review before drafting public dossier copy.",
+        "recommendedAction": "Review the best public-side conversation and community/music signals before drafting public dossier copy.",
         "confidence": "low",
         "queueSubmissionStatus": "not_connected",
         "queueSubmissionNote": QUEUE_NOT_CONNECTED_NOTE,
@@ -619,7 +657,8 @@ def build_entity_activity_summary(
     if summary["rawProvenance"]["rawFragments"] and not summary["knownContext"]:
         _add_unique(summary["knownContext"], f"Internal BNL context exists for {subject}.")
     if summary["publicSafePossibilities"]:
-        _add_unique(summary["notPublicYet"], "Public-safe possibilities are candidates only until owner review confirms wording.")
+        _add_unique(summary["notPublicYet"], "Public-safe possibilities are review candidates, not confirmed public facts or ready dossier copy.")
+        _add_unique(summary["notPublicYet"], "Owner/admin review is still required; many candidate rows may only be supporting evidence.")
     if not summary["publicSafePossibilities"]:
         _add_unique(summary["publicSafePossibilities"], "No public-safe facts confirmed yet.")
     if not summary["publicUseCandidates"] and any(item != "No public-safe facts confirmed yet." for item in summary["publicSafePossibilities"]):
@@ -636,6 +675,7 @@ def build_entity_activity_summary(
         _add_unique(summary["communitySignals"], "Internal context exists, but community role or public identity still needs owner review.")
     for note in summary["privateOnlyNotes"]:
         _add_unique(summary["reviewOnlyEvidence"], note)
+    _cap_review_only_evidence(summary)
     source_count = len(summary["rawProvenance"]["rawFragments"])
     if source_count >= 4 and len(summary["rawProvenance"]["sourceCounts"]) >= 2:
         summary["confidence"] = "medium"
@@ -668,27 +708,44 @@ def format_entity_activity_summary_response(summary: dict[str, Any]) -> str:
     """Format a concise operator-only Discord readout without raw provenance labels."""
 
     subject = summary.get("subjectName") or "subject"
-    known = f"Internal BNL context exists for {subject}." if (summary.get("rawProvenance") or {}).get("rawFragments") else f"No approved local context found for {subject}."
+    has_context = bool((summary.get("rawProvenance") or {}).get("rawFragments"))
+    if has_context:
+        if summary.get("publicSafePossibilities") and summary.get("publicSafePossibilities") != ["No public-safe facts confirmed yet."]:
+            known = f"Internal BNL context exists for {subject}. Structured evidence exists, but public role and queue/submission identity are not confirmed."
+        else:
+            known = f"Internal BNL context exists for {subject}. Public role and queue/submission identity are not confirmed."
+    else:
+        known = f"No approved local context found for {subject}."
+
     useful_bits: list[str] = []
     if summary.get("matchedNames"):
         useful_bits.append("Local profile match found.")
-    useful_bits.extend((summary.get("channelActivity") or [])[:3])
-    useful_bits.extend((summary.get("conversationHighlights") or [])[:2])
+    useful_bits.extend((summary.get("conversationHighlights") or [])[:3])
+    useful_bits.extend([item for item in (summary.get("observedChannels") or []) if "#" in item][:2])
+    useful_bits.extend((summary.get("musicSignals") or [])[:1])
+    useful_bits.extend((summary.get("communitySignals") or [])[:2])
+    useful_bits.extend((summary.get("bnlInteractionSignals") or [])[:1])
     if summary.get("relationshipSignals"):
-        useful_bits.append((summary.get("relationshipSignals") or [])[0])
-    useful_bits = useful_bits[:6] or ["No strong reusable evidence found yet."]
-    topics = (summary.get("topicBreakdown") or summary.get("recurringTopics") or ["No clear topics yet."])[:4]
+        useful_bits.append("Relationship/context notes exist but are private review-only.")
+    useful_bits = useful_bits[:7] or ["No strong reusable evidence found yet."]
+
+    best_review = (summary.get("bestEvidenceToReview") or summary.get("topicBreakdown") or summary.get("recurringTopics") or ["No clear evidence review queue yet."])[:6]
     public_safe = (summary.get("publicUseCandidates") or summary.get("publicSafePossibilities") or ["No public-safe facts confirmed yet."])[:3]
-    private = (summary.get("reviewOnlyEvidence") or summary.get("privateOnlyNotes") or ["No private-only notes found in approved lanes."])[:4]
+    candidate_note = "Public-safe candidate events are review candidates, not confirmed public facts; owner/admin review is required before reuse."
+    if candidate_note not in public_safe:
+        public_safe.append(candidate_note)
+    private = (summary.get("reviewOnlyEvidence") or summary.get("privateOnlyNotes") or ["No private-only notes found in approved lanes."])[:6]
     missing_items = (summary.get("missingInfo") or [])[:6]
     action = summary.get("recommendedAction") or "Keep internal and review before public use."
+
     def bullets(items: list[str]) -> str:
         return "\n".join(f"- {item}" for item in items)
+
     return (
         f"BNL Entity Activity Summary — {subject}\n\n"
         f"Current read:\n{known}\n\n"
         f"Useful evidence:\n{bullets(useful_bits)}\n\n"
-        f"Topics:\n{bullets(topics)}\n\n"
+        f"Best evidence to review:\n{bullets(best_review)}\n\n"
         f"Public-safe candidates:\n{bullets(public_safe)}\n\n"
         f"Review-only:\n{bullets(private)}\n\n"
         f"Missing:\n{bullets(missing_items or ['none listed'])}\n\n"

--- a/bnl_entity_evidence.py
+++ b/bnl_entity_evidence.py
@@ -297,7 +297,7 @@ def derive_entity_evidence_from_conversation_row(
     relation = "authored" if authored else "mentioned"
     kind = f"{relation}_{'public' if public else 'review_only'}_conversation"
     if public:
-        safe_summary = f"Subject {relation} approved public-side conversation about {_topic(text)}."
+        safe_summary = (f"Subject authored approved public-side conversation about {_topic(text)}." if authored else f"Subject was mentioned in approved public-side conversation about {_topic(text)}.")
         channel_name = safe_text(data.get("channel_name") or "", 80) or None
     else:
         safe_summary = f"Subject {relation} review-only conversation context; private/internal channel details require owner review."
@@ -541,7 +541,80 @@ def derive_entity_evidence_for_subject(db_path: str, subject_name: str, guild_id
     return result
 
 
-def get_entity_evidence_for_subject(conn: sqlite3.Connection, subject_name: str, guild_id: int | None = None, limit: int = 200) -> list[sqlite3.Row]:
+def _row_value(row: sqlite3.Row | dict[str, Any], key: str, default: Any = None) -> Any:
+    data = dict(row) if not isinstance(row, dict) else row
+    return data.get(key, default)
+
+
+def evidence_event_priority(row: sqlite3.Row | dict[str, Any]) -> int:
+    """Return a usefulness priority for entity evidence rows; lower is stronger."""
+
+    kind = str(_row_value(row, "evidence_kind", "") or "")
+    source_type = str(_row_value(row, "source_type", "") or "")
+    public_candidate = bool(_row_value(row, "public_safe_candidate", False))
+    if kind == "profile_match":
+        return 10
+    if kind == "authored_public_conversation":
+        return 20
+    if kind == "mentioned_public_conversation":
+        return 30
+    if kind == "broadcast_memory_signal" and public_candidate:
+        return 40
+    if kind == "music_or_show_signal" or bool(_row_value(row, "music_signal", False)):
+        return 50
+    if bool(_row_value(row, "bnl_interaction", False)):
+        return 60
+    if kind == "community_presence_signal":
+        return 70
+    if kind == "relationship_context_review_only":
+        return 80
+    if kind == "source_blind_memory_review_only" or source_type == "source_blind_memory":
+        return 90
+    if bool(_row_value(row, "review_only", True)):
+        return 100
+    return 110
+
+
+def _timestamp_rank(value: str) -> float:
+    text = str(value or "").strip()
+    if not text:
+        return 0.0
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return float(sum((idx + 1) * ord(ch) for idx, ch in enumerate(text[:80])))
+
+
+def _entity_evidence_sort_key(row: sqlite3.Row | dict[str, Any]) -> tuple[Any, ...]:
+    kind = str(_row_value(row, "evidence_kind", "") or "")
+    source_type = str(_row_value(row, "source_type", "") or "")
+    relation = str(_row_value(row, "relation_to_subject", "") or "")
+    topic = str(_row_value(row, "topic", "") or "")
+    safe_summary = str(_row_value(row, "safe_summary", "") or "")
+    confidence = float(_row_value(row, "confidence", 0) or 0)
+    observed = str(_row_value(row, "observed_at", "") or "")
+    updated = str(_row_value(row, "updated_at", "") or "")
+    row_id = int(_row_value(row, "id", 0) or 0)
+    source_rank = {"conversation": 0, "broadcast_memory": 1, "community_presence": 2, "user_profiles": 3, "relationship_context": 4, "source_blind_memory": 9}.get(source_type, 5)
+    return (
+        evidence_event_priority(row),
+        0 if bool(_row_value(row, "public_safe_candidate", False)) else 1,
+        0 if relation == "authored" or kind.startswith("authored_") else 1,
+        -confidence,
+        0 if topic and safe_summary else 1,
+        source_rank,
+        -_timestamp_rank(observed or updated),
+        -row_id,
+    )
+
+
+def sort_entity_evidence_rows(rows: list[sqlite3.Row]) -> list[sqlite3.Row]:
+    """Sort structured evidence by operator usefulness instead of insertion recency."""
+
+    return sorted(rows, key=_entity_evidence_sort_key)
+
+
+def get_ranked_entity_evidence_for_subject(conn: sqlite3.Connection, subject_name: str, guild_id: int | None = None, limit: int = 200) -> list[sqlite3.Row]:
     if not table_exists(conn, ENTITY_EVIDENCE_TABLE):
         return []
     key = subject_key(normalize_subject_name(subject_name))
@@ -550,4 +623,17 @@ def get_entity_evidence_for_subject(conn: sqlite3.Connection, subject_name: str,
     if guild_id is not None:
         where += " AND guild_id=?"
         params.append(guild_id)
-    return list(conn.execute(f"SELECT * FROM {ENTITY_EVIDENCE_TABLE} WHERE {where} ORDER BY updated_at DESC, id DESC LIMIT ?", [*params, max(1, limit)]))
+    cur = conn.cursor()
+    cur.row_factory = sqlite3.Row
+    rows = list(cur.execute(f"SELECT * FROM {ENTITY_EVIDENCE_TABLE} WHERE {where}", params))
+    return sort_entity_evidence_rows(rows)[: max(1, limit)]
+
+
+def get_entity_evidence_for_subject(conn: sqlite3.Connection, subject_name: str, guild_id: int | None = None, limit: int = 200) -> list[sqlite3.Row]:
+    """Return ranked entity evidence for summaries/readouts.
+
+    This deliberately does not simply read newest rows because bulk legacy/source-blind
+    refreshes can otherwise bury stronger public-side conversation evidence.
+    """
+
+    return get_ranked_entity_evidence_for_subject(conn, subject_name, guild_id=guild_id, limit=limit)

--- a/tests/test_entity_activity_summary.py
+++ b/tests/test_entity_activity_summary.py
@@ -114,6 +114,84 @@ class EntityActivitySummaryBuilderTests(unittest.TestCase):
         self.assertTrue(any(fragment.get("rawRefJson") for fragment in summary["rawProvenance"]["rawFragments"]))
         self.assertIn(entity.QUEUE_NOT_CONNECTED_NOTE, summary["notPublicYet"])
 
+    def test_ranked_evidence_prioritizes_public_conversation_over_bulk_source_blind(self):
+        evidence.ensure_entity_evidence_schema(self.conn)
+        for idx in range(12):
+            evidence.upsert_entity_evidence_event(
+                self.conn, guild_id=1, subject_name="Crow", source_type="source_blind_memory", source_table="memory_tiers",
+                source_row_id=f"legacy-{idx}", source_label="memory_tiers/source_blind_memory_trace", channel_policy="source_blind",
+                visibility="review_only", authority="source_blind_legacy_memory", confidence=0.35,
+                relation_to_subject="source_blind_memory", topic="local context", evidence_kind="source_blind_memory_review_only",
+                safe_summary="Source-blind legacy memory exists and requires review.",
+                public_safe_candidate=False, review_only=True, raw_ref_json={"snippet": f"legacy raw {idx}"}, observed_at=f"2026-06-03T00:{idx:02d}:00",
+            )
+        evidence.upsert_entity_evidence_event(
+            self.conn, guild_id=1, subject_name="Crow", source_type="conversation", source_table="conversations",
+            source_row_id="older-public", source_label="conversations/public_discord_observed", channel_name="barcode-bot",
+            channel_policy="public_context", visibility="public_side", authority="channel_policy_observed", confidence=0.72,
+            relation_to_subject="authored", topic="source-file/dossier planning context", evidence_kind="authored_public_conversation",
+            safe_summary="Subject authored approved public-side conversation about BNL/source-file/dossier handling.",
+            public_safe_candidate=True, review_only=False, bnl_interaction=True, raw_ref_json={"content": "raw transcript 123456789012345678"}, observed_at="2026-06-01T00:00:00",
+        )
+        self.conn.commit()
+
+        ranked = evidence.get_ranked_entity_evidence_for_subject(self.conn, "Crow", guild_id=1, limit=3)
+
+        self.assertEqual(ranked[0]["evidence_kind"], "authored_public_conversation")
+        self.assertEqual(ranked[0]["source_row_id"], "older-public")
+
+    def test_source_blind_is_capped_deduped_and_best_review_uses_safe_summaries(self):
+        evidence.ensure_entity_evidence_schema(self.conn)
+        evidence.upsert_entity_evidence_event(
+            self.conn, guild_id=1, subject_name="Crow", source_type="conversation", source_table="conversations",
+            source_row_id="public-1", source_label="conversations/public_discord_observed", channel_name="barcode-bot",
+            channel_policy="public_context", visibility="public_side", authority="channel_policy_observed", confidence=0.8,
+            relation_to_subject="mentioned", topic="source-file/dossier planning context", evidence_kind="mentioned_public_conversation",
+            safe_summary="Subject was mentioned in approved public-side conversation as a possible source-file candidate.",
+            public_safe_candidate=True, review_only=False, community_signal=True, raw_ref_json={"content": "VERY RAW TRANSCRIPT 123456789012345678"}, observed_at="2026-06-02",
+        )
+        for idx in range(6):
+            evidence.upsert_entity_evidence_event(
+                self.conn, guild_id=1, subject_name="Crow", source_type="source_blind_memory", source_table="memory_tiers",
+                source_row_id=f"blind-{idx}", source_label="memory_tiers/source_blind_memory_trace", channel_policy="source_blind",
+                visibility="review_only", authority="source_blind_legacy_memory", confidence=0.35,
+                relation_to_subject="source_blind_memory", topic="local context", evidence_kind="source_blind_memory_review_only",
+                safe_summary="Source-blind legacy memory exists and requires review.",
+                public_safe_candidate=False, review_only=True, raw_ref_json={"snippet": f"VERY RAW MEMORY {idx} 123456789012345678"}, observed_at=f"2026-06-03-{idx}",
+            )
+        self.conn.commit()
+
+        summary = self._summary()
+        formatted = entity.format_entity_activity_summary_response(summary)
+        normal_text = json.dumps({k: v for k, v in summary.items() if k != "rawProvenance"}) + formatted
+
+        self.assertLessEqual(sum(1 for item in summary["reviewOnlyEvidence"] if "Source-blind" in item), 2)
+        self.assertIn("Best evidence to review:", formatted)
+        self.assertTrue(any("possible source-file candidate" in item for item in summary["bestEvidenceToReview"]))
+        self.assertNotIn("VERY RAW TRANSCRIPT", normal_text)
+        self.assertNotIn("123456789012345678", normal_text)
+        self.assertIn("Public-safe candidate events are review candidates, not confirmed public facts", formatted)
+        self.assertNotRegex(formatted, r"\b6 public-safe candidates\b|\b6 usable dossier facts\b")
+        raw_text = json.dumps(summary["rawProvenance"])
+        self.assertIn("rawRefJson", raw_text)
+
+    def test_normal_readout_excludes_private_channel_names_and_queue_stays_unconnected(self):
+        c = self.conn.cursor()
+        c.execute("INSERT INTO conversations VALUES (NULL,7,'User',1,'research-and-development','internal_controlled','user','Crow private mod note with 123456789012345678 raw transcript.','now')")
+        c.execute("INSERT INTO conversations VALUES (NULL,7,'User',1,'barcode-bot','public_context','user','Crow was mentioned in BARCODE community source-file discussion.','now')")
+        self.conn.commit()
+
+        summary = self._summary()
+        formatted = entity.format_entity_activity_summary_response(summary)
+
+        self.assertNotIn("research-and-development", formatted)
+        self.assertNotIn("123456789012345678", formatted)
+        self.assertIn("#barcode-bot", formatted)
+        self.assertEqual(summary["queueSubmissionStatus"], "not_connected")
+        self.assertIn(entity.QUEUE_NOT_CONNECTED_NOTE, formatted)
+        for forbidden in ("websiteIngest", "dossierCreated", "published", "payment", "artistAccount", "ambient", "publicDiscordPost"):
+            self.assertNotIn(forbidden, json.dumps(summary))
+
     def test_entity_summary_finds_local_profile_match(self):
         self.conn.execute("INSERT INTO user_profiles VALUES (42,1,'Crow','Crow',NULL,NULL)")
         self.conn.commit()


### PR DESCRIPTION
### Motivation
- Improve entity summary readouts so they surface the most useful structured evidence rather than just the newest rows, and prevent bulk source-blind inserts from drowning out concrete public-side conversation signals. 
- Provide operators with a concise, privacy-safe "best evidence to review" queue and clearer guidance about public-safe candidates vs review-only warnings.

### Description
- Added usefulness-first evidence ranking to `bnl_entity_evidence.py` with helpers `evidence_event_priority`, `_entity_evidence_sort_key`, `sort_entity_evidence_rows`, and `get_ranked_entity_evidence_for_subject`, and made `get_entity_evidence_for_subject` return ranked rows instead of naive `updated_at` ordering. 
- Made conversation safe-summary generation more specific by distinguishing authored vs mentioned public-side conversation wording in `derive_entity_evidence_from_conversation_row`. 
- Built a sanitized review queue and review-only caps in `bnl_entity_activity_summary.py` by adding `bestEvidenceToReview`, `_evidence_review_label`, `_append_best_evidence`, and `_cap_review_only_evidence`, and by appending best-evidence items while keeping raw transcripts/IDs in `rawProvenance` only. 
- Capped and de-duplicated source-blind/review-only messages so at most a small number of source-blind warnings appear in summaries and review-only lists are limited. 
- Improved `format_entity_activity_summary_response` to show concrete useful evidence, observed public channels, a “Best evidence to review” section, honest public-safe candidate language, missing info and a next action, while preserving privacy boundaries (no private channel names, Discord IDs, raw transcripts, or private provenance in normal fields). 
- Added/updated tests in `tests/test_entity_activity_summary.py` to validate ranking, source-blind capping, sanitized best-evidence queue, honest public-safe candidate messaging, and privacy boundaries.

### Testing
- Ran unit tests with `python -m unittest discover -s tests -v`, which completed successfully (all tests passed: 306 tests OK). 
- Verified code compiles with `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py bnl_source_file_lookup.py bnl_source_file_enrichment.py bnl_source_knowledge_bridge.py bnl_entity_activity_summary.py bnl_community_scouting.py bnl_entity_evidence.py`, which succeeded. 
- Ran `git diff --check` as part of verification and observed no trailing/whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2067f3c65883218910f1a357c92925)