### PR TITLE
Entity Intelligence Ledger + Context Resolver v1

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -4814,6 +4814,42 @@ async def maybe_handle_dossier_discovery_command(message: discord.Message, clean
 
 
 
+def _parse_rd_entity_context_subject(text: str) -> str:
+    match = re.search(r"(?i)\b(?:entity intelligence|context resolver|source context|dossier context)\s+(?:for\s+|on\s+|about\s+)?([A-Za-z0-9 _.-]{2,80})", text or "")
+    if not match:
+        return ""
+    subject = re.sub(r"\s+", " ", match.group(1)).strip(" .,:;|!?\n\t")
+    return subject[:80]
+
+
+def _format_rd_entity_context_response(subject: str, context: dict) -> str:
+    def labels(items, key="label", limit=4):
+        out = []
+        for item in items or []:
+            label = str(item.get(key) or item.get("label") or item.get("objectLabel") or "").strip()
+            rel = str(item.get("relationType") or "").strip()
+            if key == "objectLabel" and rel:
+                label = f"{label}: {rel}"
+            if label and label not in out:
+                out.append(label[:120])
+            if len(out) >= limit:
+                break
+        return out
+    roles = labels(context.get("allowedRoles"))
+    rels = labels(context.get("allowedRelationships"), "objectLabel")
+    activity = labels(context.get("allowedActivity"), limit=5)
+    actions = labels(context.get("allowedActionItems"), limit=4)
+    missing = [str(x)[:120] for x in (context.get("missingInfo") or [])[:4]]
+    lines = [f"Entity context resolver (R&D/mod ops) for {subject}:"]
+    lines.append("Roles: " + (", ".join(roles) or "none detected"))
+    lines.append("Relationships: " + (", ".join(rels) or "none detected"))
+    lines.append("Activity/themes: " + (", ".join(activity) or "none detected"))
+    lines.append("Mod action items: " + ("; ".join(actions) or "none"))
+    lines.append("Missing info: " + ("; ".join(missing) or "none"))
+    lines.append("Review-only/internal context is labeled by the resolver; no raw transcripts are included.")
+    return "\n".join(lines)[:1900]
+
+
 async def maybe_handle_source_file_enrichment_command(message: discord.Message, clean_content: str) -> bool:
     """Handle operator-triggered Source File enrichment commands."""
 
@@ -14892,6 +14928,14 @@ async def on_message(message: discord.Message):
         previous_rd_context = _get_recent_rd_ops_context(message)
         rd_channel_context = _get_recent_rd_ops_channel_context(message)
         rd_intent = detect_rd_ops_intent(clean_content)
+        rd_entity_subject = _parse_rd_entity_context_subject(clean_content)
+        if rd_entity_subject:
+            context = await asyncio.to_thread(build_entity_context_for_rd_mod_ops, DB_FILE, message.guild.id, rd_entity_subject)
+            response = _format_rd_entity_context_response(rd_entity_subject, context)
+            await message.reply(response)
+            _remember_rd_ops_context(message, clean_content, "entity_context_resolver", rd_entity_subject, "#research-and-development", response)
+            _mark_recent_direct_response(message.channel.id, message.author.id)
+            return
         if rd_intent == "member_activity":
             events = get_recent_member_activity_events(message.guild.id, limit=10, days=14)
             response = format_member_activity_summary(events)

--- a/bnl_dossier_recommendations.py
+++ b/bnl_dossier_recommendations.py
@@ -80,6 +80,7 @@ SUPPORTED_PAYLOAD_FIELDS = {
     "rawProvenance",
     "queueSubmissionStatus",
     "queueSubmissionNote",
+    "entityIntelligenceProfile",
 }
 _SAFE_LANE_PATTERN = re.compile(r"[^a-z0-9_-]+")
 VALID_DOSSIER_CATEGORIES = {"Entity", "Personnel", "Sponsor", "Interface", "Production"}

--- a/bnl_entity_intelligence.py
+++ b/bnl_entity_intelligence.py
@@ -1,0 +1,754 @@
+"""Source-aware Entity Intelligence Ledger and Context Resolver v1.
+
+This module intentionally uses only local stored rows. It does not fetch live
+Discord history, does not publish, and does not treat Discord music links as
+queue/submission/payment facts. Future website public dossier reads should feed
+``official_public_dossier`` authority facts here; future queue integrations
+should feed ``queue_submission_confirmed`` facts here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+ENTITY_SOURCE_AUTHORITY_ORDER = (
+    "owner_confirmed",
+    "official_public_dossier",
+    "broadcast_memory",
+    "mod_confirmed",
+    "queue_submission_confirmed",
+    "public_discord_observed",
+    "internal_observation",
+    "bnl_inferred",
+    "source_blind_memory",
+    "unknown",
+)
+ENTITY_VISIBILITY_VALUES = (
+    "public",
+    "public_safe_candidate",
+    "review_only",
+    "mod_only",
+    "admin_only",
+    "internal_only",
+    "source_blind",
+    "account_private",
+    "unknown",
+)
+SURFACES = {
+    "public_conversation",
+    "ambient_public",
+    "website_relay",
+    "rd_mod_ops",
+    "source_file",
+    "dossier_draft",
+    "owner_review",
+    "internal_diagnostics",
+}
+PUBLIC_POLICIES = {"public", "public_home", "public_discussion", "public_music", "public_show", "community_public"}
+PRIVATE_POLICY_RE = re.compile(r"(?i)(?:private|internal|admin|mod|staff|dm|direct)")
+URL_RE = re.compile(r"https?://\S+", re.I)
+MENTION_RE = re.compile(r"<@!?\d+>|<@&\d+>|<#\d+>")
+LONG_ID_RE = re.compile(r"\b\d{15,22}\b")
+EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}\b")
+
+ROLE_PATTERNS = [
+    ("moderator", re.compile(r"\b(?:mod|mods|moderator|staff|admin|operator)\b", re.I), "mod/staff language observed"),
+    ("artist", re.compile(r"\b(?:artist|producer|musician|songwriter|music maker|track|song|album|suno|udio|soundcloud|spotify|bandcamp)\b", re.I), "creative/music language observed"),
+    ("collaborator", re.compile(r"\b(?:collab\w*|collaborat\w*|feature\s+with|work\s+with|team\s+up)\b", re.I), "collaboration language observed"),
+    ("contest operator", re.compile(r"\b(?:contest|competition|event|rules|deadline|submit entries|winner|prize|challenge)\b", re.I), "contest/event language observed"),
+    ("support/helper", re.compile(r"\b(?:helping|helper|support|answers?|guides?|welcome|onboard)\b", re.I), "community support language observed"),
+    ("lore/entity/persona/project creator", re.compile(r"\b(?:created|made|built|my ai|my bot|persona|character|entity|project|speaking through|through)\b", re.I), "entity/persona/project language observed"),
+    ("antagonist/challenger", re.compile(r"\b(?:challenge|challenging|argue|arguing|bait|teas|hostile|antagonistic|fight me|prove it|you can't)\b", re.I), "challenging language observed"),
+]
+THEME_PATTERNS = [
+    ("BNL behavior/boundaries", re.compile(r"\b(?:BNL|bot|boundary|boundaries|behavior|rules|what can you say)\b", re.I)),
+    ("source files/dossiers", re.compile(r"\b(?:source files?|dossiers?|case file|public dossier)\b", re.I)),
+    ("music/track sharing", re.compile(r"\b(?:music|track|song|suno|udio|youtube|soundcloud|spotify|bandcamp|listen|demo|wip)\b", re.I)),
+    ("collaboration", re.compile(r"\b(?:collab\w*|collaborat\w*|feature|work together|open verse)\b", re.I)),
+    ("contests/events", re.compile(r"\b(?:contest|competition|event|rules|deadline|winner|prize|challenge)\b", re.I)),
+    ("show operations", re.compile(r"\b(?:BARCODE Radio|show|episode|broadcast|queue)\b", re.I)),
+    ("moderation/community support", re.compile(r"\b(?:mod|moderator|staff|admin|help|support|welcome|community)\b", re.I)),
+    ("strange/anomaly conversations", re.compile(r"\b(?:anomaly|strange|weird|theory|signal|glitch|lore|cipher|riddle)\b", re.I)),
+    ("AI/persona/project interaction", re.compile(r"\b(?:AI|bot|persona|entity|project|created|speaking through|through)\b", re.I)),
+    ("public links/socials", re.compile(r"\b(?:https?://|youtube|suno|udio|soundcloud|spotify|bandcamp|instagram|tiktok)\b", re.I)),
+    ("BARCODE Network behavior", re.compile(r"\b(?:BARCODE|BNL|Barcode Network)\b", re.I)),
+]
+MUSIC_RE = re.compile(r"\b(?:suno|udio|youtube|youtu\.be|soundcloud|spotify|bandcamp|track|song|demo|wip|finished[- ]tracks?)\b|https?://", re.I)
+BNL_RE = re.compile(r"\b(?:BNL|bot|source files?|dossiers?|BARCODE)\b", re.I)
+ANTAGONISTIC_RE = re.compile(r"\b(?:challenge|challenging|argu|bait|teas|hostile|antagon|prove it|wrong|you can't|fight me)\b", re.I)
+ANOMALY_RE = re.compile(r"\b(?:anomaly|strange|weird|theory|signal|glitch|lore|cipher|riddle)\b", re.I)
+CONTEST_RE = re.compile(r"\b(?:contest|competition|event|rules|deadline|entries|winner|prize|challenge)\b", re.I)
+COLLAB_RE = re.compile(r"\b(?:collab\w*|collaborat\w*|feature|work together|open verse|team up)\b", re.I)
+CREATED_RE = re.compile(r"\b([A-Z][A-Za-z0-9_-]{2,}(?:\s+[A-Z][A-Za-z0-9_-]{2,}){0,2})\s+(?:created|made|built)\s+([A-Z][A-Za-z0-9_-]{2,}(?:\s+[A-Z][A-Za-z0-9_-]{2,}){0,2})\b")
+CREATED_MY_RE = re.compile(r"\b([A-Z][A-Za-z0-9_-]{2,}(?:\s+[A-Z][A-Za-z0-9_-]{2,}){0,2})\s+is\s+my\s+(?:AI|bot|project|persona|character|entity)\b", re.I)
+THROUGH_RE = re.compile(r"\b([A-Z][A-Za-z0-9_-]{2,}(?:\s+[A-Z][A-Za-z0-9_-]{2,}){0,2})\s+(?:through|via|speaking\s+through|relayed\s+through)\s+([A-Z][A-Za-z0-9_-]{2,}(?:\s+[A-Z][A-Za-z0-9_-]{2,}){0,2})\b", re.I)
+HERE_RE = re.compile(r"\b([A-Z][A-Za-z0-9_-]{2,})\s+here\b")
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def subject_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", str(value or "").strip().lower()).strip("-") or "unknown-subject"
+
+
+def safe_text(value: Any, limit: int = 220) -> str:
+    text = str(value or "")
+    text = MENTION_RE.sub("[redacted-mention]", text)
+    text = LONG_ID_RE.sub("[redacted-id]", text)
+    text = EMAIL_RE.sub("[redacted-email]", text)
+    text = URL_RE.sub("[redacted-url]", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)).fetchone() is not None
+
+
+def columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    if not table_exists(conn, table):
+        return set()
+    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def ensure_entity_intelligence_schema(conn: sqlite3.Connection) -> None:
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS entity_intelligence_facts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER, subject_key TEXT NOT NULL,
+            subject_name TEXT, fact_type TEXT NOT NULL, fact_label TEXT NOT NULL, fact_value TEXT,
+            source_type TEXT, source_table TEXT, source_row_id TEXT, source_channel_name TEXT,
+            source_channel_policy TEXT, visibility TEXT NOT NULL, authority TEXT NOT NULL,
+            confidence REAL NOT NULL DEFAULT 0.5, public_safe INTEGER NOT NULL DEFAULT 0,
+            review_only INTEGER NOT NULL DEFAULT 1, needs_owner_review INTEGER NOT NULL DEFAULT 0,
+            first_seen_at TEXT, last_seen_at TEXT, evidence_count INTEGER NOT NULL DEFAULT 1,
+            mention_count INTEGER NOT NULL DEFAULT 1, status TEXT NOT NULL DEFAULT 'active',
+            UNIQUE(guild_id, subject_key, fact_type, fact_label, fact_value, authority, visibility)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS entity_intelligence_edges (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER, subject_key TEXT NOT NULL,
+            object_key TEXT NOT NULL, object_label TEXT NOT NULL, relation_type TEXT NOT NULL,
+            source_type TEXT, source_channel_policy TEXT, visibility TEXT NOT NULL,
+            authority TEXT NOT NULL, confidence REAL NOT NULL DEFAULT 0.5, first_seen_at TEXT,
+            last_seen_at TEXT, evidence_count INTEGER NOT NULL DEFAULT 1, status TEXT NOT NULL DEFAULT 'active',
+            UNIQUE(guild_id, subject_key, object_key, relation_type, authority, visibility)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS entity_activity_rollups (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER, subject_key TEXT NOT NULL,
+            channel_name TEXT, channel_policy TEXT, activity_type TEXT NOT NULL, first_seen_at TEXT,
+            last_seen_at TEXT, authored_count INTEGER NOT NULL DEFAULT 0, mentioned_count INTEGER NOT NULL DEFAULT 0,
+            link_count INTEGER NOT NULL DEFAULT 0, bnl_interaction_count INTEGER NOT NULL DEFAULT 0,
+            music_signal_count INTEGER NOT NULL DEFAULT 0, contest_signal_count INTEGER NOT NULL DEFAULT 0,
+            collaboration_signal_count INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'active',
+            UNIQUE(guild_id, subject_key, channel_name, channel_policy, activity_type)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS entity_open_questions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER, subject_key TEXT NOT NULL,
+            question TEXT NOT NULL, reason TEXT, source_type TEXT, visibility TEXT NOT NULL DEFAULT 'review_only',
+            priority INTEGER NOT NULL DEFAULT 50, status TEXT NOT NULL DEFAULT 'open', created_at TEXT, updated_at TEXT,
+            UNIQUE(guild_id, subject_key, question)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS entity_profile_snapshots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER, subject_key TEXT NOT NULL,
+            subject_name TEXT, summary_json TEXT NOT NULL, source_hash TEXT, created_at TEXT, updated_at TEXT,
+            UNIQUE(guild_id, subject_key)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS entity_scouting_queue (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER, subject_key TEXT NOT NULL,
+            subject_name TEXT, reason TEXT, source TEXT, last_seen_at TEXT, status TEXT NOT NULL DEFAULT 'stale',
+            created_at TEXT, updated_at TEXT, UNIQUE(guild_id, subject_key, reason, source)
+        )
+    """)
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_entity_facts_subject ON entity_intelligence_facts(guild_id, subject_key, status)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_entity_edges_subject ON entity_intelligence_edges(guild_id, subject_key, status)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_entity_queue_status ON entity_scouting_queue(guild_id, status, updated_at)")
+    conn.commit()
+
+
+def authority_rank(authority: str) -> int:
+    try:
+        return ENTITY_SOURCE_AUTHORITY_ORDER.index(str(authority or "unknown"))
+    except ValueError:
+        return len(ENTITY_SOURCE_AUTHORITY_ORDER) - 1
+
+
+def _visibility_for_source(source: str, row: dict[str, Any]) -> tuple[str, str, bool, bool]:
+    policy = str(row.get("channel_policy") or row.get("source_channel_policy") or "").lower()
+    channel = str(row.get("channel_name") or row.get("source_channel_name") or "")
+    if source == "broadcast_memory" and bool(row.get("public_safe")) and str(row.get("status") or "active").lower() == "active":
+        return "public", "broadcast_memory", True, False
+    if source == "entity_evidence_events":
+        authority = str(row.get("authority") or "public_discord_observed")
+        if bool(row.get("public_safe_candidate")) and not bool(row.get("review_only")):
+            return "public_safe_candidate", authority, True, False
+        return "review_only", authority, False, True
+    if source == "memory_tiers":
+        trust = str(row.get("source_trust") or "").lower()
+        if not trust or trust in {"legacy_unknown", "unknown", "source_blind"}:
+            return "source_blind", "source_blind_memory", False, True
+    if PRIVATE_POLICY_RE.search(policy) or PRIVATE_POLICY_RE.search(channel):
+        return "internal_only", "internal_observation", False, True
+    if source == "conversations" and (policy in PUBLIC_POLICIES or policy.startswith("public")):
+        return "public_safe_candidate", "public_discord_observed", True, False
+    if source == "community_presence":
+        return "public_safe_candidate", "public_discord_observed", True, False
+    return "review_only", "internal_observation", False, True
+
+
+def _row_text(source: str, row: dict[str, Any]) -> str:
+    fields = {
+        "conversations": ["content"],
+        "entity_evidence_events": ["safe_summary", "topic", "dossier_relevance", "raw_ref_json"],
+        "relationship_journal": ["entry_type", "summary"],
+        "relationship_state": ["trust_stage", "social_stance", "last_topic"],
+        "memory_tiers": ["tier", "summary"],
+        "user_memory_facts": ["fact_key", "fact_value"],
+        "broadcast_memory": ["entry_type", "cleaned_summary", "summary", "raw_note"],
+        "community_presence": ["display_name", "connection_notes", "evidence_snippets", "category"],
+    }.get(source, [])
+    return " ".join(str(row.get(f) or "") for f in fields).strip()
+
+
+def _collect_rows(conn: sqlite3.Connection, subject: str, guild_id: int | None, max_rows: int) -> list[dict[str, Any]]:
+    skey = subject_key(subject)
+    terms = {subject.lower(), skey.replace("-", " ").lower()}
+    rows: list[dict[str, Any]] = []
+    matched_ids: set[int] = set()
+
+    def has_subject(text: Any) -> bool:
+        lowered = str(text or "").lower()
+        return any(term and term in lowered for term in terms)
+
+    if table_exists(conn, "user_profiles"):
+        cols = columns(conn, "user_profiles")
+        select = [c for c in ("user_id", "guild_id", "display_name", "preferred_name") if c in cols]
+        where = " WHERE guild_id=?" if guild_id is not None and "guild_id" in cols else ""
+        params = (guild_id,) if where else ()
+        for r in conn.execute(f"SELECT {', '.join(select)} FROM user_profiles{where} LIMIT ?", (*params, max_rows * 3)):
+            d = dict(r)
+            if has_subject(" ".join(str(d.get(k) or "") for k in ("display_name", "preferred_name"))):
+                uid = d.get("user_id")
+                if uid is not None:
+                    try:
+                        matched_ids.add(int(uid))
+                    except (TypeError, ValueError):
+                        pass
+    table_cols = {
+        "conversations": ["id", "rowid", "user_id", "author_id", "discord_user_id", "member_id", "user_name", "author_name", "guild_id", "channel_name", "channel_policy", "role", "content", "timestamp"],
+        "entity_evidence_events": ["id", "guild_id", "subject_key", "subject_name", "source_type", "source_table", "source_row_id", "channel_name", "channel_policy", "visibility", "authority", "safe_summary", "topic", "dossier_relevance", "public_safe_candidate", "review_only", "raw_ref_json", "created_at", "observed_at"],
+        "relationship_journal": ["id", "user_id", "guild_id", "entry_type", "summary", "timestamp"],
+        "relationship_state": ["user_id", "guild_id", "trust_stage", "social_stance", "last_topic", "updated_at"],
+        "memory_tiers": ["id", "user_id", "guild_id", "tier", "summary", "mentions", "updated_at", "source_trust", "source_channel_policy"],
+        "user_memory_facts": ["id", "user_id", "guild_id", "fact_key", "fact_value", "confidence", "updated_at"],
+        "broadcast_memory": ["id", "guild_id", "entry_type", "cleaned_summary", "summary", "raw_note", "public_safe", "status", "created_at"],
+        "community_presence": ["guild_id", "subject_key", "display_name", "connection_notes", "evidence_snippets", "category", "mention_count", "direct_interaction_count", "last_seen_at"],
+    }
+    for table, wanted in table_cols.items():
+        if not table_exists(conn, table):
+            continue
+        cols = columns(conn, table)
+        select = [c for c in wanted if c in cols or c == "rowid"]
+        if not select:
+            continue
+        select_sql = ", ".join("rowid AS rowid" if c == "rowid" else c for c in select)
+        where = " WHERE guild_id=?" if guild_id is not None and "guild_id" in cols else ""
+        params = (guild_id,) if where else ()
+        order = " ORDER BY " + ("timestamp" if "timestamp" in cols else "updated_at" if "updated_at" in cols else "created_at" if "created_at" in cols else "rowid") + " DESC"
+        for r in conn.execute(f"SELECT {select_sql} FROM {table}{where}{order} LIMIT ?", (*params, max_rows * 6)):
+            d = dict(r)
+            text = _row_text(table, d)
+            id_match = any(str(d.get(c) or "").isdigit() and int(d.get(c)) in matched_ids for c in ("user_id", "author_id", "discord_user_id", "member_id"))
+            key_match = table in {"entity_evidence_events", "community_presence"} and str(d.get("subject_key") or "") == skey
+            name_match = has_subject(" ".join(str(d.get(k) or "") for k in ("user_name", "author_name", "display_name", "subject_name")))
+            if id_match or key_match or name_match or has_subject(text):
+                visibility, authority, public_safe, review_only = _visibility_for_source(table, d)
+                rows.append({
+                    "source": table,
+                    "row_id": d.get("id") or d.get("rowid"),
+                    "text": text,
+                    "channel_name": d.get("channel_name"),
+                    "channel_policy": d.get("channel_policy") or d.get("source_channel_policy"),
+                    "observed_at": d.get("timestamp") or d.get("updated_at") or d.get("created_at") or d.get("last_seen_at") or now_iso(),
+                    "relation": "authored" if id_match or name_match else "mentioned",
+                    "visibility": visibility,
+                    "authority": authority,
+                    "public_safe": public_safe,
+                    "review_only": review_only,
+                })
+            if len(rows) >= max_rows:
+                return rows
+    return rows[:max_rows]
+
+
+def _item(label: str, value: str = "", *, visibility: str, authority: str, confidence: float = 0.65, public_safe: bool = False, review_only: bool = True, needs_owner_review: bool = False, evidence_count: int = 1) -> dict[str, Any]:
+    return {
+        "label": label,
+        "value": value or label,
+        "visibility": visibility,
+        "authority": authority,
+        "confidence": confidence,
+        "publicSafe": bool(public_safe),
+        "reviewOnly": bool(review_only),
+        "needsOwnerReview": bool(needs_owner_review),
+        "evidenceCount": int(evidence_count),
+    }
+
+
+def _classify(subject: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    role_counts: Counter[str] = Counter()
+    role_reasons: dict[str, str] = {}
+    themes: Counter[str] = Counter()
+    behaviors: Counter[str] = Counter()
+    music = Counter()
+    events = Counter()
+    activity = Counter()
+    edges: dict[tuple[str, str], dict[str, Any]] = {}
+    facts: list[dict[str, Any]] = []
+    skey = subject_key(subject)
+    source_counts = Counter(r["source"] for r in rows)
+    public_rows = sum(1 for r in rows if r.get("public_safe"))
+    review_rows = len(rows) - public_rows
+
+    def add_edge(obj: str, rel: str, row: dict[str, Any], confidence: float = 0.62) -> None:
+        obj = safe_text(obj, 80).strip()
+        if not obj or subject_key(obj) == skey or obj.lower() in {"BNL".lower(), "BARCODE".lower()}:
+            return
+        key = (subject_key(obj), rel)
+        existing = edges.get(key)
+        if existing:
+            existing["evidenceCount"] += 1
+            existing["confidence"] = min(0.95, max(existing["confidence"], confidence) + 0.05)
+            existing["publicSafe"] = existing["publicSafe"] and bool(row.get("public_safe"))
+            existing["reviewOnly"] = existing["reviewOnly"] or bool(row.get("review_only"))
+            return
+        edges[key] = {
+            "objectKey": subject_key(obj), "objectLabel": obj, "relationType": rel,
+            "visibility": "review_only" if row.get("review_only") else "public_safe_candidate",
+            "authority": row.get("authority") or "bnl_inferred", "confidence": confidence,
+            "publicSafe": bool(row.get("public_safe")) and rel in {"collaborates_with", "offers_collaboration", "associated_with"},
+            "reviewOnly": True if rel in {"speaks_through", "created", "created_by", "co_mentioned_only"} else bool(row.get("review_only")),
+            "needsOwnerReview": rel in {"speaks_through", "created", "created_by", "co_mentioned_only"},
+            "evidenceCount": 1,
+        }
+
+    for row in rows:
+        text = str(row.get("text") or "")
+        low = text.lower()
+        for role, pat, reason in ROLE_PATTERNS:
+            if pat.search(text):
+                role_counts[role] += 1
+                role_reasons.setdefault(role, reason)
+        for theme, pat in THEME_PATTERNS:
+            if pat.search(text):
+                themes[theme] += 1
+        if BNL_RE.search(text):
+            activity["frequent BNL-facing conversation"] += 1
+        if re.search(r"\bsource files?|dossiers?\b", text, re.I):
+            activity["asks BNL Source File questions"] += 1
+        if re.search(r"\bboundar|behavior|what can you say|liaison|interface\b", text, re.I):
+            activity["discusses BNL boundaries/behavior"] += 1
+        if MUSIC_RE.search(text):
+            music["shares music links"] += 1
+            if re.search(r"\b(?:suno|udio|youtube|youtu\.be|soundcloud|spotify|bandcamp)\b|https?://", text, re.I):
+                music["shares Suno/Udio/YouTube/SoundCloud/Spotify/Bandcamp links"] += 1
+        if "finished-tracks" in low:
+            music["posts in finished-tracks"] += 1
+        if "wips-and-demos" in low or "wip" in low or "demo" in low:
+            music["posts in wips-and-demos"] += 1
+        if "collaboration-hub" in low:
+            music["posts in collaboration-hub"] += 1
+        if COLLAB_RE.search(text):
+            music["offers collaboration"] += 1
+            activity["collaboration-offer facet"] += 1
+        if re.search(r"\bfeedback\b", text, re.I):
+            music["asks for feedback"] += 1
+        if ANTAGONISTIC_RE.search(text):
+            behaviors["antagonistic/challenging"] += 1
+            activity["challenges BNL"] += 1 if BNL_RE.search(text) else 0
+        if ANOMALY_RE.search(text):
+            behaviors["theory/anomaly-heavy"] += 1
+        if CONTEST_RE.search(text):
+            behaviors["contest-focused"] += 1
+            events["contest/event activity"] += 1
+            if re.search(r"\b(?:rules|instructions|deadline|entries)\b", text, re.I):
+                events["rules/instructions poster"] += 1
+            if re.search(r"\b(?:organize|run|host|operator|promote)\b", text, re.I):
+                events["contest organizer"] += 1
+        if re.search(r"\b(?:help|support|welcome|community)\b", text, re.I):
+            behaviors["helpful/supportive"] += 1
+        if re.search(r"\b(?:playful|chaotic|teas)\b", text, re.I):
+            behaviors["playful/chaotic"] += 1
+        if re.search(r"\b(?:lore|persona|entity|cipher|riddle)\b", text, re.I):
+            behaviors["lore-heavy"] += 1
+        # relationship semantics
+        for m in THROUGH_RE.finditer(text):
+            a, b = m.group(1), m.group(2)
+            if subject_key(b) == skey:
+                add_edge(a, "speaks_through", row, 0.72)
+            elif subject_key(a) == skey:
+                add_edge(b, "relayed_through", row, 0.66)
+        for m in CREATED_RE.finditer(text):
+            a, b = m.group(1), m.group(2)
+            if subject_key(a) == skey:
+                add_edge(b, "created", row, 0.78)
+            elif subject_key(b) == skey:
+                add_edge(a, "created_by", row, 0.78)
+        for m in CREATED_MY_RE.finditer(text):
+            add_edge(m.group(1), "created", row, 0.70)
+        for m in HERE_RE.finditer(text):
+            obj = m.group(1)
+            if subject_key(obj) != skey:
+                add_edge(obj, "associated_with", row, 0.50)
+        cm = re.search(r"\bcollab(?:orate)?\s+with\s+([A-Z][A-Za-z0-9_-]{2,}(?:\s+[A-Z][A-Za-z0-9_-]{2,}){0,2})", text, re.I)
+        if cm:
+            add_edge(cm.group(1), "offers_collaboration", row, 0.68)
+
+    source_blind_count = sum(1 for row in rows if row.get("authority") == "source_blind_memory" or row.get("visibility") == "source_blind")
+    source_blind_facts = []
+    if source_blind_count:
+        source_blind_facts.append(_item("source-blind memory present", "review-only; do not use publicly without owner/admin review", visibility="source_blind", authority="source_blind_memory", confidence=0.4, public_safe=False, review_only=True, needs_owner_review=True, evidence_count=source_blind_count) | {"type": "source_warning"})
+    if not role_counts:
+        role_counts["unknown"] = 1
+        role_reasons["unknown"] = "not enough structured role evidence yet"
+    if len(rows) >= 8:
+        behaviors["frequent poster"] += len(rows)
+    elif rows:
+        behaviors["occasional/low activity"] += len(rows)
+    for label, count in role_counts.items():
+        # moderator/contest roles are review-needed until public role is confirmed.
+        review_needed = label in {"moderator", "contest operator", "lore/entity/persona/project creator", "antagonist/challenger"}
+        facts.append(_item(label, role_reasons.get(label, label), visibility="review_only" if review_needed else "public_safe_candidate", authority="bnl_inferred", confidence=min(0.9, 0.55 + count * 0.08), public_safe=not review_needed and label != "unknown", review_only=review_needed or label == "unknown", needs_owner_review=review_needed, evidence_count=count) | {"type": "role"})
+    roles = facts[:]
+    creative = [_item(k, k, visibility="public_safe_candidate", authority="public_discord_observed", confidence=min(0.9, .55 + v*.08), public_safe=True, review_only=False, needs_owner_review=k.startswith("shares") and "links" in k, evidence_count=v) | {"type": "creative_music"} for k, v in music.items()]
+    bnl = [_item(k, k, visibility="review_only" if "challenges" in k else "public_safe_candidate", authority="bnl_inferred", confidence=min(.9,.55+v*.08), public_safe="challenges" not in k, review_only="challenges" in k, needs_owner_review="challenges" in k, evidence_count=v) | {"type": "bnl_interaction"} for k, v in activity.items() if "BNL" in k or "source-file" in k or "boundaries" in k or "challenges" in k]
+    behavior = [_item(k, k, visibility="review_only" if k in {"antagonistic/challenging", "theory/anomaly-heavy", "lore-heavy"} else "public_safe_candidate", authority="bnl_inferred", confidence=min(.9,.55+v*.06), public_safe=k not in {"antagonistic/challenging", "theory/anomaly-heavy", "lore-heavy"}, review_only=k in {"antagonistic/challenging", "theory/anomaly-heavy", "lore-heavy"}, needs_owner_review=k in {"antagonistic/challenging", "theory/anomaly-heavy", "lore-heavy"}, evidence_count=v) | {"type": "behavior_posture"} for k, v in behaviors.items()]
+    theme_items = [_item(k, k, visibility="review_only" if k in {"strange/anomaly conversations", "AI/persona/project interaction"} else "public_safe_candidate", authority="bnl_inferred", confidence=min(.9,.55+v*.06), public_safe=k not in {"strange/anomaly conversations", "AI/persona/project interaction"}, review_only=k in {"strange/anomaly conversations", "AI/persona/project interaction"}, needs_owner_review=k in {"strange/anomaly conversations", "AI/persona/project interaction"}, evidence_count=v) | {"type": "conversation_theme"} for k, v in themes.items()]
+    event_items = [_item(k, k, visibility="review_only" if k != "contest/event activity" else "public_safe_candidate", authority="bnl_inferred", confidence=min(.9,.55+v*.08), public_safe=k == "contest/event activity", review_only=k != "contest/event activity", needs_owner_review=True, evidence_count=v) | {"type": "event_contest"} for k, v in events.items()]
+    action_items = []
+    missing = []
+    if edges:
+        for edge in edges.values():
+            if edge.get("needsOwnerReview"):
+                action_items.append(_item(f"Confirm whether {edge['objectLabel']} relationship/context can be public", edge["relationType"], visibility="review_only", authority="bnl_inferred", public_safe=False, review_only=True, needs_owner_review=True, confidence=.7) | {"type": "action_item"})
+    if music:
+        action_items.append(_item("Confirm public artist links and whether music links are portfolio material, not submissions", "queue submission bridge not connected", visibility="review_only", authority="bnl_inferred", public_safe=False, review_only=True, needs_owner_review=True) | {"type": "action_item"})
+        missing.append("public artist links / public music role")
+    if role_counts.get("moderator"):
+        action_items.append(_item("Confirm public-safe mod/staff role wording", "mod role should not be published without confirmation", visibility="review_only", authority="bnl_inferred", public_safe=False, review_only=True, needs_owner_review=True) | {"type": "action_item"})
+        missing.append("public-safe role confirmation")
+    if events:
+        action_items.append(_item("Confirm contest name, rules, channel, dates, and public link", "contest/event evidence needs owner/mod confirmation", visibility="review_only", authority="bnl_inferred", public_safe=False, review_only=True, needs_owner_review=True) | {"type": "action_item"})
+        missing.append("contest name/rules/channel/dates/public link")
+    if behaviors.get("antagonistic/challenging"):
+        action_items.append(_item("Keep antagonistic/challenging posture review-only; do not produce defamatory public copy", "public-safety caution", visibility="review_only", authority="bnl_inferred", public_safe=False, review_only=True, needs_owner_review=True) | {"type": "warning"})
+    if behaviors.get("theory/anomaly-heavy") or themes.get("strange/anomaly conversations"):
+        action_items.append(_item("Determine whether anomaly/lore context is public-safe lore or internal-only", "lore/anomaly context needs review", visibility="review_only", authority="bnl_inferred", public_safe=False, review_only=True, needs_owner_review=True) | {"type": "action_item"})
+        missing.append("lore/anomaly public-safety status")
+    missing.extend(["official_public_dossier source not connected yet", "queue submission bridge not_connected"])
+    dossier = []
+    if rows:
+        dossier.append(_item("active community source file candidate", "local stored evidence exists", visibility="review_only", authority="bnl_inferred", public_safe=False, review_only=True, needs_owner_review=True, evidence_count=len(rows)) | {"type": "dossier_usefulness"})
+    if source_blind_count:
+        dossier.append(_item("source-blind memory present", "source_blind_memory review-only; do not use publicly without owner/admin review", visibility="source_blind", authority="source_blind_memory", confidence=0.4, public_safe=False, review_only=True, needs_owner_review=True, evidence_count=source_blind_count) | {"type": "dossier_usefulness"})
+    if missing:
+        dossier.append(_item("needs owner approval", "; ".join(sorted(set(missing))[:4]), visibility="review_only", authority="bnl_inferred", public_safe=False, review_only=True, needs_owner_review=True) | {"type": "dossier_usefulness"})
+    return {
+        "facts": facts + source_blind_facts + creative + bnl + behavior + theme_items + event_items + dossier,
+        "roles": roles,
+        "relationships": list(edges.values()),
+        "creativeMusic": creative,
+        "bnlInteraction": bnl,
+        "behaviorPosture": behavior,
+        "conversationThemes": theme_items,
+        "eventContest": event_items,
+        "dossierUsefulness": dossier,
+        "actionItems": action_items,
+        "missingInfo": sorted(set(missing)),
+        "warnings": [i for i in action_items if i.get("type") == "warning"],
+        "sourceCounts": dict(source_counts),
+        "publicSafeRows": public_rows,
+        "reviewOnlyRows": review_rows,
+    }
+
+
+def _upsert_fact(conn: sqlite3.Connection, guild_id: int | None, skey: str, subject: str, fact_type: str, fact: dict[str, Any]) -> None:
+    ts = now_iso()
+    conn.execute("""
+        INSERT INTO entity_intelligence_facts (guild_id, subject_key, subject_name, fact_type, fact_label, fact_value, source_type, source_table, source_row_id, source_channel_name, source_channel_policy, visibility, authority, confidence, public_safe, review_only, needs_owner_review, first_seen_at, last_seen_at, evidence_count, mention_count, status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
+        ON CONFLICT(guild_id, subject_key, fact_type, fact_label, fact_value, authority, visibility)
+        DO UPDATE SET last_seen_at=excluded.last_seen_at, evidence_count=entity_intelligence_facts.evidence_count + excluded.evidence_count, mention_count=entity_intelligence_facts.mention_count + excluded.mention_count, confidence=max(entity_intelligence_facts.confidence, excluded.confidence), status='active'
+    """, (guild_id, skey, subject, fact_type, fact.get("label"), fact.get("value"), fact.get("sourceType") or "entity_intelligence_engine", fact.get("sourceTable"), None, None, None, fact.get("visibility") or "review_only", fact.get("authority") or "bnl_inferred", float(fact.get("confidence") or .5), int(bool(fact.get("publicSafe"))), int(bool(fact.get("reviewOnly"))), int(bool(fact.get("needsOwnerReview"))), ts, ts, int(fact.get("evidenceCount") or 1), int(fact.get("evidenceCount") or 1)))
+
+
+def _upsert_edge(conn: sqlite3.Connection, guild_id: int | None, skey: str, edge: dict[str, Any]) -> None:
+    ts = now_iso()
+    conn.execute("""
+        INSERT INTO entity_intelligence_edges (guild_id, subject_key, object_key, object_label, relation_type, source_type, source_channel_policy, visibility, authority, confidence, first_seen_at, last_seen_at, evidence_count, status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
+        ON CONFLICT(guild_id, subject_key, object_key, relation_type, authority, visibility)
+        DO UPDATE SET last_seen_at=excluded.last_seen_at, evidence_count=entity_intelligence_edges.evidence_count + excluded.evidence_count, confidence=max(entity_intelligence_edges.confidence, excluded.confidence), status='active'
+    """, (guild_id, skey, edge.get("objectKey"), edge.get("objectLabel"), edge.get("relationType"), "entity_intelligence_engine", None, edge.get("visibility") or "review_only", edge.get("authority") or "bnl_inferred", float(edge.get("confidence") or .5), ts, ts, int(edge.get("evidenceCount") or 1)))
+
+
+def _upsert_question(conn: sqlite3.Connection, guild_id: int | None, skey: str, question: str, reason: str, priority: int = 50) -> None:
+    ts = now_iso()
+    conn.execute("""
+        INSERT INTO entity_open_questions (guild_id, subject_key, question, reason, source_type, visibility, priority, status, created_at, updated_at)
+        VALUES (?, ?, ?, ?, 'entity_intelligence_engine', 'review_only', ?, 'open', ?, ?)
+        ON CONFLICT(guild_id, subject_key, question) DO UPDATE SET reason=excluded.reason, priority=excluded.priority, updated_at=excluded.updated_at, status='open'
+    """, (guild_id, skey, question, reason, priority, ts, ts))
+
+
+def build_entity_intelligence_profile(db_path: str, guild_id: int | None, subject: str, *, refresh: bool = False, max_rows: int = 240) -> dict[str, Any]:
+    subject = safe_text(subject, 90) or "Unknown subject"
+    skey = subject_key(subject)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        ensure_entity_intelligence_schema(conn)
+        rows = _collect_rows(conn, subject, guild_id, max_rows)
+        classified = _classify(subject, rows)
+        for fact in classified["facts"]:
+            _upsert_fact(conn, guild_id, skey, subject, fact.get("type") or "fact", fact)
+        for edge in classified["relationships"]:
+            _upsert_edge(conn, guild_id, skey, edge)
+        for item in classified["actionItems"]:
+            _upsert_question(conn, guild_id, skey, str(item.get("label") or "Confirm context"), str(item.get("value") or item.get("label") or ""), 70 if item.get("needsOwnerReview") else 50)
+        # simple activity rollups by safe channel label/policy, never exposed as raw provenance
+        roll: dict[tuple[str, str], Counter] = defaultdict(Counter)
+        for row in rows:
+            chan = safe_text(row.get("channel_name") or "local stored context", 80)
+            pol = safe_text(row.get("channel_policy") or row.get("visibility") or "unknown", 80)
+            key = (chan, pol)
+            if row.get("relation") == "authored": roll[key]["authored"] += 1
+            else: roll[key]["mentioned"] += 1
+            if URL_RE.search(str(row.get("text") or "")): roll[key]["links"] += 1
+            if BNL_RE.search(str(row.get("text") or "")): roll[key]["bnl"] += 1
+            if MUSIC_RE.search(str(row.get("text") or "")): roll[key]["music"] += 1
+            if CONTEST_RE.search(str(row.get("text") or "")): roll[key]["contest"] += 1
+            if COLLAB_RE.search(str(row.get("text") or "")): roll[key]["collab"] += 1
+        ts = now_iso()
+        for (chan, pol), cnt in roll.items():
+            conn.execute("""
+                INSERT INTO entity_activity_rollups (guild_id, subject_key, channel_name, channel_policy, activity_type, first_seen_at, last_seen_at, authored_count, mentioned_count, link_count, bnl_interaction_count, music_signal_count, contest_signal_count, collaboration_signal_count, status)
+                VALUES (?, ?, ?, ?, 'stored_context', ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
+                ON CONFLICT(guild_id, subject_key, channel_name, channel_policy, activity_type)
+                DO UPDATE SET last_seen_at=excluded.last_seen_at, authored_count=excluded.authored_count, mentioned_count=excluded.mentioned_count, link_count=excluded.link_count, bnl_interaction_count=excluded.bnl_interaction_count, music_signal_count=excluded.music_signal_count, contest_signal_count=excluded.contest_signal_count, collaboration_signal_count=excluded.collaboration_signal_count, status='active'
+            """, (guild_id, skey, chan, pol, ts, ts, cnt["authored"], cnt["mentioned"], cnt["links"], cnt["bnl"], cnt["music"], cnt["contest"], cnt["collab"]))
+        diagnostics = {
+            "ledgerStatus": "ready",
+            "profileStatus": "refreshed" if refresh else "built",
+            "rowsScanned": len(rows),
+            "rowsBySource": classified["sourceCounts"],
+            "publicSafeRows": classified["publicSafeRows"],
+            "reviewOnlyRows": classified["reviewOnlyRows"],
+            "officialPublicDossierConnected": False,
+            "officialPublicDossierNote": "official_public_dossier source not connected yet",
+            "queueSubmissionStatus": "not_connected",
+        }
+        profile = {
+            "subjectKey": skey,
+            "subjectName": subject,
+            "authorityOrder": list(ENTITY_SOURCE_AUTHORITY_ORDER),
+            "visibilityValues": list(ENTITY_VISIBILITY_VALUES),
+            "roles": classified["roles"],
+            "relationships": classified["relationships"],
+            "creativeMusic": classified["creativeMusic"],
+            "bnlInteraction": classified["bnlInteraction"],
+            "behaviorPosture": classified["behaviorPosture"],
+            "conversationThemes": classified["conversationThemes"],
+            "eventContest": classified["eventContest"],
+            "dossierUsefulness": classified["dossierUsefulness"],
+            "actionItems": classified["actionItems"],
+            "missingInfo": classified["missingInfo"],
+            "warnings": classified["warnings"],
+            "sourceCoverage": [{"source": k, "count": v, "status": "used"} for k, v in sorted(classified["sourceCounts"].items())],
+            "diagnostics": diagnostics,
+        }
+        source_hash = hashlib.sha256(json.dumps(profile, sort_keys=True, default=str).encode("utf-8")).hexdigest()
+        conn.execute("""
+            INSERT INTO entity_profile_snapshots (guild_id, subject_key, subject_name, summary_json, source_hash, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(guild_id, subject_key) DO UPDATE SET subject_name=excluded.subject_name, summary_json=excluded.summary_json, source_hash=excluded.source_hash, updated_at=excluded.updated_at
+        """, (guild_id, skey, subject, json.dumps(profile, sort_keys=True, default=str), source_hash, ts, ts))
+        conn.commit()
+        return profile
+    finally:
+        conn.close()
+
+
+def _safe_item_for_output(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "label": safe_text(item.get("label") or item.get("objectLabel") or item.get("relationType") or "", 160),
+        "value": safe_text(item.get("value") or item.get("relationType") or "", 180),
+        "visibility": item.get("visibility") or "unknown",
+        "authority": item.get("authority") or "unknown",
+        "confidence": round(float(item.get("confidence") or 0), 2),
+        "reviewOnly": bool(item.get("reviewOnly")),
+        "publicSafe": bool(item.get("publicSafe")),
+        "needsOwnerReview": bool(item.get("needsOwnerReview")),
+        "evidenceCount": int(item.get("evidenceCount") or 1),
+    }
+
+
+def _edge_for_output(edge: dict[str, Any]) -> dict[str, Any]:
+    out = _safe_item_for_output(edge)
+    out.update({"objectLabel": safe_text(edge.get("objectLabel"), 120), "relationType": safe_text(edge.get("relationType"), 80)})
+    return out
+
+
+def _allow_item(item: dict[str, Any], surface: str) -> tuple[bool, str]:
+    visibility = str(item.get("visibility") or "unknown")
+    authority = str(item.get("authority") or "unknown")
+    public_safe = bool(item.get("publicSafe")) or visibility == "public"
+    review_only = bool(item.get("reviewOnly")) or visibility in {"review_only", "mod_only", "admin_only", "internal_only", "source_blind", "account_private"}
+    if authority == "source_blind_memory" and surface not in {"rd_mod_ops", "source_file", "owner_review", "internal_diagnostics"}:
+        return False, "source_blind_memory"
+    if surface in {"public_conversation", "ambient_public", "website_relay", "dossier_draft"}:
+        if review_only or not public_safe:
+            return False, "not_public_safe"
+        if visibility not in {"public", "public_safe_candidate"} and authority not in {"owner_confirmed", "official_public_dossier", "broadcast_memory"}:
+            return False, "visibility_restricted"
+    if surface == "dossier_draft" and authority not in {"owner_confirmed", "official_public_dossier", "broadcast_memory", "public_discord_observed"}:
+        return False, "authority_too_low"
+    if surface in {"ambient_public", "website_relay"} and item.get("needsOwnerReview"):
+        return False, "needs_owner_review"
+    if surface == "owner_review" and visibility in {"account_private", "source_blind"}:
+        return False, "unsafe_for_owner_public_copy"
+    return True, "allowed"
+
+
+def resolve_entity_context_for_surface(profile: dict[str, Any], surface: str, *, channel_policy: str | None = None, viewer_role: str | None = None, max_items: int = 12) -> dict[str, Any]:
+    if surface not in SURFACES:
+        raise ValueError(f"unsupported entity context surface: {surface}")
+    excluded: Counter[str] = Counter()
+
+    def filter_items(items: list[dict[str, Any]], *, edge: bool = False) -> list[dict[str, Any]]:
+        allowed = []
+        for item in items or []:
+            ok, reason = _allow_item(item, surface)
+            if ok:
+                allowed.append(_edge_for_output(item) if edge else _safe_item_for_output(item))
+            else:
+                excluded[reason] += 1
+        return allowed[:max_items]
+
+    if surface == "internal_diagnostics":
+        diag = dict(profile.get("diagnostics") or {})
+        return {
+            "surface": surface,
+            "allowedFacts": [], "allowedRoles": [], "allowedRelationships": [], "allowedThemes": [], "allowedActivity": [],
+            "allowedWarnings": [], "allowedActionItems": [], "missingInfo": [],
+            "excludedReasonCounts": {},
+            "sourceAuthority": list(ENTITY_SOURCE_AUTHORITY_ORDER),
+            "diagnostics": {
+                "ledgerStatus": diag.get("ledgerStatus"), "rowsScanned": int(diag.get("rowsScanned") or 0),
+                "rowsBySource": dict(diag.get("rowsBySource") or {}),
+                "publicSafeRows": int(diag.get("publicSafeRows") or 0), "reviewOnlyRows": int(diag.get("reviewOnlyRows") or 0),
+                "officialPublicDossierConnected": bool(diag.get("officialPublicDossierConnected")),
+                "queueSubmissionStatus": diag.get("queueSubmissionStatus") or "not_connected",
+            },
+        }
+
+    roles = filter_items(profile.get("roles") or [])
+    rels = filter_items(profile.get("relationships") or [], edge=True)
+    themes = filter_items(profile.get("conversationThemes") or [])
+    activity = []
+    for key in ("creativeMusic", "bnlInteraction", "behaviorPosture", "eventContest", "dossierUsefulness"):
+        activity.extend(filter_items(profile.get(key) or []))
+    actions = filter_items(profile.get("actionItems") or []) if surface in {"rd_mod_ops", "source_file", "owner_review"} else []
+    warnings = filter_items(profile.get("warnings") or []) if surface in {"rd_mod_ops", "source_file", "owner_review"} else []
+    missing = [safe_text(x, 180) for x in (profile.get("missingInfo") or [])]
+    if surface in {"public_conversation", "ambient_public", "website_relay"}:
+        missing = []
+    elif surface == "dossier_draft":
+        missing = [x for x in missing if "not_connected" not in x][:max_items]
+    context = {
+        "surface": surface,
+        "allowedFacts": (roles + themes + activity)[:max_items],
+        "allowedRoles": roles,
+        "allowedRelationships": rels,
+        "allowedThemes": themes,
+        "allowedActivity": activity[:max_items],
+        "allowedWarnings": warnings,
+        "allowedActionItems": actions,
+        "missingInfo": missing[:max_items],
+        "excludedReasonCounts": dict(excluded),
+        "sourceAuthority": list(ENTITY_SOURCE_AUTHORITY_ORDER),
+        "officialPublicDossierConnected": bool((profile.get("diagnostics") or {}).get("officialPublicDossierConnected")),
+        "queueSubmissionStatus": (profile.get("diagnostics") or {}).get("queueSubmissionStatus") or "not_connected",
+    }
+    if surface in {"ambient_public", "website_relay"}:
+        # Keep these surfaces broad: strip individual relationship objects unless official/public.
+        context["allowedRelationships"] = [r for r in context["allowedRelationships"] if r.get("authority") in {"owner_confirmed", "official_public_dossier", "broadcast_memory"}][:max_items]
+    return context
+
+
+def build_entity_context_for_public_conversation(profile: dict[str, Any], *, max_lines: int = 4) -> list[str]:
+    context = resolve_entity_context_for_surface(profile, "public_conversation", max_items=max_lines)
+    lines = []
+    for item in (context.get("allowedRoles") or []) + (context.get("allowedThemes") or []) + (context.get("allowedActivity") or []):
+        label = safe_text(item.get("label"), 100)
+        if label and label not in lines:
+            lines.append(label)
+        if len(lines) >= max_lines:
+            break
+    return lines
+
+
+def build_entity_context_for_ambient_public(profile: dict[str, Any], *, max_items: int = 6) -> dict[str, Any]:
+    return resolve_entity_context_for_surface(profile, "ambient_public", max_items=max_items)
+
+
+def build_entity_context_for_website_relay(profile: dict[str, Any], *, max_items: int = 6) -> dict[str, Any]:
+    return resolve_entity_context_for_surface(profile, "website_relay", max_items=max_items)
+
+
+def build_entity_context_for_rd_mod_ops(db_path: str, guild_id: int | None, subject: str, *, max_items: int = 8) -> dict[str, Any]:
+    profile = build_entity_intelligence_profile(db_path, guild_id, subject, refresh=True)
+    return resolve_entity_context_for_surface(profile, "rd_mod_ops", max_items=max_items)
+
+
+def mark_entity_scouting_stale(conn: sqlite3.Connection, guild_id: int | None, subject: str, *, reason: str, source: str, last_seen_at: str | None = None) -> None:
+    ensure_entity_intelligence_schema(conn)
+    ts = now_iso()
+    conn.execute("""
+        INSERT INTO entity_scouting_queue (guild_id, subject_key, subject_name, reason, source, last_seen_at, status, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, 'stale', ?, ?)
+        ON CONFLICT(guild_id, subject_key, reason, source) DO UPDATE SET last_seen_at=excluded.last_seen_at, status='stale', updated_at=excluded.updated_at
+    """, (guild_id, subject_key(subject), safe_text(subject, 90), safe_text(reason, 180), safe_text(source, 80), last_seen_at or ts, ts, ts))
+    conn.commit()
+
+
+def resolve_authoritative_fact(facts: list[dict[str, Any]]) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    """Return highest-authority fact and owner-review conflicts for same labels."""
+    if not facts:
+        return None, []
+    ordered = sorted(facts, key=lambda f: (authority_rank(str(f.get("authority") or "unknown")), -float(f.get("confidence") or 0)))
+    winner = ordered[0]
+    conflicts = []
+    for fact in ordered[1:]:
+        if safe_text(fact.get("label")).lower() == safe_text(winner.get("label")).lower() and safe_text(fact.get("value")).lower() != safe_text(winner.get("value")).lower():
+            if authority_rank(str(fact.get("authority") or "unknown")) <= authority_rank("public_discord_observed"):
+                conflicts.append(_item("Owner review needed for conflicting high-authority entity fact", f"{winner.get('value')} vs {fact.get('value')}", visibility="review_only", authority="bnl_inferred", public_safe=False, review_only=True, needs_owner_review=True) | {"type": "action_item"})
+    return winner, conflicts

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -18,6 +18,7 @@ from typing import Any, Callable
 from bnl_dossier_recommendations import build_dossier_recommendation_payload, send_dossier_recommendation
 from bnl_entity_activity_summary import build_entity_activity_summary, refresh_entity_evidence_for_subject
 from bnl_entity_evidence import _website_safe_payload_text
+from bnl_entity_intelligence import build_entity_intelligence_profile, resolve_entity_context_for_surface, safe_text as _entity_safe_text
 from bnl_source_file_lookup import lookup_source_file
 
 ENRICHMENT_INGEST_SOURCE = "bnl_source_file_enrichment"
@@ -1209,6 +1210,7 @@ def _copy_evidence_fields(target: dict[str, Any], source: dict[str, Any]) -> Non
         "privateOnlyNotes",
         "notPublicYet",
         "sourceAuthority",
+        "entityIntelligenceProfile",
         *ENTITY_SUMMARY_EVIDENCE_FIELDS.keys(),
     ):
         if key in source:
