### PR TITLE
Fix refresh-now cooldown queue trap

### DIFF
--- a/bnl_source_file_refresh.py
+++ b/bnl_source_file_refresh.py
@@ -483,6 +483,7 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
         logging.warning("source_refresh_now_failed request_id=%s reason=%s", request_id or "none", failure)
         return summary
 
+    immediate_not_before = utc_now()
     enqueue_source_file_refresh(
         db_path,
         guild_id=guild_id,
@@ -492,6 +493,7 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
         priority=100,
         refresh_mode=mode,
         created_by=source or "source_refresh_now",
+        not_before_at=immediate_not_before,
         evidence_count=1,
     )
     local = process_source_file_refresh_queue(
@@ -507,6 +509,22 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
         subject_key=skey,
     )
     item = (local.get("items") or [{}])[0]
+    if not item:
+        state = get_refresh_state(db_path, guild_id, skey)
+        if _state_has_current_success(state):
+            _mark_current_cooldown_terminal(db_path, guild_id=guild_id, subject_key=skey, reason="cooldown_current_no_item")
+            item = {
+                "subject": subject or lookup_value,
+                "status": "current",
+                "reason": "cooldown_current_no_item",
+                "recommendationId": _safe_text(state.get("last_recommendation_id") or "", 120),
+                "recommendationSent": bool(state.get("last_recommendation_id")),
+            }
+            local["items"] = [item]
+            logging.info("source_refresh_now_current request_id=%s subject_key=%s reason=cooldown_current_no_item", request_id or "none", skey or "none")
+        else:
+            item = {"subject": subject or lookup_value, "status": "failed", "error": "refresh_not_processed"}
+            local["items"] = [item]
     if str(item.get("status") or "").lower() == "cooldown":
         state = get_refresh_state(db_path, guild_id, skey)
         if _state_has_current_success(state):

--- a/tests/test_source_file_refresh.py
+++ b/tests/test_source_file_refresh.py
@@ -605,6 +605,91 @@ class SourceFileRefreshTests(unittest.TestCase):
         self.assertEqual([p["status"] for p in opener.posts], ["claimed", "skipped"])
         self.assertEqual(opener.posts[-1]["failureReason"], "cooldown_deferred")
 
