### PR TITLE
Treat fresh source refresh cooldown as current (not failed)

### DIFF
--- a/bnl_source_file_refresh.py
+++ b/bnl_source_file_refresh.py
@@ -336,7 +336,7 @@ def _site_refresh_mode(request: dict[str, Any]) -> str:
     source = str(request.get("source") or "").lower()
     reason = str(request.get("reason") or "").lower()
     high_priority = bool(request.get("highPriority") or request.get("manual") or request.get("force"))
-    if source in {"admin_manual_retry", "admin_source_file_open"} or reason in {"manual_retry", "opened_source_file", "file_not_updated"}:
+    if source in {"admin_manual_retry"} or reason in {"manual_retry", "file_not_updated"}:
         high_priority = True
     return "site_manual_request" if high_priority or "manual" in raw or "button" in raw else "site_open_request"
 
@@ -366,7 +366,7 @@ def _site_refresh_lookup_parts(site_request: dict[str, Any]) -> tuple[str, str]:
 
 def _site_status_for_local_item(item: dict[str, Any]) -> tuple[str, str]:
     status = str(item.get("status") or "").lower()
-    if status == "succeeded":
+    if status in {"succeeded", "current", "already_current"}:
         return "completed", ""
     if status in {"skipped", "cooldown", "deferred", "no_target", "dry_run"}:
         return "skipped", _safe_text(item.get("reason") or item.get("error") or status, 240)
