### PR TITLE
Website-safe Source File evidence labels

### DIFF
--- a/bnl_entity_activity_summary.py
+++ b/bnl_entity_activity_summary.py
@@ -21,6 +21,7 @@ from bnl_entity_evidence import (
     get_entity_evidence_for_subject,
     group_entity_evidence_details,
     table_exists as _evidence_table_exists,
+    _website_safe_topic_label,
 )
 
 DEFAULT_ENTITY_SUMMARY_LIMIT = 50
@@ -574,7 +575,8 @@ def build_entity_activity_summary(
                     _add_unique(summary["channelActivity"], f"Appears in approved public-side conversation context in {channel_display} as {relation} context.")
                     _add_unique(summary["observedChannels"], f"{channel_display} — approved public-side; subject {relation}.")
                     _add_unique(summary["conversationHighlights"], _conversation_highlight(text, authored=authored, public_safe=True, channel_name=channel_name, channel_policy=policy))
-                    _add_unique(summary["evidenceDetails"], f"{channel_display}: subject {relation} approved public-side {topics[0].replace(' discussion', '').lower()} discussion.")
+                    safe_topic = _website_safe_topic_label(topics[0])
+                    _add_unique(summary["evidenceDetails"], f"{channel_display}: approved public-side item classified under {safe_topic}; review before treating it as a subject claim.")
                     if _MUSIC_PATTERN.search(text):
                         _add_unique(summary["musicSignals"], "Approved context connects this subject to music, track, queue, radio, or show discussion; queue identity still needs review.")
                     if _COMMUNITY_PATTERN.search(text):
@@ -602,7 +604,7 @@ def build_entity_activity_summary(
                     _add_unique(summary["conversationHighlights"], _conversation_highlight(text, authored=authored, public_safe=False, channel_name=channel_name, channel_policy=policy))
                     quality = "internal_context_review_only"
                 for topic in topics:
-                    _add_unique(summary["topicBreakdown"], f"{topic}: observed in conversation context.")
+                    _add_unique(summary["topicBreakdown"], f"{_website_safe_topic_label(topic)}: observed in conversation context.")
                 _record_raw(summary["rawProvenance"], "conversations", quality, _safe_snippet(text), channelPolicy=policy, channelName=channel_name, subjectRelation=relation, timestamp=timestamp)
 
         if "memory_tiers" in lanes:
@@ -709,12 +711,12 @@ def build_entity_activity_summary(
         _add_unique(summary["publicUseCandidates"], "Possible community/source-file candidate, pending owner review.")
     _add_unique(summary["notPublicYet"], QUEUE_NOT_CONNECTED_NOTE)
 
-    summary["recurringTopics"] = [f"Observed topic pattern: {topic}." for topic, count in topic_counts.most_common(5) if count > 0]
+    summary["recurringTopics"] = [f"Observed topic classification: {_website_safe_topic_label(topic)}." for topic, count in topic_counts.most_common(5) if count > 0]
     has_detail_breakdown = any("public-side authored" in item or "public-side mentioned" in item for item in summary["topicBreakdown"])
     if not has_detail_breakdown:
         for topic, count in topic_counts.most_common(8):
             if count > 0:
-                _add_unique(summary["topicBreakdown"], f"{topic}: {count} approved/reviewed source row(s).")
+                _add_unique(summary["topicBreakdown"], f"{_website_safe_topic_label(topic)}: {count} approved/reviewed source item(s).")
     if not summary["musicSignals"]:
         _add_unique(summary["musicSignals"], "No queue/submission identity is connected yet; do not claim music submissions or counts from this summary.")
     if not summary["communitySignals"] and summary["rawProvenance"]["rawFragments"]:

--- a/bnl_entity_evidence.py
+++ b/bnl_entity_evidence.py
@@ -58,6 +58,76 @@ _TOPIC_PATTERNS = [
     ("Admin/operator review context", re.compile(r"\b(admin|operator|moderation|mod|staff|review-only|internal|private)\b", re.I)),
 ]
 
+_SLASH_TOPIC_LABEL_REPLACEMENTS = {
+    "bnl/source-file/dossier discussion": "BNL source-file and dossier classification",
+    "bnl/source-file/dossier": "BNL source-file and dossier classification",
+    "music/track-sharing discussion": "music and track-sharing classification",
+    "music/track-sharing": "music and track-sharing classification",
+    "wip/demo discussion": "WIP and demo classification",
+    "wip/demo": "WIP and demo classification",
+    "community/server participation": "community and server participation classification",
+    "community/server": "community and server classification",
+    "event/riddle/engagement activity": "event, riddle, or engagement classification",
+    "event/riddle/engagement": "event, riddle, or engagement classification",
+    "help/support requests": "help and support classification",
+    "help/support": "help and support classification",
+}
+_CLASSIFICATION_SUFFIX_RE = re.compile(r"\s+(?:discussion|activity|requests?|context)\s*$", re.I)
+
+
+def _join_topic_parts_for_payload(parts: list[str]) -> str:
+    cleaned = [part.strip() for part in parts if part and part.strip()]
+    if not cleaned:
+        return "local context"
+    if len(cleaned) == 1:
+        return cleaned[0]
+    if len(cleaned) == 2:
+        return f"{cleaned[0]} and {cleaned[1]}"
+    return f"{', '.join(cleaned[:-1])}, or {cleaned[-1]}"
+
+
+def _website_safe_topic_label(value: Any) -> str:
+    """Convert internal slash taxonomy into website-safe classification wording."""
+
+    raw = re.sub(r"\s+", " ", str(value or "")).strip()
+    if not raw:
+        return "local context classification"
+    lowered = raw.lower()
+    if lowered in _SLASH_TOPIC_LABEL_REPLACEMENTS:
+        return _SLASH_TOPIC_LABEL_REPLACEMENTS[lowered]
+    if "/" not in raw:
+        return raw
+    first, *tail = raw.split(" ")
+    taxonomy = first if "/" in first else raw
+    suffix = " ".join(tail) if taxonomy == first else ""
+    if taxonomy != first:
+        taxonomy = _CLASSIFICATION_SUFFIX_RE.sub("", taxonomy)
+    pieces = taxonomy.split("/")
+    normalized_parts: list[str] = []
+    for piece in pieces:
+        cleaned = re.sub(r"[^A-Za-z0-9 -]+", " ", piece).strip()
+        if cleaned.upper() in {"BNL", "WIP"}:
+            cleaned = cleaned.upper()
+        elif cleaned:
+            cleaned = cleaned[:1].lower() + cleaned[1:]
+        if cleaned:
+            normalized_parts.append(cleaned)
+    suffix = _CLASSIFICATION_SUFFIX_RE.sub("", suffix).strip()
+    if suffix and suffix.lower() == "participation":
+        normalized_parts.append("participation")
+    label = _join_topic_parts_for_payload(normalized_parts)
+    return f"{label} classification"
+
+
+def _website_safe_payload_text(value: Any) -> str:
+    """Sanitize known internal topic taxonomy embedded in normal website fields."""
+
+    text = str(value or "")
+    for raw_label in sorted(_SLASH_TOPIC_LABEL_REPLACEMENTS, key=len, reverse=True):
+        safe_label = _SLASH_TOPIC_LABEL_REPLACEMENTS[raw_label]
+        text = re.sub(re.escape(raw_label), safe_label, text, flags=re.I)
+    return text.replace("/", " and ")
+
 
 def now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -306,7 +376,7 @@ def build_conversation_safe_summary(*, text: str, authored: bool, public_safe: b
         role = "authored" if authored else "was mentioned in"
         return f"Subject {role} review-only conversation context; private/internal channel details require owner review."
     labels = extract_conversation_topic_details(text, review_only=False)
-    primary = labels[0].replace(" discussion", "").replace("BNL/source-file/dossier", "dossier/source-file")
+    primary = _website_safe_topic_label(labels[0]).removesuffix(" classification")
     if primary == "Help/support requests":
         action = "help/support request"
     elif primary == "Community/server participation":
@@ -340,9 +410,12 @@ def extract_entity_activity_details(row: sqlite3.Row | dict[str, Any]) -> dict[s
 def _representative_evidence_line(detail: dict[str, Any]) -> str:
     if not detail.get("publicSafe"):
         return "Review-only evidence exists; private/internal details require owner review."
-    relation = "authored" if detail.get("relation") == "authored" else "mentioned"
-    topic = str(detail.get("topic") or "community/server participation").replace(" discussion", "").lower()
-    return f"{detail.get('channel')}: {relation} {topic} discussion."
+    channel = _website_safe_payload_text(detail.get("channel") or "approved public-side channel")
+    topic = _website_safe_topic_label(detail.get("topic") or "Community/server participation")
+    topic_context = topic.removesuffix(" classification")
+    if topic_context.lower().startswith("bnl source-file and dossier"):
+        return f"{channel}: BNL classified this approved public-context item under {topic_context} context; review before treating it as a subject claim."
+    return f"{channel}: approved public-context item classified under {topic_context}; review before using as a subject claim."
 
 
 def group_entity_evidence_details(rows: list[sqlite3.Row | dict[str, Any]]) -> dict[str, Any]:
@@ -368,11 +441,12 @@ def group_entity_evidence_details(rows: list[sqlite3.Row | dict[str, Any]]) -> d
         relations = topic_relation_counts.get(topic, Counter())
         rel_bits = []
         if relations.get("authored"):
-            rel_bits.append(f"{relations['authored']} public-side authored row(s)")
+            rel_bits.append(f"{relations['authored']} public-side authored item(s)")
         mentioned = count - relations.get("authored", 0)
         if mentioned:
-            rel_bits.append(f"{mentioned} public-side mentioned row(s)")
-        line = f"{topic}: {', '.join(rel_bits) or f'{count} public-side row(s)'}"
+            rel_bits.append(f"{mentioned} public-side mentioned item(s)")
+        safe_topic = _website_safe_topic_label(topic)
+        line = f"{safe_topic}: {', '.join(rel_bits) or f'{count} public-side item(s)'}"
         channel, channel_count = (topic_channel_counts.get(topic, Counter()).most_common(1) or [("", 0)])[0]
         if channel.startswith("#") and channel_count >= max(1, count // 2):
             line += f", mostly in {channel}"
@@ -397,10 +471,10 @@ def group_entity_evidence_details(rows: list[sqlite3.Row | dict[str, Any]]) -> d
             "reviewOnlyEvidenceCount": review_only_count,
             "mostRecentObservedAt": most_recent,
         },
-        "authoredVsMentionedSummary": f"{authored_count} approved public-side authored row(s); {mentioned_count} approved public-side mentioned row(s).",
+        "authoredVsMentionedSummary": f"{authored_count} approved public-side authored item(s); {mentioned_count} approved public-side mentioned item(s).",
         "recentActivitySummary": f"Most recent observed evidence timestamp: {most_recent}." if most_recent else "No observed timestamp available in structured evidence.",
         "topChannels": [{"channel": channel, "count": count} for channel, count in channel_counts.most_common(5)],
-        "topTopicDetails": [{"topic": topic, "count": count} for topic, count in topic_counts.most_common(8)],
+        "topTopicDetails": [{"topic": _website_safe_topic_label(topic), "count": count} for topic, count in topic_counts.most_common(8)],
         "topicBreakdown": topic_breakdown,
         "representativeEvidence": representative[:6],
     }

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -17,6 +17,7 @@ from typing import Any, Callable
 
 from bnl_dossier_recommendations import build_dossier_recommendation_payload, send_dossier_recommendation
 from bnl_entity_activity_summary import build_entity_activity_summary, refresh_entity_evidence_for_subject
+from bnl_entity_evidence import _website_safe_payload_text
 from bnl_source_file_lookup import lookup_source_file
 
 ENRICHMENT_INGEST_SOURCE = "bnl_source_file_enrichment"
@@ -59,6 +60,12 @@ SITE_BOUND_LIST_FIELDS = (
     "doNotSay",
 )
 _PRIVATE_CHANNEL_NAME_RE = re.compile(r"(?i)(?:#?(?:research-and-development|private[-_ ]?internal|private[-_ ]?chat|staff[-_ ]?only|mod[-_ ]?chat|direct[-_ ]?message)s?|\bdm\b)")
+
+_RAW_REPRESENTATIVE_EVIDENCE_RE = re.compile(
+    r"(?:\b(?:source(?:_file)?_?lookup|entity_evidence_events|conversations|user_profiles|memory_tiers|broadcast_memory|rd_context|rawRefJson|sourceTable|sourceRowId|sourceLabel)\b|\b(?:row|id)[:=]\s*[A-Za-z0-9_-]+|\b[a-z_]+/[A-Za-z0-9_-]+)",
+    re.I,
+)
+_UNSAFE_REPRESENTATIVE_EVIDENCE_TOKENS = ("authored_public_conversation", "profile_match", "[object Object]")
 
 ENTITY_SUMMARY_EVIDENCE_FIELDS = {
     "observedChannels": 6,
@@ -1572,8 +1579,37 @@ def _section_text(sections: dict[str, list[str]], name: str, *, limit: int = 4) 
 
 def _site_safe_text(value: Any, limit: int = SITE_LIST_ITEM_LIMIT) -> str:
     text = _safe_text(value, limit)
+    text = _website_safe_payload_text(text)
+    text = text.replace("authored_public_conversation", "authored public conversation classification")
+    text = text.replace("mentioned_public_conversation", "mentioned public conversation classification")
+    text = text.replace("profile_match", "local profile match classification")
+    text = re.sub(r"\brow\(s\)", "item(s)", text, flags=re.I)
+    text = re.sub(r"\brows\b", "items", text, flags=re.I)
     text = _PRIVATE_CHANNEL_NAME_RE.sub("[private-channel]", text)
     return text.replace("[object Object]", "[unsupported-object]")
+
+
+def _compact_representative_evidence_item_for_site(value: Any) -> str:
+    text = _site_safe_text(value, SITE_LIST_ITEM_LIMIT)
+    channel = "approved public-side channel"
+    body = text
+    if ":" in text:
+        maybe_channel, body = text.split(":", 1)
+        if maybe_channel.strip().startswith("#"):
+            channel = maybe_channel.strip()
+    body = body.strip().rstrip(".")
+    lowered = body.lower()
+    if "classified under" in lowered and "review before" in lowered and "/" not in body:
+        return f"{channel}: {body}." if channel not in text[: len(channel) + 1] else text
+    match = re.search(r"(?:authored|mentioned)?\s*([A-Za-z0-9 -]+(?: and |, or )[A-Za-z0-9 ,or-]+)(?: classification)?(?: discussion)?", body, flags=re.I)
+    if match:
+        topic = _website_safe_payload_text(match.group(1)).removesuffix(" classification")
+        if topic.lower().startswith("bnl source-file and dossier"):
+            return f"{channel}: BNL classified this approved public-context item under {topic} context; review before treating it as a subject claim."
+        return f"{channel}: approved public-context item classified under {topic}; review before using as a subject claim."
+    if "/" in text or "authored" in lowered or "mentioned" in lowered or _RAW_REPRESENTATIVE_EVIDENCE_RE.search(text):
+        return f"{channel}: approved public-context item has a BNL classification; review before using as a subject claim."
+    return text
 
 
 def _compact_value_for_site(value: Any, *, text_limit: int = SITE_LIST_ITEM_LIMIT, depth: int = 0) -> Any:
@@ -1756,7 +1792,16 @@ def compact_enrichment_payload_for_site(payload: dict[str, Any]) -> dict[str, An
     compact["evidenceSummary"] = _site_safe_text(compact.get("evidenceSummary"), SITE_EVIDENCE_SUMMARY_TARGET)
     for key in SITE_BOUND_LIST_FIELDS:
         if key in compact:
-            compact[key] = _compact_list_for_site(compact.get(key), max_items=SITE_LIST_MAX_ITEMS, item_limit=SITE_LIST_ITEM_LIMIT)
+            if key == "representativeEvidence":
+                compact[key] = []
+                seen_rep: set[str] = set()
+                for item in _compact_list_for_site(compact.get(key) or payload.get(key), max_items=SITE_LIST_MAX_ITEMS, item_limit=SITE_LIST_ITEM_LIMIT):
+                    rep_item = _compact_representative_evidence_item_for_site(item)
+                    if rep_item and rep_item not in seen_rep:
+                        compact[key].append(rep_item)
+                        seen_rep.add(rep_item)
+            else:
+                compact[key] = _compact_list_for_site(compact.get(key), max_items=SITE_LIST_MAX_ITEMS, item_limit=SITE_LIST_ITEM_LIMIT)
     if "sourceCoverage" in compact:
         compact["sourceCoverage"] = _compact_source_coverage_for_site(compact.get("sourceCoverage"))
     compact["rawProvenance"] = _compact_raw_provenance_for_site(compact.get("rawProvenance"))
@@ -1816,6 +1861,25 @@ def _validate_source_coverage_for_site(source_coverage: Any) -> list[str]:
     return issues
 
 
+
+def _validate_representative_evidence_for_site(value: Any) -> list[str]:
+    issues: list[str] = []
+    if not isinstance(value, list):
+        return ["representativeEvidence must be a list"]
+    for item in value:
+        text = json.dumps(item, sort_keys=True, default=str) if isinstance(item, (dict, list)) else str(item)
+        lowered = text.lower()
+        if "/" in text:
+            issues.append("representativeEvidence contains slash taxonomy")
+            break
+        if any(token.lower() in lowered for token in _UNSAFE_REPRESENTATIVE_EVIDENCE_TOKENS):
+            issues.append("representativeEvidence contains unsupported raw metadata")
+            break
+        if _LONG_ID_RE.search(text) or _RAW_REPRESENTATIVE_EVIDENCE_RE.search(text):
+            issues.append("representativeEvidence contains unsupported raw metadata")
+            break
+    return issues
+
 def validate_enrichment_payload_for_site(payload: dict[str, Any]) -> list[str]:
     issues: list[str] = []
     if len(str(payload.get("evidenceSummary") or "")) > SITE_EVIDENCE_SUMMARY_LIMIT:
@@ -1825,6 +1889,8 @@ def validate_enrichment_payload_for_site(payload: dict[str, Any]) -> list[str]:
         issues.append("rawProvenance exceeds site JSON limit")
     if "sourceCoverage" in payload:
         issues.extend(_validate_source_coverage_for_site(payload.get("sourceCoverage")))
+    if "representativeEvidence" in payload:
+        issues.extend(_validate_representative_evidence_for_site(payload.get("representativeEvidence")))
     for key in SITE_BOUND_LIST_FIELDS:
         if key not in payload:
             continue

--- a/tests/test_dossier_recommendations.py
+++ b/tests/test_dossier_recommendations.py
@@ -205,7 +205,7 @@ class DossierSourcePacketTests(unittest.TestCase):
             self.assertTrue(any("Local profile match found for Signal Witch" in item for item in payload["knownContext"]))
             self.assertTrue(any("relationship/context" in item for item in payload["relationshipSignals"]))
             self.assertTrue(any("#finished-tracks" in item for item in payload["observedChannels"]))
-            self.assertTrue(any("dossier/source-file" in item for item in payload["conversationHighlights"]))
+            self.assertTrue(any("BNL source-file and dossier" in item for item in payload["conversationHighlights"]))
             self.assertTrue(any("music" in item.lower() for item in payload["musicSignals"]))
             self.assertFalse(any("relationship" in item.lower() for item in payload["publicSafePossibilities"]))
             self.assertIn("queue/submission identity is not connected yet", payload["recommendedAction"])

--- a/tests/test_entity_activity_summary.py
+++ b/tests/test_entity_activity_summary.py
@@ -238,10 +238,10 @@ class EntityActivitySummaryBuilderTests(unittest.TestCase):
 
         self.assertTrue(any("#finished-tracks" in item and "authored" in item for item in summary["observedChannels"]))
         self.assertTrue(any("#barcode-bot" in item and "mentioned" in item for item in summary["observedChannels"]))
-        self.assertTrue(any("Subject authored" in item and "dossier/source-file" in item for item in summary["conversationHighlights"]))
+        self.assertTrue(any("Subject authored" in item and "BNL source-file and dossier" in item for item in summary["conversationHighlights"]))
         self.assertTrue(any("Subject was mentioned" in item for item in summary["conversationHighlights"]))
         self.assertTrue(any("music" in item.lower() for item in summary["topicBreakdown"]))
-        self.assertTrue(any("source-file/dossier" in item.lower() for item in summary["topicBreakdown"]))
+        self.assertTrue(any("source-file and dossier" in item.lower() for item in summary["topicBreakdown"]))
         self.assertTrue(any("music" in item.lower() for item in summary["musicSignals"]))
         self.assertTrue(any("community" in item.lower() for item in summary["communitySignals"]))
         self.assertTrue(any("BNL-related" in item for item in summary["bnlInteractionSignals"]))
@@ -322,10 +322,12 @@ class EntityActivitySummaryBuilderTests(unittest.TestCase):
         self.assertIn("2026-06-05T10:00:00", summary["recentActivitySummary"])
         self.assertTrue(any(item.get("channel") == "#barcode-bot" and item.get("count") == 2 for item in summary["topChannels"]))
         topic_text = json.dumps(summary["topTopicDetails"] + summary["topicBreakdown"])
-        self.assertIn("Music/track-sharing discussion", topic_text)
-        self.assertIn("BNL/source-file/dossier discussion", topic_text)
-        self.assertIn("Help/support requests", topic_text)
-        self.assertIn("Community/server participation", topic_text)
+        self.assertIn("music and track-sharing classification", topic_text)
+        self.assertIn("BNL source-file and dossier classification", topic_text)
+        self.assertIn("help and support classification", topic_text)
+        self.assertIn("community and server participation classification", topic_text)
+        self.assertNotIn("Music/track-sharing", topic_text)
+        self.assertNotIn("BNL/source-file/dossier", topic_text)
         self.assertIn("#finished-tracks", json.dumps(summary["representativeEvidence"]))
         self.assertIn("#barcode-bot", json.dumps(summary["representativeEvidence"]))
         self.assertNotIn("research-and-development", normal_text)
@@ -334,6 +336,32 @@ class EntityActivitySummaryBuilderTests(unittest.TestCase):
         self.assertNotIn("EDGE_SESSION", normal_text)
         self.assertEqual(summary["queueSubmissionStatus"], "not_connected")
         self.assertNotRegex(normal_text, r"submitted\s+\d+|\d+\s+songs|Priority|payment")
+
+    def test_website_safe_topic_labels_cover_slash_taxonomy(self):
+        cases = {
+            "BNL/source-file/dossier discussion": "BNL source-file and dossier classification",
+            "Music/track-sharing discussion": "music and track-sharing classification",
+            "WIP/demo discussion": "WIP and demo classification",
+            "Community/server participation": "community and server participation classification",
+            "Event/riddle/engagement activity": "event, riddle, or engagement classification",
+            "Help/support requests": "help and support classification",
+        }
+        for raw, safe in cases.items():
+            with self.subTest(raw=raw):
+                self.assertEqual(evidence._website_safe_topic_label(raw), safe)
+                self.assertNotIn("/", safe)
+
+    def test_representative_evidence_line_is_website_safe_and_not_subject_claim(self):
+        line = evidence._representative_evidence_line({
+            "publicSafe": True,
+            "relation": "authored",
+            "topic": "BNL/source-file/dossier discussion",
+            "channel": "#barcode-bot",
+        })
+        self.assertNotIn("/", line)
+        self.assertNotIn("authored", line.lower())
+        self.assertIn("BNL classified this approved public-context item", line)
+        self.assertIn("review before treating it as a subject claim", line)
 
     def test_no_queue_submission_counts_are_invented(self):
         self.conn.execute("INSERT INTO user_profiles VALUES (42,1,'Crow','Crow',NULL,NULL)")

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -579,7 +579,7 @@ class SourceFileEnrichmentTests(unittest.TestCase):
         self.assertTrue(any(item.get("source") == "conversations" for item in payload["sourceCoverage"] if isinstance(item, dict)))
         self.assertEqual(payload["queueSubmissionStatus"], "not_connected")
         self.assertEqual(payload["queueSubmissionNote"], enrich.QUEUE_NOT_CONNECTED_NOTE)
-        self.assertTrue(any("pending owner/admin review" in item for item in payload["publicUseCandidates"]))
+        self.assertTrue(any("pending owner and admin review" in item for item in payload["publicUseCandidates"]))
         self.assertTrue(any("Review-only planning context" in item for item in payload["reviewOnlyEvidence"]))
         public_normal_text = json.dumps({key: payload.get(key) for key in ("observedChannels", "conversationHighlights", "representativeEvidence", "evidenceDetails", "bestEvidenceToReview", "publicUseCandidates")})
         self.assertNotIn("Review-only planning context", public_normal_text)
@@ -622,12 +622,59 @@ class SourceFileEnrichmentTests(unittest.TestCase):
             "rawProvenance": {"rawFragments": [{"rawRefJson": "raw transcript"}]},
         }
         payload = enrich.build_enrichment_recommendation_payload(packet, environ={})
-        for key in ("observedChannels", "conversationHighlights", "representativeEvidence", "topicBreakdown", "topChannels", "topTopicDetails", "activityFrequencySummary", "recentActivitySummary", "authoredVsMentionedSummary", "bestEvidenceToReview", "bnlInteractionSignals", "musicSignals", "communitySignals", "sourceCoverage", "evidenceDetails", "publicUseCandidates", "reviewOnlyEvidence", "queueSubmissionStatus", "queueSubmissionNote"):
+        passthrough_keys = ("observedChannels", "conversationHighlights", "topChannels", "activityFrequencySummary", "recentActivitySummary", "authoredVsMentionedSummary", "bnlInteractionSignals", "communitySignals", "sourceCoverage", "evidenceDetails", "reviewOnlyEvidence", "queueSubmissionStatus", "queueSubmissionNote")
+        for key in passthrough_keys:
             self.assertEqual(payload[key], packet[key])
+        self.assertEqual(payload["topicBreakdown"], ["music and track-sharing classification: 1 public-side authored item(s), mostly in #finished-tracks."])
+        self.assertEqual(payload["representativeEvidence"], ["#finished-tracks: approved public-context item classified under music and track-sharing; review before using as a subject claim."])
+        self.assertEqual(payload["topTopicDetails"], [{"topic": "music and track-sharing classification", "count": 1}])
+        self.assertEqual(payload["bestEvidenceToReview"], ["discord: authored public conversation classification — Sanitized highlight."])
+        self.assertEqual(payload["musicSignals"], ["Music and radio and show context exists; queue identity still needs review."])
+        self.assertEqual(payload["publicUseCandidates"], ["Possible community and source-file candidate, pending owner and admin review."])
         self.assertEqual(payload["rawProvenance"], packet["rawProvenance"])
         normal = dict(payload)
         normal.pop("rawProvenance")
         self.assertNotIn("raw transcript", json.dumps(normal))
+
+    def test_representative_evidence_payload_validation_catches_raw_metadata(self):
+        issues = enrich.validate_enrichment_payload_for_site({
+            "evidenceSummary": "summary",
+            "rawProvenance": {},
+            "representativeEvidence": [
+                "#barcode-bot: authored_public_conversation row id=123456789012345678 BNL/source-file/dossier [object Object] profile_match"
+            ],
+        })
+        self.assertTrue(any("representativeEvidence contains" in issue for issue in issues))
+
+    def test_representative_evidence_and_topic_fields_are_sanitized_before_send(self):
+        packet = {
+            "subject": "Crow",
+            "matchKind": "active_source_file",
+            "sourceFile": {"id": "sf_1", "name": "Crow"},
+            "sections": {"Public-Safe Notes": ["No public copy yet."], "Do Not Say": ["Do not publish raw notes."], "Missing Info": ["public links"], "Suggested Next Action": ["owner review"]},
+            "topicBreakdown": ["BNL/source-file/dossier discussion: 1 public-side authored row(s), mostly in #barcode-bot."],
+            "representativeEvidence": ["#barcode-bot: authored bnl/source-file/dossier discussion."],
+            "topTopicDetails": [{"topic": "Event/riddle/engagement activity", "count": 2}],
+            "queueSubmissionStatus": "not_connected",
+            "queueSubmissionNote": enrich.QUEUE_NOT_CONNECTED_NOTE,
+            "rawProvenance": {"sourceLabels": ["entity_evidence_events/structured"], "rawFragments": [{"rawRefJson": "raw BNL/source-file/dossier transcript", "sourceRowId": "99"}]},
+        }
+        payload = enrich.build_enrichment_recommendation_payload(packet, environ={})
+        normal = dict(payload)
+        raw = normal.pop("rawProvenance")
+        normal_text = json.dumps(normal)
+        rep_text = json.dumps(payload["representativeEvidence"])
+        self.assertNotIn("/", rep_text)
+        self.assertNotIn("authored", rep_text.lower())
+        self.assertIn("BNL classified this approved public-context item", rep_text)
+        self.assertIn("BNL source-file and dossier classification", json.dumps(payload["topicBreakdown"]))
+        self.assertIn("event, riddle, or engagement classification", json.dumps(payload["topTopicDetails"]))
+        self.assertNotIn("BNL/source-file/dossier", normal_text)
+        self.assertNotIn("row(s)", normal_text)
+        self.assertNotIn("sourceRowId", normal_text)
+        self.assertIn("rawFragments", raw)
+        self.assertEqual(payload["queueSubmissionStatus"], "not_connected")
+        self.assertNotIn("siteValidationIssues", payload)
 
     def test_enrichment_payload_is_compacted_to_site_limits(self):
         long_item = "approved evidence " + ("x" * 3000) + " 123456789012345678"


### PR DESCRIPTION
### Motivation
- The website ingest now rejects representativeEvidence containing raw slash-taxonomy or source/path-like labels, so normal payload fields must avoid raw metadata while preserving raw provenance separately.
- Representative evidence lines must not claim subject behavior (e.g., “authored”) when the evidence only supports a BNL classification.

### Description
- Add website-safe label normalization helpers in `bnl_entity_evidence.py` (`_website_safe_topic_label`, `_website_safe_payload_text`, `_join_topic_parts_for_payload`, and mapping `_SLASH_TOPIC_LABEL_REPLACEMENTS`) to convert slash-heavy taxonomy into human-friendly classification wording (e.g., `BNL/source-file/dossier discussion` → `BNL source-file and dossier classification`).
- Replace representative evidence generation to emit review-safe paraphrases in `_representative_evidence_line(...)` (no raw slashes, avoid overclaiming subject behavior, explicit review prompts) and use normalized labels in grouped topic outputs and `topTopicDetails`.
- Sanitize normal website-bound payload text in `bnl_source_file_enrichment.py` via `_site_safe_text` and a new `_compact_representative_evidence_item_for_site(...)` used by `compact_enrichment_payload_for_site(...)` to rewrite or collapse unsafe representativeEvidence entries before send.
- Add validation `_validate_representative_evidence_for_site(...)` called from `validate_enrichment_payload_for_site(...)` to catch slashes, raw source/path tokens, long raw IDs, `authored_public_conversation`, `profile_match`, and `[object Object]` in representativeEvidence prior to POST; raw provenance is preserved in `rawProvenance` only.
- Update `bnl_entity_activity_summary.py` to emit website-safe classification wording in `evidenceDetails`, `topicBreakdown`, `recurringTopics`, and other summary fields instead of raw slash taxonomy.
- Update and add tests to assert: website-safe label conversions, representativeEvidence contains no slashes or authored overclaims, topicBreakdown/topTopicDetails are normalized, representativeEvidence payload validation flags raw-looking items, raw provenance remains in `rawFragments`, and `queueSubmissionStatus` stays `not_connected`.

### Testing
- Ran unit test suite: `python -m unittest discover -s tests -v` (all tests passed).
- Type-checked/compiled modules: `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_dossier_source_packets.py bnl_dossier_candidate_discovery.py bnl_source_file_lookup.py bnl_source_file_enrichment.py bnl_source_knowledge_bridge.py bnl_entity_activity_summary.py bnl_community_scouting.py bnl_entity_evidence.py` (succeeded).
- Ran `git diff --check` (no whitespace or diff-check issues).
- Tests specifically added/updated in `tests/test_entity_activity_summary.py`, `tests/test_source_file_enrichment.py`, and `tests/test_dossier_recommendations.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2097ecaa488321b0f43e7265eabe06)