### PR TITLE
Add secure immediate Source File refresh endpoint

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -104,8 +104,12 @@ from bnl_source_file_refresh import (
     list_source_file_refresh_queue,
     mark_subject_dirty_for_evidence,
     parse_source_refresh_command,
+    SOURCE_REFRESH_NOW_PATH,
+    SOURCE_REFRESH_NOW_TOKEN_HEADER,
+    is_source_refresh_now_token_valid,
     process_single_source_file_refresh,
     process_site_refresh_requests,
+    process_source_file_refresh_now,
     process_source_file_refresh_queue,
 )
 from collections import Counter, defaultdict, deque
@@ -3454,12 +3458,66 @@ async def _handle_force_pull(request: web.Request) -> web.Response:
     }, status=202)
 
 
+async def _handle_source_file_refresh_now(request: web.Request) -> web.Response:
+    provided_token = request.headers.get(SOURCE_REFRESH_NOW_TOKEN_HEADER) or request.headers.get(
+        SOURCE_REFRESH_NOW_TOKEN_HEADER.lower()
+    )
+    if not is_source_refresh_now_token_valid(provided_token):
+        logging.warning("source_refresh_now_auth_failed reason=missing_or_invalid_token")
+        return web.json_response({"ok": False, "error": "unauthorized"}, status=401)
+
+    try:
+        payload = await request.json()
+    except Exception:
+        logging.warning("source_refresh_now_failed reason=invalid_json")
+        return web.json_response({"ok": False, "status": "failed", "failureReason": "invalid_json"}, status=400)
+    if not isinstance(payload, dict):
+        logging.warning("source_refresh_now_failed reason=invalid_payload")
+        return web.json_response({"ok": False, "status": "failed", "failureReason": "invalid_payload"}, status=400)
+
+    request_id = str(payload.get("requestId") or payload.get("id") or "")[:120]
+    candidate_id = str(payload.get("candidateId") or "")[:120]
+    subject_key = str(
+        payload.get("normalizedSubjectKey") or payload.get("subjectKey") or payload.get("subjectName") or ""
+    )[:120]
+    source = str(payload.get("source") or "")[:80]
+    reason = str(payload.get("reason") or "")[:80]
+    logging.info(
+        "source_refresh_now_received request_id=%s candidate_id=%s subject_key=%s source=%s reason=%s",
+        request_id or "none",
+        candidate_id or "none",
+        subject_key or "none",
+        source or "none",
+        reason or "none",
+    )
+
+    guild_id = _resolve_force_pull_guild()
+    if not guild_id:
+        logging.warning("source_refresh_now_failed reason=no_guild_available")
+        return web.json_response(
+            {"ok": False, "status": "failed", "failureReason": "no_guild_available"}, status=503
+        )
+
+    try:
+        result = await asyncio.to_thread(
+            process_source_file_refresh_now, DB_FILE, payload, guild_id=guild_id
+        )
+    except Exception as exc:
+        safe_error = _safe_force_pull_error(exc)
+        logging.warning("source_refresh_now_failed request_id=%s reason=%s", request_id or "none", safe_error)
+        return web.json_response({"ok": False, "status": "failed", "failureReason": safe_error}, status=500)
+
+    status = result.get("status") or ("success" if result.get("ok") else "failed")
+    http_status = 200 if status in {"success", "skipped", "dry_run"} else 500
+    return web.json_response(result, status=http_status)
+
 async def start_force_pull_listener():
     global force_pull_runner
     if force_pull_runner is not None:
         return
     app = web.Application()
     app.router.add_post("/force-pull", _handle_force_pull)
+    app.router.add_post(SOURCE_REFRESH_NOW_PATH, _handle_source_file_refresh_now)
     force_pull_runner = web.AppRunner(app)
     await force_pull_runner.setup()
     site = web.TCPSite(force_pull_runner, host="0.0.0.0", port=BNL_FORCE_PULL_PORT)

