### PR TITLE
Compact Source File enrichment payloads for website ingest

### DIFF
--- a/bnl_dossier_recommendations.py
+++ b/bnl_dossier_recommendations.py
@@ -210,6 +210,32 @@ def _extract_recommendation_id(response_json: dict[str, Any]) -> Any:
     return None
 
 
+
+def _safe_response_error_text(raw: Any, limit: int = 280) -> str:
+    """Return compact endpoint error text without secrets or payload material."""
+
+    text = ""
+    try:
+        if isinstance(raw, (bytes, bytearray)):
+            text = raw.decode("utf-8", errors="replace")
+        else:
+            text = str(raw or "")
+        parsed = json.loads(text) if text.strip().startswith(("{", "[")) else None
+        if isinstance(parsed, dict):
+            for key in ("error", "message", "detail", "reason"):
+                if parsed.get(key):
+                    text = str(parsed.get(key))
+                    break
+    except Exception:
+        text = str(raw or "")
+    text = re.sub(r"Bearer\s+[A-Za-z0-9._~+/-]+", "Bearer [redacted]", text, flags=re.I)
+    text = re.sub(r"(?i)(token|secret|authorization)\s*[:=]\s*[^\s,;}]+", r"\1=[redacted]", text)
+    text = re.sub(r"\b\d{15,22}\b", "[redacted-id]", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > limit:
+        text = text[: max(0, limit - 1)].rstrip() + "…"
+    return text
+
 def _safe_failure(error: str, status: int | None = None, duplicate: bool = False) -> dict[str, Any]:
     return {
         "ok": False,
@@ -254,8 +280,16 @@ def send_dossier_recommendation(payload: dict[str, Any], *, environ: dict[str, s
             raw = response.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
         status = exc.code
-        logging.warning(f"dossier_recommendation_send_failed status={status}")
-        return _safe_failure("Dossier recommendation endpoint rejected the request.", status=status)
+        body_text = ""
+        try:
+            body_text = _safe_response_error_text(exc.read())
+        except Exception:
+            body_text = _safe_response_error_text(getattr(exc, "reason", ""))
+        error = "Dossier recommendation endpoint rejected the request."
+        if body_text:
+            error = f"{error} {body_text}"
+        logging.warning(f"dossier_recommendation_send_failed status={status} endpoint_error={body_text or 'unavailable'}")
+        return _safe_failure(error, status=status)
     except (urllib.error.URLError, TimeoutError, socket.timeout):
         logging.warning("dossier_recommendation_send_failed reason=network_or_timeout")
         return _safe_failure("Dossier recommendation endpoint was unreachable or timed out.")

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -1750,6 +1750,59 @@ def compact_enrichment_payload_for_site(payload: dict[str, Any]) -> dict[str, An
     return compact
 
 
+def _validate_source_coverage_for_site(source_coverage: Any) -> list[str]:
+    issues: list[str] = []
+    if not isinstance(source_coverage, list):
+        return ["sourceCoverage must be a list"]
+    if len(source_coverage) > SITE_LIST_MAX_ITEMS:
+        issues.append("sourceCoverage has too many items")
+    for item in source_coverage:
+        if isinstance(item, str):
+            if len(item) > 1000 or _LONG_ID_RE.search(item) or _PRIVATE_CHANNEL_NAME_RE.search(item) or "[object Object]" in item:
+                issues.append("sourceCoverage contains unsafe text")
+                break
+            continue
+        if not isinstance(item, dict):
+            issues.append("sourceCoverage contains unsupported item type")
+            break
+        unsupported = set(item) - SITE_SOURCE_COVERAGE_ALLOWED_KEYS
+        if unsupported:
+            issues.append("sourceCoverage contains unsupported object keys")
+            break
+        text = json.dumps(item, sort_keys=True, default=str)
+        if len(text) > 1000 or _LONG_ID_RE.search(text) or _PRIVATE_CHANNEL_NAME_RE.search(text) or "[object Object]" in text:
+            issues.append("sourceCoverage contains unsafe text")
+            break
+        for text_key in ("source", "status"):
+            if text_key in item and (not isinstance(item.get(text_key), str) or len(item.get(text_key) or "") > 1000):
+                issues.append(f"sourceCoverage {text_key} must be a bounded string")
+                break
+        if issues and issues[-1].startswith("sourceCoverage "):
+            break
+        if "count" in item and not _is_finite_number(item.get("count")):
+            issues.append("sourceCoverage count must be finite")
+            break
+        if "counts" in item:
+            counts = item.get("counts")
+            if not isinstance(counts, dict):
+                issues.append("sourceCoverage counts must be an object")
+                break
+            if len(counts) > SITE_SOURCE_COVERAGE_COUNTS_MAX_KEYS:
+                issues.append("sourceCoverage counts has too many keys")
+                break
+            for count_key, count_value in counts.items():
+                count_key_text = str(count_key or "")
+                if len(count_key_text) > 1000 or _LONG_ID_RE.search(count_key_text) or _PRIVATE_CHANNEL_NAME_RE.search(count_key_text) or "[object Object]" in count_key_text:
+                    issues.append("sourceCoverage counts contains unsafe keys")
+                    break
+                if not _is_finite_number(count_value):
+                    issues.append("sourceCoverage counts values must be finite")
+                    break
+            if issues and issues[-1].startswith("sourceCoverage counts"):
+                break
+    return issues
+
+
 def validate_enrichment_payload_for_site(payload: dict[str, Any]) -> list[str]:
     issues: list[str] = []
     if len(str(payload.get("evidenceSummary") or "")) > SITE_EVIDENCE_SUMMARY_LIMIT:
@@ -1758,56 +1811,7 @@ def validate_enrichment_payload_for_site(payload: dict[str, Any]) -> list[str]:
     if raw_len > SITE_RAW_PROVENANCE_JSON_LIMIT:
         issues.append("rawProvenance exceeds site JSON limit")
     if "sourceCoverage" in payload:
-        source_coverage = payload.get("sourceCoverage")
-        if not isinstance(source_coverage, list):
-            issues.append("sourceCoverage must be a list")
-        else:
-            if len(source_coverage) > SITE_LIST_MAX_ITEMS:
-                issues.append("sourceCoverage has too many items")
-            for item in source_coverage:
-                if isinstance(item, str):
-                    if len(item) > 1000 or _LONG_ID_RE.search(item) or _PRIVATE_CHANNEL_NAME_RE.search(item) or "[object Object]" in item:
-                        issues.append("sourceCoverage contains unsafe text")
-                        break
-                    continue
-                if not isinstance(item, dict):
-                    issues.append("sourceCoverage contains unsupported item type")
-                    break
-                unsupported = set(item) - SITE_SOURCE_COVERAGE_ALLOWED_KEYS
-                if unsupported:
-                    issues.append("sourceCoverage contains unsupported object keys")
-                    break
-                text = json.dumps(item, sort_keys=True, default=str)
-                if len(text) > 1000 or _LONG_ID_RE.search(text) or _PRIVATE_CHANNEL_NAME_RE.search(text) or "[object Object]" in text:
-                    issues.append("sourceCoverage contains unsafe text")
-                    break
-                for text_key in ("source", "status"):
-                    if text_key in item and (not isinstance(item.get(text_key), str) or len(item.get(text_key) or "") > 1000):
-                        issues.append(f"sourceCoverage {text_key} must be a bounded string")
-                        break
-                if issues and issues[-1].startswith("sourceCoverage "):
-                    break
-                if "count" in item and not _is_finite_number(item.get("count")):
-                    issues.append("sourceCoverage count must be finite")
-                    break
-                if "counts" in item:
-                    counts = item.get("counts")
-                    if not isinstance(counts, dict):
-                        issues.append("sourceCoverage counts must be an object")
-                        break
-                    if len(counts) > SITE_SOURCE_COVERAGE_COUNTS_MAX_KEYS:
-                        issues.append("sourceCoverage counts has too many keys")
-                        break
-                    for count_key, count_value in counts.items():
-                        count_key_text = str(count_key or "")
-                        if len(count_key_text) > 1000 or _LONG_ID_RE.search(count_key_text) or _PRIVATE_CHANNEL_NAME_RE.search(count_key_text) or "[object Object]" in count_key_text:
-                            issues.append("sourceCoverage counts contains unsafe keys")
-                            break
-                        if not _is_finite_number(count_value):
-                            issues.append("sourceCoverage counts values must be finite")
-                            break
-                    if issues and issues[-1].startswith("sourceCoverage counts"):
-                        break
+        issues.extend(_validate_source_coverage_for_site(payload.get("sourceCoverage")))
     for key in SITE_BOUND_LIST_FIELDS:
         if key not in payload:
             continue

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -23,6 +23,39 @@ ENRICHMENT_INGEST_SOURCE = "bnl_source_file_enrichment"
 FALLBACK_INGEST_SOURCE = "bnl_source_knowledge_bridge"
 SOURCE_BLIND_WARNING = "source-blind memory is review-only; do not treat as confirmed fact"
 QUEUE_NOT_CONNECTED_NOTE = "Queue/submission identity is not connected yet."
+SITE_EVIDENCE_SUMMARY_LIMIT = 2000
+SITE_EVIDENCE_SUMMARY_TARGET = 1800
+SITE_RAW_PROVENANCE_JSON_LIMIT = 20000
+SITE_RAW_PROVENANCE_JSON_TARGET = 18000
+SITE_LIST_ITEM_LIMIT = 500
+SITE_LIST_MAX_ITEMS = 25
+SITE_RAW_FRAGMENT_MAX_ITEMS = 4
+SITE_RAW_FRAGMENT_TEXT_LIMIT = 500
+SITE_BOUND_LIST_FIELDS = (
+    "knownContext",
+    "usefulEvidence",
+    "relationshipSignals",
+    "observedChannels",
+    "conversationHighlights",
+    "topicBreakdown",
+    "bestEvidenceToReview",
+    "bnlInteractionSignals",
+    "musicSignals",
+    "communitySignals",
+    "sourceCoverage",
+    "evidenceDetails",
+    "publicSafePossibilities",
+    "publicUseCandidates",
+    "privateOnlyNotes",
+    "reviewOnlyEvidence",
+    "notPublicYet",
+    "sourceAuthority",
+    "missingInfo",
+    "publicSafetyNotes",
+    "doNotSay",
+)
+_PRIVATE_CHANNEL_NAME_RE = re.compile(r"(?i)(?:#?(?:research-and-development|private[-_ ]?internal|private[-_ ]?chat|staff[-_ ]?only|mod[-_ ]?chat|direct[-_ ]?message)s?|\bdm\b)")
+
 ENTITY_SUMMARY_EVIDENCE_FIELDS = {
     "observedChannels": 6,
     "conversationHighlights": 6,
@@ -1523,6 +1556,174 @@ def _section_text(sections: dict[str, list[str]], name: str, *, limit: int = 4) 
     return "\n".join(f"- {_safe_text(item, 240)}" for item in items[:limit]) or "- currently unknown."
 
 
+def _site_safe_text(value: Any, limit: int = SITE_LIST_ITEM_LIMIT) -> str:
+    text = _safe_text(value, limit)
+    text = _PRIVATE_CHANNEL_NAME_RE.sub("[private-channel]", text)
+    return text.replace("[object Object]", "[unsupported-object]")
+
+
+def _compact_value_for_site(value: Any, *, text_limit: int = SITE_LIST_ITEM_LIMIT, depth: int = 0) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return _site_safe_text(value, text_limit)
+    if isinstance(value, (int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        if depth >= 3:
+            return _site_safe_text(json.dumps(value, sort_keys=True, default=str), text_limit)
+        compact: dict[str, Any] = {}
+        for key, raw in value.items():
+            safe_key = _site_safe_text(key, 80)
+            nested_limit = min(text_limit, SITE_RAW_FRAGMENT_TEXT_LIMIT) if key in {"content", "message", "raw", "transcript", "snippet", "rawRefJson", "channel_name", "channelName"} else text_limit
+            compact[safe_key] = _compact_value_for_site(raw, text_limit=nested_limit, depth=depth + 1)
+        return compact
+    if isinstance(value, (list, tuple, set)):
+        out = []
+        for item in list(value)[:SITE_LIST_MAX_ITEMS]:
+            compact_item = _compact_value_for_site(item, text_limit=text_limit, depth=depth + 1)
+            if compact_item not in (None, "", [], {}):
+                out.append(compact_item)
+        return out
+    return _site_safe_text(value, text_limit)
+
+
+def _compact_list_for_site(value: Any, *, max_items: int = SITE_LIST_MAX_ITEMS, item_limit: int = SITE_LIST_ITEM_LIMIT) -> list[Any]:
+    raw_items = value if isinstance(value, (list, tuple, set)) else ([value] if value not in (None, "") else [])
+    compact: list[Any] = []
+    seen: set[str] = set()
+    for item in list(raw_items)[:max_items]:
+        compact_item = _compact_value_for_site(item, text_limit=item_limit)
+        if compact_item in (None, "", [], {}):
+            continue
+        fingerprint = json.dumps(compact_item, sort_keys=True, default=str) if isinstance(compact_item, (dict, list)) else str(compact_item)
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        compact.append(compact_item)
+    return compact
+
+
+def _compact_raw_provenance_for_site(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    source_labels = _compact_list_for_site(raw.get("sourceLabels"), max_items=25, item_limit=160)
+    if source_labels:
+        compact["sourceLabels"] = source_labels
+    source_counts = dict(raw.get("sourceCounts") or {})
+    if source_counts:
+        compact["sourceCounts"] = source_counts
+    channel_counts = dict(raw.get("channelPolicyCounts") or raw.get("channelPolicies") or {})
+    if channel_counts:
+        compact["channelPolicyCounts"] = channel_counts
+    source_authority = _compact_list_for_site(raw.get("sourceAuthority"), max_items=10, item_limit=240)
+    if source_authority:
+        compact["sourceAuthority"] = source_authority
+    fragments = []
+    for fragment in list(raw.get("rawFragments") or [])[:SITE_RAW_FRAGMENT_MAX_ITEMS]:
+        if isinstance(fragment, dict):
+            kept = {}
+            for key in ("table", "sourceTable", "sourceLabel", "sourceRowId", "visibility", "authority", "confidence", "relationToSubject", "topic", "evidenceKind", "safeSummary", "snippet", "rawRefJson", "channelPolicy"):
+                if key in fragment and fragment.get(key) not in (None, ""):
+                    limit = SITE_RAW_FRAGMENT_TEXT_LIMIT if key in {"safeSummary", "snippet", "rawRefJson"} else 180
+                    kept[key] = _compact_value_for_site(fragment.get(key), text_limit=limit)
+            if kept:
+                fragments.append(kept)
+        else:
+            fragments.append(_site_safe_text(fragment, SITE_RAW_FRAGMENT_TEXT_LIMIT))
+    if fragments:
+        compact["rawFragments"] = fragments
+    # Last-resort trim to stay below the website's rawProvenance JSON limit.
+    while len(json.dumps(compact, sort_keys=True, default=str)) > SITE_RAW_PROVENANCE_JSON_TARGET and compact.get("rawFragments"):
+        compact["rawFragments"] = compact["rawFragments"][:-1]
+    if len(json.dumps(compact, sort_keys=True, default=str)) > SITE_RAW_PROVENANCE_JSON_TARGET:
+        compact.pop("sourceAuthority", None)
+    return compact
+
+
+def build_compact_enrichment_evidence_summary(packet: dict[str, Any]) -> str:
+    classification = packet.get("classification") or {}
+    sections = packet.get("sections") or {}
+    lines: list[str] = ["Source File enrichment review summary."]
+    if classification:
+        lines.append("## Internal Classification")
+        lines.append(
+            f"- Role read: {_site_safe_text(classification.get('roleRead') or ROLE_LABELS.get(classification.get('primaryRole'), 'Unknown / needs review'), 120)}"
+        )
+        lines.append(
+            f"- Activity read: {_site_safe_text(classification.get('activityRead') or classification.get('activityLevel') or 'unknown', 120)}; "
+            f"dossier={_site_safe_text(classification.get('dossierRead') or DOSSIER_LABELS.get(classification.get('dossierUse'), 'Unknown'), 120)}."
+        )
+    section_useful: list[Any] = []
+    useful_sources = (
+        ("Subject Overview", 0),
+        ("History With BARCODE / BNL / Discord / BARCODE Radio", 1),
+        ("Observed Patterns", 0),
+        ("Why This Subject Matters", 0),
+        ("Known Facts", 0),
+    )
+    for section_name, item_index in useful_sources:
+        section_items = sections.get(section_name) or []
+        if len(section_items) > item_index:
+            section_useful.append(section_items[item_index])
+    useful = _compact_list_for_site(packet.get("usefulEvidence") or section_useful or packet.get("knownContext") or packet.get("evidenceDetails"), max_items=3, item_limit=220)
+    if useful:
+        lines.append("Useful evidence:")
+        lines.extend(f"- {item if isinstance(item, str) else _site_safe_text(json.dumps(item, sort_keys=True, default=str), 220)}" for item in useful[:3])
+    best = _compact_list_for_site(packet.get("bestEvidenceToReview"), max_items=3, item_limit=240)
+    if best:
+        lines.append("Best evidence to review:")
+        lines.extend(f"- {item if isinstance(item, str) else _site_safe_text(json.dumps(item, sort_keys=True, default=str), 240)}" for item in best[:3])
+    missing = _compact_list_for_site(packet.get("missingInfo") or sections.get("Missing Info"), max_items=3, item_limit=180)
+    action = _section_text(sections, "Suggested Next Action", limit=1)
+    lines.append("Missing info / next action:")
+    if missing:
+        lines.extend(f"- {item if isinstance(item, str) else _site_safe_text(json.dumps(item, sort_keys=True, default=str), 180)}" for item in missing[:3])
+    lines.append(_site_safe_text(action, 240))
+    summary = "\n".join(lines).strip()
+    if len(summary) > SITE_EVIDENCE_SUMMARY_TARGET:
+        summary = summary[: SITE_EVIDENCE_SUMMARY_TARGET - 1].rstrip() + "…"
+    return summary
+
+
+def compact_enrichment_payload_for_site(payload: dict[str, Any]) -> dict[str, Any]:
+    compact = dict(payload or {})
+    compact["evidenceSummary"] = _site_safe_text(compact.get("evidenceSummary"), SITE_EVIDENCE_SUMMARY_TARGET)
+    for key in SITE_BOUND_LIST_FIELDS:
+        if key in compact:
+            compact[key] = _compact_list_for_site(compact.get(key), max_items=SITE_LIST_MAX_ITEMS, item_limit=SITE_LIST_ITEM_LIMIT)
+    compact["rawProvenance"] = _compact_raw_provenance_for_site(compact.get("rawProvenance"))
+    return compact
+
+
+def validate_enrichment_payload_for_site(payload: dict[str, Any]) -> list[str]:
+    issues: list[str] = []
+    if len(str(payload.get("evidenceSummary") or "")) > SITE_EVIDENCE_SUMMARY_LIMIT:
+        issues.append("evidenceSummary exceeds site limit")
+    raw_len = len(json.dumps(payload.get("rawProvenance") or {}, sort_keys=True, default=str))
+    if raw_len > SITE_RAW_PROVENANCE_JSON_LIMIT:
+        issues.append("rawProvenance exceeds site JSON limit")
+    for key in SITE_BOUND_LIST_FIELDS:
+        if key not in payload:
+            continue
+        value = payload.get(key)
+        if not isinstance(value, list):
+            issues.append(f"{key} must be a list")
+            continue
+        if len(value) > SITE_LIST_MAX_ITEMS:
+            issues.append(f"{key} has too many items")
+        for item in value:
+            text = json.dumps(item, sort_keys=True, default=str) if isinstance(item, (dict, list)) else str(item)
+            if len(text) > 1000:
+                issues.append(f"{key} contains an oversized item")
+                break
+            if _LONG_ID_RE.search(text) or _PRIVATE_CHANNEL_NAME_RE.search(text) or "[object Object]" in text:
+                issues.append(f"{key} contains unsafe text")
+                break
+    return issues
+
+
 def build_enrichment_markdown(packet: dict[str, Any]) -> str:
     sections = packet.get("sections") or {}
     lines: list[str] = []
@@ -1558,7 +1759,7 @@ def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: 
     source_file = packet.get("sourceFile") if isinstance(packet.get("sourceFile"), dict) else {}
     target_candidate_id = _first(source_file, ("candidateId", "targetCandidateId", "id")) if match_kind in {"candidate_intake", "active_source_file"} else None
     target_dossier_id = _first(source_file, ("targetDossierId", "dossierId", "publicDossierId")) if match_kind == "existing_dossier_update" else None
-    evidence = build_enrichment_markdown(packet)
+    evidence = build_compact_enrichment_evidence_summary(packet)
     payload = {
         "type": "modify_existing_dossier" if match_kind in {"active_source_file", "existing_dossier_update", "candidate_intake"} else "new_subject",
         "targetCandidateId": target_candidate_id,
@@ -1582,6 +1783,7 @@ def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: 
         "identityDiagnostics": dict(packet.get("diagnostics") or {}),
         "internalClassification": dict(packet.get("classification") or {}),
         "knownContext": list(packet.get("knownContext") or []),
+        "usefulEvidence": list(packet.get("usefulEvidence") or packet.get("evidenceDetails") or []),
         "relationshipSignals": list(packet.get("relationshipSignals") or []),
         "publicSafePossibilities": list(packet.get("publicSafePossibilities") or []),
         "privateOnlyNotes": list(packet.get("privateOnlyNotes") or []),
@@ -1606,7 +1808,11 @@ def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: 
         "ingestSource": source_enrichment_ingest_source(environ),
         "ingestKey": deterministic_enrichment_ingest_key(subject, match_kind, sections),
     }
-    return build_dossier_recommendation_payload(payload)
+    compact_payload = compact_enrichment_payload_for_site(build_dossier_recommendation_payload(payload))
+    compact_payload["siteValidationIssues"] = validate_enrichment_payload_for_site(compact_payload)
+    if not compact_payload["siteValidationIssues"]:
+        compact_payload.pop("siteValidationIssues", None)
+    return compact_payload
 
 
 def run_source_file_enrichment(

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -31,6 +31,8 @@ SITE_LIST_ITEM_LIMIT = 500
 SITE_LIST_MAX_ITEMS = 25
 SITE_RAW_FRAGMENT_MAX_ITEMS = 4
 SITE_RAW_FRAGMENT_TEXT_LIMIT = 500
+SITE_SOURCE_COVERAGE_ALLOWED_KEYS = {"source", "count", "counts", "status"}
+SITE_SOURCE_COVERAGE_COUNTS_MAX_KEYS = 25
 SITE_BOUND_LIST_FIELDS = (
     "knownContext",
     "usefulEvidence",
@@ -42,7 +44,6 @@ SITE_BOUND_LIST_FIELDS = (
     "bnlInteractionSignals",
     "musicSignals",
     "communitySignals",
-    "sourceCoverage",
     "evidenceDetails",
     "publicSafePossibilities",
     "publicUseCandidates",
@@ -1604,6 +1605,56 @@ def _compact_list_for_site(value: Any, *, max_items: int = SITE_LIST_MAX_ITEMS, 
     return compact
 
 
+def _is_finite_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and value == value and value not in (float("inf"), float("-inf"))
+
+
+def _compact_source_coverage_counts_for_site(value: Any) -> dict[str, int | float]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, int | float] = {}
+    for key, raw_count in list(value.items())[:SITE_SOURCE_COVERAGE_COUNTS_MAX_KEYS]:
+        if not _is_finite_number(raw_count):
+            continue
+        safe_key = _site_safe_text(key, 120)
+        if not safe_key:
+            continue
+        compact[safe_key] = raw_count
+    return compact
+
+
+def _compact_source_coverage_for_site(value: Any) -> list[Any]:
+    raw_items = value if isinstance(value, (list, tuple, set)) else ([value] if value not in (None, "") else [])
+    compact: list[Any] = []
+    seen: set[str] = set()
+    for item in list(raw_items)[:SITE_LIST_MAX_ITEMS]:
+        compact_item: Any = None
+        if isinstance(item, str):
+            compact_item = _site_safe_text(item, SITE_LIST_ITEM_LIMIT)
+        elif isinstance(item, dict):
+            entry: dict[str, Any] = {}
+            if item.get("source") not in (None, ""):
+                entry["source"] = _site_safe_text(item.get("source"), 160)
+            if _is_finite_number(item.get("count")):
+                entry["count"] = item.get("count")
+            counts = _compact_source_coverage_counts_for_site(item.get("counts"))
+            if counts:
+                entry["counts"] = counts
+            if item.get("status") not in (None, ""):
+                entry["status"] = _site_safe_text(item.get("status"), 160)
+            compact_item = entry
+        else:
+            compact_item = _site_safe_text(item, SITE_LIST_ITEM_LIMIT)
+        if compact_item in (None, "", {}, []):
+            continue
+        fingerprint = json.dumps(compact_item, sort_keys=True, default=str) if isinstance(compact_item, (dict, list)) else str(compact_item)
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        compact.append(compact_item)
+    return compact
+
+
 def _compact_raw_provenance_for_site(raw: Any) -> dict[str, Any]:
     if not isinstance(raw, dict):
         return {}
@@ -1693,6 +1744,8 @@ def compact_enrichment_payload_for_site(payload: dict[str, Any]) -> dict[str, An
     for key in SITE_BOUND_LIST_FIELDS:
         if key in compact:
             compact[key] = _compact_list_for_site(compact.get(key), max_items=SITE_LIST_MAX_ITEMS, item_limit=SITE_LIST_ITEM_LIMIT)
+    if "sourceCoverage" in compact:
+        compact["sourceCoverage"] = _compact_source_coverage_for_site(compact.get("sourceCoverage"))
     compact["rawProvenance"] = _compact_raw_provenance_for_site(compact.get("rawProvenance"))
     return compact
 
@@ -1704,6 +1757,57 @@ def validate_enrichment_payload_for_site(payload: dict[str, Any]) -> list[str]:
     raw_len = len(json.dumps(payload.get("rawProvenance") or {}, sort_keys=True, default=str))
     if raw_len > SITE_RAW_PROVENANCE_JSON_LIMIT:
         issues.append("rawProvenance exceeds site JSON limit")
+    if "sourceCoverage" in payload:
+        source_coverage = payload.get("sourceCoverage")
+        if not isinstance(source_coverage, list):
+            issues.append("sourceCoverage must be a list")
+        else:
+            if len(source_coverage) > SITE_LIST_MAX_ITEMS:
+                issues.append("sourceCoverage has too many items")
+            for item in source_coverage:
+                if isinstance(item, str):
+                    if len(item) > 1000 or _LONG_ID_RE.search(item) or _PRIVATE_CHANNEL_NAME_RE.search(item) or "[object Object]" in item:
+                        issues.append("sourceCoverage contains unsafe text")
+                        break
+                    continue
+                if not isinstance(item, dict):
+                    issues.append("sourceCoverage contains unsupported item type")
+                    break
+                unsupported = set(item) - SITE_SOURCE_COVERAGE_ALLOWED_KEYS
+                if unsupported:
+                    issues.append("sourceCoverage contains unsupported object keys")
+                    break
+                text = json.dumps(item, sort_keys=True, default=str)
+                if len(text) > 1000 or _LONG_ID_RE.search(text) or _PRIVATE_CHANNEL_NAME_RE.search(text) or "[object Object]" in text:
+                    issues.append("sourceCoverage contains unsafe text")
+                    break
+                for text_key in ("source", "status"):
+                    if text_key in item and (not isinstance(item.get(text_key), str) or len(item.get(text_key) or "") > 1000):
+                        issues.append(f"sourceCoverage {text_key} must be a bounded string")
+                        break
+                if issues and issues[-1].startswith("sourceCoverage "):
+                    break
+                if "count" in item and not _is_finite_number(item.get("count")):
+                    issues.append("sourceCoverage count must be finite")
+                    break
+                if "counts" in item:
+                    counts = item.get("counts")
+                    if not isinstance(counts, dict):
+                        issues.append("sourceCoverage counts must be an object")
+                        break
+                    if len(counts) > SITE_SOURCE_COVERAGE_COUNTS_MAX_KEYS:
+                        issues.append("sourceCoverage counts has too many keys")
+                        break
+                    for count_key, count_value in counts.items():
+                        count_key_text = str(count_key or "")
+                        if len(count_key_text) > 1000 or _LONG_ID_RE.search(count_key_text) or _PRIVATE_CHANNEL_NAME_RE.search(count_key_text) or "[object Object]" in count_key_text:
+                            issues.append("sourceCoverage counts contains unsafe keys")
+                            break
+                        if not _is_finite_number(count_value):
+                            issues.append("sourceCoverage counts values must be finite")
+                            break
+                    if issues and issues[-1].startswith("sourceCoverage counts"):
+                        break
     for key in SITE_BOUND_LIST_FIELDS:
         if key not in payload:
             continue

--- a/tests/test_dossier_recommendations.py
+++ b/tests/test_dossier_recommendations.py
@@ -1,4 +1,5 @@
 import asyncio
+import io
 import json
 import os
 import sqlite3
@@ -292,6 +293,23 @@ class DossierRecommendationSenderTests(unittest.TestCase):
         self.assertFalse(result["ok"])
         self.assertIsNone(result["status"])
         self.assertIn("unreachable", result["error"])
+
+
+    def test_400_response_includes_safe_endpoint_error_text(self):
+        body = b'{"error":"Text field is too long","token":"secret-token","payload":"rawProvenance should not be copied"}'
+        http_error = urllib.error.HTTPError("https://example.test", 400, "Bad Request", hdrs=None, fp=io.BytesIO(body))
+        opener = FakeOpener(error=http_error)
+        result = dossier.send_dossier_recommendation(
+            {"subjectName": "Signal Witch", "reason": "Review", "sourceLanes": ["rd_context"]},
+            environ={"BNL_DOSSIER_INGEST_TOKEN": "secret-token"},
+            opener=opener,
+        )
+        result_text = json.dumps(result)
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["status"], 400)
+        self.assertIn("Text field is too long", result["error"])
+        self.assertNotIn("secret-token", result_text)
+        self.assertNotIn("rawProvenance should not be copied", result_text)
 
 
 class DossierRecommendationPermissionTests(unittest.TestCase):

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -699,6 +699,9 @@ class SourceFileEnrichmentTests(unittest.TestCase):
         self.assertEqual(compact["sourceCoverage"][2], {"source": "entity_evidence_events", "counts": {"public": 2, "review_only": 1}, "status": "found"})
         self.assertNotIn("notes", compact["sourceCoverage"][1])
         self.assertNotIn("rawTranscript", compact["sourceCoverage"][2])
+        for item in compact["sourceCoverage"]:
+            if isinstance(item, dict):
+                self.assertLessEqual(set(item), {"source", "count", "counts", "status"})
         self.assertFalse(enrich.validate_enrichment_payload_for_site(compact))
         self.assertNotIn("[object Object]", json.dumps(compact))
 

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -623,6 +623,57 @@ class SourceFileEnrichmentTests(unittest.TestCase):
         normal.pop("rawProvenance")
         self.assertNotIn("raw transcript", json.dumps(normal))
 
+    def test_enrichment_payload_is_compacted_to_site_limits(self):
+        long_item = "approved evidence " + ("x" * 3000) + " 123456789012345678"
+        packet = {
+            "subject": "HellcatNZ",
+            "matchKind": "active_source_file",
+            "sourceFile": {"id": "sf_1", "name": "HellcatNZ"},
+            "sections": {
+                "Subject Overview": [long_item for _ in range(20)],
+                "History With BARCODE / BNL / Discord / BARCODE Radio": ["prior history", "prior interaction history with review context"],
+                "Observed Patterns": ["community-side activity"],
+                "Missing Info": ["public links"],
+                "Suggested Next Action": ["owner review"],
+            },
+            "classification": {"primaryRole": "active_community_member", "activityLevel": "recurring", "dossierUse": "source_file_only"},
+            "bestEvidenceToReview": [long_item for _ in range(40)],
+            "observedChannels": ["#research-and-development 123456789012345678 " + ("x" * 2000) for _ in range(40)],
+            "conversationHighlights": ["highlight " + ("x" * 2000) for _ in range(40)],
+            "musicSignals": ["music signal"],
+            "communitySignals": ["community signal"],
+            "reviewOnlyEvidence": ["review-only note"],
+            "sourceCoverage": [{"source": "conversations", "count": 30, "status": "found", "notes": long_item}],
+            "queueSubmissionStatus": "not_connected",
+            "queueSubmissionNote": enrich.QUEUE_NOT_CONNECTED_NOTE,
+            "rawProvenance": {
+                "sourceLabels": ["entity_evidence_events/structured"],
+                "sourceCounts": {"entity_evidence_events": 40},
+                "channelPolicyCounts": {"public_safe": 20},
+                "sourceAuthority": ["local_observed"],
+                "rawFragments": [
+                    {"table": "conversations", "snippet": "full raw transcript " + ("x" * 10000), "rawRefJson": {"content": "full raw transcript " + ("y" * 10000), "channel_name": "research-and-development"}}
+                    for _ in range(20)
+                ],
+            },
+        }
+        payload = enrich.build_enrichment_recommendation_payload(packet, environ={})
+        self.assertLessEqual(len(payload["evidenceSummary"]), 2000)
+        self.assertLess(len(json.dumps(payload["rawProvenance"], sort_keys=True)), 20000)
+        self.assertLessEqual(len(payload["rawProvenance"].get("rawFragments", [])), 4)
+        for key in ("bestEvidenceToReview", "observedChannels", "conversationHighlights", "musicSignals", "communitySignals", "reviewOnlyEvidence", "sourceCoverage"):
+            self.assertIn(key, payload)
+            self.assertLessEqual(len(payload[key]), 25)
+        self.assertEqual(payload["queueSubmissionStatus"], "not_connected")
+        self.assertEqual(payload["queueSubmissionNote"], enrich.QUEUE_NOT_CONNECTED_NOTE)
+        normal = dict(payload)
+        normal.pop("rawProvenance", None)
+        normal_text = json.dumps(normal)
+        self.assertNotIn("123456789012345678", normal_text)
+        self.assertNotIn("research-and-development", normal_text)
+        self.assertNotIn("[object Object]", normal_text)
+        self.assertFalse(enrich.validate_enrichment_payload_for_site(payload))
+
     def test_payload_keeps_machine_metadata(self):
         result = enrich.run_source_file_enrichment(self.db, 1, "HellcatNZ", dry_run=True, lookup_func=self._lookup("active"))
         payload = result["payload"]

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -643,7 +643,10 @@ class SourceFileEnrichmentTests(unittest.TestCase):
             "musicSignals": ["music signal"],
             "communitySignals": ["community signal"],
             "reviewOnlyEvidence": ["review-only note"],
-            "sourceCoverage": [{"source": "conversations", "count": 30, "status": "found", "notes": long_item}],
+            "sourceCoverage": [
+                "entity_evidence_events checked",
+                {"source": "conversations", "count": 30, "counts": {"public": 20, "review": 10}, "status": "found", "notes": long_item},
+            ],
             "queueSubmissionStatus": "not_connected",
             "queueSubmissionNote": enrich.QUEUE_NOT_CONNECTED_NOTE,
             "rawProvenance": {
@@ -664,6 +667,12 @@ class SourceFileEnrichmentTests(unittest.TestCase):
         for key in ("bestEvidenceToReview", "observedChannels", "conversationHighlights", "musicSignals", "communitySignals", "reviewOnlyEvidence", "sourceCoverage"):
             self.assertIn(key, payload)
             self.assertLessEqual(len(payload[key]), 25)
+        self.assertEqual(payload["sourceCoverage"][0], "entity_evidence_events checked")
+        self.assertEqual(payload["sourceCoverage"][1]["source"], "conversations")
+        self.assertEqual(payload["sourceCoverage"][1]["count"], 30)
+        self.assertEqual(payload["sourceCoverage"][1]["counts"], {"public": 20, "review": 10})
+        self.assertEqual(payload["sourceCoverage"][1]["status"], "found")
+        self.assertNotIn("notes", payload["sourceCoverage"][1])
         self.assertEqual(payload["queueSubmissionStatus"], "not_connected")
         self.assertEqual(payload["queueSubmissionNote"], enrich.QUEUE_NOT_CONNECTED_NOTE)
         normal = dict(payload)
@@ -673,6 +682,45 @@ class SourceFileEnrichmentTests(unittest.TestCase):
         self.assertNotIn("research-and-development", normal_text)
         self.assertNotIn("[object Object]", normal_text)
         self.assertFalse(enrich.validate_enrichment_payload_for_site(payload))
+
+    def test_source_coverage_compactor_matches_site_contract(self):
+        payload = {
+            "evidenceSummary": "compact",
+            "sourceCoverage": [
+                "source_file_lookup checked",
+                {"source": "conversations", "count": 3, "status": "found", "notes": "drop me"},
+                {"source": "entity_evidence_events", "counts": {"public": 2, "review_only": 1}, "status": "found", "rawTranscript": "drop me too"},
+            ],
+            "rawProvenance": {},
+        }
+        compact = enrich.compact_enrichment_payload_for_site(payload)
+        self.assertEqual(compact["sourceCoverage"][0], "source_file_lookup checked")
+        self.assertEqual(compact["sourceCoverage"][1], {"source": "conversations", "count": 3, "status": "found"})
+        self.assertEqual(compact["sourceCoverage"][2], {"source": "entity_evidence_events", "counts": {"public": 2, "review_only": 1}, "status": "found"})
+        self.assertNotIn("notes", compact["sourceCoverage"][1])
+        self.assertNotIn("rawTranscript", compact["sourceCoverage"][2])
+        self.assertFalse(enrich.validate_enrichment_payload_for_site(compact))
+        self.assertNotIn("[object Object]", json.dumps(compact))
+
+    def test_source_coverage_validation_flags_uncompacted_contract_violations(self):
+        payload = {
+            "evidenceSummary": "compact",
+            "sourceCoverage": [
+                {"source": "conversations", "count": 3, "status": "found", "notes": "unsupported"},
+                {"source": "bad", "counts": {"private": float("inf")}, "status": "found"},
+            ],
+            "rawProvenance": {},
+        }
+        issues = enrich.validate_enrichment_payload_for_site(payload)
+        self.assertTrue(any("unsupported object keys" in issue for issue in issues))
+        count_issues = enrich.validate_enrichment_payload_for_site({"evidenceSummary": "compact", "sourceCoverage": [{"source": "bad", "count": float("inf"), "status": "found"}], "rawProvenance": {}})
+        self.assertTrue(any("count must be finite" in issue for issue in count_issues))
+        counts_issues = enrich.validate_enrichment_payload_for_site({"evidenceSummary": "compact", "sourceCoverage": [{"source": "bad", "counts": {"private": float("inf")}, "status": "found"}], "rawProvenance": {}})
+        self.assertTrue(any("counts values must be finite" in issue for issue in counts_issues))
+        compact = enrich.compact_enrichment_payload_for_site(payload)
+        self.assertFalse(enrich.validate_enrichment_payload_for_site(compact))
+        self.assertNotIn("notes", compact["sourceCoverage"][0])
+        self.assertNotIn("counts", compact["sourceCoverage"][1])
 
     def test_payload_keeps_machine_metadata(self):
         result = enrich.run_source_file_enrichment(self.db, 1, "HellcatNZ", dry_run=True, lookup_func=self._lookup("active"))


### PR DESCRIPTION
### Motivation
- Operator sends of Source File enrichments were failing with HTTP 400 from the website because recently richer payloads exceeded strict site validation limits (evidenceSummary, rawProvenance, list field sizes, etc.).
- The bot must continue to produce full dry-run previews locally while sending compact, contract-safe payloads to the site ingest endpoint. 
- Improve failure diagnostics for rejected POSTs without leaking tokens, full payloads, or raw provenance so future problems are diagnosable.

### Description
- Add site contract constants and a private-channel/ID redaction regex, and implement compaction helpers: `_site_safe_text`, `_compact_value_for_site`, `_compact_list_for_site`, and `_compact_raw_provenance_for_site` in `bnl_source_file_enrichment.py` to bound item lengths, number of items, and raw fragment content. 
- Implement `build_compact_enrichment_evidence_summary(...)`, `compact_enrichment_payload_for_site(...)`, and `validate_enrichment_payload_for_site(...)` and switch enrichment payload construction to produce a compact `evidenceSummary` and a compact/validated payload before returning/sending. 
- Preserve structured fields required by the site (e.g., `bestEvidenceToReview`, `observedChannels`, `conversationHighlights`, `musicSignals`, `communitySignals`, `reviewOnlyEvidence`, `queueSubmissionStatus`, `queueSubmissionNote`, `sourceCoverage`) while ensuring list bounds and item redaction. 
- Improve HTTP 400 diagnostics in `bnl_dossier_recommendations.send_dossier_recommendation` by extracting compact, redacted error text from the endpoint body and returning it in the safe `sendResult` without exposing tokens, full payloads, or rawProvenance. 
- Add/extend unit tests to cover payload compaction, rawProvenance bounds, redaction of IDs and private channel names, preservation of required structured fields, and safe 400 error handling, and update existing tests to assert site-compatibility behavior.

### Testing
- Ran unit test suite with `python -m unittest discover -s tests -v`, which completed successfully (all tests passed in the final run). 
- Verified syntax with `python -m py_compile` on the main modules and observed no compile errors. 
- Ran `git diff --check` and ensured no whitespace/git-diff issues were reported.
- New/updated tests exercise evidenceSummary compaction, rawProvenance trimming, list-field bounds, and safe HTTP 400 diagnostics and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20779b5cd4832194edbb12da07b784)