@@ -2015,7 +2017,7 @@ def build_compact_enrichment_evidence_summary(packet: dict[str, Any]) -> str:
         section_items = sections.get(section_name) or []
         if len(section_items) > item_index:
             section_useful.append(section_items[item_index])
-    useful = _compact_list_for_site(packet.get("usefulEvidence") or section_useful or packet.get("knownContext") or packet.get("evidenceDetails"), max_items=3, item_limit=220)
+    useful = _compact_list_for_site(section_useful or packet.get("usefulEvidence") or packet.get("knownContext") or packet.get("evidenceDetails"), max_items=3, item_limit=220)
     if useful:
         lines.append("Useful evidence:")
         lines.extend(f"- {item if isinstance(item, str) else _site_safe_text(json.dumps(item, sort_keys=True, default=str), 220)}" for item in useful[:3])
@@ -2123,7 +2125,7 @@ def _readout_text_validation_issue(field_name: str, text: str) -> str | None:
         return f"{field_name} contains raw IDs"
     if _PRIVATE_CHANNEL_NAME_RE.search(text):
         return f"{field_name} contains private channel names"
-    if _RAW_SOURCE_LABEL_RE.search(text):
+    if _RAW_SOURCE_LABEL_RE.search(validation_text):
         return f"{field_name} contains raw source labels"
     if _SOURCE_TABLE_NAME_RE.search(text):
         return f"{field_name} contains source table names"
