### PR TITLE
Send full Source File archive envelopes to site archive endpoint and keep compact recommendation path separate

### DIFF
--- a/bnl_dossier_recommendations.py
+++ b/bnl_dossier_recommendations.py
@@ -18,7 +18,9 @@ import urllib.request
 from typing import Any
 
 DEFAULT_DOSSIER_INGEST_URL = "https://www.barcode-network.com/api/bnl/dossier-recommendations"
+DEFAULT_SOURCE_FILE_ARCHIVE_URL = "https://www.barcode-network.com/api/bnl/source-file-enrichments"
 DOSSIER_INGEST_TIMEOUT_SECONDS = 10
+SOURCE_FILE_ARCHIVE_TIMEOUT_SECONDS = 15
 SUPPORTED_PAYLOAD_FIELDS = {
     "type",
     "subjectName",
@@ -100,6 +102,30 @@ def is_dossier_ingest_token_configured(environ: dict[str, str] | None = None) ->
 
     env = environ if environ is not None else os.environ
     return bool((env.get("BNL_DOSSIER_INGEST_TOKEN") or "").strip())
+
+
+def get_source_file_archive_url(environ: dict[str, str] | None = None) -> str:
+    """Return configured Source File archive URL or production fallback."""
+
+    env = environ if environ is not None else os.environ
+    configured = (env.get("BNL_SOURCE_FILE_ARCHIVE_URL") or "").strip()
+    return configured or DEFAULT_SOURCE_FILE_ARCHIVE_URL
+
+
+def get_source_file_archive_token(environ: dict[str, str] | None = None) -> str:
+    """Return archive token, falling back to dossier ingest token when needed."""
+
+    env = environ if environ is not None else os.environ
+    archive_token = (env.get("BNL_SOURCE_FILE_ARCHIVE_TOKEN") or "").strip()
+    if archive_token:
+        return archive_token
+    return (env.get("BNL_DOSSIER_INGEST_TOKEN") or "").strip()
+
+
+def is_source_file_archive_token_configured(environ: dict[str, str] | None = None) -> bool:
+    """Return whether the Source File archive sender has a usable token."""
+
+    return bool(get_source_file_archive_token(environ))
 
 
 def _normalize_subject_key(subject_name: str) -> str:
@@ -328,3 +354,86 @@ def send_dossier_recommendation(payload: dict[str, Any], *, environ: dict[str, s
 
     logging.warning(f"dossier_recommendation_send_failed status={status}")
     return _safe_failure("Dossier recommendation endpoint returned a failure.", status=status, duplicate=duplicate)
+
+
+def _extract_archive_id(parsed: dict[str, Any]) -> str | None:
+    for key in ("archiveId", "archive_id", "sourceFileEnrichmentId", "source_file_enrichment_id", "id"):
+        value = parsed.get(key)
+        if value:
+            return str(value)[:160]
+    data = parsed.get("data")
+    if isinstance(data, dict):
+        return _extract_archive_id(data)
+    archive = parsed.get("archive") or parsed.get("enrichment")
+    if isinstance(archive, dict):
+        return _extract_archive_id(archive)
+    return None
+
+
+def _safe_archive_failure(error: str, status: int | None = None) -> dict[str, Any]:
+    return {"ok": False, "archiveId": None, "error": error, "status": status}
+
+
+def send_source_file_archive_enrichment(payload: dict[str, Any], *, environ: dict[str, str] | None = None, opener=None) -> dict[str, Any]:
+    """POST a full Source File enrichment envelope to the review-only archive endpoint.
+
+    This sender is intentionally separate from send_dossier_recommendation() so
+    large case-file packages never have to fit through compact recommendation
+    card fields. Logs include only routing/status metadata, never tokens or the
+    archive payload body.
+    """
+
+    env = environ if environ is not None else os.environ
+    token = get_source_file_archive_token(env)
+    if not token:
+        logging.warning("source_file_archive_send_failed reason=missing_archive_token")
+        return _safe_archive_failure("Source File archive token is not configured.")
+
+    url = get_source_file_archive_url(env)
+    safe_payload = dict(payload or {})
+    subject_key = _normalize_subject_key(str(safe_payload.get("subjectKey") or safe_payload.get("subjectName") or ""))
+    logging.info("source_file_archive_send_attempted endpoint_configured=%s subject_key=%s", bool(url), subject_key)
+
+    body = json.dumps(safe_payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {token}"},
+        method="POST",
+    )
+    urlopen = opener.open if opener is not None else urllib.request.urlopen
+    try:
+        with urlopen(request, timeout=SOURCE_FILE_ARCHIVE_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", None) or response.getcode()
+            raw = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        try:
+            body_text = _safe_response_error_text(exc.read())
+        except Exception:
+            body_text = _safe_response_error_text(getattr(exc, "reason", ""))
+        error = "Source File archive endpoint rejected the request."
+        if body_text:
+            error = f"{error} {body_text}"
+        logging.warning("source_file_archive_send_failed status=%s endpoint_error=%s", status, body_text or "unavailable")
+        return _safe_archive_failure(error, status=status)
+    except (urllib.error.URLError, TimeoutError, socket.timeout):
+        logging.warning("source_file_archive_send_failed reason=network_or_timeout")
+        return _safe_archive_failure("Source File archive endpoint was unreachable or timed out.")
+    except Exception:
+        logging.warning("source_file_archive_send_failed reason=unexpected_error")
+        return _safe_archive_failure("Source File archive send failed unexpectedly.")
+
+    try:
+        parsed = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        logging.warning("source_file_archive_send_failed status=%s reason=invalid_json", status)
+        return _safe_archive_failure("Source File archive endpoint returned invalid JSON.", status=status)
+
+    ok = bool(parsed.get("ok", True)) and 200 <= int(status or 0) < 300
+    archive_id = _extract_archive_id(parsed) if isinstance(parsed, dict) else None
+    if ok:
+        logging.info("source_file_archive_send_succeeded status=%s archive_id=%s", status, archive_id or "none")
+        return {"ok": True, "archiveId": archive_id, "error": "", "status": status}
+    logging.warning("source_file_archive_send_failed status=%s", status)
+    return _safe_archive_failure("Source File archive endpoint returned a failure.", status=status)

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -16,7 +16,7 @@ from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from typing import Any, Callable
 
-from bnl_dossier_recommendations import build_dossier_recommendation_payload, send_dossier_recommendation
+from bnl_dossier_recommendations import build_dossier_recommendation_payload, is_source_file_archive_token_configured, send_dossier_recommendation, send_source_file_archive_enrichment
 from bnl_entity_activity_summary import build_entity_activity_summary, refresh_entity_evidence_for_subject
 from bnl_entity_evidence import _website_safe_payload_text
 from bnl_entity_intelligence import build_entity_intelligence_profile, resolve_entity_context_for_surface, safe_text as _entity_safe_text
@@ -2416,6 +2416,87 @@ def deterministic_enrichment_ingest_key(subject: str, match_kind: str, sections:
     return f"bnl:source-enrichment:{_subject_key(subject)}:{match_kind}:{digest}"
 
 
+
+_ARCHIVE_REDACT_KEY_RE = re.compile(r"(?i)(token|secret|authorization|api[_-]?key|password|customer[_-]?id|payment[_-]?id|stripe|raw[_-]?discord[_-]?id|discord[_-]?user[_-]?id|user[_-]?id|member[_-]?id|channel[_-]?id|private.*transcript|raw.*transcript)")
+_ARCHIVE_ALLOWED_KEYS_TO_KEEP_AS_REDACTED = {"channelPolicy", "visibility", "authority", "sourceScope", "sourceTable", "sourceLabel", "sourceRowId"}
+
+
+def _archive_safe_scalar(value: Any, limit: int = 5000) -> Any:
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    text = str(value)
+    text = _DISCORD_MENTION_RE.sub("[redacted-mention]", text)
+    text = _LONG_ID_RE.sub("[redacted-id]", text)
+    text = _EMAIL_RE.sub("[redacted-email]", text)
+    text = re.sub(r"(?i)(Bearer\s+)[A-Za-z0-9._~+/-]+", r"\1[redacted]", text)
+    text = re.sub(r"(?i)(token|secret|authorization|api[_-]?key|password)\s*[:=]\s*[^\s,;}]+", r"\1=[redacted]", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > limit:
+        text = text[: max(0, limit - 1)].rstrip() + "…"
+    return text
+
+
+def _sanitize_archive_value(value: Any, *, key: str = "", depth: int = 0) -> Any:
+    if depth > 12:
+        return "[redacted-depth]"
+    if key and _ARCHIVE_REDACT_KEY_RE.search(key) and key not in _ARCHIVE_ALLOWED_KEYS_TO_KEEP_AS_REDACTED:
+        return "[redacted]"
+    if isinstance(value, dict):
+        cleaned: dict[str, Any] = {}
+        for raw_key, raw_value in value.items():
+            safe_key = _archive_safe_scalar(raw_key, 120)
+            if not safe_key:
+                continue
+            cleaned[str(safe_key)] = _sanitize_archive_value(raw_value, key=str(safe_key), depth=depth + 1)
+        return cleaned
+    if isinstance(value, (list, tuple, set)):
+        return [_sanitize_archive_value(item, key=key, depth=depth + 1) for item in list(value)]
+    return _archive_safe_scalar(value)
+
+
+def _source_package_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
+    """Build the full review-only archive package without compact-card trimming."""
+
+    excluded = {"payload", "sendResult", "archiveResult", "sourcePackage"}
+    package = {key: value for key, value in (packet or {}).items() if key not in excluded}
+    package["archiveNotice"] = "Internal/review-only Source File archive package. No public publishing, draft creation, tag creation, queue/payment action, identity merge, or alias confirmation is requested."
+    return _sanitize_archive_value(package)
+
+
+def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[str, str] | None = None) -> dict[str, Any]:
+    """Build the full Source File archive envelope for the site archive endpoint."""
+
+    source_file = packet.get("sourceFile") if isinstance(packet.get("sourceFile"), dict) else {}
+    compact_summary = build_compact_enrichment_evidence_summary(packet)
+    subject = _safe_text(packet.get("subject") or _first(source_file, ("name", "sourceFileName", "subject", "displayName", "title", "normalizedName")), 140)
+    subject_key = _subject_key(subject or _first(source_file, ("normalizedName", "subjectKey", "slug")))
+    candidate_id = _first(source_file, ("candidateId", "targetCandidateId", "candidate_id", "id"))
+    sections = packet.get("sections") or {}
+    receipt = {
+        "qualityScore": packet.get("qualityScore"),
+        "qualityStatus": packet.get("qualityStatus"),
+        "sourceCounts": dict(packet.get("sourceCounts") or {}),
+        "sourceTypes": list(packet.get("sourceTypes") or []),
+        "warningCounts": dict(packet.get("warningCounts") or {}),
+        "warnings": list(packet.get("warnings") or []),
+        "matchKind": packet.get("matchKind"),
+        "runTime": packet.get("runTime"),
+    }
+    envelope = {
+        "candidateId": _sanitize_archive_value(candidate_id) if candidate_id else None,
+        "subjectName": subject,
+        "subjectKey": subject_key,
+        "ingestKey": packet.get("ingestKey") or deterministic_enrichment_ingest_key(subject, str(packet.get("matchKind") or "none"), sections),
+        "compactSummary": compact_summary,
+        "publicSafePossibilities": _sanitize_archive_value(list(packet.get("publicSafePossibilities") or [])),
+        "missingInfo": _sanitize_archive_value(_section_text(sections, "Missing Info", limit=10) or packet.get("missingInfo") or ""),
+        "publicSafetyNotes": _sanitize_archive_value(_section_text(sections, "Public-Safe Notes", limit=10) or packet.get("publicSafetyNotes") or ""),
+        "doNotSay": _sanitize_archive_value(_section_text(sections, "Do Not Say", limit=10) or packet.get("doNotSay") or ""),
+        "evidenceReceiptSummary": _sanitize_archive_value(receipt),
+        "sourcePackage": _source_package_from_packet(packet),
+    }
+    return envelope
+
 def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: dict[str, str] | None = None) -> dict[str, Any]:
     sections = packet.get("sections") or {}
     subject = str(packet.get("subject") or "").strip()
@@ -2499,6 +2580,7 @@ def run_source_file_enrichment(
     rd_context: list[dict[str, Any]] | None = None,
     lookup_func: Callable[[dict[str, str]], dict[str, Any]] = lookup_source_file,
     sender: Callable[[dict[str, Any]], dict[str, Any]] = send_dossier_recommendation,
+    archive_sender: Callable[[dict[str, Any]], dict[str, Any]] = send_source_file_archive_enrichment,
     environ: dict[str, str] | None = None,
     lookup_key: str = "subject",
     lookup_value: str | None = None,
@@ -2636,10 +2718,35 @@ def run_source_file_enrichment(
         packet["sendResult"] = {"ok": False, "error": quality["suppressedReason"]}
         packet["status"] = "suppressed_too_thin"
         return packet
+    archive_payload = build_source_file_archive_payload(packet, environ=environ)
+    packet["archivePayload"] = archive_payload
+    archive_required = is_source_file_archive_token_configured(environ)
+    if archive_required:
+        archive_result = archive_sender(archive_payload)
+    else:
+        archive_result = {"ok": True, "archiveId": None, "error": "", "status": "not_configured_skipped"}
+        logging.info("source_file_archive_send_skipped reason=archive_token_not_configured subject_key=%s", _subject_key(subject))
+    packet["archiveResult"] = archive_result
+    packet["archiveSent"] = bool(archive_required and (archive_result or {}).get("ok"))
+    packet["archiveStatus"] = (archive_result or {}).get("status")
+    packet["archiveId"] = (archive_result or {}).get("archiveId") or ""
+    packet["archiveError"] = _safe_text((archive_result or {}).get("error") or "", 240)
+
     send_result = sender(payload)
     packet["sendResult"] = send_result
-    packet["sent"] = bool((send_result or {}).get("ok"))
-    packet["status"] = "sent" if packet["sent"] else "send_failed"
+    packet["recommendationSent"] = bool((send_result or {}).get("ok"))
+    packet["recommendationId"] = (send_result or {}).get("recommendationId") or (send_result or {}).get("id") or ""
+    packet["sent"] = bool(packet["recommendationSent"] and ((not archive_required) or packet["archiveSent"]))
+    if packet["sent"]:
+        packet["status"] = "sent"
+    elif (packet["archiveSent"] or not archive_required) and not packet["recommendationSent"]:
+        packet["status"] = "recommendation_send_failed"
+        logging.warning("source_enrichment_compact_recommendation_failed archive_ok=true subject_key=%s", _subject_key(subject))
+    elif packet["recommendationSent"] and not packet["archiveSent"]:
+        packet["status"] = "archive_send_failed"
+        logging.warning("source_enrichment_archive_failed recommendation_ok=true subject_key=%s", _subject_key(subject))
+    else:
+        packet["status"] = "send_failed"
     return packet
 
 

--- a/bnl_source_file_refresh.py
+++ b/bnl_source_file_refresh.py
@@ -23,7 +23,7 @@ import urllib.request
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
 
-from bnl_dossier_recommendations import is_dossier_ingest_token_configured, send_dossier_recommendation
+from bnl_dossier_recommendations import is_dossier_ingest_token_configured, is_source_file_archive_token_configured, send_dossier_recommendation
 from bnl_source_file_enrichment import run_source_file_enrichment
 from bnl_source_file_lookup import lookup_source_file
 from bnl_source_refresh_context import is_refresh_generation_subject, refresh_generation_context
@@ -408,7 +408,7 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
     reason = _safe_text(site_request.get("reason") or "", 80)
     logging.info("source_refresh_now_started request_id=%s subject_key=%s source=%s reason=%s", request_id or "none", skey or "none", source or "none", reason or "none")
 
-    summary: dict[str, Any] = {"ok": True, "dryRun": dry_run, "requestId": request_id, "candidateId": candidate_id, "subject": subject or skey, "subjectKey": skey, "status": "skipped", "recommendationId": "", "failureReason": ""}
+    summary: dict[str, Any] = {"ok": True, "dryRun": dry_run, "requestId": request_id, "candidateId": candidate_id, "subject": subject or skey, "subjectKey": skey, "status": "skipped", "recommendationId": "", "recommendationSent": False, "archiveSent": False, "archiveStatus": None, "archiveId": "", "archiveError": "", "failureReason": ""}
     if dry_run:
         summary.update({"status": "dry_run", "processed": 1})
         return summary
@@ -481,10 +481,16 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
     if request_id:
         _mark_site_request_terminal(request_id, item, environ=env, opener=opener)
     rec_id = _safe_text(item.get("recommendationId") or "", 120)
+    archive_id = _safe_text(item.get("archiveId") or "", 120)
     summary.update({
         "ok": site_status in {"completed", "skipped"},
         "status": "success" if site_status == "completed" else site_status,
         "recommendationId": rec_id,
+        "recommendationSent": bool(item.get("recommendationSent") or rec_id),
+        "archiveSent": bool(item.get("archiveSent")),
+        "archiveStatus": item.get("archiveStatus"),
+        "archiveId": archive_id,
+        "archiveError": _safe_text(item.get("archiveError") or "", 180),
         "failureReason": terminal_reason,
         "local": local,
     })
@@ -622,12 +628,12 @@ def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = No
         rows = conn.execute(f"SELECT * FROM {QUEUE_TABLE} WHERE {where} ORDER BY priority DESC, queued_at ASC LIMIT ?", [*params, max(1, int(max_items or 1))]).fetchall()
         if not rows:
             return summary
-        if not dry_run and not is_dossier_ingest_token_configured(env):
+        if not dry_run and not (is_dossier_ingest_token_configured(env) or is_source_file_archive_token_configured(env)):
             for row in rows:
-                conn.execute(f"UPDATE {QUEUE_TABLE} SET status='deferred', updated_at=?, last_error='missing_ingest_token' WHERE id=?", (now, row["id"]))
-                logging.info("source_refresh_skipped subject_key=%s reason=missing_ingest_token", row["subject_key"])
+                conn.execute(f"UPDATE {QUEUE_TABLE} SET status='deferred', updated_at=?, last_error='missing_source_refresh_token' WHERE id=?", (now, row["id"]))
+                logging.info("source_refresh_skipped subject_key=%s reason=missing_source_refresh_token", row["subject_key"])
                 summary["skipped"] += 1
-                summary["items"].append({"subject": row["subject_name"], "status": "deferred", "reason": "missing_ingest_token"})
+                summary["items"].append({"subject": row["subject_name"], "status": "deferred", "reason": "missing_source_refresh_token"})
             conn.commit()
             return summary
         for row in rows:
@@ -670,23 +676,32 @@ def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = No
                     summary["items"].append({"subject": row["subject_name"], "status": "skipped", "reason": "no_target", "error": "no_target"})
                 elif result.get("sent"):
                     send_result = result.get("sendResult") or {}
-                    recommendation_id = str(send_result.get("recommendationId") or send_result.get("recommendation_id") or send_result.get("id") or "")[:120]
+                    recommendation_id = str(send_result.get("recommendationId") or send_result.get("recommendation_id") or result.get("recommendationId") or send_result.get("id") or "")[:120]
+                    archive_result = result.get("archiveResult") or {}
+                    archive_id = str(archive_result.get("archiveId") or result.get("archiveId") or "")[:120]
                     cooldown_until_text = _cooldown_until_from(now_dt, cooldown_minutes)
                     evidence_count = sum(int(v or 0) for v in (result.get("sourceCounts") or {}).values()) if isinstance(result.get("sourceCounts"), dict) else int(row["evidence_count"] or 0)
                     conn.execute(f"UPDATE {QUEUE_TABLE} SET status='succeeded', updated_at=?, last_error=NULL WHERE id=?", (utc_now(), row["id"]))
                     _state_upsert(conn, guild_id=row["guild_id"], subject_key=row["subject_key"], subject_name=row["subject_name"], fields={"last_refresh_completed_at": utc_now(), "last_refresh_status": "succeeded", "last_recommendation_id": recommendation_id, "last_evidence_hash": _evidence_hash_for_result(result), "last_evidence_count": evidence_count, "last_error": None, "cooldown_until": cooldown_until_text})
                     conn.commit()
-                    logging.info("source_refresh_succeeded subject_key=%s recommendation_id=%s", row["subject_key"], recommendation_id or "none")
+                    logging.info("source_refresh_succeeded subject_key=%s recommendation_id=%s archive_id=%s", row["subject_key"], recommendation_id or "none", archive_id or "none")
                     summary["processed"] += 1
-                    summary["items"].append({"subject": row["subject_name"], "status": "succeeded", "recommendationId": recommendation_id})
+                    summary["items"].append({"subject": row["subject_name"], "status": "succeeded", "recommendationId": recommendation_id, "recommendationSent": bool(result.get("recommendationSent", bool(send_result.get("ok")))), "archiveSent": bool(result.get("archiveSent", bool(archive_result.get("ok")))), "archiveStatus": result.get("archiveStatus") or archive_result.get("status"), "archiveId": archive_id, "archiveError": _safe_text(result.get("archiveError") or archive_result.get("error") or "", 180)})
                 else:
-                    err = _safe_text((result.get("sendResult") or {}).get("error") or result.get("suppressedReason") or result.get("status") or "send_failed", 240)
+                    archive_result = result.get("archiveResult") or {}
+                    send_result = result.get("sendResult") or {}
+                    if result.get("recommendationSent") and not result.get("archiveSent"):
+                        err = _safe_text(result.get("archiveError") or archive_result.get("error") or "archive_send_failed", 240)
+                    elif result.get("archiveSent") and not result.get("recommendationSent"):
+                        err = _safe_text(send_result.get("error") or "recommendation_send_failed", 240)
+                    else:
+                        err = _safe_text(send_result.get("error") or archive_result.get("error") or result.get("suppressedReason") or result.get("status") or "send_failed", 240)
                     conn.execute(f"UPDATE {QUEUE_TABLE} SET status='failed', updated_at=?, last_error=? WHERE id=?", (utc_now(), err, row["id"]))
                     _state_upsert(conn, guild_id=row["guild_id"], subject_key=row["subject_key"], subject_name=row["subject_name"], fields={"last_refresh_status": "failed", "last_failure_at": utc_now(), "last_error": err})
                     conn.commit()
                     logging.warning("source_refresh_failed subject_key=%s error=%s", row["subject_key"], err)
                     summary["failed"] += 1
-                    summary["items"].append({"subject": row["subject_name"], "status": "failed", "error": err})
+                    summary["items"].append({"subject": row["subject_name"], "status": "failed", "error": err, "recommendationSent": bool(result.get("recommendationSent")), "archiveSent": bool(result.get("archiveSent")), "archiveStatus": result.get("archiveStatus") or archive_result.get("status"), "archiveId": str(archive_result.get("archiveId") or result.get("archiveId") or "")[:120], "archiveError": _safe_text(result.get("archiveError") or archive_result.get("error") or "", 180), "recommendationId": str(send_result.get("recommendationId") or result.get("recommendationId") or "")[:120]})
             except Exception as exc:
                 err = _safe_text(exc, 240)
                 conn.execute(f"UPDATE {QUEUE_TABLE} SET status='failed', updated_at=?, last_error=? WHERE id=?", (utc_now(), err, row["id"]))

--- a/tests/test_source_file_archive.py
+++ b/tests/test_source_file_archive.py
@@ -1,0 +1,165 @@
+import json
+import logging
+import unittest
+from unittest import mock
+
+import bnl_dossier_recommendations as recs
+import bnl_source_file_enrichment as enrichment
+
+
+class FakeResponse:
+    def __init__(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def getcode(self):
+        return self.status
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class CapturingOpener:
+    def __init__(self, payload=None, status=200):
+        self.payload = payload if payload is not None else {"ok": True, "archiveId": "arc_1"}
+        self.status = status
+        self.requests = []
+
+    def open(self, request, timeout=0):
+        self.requests.append(request)
+        return FakeResponse(self.payload, status=self.status)
+
+
+class SourceFileArchiveTests(unittest.TestCase):
+    def large_packet(self):
+        evidence = [f"6-bit recurring source intelligence item {i} with meaningful context" for i in range(80)]
+        return {
+            "ok": True,
+            "subject": "6-bit",
+            "matchKind": "active_source_file",
+            "sourceFile": {"candidateId": "cand_6bit", "name": "6-bit", "discord_user_id": "123456789012345678"},
+            "sections": {
+                "Missing Info": ["owner confirmation still needed"],
+                "Public-Safe Notes": ["public-safe possibility after review"],
+                "Do Not Say": ["do not claim identity merge"],
+            },
+            "sourceCounts": {"conversations": 80, "entity_evidence_events": 25},
+            "sourceTypes": ["conversations", "entity_evidence_events"],
+            "warningCounts": {"review_only": 2},
+            "warnings": ["review-only archive"],
+            "qualityScore": 95,
+            "qualityStatus": "sendable",
+            "publicSafePossibilities": ["Possible public-safe 6-bit summary after admin review"],
+            "bestEvidenceToReview": evidence,
+            "conversationHighlights": evidence,
+            "rawProvenance": {
+                "rawFragments": [
+                    {"sourceTable": "conversations", "sourceRowId": f"row_{i}", "safeSummary": item, "user_id": "123456789012345678"}
+                    for i, item in enumerate(evidence)
+                ]
+            },
+            "runTime": "2026-06-08T00:00:00+00:00",
+            "ingestKey": "bnl:source-enrichment:6-bit:test",
+        }
+
+    def test_archive_url_and_token_config_with_dossier_fallback(self):
+        self.assertEqual(
+            recs.get_source_file_archive_url({}),
+            "https://www.barcode-network.com/api/bnl/source-file-enrichments",
+        )
+        self.assertEqual(recs.get_source_file_archive_url({"BNL_SOURCE_FILE_ARCHIVE_URL": "https://site.test/archive"}), "https://site.test/archive")
+        self.assertEqual(recs.get_source_file_archive_token({"BNL_DOSSIER_INGEST_TOKEN": "dossier-token"}), "dossier-token")
+        self.assertEqual(
+            recs.get_source_file_archive_token({"BNL_SOURCE_FILE_ARCHIVE_TOKEN": "archive-token", "BNL_DOSSIER_INGEST_TOKEN": "dossier-token"}),
+            "archive-token",
+        )
+
+    def test_archive_sender_posts_to_archive_endpoint_without_logging_token_or_payload(self):
+        opener = CapturingOpener({"ok": True, "archiveId": "arc_safe"})
+        payload = enrichment.build_source_file_archive_payload(self.large_packet())
+        with mock.patch.object(logging, "info") as info_mock, mock.patch.object(logging, "warning") as warning_mock:
+            result = recs.send_source_file_archive_enrichment(
+                payload,
+                environ={"BNL_SOURCE_FILE_ARCHIVE_URL": "https://site.test/archive", "BNL_SOURCE_FILE_ARCHIVE_TOKEN": "secret-archive-token"},
+                opener=opener,
+            )
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["archiveId"], "arc_safe")
+        request = opener.requests[0]
+        self.assertEqual(request.full_url, "https://site.test/archive")
+        self.assertEqual(request.headers["Authorization"], "Bearer secret-archive-token")
+        log_text = " ".join(str(call) for call in [*info_mock.call_args_list, *warning_mock.call_args_list])
+        self.assertNotIn("secret-archive-token", log_text)
+        self.assertNotIn("6-bit recurring source intelligence item 79", log_text)
+
+    def test_large_source_package_is_preserved_in_archive_not_compact_recommendation_fields(self):
+        packet = self.large_packet()
+        archive_payload = enrichment.build_source_file_archive_payload(packet)
+        compact_payload = enrichment.build_enrichment_recommendation_payload(packet)
+        archive_body = json.dumps(archive_payload, sort_keys=True)
+        compact_body = json.dumps(compact_payload, sort_keys=True)
+        self.assertIn("6-bit recurring source intelligence item 79", archive_body)
+        self.assertIn("sourcePackage", archive_payload)
+        self.assertNotIn("6-bit recurring source intelligence item 79", compact_body)
+        self.assertLess(len(compact_payload["evidenceSummary"]), 2000)
+
+    def test_archive_payload_redacts_discord_payment_and_secret_material(self):
+        packet = self.large_packet()
+        packet["sourceFile"]["payment_customer_id"] = "cus_123"
+        packet["sourceFile"]["apiToken"] = "token-value"
+        archive_payload = enrichment.build_source_file_archive_payload(packet)
+        body = json.dumps(archive_payload, sort_keys=True)
+        self.assertNotIn("123456789012345678", body)
+        self.assertNotIn("cus_123", body)
+        self.assertNotIn("token-value", body)
+        self.assertIn("[redacted]", body)
+
+    def test_run_enrichment_distinguishes_archive_and_recommendation_results(self):
+        packet = self.large_packet()
+        with mock.patch.object(enrichment, "collect_source_enrichment_evidence", return_value={
+                 "sections": packet["sections"], "sourceCounts": packet["sourceCounts"], "warningCounts": packet["warningCounts"],
+                 "sourceTypes": packet["sourceTypes"], "warnings": [], "diagnostics": {}, "classification": {},
+                 "bestEvidenceToReview": packet["bestEvidenceToReview"], "conversationHighlights": packet["conversationHighlights"],
+                 "publicSafePossibilities": packet["publicSafePossibilities"], "rawProvenance": packet["rawProvenance"],
+             }), \
+             mock.patch.object(enrichment, "build_entity_intelligence_profile", return_value={"diagnostics": {}}), \
+             mock.patch.object(enrichment, "resolve_entity_context_for_surface", return_value={}):
+            archive_calls = []
+            rec_calls = []
+            result = enrichment.run_source_file_enrichment(
+                ":memory:", 1, "6-bit", force=True,
+                lookup_func=lambda query: {"ok": True, "found": True, "sourceFile": packet["sourceFile"], "matchKind": "active_source_file"},
+                environ={"BNL_SOURCE_FILE_ARCHIVE_TOKEN": "archive-token"},
+                archive_sender=lambda payload: archive_calls.append(payload) or {"ok": True, "archiveId": "arc_1", "status": 200},
+                sender=lambda payload: rec_calls.append(payload) or {"ok": False, "error": "compact too long", "status": 413},
+            )
+        self.assertTrue(result["archiveSent"])
+        self.assertFalse(result["recommendationSent"])
+        self.assertFalse(result["sent"])
+        self.assertEqual(result["status"], "recommendation_send_failed")
+        self.assertIn("sourcePackage", archive_calls[0])
+        self.assertNotIn("sourcePackage", rec_calls[0])
+
+    def test_compact_success_archive_failure_is_not_fully_sent(self):
+        packet = self.large_packet()
+        payload = enrichment.build_enrichment_recommendation_payload(packet)
+        archive_payload = enrichment.build_source_file_archive_payload(packet)
+        archive_result = {"ok": False, "error": "archive rejected", "status": 500}
+        rec_result = {"ok": True, "recommendationId": "rec_1", "status": 200}
+        self.assertFalse(archive_result["ok"])
+        self.assertTrue(rec_result["ok"])
+        self.assertIn("sourcePackage", archive_payload)
+        self.assertNotIn("sourcePackage", payload)
+
+    def test_no_public_publish_or_identity_merge_flags_introduced(self):
+        packet = self.large_packet()
+        archive_payload = enrichment.build_source_file_archive_payload(packet)
+        body = json.dumps(archive_payload, sort_keys=True).lower()
+        for forbidden in ("publish_public", "draft_create", "tag_create", "identity_merge", "queue_payment", "alias_confirm"):
+            self.assertNotIn(forbidden, body)


### PR DESCRIPTION
### Motivation

- Add a dedicated review-only archive flow so large Source File enrichment packages are stored in the new site archive endpoint instead of being forced through the compact dossier recommendation endpoint.
- Preserve full case-file intelligence in an archive package while keeping the compact recommendation/readout bounded for the existing UI and recommendation card limits.

### Description

- Added site-archive configuration and token helpers and a safe archive sender in `bnl_dossier_recommendations.py` (`DEFAULT_SOURCE_FILE_ARCHIVE_URL`, `get_source_file_archive_url()`, `get_source_file_archive_token()`, `is_source_file_archive_token_configured()`, `_extract_archive_id()`, `send_source_file_archive_enrichment()`).
- Built full review-only archive envelopes and redaction/sanitization helpers in `bnl_source_file_enrichment.py` (`_archive_safe_scalar`, `_sanitize_archive_value`, `_source_package_from_packet`, `build_source_file_archive_payload`) and wire `run_source_file_enrichment()` to call an `archive_sender` separately from the compact `sender` and to populate `archiveResult`, `archiveSent`, `archiveStatus`, `archiveId`, and `archiveError` on the enrichment result.
- Made `bnl_source_file_refresh.py` accept archive-token fallback for processing and adjusted worker gating so queue processing requires either the dossier ingest token or the archive token; updated status updates and immediate-refresh response shapes to include `archiveSent`, `archiveStatus`, `archiveId`, and `archiveError` while preserving the existing recommendation fields and immediate refresh endpoint behavior.
- Added tests `tests/test_source_file_archive.py` that validate URL/token config fallback, that large 6-bit-like packages are preserved in the archive envelope (not the compact recommendation), that sensitive fields are redacted in the archive body and logs, and that sender interactions distinguish archive vs compact recommendation success/failure.

### Testing

- Ran the new archive unit tests `python -m unittest tests.test_source_file_archive -v` and they passed after wiring the token fallback into the test harness.
- Ran the existing source-refresh unit tests `python -m unittest tests.test_source_file_refresh -v` and they passed, confirming immediate refresh and polling behavior remained intact.
- Compiled core modules with `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_source_file_refresh.py bnl_dossier_source_packets.py bnl_entity_intelligence.py bnl_source_file_enrichment.py` and ran focused enrichment tests; the new and modified tests passed and integration points logged expected archive/recommendation outcomes.

Changed files: `bnl_dossier_recommendations.py`, `bnl_source_file_enrichment.py`, `bnl_source_file_refresh.py`, `tests/test_source_file_archive.py`.

Environment variables added/used: `BNL_SOURCE_FILE_ARCHIVE_URL` (defaults to `https://www.barcode-network.com/api/bnl/source-file-enrichments`), `BNL_SOURCE_FILE_ARCHIVE_TOKEN` (falls back to `BNL_DOSSIER_INGEST_TOKEN` when unset).

VPS deployment steps: set `BNL_SOURCE_FILE_ARCHIVE_URL`/`BNL_SOURCE_FILE_ARCHIVE_TOKEN` on the server (or ensure `BNL_DOSSIER_INGEST_TOKEN` is present for fallback), deploy updated code, restart the bot service, and monitor logs for `source_file_archive_send_*` and `dossier_recommendation_send_*` entries to verify archive ingestion and recommendation behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a262a407ec8832180415ee57c62760f)