--- a/bnl_source_file_refresh.py
+++ b/bnl_source_file_refresh.py
@@ -10,6 +10,7 @@ accounts.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import logging
 import os
@@ -38,6 +39,8 @@ DEFAULT_PROCESS_INTERVAL_MINUTES = 15
 DEFAULT_MAX_AUTOMATIC_PER_CYCLE = 3
 DEFAULT_MAX_SITE_REQUESTS_PER_CYCLE = 3
 SITE_REFRESH_REQUEST_TIMEOUT_SECONDS = 8
+SOURCE_REFRESH_NOW_PATH = "/internal/source-files/refresh-now"
+SOURCE_REFRESH_NOW_TOKEN_HEADER = "X-BNL-REFRESH-TOKEN"
 SITE_REFRESH_REQUEST_PATH = "/api/bnl/source-files/refresh-requests"
 MEANINGFUL_MIN_TEXT_LENGTH = 16
 
@@ -330,8 +333,166 @@ def _site_refresh_subject_key(request: dict[str, Any]) -> str:
 
 def _site_refresh_mode(request: dict[str, Any]) -> str:
     raw = str(request.get("refreshMode") or request.get("refresh_mode") or request.get("requestType") or request.get("type") or "").lower()
+    source = str(request.get("source") or "").lower()
+    reason = str(request.get("reason") or "").lower()
     high_priority = bool(request.get("highPriority") or request.get("manual") or request.get("force"))
+    if source in {"admin_manual_retry", "admin_source_file_open"} or reason in {"manual_retry", "opened_source_file", "file_not_updated"}:
+        high_priority = True
     return "site_manual_request" if high_priority or "manual" in raw or "button" in raw else "site_open_request"
