### PR TITLE
Deduplicate link evidence and classify platform/video/event signals

### DIFF
--- a/bnl_entity_activity_summary.py
+++ b/bnl_entity_activity_summary.py
@@ -14,6 +14,14 @@ from collections import Counter
 from typing import Any
 
 from bnl_dossier_source_packets import normalize_subject_name, subject_key
+from bnl_entity_intelligence import (
+    _classify_url_domain,
+    _extract_urls,
+    _has_music_discussion_terms,
+    _has_song_track_demo_terms,
+    _normalized_url_fingerprint,
+    _platform_mentions_without_urls,
+)
 from bnl_entity_evidence import (
     ENTITY_EVIDENCE_TABLE,
     build_conversation_safe_summary,
@@ -1129,6 +1137,74 @@ def _row_text(row: sqlite3.Row, fields: list[str]) -> str:
     return " ".join(str(data.get(field) or "") for field in fields if field in data)
 
 
+
+
+def _record_link_signal(summary: dict[str, Any], text: str, *, source_kind: str = "primary") -> None:
+    diagnostics = summary.setdefault("linkSignalDiagnostics", {
+        "distinctActualLinkCount": 0,
+        "musicPlatformLinkCount": 0,
+        "videoPlatformLinkCount": 0,
+        "eventContestLinkCount": 0,
+        "communityServerLinkCount": 0,
+        "genericLinkCount": 0,
+        "platformReferenceCount": 0,
+        "musicDiscussionCount": 0,
+        "derivedDuplicateLinkCount": 0,
+    })
+    seen = summary.setdefault("_linkSignalFingerprints", set())
+    primary_seen = summary.setdefault("_primaryLinkSignalFingerprints", set())
+    derived = source_kind != "primary"
+    for url in _extract_urls(text):
+        signal_type = _classify_url_domain(url)
+        fp = f"{signal_type}:{_normalized_url_fingerprint(url)}"
+        if fp in seen:
+            if derived and fp in primary_seen:
+                diagnostics["derivedDuplicateLinkCount"] = int(diagnostics.get("derivedDuplicateLinkCount") or 0) + 1
+            continue
+        seen.add(fp)
+        if not derived:
+            primary_seen.add(fp)
+        diagnostics["distinctActualLinkCount"] = int(diagnostics.get("distinctActualLinkCount") or 0) + 1
+        if signal_type == "music_platform_link":
+            diagnostics["musicPlatformLinkCount"] = int(diagnostics.get("musicPlatformLinkCount") or 0) + 1
+        elif signal_type == "video_platform_link":
+            diagnostics["videoPlatformLinkCount"] = int(diagnostics.get("videoPlatformLinkCount") or 0) + 1
+        elif signal_type == "event_contest_link":
+            diagnostics["eventContestLinkCount"] = int(diagnostics.get("eventContestLinkCount") or 0) + 1
+        elif signal_type == "community_server_link":
+            diagnostics["communityServerLinkCount"] = int(diagnostics.get("communityServerLinkCount") or 0) + 1
+        elif signal_type == "generic_link":
+            diagnostics["genericLinkCount"] = int(diagnostics.get("genericLinkCount") or 0) + 1
+    for platform in _platform_mentions_without_urls(text):
+        fp = f"platform_reference:{platform.lower()}"
+        if fp not in seen:
+            seen.add(fp)
+            diagnostics["platformReferenceCount"] = int(diagnostics.get("platformReferenceCount") or 0) + 1
+    if _has_music_discussion_terms(text) or _has_song_track_demo_terms(text):
+        diagnostics["musicDiscussionCount"] = int(diagnostics.get("musicDiscussionCount") or 0) + 1
+
+
+def _apply_link_signal_readouts(summary: dict[str, Any]) -> None:
+    diagnostics = summary.get("linkSignalDiagnostics") or {}
+    lines: list[tuple[str, str]] = []
+    if diagnostics.get("musicPlatformLinkCount"):
+        lines.append(("musicSignals", f"Actual music platform links: {int(diagnostics['musicPlatformLinkCount'])}"))
+    if diagnostics.get("videoPlatformLinkCount"):
+        lines.append(("musicSignals", f"Video platform links: {int(diagnostics['videoPlatformLinkCount'])}"))
+    if diagnostics.get("eventContestLinkCount"):
+        lines.append(("communitySignals", f"Event/contest links: {int(diagnostics['eventContestLinkCount'])}"))
+    if diagnostics.get("communityServerLinkCount"):
+        lines.append(("communitySignals", f"Community/server links: {int(diagnostics['communityServerLinkCount'])}"))
+    if diagnostics.get("musicDiscussionCount") and not diagnostics.get("musicPlatformLinkCount"):
+        lines.append(("musicSignals", f"Music discussion only: {int(diagnostics['musicDiscussionCount'])}"))
+    if diagnostics.get("derivedDuplicateLinkCount"):
+        lines.append(("reviewOnlyEvidence", f"Derived duplicate references suppressed: {int(diagnostics['derivedDuplicateLinkCount'])}"))
+    for key, line in lines:
+        _add_unique(summary[key], line)
+        if key != "reviewOnlyEvidence":
+            _add_unique(summary["evidenceDetails"], line)
+            _add_unique(summary["usefulEvidence"], line)
+
 def _add_unique(target: list[str], value: str) -> None:
     clean = re.sub(r"\s+", " ", str(value or "")).strip()
     if clean and clean not in target:
@@ -1280,6 +1356,7 @@ def _apply_structured_evidence(summary: dict[str, Any], rows: list[sqlite3.Row],
         if topic:
             topic_counts[topic] += 1
         _add_unique(summary["evidenceDetails"], safe_summary)
+        _record_link_signal(summary, safe_summary, source_kind="derived")
         if kind != "source_blind_memory_review_only":
             _append_best_evidence(summary, data, channel_display, safe_summary)
 
@@ -1394,6 +1471,17 @@ def build_entity_activity_summary(
         "queueSubmissionStatus": "not_connected",
         "queueSubmissionNote": QUEUE_NOT_CONNECTED_NOTE,
         "rawProvenance": {"sourceLabels": [], "sourceCounts": Counter(), "rawFragments": [], "channelPolicies": Counter()},
+        "linkSignalDiagnostics": {
+            "distinctActualLinkCount": 0,
+            "musicPlatformLinkCount": 0,
+            "videoPlatformLinkCount": 0,
+            "eventContestLinkCount": 0,
+            "communityServerLinkCount": 0,
+            "genericLinkCount": 0,
+            "platformReferenceCount": 0,
+            "musicDiscussionCount": 0,
+            "derivedDuplicateLinkCount": 0,
+        },
     }
     topic_counts: Counter = Counter()
     public_fact_texts: list[str] = []
@@ -1586,6 +1674,7 @@ def build_entity_activity_summary(
                 channel_name = data.get("channel_name") or ""
                 channel_display = _channel_display_name(channel_name, policy)
                 authored = data.get("user_id") in matched_user_ids or contains_subject_mention(str(data.get("user_name") or ""), subject, aliases=aliases)
+                _record_link_signal(summary, text, source_kind="primary" if authored else "derived")
                 relation = "authored" if authored else "mentioned"
                 timestamp = str(data.get("timestamp") or "")
                 topics = _topic_labels_for_text(text, review_only=policy not in PUBLIC_CONVERSATION_POLICIES)
@@ -1647,6 +1736,7 @@ def build_entity_activity_summary(
                 if not row_matches(row, ["summary", "tier"]):
                     continue
                 text = _row_text(row, ["summary", "tier"])
+                _record_link_signal(summary, text, source_kind="derived")
                 _add_unique(summary["privateOnlyNotes"], SOURCE_BLIND_REVIEW_NOTE)
                 _add_unique(summary["reviewOnlyEvidence"], SOURCE_BLIND_REVIEW_NOTE)
                 _add_unique(summary["notPublicYet"], "Source-blind memory cannot be used as a public fact without review.")
@@ -1764,6 +1854,7 @@ def build_entity_activity_summary(
         for topic, count in topic_counts.most_common(8):
             if count > 0:
                 _add_unique(summary["topicBreakdown"], f"{_website_safe_topic_label(topic)}: {count} approved/reviewed source item(s).")
+    _apply_link_signal_readouts(summary)
     if not summary["musicSignals"]:
         _add_unique(summary["musicSignals"], "No queue/submission identity is connected yet; do not claim music submissions or counts from this summary.")
     if not summary["communitySignals"] and summary["rawProvenance"]["rawFragments"]:
@@ -1795,6 +1886,8 @@ def build_entity_activity_summary(
         summary["sourceCoverage"].append({"source": "channel_policy", "counts": dict(raw["channelPolicies"]), "status": "found"})
     raw["sourceCounts"] = dict(raw["sourceCounts"])
     raw["channelPolicies"] = dict(raw["channelPolicies"])
+    summary.pop("_linkSignalFingerprints", None)
+    summary.pop("_primaryLinkSignalFingerprints", None)
     if output_mode != "admin_internal":
         # Raw provenance remains separate, but public-facing callers should not receive snippets.
         raw["rawFragments"] = [{k: v for k, v in frag.items() if k != "snippet"} for frag in raw["rawFragments"]]

--- a/bnl_entity_intelligence.py
+++ b/bnl_entity_intelligence.py
@@ -81,6 +81,16 @@ THEME_PATTERNS = [
     ("BARCODE Network behavior", re.compile(r"\b(?:BARCODE|BNL|Barcode Network)\b", re.I)),
 ]
 MUSIC_RE = re.compile(r"\b(?:suno|udio|youtube|youtu\.be|soundcloud|spotify|bandcamp|track|song|demo|wip|finished[- ]tracks?)\b|https?://", re.I)
+
+MUSIC_PLATFORM_DOMAINS = {"suno.com", "udio.com", "soundcloud.com", "spotify.com", "bandcamp.com"}
+VIDEO_PLATFORM_DOMAINS = {"youtube.com", "youtu.be"}
+SOCIAL_PLATFORM_DOMAINS = {"instagram.com", "tiktok.com"}
+COMMUNITY_DOMAINS = {"discord.gg", "discord.com"}
+PLATFORM_NAME_RE = re.compile(r"\b(?:suno|udio|soundcloud|spotify|bandcamp|youtube|youtu\.be|instagram|tiktok|discord)\b", re.I)
+MUSIC_DISCUSSION_RE = re.compile(r"\b(?:music|artist|producer|musician|songwriter|album|playlist|mix|master|beat|radio|show)\b", re.I)
+SONG_TRACK_DEMO_RE = re.compile(r"\b(?:song|track|demo|wip|finished[- ]tracks?|wips[- ]and[- ]demos|wips?)\b", re.I)
+FEEDBACK_RE = re.compile(r"\bfeedback\b", re.I)
+_TRACKING_QUERY_KEYS = {"utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "si", "feature"}
 BNL_RE = re.compile(r"\b(?:BNL|bot|source files?|dossiers?|BARCODE)\b", re.I)
 ANTAGONISTIC_RE = re.compile(r"\b(?:challenge|challenging|argu|bait|teas|hostile|antagon|prove it|wrong|you can't|fight me)\b", re.I)
 ANOMALY_RE = re.compile(r"\b(?:anomaly|strange|weird|theory|signal|glitch|lore|cipher|riddle)\b", re.I)
@@ -277,6 +287,147 @@ def _clean_through_left_label(label: str) -> str:
         cleaned = _THROUGH_LEFT_TRAILING_ACTION_RE.sub("", cleaned).strip()
     return _canonical_entity_label(cleaned) if cleaned else ""
 
+
+
+def _strip_url_punctuation(value: str) -> str:
+    return str(value or "").rstrip(").,!?;:'\"”’]")
+
+
+def _extract_urls(text: str) -> list[str]:
+    return [_strip_url_punctuation(m.group(0)) for m in URL_RE.finditer(str(text or ""))]
+
+
+def _url_parts(url: str):
+    from urllib.parse import parse_qsl, urlencode, urlparse
+
+    parsed = urlparse(_strip_url_punctuation(url))
+    domain = (parsed.netloc or "").lower().removeprefix("www.")
+    path = re.sub(r"/+$", "", parsed.path or "/") or "/"
+    pairs = [(k, v) for k, v in parse_qsl(parsed.query, keep_blank_values=True) if k.lower() not in _TRACKING_QUERY_KEYS]
+    query = urlencode(sorted(pairs))
+    return domain, path, query
+
+
+def _normalized_url_fingerprint(url: str) -> str:
+    domain, path, query = _url_parts(url)
+    return f"{domain}{path}" + (f"?{query}" if query else "")
+
+
+def _classify_url_domain(url: str) -> str:
+    domain, path, query = _url_parts(url)
+    if domain in COMMUNITY_DOMAINS:
+        combined = f"{path}?{query}".lower()
+        if "event=" in combined or "/events/" in combined:
+            return "event_contest_link"
+        return "community_server_link"
+    if domain in MUSIC_PLATFORM_DOMAINS or any(domain.endswith("." + d) for d in MUSIC_PLATFORM_DOMAINS):
+        return "music_platform_link"
+    if domain in VIDEO_PLATFORM_DOMAINS or any(domain.endswith("." + d) for d in VIDEO_PLATFORM_DOMAINS):
+        return "video_platform_link"
+    if domain in SOCIAL_PLATFORM_DOMAINS or any(domain.endswith("." + d) for d in SOCIAL_PLATFORM_DOMAINS):
+        return "social_platform_link"
+    return "generic_link"
+
+
+def _platform_label_from_domain(domain: str) -> str:
+    domain = (domain or "").lower().removeprefix("www.")
+    if domain.endswith("suno.com"):
+        return "Suno"
+    if domain.endswith("udio.com"):
+        return "Udio"
+    if domain.endswith("soundcloud.com"):
+        return "SoundCloud"
+    if domain.endswith("spotify.com"):
+        return "Spotify"
+    if domain.endswith("bandcamp.com"):
+        return "Bandcamp"
+    if domain.endswith("youtube.com") or domain == "youtu.be":
+        return "YouTube/youtu.be"
+    if domain.endswith("discord.gg") or domain.endswith("discord.com"):
+        return "Discord"
+    if domain.endswith("instagram.com"):
+        return "Instagram"
+    if domain.endswith("tiktok.com"):
+        return "TikTok"
+    return domain or "unknown platform"
+
+
+def _extract_platform_domains(text: str) -> set[str]:
+    domains: set[str] = set()
+    for url in _extract_urls(text):
+        domain, _path, _query = _url_parts(url)
+        if domain:
+            domains.add(domain)
+    return domains
+
+
+def _has_actual_url(text: str) -> bool:
+    return bool(_extract_urls(text))
+
+
+def _has_music_platform_url(text: str) -> bool:
+    return any(_classify_url_domain(url) == "music_platform_link" for url in _extract_urls(text))
+
+
+def _has_video_platform_url(text: str) -> bool:
+    return any(_classify_url_domain(url) == "video_platform_link" for url in _extract_urls(text))
+
+
+def _has_event_or_community_url(text: str) -> bool:
+    return any(_classify_url_domain(url) in {"event_contest_link", "community_server_link"} for url in _extract_urls(text))
+
+
+def _has_music_discussion_terms(text: str) -> bool:
+    return bool(MUSIC_DISCUSSION_RE.search(str(text or "")))
+
+
+def _has_song_track_demo_terms(text: str) -> bool:
+    return bool(SONG_TRACK_DEMO_RE.search(str(text or "")))
+
+
+def _platform_mentions_without_urls(text: str) -> set[str]:
+    no_urls = URL_RE.sub(" ", str(text or ""))
+    labels: set[str] = set()
+    for match in PLATFORM_NAME_RE.finditer(no_urls):
+        raw = match.group(0).lower()
+        if raw in {"youtu.be", "youtube"}:
+            labels.add("YouTube/youtu.be")
+        elif raw == "soundcloud":
+            labels.add("SoundCloud")
+        elif raw == "bandcamp":
+            labels.add("Bandcamp")
+        elif raw == "discord":
+            labels.add("Discord")
+        elif raw == "instagram":
+            labels.add("Instagram")
+        elif raw == "tiktok":
+            labels.add("TikTok")
+        else:
+            labels.add(raw.capitalize())
+    return labels
+
+
+def _is_primary_evidence_row(row: dict[str, Any]) -> bool:
+    if row.get("source") == "conversations" and row.get("scope") == "subject_authored":
+        return True
+    if row.get("source") == "entity_evidence_events" and row.get("scope") in {"subject_keyed", "subject_direct_evidence"}:
+        return True
+    return row.get("scope") in {"subject_owned", "subject_keyed", "subject_authored", "subject_direct_evidence"} and row.get("source") not in {"memory_tiers", "relationship_journal", "community_presence"}
+
+
+def _primary_evidence_fingerprint(subject_skey: str, signal_type: str, *, url: str = "", platform: str = "", row: dict[str, Any] | None = None, text: str = "") -> str:
+    if url:
+        core = _normalized_url_fingerprint(url)
+    elif platform:
+        core = re.sub(r"[^a-z0-9]+", "-", platform.lower()).strip("-")
+    else:
+        excerpt = re.sub(r"\s+", " ", str(text or "").lower()).strip()[:240]
+        core = hashlib.sha1(excerpt.encode("utf-8")).hexdigest()[:16]
+    return f"{subject_skey}:{signal_type}:{core}"
+
+
+def _is_derived_evidence_row(row: dict[str, Any]) -> bool:
+    return not _is_primary_evidence_row(row) or row.get("source") in {"memory_tiers", "relationship_journal", "community_presence", "broadcast_memory"} or row.get("authority") == "source_blind_memory"
 
 def _has_contest_event_signal(text: str) -> bool:
     if not CONTEST_RE.search(text):
@@ -720,6 +871,10 @@ def _classify(subject: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
     music = Counter()
     events = Counter()
     activity = Counter()
+    signal_counts = Counter()
+    signal_domains: dict[str, Counter[str]] = defaultdict(Counter)
+    seen_signal_fingerprints: set[str] = set()
+    primary_signal_fingerprints: set[str] = set()
     edges: dict[tuple[str, str], dict[str, Any]] = {}
     label_traces: list[dict[str, Any]] = []
     facts: list[dict[str, Any]] = []
@@ -770,7 +925,8 @@ def _classify(subject: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
             "evidenceCount": 1,
         }
 
-    for row in extraction_rows:
+    ordered_extraction_rows = sorted(extraction_rows, key=lambda r: 0 if _is_primary_evidence_row(r) else 1)
+    for row in ordered_extraction_rows:
         text = str(row.get("text") or "")
         low = text.lower()
         for role, pat, reason in ROLE_PATTERNS:
@@ -788,10 +944,59 @@ def _classify(subject: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
             activity["asks BNL Source File questions"] += 1
         if re.search(r"\bboundar|behavior|what can you say|liaison|interface\b", text, re.I):
             activity["discusses BNL boundaries/behavior"] += 1
-        if MUSIC_RE.search(text):
-            music["shares music links"] += 1
-            if re.search(r"\b(?:suno|udio|youtube|youtu\.be|soundcloud|spotify|bandcamp)\b|https?://", text, re.I):
-                music["shares Suno/Udio/YouTube/SoundCloud/Spotify/Bandcamp links"] += 1
+        row_is_primary = _is_primary_evidence_row(row)
+        for url in _extract_urls(text):
+            signal_type = _classify_url_domain(url)
+            fp = _primary_evidence_fingerprint(skey, signal_type, url=url, row=row, text=text)
+            domain, _path, _query = _url_parts(url)
+            if fp in seen_signal_fingerprints:
+                if _is_derived_evidence_row(row) and fp in primary_signal_fingerprints:
+                    signal_counts["derivedDuplicateLinkCount"] += 1
+                continue
+            seen_signal_fingerprints.add(fp)
+            if row_is_primary:
+                primary_signal_fingerprints.add(fp)
+            signal_counts["distinctActualLinkCount"] += 1
+            signal_domains[signal_type][_platform_label_from_domain(domain)] += 1
+            if signal_type == "music_platform_link":
+                signal_counts["musicPlatformLinkCount"] += 1
+                music["actual music platform links"] += 1
+            elif signal_type == "video_platform_link":
+                signal_counts["videoPlatformLinkCount"] += 1
+                music["video platform links"] += 1
+            elif signal_type == "event_contest_link":
+                signal_counts["eventContestLinkCount"] += 1
+                events["event/contest link evidence"] += 1
+            elif signal_type == "community_server_link":
+                signal_counts["communityServerLinkCount"] += 1
+                events["community/server link evidence"] += 1
+            elif signal_type == "generic_link":
+                signal_counts["genericLinkCount"] += 1
+                music["generic links"] += 1
+            elif signal_type == "social_platform_link":
+                signal_counts["socialPlatformLinkCount"] += 1
+                music["social/platform links"] += 1
+        for platform in _platform_mentions_without_urls(text):
+            fp = _primary_evidence_fingerprint(skey, "platform_reference", platform=platform, row=row, text=text)
+            if fp not in seen_signal_fingerprints:
+                seen_signal_fingerprints.add(fp)
+                if row_is_primary:
+                    primary_signal_fingerprints.add(fp)
+                signal_counts["platformReferenceCount"] += 1
+                signal_domains["platform_reference"][platform] += 1
+                music["platform references"] += 1
+        if _has_music_discussion_terms(text):
+            fp = _primary_evidence_fingerprint(skey, "music_discussion", row=row, text=text)
+            if fp not in seen_signal_fingerprints:
+                seen_signal_fingerprints.add(fp)
+                signal_counts["musicDiscussionCount"] += 1
+                music["music discussion"] += 1
+        if _has_song_track_demo_terms(text):
+            fp = _primary_evidence_fingerprint(skey, "song_track_demo_mention", row=row, text=text)
+            if fp not in seen_signal_fingerprints:
+                seen_signal_fingerprints.add(fp)
+                signal_counts["songTrackDemoMentionCount"] += 1
+                music["song/track/demo/WIP mentions"] += 1
         if "finished-tracks" in low:
             music["posts in finished-tracks"] += 1
         if "wips-and-demos" in low or "wip" in low or "demo" in low:
@@ -799,10 +1004,10 @@ def _classify(subject: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
         if "collaboration-hub" in low:
             music["posts in collaboration-hub"] += 1
         if COLLAB_RE.search(text):
-            music["offers collaboration"] += 1
+            music["collaboration offers"] += 1
             activity["collaboration-offer facet"] += 1
-        if re.search(r"\bfeedback\b", text, re.I):
-            music["asks for feedback"] += 1
+        if FEEDBACK_RE.search(text):
+            music["feedback requests"] += 1
         if ANTAGONISTIC_RE.search(text):
             behaviors["antagonistic/challenging"] += 1
             if BNL_RE.search(text):
@@ -874,11 +1079,48 @@ def _classify(subject: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
         review_needed = label in {"moderator", "contest operator", "lore/entity/persona/project creator", "antagonist/challenger"}
         facts.append(_item(label, role_reasons.get(label, label), visibility="review_only" if review_needed else "public_safe_candidate", authority="bnl_inferred", confidence=min(0.9, 0.55 + count * 0.08), public_safe=not review_needed and label != "unknown", review_only=review_needed or label == "unknown", needs_owner_review=review_needed, evidence_count=count) | {"type": "role"})
     roles = facts[:]
-    creative = [_item(k, k, visibility="public_safe_candidate", authority="public_discord_observed", confidence=min(0.9, .55 + v*.08), public_safe=True, review_only=False, needs_owner_review=k.startswith("shares") and "links" in k, evidence_count=v) | {"type": "creative_music"} for k, v in _positive_counter_items(music)]
+
+    def creative_value(label: str, count: int) -> str:
+        if label == "actual music platform links":
+            platforms = ", ".join(f"{name} ({num})" for name, num in signal_domains["music_platform_link"].most_common())
+            return f"Actual music platform links: {count}" + (f" — {platforms}" if platforms else "")
+        if label == "video platform links":
+            platforms = ", ".join(f"{name} ({num})" for name, num in signal_domains["video_platform_link"].most_common())
+            return f"Video platform links: {count}" + (f" — {platforms}" if platforms else "")
+        if label == "generic links":
+            return f"Generic links: {count}; generic URLs are not treated as music links."
+        if label == "social/platform links":
+            platforms = ", ".join(f"{name} ({num})" for name, num in signal_domains["social_platform_link"].most_common())
+            return f"Social/platform links: {count}" + (f" — {platforms}" if platforms else "")
+        if label == "platform references":
+            platforms = ", ".join(f"{name} ({num})" for name, num in signal_domains["platform_reference"].most_common())
+            return f"Platform references without URLs: {count}" + (f" — {platforms}" if platforms else "")
+        if label == "music discussion":
+            return f"Music discussion only: {count}"
+        if label == "song/track/demo/WIP mentions":
+            return f"Song/track/demo/WIP mentions without link claims: {count}"
+        if label == "collaboration offers":
+            return f"Collaboration offers: {count}"
+        if label == "feedback requests":
+            return f"Feedback requests: {count}"
+        return label
+
+    creative = [_item(k, creative_value(k, v), visibility="public_safe_candidate", authority="public_discord_observed", confidence=min(0.9, .55 + v*.08), public_safe=True, review_only=False, needs_owner_review=k in {"actual music platform links", "video platform links", "generic links", "social/platform links"}, evidence_count=v) | {"type": "creative_music"} for k, v in _positive_counter_items(music)]
+    if signal_counts.get("derivedDuplicateLinkCount"):
+        creative.append(_item("derived duplicate link references suppressed", f"Derived duplicate references suppressed: {int(signal_counts['derivedDuplicateLinkCount'])}", visibility="review_only", authority="bnl_inferred", confidence=0.75, public_safe=False, review_only=True, needs_owner_review=True, evidence_count=int(signal_counts["derivedDuplicateLinkCount"])) | {"type": "creative_music"})
     bnl = [_item(k, k, visibility="review_only" if "challenges" in k else "public_safe_candidate", authority="bnl_inferred", confidence=min(.9,.55+v*.08), public_safe="challenges" not in k, review_only="challenges" in k, needs_owner_review="challenges" in k, evidence_count=v) | {"type": "bnl_interaction"} for k, v in _positive_counter_items(activity) if "BNL" in k or "source-file" in k or "boundaries" in k or "challenges" in k]
     behavior = [_item(k, k, visibility="review_only" if k in {"antagonistic/challenging", "theory/anomaly-heavy", "lore-heavy"} else "public_safe_candidate", authority="bnl_inferred", confidence=min(.9,.55+v*.06), public_safe=k not in {"antagonistic/challenging", "theory/anomaly-heavy", "lore-heavy"}, review_only=k in {"antagonistic/challenging", "theory/anomaly-heavy", "lore-heavy"}, needs_owner_review=k in {"antagonistic/challenging", "theory/anomaly-heavy", "lore-heavy"}, evidence_count=v) | {"type": "behavior_posture"} for k, v in _positive_counter_items(behaviors)]
     theme_items = [_item(k, k, visibility="review_only" if k in {"strange/anomaly conversations", "AI/persona/project interaction"} else "public_safe_candidate", authority="bnl_inferred", confidence=min(.9,.55+v*.06), public_safe=k not in {"strange/anomaly conversations", "AI/persona/project interaction"}, review_only=k in {"strange/anomaly conversations", "AI/persona/project interaction"}, needs_owner_review=k in {"strange/anomaly conversations", "AI/persona/project interaction"}, evidence_count=v) | {"type": "conversation_theme"} for k, v in _positive_counter_items(themes)]
-    event_items = [_item(k, k, visibility="review_only" if k != "contest/event activity" else "public_safe_candidate", authority="bnl_inferred", confidence=min(.9,.55+v*.08), public_safe=k == "contest/event activity", review_only=k != "contest/event activity", needs_owner_review=True, evidence_count=v) | {"type": "event_contest"} for k, v in _positive_counter_items(events)]
+    def event_value(label: str, count: int) -> str:
+        if label == "event/contest link evidence":
+            platforms = ", ".join(f"{name} ({num})" for name, num in signal_domains["event_contest_link"].most_common())
+            return f"Event/contest links: {count}" + (f" — {platforms}" if platforms else "")
+        if label == "community/server link evidence":
+            platforms = ", ".join(f"{name} ({num})" for name, num in signal_domains["community_server_link"].most_common())
+            return f"Community/server links: {count}" + (f" — {platforms}" if platforms else "")
+        return label
+
+    event_items = [_item(k, event_value(k, v), visibility="review_only" if k != "contest/event activity" else "public_safe_candidate", authority="bnl_inferred", confidence=min(.9,.55+v*.08), public_safe=k == "contest/event activity", review_only=k != "contest/event activity", needs_owner_review=True, evidence_count=v) | {"type": "event_contest"} for k, v in _positive_counter_items(events)]
     action_items = []
     missing = []
     if edges:
@@ -928,6 +1170,19 @@ def _classify(subject: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
         "reviewOnlyRows": review_rows,
         "globalMixedRows": global_mixed_count,
         "sourceBlindRows": source_blind_count,
+        "signalDiagnostics": {
+            "distinctActualLinkCount": int(signal_counts.get("distinctActualLinkCount") or 0),
+            "musicPlatformLinkCount": int(signal_counts.get("musicPlatformLinkCount") or 0),
+            "videoPlatformLinkCount": int(signal_counts.get("videoPlatformLinkCount") or 0),
+            "eventContestLinkCount": int(signal_counts.get("eventContestLinkCount") or 0),
+            "communityServerLinkCount": int(signal_counts.get("communityServerLinkCount") or 0),
+            "genericLinkCount": int(signal_counts.get("genericLinkCount") or 0),
+            "socialPlatformLinkCount": int(signal_counts.get("socialPlatformLinkCount") or 0),
+            "platformReferenceCount": int(signal_counts.get("platformReferenceCount") or 0),
+            "musicDiscussionCount": int(signal_counts.get("musicDiscussionCount") or 0),
+            "songTrackDemoMentionCount": int(signal_counts.get("songTrackDemoMentionCount") or 0),
+            "derivedDuplicateLinkCount": int(signal_counts.get("derivedDuplicateLinkCount") or 0),
+        },
     }
 
 
@@ -1002,9 +1257,10 @@ def build_entity_intelligence_profile(db_path: str, guild_id: int | None, subjec
             key = (chan, pol)
             if row.get("relation") == "authored": roll[key]["authored"] += 1
             else: roll[key]["mentioned"] += 1
-            if URL_RE.search(str(row.get("text") or "")): roll[key]["links"] += 1
-            if BNL_RE.search(str(row.get("text") or "")): roll[key]["bnl"] += 1
-            if MUSIC_RE.search(str(row.get("text") or "")): roll[key]["music"] += 1
+            row_text = str(row.get("text") or "")
+            if _has_actual_url(row_text): roll[key]["links"] += len(_extract_urls(row_text))
+            if BNL_RE.search(row_text): roll[key]["bnl"] += 1
+            if _has_music_platform_url(row_text) or _has_music_discussion_terms(row_text) or _has_song_track_demo_terms(row_text) or _platform_mentions_without_urls(row_text): roll[key]["music"] += 1
             if CONTEST_RE.search(str(row.get("text") or "")): roll[key]["contest"] += 1
             if COLLAB_RE.search(str(row.get("text") or "")): roll[key]["collab"] += 1
         ts = now_iso()
@@ -1030,7 +1286,9 @@ def build_entity_intelligence_profile(db_path: str, guild_id: int | None, subjec
             "officialPublicDossierNote": "official_public_dossier source not connected yet",
             "queueSubmissionStatus": "not_connected",
             "labelEvidenceTraces": classified.get("labelEvidenceTraces") or [],
+            "signalDiagnostics": classified.get("signalDiagnostics") or {},
         }
+        diagnostics.update(classified.get("signalDiagnostics") or {})
         profile = {
             "subjectKey": skey,
             "subjectName": subject,

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -1655,6 +1655,7 @@ def collect_source_enrichment_evidence(db_path: str, guild_id: int | None, subje
         "notPublicYet": list(entity_summary.get("notPublicYet") or [])[:6] if raw_provenance else [],
         "sourceAuthority": list(entity_summary.get("sourceAuthority") or [])[:5] if raw_provenance else [],
         "subjectIntelligenceDiagnostics": entity_summary.get("subjectIntelligenceDiagnostics") or {},
+        "linkSignalDiagnostics": entity_summary.get("linkSignalDiagnostics") or {},
         **_bounded_entity_summary_fields(entity_summary, include=bool(raw_provenance)),
         "queueSubmissionStatus": str(entity_summary.get("queueSubmissionStatus") or "not_connected") if raw_provenance else "not_connected",
         "queueSubmissionNote": str(entity_summary.get("queueSubmissionNote") or QUEUE_NOT_CONNECTED_NOTE) if raw_provenance else QUEUE_NOT_CONNECTED_NOTE,
@@ -2471,6 +2472,7 @@ def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: 
         "queueSubmissionStatus": packet.get("queueSubmissionStatus") or "not_connected",
         "queueSubmissionNote": packet.get("queueSubmissionNote") or QUEUE_NOT_CONNECTED_NOTE,
         "entityIntelligenceProfile": dict(packet.get("entityIntelligenceProfile") or {}),
+        "linkSignalDiagnostics": dict(packet.get("linkSignalDiagnostics") or {}),
         "rawProvenance": dict(packet.get("rawProvenance") or {}),
         "visibilityLabels": ["internal_review_only", "admin_review_required"],
         "confidence": "low" if packet.get("qualityStatus") in {"too_thin", "forced_low_confidence"} else ("medium" if match_kind == "active_source_file" else "low"),
@@ -2611,6 +2613,7 @@ def run_source_file_enrichment(
     }
     _copy_evidence_fields(packet, evidence)
     packet["subjectIntelligenceDiagnostics"] = evidence.get("subjectIntelligenceDiagnostics") or {}
+    packet["linkSignalDiagnostics"] = evidence.get("linkSignalDiagnostics") or {}
     packet["diagnosticsRequested"] = bool(diagnostics)
     quality = evaluate_enrichment_quality(packet)
     packet["qualityScore"] = quality["score"]

--- a/tests/test_entity_intelligence.py
+++ b/tests/test_entity_intelligence.py
@@ -65,7 +65,7 @@ class EntityIntelligenceTests(unittest.TestCase):
         rels = {(e["objectLabel"], e["relationType"]) for e in p["relationships"]}
         self.assertIn(("Orion", "speaks_through"), rels)
         self.assertIn(("Orion", "created"), rels)
-        self.assertIn("shares Suno/Udio/YouTube/SoundCloud/Spotify/Bandcamp links", self.labels(p["creativeMusic"]))
+        self.assertIn("actual music platform links", self.labels(p["creativeMusic"]))
         self.assertIn("frequent BNL-facing conversation", self.labels(p["bnlInteraction"]))
         self.assertIn("AI/persona/project interaction", self.labels(p["conversationThemes"]))
         self.assertIn("Confirm whether Orion relationship/context can be public", self.labels(p["actionItems"]))
@@ -76,8 +76,8 @@ class EntityIntelligenceTests(unittest.TestCase):
         self.add_msg(11, "Lost Marbles", "collaboration-hub", "public_music", "As a mod and staff helper, Lost Marbles can collab with artists and share SoundCloud music demos.")
         p = self.profile_for("Lost Marbles")
         self.assertIn("moderator", self.labels(p["roles"]))
-        self.assertIn("shares Suno/Udio/YouTube/SoundCloud/Spotify/Bandcamp links", self.labels(p["creativeMusic"]))
-        self.assertIn("offers collaboration", self.labels(p["creativeMusic"]))
+        self.assertIn("platform references", self.labels(p["creativeMusic"]))
+        self.assertIn("collaboration offers", self.labels(p["creativeMusic"]))
         self.assertIn("Confirm public-safe mod/staff role wording", self.labels(p["actionItems"]))
         self.assertIn("Confirm public artist links", self.labels(p["actionItems"]))
         self.assertEqual(p["diagnostics"]["queueSubmissionStatus"], "not_connected")
@@ -118,7 +118,7 @@ class EntityIntelligenceTests(unittest.TestCase):
         self.add_msg(15, "Nova Finch", "collaboration-hub", "public_music", "Nova Finch is an artist asking for feedback on a demo and wants to collaborate with Blue Kite.")
         p = self.profile_for("Nova Finch")
         self.assertIn("artist", self.labels(p["roles"]))
-        self.assertIn("offers collaboration", self.labels(p["creativeMusic"]))
+        self.assertIn("collaboration offers", self.labels(p["creativeMusic"]))
         self.assertIn("collaboration", self.labels(p["conversationThemes"]))
 
     def test_surface_filters(self):
@@ -163,7 +163,7 @@ class EntityIntelligenceTests(unittest.TestCase):
         self.conn.execute("INSERT INTO memory_tiers VALUES (NULL,NULL,1,'long','Orion through Crow appears near Lost Marbles in a source-blind global memory bundle.',0.9,1,'now',NULL,NULL)")
         p = self.profile_for("Lost Marbles")
         labels = self.labels(p["relationships"] + p["conversationThemes"] + p["creativeMusic"] + p["dossierUsefulness"])
-        self.assertIn("offers collaboration", self.labels(p["creativeMusic"]))
+        self.assertIn("collaboration offers", self.labels(p["creativeMusic"]))
         self.assertNotIn("Orion", labels)
         self.assertNotIn("Crow", labels)
         scopes = p["diagnostics"]["rowScopeCounts"]
@@ -264,8 +264,8 @@ class EntityIntelligenceTests(unittest.TestCase):
         self.add_msg(23, "LostMarbles", "collaboration-hub", "public_music", "Hey B, Friday 7 PM Pacific Time User says LostMarbles can collab with artists and share SoundCloud music demos.")
         p = self.profile_for("LostMarbles")
         text = self.labels(p["roles"] + p["creativeMusic"] + p["relationships"] + p["conversationThemes"])
-        self.assertIn("offers collaboration", text)
-        self.assertIn("shares Suno/Udio/YouTube/SoundCloud/Spotify/Bandcamp links", text)
+        self.assertIn("collaboration offers", text)
+        self.assertIn("platform references", text)
         for bad in ("Orion", "Friday", "PM Pacific Time", "Hey B", "User"):
             self.assertNotIn(bad, text)
 
@@ -312,6 +312,81 @@ class EntityIntelligenceTests(unittest.TestCase):
                 for child in value:
                     walk(child)
         walk(p)
+
+
+    def test_antigrain_youtube_links_dedupe_derived_memory(self):
+        self.add_profile(31, "Antigrain")
+        links = [
+            "https://youtu.be/8C4lK41SX-Q?si=one",
+            "https://youtu.be/PBwAxmrE194?si=two",
+            "https://youtu.be/rrbFQEcpJ3A?si=three",
+        ]
+        for link in links:
+            self.add_msg(31, "Antigrain", "barcode-bot", "public_home", f"Antigrain shared this YouTube link {link}")
+            self.conn.execute(
+                "INSERT INTO memory_tiers VALUES (NULL,31,1,'long',?,0.9,1,'now','public_discord_observed','public_home')",
+                (f"Antigrain consolidated local stored context repeats {link}",),
+            )
+        p = self.profile_for("Antigrain")
+        diagnostics = p["diagnostics"]
+        text = self.labels(p["creativeMusic"])
+        self.assertEqual(diagnostics["videoPlatformLinkCount"], 3)
+        self.assertEqual(diagnostics["distinctActualLinkCount"], 3)
+        self.assertEqual(diagnostics["derivedDuplicateLinkCount"], 3)
+        self.assertIn("video platform links", text)
+        self.assertIn("derived duplicate link references suppressed", text)
+        self.assertNotIn("shares music links", text)
+        self.assertNotIn("shares Suno/Udio/YouTube/SoundCloud/Spotify/Bandcamp links", text)
+        self.assertEqual(diagnostics["musicPlatformLinkCount"], 0)
+        self.assertEqual(diagnostics["queueSubmissionStatus"], "not_connected")
+
+    def test_hellcat_discord_event_links_are_event_not_music(self):
+        self.add_profile(32, "HellcatNZ")
+        for idx in range(3):
+            self.add_msg(32, "HellcatNZ", "hellcat-nz", "public_home", f"HellcatNZ event contest link https://discord.gg/hellcatnz?event={idx}")
+        p = self.profile_for("HellcatNZ")
+        self.assertEqual(p["diagnostics"]["eventContestLinkCount"], 3)
+        self.assertEqual(p["diagnostics"]["musicPlatformLinkCount"], 0)
+        self.assertIn("event/contest link evidence", self.labels(p["eventContest"]))
+        self.assertIn("contest/event activity", self.labels(p["eventContest"]))
+        self.assertNotIn("actual music platform links", self.labels(p["creativeMusic"]))
+
+    def test_music_words_and_platform_mentions_without_urls_are_not_link_claims(self):
+        self.add_profile(33, "NoLinkArtist")
+        self.add_msg(33, "NoLinkArtist", "wips-and-demos", "public_music", "This song track demo wip music idea was made in Suno, no link yet.")
+        p = self.profile_for("NoLinkArtist")
+        text = self.labels(p["creativeMusic"])
+        self.assertIn("music discussion", text)
+        self.assertIn("song/track/demo/WIP mentions", text)
+        self.assertIn("platform references", text)
+        self.assertEqual(p["diagnostics"]["distinctActualLinkCount"], 0)
+        self.assertNotIn("actual music platform links", text)
+        self.assertNotIn("video platform links", text)
+
+    def test_crow_suno_links_dedupe_and_queue_boundary(self):
+        self.add_profile(34, "Crow")
+        for link in ("https://suno.com/song/a", "https://suno.com/song/b"):
+            self.add_msg(34, "Crow", "finished-tracks", "public_music", f"Crow music link {link}")
+            self.conn.execute(
+                "INSERT INTO memory_tiers VALUES (NULL,34,1,'long',?,0.9,1,'now','public_discord_observed','public_music')",
+                (f"Crow consolidated memory repeats {link}",),
+            )
+        p = self.profile_for("Crow")
+        self.assertEqual(p["diagnostics"]["musicPlatformLinkCount"], 2)
+        self.assertEqual(p["diagnostics"]["derivedDuplicateLinkCount"], 2)
+        self.assertEqual(p["diagnostics"]["queueSubmissionStatus"], "not_connected")
+        self.assertIn("actual music platform links", self.labels(p["creativeMusic"]))
+
+    def test_lost_marbles_collab_music_without_actual_link_claim(self):
+        self.add_profile(35, "LostMarbles")
+        self.add_msg(35, "LostMarbles", "collaboration-hub", "public_music", "LostMarbles can collab, asks for feedback on music demos, and wants to work together.")
+        p = self.profile_for("LostMarbles")
+        text = self.labels(p["creativeMusic"])
+        self.assertIn("collaboration offers", text)
+        self.assertIn("music discussion", text)
+        self.assertIn("feedback requests", text)
+        self.assertEqual(p["diagnostics"]["distinctActualLinkCount"], 0)
+        self.assertNotIn("actual music platform links", text)
 
 
 if __name__ == "__main__":

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -416,7 +416,7 @@ class SourceFileEnrichmentTests(unittest.TestCase):
                 "rejectedGarbageCandidates": ["BNL", "Discord"],
                 "topRecurringThemes": ["liaison interface"],
                 "topConversationClusters": ["repeated BNL questions", "music tool links"],
-                "topActivityPatterns": ["asks about source thresholds", "shares Suno links"],
+                "topActivityPatterns": ["asks about source thresholds", "actual music platform links"],
                 "topDomains": ["suno.com"],
                 "publicSafeRows": 2,
                 "reviewOnlyRows": 2,
@@ -465,7 +465,7 @@ class SourceFileEnrichmentTests(unittest.TestCase):
         self.assertNotIn("Recurring named topic:", payload_text)
         self.assertIn("Orion: speaks_through", payload_text)
         self.assertIn("Conversation theme:", payload_text)
-        self.assertIn("shares Suno", payload_text)
+        self.assertIn("Actual music platform links", payload_text)
         self.assertEqual(payload["queueSubmissionStatus"], "not_connected")
         self.assertNotRegex(payload_text, r"submitted\s+\d+|play count|source type:|Priority|payment|rawRefJson|sourceRowId|research-and-development")
         self.assertLessEqual(len(formatted), 1900)
@@ -685,7 +685,7 @@ class SourceFileEnrichmentTests(unittest.TestCase):
 
         self.assertNotIn("Recurring named topic", json.dumps(payload["topicBreakdown"] + payload["evidenceDetails"] + payload["bestEvidenceToReview"]))
         self.assertNotIn("Recurring named topic", normal_text)
-        self.assertIn("shares music links", normal_text)
+        self.assertIn("Music discussion only", normal_text)
         self.assertIn("Conversation theme", json.dumps(payload["conversationHighlights"]))
         self.assertEqual(payload["queueSubmissionStatus"], "not_connected")
         self.assertIn(enrich.QUEUE_NOT_CONNECTED_NOTE, payload["queueSubmissionNote"])
@@ -968,6 +968,37 @@ class SourceFileEnrichmentTests(unittest.TestCase):
         self.assertNotIn("Observed Patterns", result["sections"])
         self.assertIn("Missing Info", result["sections"])
 
+    def test_source_file_payload_dedupes_link_signal_categories_without_queue_claims(self):
+        self.conn.execute("INSERT INTO user_profiles VALUES (77,1,'Antigrain','Antigrain',NULL,NULL)")
+        links = [
+            "https://youtu.be/8C4lK41SX-Q?si=one",
+            "https://youtu.be/PBwAxmrE194?si=two",
+            "https://youtu.be/rrbFQEcpJ3A?si=three",
+        ]
+        for link in links:
+            self.conn.execute(
+                "INSERT INTO conversations VALUES (NULL,77,'Antigrain',1,'barcode-bot','public_home','user',?,'now')",
+                (f"Antigrain shared a YouTube link {link}",),
+            )
+            self.conn.execute(
+                "INSERT INTO memory_tiers VALUES (NULL,77,1,'long',?,0.9,1,'now','public_discord_observed','public_home')",
+                (f"Antigrain local stored context repeats {link}",),
+            )
+        self.conn.commit()
+        with mock.patch.object(enrich, "refresh_entity_evidence_for_subject", return_value={"ok": True}):
+            result = enrich.run_source_file_enrichment(self.db, 1, "Antigrain", dry_run=True, lookup_func=self._lookup("active"), force=True)
+        payload = result["payload"]
+        diagnostics = result.get("linkSignalDiagnostics") or {}
+        text = json.dumps({key: payload.get(key) for key in ("musicSignals", "communitySignals", "usefulEvidence", "evidenceDetails", "reviewOnlyEvidence", "recommendedAction", "queueSubmissionStatus")})
+        self.assertEqual(diagnostics.get("videoPlatformLinkCount"), 3)
+        self.assertEqual(diagnostics.get("musicPlatformLinkCount"), 0)
+        self.assertEqual(diagnostics.get("derivedDuplicateLinkCount"), 3)
+        self.assertIn("Video platform links: 3", text)
+        self.assertIn("Derived duplicate references suppressed: 3", text)
+        self.assertNotIn("shares music links", text)
+        self.assertNotIn("submitted songs", text.lower())
+        self.assertEqual(payload.get("queueSubmissionStatus"), "not_connected")
+
 
 class SourceFileEnrichmentBotTests(unittest.TestCase):
     class Perms:
@@ -1126,6 +1157,7 @@ class SourceFileEnrichmentBotTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
 
 class SourceFileEntityIntelligenceIntegrationTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
### Motivation

- Fix overcounting and imprecise labels where the same URL appeared as both primary authored evidence and again in derived/consolidated memory, which produced misleading “shares music links” claims (e.g., Antigrain 3 YouTube links counted as 6). 
- Make link-related intelligence more precise so generic URLs, Discord event links, YouTube/video links, and true music-platform links are distinguished and not conflated. 
- Preserve the queue/submission boundary by never inferring queue/submission status or play/payment claims from simple chat links. 

### Description

- Add URL/platform helpers (`_extract_urls`, `_url_parts`, `_classify_url_domain`, `_normalized_url_fingerprint`, `_platform_label_from_domain`, `_platform_mentions_without_urls`, and term detectors) and tracking of primary vs derived evidence via `_is_primary_evidence_row` and `_primary_evidence_fingerprint`. 
- Change the entity classification flow to process primary evidence first, fingerprint distinct signals, suppress derived duplicates and increment `derivedDuplicateLinkCount`, and populate typed counters (`distinctActualLinkCount`, `musicPlatformLinkCount`, `videoPlatformLinkCount`, `eventContestLinkCount`, `communityServerLinkCount`, `genericLinkCount`, `platformReferenceCount`, `musicDiscussionCount`, `songTrackDemoMentionCount`). 
- Replace broad creative/music labels with focused readouts (actual music platform links, video platform links, generic/social links, platform references, music discussion, song/track/demo mentions, collaboration offers, feedback requests) and add an explicit derived-duplicate suppression label. 
- Wire the new diagnostics and readouts through `entity_activity_summary` and `bnl_source_file_enrichment` so `linkSignalDiagnostics` (and site-visible `musicSignals`/`communitySignals`/`evidenceDetails`/`reviewOnlyEvidence`) reflect the new counts and wording. 
- Update tests to cover Antigrain (YouTube dedupe), Hellcat (Discord event links classified as events, not music), music words/platform mentions without URLs, Crow (Suno link dedupe), LostMarbles (collab/music discussion without claiming links), and Source File payload dedupe/no queue overclaims. 
- Notes: no website publishing, queue/payment integration, artist account changes, canonical profile merging, ambient expansion, public Discord scraping/behavior changes, identity alias work, #welcome/#episode-tracker, direct session timing, Gemini fallback, website relay contracts, or force-pull/control flags were modified. 

### Testing

- Ran full unit test suite with `python -m unittest discover -s tests -v`, which completed successfully (all tests passed). 
- Ran targeted pytest and full pytest commands (`python -m pytest tests/test_entity_intelligence.py tests/test_source_file_enrichment.py tests/test_entity_activity_summary.py -q`), which completed successfully. 
- Verified modules compile with `python -m py_compile ...` for the main modules and confirmed `git diff --check` produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21ab73606c83218fd00840f95c1a5b)