### PR TITLE
Fix source enrichment diagnostics formatter syntax

### DIFF
--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -2532,15 +2532,34 @@ def format_source_enrichment_response(result: dict[str, Any]) -> str:
         subject_intel = (result.get("diagnostics") or {}).get("subjectIntelligence") or result.get("subjectIntelligenceDiagnostics") or {}
         if subject_intel:
             rows_by_source = subject_intel.get("rowsBySource") or {}
+
+            accepted_subjects = subject_intel.get("acceptedRecurringSubjects") or []
+            accepted_subject_parts = []
+            for item in accepted_subjects:
+                if not isinstance(item, dict):
+                    continue
+                label = _safe_text(item.get("label") or "", 80)
+                reason = _safe_text(item.get("reason") or "", 80)
+                if label:
+                    accepted_subject_parts.append(f"{label}: {reason}" if reason else label)
+            accepted_subject_text = ", ".join(accepted_subject_parts) or "none"
+
+            rejected_candidates = [_safe_text(item, 80) for item in (subject_intel.get("rejectedGarbageCandidates") or [])]
+            rejected_candidate_text = ", ".join(item for item in rejected_candidates if item) or "none"
+            conversation_clusters = [_safe_text(item, 100) for item in (subject_intel.get("topConversationClusters") or [])]
+            conversation_cluster_text = ", ".join(item for item in conversation_clusters if item) or "none"
+            activity_patterns = [_safe_text(item, 120) for item in (subject_intel.get("topActivityPatterns") or [])]
+            activity_pattern_text = " | ".join(item for item in activity_patterns if item) or "none"
+
             preview_lines.extend([
                 f"Subject intelligence rows scanned: {int(subject_intel.get('rowsScanned') or 0)}.",
                 f"Subject intelligence rows by source: {_safe_text(', '.join(f'{k} {v}' for k, v in rows_by_source.items()) or 'none', 220)}.",
                 f"Top recurring subjects: {_safe_text(', '.join(subject_intel.get('topRecurringSubjects') or []) or 'none', 180)}.",
-                f"Accepted recurring subjects with reason: {_safe_text(', '.join(f"{(item or {}).get('label')}: {(item or {}).get('reason')}" for item in (subject_intel.get('acceptedRecurringSubjects') or [])) or 'none', 220)}.",
-                f"Rejected top garbage candidates: {_safe_text(', '.join(subject_intel.get('rejectedGarbageCandidates') or []) or 'none', 180)}.",
+                f"Accepted recurring subjects with reason: {_safe_text(accepted_subject_text, 220)}.",
+                f"Rejected top garbage candidates: {_safe_text(rejected_candidate_text, 180)}.",
                 f"Top recurring themes: {_safe_text(', '.join(subject_intel.get('topRecurringThemes') or []) or 'none', 220)}.",
-                f"Top conversation clusters: {_safe_text(', '.join(subject_intel.get('topConversationClusters') or []) or 'none', 240)}.",
-                f"Top activity patterns: {_safe_text(' | '.join(subject_intel.get('topActivityPatterns') or []) or 'none', 260)}.",
+                f"Top conversation clusters: {_safe_text(conversation_cluster_text, 240)}.",
+                f"Top activity patterns: {_safe_text(activity_pattern_text, 260)}.",
                 f"Top domains/tools: {_safe_text(', '.join(subject_intel.get('topDomains') or []) or 'none', 180)}.",
                 f"Public-safe vs review-only intelligence rows: {int(subject_intel.get('publicSafeRows') or 0)} public-safe / {int(subject_intel.get('reviewOnlyRows') or 0)} review-only.",
             ])

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -397,6 +397,42 @@ class SourceFileEnrichmentTests(unittest.TestCase):
         self.assertIn("approve a public-safe summary", action)
 
 
+    def test_dry_run_preview_formats_subject_intelligence_diagnostic_lists(self):
+        result = {
+            "subject": "Crow",
+            "matchKind": "active_source_file",
+            "dryRun": True,
+            "qualityStatus": "ok",
+            "sourceTypes": ["source_file_lookup", "conversations_by_author"],
+            "subjectIntelligenceDiagnostics": {
+                "rowsScanned": 4,
+                "rowsBySource": {"conversations_by_author": 3, "community_presence": 1},
+                "topRecurringSubjects": ["Orion"],
+                "acceptedRecurringSubjects": [
+                    {"label": "Orion", "reason": "repeated liaison context"},
+                    {"label": "Suno", "reason": "recurring tool mention"},
+                ],
+                "rejectedGarbageCandidates": ["BNL", "Discord"],
+                "topRecurringThemes": ["liaison interface"],
+                "topConversationClusters": ["repeated BNL questions", "music tool links"],
+                "topActivityPatterns": ["asks about source thresholds", "shares Suno links"],
+                "topDomains": ["suno.com"],
+                "publicSafeRows": 2,
+                "reviewOnlyRows": 2,
+            },
+        }
+
+        formatted = enrich.format_source_enrichment_response(result)
+
+        self.assertIn("Accepted recurring subjects with reason", formatted)
+        self.assertIn("Orion: repeated liaison context", formatted)
+        self.assertIn("Rejected top garbage candidates", formatted)
+        self.assertIn("BNL, Discord", formatted)
+        self.assertIn("Top conversation clusters", formatted)
+        self.assertIn("repeated BNL questions", formatted)
+        self.assertIn("Top activity patterns", formatted)
+        self.assertIn("asks about source thresholds", formatted)
+
     def test_dry_run_preview_includes_subject_intelligence_diagnostics(self):
         self.conn.execute("INSERT INTO user_profiles VALUES (42,1,'Crow','Crow',NULL,NULL)")
         self.conn.execute("INSERT INTO conversations VALUES (NULL,42,'Crow',1,'general','public_home','user','Orion through Crow asks BNL about Suno links and presence threshold behavior: https://suno.com/song/a', '2026-06-01')")


### PR DESCRIPTION
### Motivation

- A `SyntaxError` was caused by a nested f-string in `format_source_enrichment_response(...)` when formatting the "Accepted recurring subjects with reason" dry-run diagnostic line, preventing the bot from importing and starting. 
- The change must be an emergency syntax/import fix that preserves the diagnostics output while restoring startup. 

### Description

- Replaced the invalid nested f-string with precomputed, sanitized text variables: `accepted_subject_text`, `rejected_candidate_text`, `conversation_cluster_text`, and `activity_pattern_text`, each assembled with `_safe_text` before insertion into the preview lines. 
- Updated the dry-run `preview_lines` to use those precomputed safe strings instead of inline nested expressions in `bnl_source_file_enrichment.py` (`format_source_enrichment_response`).
- Added a unit test `test_dry_run_preview_formats_subject_intelligence_diagnostic_lists` to `tests/test_source_file_enrichment.py` that calls `format_source_enrichment_response(...)` with `subjectIntelligenceDiagnostics` covering `acceptedRecurringSubjects`, `rejectedGarbageCandidates`, `topConversationClusters`, and `topActivityPatterns` and asserts expected formatted output is present.

### Testing

- Ran `python3 -m unittest discover -s tests -v` and all tests passed (344 tests, `OK`).
- Verified `python3 -m py_compile` on the bot entrypoint and related modules (`bnl01_bot.py`, `bnl_source_file_enrichment.py`, etc.) completed without syntax errors.
- The diagnostics formatting changes are exercised by the new unit test and existing test suite, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20cf0235b88321b1a13e3d77c3e661)