+
+
+
+def is_source_refresh_now_token_valid(provided_token: str | None, *, environ: dict[str, str] | None = None) -> bool:
+    """Return True only when the internal immediate-refresh token matches env config."""
+
+    env = environ if environ is not None else os.environ
+    expected = (env.get("BNL_SOURCE_FILE_REFRESH_TOKEN") or "").strip()
+    provided = (provided_token or "").strip()
+    if not expected or not provided:
+        return False
+    return hmac.compare_digest(provided, expected)
+
+
+def _site_refresh_lookup_parts(site_request: dict[str, Any]) -> tuple[str, str]:
+    candidate_id = _safe_text(site_request.get("candidateId") or site_request.get("candidate_id") or "", 120)
+    subject = _site_refresh_subject_name(site_request)
+    skey = _site_refresh_subject_key(site_request)
+    if candidate_id:
+        return "candidateId", candidate_id
+    if (site_request.get("normalizedSubjectKey") or site_request.get("subjectKey")) and not site_request.get("subjectName"):
+        return "normalizedName", str(site_request.get("normalizedSubjectKey") or site_request.get("subjectKey") or skey)
+    return "subject", str(subject or skey)
+
+
+def _site_status_for_local_item(item: dict[str, Any]) -> tuple[str, str]:
+    status = str(item.get("status") or "").lower()
+    if status == "succeeded":
+        return "completed", ""
+    if status in {"skipped", "cooldown", "deferred", "no_target", "dry_run"}:
+        return "skipped", _safe_text(item.get("reason") or item.get("error") or status, 240)
+    return "failed", _safe_text(item.get("error") or item.get("reason") or status or "send_failed", 240)
+
+
+def _mark_site_request_terminal(request_id: str, item: dict[str, Any], *, environ: dict[str, str], opener=None) -> dict[str, Any]:
+    site_status, reason = _site_status_for_local_item(item)
+    rec_id = _safe_text(item.get("recommendationId") or "", 120)
+    result = update_site_refresh_request_status(
+        request_id,
+        site_status,
+        environ=environ,
+        opener=opener,
+        completed_by_recommendation_id=rec_id if site_status == "completed" else None,
+        failure_reason=reason if site_status != "completed" else None,
+    )
+    logging.info("source_refresh_now_site_status_updated request_id=%s status=%s ok=%s", _safe_text(request_id, 120), site_status, bool(result.get("ok")))
+    return result
+
+
+def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, guild_id: int | None = None, dry_run: bool = False, lookup_func: Callable[[dict[str, str]], dict[str, Any]] = lookup_source_file, sender: Callable[[dict[str, Any]], dict[str, Any]] = send_dossier_recommendation, environ: dict[str, str] | None = None, opener=None) -> dict[str, Any]:
+    """Process one immediate website Source File refresh request.
+
+    This is the bot-side wake-up path for admin Source File opens/retries. The
+    existing polling worker remains independent fallback; this helper only
+    processes the supplied request and makes any claimed site request terminal or
+    retry-safe on no_target, cooldown, deferred, or send failures.
+    """
+
+    env = environ if environ is not None else os.environ
+    site_request = dict(payload or {})
+    request_id = _site_refresh_request_id(site_request)
+    subject = _site_refresh_subject_name(site_request)
+    skey = _site_refresh_subject_key(site_request)
+    candidate_id = _safe_text(site_request.get("candidateId") or site_request.get("candidate_id") or "", 120)
+    mode = _site_refresh_mode(site_request)
+    source = _safe_text(site_request.get("source") or "", 80)
+    reason = _safe_text(site_request.get("reason") or "", 80)
+    logging.info("source_refresh_now_started request_id=%s subject_key=%s source=%s reason=%s", request_id or "none", skey or "none", source or "none", reason or "none")
+
+    summary: dict[str, Any] = {"ok": True, "dryRun": dry_run, "requestId": request_id, "candidateId": candidate_id, "subject": subject or skey, "subjectKey": skey, "status": "skipped", "recommendationId": "", "failureReason": ""}
+    if dry_run:
+        summary.update({"status": "dry_run", "processed": 1})
+        return summary
+    if not (candidate_id or subject or skey):
+        summary.update({"ok": False, "status": "failed", "failureReason": "missing_target"})
+        return summary
+
+    if request_id:
+        claim = update_site_refresh_request_status(request_id, "claimed", environ=env, opener=opener)
+        if not claim.get("ok"):
+            failure = _safe_text(claim.get("reason") or claim.get("error") or "claim_failed", 160)
+            logging.warning("source_refresh_now_failed request_id=%s reason=%s", request_id, failure)
+            summary.update({"ok": False, "status": "failed", "failureReason": failure})
+            return summary
+
+    lookup_key, lookup_value = _site_refresh_lookup_parts(site_request)
+    try:
+        target_check = lookup_func({"lookupKey": lookup_key, "lookupValue": lookup_value, lookup_key: lookup_value})
+        found = bool(target_check.get("found") or target_check.get("sourceFile") or target_check.get("source_file") or target_check.get("candidate") or target_check.get("dossier"))
+        if target_check.get("ok") is False or not found:
+            failure = "lookup_failed" if target_check.get("ok") is False else "no_target"
+            if failure == "no_target":
+                conn = sqlite3.connect(db_path)
+                try:
+                    ensure_source_file_refresh_schema(conn)
+                    _state_upsert(conn, guild_id=guild_id, subject_key=skey, subject_name=subject or lookup_value, fields={"last_refresh_completed_at": utc_now(), "last_refresh_status": "no_target", "last_failure_at": utc_now(), "last_error": "no_target"})
+                    conn.commit()
+                finally:
+                    conn.close()
+            item = {"subject": subject or lookup_value, "status": "skipped" if failure == "no_target" else "failed", "reason": failure, "error": failure}
+            if request_id:
+                _mark_site_request_terminal(request_id, item, environ=env, opener=opener)
+            summary.update({"ok": failure == "no_target", "status": "skipped" if failure == "no_target" else "failed", "failureReason": failure})
+            logging.warning("source_refresh_now_failed request_id=%s reason=%s", request_id or "none", failure)
+            return summary
+    except Exception as exc:
+        failure = _safe_text(exc, 160) or "lookup_failed"
+        item = {"subject": subject or skey, "status": "failed", "error": failure}
+        if request_id:
+            _mark_site_request_terminal(request_id, item, environ=env, opener=opener)
+        summary.update({"ok": False, "status": "failed", "failureReason": failure})
+        logging.warning("source_refresh_now_failed request_id=%s reason=%s", request_id or "none", failure)
+        return summary
+
+    enqueue_source_file_refresh(
+        db_path,
+        guild_id=guild_id,
+        subject_name=subject or lookup_value,
+        reason=f"source_refresh_now:{request_id or candidate_id or skey}",
+        evidence_source="source_refresh_now",
+        priority=100,
+        refresh_mode=mode,
+        created_by=source or "source_refresh_now",
+        evidence_count=1,
+    )
+    local = process_source_file_refresh_queue(
+        db_path,
+        guild_id=guild_id,
+        dry_run=False,
+        max_items=1,
+        lookup_func=lookup_func,
+        sender=sender,
+        environ=env,
+        bypass_cooldown=source in {"admin_source_file_open", "admin_manual_retry"} or reason in {"opened_source_file", "manual_retry", "file_not_updated"},
+        refresh_mode=mode,
+        subject_key=skey,
+    )
+    item = (local.get("items") or [{}])[0]
+    site_status, terminal_reason = _site_status_for_local_item(item)
+    if request_id:
+        _mark_site_request_terminal(request_id, item, environ=env, opener=opener)
+    rec_id = _safe_text(item.get("recommendationId") or "", 120)
+    summary.update({
+        "ok": site_status in {"completed", "skipped"},
+        "status": "success" if site_status == "completed" else site_status,
+        "recommendationId": rec_id,
+        "failureReason": terminal_reason,
+        "local": local,
+    })
+    if site_status == "completed":
+        logging.info("source_refresh_now_completed request_id=%s recommendation_id=%s", request_id or "none", rec_id or "none")
+    else:
+        logging.warning("source_refresh_now_failed request_id=%s reason=%s", request_id or "none", terminal_reason or site_status)
+    return summary
 
 
 def fetch_site_refresh_requests(*, environ: dict[str, str] | None = None, opener=None, limit: int = DEFAULT_MAX_SITE_REQUESTS_PER_CYCLE) -> dict[str, Any]:
