### PR TITLE
Wire structured entity evidence into Source File enrichment payloads

### DIFF
--- a/bnl_dossier_recommendations.py
+++ b/bnl_dossier_recommendations.py
@@ -63,6 +63,7 @@ SUPPORTED_PAYLOAD_FIELDS = {
     "communitySignals",
     "sourceCoverage",
     "evidenceDetails",
+    "bestEvidenceToReview",
     "publicSafePossibilities",
     "publicUseCandidates",
     "privateOnlyNotes",
@@ -71,6 +72,8 @@ SUPPORTED_PAYLOAD_FIELDS = {
     "recommendedAction",
     "sourceAuthority",
     "rawProvenance",
+    "queueSubmissionStatus",
+    "queueSubmissionNote",
 }
 _SAFE_LANE_PATTERN = re.compile(r"[^a-z0-9_-]+")
 VALID_DOSSIER_CATEGORIES = {"Entity", "Personnel", "Sponsor", "Interface", "Production"}

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -16,12 +16,26 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 from bnl_dossier_recommendations import build_dossier_recommendation_payload, send_dossier_recommendation
-from bnl_entity_activity_summary import build_entity_activity_summary
+from bnl_entity_activity_summary import build_entity_activity_summary, refresh_entity_evidence_for_subject
 from bnl_source_file_lookup import lookup_source_file
 
 ENRICHMENT_INGEST_SOURCE = "bnl_source_file_enrichment"
 FALLBACK_INGEST_SOURCE = "bnl_source_knowledge_bridge"
 SOURCE_BLIND_WARNING = "source-blind memory is review-only; do not treat as confirmed fact"
+QUEUE_NOT_CONNECTED_NOTE = "Queue/submission identity is not connected yet."
+ENTITY_SUMMARY_EVIDENCE_FIELDS = {
+    "observedChannels": 6,
+    "conversationHighlights": 6,
+    "topicBreakdown": 8,
+    "bestEvidenceToReview": 6,
+    "bnlInteractionSignals": 5,
+    "musicSignals": 5,
+    "communitySignals": 5,
+    "sourceCoverage": 10,
+    "evidenceDetails": 8,
+    "publicUseCandidates": 6,
+    "reviewOnlyEvidence": 6,
+}
 SECTION_ORDER = [
     "Subject Overview",
     "Why This Subject Matters",
@@ -1046,6 +1060,69 @@ def _add_source_file_context(sections: dict[str, list[str]], source_file: dict[s
         _append_section(sections, "Possible Aliases / Connections", f"Possible connection only; needs owner review before identity fields are changed: {_safe_text(aliases, 180)}")
 
 
+def _owner_admin_review_label(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    return (
+        value.replace("pending owner review", "pending owner/admin review")
+        .replace("after owner review", "after owner/admin review")
+        .replace("before owner review", "before owner/admin review")
+    )
+
+
+def _is_review_only_summary_item(value: Any, review_only_evidence: list[str]) -> bool:
+    text = str(value or "")
+    lowered = text.lower()
+    if "review-only channel" in lowered:
+        return True
+    return any(item and item in text for item in review_only_evidence)
+
+
+def _bounded_entity_summary_fields(summary: dict[str, Any], *, include: bool) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    review_only_evidence = [str(item or "") for item in (summary.get("reviewOnlyEvidence") or [])]
+    public_normal_fields = {"observedChannels", "conversationHighlights", "evidenceDetails", "bestEvidenceToReview"}
+    for key, limit in ENTITY_SUMMARY_EVIDENCE_FIELDS.items():
+        value = summary.get(key) if include else []
+        if isinstance(value, list):
+            items = list(value)
+            if key in public_normal_fields:
+                items = [item for item in items if not _is_review_only_summary_item(item, review_only_evidence)]
+            items = items[:limit]
+            if key == "publicUseCandidates":
+                items = [_owner_admin_review_label(item) for item in items]
+            fields[key] = items
+        else:
+            fields[key] = value if value else ([] if key != "sourceCoverage" else [])
+    return fields
+
+
+def _copy_evidence_fields(target: dict[str, Any], source: dict[str, Any]) -> None:
+    for key in (
+        "knownContext",
+        "relationshipSignals",
+        "publicSafePossibilities",
+        "privateOnlyNotes",
+        "notPublicYet",
+        "sourceAuthority",
+        *ENTITY_SUMMARY_EVIDENCE_FIELDS.keys(),
+    ):
+        if key in source:
+            value = source.get(key)
+            if isinstance(value, list):
+                items = list(value)
+                if key == "publicUseCandidates":
+                    items = [_owner_admin_review_label(item) for item in items]
+                target[key] = items
+            elif isinstance(value, dict):
+                target[key] = dict(value)
+            else:
+                target[key] = value
+    target["queueSubmissionStatus"] = source.get("queueSubmissionStatus") or "not_connected"
+    target["queueSubmissionNote"] = source.get("queueSubmissionNote") or QUEUE_NOT_CONNECTED_NOTE
+    target["rawProvenance"] = dict(source.get("rawProvenance") or {})
+
+
 def collect_source_enrichment_evidence(db_path: str, guild_id: int | None, subject: str, *, rd_context: list[dict[str, Any]] | None = None, lookup_result: dict[str, Any] | None = None) -> dict[str, Any]:
     """Collect bounded evidence from approved local stores only."""
 
@@ -1324,11 +1401,18 @@ def collect_source_enrichment_evidence(db_path: str, guild_id: int | None, subje
     if "rd_context" not in source_statuses:
         _source_status(source_statuses, "rd_context", "no_match" if rd_context else "not_provided")
 
+    refresh_result: dict[str, Any] = {}
+    try:
+        refresh_result = refresh_entity_evidence_for_subject(db_path, subject, guild_id=guild_id, limit=50)
+    except Exception as exc:  # pragma: no cover - defensive: enrichment should still read existing evidence.
+        refresh_result = {"ok": False, "error": _safe_text(str(exc), 180)}
+
     entity_summary = build_entity_activity_summary(
         db_path,
         subject,
         guild_id,
         [
+            "entity_evidence_events",
             "user_profiles",
             "user_memory_facts",
             "user_habits",
@@ -1337,6 +1421,7 @@ def collect_source_enrichment_evidence(db_path: str, guild_id: int | None, subje
             "memory_tiers",
             "conversations",
             "broadcast_memory",
+            "community_presence",
             "rd_context",
         ],
         "admin_internal",
@@ -1376,6 +1461,7 @@ def collect_source_enrichment_evidence(db_path: str, guild_id: int | None, subje
         "channelEvidenceFound": channel_evidence_found,
         "publicDossierMatchFound": bool(identity.get("publicDossierMatchFound")),
         "existingDossierUpdateLane": bool(identity.get("existingDossierUpdateLane")),
+        "entityEvidenceRefresh": refresh_result if isinstance(refresh_result, dict) else {},
     }
     classification_bundle = {
         "sections": {name: values for name, values in sections.items() if values},
@@ -1420,6 +1506,9 @@ def collect_source_enrichment_evidence(db_path: str, guild_id: int | None, subje
         "privateOnlyNotes": list(entity_summary.get("privateOnlyNotes") or [])[:6] if raw_provenance else [],
         "notPublicYet": list(entity_summary.get("notPublicYet") or [])[:6] if raw_provenance else [],
         "sourceAuthority": list(entity_summary.get("sourceAuthority") or [])[:5] if raw_provenance else [],
+        **_bounded_entity_summary_fields(entity_summary, include=bool(raw_provenance)),
+        "queueSubmissionStatus": str(entity_summary.get("queueSubmissionStatus") or "not_connected") if raw_provenance else "not_connected",
+        "queueSubmissionNote": str(entity_summary.get("queueSubmissionNote") or QUEUE_NOT_CONNECTED_NOTE) if raw_provenance else QUEUE_NOT_CONNECTED_NOTE,
         "rawProvenance": {
             "sourceLabels": list(raw_provenance.get("sourceLabels") or []),
             "sourceCounts": dict(raw_provenance.get("sourceCounts") or {}),
@@ -1489,7 +1578,7 @@ def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: 
         "qualityStatus": packet.get("qualityStatus"),
         "forced": bool(packet.get("forced")),
         "safetyWarnings": list(packet.get("warnings") or []),
-        "sourceCoverage": dict(packet.get("sourceTypesChecked") or {}),
+        "sourceCoverage": list(packet.get("sourceCoverage") or []),
         "identityDiagnostics": dict(packet.get("diagnostics") or {}),
         "internalClassification": dict(packet.get("classification") or {}),
         "knownContext": list(packet.get("knownContext") or []),
@@ -1498,6 +1587,18 @@ def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: 
         "privateOnlyNotes": list(packet.get("privateOnlyNotes") or []),
         "notPublicYet": list(packet.get("notPublicYet") or []),
         "sourceAuthority": list(packet.get("sourceAuthority") or []),
+        "observedChannels": list(packet.get("observedChannels") or []),
+        "conversationHighlights": list(packet.get("conversationHighlights") or []),
+        "topicBreakdown": list(packet.get("topicBreakdown") or []),
+        "bestEvidenceToReview": list(packet.get("bestEvidenceToReview") or []),
+        "bnlInteractionSignals": list(packet.get("bnlInteractionSignals") or []),
+        "musicSignals": list(packet.get("musicSignals") or []),
+        "communitySignals": list(packet.get("communitySignals") or []),
+        "evidenceDetails": list(packet.get("evidenceDetails") or []),
+        "publicUseCandidates": list(packet.get("publicUseCandidates") or []),
+        "reviewOnlyEvidence": list(packet.get("reviewOnlyEvidence") or []),
+        "queueSubmissionStatus": packet.get("queueSubmissionStatus") or "not_connected",
+        "queueSubmissionNote": packet.get("queueSubmissionNote") or QUEUE_NOT_CONNECTED_NOTE,
         "rawProvenance": dict(packet.get("rawProvenance") or {}),
         "visibilityLabels": ["internal_review_only", "admin_review_required"],
         "confidence": "low" if packet.get("qualityStatus") in {"too_thin", "forced_low_confidence"} else ("medium" if match_kind == "active_source_file" else "low"),
@@ -1617,6 +1718,7 @@ def run_source_file_enrichment(
         "runTime": datetime.now(timezone.utc).isoformat(),
         "forced": bool(force),
     }
+    _copy_evidence_fields(packet, evidence)
     quality = evaluate_enrichment_quality(packet)
     packet["qualityScore"] = quality["score"]
     packet["qualityStatus"] = "forced_low_confidence" if force and quality["status"] != "sendable" else quality["status"]

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -498,6 +498,131 @@ class SourceFileEnrichmentTests(unittest.TestCase):
         self.assertIn("production", result["topicThemes"])
         self.assertNotIn("working on the mix", json.dumps(result))
 
+
+    def test_entity_summary_called_with_structured_evidence_lane(self):
+        fake_summary = {
+            "knownContext": ["Structured context exists."],
+            "rawProvenance": {"sourceLabels": ["entity_evidence_events/structured"], "sourceCounts": {"entity_evidence_events": 1}, "rawFragments": [{"table": "entity_evidence_events"}], "channelPolicies": {}},
+            "missingInfo": [],
+            "sourceAuthority": [],
+        }
+        with mock.patch.object(enrich, "refresh_entity_evidence_for_subject", return_value={"ok": True}) as refresh_mock, \
+             mock.patch.object(enrich, "build_entity_activity_summary", return_value=fake_summary) as builder:
+            result = enrich.collect_source_enrichment_evidence(self.db, 1, "HellcatNZ", lookup_result=self._lookup("active")({"lookupValue": "HellcatNZ"}))
+        self.assertIn("entity_activity_summary", result["sourceTypes"])
+        refresh_mock.assert_called_once_with(self.db, "HellcatNZ", guild_id=1, limit=50)
+        lanes = builder.call_args.args[3]
+        for lane in ("entity_evidence_events", "user_profiles", "user_memory_facts", "user_habits", "relationship_state", "relationship_journal", "memory_tiers", "conversations", "broadcast_memory", "community_presence", "rd_context"):
+            self.assertIn(lane, lanes)
+
+    def test_structured_entity_evidence_fields_flow_to_result_and_payload_privately(self):
+        import bnl_entity_evidence as entity_evidence
+        conn = sqlite3.connect(self.db)
+        try:
+            entity_evidence.ensure_entity_evidence_schema(conn)
+            entity_evidence.upsert_entity_evidence_event(
+                conn,
+                guild_id=1,
+                subject_name="HellcatNZ",
+                matched_user_id=123456789012345678,
+                source_type="discord",
+                source_table="conversations",
+                source_row_id="42",
+                source_label="conversations/public_selective",
+                channel_name="finished-tracks",
+                channel_policy="public_selective",
+                visibility="approved_public_side",
+                authority="local_observed",
+                confidence=0.8,
+                relation_to_subject="authored",
+                topic="music/community context",
+                evidence_kind="authored_public_conversation",
+                safe_summary="Approved public-side activity indicates music/community context for review.",
+                public_safe_candidate=True,
+                review_only=False,
+                music_signal=True,
+                community_signal=True,
+                bnl_interaction=True,
+                raw_ref_json={"content": "raw transcript with 123456789012345678 should stay provenance-only", "channel_name": "finished-tracks"},
+            )
+            entity_evidence.upsert_entity_evidence_event(
+                conn,
+                guild_id=1,
+                subject_name="HellcatNZ",
+                source_type="discord",
+                source_table="conversations",
+                source_row_id="43",
+                source_label="conversations/private",
+                channel_name="research-and-development",
+                channel_policy="private_internal",
+                visibility="review_only",
+                authority="local_observed",
+                confidence=0.6,
+                relation_to_subject="mentioned",
+                topic="source-file/dossier planning context",
+                evidence_kind="mentioned_review_only_conversation",
+                safe_summary="Review-only planning context exists for owner review.",
+                public_safe_candidate=False,
+                review_only=True,
+                raw_ref_json={"content": "private raw transcript", "channel_name": "research-and-development"},
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        with mock.patch.object(enrich, "refresh_entity_evidence_for_subject", return_value={"ok": True}):
+            result = enrich.run_source_file_enrichment(self.db, 1, "HellcatNZ", dry_run=True, lookup_func=self._lookup("active"))
+        payload = result["payload"]
+        for key in ("observedChannels", "conversationHighlights", "topicBreakdown", "bestEvidenceToReview", "bnlInteractionSignals", "musicSignals", "communitySignals", "sourceCoverage", "evidenceDetails", "publicUseCandidates", "reviewOnlyEvidence", "queueSubmissionStatus", "queueSubmissionNote"):
+            self.assertIn(key, result)
+            self.assertIn(key, payload)
+        self.assertIsInstance(payload["sourceCoverage"], list)
+        self.assertTrue(any(item.get("source") == "conversations" for item in payload["sourceCoverage"] if isinstance(item, dict)))
+        self.assertEqual(payload["queueSubmissionStatus"], "not_connected")
+        self.assertEqual(payload["queueSubmissionNote"], enrich.QUEUE_NOT_CONNECTED_NOTE)
+        self.assertTrue(any("pending owner/admin review" in item for item in payload["publicUseCandidates"]))
+        self.assertTrue(any("Review-only planning context" in item for item in payload["reviewOnlyEvidence"]))
+        public_normal_text = json.dumps({key: payload.get(key) for key in ("observedChannels", "conversationHighlights", "evidenceDetails", "bestEvidenceToReview", "publicUseCandidates")})
+        self.assertNotIn("Review-only planning context", public_normal_text)
+        normal = dict(payload)
+        raw = normal.pop("rawProvenance")
+        normal_text = json.dumps(normal)
+        self.assertNotIn("private raw transcript", normal_text)
+        self.assertNotIn("123456789012345678", normal_text)
+        self.assertNotIn("research-and-development", normal_text)
+        self.assertIn("rawFragments", raw)
+
+    def test_build_enrichment_payload_includes_new_fields_and_keeps_raw_provenance_separate(self):
+        packet = {
+            "subject": "HellcatNZ",
+            "matchKind": "active_source_file",
+            "sourceFile": {"id": "sf_1", "name": "HellcatNZ"},
+            "sections": {"Public-Safe Notes": ["No public copy yet."], "Do Not Say": ["Do not publish raw notes."], "Missing Info": ["public links"], "Suggested Next Action": ["owner review"]},
+            "sourceTypes": ["entity_activity_summary"],
+            "sourceCounts": {"entity_activity_summary": 2},
+            "sourceCoverage": [{"source": "entity_evidence_events", "count": 2, "status": "found"}],
+            "knownContext": ["Structured context exists."],
+            "observedChannels": ["#finished-tracks — approved public-side; subject authored."],
+            "conversationHighlights": ["Sanitized highlight."],
+            "topicBreakdown": ["music/community context: 1 approved/reviewed source row(s)."],
+            "bestEvidenceToReview": ["discord: authored_public_conversation — Sanitized highlight."],
+            "bnlInteractionSignals": ["BNL-related interaction context exists."],
+            "musicSignals": ["Music/radio/show context exists; queue identity still needs review."],
+            "communitySignals": ["Community context exists; owner review must confirm wording."],
+            "evidenceDetails": ["Sanitized detail."],
+            "publicUseCandidates": ["Possible community/source-file candidate, pending owner/admin review."],
+            "reviewOnlyEvidence": ["Review-only note."],
+            "queueSubmissionStatus": "not_connected",
+            "queueSubmissionNote": enrich.QUEUE_NOT_CONNECTED_NOTE,
+            "rawProvenance": {"rawFragments": [{"rawRefJson": "raw transcript"}]},
+        }
+        payload = enrich.build_enrichment_recommendation_payload(packet, environ={})
+        for key in ("observedChannels", "conversationHighlights", "topicBreakdown", "bestEvidenceToReview", "bnlInteractionSignals", "musicSignals", "communitySignals", "sourceCoverage", "evidenceDetails", "publicUseCandidates", "reviewOnlyEvidence", "queueSubmissionStatus", "queueSubmissionNote"):
+            self.assertEqual(payload[key], packet[key])
+        self.assertEqual(payload["rawProvenance"], packet["rawProvenance"])
+        normal = dict(payload)
+        normal.pop("rawProvenance")
+        self.assertNotIn("raw transcript", json.dumps(normal))
+
     def test_payload_keeps_machine_metadata(self):
         result = enrich.run_source_file_enrichment(self.db, 1, "HellcatNZ", dry_run=True, lookup_func=self._lookup("active"))
         payload = result["payload"]


### PR DESCRIPTION
### Motivation
- Ensure Source File enrichment sends the new structured entity evidence fields the website now supports so review material is complete and current.
- Use operator-triggered evidence refresh/derivation so enrichment can include up-to-date structured evidence without adding broad autonomous scanning.
- Keep privacy boundaries and provenance separation intact so raw transcripts/IDs/private channel names remain only in `rawProvenance` and review-only evidence stays review-only.

### Description
- Before building the entity summary, call `refresh_entity_evidence_for_subject(...)` and include `entity_evidence_events` (and `community_presence`) in the `build_entity_activity_summary(...)` lanes so structured evidence is considered.
- Add bounded structured-evidence handling via `ENTITY_SUMMARY_EVIDENCE_FIELDS` and helpers (`_bounded_entity_summary_fields`, `_copy_evidence_fields`, `_is_review_only_summary_item`, `_owner_admin_review_label`) and apply those fields into the enrichment result when entity evidence exists.
- Wire the new fields into the recommendation payload returned by `build_enrichment_recommendation_payload(...)` including `observedChannels`, `conversationHighlights`, `topicBreakdown`, `bestEvidenceToReview`, `bnlInteractionSignals`, `musicSignals`, `communitySignals`, `sourceCoverage`, `evidenceDetails`, `publicUseCandidates`, `reviewOnlyEvidence`, `queueSubmissionStatus`, and `queueSubmissionNote`, while preserving `rawProvenance` as the only raw-provenance container and keeping queue/submission as not connected by default.
- Add `bestEvidenceToReview`/`queueSubmissionStatus`/`queueSubmissionNote` to `SUPPORTED_PAYLOAD_FIELDS` and add/update unit tests to assert lane inclusion, result/payload field flow, `sourceCoverage` shape, privacy boundaries, and dry-run/force behavior.

### Testing
- Ran the full unit test suite with `python -m unittest discover -s tests -v` and all tests passed (including new tests added for structured evidence fields).
- Verified code compiles with `python -m py_compile` across the core modules listed and `git diff --check` reported no problems.
- Exercised the specific new tests in `tests/test_source_file_enrichment.py` which validate refresh invocation, lane inclusion, private/public filtering, payload fields, and provenance separation; they passed as part of the automated run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20731268108321a7af190de064ac71)