@@ -2223,6 +2225,121 @@ def validate_enrichment_payload_for_site(payload: dict[str, Any]) -> list[str]:
     return issues
 
 
+
+
+def _entity_context_labels(items: list[dict[str, Any]], *, label_key: str = "label", limit: int = 8) -> list[str]:
+    labels: list[str] = []
+    for item in items or []:
+        label = _safe_text(item.get(label_key) or item.get("label") or item.get("objectLabel") or "", 180)
+        value = _safe_text(item.get("value") or "", 180)
+        if label and value and value != label and label_key != "objectLabel":
+            text = f"{label}: {value}"
+        else:
+            text = label
+        if text and text not in labels:
+            labels.append(text)
+        if len(labels) >= limit:
+            break
+    return labels
+
+
+def _merge_entity_intelligence_into_evidence(evidence: dict[str, Any], profile: dict[str, Any], resolver: dict[str, Any]) -> None:
+    """Map the Entity Intelligence Resolver's source_file surface into existing website-safe fields."""
+
+    roles = _entity_context_labels(resolver.get("allowedRoles") or [], limit=8)
+    relationships = []
+    for rel in resolver.get("allowedRelationships") or []:
+        obj = _safe_text(rel.get("objectLabel") or rel.get("label"), 120)
+        relation = _safe_text(rel.get("relationType") or rel.get("value"), 80)
+        if obj and relation:
+            relationships.append(f"{obj}: {relation}")
+    themes = _entity_context_labels(resolver.get("allowedThemes") or [], limit=8)
+    activity = _entity_context_labels(resolver.get("allowedActivity") or [], limit=12)
+    action_items = _entity_context_labels(resolver.get("allowedActionItems") or [], limit=8)
+    warnings = _entity_context_labels(resolver.get("allowedWarnings") or [], limit=6)
+    missing = [_safe_text(item, 180) for item in (resolver.get("missingInfo") or []) if _safe_text(item, 180)]
+
+    def add_list(key: str, values: list[str]) -> None:
+        bucket = evidence.setdefault(key, [])
+        for value in values:
+            clean = _safe_text(value, 220)
+            if clean and clean not in bucket:
+                bucket.append(clean)
+
+    add_list("knownContext", [f"Detected role facet: {r}" for r in roles])
+    add_list("relationshipSignals", [f"Detected relationship facet: {r}" for r in relationships])
+    add_list("conversationHighlights", [f"Conversation theme: {t}" for t in themes])
+    add_list("topicBreakdown", themes)
+    music = [a for a in activity if re.search(r"music|suno|udio|youtube|soundcloud|spotify|bandcamp|track|song|demo|wip|collab", a, re.I)]
+    bnl = [a for a in activity if re.search(r"BNL|source-file|boundary|challenge", a, re.I)]
+    community = [a for a in activity if re.search(r"community|mod|contest|event|dossier|source file", a, re.I)]
+    add_list("musicSignals", music)
+    add_list("bnlInteractionSignals", bnl)
+    add_list("communitySignals", community)
+    add_list("bestEvidenceToReview", action_items + warnings)
+    add_list("reviewOnlyEvidence", action_items + warnings)
+    add_list("missingInfo", missing)
+    add_list("usefulEvidence", roles + relationships + themes + activity[:8])
+    add_list("evidenceDetails", [f"Entity intelligence surface {resolver.get('surface')}: {item}" for item in (roles + relationships + themes + activity[:8])])
+    sections = evidence.setdefault("sections", {})
+    if missing:
+        section_missing = sections.setdefault("Missing Info", [])
+        for item in reversed(missing[:8]):
+            if item in section_missing:
+                section_missing.remove(item)
+            section_missing.insert(0, item)
+    if action_items:
+        evidence["recommendedAction"] = action_items[0]
+        suggested = sections.setdefault("Suggested Next Action", [])
+        if action_items[0] not in suggested:
+            suggested.insert(0, action_items[0])
+    elif missing:
+        evidence["recommendedAction"] = f"Confirm missing info: {missing[0]}"
+    evidence["queueSubmissionStatus"] = resolver.get("queueSubmissionStatus") or "not_connected"
+    evidence["queueSubmissionNote"] = QUEUE_NOT_CONNECTED_NOTE
+    coverage = evidence.setdefault("sourceCoverage", [])
+    for item in profile.get("sourceCoverage") or []:
+        safe_item = {"source": _safe_text(item.get("source"), 80), "count": int(item.get("count") or 0), "status": _safe_text(item.get("status") or "used", 40)}
+        if safe_item not in coverage:
+            coverage.append(safe_item)
+    evidence["entityIntelligenceProfile"] = {
+        "subjectKey": _safe_text(profile.get("subjectKey"), 120),
+        "subjectName": _safe_text(profile.get("subjectName"), 120),
+        "roles": roles[:8],
+        "relationships": relationships[:8],
+        "creativeMusic": music[:8],
+        "bnlInteraction": bnl[:8],
+        "behaviorPosture": [a for a in activity if re.search(r"challenging|lore|anomaly|supportive|frequent|occasional", a, re.I)][:8],
+        "conversationThemes": themes[:8],
+        "eventContest": [a for a in activity if re.search(r"contest|event|rules", a, re.I)][:8],
+        "dossierUsefulness": [a for a in activity if re.search(r"dossier|source file|approval|candidate", a, re.I)][:8],
+        "missingInfo": missing[:8],
+        "officialPublicDossierConnected": bool(resolver.get("officialPublicDossierConnected")),
+        "queueSubmissionStatus": resolver.get("queueSubmissionStatus") or "not_connected",
+    }
+    diagnostics = evidence.setdefault("diagnostics", {})
+    diagnostics["entityIntelligence"] = {
+        "ledgerStatus": (profile.get("diagnostics") or {}).get("ledgerStatus") or "unknown",
+        "profileStatus": (profile.get("diagnostics") or {}).get("profileStatus") or "unknown",
+        "resolverSurface": resolver.get("surface") or "source_file",
+        "detectedRoleFacets": roles,
+        "detectedRelationshipFacets": relationships,
+        "creativeMusicFacets": music,
+        "behaviorPostureFacets": evidence["entityIntelligenceProfile"]["behaviorPosture"],
+        "conversationThemes": themes,
+        "eventContestActivity": evidence["entityIntelligenceProfile"]["eventContest"],
+        "dossierUsefulness": evidence["entityIntelligenceProfile"]["dossierUsefulness"],
+        "modActionItems": action_items,
+        "missingInfo": missing,
+        "sourceRowsBySource": (profile.get("diagnostics") or {}).get("rowsBySource") or {},
+        "publicSafeRows": int((profile.get("diagnostics") or {}).get("publicSafeRows") or 0),
+        "reviewOnlyRows": int((profile.get("diagnostics") or {}).get("reviewOnlyRows") or 0),
+        "officialPublicDossierConnected": bool((profile.get("diagnostics") or {}).get("officialPublicDossierConnected")),
+        "officialPublicDossierNote": (profile.get("diagnostics") or {}).get("officialPublicDossierNote") or "official_public_dossier source not connected yet",
+    }
+    evidence["subjectIntelligenceDiagnostics"] = dict(evidence.get("subjectIntelligenceDiagnostics") or {})
+    evidence["subjectIntelligenceDiagnostics"]["entityIntelligence"] = diagnostics["entityIntelligence"]
+
 def build_enrichment_markdown(packet: dict[str, Any]) -> str:
     sections = packet.get("sections") or {}
     lines: list[str] = []