@@ -387,6 +387,36 @@ def _mark_site_request_terminal(request_id: str, item: dict[str, Any], *, enviro
     logging.info("source_refresh_now_site_status_updated request_id=%s status=%s ok=%s", _safe_text(request_id, 120), site_status, bool(result.get("ok")))
     return result
 
+
+def _state_has_current_success(state: dict[str, Any] | sqlite3.Row | None) -> bool:
+    if not state:
+        return False
+    if isinstance(state, sqlite3.Row):
+        status_value = state["last_refresh_status"]
+        completed_value = state["last_refresh_completed_at"]
+        cooldown_value = state["cooldown_until"]
+    else:
+        status_value = state.get("last_refresh_status")
+        completed_value = state.get("last_refresh_completed_at")
+        cooldown_value = state.get("cooldown_until")
+    status = str(status_value or "").lower()
+    completed = parse_iso(completed_value)
+    cooldown_until = parse_iso(cooldown_value)
+    now_dt = datetime.now(timezone.utc).replace(microsecond=0)
+    return status == "succeeded" and completed is not None and cooldown_until is not None and cooldown_until > now_dt
+
+
+def _mark_current_cooldown_terminal(db_path: str, *, guild_id: int | None, subject_key: str, reason: str = "cooldown_current") -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        ensure_source_file_refresh_schema(conn)
+        conn.execute(
+            f"UPDATE {QUEUE_TABLE} SET status='skipped', updated_at=?, last_error=? WHERE (guild_id IS ? OR guild_id=?) AND subject_key=? AND status IN ('queued','deferred','cooldown','failed') AND evidence_source='source_refresh_now'",
+            (utc_now(), reason, guild_id, guild_id, source_refresh_subject_key(subject_key)),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, guild_id: int | None = None, dry_run: bool = False, lookup_func: Callable[[dict[str, str]], dict[str, Any]] = lookup_source_file, sender: Callable[[dict[str, Any]], dict[str, Any]] = send_dossier_recommendation, environ: dict[str, str] | None = None, opener=None) -> dict[str, Any]:
     """Process one immediate website Source File refresh request.
@@ -472,11 +502,24 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
         lookup_func=lookup_func,
         sender=sender,
         environ=env,
-        bypass_cooldown=source in {"admin_source_file_open", "admin_manual_retry"} or reason in {"opened_source_file", "manual_retry", "file_not_updated"},
+        bypass_cooldown=source in {"admin_manual_retry"} or reason in {"manual_retry", "file_not_updated"},
         refresh_mode=mode,
         subject_key=skey,
     )
     item = (local.get("items") or [{}])[0]
+    if str(item.get("status") or "").lower() == "cooldown":
+        state = get_refresh_state(db_path, guild_id, skey)
+        if _state_has_current_success(state):
+            _mark_current_cooldown_terminal(db_path, guild_id=guild_id, subject_key=skey, reason="cooldown_current")
+            item = {
+                **item,
+                "status": "current",
+                "reason": "cooldown_current",
+                "recommendationId": _safe_text(state.get("last_recommendation_id") or "", 120),
+                "recommendationSent": bool(state.get("last_recommendation_id")),
+            }
+            local["items"] = [item, *(local.get("items") or [])[1:]]
+            logging.info("source_refresh_now_current request_id=%s subject_key=%s reason=cooldown_current", request_id or "none", skey or "none")
     site_status, terminal_reason = _site_status_for_local_item(item)
     if request_id:
         _mark_site_request_terminal(request_id, item, environ=env, opener=opener)

--- a/tests/test_source_file_refresh.py
+++ b/tests/test_source_file_refresh.py
@@ -429,7 +429,7 @@ class SourceFileRefreshTests(unittest.TestCase):
     def test_refresh_now_valid_request_processes_immediately_and_completes(self):
         opener = FakeOpener({"ok": True, "requests": []})
         lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
-        with mock.patch.object(refresh, "run_source_file_enrichment", return_value={"sent": True, "sendResult": {"recommendationId": "rec_now"}, "sourceCounts": {"conversations": 1}, "sourceTypes": ["conversations"], "subject": "Signal Fox", "qualityScore": 88}) as mocked:
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value={"sent": True, "recommendationSent": True, "archiveSent": True, "sendResult": {"recommendationId": "rec_now", "ok": True}, "archiveResult": {"archiveId": "arc_now", "ok": True, "status": 200}, "sourceCounts": {"conversations": 1}, "sourceTypes": ["conversations"], "subject": "Signal Fox", "qualityScore": 88}) as mocked:
             result = refresh.process_source_file_refresh_now(
                 self.db,
                 {"requestId": "req_now", "candidateId": "cand_1", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "opened_source_file", "source": "admin_source_file_open"},
@@ -440,6 +440,8 @@ class SourceFileRefreshTests(unittest.TestCase):
             )
         self.assertEqual(result["status"], "success")
         self.assertEqual(result["recommendationId"], "rec_now")
+        self.assertTrue(result["archiveSent"])
+        self.assertEqual(result["archiveId"], "arc_now")
         self.assertEqual(mocked.call_count, 1)
         self.assertEqual([p["status"] for p in opener.posts], ["claimed", "completed"])
         self.assertEqual(opener.posts[-1]["completedByRecommendationId"], "rec_now")
@@ -460,6 +462,43 @@ class SourceFileRefreshTests(unittest.TestCase):
         self.assertEqual([p["status"] for p in opener.posts], ["claimed", "failed"])
         self.assertIn("site rejected", opener.posts[-1]["failureReason"])
 
+    def test_refresh_now_archive_failure_still_reports_failure(self):
+        opener = FakeOpener({"ok": True, "requests": []})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value={"sent": False, "recommendationSent": True, "archiveSent": False, "sendResult": {"recommendationId": "rec_partial", "ok": True}, "archiveResult": {"ok": False, "error": "archive rejected", "status": 500}, "archiveError": "archive rejected", "status": "archive_send_failed"}):
+            result = refresh.process_source_file_refresh_now(
+                self.db,
+                {"requestId": "req_archive", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "manual_retry", "source": "admin_manual_retry"},
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+        self.assertEqual(result["status"], "failed")
+        self.assertFalse(result["archiveSent"])
+        self.assertIn("archive rejected", result["archiveError"])
+        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "failed"])
+        self.assertIn("archive rejected", opener.posts[-1]["failureReason"])
+
+    def test_refresh_now_compact_recommendation_failure_still_reports_failure(self):
+        opener = FakeOpener({"ok": True, "requests": []})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value={"sent": False, "recommendationSent": False, "archiveSent": True, "sendResult": {"ok": False, "error": "compact rejected"}, "archiveResult": {"ok": True, "archiveId": "arc_partial", "status": 200}, "status": "recommendation_send_failed"}):
+            result = refresh.process_source_file_refresh_now(
+                self.db,
+                {"requestId": "req_compact", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "manual_retry", "source": "admin_manual_retry"},
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+        self.assertEqual(result["status"], "failed")
+        self.assertTrue(result["archiveSent"])
+        self.assertEqual(result["archiveId"], "arc_partial")
+        self.assertIn("compact rejected", result["failureReason"])
+        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "failed"])
+        self.assertIn("compact rejected", opener.posts[-1]["failureReason"])
+
     def test_refresh_now_no_target_does_not_stay_claimed(self):
         opener = FakeOpener({"ok": True, "requests": []})
         lookup = lambda query: {"ok": True, "found": False}
@@ -479,19 +518,54 @@ class SourceFileRefreshTests(unittest.TestCase):
         self.assertEqual(opener.posts[-1]["failureReason"], "no_target")
         self.assertEqual(self.rows(), [])
 
-    def test_refresh_now_cooldown_bypassed_for_admin_open(self):
+    def test_refresh_now_fresh_cooldown_is_current_not_failed_for_admin_open(self):
+        opener = FakeOpener({"ok": True, "requests": []})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value={"sent": True, "recommendationSent": True, "archiveSent": True, "sendResult": {"recommendationId": "rec_first", "ok": True}, "archiveResult": {"archiveId": "arc_first", "ok": True, "status": 200}, "sourceCounts": {"conversations": 1}, "sourceTypes": ["conversations"], "subject": "Signal Fox", "qualityScore": 88}) as mocked:
+            first = refresh.process_source_file_refresh_now(
+                self.db,
+                {"requestId": "req_first", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "opened_source_file", "source": "admin_source_file_open"},
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+            with mock.patch.object(refresh.logging, "warning") as warning_mock:
+                second = refresh.process_source_file_refresh_now(
+                    self.db,
+                    {"requestId": "req_second", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "opened_source_file", "source": "admin_source_file_open"},
+                    guild_id=1,
+                    environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                    opener=opener,
+                    lookup_func=lookup,
+                )
+        self.assertEqual(first["status"], "success")
+        self.assertEqual(first["recommendationId"], "rec_first")
+        self.assertTrue(first["archiveSent"])
+        self.assertEqual(first["archiveId"], "arc_first")
+        self.assertEqual(second["status"], "success")
+        self.assertEqual(second["failureReason"], "")
+        self.assertEqual(second["local"]["items"][0]["reason"], "cooldown_current")
+        self.assertEqual(second["recommendationId"], "rec_first")
+        self.assertEqual(mocked.call_count, 1)
+        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "completed", "claimed", "completed"])
+        warning_text = " ".join(str(call) for call in warning_mock.call_args_list)
+        self.assertNotIn("source_refresh_now_failed", warning_text)
+        self.assertEqual(self.rows(), [])
+
+    def test_refresh_now_cooldown_after_failure_is_not_reported_current(self):
         conn = sqlite3.connect(self.db)
         try:
             refresh.ensure_source_file_refresh_schema(conn)
             conn.execute(
-                f"INSERT OR REPLACE INTO {refresh.STATE_TABLE} (guild_id, subject_key, subject_name, cooldown_until, updated_at) VALUES (1, 'signal-fox', 'Signal Fox', '2999-01-01T00:00:00+00:00', 'now')"
+                f"INSERT OR REPLACE INTO {refresh.STATE_TABLE} (guild_id, subject_key, subject_name, last_refresh_status, last_failure_at, last_error, cooldown_until, updated_at) VALUES (1, 'signal-fox', 'Signal Fox', 'failed', 'now', 'site rejected', '2999-01-01T00:00:00+00:00', 'now')"
             )
             conn.commit()
         finally:
             conn.close()
         opener = FakeOpener({"ok": True, "requests": []})
         lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
-        with mock.patch.object(refresh, "run_source_file_enrichment", return_value={"sent": True, "sendResult": {"recommendationId": "rec_fresh"}, "sourceCounts": {"conversations": 1}, "sourceTypes": ["conversations"], "subject": "Signal Fox", "qualityScore": 88}):
+        with mock.patch.object(refresh, "run_source_file_enrichment") as mocked:
             result = refresh.process_source_file_refresh_now(
                 self.db,
                 {"requestId": "req_now", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "opened_source_file", "source": "admin_source_file_open"},
@@ -500,8 +574,11 @@ class SourceFileRefreshTests(unittest.TestCase):
                 opener=opener,
                 lookup_func=lookup,
             )
-        self.assertEqual(result["status"], "success")
-        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "completed"])
+        mocked.assert_not_called()
+        self.assertEqual(result["status"], "skipped")
+        self.assertEqual(result["failureReason"], "cooldown")
+        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "skipped"])
+        self.assertEqual(opener.posts[-1]["failureReason"], "cooldown")
 
     def test_site_polling_cooldown_does_not_leave_request_claimed(self):
         conn = sqlite3.connect(self.db)


### PR DESCRIPTION
### Motivation
- Immediate admin-triggered refreshes (`/internal/source-files/refresh-now`) can hit a local cooldown right after a successful refresh and were reported as failed/skipped, making a fresh Source File look like a failure.
- For admin open / operator retries we want to treat a cooldown that follows a recent successful refresh as “already current” rather than a failure while preserving true failure reporting and cooldown behavior.

### Description
- Update site-status mapping so local outcomes `current` / `already_current` count as a completed site `completed` result (non-failure). (modified `bnl_source_file_refresh.py`)
- Detect the case where `process_source_file_refresh_now` receives a queued item that was deferred to `cooldown` and the refresh state shows a recent successful completion; convert that local cooldown row into a terminal non-failure `current` result and populate a safe reason `cooldown_current` and the last `recommendationId`. (added `_state_has_current_success` and `_mark_current_cooldown_terminal`, and new logic in `process_source_file_refresh_now`) 
- Preserve explicit manual-retry bypass semantics for true manual retries while tightening which site sources/ reasons bypass cooldown; do not disable cooldown globally. (adjusted immediate-request bypass set)
- Add unit tests covering: fresh successful immediate refresh (archive + recommendation), immediate reopen during fresh cooldown being treated as current (no `source_refresh_now_failed`), cooldown after a prior failure remains a cooldown/failure, archive failure and compact recommendation failure still surface as failures. (modified `tests/test_source_file_refresh.py`)
- Files changed: `bnl_source_file_refresh.py`, `tests/test_source_file_refresh.py` (test additions/updates); no changes to dossier recommendation payload structure, archive envelope payloads, queue/payment/public publishing/identity behavior, or `bnl_source_file_enrichment.py` logic.

### Testing
- Ran unit tests: `python -m unittest tests.test_source_file_refresh -v` (OK), `python -m unittest tests.test_source_file_archive -v` (OK), and `python -m unittest discover -s tests -v` (OK); all affected tests passed.
- Verified byte-compile: `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_source_file_refresh.py bnl_dossier_source_packets.py bnl_entity_intelligence.py bnl_source_file_enrichment.py` (OK).
- Quick summary of executed commands: `python -m unittest tests.test_source_file_refresh -v`, `python -m unittest tests.test_source_file_archive -v`, `python -m unittest discover -s tests -v`, `python -m py_compile ...` and all completed successfully.
- VPS deployment steps: SSH to VPS, update checkout with this change, verify env vars `BNL_SOURCE_FILE_REFRESH_TOKEN`, `BNL_SOURCE_FILE_READ_TOKEN`, `BNL_WEBSITE_BASE_URL`, and dossier/archive tokens, run the same unit tests and `py_compile` commands, then restart the bot service and verify reopening a recently refreshed Source File logs `source_refresh_now_current` / `source_refresh_now_completed` (not `source_refresh_now_failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2631892dd883218dc63b714f35d1dd)