@@ -640,6 +801,7 @@ def process_site_refresh_requests(db_path: str, *, guild_id: int | None = None, 
             summary["processed"] += 1
             summary["items"].append({"subject": subject or item.get("subject") or skey, "subjectKey": skey, "requestId": request_id, "status": "succeeded", "recommendationId": rec_id})
         elif status == "cooldown":
+            update_site_refresh_request_status(request_id, "skipped", environ=env, opener=opener, failure_reason="cooldown_deferred")
             logging.info("source_refresh_site_request_failed request_id=%s reason=cooldown_deferred", request_id)
             summary["skipped"] += 1
             summary["items"].append({"subject": subject or item.get("subject") or skey, "subjectKey": skey, "requestId": request_id, "status": "deferred", "reason": "cooldown"})

--- a/tests/test_source_file_refresh.py
+++ b/tests/test_source_file_refresh.py
@@ -419,6 +419,137 @@ class SourceFileRefreshTests(unittest.TestCase):
         self.assertEqual(summary["items"][0]["status"], "dry_run")
         self.assertEqual(self.rows(), before_rows)
 
+    def test_refresh_now_missing_token_rejected(self):
+        self.assertFalse(refresh.is_source_refresh_now_token_valid(None, environ={"BNL_SOURCE_FILE_REFRESH_TOKEN": "secret"}))
+
+    def test_refresh_now_invalid_token_rejected(self):
+        self.assertFalse(refresh.is_source_refresh_now_token_valid("wrong", environ={"BNL_SOURCE_FILE_REFRESH_TOKEN": "secret"}))
+        self.assertTrue(refresh.is_source_refresh_now_token_valid("secret", environ={"BNL_SOURCE_FILE_REFRESH_TOKEN": "secret"}))
+
+    def test_refresh_now_valid_request_processes_immediately_and_completes(self):
+        opener = FakeOpener({"ok": True, "requests": []})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value={"sent": True, "sendResult": {"recommendationId": "rec_now"}, "sourceCounts": {"conversations": 1}, "sourceTypes": ["conversations"], "subject": "Signal Fox", "qualityScore": 88}) as mocked:
+            result = refresh.process_source_file_refresh_now(
+                self.db,
+                {"requestId": "req_now", "candidateId": "cand_1", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "opened_source_file", "source": "admin_source_file_open"},
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["recommendationId"], "rec_now")
+        self.assertEqual(mocked.call_count, 1)
+        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "completed"])
+        self.assertEqual(opener.posts[-1]["completedByRecommendationId"], "rec_now")
+
+    def test_refresh_now_failed_refresh_marks_site_failed(self):
+        opener = FakeOpener({"ok": True, "requests": []})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value={"sent": False, "sendResult": {"error": "site rejected"}, "status": "send_failed"}):
+            result = refresh.process_source_file_refresh_now(
+                self.db,
+                {"requestId": "req_now", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "manual_retry", "source": "admin_manual_retry"},
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "failed"])
+        self.assertIn("site rejected", opener.posts[-1]["failureReason"])
+
+    def test_refresh_now_no_target_does_not_stay_claimed(self):
+        opener = FakeOpener({"ok": True, "requests": []})
+        lookup = lambda query: {"ok": True, "found": False}
+        with mock.patch.object(refresh, "run_source_file_enrichment") as mocked:
+            result = refresh.process_source_file_refresh_now(
+                self.db,
+                {"requestId": "req_now", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "opened_source_file", "source": "admin_source_file_open"},
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+        mocked.assert_not_called()
+        self.assertEqual(result["status"], "skipped")
+        self.assertEqual(result["failureReason"], "no_target")
+        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "skipped"])
+        self.assertEqual(opener.posts[-1]["failureReason"], "no_target")
+        self.assertEqual(self.rows(), [])
+
+    def test_refresh_now_cooldown_bypassed_for_admin_open(self):
+        conn = sqlite3.connect(self.db)
+        try:
+            refresh.ensure_source_file_refresh_schema(conn)
+            conn.execute(
+                f"INSERT OR REPLACE INTO {refresh.STATE_TABLE} (guild_id, subject_key, subject_name, cooldown_until, updated_at) VALUES (1, 'signal-fox', 'Signal Fox', '2999-01-01T00:00:00+00:00', 'now')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        opener = FakeOpener({"ok": True, "requests": []})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value={"sent": True, "sendResult": {"recommendationId": "rec_fresh"}, "sourceCounts": {"conversations": 1}, "sourceTypes": ["conversations"], "subject": "Signal Fox", "qualityScore": 88}):
+            result = refresh.process_source_file_refresh_now(
+                self.db,
+                {"requestId": "req_now", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "opened_source_file", "source": "admin_source_file_open"},
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+        self.assertEqual(result["status"], "success")
+        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "completed"])
+
+    def test_site_polling_cooldown_does_not_leave_request_claimed(self):
+        conn = sqlite3.connect(self.db)
+        try:
+            refresh.ensure_source_file_refresh_schema(conn)
+            conn.execute(
+                f"INSERT OR REPLACE INTO {refresh.STATE_TABLE} (guild_id, subject_key, subject_name, cooldown_until, updated_at) VALUES (1, 'signal-fox', 'Signal Fox', '2999-01-01T00:00:00+00:00', 'now')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        opener = FakeOpener({"ok": True, "requests": [{"id": "req_1", "subjectName": "Signal Fox", "status": "pending", "reason": "stale_file", "source": "background"}]})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
+        with mock.patch.object(refresh, "run_source_file_enrichment") as mocked:
+            summary = refresh.process_site_refresh_requests(
+                self.db,
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+        mocked.assert_not_called()
+        self.assertEqual(summary["skipped"], 1)
+        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "skipped"])
+        self.assertEqual(opener.posts[-1]["failureReason"], "cooldown_deferred")
+
+    def test_refresh_now_dry_run_behavior_unchanged(self):
+        opener = FakeOpener({"ok": True, "requests": []})
+        with mock.patch.object(refresh, "run_source_file_enrichment") as mocked:
+            result = refresh.process_source_file_refresh_now(
+                self.db,
+                {"requestId": "req_now", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "opened_source_file", "source": "admin_source_file_open"},
+                guild_id=1,
+                dry_run=True,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test"},
+                opener=opener,
+            )
+        mocked.assert_not_called()
+        self.assertEqual(result["status"], "dry_run")
+        self.assertEqual(opener.posts, [])
+        self.assertEqual(self.rows(), [])
+
+    def test_refresh_now_does_not_add_public_publishing_queue_payment_or_identity_flags(self):
+        with open("bnl_source_file_refresh.py", encoding="utf-8") as handle:
+            source = handle.read()
+        for forbidden in ("publish_public", "queue_payment", "artist_account", "canonical_profile_merge", "identity_alias"):
+            self.assertNotIn(forbidden, source)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Provide the website a secure, synchronous way to ask BNL to refresh a Source File immediately instead of waiting for the poll-based worker.
- Ensure immediate refreshes do not leave site requests claimed forever and preserve existing worker polling as a fallback.