@@ -2306,6 +2423,7 @@ def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: 
         "reviewOnlyEvidence": list(packet.get("reviewOnlyEvidence") or []),
         "queueSubmissionStatus": packet.get("queueSubmissionStatus") or "not_connected",
         "queueSubmissionNote": packet.get("queueSubmissionNote") or QUEUE_NOT_CONNECTED_NOTE,
+        "entityIntelligenceProfile": dict(packet.get("entityIntelligenceProfile") or {}),
         "rawProvenance": dict(packet.get("rawProvenance") or {}),
         "visibilityLabels": ["internal_review_only", "admin_review_required"],
         "confidence": "low" if packet.get("qualityStatus") in {"too_thin", "forced_low_confidence"} else ("medium" if match_kind == "active_source_file" else "low"),
@@ -2404,6 +2522,9 @@ def run_source_file_enrichment(
 
     effective_subject = _first(source_file, ("name", "sourceFileName", "subject", "displayName", "title", "normalizedName")) or target_value
     evidence = collect_source_enrichment_evidence(db_path, guild_id, str(effective_subject), rd_context=rd_context, lookup_result=lookup_result)
+    entity_profile = build_entity_intelligence_profile(db_path, guild_id, str(effective_subject), refresh=True)
+    entity_resolver = resolve_entity_context_for_surface(entity_profile, "source_file", max_items=16)
+    _merge_entity_intelligence_into_evidence(evidence, entity_profile, entity_resolver)
     packet = {
         "ok": True,
         "dryRun": dry_run,
@@ -2523,12 +2644,15 @@ def format_source_enrichment_response(result: dict[str, Any]) -> str:
             f"Target lane: {attach_label}.",
             f"Would send as BNL Source File Enrichment: {'yes' if result.get('qualityStatus') != 'too_thin' else 'no — too thin'}.",
             f"Source types used: {source_types}.",
-            f"Source coverage: {_format_source_coverage(result)}.",
+            f"Source coverage: {_safe_text(_format_source_coverage(result), 220)}.",
             f"Matched local profiles/users: {int((result.get('diagnostics') or {}).get('matchedUserProfileCount') or 0)}/{int((result.get('diagnostics') or {}).get('matchedUserIdCount') or 0)}.",
             f"Matched identity labels: {_safe_text(', '.join((result.get('diagnostics') or {}).get('matchedIdentityLabels') or []) or 'none', 160)}.",
             f"Channel evidence found: {'yes' if (result.get('diagnostics') or {}).get('channelEvidenceFound') else 'no'}; public dossier match found: {'yes' if (result.get('diagnostics') or {}).get('publicDossierMatchFound') else 'no'}; existing dossier update lane: {'yes' if (result.get('diagnostics') or {}).get('existingDossierUpdateLane') else 'no'}.",
             f"Warning count: {warning_text}.",
         ]
+        early_entity_diag = ((result.get("diagnostics") or {}).get("entityIntelligence") or {})
+        if early_entity_diag:
+            preview_lines.append(f"Entity intelligence ledger/profile: {_safe_text(early_entity_diag.get('ledgerStatus') or 'unknown', 40)} / {_safe_text(early_entity_diag.get('profileStatus') or 'unknown', 40)}; Resolver surface: {_safe_text(early_entity_diag.get('resolverSurface') or 'source_file', 40)}.")
         subject_intel = (result.get("diagnostics") or {}).get("subjectIntelligence") or result.get("subjectIntelligenceDiagnostics") or {}
         if subject_intel:
             rows_by_source = subject_intel.get("rowsBySource") or {}
@@ -2556,10 +2680,10 @@ def format_source_enrichment_response(result: dict[str, Any]) -> str:
                 f"Subject intelligence rows by source: {_safe_text(', '.join(f'{k} {v}' for k, v in rows_by_source.items()) or 'none', 220)}.",
                 f"Top recurring subjects: {_safe_text(', '.join(subject_intel.get('topRecurringSubjects') or []) or 'none', 180)}.",
                 f"Accepted recurring subjects with reason: {_safe_text(accepted_subject_text, 220)}.",
-                f"Rejected top garbage candidates: {_safe_text(rejected_candidate_text, 180)}.",
-                f"Top recurring themes: {_safe_text(', '.join(subject_intel.get('topRecurringThemes') or []) or 'none', 220)}.",
-                f"Top conversation clusters: {_safe_text(conversation_cluster_text, 240)}.",
-                f"Top activity patterns: {_safe_text(activity_pattern_text, 260)}.",
+                f"Rejected top garbage candidates: {_safe_text(rejected_candidate_text, 100)}.",
+                f"Top recurring themes: {_safe_text(', '.join(subject_intel.get('topRecurringThemes') or []) or 'none', 140)}.",
+                f"Top conversation clusters: {_safe_text(conversation_cluster_text, 150)}.",
+                f"Top activity patterns: {_safe_text(activity_pattern_text, 150)}.",
                 f"Top domains/tools: {_safe_text(', '.join(subject_intel.get('topDomains') or []) or 'none', 180)}.",
                 f"Public-safe vs review-only intelligence rows: {int(subject_intel.get('publicSafeRows') or 0)} public-safe / {int(subject_intel.get('reviewOnlyRows') or 0)} review-only.",
             ])