+
+    def test_refresh_now_existing_future_not_before_recent_success_returns_current(self):
+        conn = sqlite3.connect(self.db)
+        try:
+            refresh.ensure_source_file_refresh_schema(conn)
+            conn.execute(
+                f"INSERT INTO {refresh.QUEUE_TABLE} (guild_id, subject_key, subject_name, reason, evidence_source, evidence_count, priority, status, queued_at, updated_at, not_before_at, attempts, refresh_mode, created_by) VALUES (1, 'signal-fox', 'Signal Fox', 'old cooldown', 'source_refresh_now', 1, 10, 'cooldown', 'now', 'now', '2999-01-01T00:00:00+00:00', 0, 'site_open_request', 'test')"
+            )
+            conn.execute(
+                f"INSERT OR REPLACE INTO {refresh.STATE_TABLE} (guild_id, subject_key, subject_name, last_refresh_completed_at, last_refresh_status, last_recommendation_id, cooldown_until, updated_at) VALUES (1, 'signal-fox', 'Signal Fox', '2026-01-01T00:00:00+00:00', 'succeeded', 'rec_recent', '2999-01-01T00:00:00+00:00', 'now')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        opener = FakeOpener({"ok": True, "requests": []})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
+        with mock.patch.object(refresh, "run_source_file_enrichment") as mocked, mock.patch.object(refresh.logging, "warning") as warning_mock:
+            result = refresh.process_source_file_refresh_now(
+                self.db,
+                {"requestId": "req_recent", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "opened_source_file", "source": "admin_source_file_open"},
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+        mocked.assert_not_called()
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["recommendationId"], "rec_recent")
+        self.assertEqual(result["local"]["items"][0]["reason"], "cooldown_current")
+        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "completed"])
+        warning_text = " ".join(str(call) for call in warning_mock.call_args_list)
+        self.assertNotIn("source_refresh_now_failed", warning_text)
+
+    def test_refresh_now_existing_future_not_before_without_recent_success_attempts_or_fails_truthfully(self):
+        conn = sqlite3.connect(self.db)
+        try:
+            refresh.ensure_source_file_refresh_schema(conn)
+            conn.execute(
+                f"INSERT INTO {refresh.QUEUE_TABLE} (guild_id, subject_key, subject_name, reason, evidence_source, evidence_count, priority, status, queued_at, updated_at, not_before_at, attempts, refresh_mode, created_by) VALUES (1, 'signal-fox', 'Signal Fox', 'old cooldown', 'source_refresh_now', 1, 10, 'cooldown', 'now', 'now', '2999-01-01T00:00:00+00:00', 0, 'site_open_request', 'test')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        opener = FakeOpener({"ok": True, "requests": []})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value={"sent": False, "sendResult": {"error": "compact rejected"}, "status": "recommendation_send_failed"}) as mocked:
+            result = refresh.process_source_file_refresh_now(
+                self.db,
+                {"requestId": "req_fail", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "opened_source_file", "source": "admin_source_file_open"},
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+        self.assertEqual(mocked.call_count, 1)
+        self.assertEqual(result["status"], "failed")
+        self.assertIn("compact rejected", result["failureReason"])
+        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "failed"])
+
+    def test_refresh_now_manual_retry_existing_future_not_before_bypasses_and_attempts(self):
+        conn = sqlite3.connect(self.db)
+        try:
+            refresh.ensure_source_file_refresh_schema(conn)
+            conn.execute(
+                f"INSERT INTO {refresh.QUEUE_TABLE} (guild_id, subject_key, subject_name, reason, evidence_source, evidence_count, priority, status, queued_at, updated_at, not_before_at, attempts, refresh_mode, created_by) VALUES (1, 'signal-fox', 'Signal Fox', 'old cooldown', 'source_refresh_now', 1, 10, 'cooldown', 'now', 'now', '2999-01-01T00:00:00+00:00', 0, 'site_open_request', 'test')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        opener = FakeOpener({"ok": True, "requests": []})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value={"sent": True, "recommendationSent": True, "archiveSent": True, "sendResult": {"recommendationId": "rec_retry", "ok": True}, "archiveResult": {"archiveId": "arc_retry", "ok": True, "status": 200}, "sourceCounts": {"conversations": 1}, "subject": "Signal Fox"}) as mocked:
+            result = refresh.process_source_file_refresh_now(
+                self.db,
+                {"requestId": "req_retry", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "manual_retry", "source": "admin_manual_retry"},
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+        self.assertEqual(mocked.call_count, 1)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["recommendationId"], "rec_retry")
+        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "completed"])
+
     def test_refresh_now_dry_run_behavior_unchanged(self):
         opener = FakeOpener({"ok": True, "requests": []})
         with mock.patch.object(refresh, "run_source_file_enrichment") as mocked:


### PR DESCRIPTION
### Motivation

- Immediate admin `refresh-now` requests were being trapped by existing local queue rows that contained future `not_before_at` cooldowns, causing `process_source_file_refresh_now` to treat the empty local result as a send failure instead of returning current/completed or attempting a truthful retry.
- The goal is to ensure admin-open and manual-retry flows bypass or safely handle local queue cooldown state without disabling cooldowns or hiding real failures.

### Description

- Force immediate `refresh-now` enqueue rows to be eligible by stamping `not_before_at` with the current refresh-now timestamp so the immediate row will be considered by the local worker (`bnl_source_file_refresh.py`).
- Handle empty immediate-queue results by checking `get_refresh_state`; if the state shows a recent successful refresh inside cooldown, convert the request to `current`/completed and avoid logging `source_refresh_now_failed`; otherwise return a truthful `refresh_not_processed` failure instead of masking as `send_failed` (`bnl_source_file_refresh.py`).
- Preserve existing behavior that converts a `cooldown` item with a recent successful state into a `current` result carrying the last recommendation id.
- Added regression tests covering: an existing future `not_before_at` row with recent successful state returning current/completed, the same scenario without recent success attempting a real refresh or failing truthfully, and manual-retry bypass behavior (`tests/test_source_file_refresh.py`).
- Files changed: `bnl_source_file_refresh.py`, `tests/test_source_file_refresh.py`.

### Testing

- Ran unit suites: `python -m unittest tests.test_source_file_refresh -v`, `python -m unittest tests.test_source_file_archive -v`, and full discovery `python -m unittest discover -s tests -v`, and they all passed (OK).
- Ensured syntax by running `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_source_file_refresh.py bnl_dossier_source_packets.py bnl_entity_intelligence.py bnl_source_file_enrichment.py` with no errors.
- VPS deployment steps: run the same tests and compile checks on the VPS, then restart the bot service after tests pass, and verify live behavior by opening a Source File once (allow normal refresh), opening it immediately again (should show current/completed), and performing manual retry from FILE NOT UPDATED to validate real retry/failure behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a263991af288321b156dfcfda0b608d)