### Description
- Added an authenticated internal HTTP endpoint `POST /internal/source-files/refresh-now` with header `X-BNL-REFRESH-TOKEN` and env var `BNL_SOURCE_FILE_REFRESH_TOKEN`, and a safe token check using `hmac.compare_digest` via `is_source_refresh_now_token_valid`.
- Implemented `process_source_file_refresh_now` which accepts requestId/candidateId/subjectName/normalizedSubjectKey payloads, looks up the target, enqueues and runs the existing enrichment path immediately (bypassing cooldown for admin open/manual sources), and returns a JSON result with `success`/`failed`/`skipped`, `recommendationId`, and `failureReason`.
- Integrated the new handler into the bot aiohttp listener (`_handle_source_file_refresh_now` wired into `start_force_pull_listener`) and added structured log events (`source_refresh_now_received`, `source_refresh_now_auth_failed`, `source_refresh_now_started`, `source_refresh_now_completed`, `source_refresh_now_failed`, `source_refresh_now_site_status_updated`) while ensuring tokens/private transcripts are not logged.
- Made site-facing behavior safe: claimed site requests are marked terminal (completed/failed/skipped) through `update_site_refresh_request_status`/`_mark_site_request_terminal` and polling cooldown cases now post a `skipped`/`cooldown_deferred` update so requests are not left claimed.
- Minor refresh-mode logic: treat `admin_source_file_open` / `admin_manual_retry` and specific reasons as high-priority so those immediate/manual sources bypass ordinary cooldown.
- Tests added to `tests/test_source_file_refresh.py` covering token validation, immediate success/failure/no-target/cooldown/dry-run behavior, and that no public publishing/queue-payment/identity/canonical-profile behavior was introduced.

### Testing
- Ran unit tests with `python -m unittest discover -s tests -v` and all relevant tests (including new `test_refresh_now_*`) passed (existing suite: 416 tests, all passed in CI run shown).
- Ran full test suite with `python -m pytest` and observed `416 passed` with no regressions.
- Performed compilation checks with `python -m py_compile bnl01_bot.py bnl_source_file_refresh.py tests/test_source_file_refresh.py` and `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25e3959a6483219f54bee9edfa2343)