@@ -2581,6 +2705,15 @@ def format_source_enrichment_response(result: dict[str, Any]) -> str:
             preview_lines.extend(f"* {_safe_text(bullet, 180)}" for bullet in bullets[:3])
         if result.get("qualityStatus") == "too_thin":
             preview_lines.append(result.get("suppressedReason") or "Enrichment is too thin to send. Add more source notes or confirm the subject’s role first.")
+        entity_diag = ((result.get("diagnostics") or {}).get("entityIntelligence") or {})
+        if entity_diag:
+            rows_by_source = entity_diag.get("sourceRowsBySource") or {}
+            preview_lines.extend([
+                f"Entity intelligence ledger/profile: {_safe_text(entity_diag.get('ledgerStatus') or 'unknown', 40)} / {_safe_text(entity_diag.get('profileStatus') or 'unknown', 40)}; resolver surface: {_safe_text(entity_diag.get('resolverSurface') or 'source_file', 40)}.",
+                f"Entity facets: roles={_safe_text(', '.join(entity_diag.get('detectedRoleFacets') or []) or 'none', 120)}; relationships={_safe_text(', '.join(entity_diag.get('detectedRelationshipFacets') or []) or 'none', 120)}; music={_safe_text(', '.join(entity_diag.get('creativeMusicFacets') or []) or 'none', 120)}.",
+                f"Entity themes/actions: themes={_safe_text(', '.join(entity_diag.get('conversationThemes') or []) or 'none', 140)}; actions={_safe_text('; '.join(entity_diag.get('modActionItems') or []) or 'none', 140)}.",
+                f"Entity source split: {_safe_text(', '.join(f'{k} {v}' for k, v in rows_by_source.items()) or 'none', 140)}; {int(entity_diag.get('publicSafeRows') or 0)} public-safe / {int(entity_diag.get('reviewOnlyRows') or 0)} review-only; official public dossier source connected: {'yes' if entity_diag.get('officialPublicDossierConnected') else 'no'}.",
+            ])
         preview_lines.append("No raw private transcripts were included; nothing was sent to the website.")
         return "\n".join(preview_lines)[:1900]
     if result.get("sent"):

--- a/tests/test_entity_intelligence.py
+++ b/tests/test_entity_intelligence.py
@@ -1,0 +1,160 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+from bnl_entity_intelligence import (
+    build_entity_context_for_public_conversation,
+    build_entity_intelligence_profile,
+    ensure_entity_intelligence_schema,
+    mark_entity_scouting_stale,
+    resolve_authoritative_fact,
+    resolve_entity_context_for_surface,
+)
+
+
+class EntityIntelligenceTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False)
+        self.tmp.close()
+        self.db = self.tmp.name
+        self.conn = sqlite3.connect(self.db)
+        self.conn.row_factory = sqlite3.Row
+        c = self.conn.cursor()
+        c.execute("CREATE TABLE user_profiles (user_id INTEGER, guild_id INTEGER, display_name TEXT, preferred_name TEXT, last_seen TEXT, last_greeting_at TEXT)")
+        c.execute("CREATE TABLE conversations (id INTEGER PRIMARY KEY, user_id INTEGER, user_name TEXT, guild_id INTEGER, channel_name TEXT, channel_policy TEXT, role TEXT, content TEXT, timestamp TEXT)")
+        c.execute("CREATE TABLE memory_tiers (id INTEGER PRIMARY KEY, user_id INTEGER, guild_id INTEGER, tier TEXT, summary TEXT, salience REAL, mentions INTEGER, updated_at TEXT, source_trust TEXT, source_channel_policy TEXT)")
+        c.execute("CREATE TABLE broadcast_memory (id INTEGER PRIMARY KEY, guild_id INTEGER, episode_date TEXT, cleaned_summary TEXT, entry_type TEXT, public_safe INTEGER, usage_scope TEXT, status TEXT, created_at TEXT)")
+        c.execute("CREATE TABLE community_presence (guild_id INTEGER, subject_key TEXT, display_name TEXT, first_seen_at TEXT, last_seen_at TEXT, source_lanes TEXT, approved_channel_labels TEXT, mention_count INTEGER, direct_interaction_count INTEGER, operator_mention_count INTEGER, active_windows TEXT, connection_notes TEXT, evidence_snippets TEXT, category TEXT, last_error_status TEXT)")
+        self.conn.commit()
+
+    def tearDown(self):
+        self.conn.close()
+        os.unlink(self.db)
+
+    def add_profile(self, user_id, name):
+        self.conn.execute("INSERT INTO user_profiles VALUES (?,1,?,?,NULL,NULL)", (user_id, name, name))
+
+    def add_msg(self, user_id, name, channel, policy, content):
+        self.conn.execute("INSERT INTO conversations VALUES (NULL,?,?,?,?,?,?,?,'now')", (user_id, name, 1, channel, policy, "user", content))
+
+    def profile_for(self, name):
+        self.conn.commit()
+        return build_entity_intelligence_profile(self.db, 1, name, refresh=True)
+
+    def labels(self, items):
+        return "\n".join(str(i.get("label") or i.get("objectLabel") or i.get("relationType") or "") + " " + str(i.get("value") or "") for i in items)
+
+    def test_schema_and_stale_queue_are_idempotent(self):
+        ensure_entity_intelligence_schema(self.conn)
+        ensure_entity_intelligence_schema(self.conn)
+        mark_entity_scouting_stale(self.conn, 1, "Test Subject", reason="new eligible public evidence", source="entity_evidence_events")
+        row = self.conn.execute("SELECT subject_key, status FROM entity_scouting_queue").fetchone()
+        self.assertEqual(row["subject_key"], "test-subject")
+        self.assertEqual(row["status"], "stale")
+
+    def test_crow_like_fixture_relationship_music_bnl_and_actions(self):
+        self.add_profile(10, "Crow")
+        self.add_msg(10, "Crow", "general", "public_home", "Orion through Crow is how this persona speaks with BNL about source-file boundaries.")
+        self.add_msg(10, "Crow", "general", "public_home", "Orion here, BNL. Crow created Orion as my AI project persona.")
+        self.add_msg(10, "Crow", "finished-tracks", "public_music", "Crow shared a Suno track link https://suno.com/song/abc and asked BNL about dossiers.")
+        p = self.profile_for("Crow")
+        rels = {(e["objectLabel"], e["relationType"]) for e in p["relationships"]}
+        self.assertIn(("Orion", "speaks_through"), rels)
+        self.assertIn(("Orion", "created"), rels)
+        self.assertIn("shares Suno/Udio/YouTube/SoundCloud/Spotify/Bandcamp links", self.labels(p["creativeMusic"]))
+        self.assertIn("frequent BNL-facing conversation", self.labels(p["bnlInteraction"]))
+        self.assertIn("AI/persona/project interaction", self.labels(p["conversationThemes"]))
+        self.assertIn("Confirm whether Orion relationship/context can be public", self.labels(p["actionItems"]))
+        self.assertEqual((p["diagnostics"] or {})["queueSubmissionStatus"], "not_connected")
+
+    def test_lost_marbles_like_mod_music_collab_fixture(self):
+        self.add_profile(11, "Lost Marbles")
+        self.add_msg(11, "Lost Marbles", "collaboration-hub", "public_music", "As a mod and staff helper, Lost Marbles can collab with artists and share SoundCloud music demos.")
+        p = self.profile_for("Lost Marbles")
+        self.assertIn("moderator", self.labels(p["roles"]))
+        self.assertIn("shares Suno/Udio/YouTube/SoundCloud/Spotify/Bandcamp links", self.labels(p["creativeMusic"]))
+        self.assertIn("offers collaboration", self.labels(p["creativeMusic"]))
+        self.assertIn("Confirm public-safe mod/staff role wording", self.labels(p["actionItems"]))
+        self.assertIn("Confirm public artist links", self.labels(p["actionItems"]))
+        self.assertEqual(p["diagnostics"]["queueSubmissionStatus"], "not_connected")
+
+    def test_shortybabe_like_challenging_fixture_stays_out_of_public_copy(self):
+        self.add_profile(12, "Shortybabe")
+        self.add_msg(12, "Shortybabe", "general", "public_home", "BNL you are wrong, prove it. I challenge your source file behavior and I am baiting the bot.")
+        self.add_msg(12, "Shortybabe", "general", "public_home", "Still arguing with BNL and teasing the bot boundaries.")
+        p = self.profile_for("Shortybabe")
+        self.assertIn("antagonistic/challenging", self.labels(p["behaviorPosture"]))
+        self.assertIn("frequent BNL-facing conversation", self.labels(p["bnlInteraction"]))
+        public = resolve_entity_context_for_surface(p, "public_conversation")
+        public_text = str(public)
+        self.assertNotIn("antagonistic", public_text)
+        self.assertNotIn("defamatory", public_text)
+        self.assertGreater(public["excludedReasonCounts"].get("not_public_safe", 0), 0)
+
+    def test_antigrain_like_anomaly_fixture(self):
+        self.add_profile(13, "Antigrain")
+        self.add_msg(13, "Antigrain", "general", "public_home", "BNL, this anomaly theory and weird signal lore keeps glitching around the dossier.")
+        p = self.profile_for("Antigrain")
+        self.assertIn("strange/anomaly conversations", self.labels(p["conversationThemes"]))
+        self.assertIn("frequent BNL-facing conversation", self.labels(p["bnlInteraction"]))
+        self.assertIn("Determine whether anomaly/lore context is public-safe lore or internal-only", self.labels(p["actionItems"]))
+
+    def test_hellcat_like_mod_contest_fixture(self):
+        self.add_profile(14, "Hellcat")
+        self.add_msg(14, "Hellcat", "contest-room", "public_home", "Hellcat mod post: contest rules, deadline, entries, winner, prize, and event instructions for the channel.")
+        p = self.profile_for("Hellcat")
+        self.assertIn("moderator", self.labels(p["roles"]))
+        self.assertIn("contest/event activity", self.labels(p["eventContest"]))
+        self.assertIn("Confirm contest name, rules, channel, dates, and public link", self.labels(p["actionItems"]))
+        draft = resolve_entity_context_for_surface(p, "dossier_draft")
+        self.assertNotIn("rules, channel, dates", str(draft.get("allowedActionItems")))
+
+    def test_generic_non_hardcoded_fixture(self):
+        self.add_profile(15, "Nova Finch")
+        self.add_msg(15, "Nova Finch", "collaboration-hub", "public_music", "Nova Finch is an artist asking for feedback on a demo and wants to collaborate with Blue Kite.")
+        p = self.profile_for("Nova Finch")
+        self.assertIn("artist", self.labels(p["roles"]))
+        self.assertIn("offers collaboration", self.labels(p["creativeMusic"]))
+        self.assertIn("collaboration", self.labels(p["conversationThemes"]))
+
+    def test_surface_filters(self):
+        self.add_profile(16, "Surface Test")
+        self.add_msg(16, "Surface Test", "general", "public_home", "Surface Test artist shares music and asks for feedback.")
+        self.conn.execute("INSERT INTO memory_tiers VALUES (NULL,16,1,'long','Surface Test private internal note with rawRefJson and conversations table mention.',0.9,1,'now','legacy_unknown','legacy_unknown')")
+        p = self.profile_for("Surface Test")
+        public = resolve_entity_context_for_surface(p, "public_conversation")
+        ambient = resolve_entity_context_for_surface(p, "ambient_public")
+        relay = resolve_entity_context_for_surface(p, "website_relay")
+        rd = resolve_entity_context_for_surface(p, "rd_mod_ops")
+        source = resolve_entity_context_for_surface(p, "source_file")
+        draft = resolve_entity_context_for_surface(p, "dossier_draft")
+        owner = resolve_entity_context_for_surface(p, "owner_review")
+        diag = resolve_entity_context_for_surface(p, "internal_diagnostics")
+        self.assertNotIn("private internal note", str(public))
+        self.assertNotIn("rawRefJson", str(ambient))
+        self.assertNotIn("rawRefJson", str(relay))
+        self.assertIn("source_blind_memory", str(rd.get("allowedFacts")) + str(rd.get("excludedReasonCounts")))
+        self.assertIn("missingInfo", source)
+        self.assertNotIn("queue/submission bridge not_connected", str(draft.get("allowedFacts")))
+        self.assertNotIn("rawRefJson", str(owner))
+        self.assertIn("rowsScanned", diag["diagnostics"])
+        self.assertNotIn("private internal note", str(diag))
+        self.assertLessEqual(len(build_entity_context_for_public_conversation(p)), 4)
+
+    def test_authority_winner_and_conflict_action(self):
+        facts = [
+            {"label": "role", "value": "public Discord says artist", "authority": "public_discord_observed", "confidence": .8},
+            {"label": "role", "value": "official dossier says producer", "authority": "official_public_dossier", "confidence": .9},
+        ]
+        winner, conflicts = resolve_authoritative_fact(facts)
+        self.assertEqual(winner["authority"], "official_public_dossier")
+        self.assertTrue(conflicts)
+        self.assertIn("Owner review needed", conflicts[0]["label"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -1084,3 +1084,65 @@ class SourceFileEnrichmentBotTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class SourceFileEntityIntelligenceIntegrationTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False)
+        self.tmp.close()
+        self.db = self.tmp.name
+        self.conn = sqlite3.connect(self.db)
+        c = self.conn.cursor()
+        c.execute("CREATE TABLE user_profiles (user_id INTEGER, guild_id INTEGER, display_name TEXT, preferred_name TEXT, last_seen TEXT, last_greeting_at TEXT)")
+        c.execute("CREATE TABLE user_memory_facts (id INTEGER PRIMARY KEY, user_id INTEGER, guild_id INTEGER, fact_key TEXT, fact_value TEXT, confidence REAL, is_core INTEGER, updated_at TEXT)")
+        c.execute("CREATE TABLE user_habits (user_id INTEGER, guild_id INTEGER, total_messages INTEGER, question_messages INTEGER, humor_messages INTEGER, late_night_messages INTEGER, avg_length REAL, last_topic TEXT, updated_at TEXT)")
+        c.execute("CREATE TABLE relationship_state (user_id INTEGER, guild_id INTEGER, interaction_count INTEGER, affinity_score REAL, trust_stage TEXT, social_stance TEXT, last_topic TEXT, updated_at TEXT)")
+        c.execute("CREATE TABLE relationship_journal (id INTEGER PRIMARY KEY, user_id INTEGER, guild_id INTEGER, entry_type TEXT, summary TEXT, timestamp TEXT)")
+        c.execute("CREATE TABLE conversations (id INTEGER PRIMARY KEY, user_id INTEGER, user_name TEXT, guild_id INTEGER, channel_name TEXT, channel_policy TEXT, role TEXT, content TEXT, timestamp TEXT)")
+        c.execute("CREATE TABLE memory_tiers (id INTEGER PRIMARY KEY, user_id INTEGER, guild_id INTEGER, tier TEXT, summary TEXT, salience REAL, mentions INTEGER, updated_at TEXT, source_trust TEXT, source_channel_policy TEXT)")
+        c.execute("CREATE TABLE broadcast_memory (id INTEGER PRIMARY KEY, guild_id INTEGER, episode_date TEXT, cleaned_summary TEXT, entry_type TEXT, public_safe INTEGER, usage_scope TEXT, status TEXT, created_at TEXT)")
+        c.execute("CREATE TABLE community_presence (guild_id INTEGER, subject_key TEXT, display_name TEXT, first_seen_at TEXT, last_seen_at TEXT, source_lanes TEXT, approved_channel_labels TEXT, mention_count INTEGER, direct_interaction_count INTEGER, operator_mention_count INTEGER, active_windows TEXT, connection_notes TEXT, evidence_snippets TEXT, category TEXT, last_error_status TEXT)")
+        self.conn.commit()
+
+    def tearDown(self):
+        self.conn.close()
+        os.unlink(self.db)
+
+    def lookup(self, query):
+        return {"ok": True, "found": True, "matchKind": "exact", "data": {"sourceFile": {"id": "sf_1", "name": query["lookupValue"], "status": "active", "candidateType": "entity"}}}
+
+    def test_source_file_payload_includes_entity_intelligence_without_raw_material_or_queue_claims(self):
+        c = self.conn.cursor()
+        c.execute("INSERT INTO user_profiles VALUES (21,1,'Crow','Crow',NULL,NULL)")
+        c.execute("INSERT INTO conversations VALUES (NULL,21,'Crow',1,'finished-tracks','public_music','user','Orion through Crow. Crow created Orion. BNL source-file boundaries and Suno music link https://suno.com/song/raw-path should be reviewed, not a submitted song. 123456789012345678','now')")
+        c.execute("INSERT INTO conversations VALUES (NULL,21,'Crow',1,'contest-room','public_home','user','Crow helps with community event contest rules and asks for feedback on a track.','now')")
+        self.conn.commit()
+        result = enrich.run_source_file_enrichment(self.db, 1, "Crow", dry_run=True, lookup_func=self.lookup)
+        payload = result["payload"]
+        profile = payload.get("entityIntelligenceProfile") or {}
+        public_payload = dict(payload)
+        public_payload.pop("rawProvenance", None)
+        joined = json.dumps(public_payload, sort_keys=True)
+        self.assertTrue(profile)
+        self.assertIn("Detected role facet", json.dumps(payload.get("knownContext", [])))
+        self.assertIn("Orion", json.dumps(payload.get("relationshipSignals", [])))
+        self.assertIn("Suno", json.dumps(payload.get("musicSignals", [])))
+        self.assertIn("BNL", json.dumps(payload.get("bnlInteractionSignals", [])))
+        self.assertIn("Conversation theme", json.dumps(payload.get("conversationHighlights", [])))
+        self.assertIn("contest", json.dumps(profile.get("eventContest", [])).lower())
+        self.assertIn("Confirm", json.dumps(payload.get("bestEvidenceToReview", [])))
+        self.assertIn("official_public_dossier source not connected yet", json.dumps(payload.get("missingInfo", [])))
+        self.assertEqual(payload.get("queueSubmissionStatus"), "not_connected")
+        self.assertNotIn("123456789012345678", joined)
+        self.assertNotIn("rawRefJson", joined)
+        self.assertNotIn("sourceRowId", joined)
+        self.assertNotIn("entity_evidence_events", joined)
+        self.assertNotIn("/song/raw-path", joined)
+        self.assertNotIn("[object Object]", joined)
+        self.assertNotIn("payment", joined.lower())
+        self.assertNotIn("priority", joined.lower())
+        self.assertNotIn("confirmed submission", joined.lower())
+        self.assertTrue(result.get("subjectIntelligenceDiagnostics", {}).get("entityIntelligence"))
+        response = enrich.format_source_enrichment_response(result)
+        self.assertIn("Entity intelligence ledger/profile", response)
+        self.assertIn("Resolver surface: source_file", response)
+        self.assertLessEqual(len(response), 1900)


### PR DESCRIPTION
### Motivation
- Provide a durable, source-aware, visibility-aware Entity Intelligence Ledger and a generic Context Resolver so BNL can build safe, structured subject profiles for Source File enrichment, R&D/mod operations, and future context surfaces without publishing or scraping live Discord history.
- Audit classification of existing state: existing Source File enrichment works but is shallow; recurring-subject extraction is partial; `memory_tiers` remains source‑blind/risky unless upgraded; website dossier read-model and queue/submission runtime are not connected to the bot-side runtime in this PR.
- The change must be conservative: expose only review-safe, bounded facts to public surfaces, keep review-only/internal context off public surfaces, and produce owner/mod action items instead of automatic publishes.

### Description
- New durable ledger and engine: add `bnl_entity_intelligence.py` implementing SQLite schema helpers (`entity_intelligence_facts`, `entity_intelligence_edges`, `entity_activity_rollups`, `entity_open_questions`, `entity_profile_snapshots`, `entity_scouting_queue`), upsert helpers, profile snapshotting, and a generic classification engine that extracts roles, relationships, creative/music signals, BNL interaction, behavior/posture, themes, event/contest signals, action items and missing info from stored rows only.
- Entity Context Resolver v1: implement `resolve_entity_context_for_surface(...)` with authority and visibility filtering and supported surfaces (`public_conversation`, `ambient_public`, `website_relay`, `rd_mod_ops`, `source_file`, `dossier_draft`, `owner_review`, `internal_diagnostics`) and helper callers for public/ambient/relay/R&D surfaces.
- Wire into Source File enrichment and R&D paths: call `build_entity_intelligence_profile(...)` and `resolve_entity_context_for_surface(..., "source_file")` inside the existing `run_source_file_enrichment(...)`, merge resolver output into existing website-safe fields (knownContext, usefulEvidence, conversationHighlights, topicBreakdown, bestEvidenceToReview, bnlInteractionSignals, musicSignals, communitySignals, reviewOnlyEvidence, missingInfo, recommendedAction, evidenceDetails, sourceCoverage) and include a bounded `entityIntelligenceProfile` snapshot in the payload only after sanitization.
- Operator R&D helper: add an explicit, operator-only `entity intelligence`/`context resolver` query handler in `bnl01_bot.py` that invokes the RD surface (`rd_mod_ops`) and returns a compact, labeled readout (no raw transcripts, no automatic publishing).
- Authority & privacy model: implement `ENTITY_SOURCE_AUTHORITY_ORDER` and visibility values with rules (owner_confirmed/official_public_dossier/broadcast_memory > public_discord_observed > internal/bnl_inferred/source_blind) and ensure review-only/internal facts are excluded from public surfaces; include placeholders/hook points for `official_public_dossier` and `queue_submission_confirmed` to be connected later.
- Scouting foundation and tests: add `entity_scouting_queue` table and helpers (idempotent, default-off behavior), and a new test suite `tests/test_entity_intelligence.py` plus integration test coverage added to `tests/test_source_file_enrichment.py` to validate payloads and privacy.
- Non-functional: minor changes to `bnl_dossier_recommendations.py` to allow `entityIntelligenceProfile` in payloads; various sanitizers and site‑validation checks were strengthened to avoid leaking raw IDs/rawRefJson/raw labels.
- Safety guarantees: no website schema changes, no public publishing behavior, no queue/payment inference, no live Discord scraping, no changes to protected behaviors (`#welcome`, `#episode-tracker`, ambient cadence, Gemini fallback, website relay contract, force-pull flags, session timing).

### Testing
- Ran full unittest suite: `python -m unittest discover -s tests -v` — 355 tests passed.
- Ran focused pytest set: `python -m pytest tests/test_entity_activity_summary.py tests/test_source_file_enrichment.py -q` — 81 tests passed (5 warnings) and subtests passed where used.
- Byte-compile checks: `python -m py_compile` succeeded for modified modules including the new `bnl_entity_intelligence.py`.
- Site payload validation helpers and `git diff --check` reported no outstanding issues after code compaction and sanitization steps.

If you want, I can split the large module into smaller files, add more inline docs for the authority rules, or open follow-up tasks for connecting `official_public_dossier` and `queue_submission_confirmed` read bridges.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2113aad08c8321a818b584fc73ec64)