### PR TITLE
Add internal read-only BNL memory snapshot endpoint

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -92,6 +92,12 @@ from bnl_source_file_enrichment import (
     run_source_file_enrichment,
     source_enrichment_ingest_source,
 )
+from bnl_memory_snapshot import (
+    DEFAULT_LIMIT as MEMORY_SNAPSHOT_DEFAULT_LIMIT,
+    build_bnl_memory_snapshot,
+    clamp_limit as clamp_memory_snapshot_limit,
+    parse_bool as parse_memory_snapshot_bool,
+)
 from bnl_source_file_refresh import (
     DEFAULT_MAX_AUTOMATIC_PER_CYCLE,
     DEFAULT_MAX_SITE_REQUESTS_PER_CYCLE,
@@ -189,6 +195,8 @@ _last_generation_status = {
 }
 
 BNL_FORCE_PULL_SHARED_SECRET = os.getenv("BNL_FORCE_PULL_SHARED_SECRET", "").strip()
+BNL_MEMORY_SNAPSHOT_TOKEN_HEADER = "x-bnl-memory-snapshot-token"
+BNL_MEMORY_SNAPSHOT_PATH = "/internal/bnl/memory-snapshot"
 BNL_FORCE_PULL_PORT = int(os.getenv("BNL_FORCE_PULL_PORT", "8787") or 8787)
 BNL_OWNER_USER_ID = int(os.getenv("BNL_OWNER_USER_ID", "0") or 0)
 BNL_MOD_ROLE_ID = int(os.getenv("BNL_MOD_ROLE_ID", "0") or 0)
@@ -3511,6 +3519,71 @@ async def _handle_source_file_refresh_now(request: web.Request) -> web.Response:
     http_status = 200 if status in {"success", "skipped", "dry_run"} else 500
     return web.json_response(result, status=http_status)
 
+
+def _memory_snapshot_configured_token() -> str:
+    return (os.getenv("BNL_MEMORY_SNAPSHOT_TOKEN") or "").strip()
+
+
+def is_memory_snapshot_token_valid(provided_token: str | None) -> bool:
+    expected = _memory_snapshot_configured_token()
+    return bool(expected and provided_token and str(provided_token).strip() == expected)
+
+
+def _memory_snapshot_auth_token_from_request(request: web.Request) -> str:
+    header_value = request.headers.get(BNL_MEMORY_SNAPSHOT_TOKEN_HEADER) or request.headers.get(
+        BNL_MEMORY_SNAPSHOT_TOKEN_HEADER.lower()
+    )
+    if header_value:
+        return str(header_value).strip()
+    auth_value = str(request.headers.get("Authorization") or "").strip()
+    if auth_value.lower().startswith("bearer "):
+        return auth_value[7:].strip()
+    return ""
+
+
+async def _handle_bnl_memory_snapshot(request: web.Request) -> web.Response:
+    if not _memory_snapshot_configured_token():
+        logging.warning("memory_snapshot_auth_failed reason=token_not_configured")
+        return web.json_response({"ok": False, "error": "unavailable"}, status=503)
+
+    provided_token = _memory_snapshot_auth_token_from_request(request)
+    if not is_memory_snapshot_token_valid(provided_token):
+        logging.warning("memory_snapshot_auth_failed reason=missing_or_invalid_token")
+        return web.json_response({"ok": False, "error": "unauthorized"}, status=401)
+
+    query = request.rel_url.query
+    limit = clamp_memory_snapshot_limit(query.get("limit", MEMORY_SNAPSHOT_DEFAULT_LIMIT))
+    subject_key = str(query.get("subject_key") or "").strip()[:120] or None
+    include_samples = parse_memory_snapshot_bool(query.get("include_samples"), default=True)
+    include_raw_refs = parse_memory_snapshot_bool(query.get("include_raw_refs"), default=False)
+
+    logging.info(
+        "memory_snapshot_requested subject_key=%s limit=%s include_samples=%s include_raw_refs=%s",
+        subject_key or "none",
+        limit,
+        include_samples,
+        include_raw_refs,
+    )
+    try:
+        snapshot = await asyncio.to_thread(
+            build_bnl_memory_snapshot,
+            DB_FILE,
+            limit=limit,
+            subject_key=subject_key,
+            include_samples=include_samples,
+            include_raw_refs=include_raw_refs,
+        )
+    except FileNotFoundError:
+        logging.warning("memory_snapshot_failed reason=database_missing")
+        return web.json_response({"ok": False, "error": "database_missing"}, status=404)
+    except sqlite3.OperationalError as exc:
+        logging.warning("memory_snapshot_failed reason=sqlite_operational_error detail=%s", str(exc)[:120])
+        return web.json_response({"ok": False, "error": "database_unavailable"}, status=503)
+    except Exception as exc:
+        logging.warning("memory_snapshot_failed reason=unexpected detail=%s", str(exc)[:120])
+        return web.json_response({"ok": False, "error": "snapshot_failed"}, status=500)
+    return web.json_response(snapshot, status=200)
+
 async def start_force_pull_listener():
     global force_pull_runner
     if force_pull_runner is not None:
@@ -3518,6 +3591,7 @@ async def start_force_pull_listener():
     app = web.Application()
     app.router.add_post("/force-pull", _handle_force_pull)
     app.router.add_post(SOURCE_REFRESH_NOW_PATH, _handle_source_file_refresh_now)
+    app.router.add_get(BNL_MEMORY_SNAPSHOT_PATH, _handle_bnl_memory_snapshot)
     force_pull_runner = web.AppRunner(app)
     await force_pull_runner.setup()
     site = web.TCPSite(force_pull_runner, host="0.0.0.0", port=BNL_FORCE_PULL_PORT)

--- a/bnl_memory_snapshot.py
+++ b/bnl_memory_snapshot.py
@@ -1,0 +1,366 @@
+"""Read-only sanitized BNL memory snapshot utilities."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SNAPSHOT_VERSION = 1
+DEFAULT_LIMIT = 25
+MAX_LIMIT = 100
+TEXT_LIMIT = 700
+SAMPLE_TEXT_LIMIT = 500
+
+_LONG_ID_RE = re.compile(r"\b\d{15,22}\b")
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I)
+_URL_RE = re.compile(r"https?://\S+", re.I)
+_MENTION_RE = re.compile(r"<@!?\d+>|<#\d+>|<@&\d+>")
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b([a-z0-9_]*(?:token|secret|api[_-]?key|authorization|password|passwd|credential)[a-z0-9_]*)\s*[:=]\s*([^\s,;\]}\)]+)"
+)
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}")
+_DISCORD_TOKEN_RE = re.compile(r"\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}\b")
+
+SECRET_FIELD_RE = re.compile(r"(?i)(token|secret|api[_-]?key|authorization|password|passwd|credential|raw_note|raw_transcript|payload_body)")
+RAW_REF_FIELD_RE = re.compile(r"(?i)(raw|transcript|message|content|payload|body|authorization|token|secret|api[_-]?key|password)")
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def clamp_limit(value: Any) -> int:
+    try:
+        limit = int(value)
+    except Exception:
+        return DEFAULT_LIMIT
+    return min(MAX_LIMIT, max(1, limit))
+
+
+def parse_bool(value: Any, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def sanitize_database_path(db_path: str) -> str:
+    return Path(db_path).name or "bnl01_conversations.db"
+
+
+def redact_text(value: Any, *, limit: int = TEXT_LIMIT) -> str:
+    text = str(value or "")
+    text = _SECRET_ASSIGNMENT_RE.sub(lambda m: f"{m.group(1)}=[redacted-secret]", text)
+    text = _BEARER_RE.sub("Bearer [redacted-secret]", text)
+    text = _DISCORD_TOKEN_RE.sub("[redacted-secret]", text)
+    text = _MENTION_RE.sub("[redacted-mention]", text)
+    text = _LONG_ID_RE.sub("[redacted-id]", text)
+    text = _EMAIL_RE.sub("[redacted-email]", text)
+    text = _URL_RE.sub("[redacted-url]", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def redact_identifier(value: Any) -> str:
+    raw = str(value or "")
+    if not raw:
+        return ""
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8", "ignore")).hexdigest()[:16]
+
+
+def sanitize_value(key: str, value: Any, *, text_limit: int = TEXT_LIMIT, include_raw_refs: bool = False) -> Any:
+    if value is None:
+        return None
+    if SECRET_FIELD_RE.search(key or "") and key not in {"raw_ref_json"}:
+        return "[redacted]"
+    if key == "matched_user_id":
+        return redact_identifier(value)
+    if key == "raw_ref_json":
+        if not include_raw_refs:
+            return None
+        return compact_raw_ref_json(value, limit=350)
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, bytes):
+        return "[redacted-bytes]"
+    return redact_text(value, limit=text_limit)
+
+
+
+def compact_raw_ref_json(value: Any, *, limit: int = 350) -> Any:
+    parsed = value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            return redact_text(value, limit=limit)
+    return sanitize_raw_ref_json(parsed, limit=limit)
+
+
+def sanitize_raw_ref_json(value: Any, *, limit: int = 350, depth: int = 0) -> Any:
+    if depth > 3:
+        return "[truncated-depth]"
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for idx, (k, v) in enumerate(value.items()):
+            if idx >= 20:
+                out["_truncatedKeys"] = True
+                break
+            key = str(k)
+            if RAW_REF_FIELD_RE.search(key):
+                out[key] = "[redacted-raw-ref]"
+            else:
+                out[key] = sanitize_raw_ref_json(v, limit=limit, depth=depth + 1)
+        return out
+    if isinstance(value, list):
+        out = [sanitize_raw_ref_json(v, limit=limit, depth=depth + 1) for v in value[:10]]
+        if len(value) > 10:
+            out.append("[truncated-list]")
+        return out
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    return redact_text(value, limit=limit)
+
+def compact_json(value: Any, *, limit: int = TEXT_LIMIT) -> Any:
+    parsed = value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            return redact_text(value, limit=limit)
+    return sanitize_json(parsed, limit=limit)
+
+
+def sanitize_json(value: Any, *, limit: int = TEXT_LIMIT, depth: int = 0) -> Any:
+    if depth > 4:
+        return "[truncated-depth]"
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for idx, (k, v) in enumerate(value.items()):
+            if idx >= 40:
+                out["_truncatedKeys"] = True
+                break
+            key = str(k)
+            if SECRET_FIELD_RE.search(key):
+                out[key] = "[redacted]"
+            else:
+                out[key] = sanitize_json(v, limit=limit, depth=depth + 1)
+        return out
+    if isinstance(value, list):
+        out = [sanitize_json(v, limit=limit, depth=depth + 1) for v in value[:25]]
+        if len(value) > 25:
+            out.append("[truncated-list]")
+        return out
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    return redact_text(value, limit=limit)
+
+
+def table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)).fetchone() is not None
+
+
+def table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    if not table_exists(conn, table):
+        return set()
+    return {str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table}")')}
+
+
+def table_counts(conn: sqlite3.Connection) -> dict[str, int]:
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name").fetchall()
+    counts: dict[str, int] = {}
+    for row in rows:
+        name = str(row[0])
+        try:
+            counts[name] = int(conn.execute(f'SELECT COUNT(*) FROM "{name}"').fetchone()[0])
+        except Exception:
+            counts[name] = -1
+    return counts
+
+
+def _order_column(cols: set[str]) -> str | None:
+    for col in ("updated_at", "created_at", "observed_at", "last_seen_at", "timestamp", "queued_at", "id"):
+        if col in cols:
+            return col
+    return None
+
+
+def fetch_rows(conn: sqlite3.Connection, table: str, wanted: list[str], *, limit: int, subject_key: str | None = None, include_raw_refs: bool = False, text_limit: int = TEXT_LIMIT, where_extra: str = "", params_extra: tuple[Any, ...] = ()) -> list[dict[str, Any]]:
+    cols = table_columns(conn, table)
+    if not cols:
+        return []
+    select = [c for c in wanted if c in cols]
+    if not select:
+        return []
+    where_parts: list[str] = []
+    params: list[Any] = []
+    if subject_key and "subject_key" in cols:
+        where_parts.append("subject_key = ?")
+        params.append(subject_key)
+    if where_extra:
+        where_parts.append(where_extra)
+        params.extend(params_extra)
+    where = " WHERE " + " AND ".join(where_parts) if where_parts else ""
+    order_col = _order_column(cols)
+    order = f' ORDER BY "{order_col}" DESC' if order_col else ""
+    sql = f'SELECT {", ".join([f"\"{c}\"" for c in select])} FROM "{table}"{where}{order} LIMIT ?'
+    rows = conn.execute(sql, (*params, limit)).fetchall()
+    result: list[dict[str, Any]] = []
+    for row in rows:
+        item: dict[str, Any] = {}
+        for key in select:
+            val = row[key]
+            if key in {"source_lanes", "approved_channel_labels", "active_windows", "evidence_snippets", "connection_notes"}:
+                item[key] = compact_json(val, limit=180)
+            else:
+                sanitized = sanitize_value(key, val, text_limit=text_limit, include_raw_refs=include_raw_refs)
+                if sanitized is not None:
+                    item[key] = sanitized
+        result.append(item)
+    return result
+
+
+def _profile_snapshots(conn: sqlite3.Connection, *, limit: int, subject_key: str | None) -> list[dict[str, Any]]:
+    rows = fetch_rows(
+        conn,
+        "entity_profile_snapshots",
+        ["guild_id", "subject_key", "subject_name", "display_name", "summary_json", "source_hash", "created_at", "updated_at"],
+        limit=limit,
+        subject_key=subject_key,
+        text_limit=TEXT_LIMIT,
+    )
+    for row in rows:
+        if "summary_json" in row:
+            summary = compact_json(row["summary_json"], limit=TEXT_LIMIT)
+            row["summary_json"] = summary
+            if isinstance(summary, dict):
+                for key in ("action_items", "actionItems", "open_questions", "openQuestions", "reviewOnly", "publicSafe", "public_safe"):
+                    if key in summary:
+                        row[key] = summary[key]
+    return rows
+
+
+def _memory_risk_summary(conn: sqlite3.Connection) -> dict[str, Any]:
+    summary: dict[str, Any] = {"memoryTierRows": 0, "conversationRows": 0, "groups": []}
+    if table_exists(conn, "memory_tiers"):
+        cols = table_columns(conn, "memory_tiers")
+        dims = [c for c in ("source_role", "source_channel_policy", "source_origin", "source_trust", "tier", "source_channel_name") if c in cols]
+        summary["memoryTierRows"] = table_counts(conn).get("memory_tiers", 0)
+        if dims:
+            sql = f'SELECT {", ".join([f"\"{c}\"" for c in dims])}, COUNT(*) AS count FROM memory_tiers GROUP BY {", ".join([f"\"{c}\"" for c in dims])} ORDER BY count DESC LIMIT 100'
+            summary["groups"] = [dict(row) for row in conn.execute(sql).fetchall()]
+    if table_exists(conn, "conversations"):
+        summary["conversationRows"] = int(conn.execute('SELECT COUNT(*) FROM "conversations"').fetchone()[0])
+        cols = table_columns(conn, "conversations")
+        dims = [c for c in ("role", "channel_policy", "channel_name") if c in cols]
+        if dims:
+            sql = f'SELECT {", ".join([f"\"{c}\"" for c in dims])}, COUNT(*) AS count FROM conversations GROUP BY {", ".join([f"\"{c}\"" for c in dims])} ORDER BY count DESC LIMIT 100'
+            summary["conversationGroups"] = [dict(row) for row in conn.execute(sql).fetchall()]
+    return sanitize_json(summary, limit=220)
+
+
+def _memory_samples(conn: sqlite3.Connection, *, limit: int, include_samples: bool) -> list[dict[str, Any]]:
+    if not include_samples or not table_exists(conn, "conversations"):
+        return []
+    return fetch_rows(
+        conn,
+        "conversations",
+        ["user_name", "role", "content", "channel_policy", "channel_name", "timestamp"],
+        limit=limit,
+        text_limit=SAMPLE_TEXT_LIMIT,
+    )
+
+
+def _ambient_log(conn: sqlite3.Connection, *, limit: int, include_samples: bool) -> dict[str, Any]:
+    result: dict[str, Any] = {"note": "ambient/context only; not dossier truth", "counts": {}, "samples": []}
+    if not table_exists(conn, "ambient_log"):
+        return result
+    cols = table_columns(conn, "ambient_log")
+    result["counts"]["total"] = int(conn.execute('SELECT COUNT(*) FROM "ambient_log"').fetchone()[0])
+    if "source_type" in cols:
+        result["counts"]["bySourceType"] = [dict(row) for row in conn.execute('SELECT source_type, COUNT(*) AS count FROM "ambient_log" GROUP BY source_type ORDER BY count DESC').fetchall()]
+    if include_samples:
+        result["samples"] = fetch_rows(conn, "ambient_log", ["guild_id", "channel_id", "message", "source_type", "posted_at", "timestamp"], limit=limit, text_limit=300)
+    return sanitize_json(result, limit=300)
+
+
+def _warnings(conn: sqlite3.Connection) -> list[str]:
+    warnings: list[str] = []
+    if table_exists(conn, "entity_evidence_events"):
+        cols = table_columns(conn, "entity_evidence_events")
+        if "authority" in cols:
+            vals = [str(r[0] or "") for r in conn.execute('SELECT DISTINCT authority FROM "entity_evidence_events"')]
+            if any(v in {"source_blind_memory", "source_blind_legacy_memory"} for v in vals):
+                warnings.append("source_blind_memory present in entity evidence")
+            if any("private" in v or "review" in v for v in vals):
+                warnings.append("entity evidence includes review-only/private authority")
+        if "review_only" in cols:
+            count = conn.execute('SELECT COUNT(*) FROM "entity_evidence_events" WHERE review_only IN (1, "1", "true", "TRUE")').fetchone()[0]
+            if int(count):
+                warnings.append("entity evidence includes review_only rows")
+    if table_exists(conn, "memory_tiers") and "source_trust" in table_columns(conn, "memory_tiers"):
+        count = conn.execute('SELECT COUNT(*) FROM "memory_tiers" WHERE source_trust IN ("mixed_or_legacy_consolidated", "legacy_unknown", "source_blind_memory", "source_blind_legacy_memory")').fetchone()[0]
+        if int(count):
+            warnings.append("memory tiers include mixed_or_legacy_consolidated/source-blind/legacy source_trust")
+    if table_exists(conn, "source_file_refresh_state"):
+        cols = table_columns(conn, "source_file_refresh_state")
+        if {"last_refresh_status", "last_error"}.issubset(cols):
+            failures = conn.execute('SELECT COUNT(*) FROM "source_file_refresh_state" WHERE last_refresh_status IN ("failed", "error") OR COALESCE(last_error, "") != ""').fetchone()[0]
+            if int(failures):
+                warnings.append("source_file_refresh_state has failures")
+            oversized = conn.execute('SELECT COUNT(*) FROM "source_file_refresh_state" WHERE LOWER(COALESCE(last_error, "")) LIKE "%text field is too long%" OR LOWER(COALESCE(last_error, "")) LIKE "%too long%"').fetchone()[0]
+            if int(oversized):
+                warnings.append("oversized compact payload failure appears in refresh state")
+    if table_exists(conn, "source_file_refresh_queue"):
+        cols = table_columns(conn, "source_file_refresh_queue")
+        if "attempts" in cols:
+            high = conn.execute('SELECT COUNT(*) FROM "source_file_refresh_queue" WHERE attempts >= 3').fetchone()[0]
+            if int(high):
+                warnings.append("source_file_refresh_queue has high attempt counts")
+        if "last_error" in cols:
+            oversized = conn.execute('SELECT COUNT(*) FROM "source_file_refresh_queue" WHERE LOWER(COALESCE(last_error, "")) LIKE "%text field is too long%" OR LOWER(COALESCE(last_error, "")) LIKE "%too long%"').fetchone()[0]
+            if int(oversized):
+                warnings.append("oversized compact payload failure appears in refresh queue")
+    return warnings
+
+
+def build_bnl_memory_snapshot(db_path: str, *, limit: int = DEFAULT_LIMIT, subject_key: str | None = None, include_samples: bool = True, include_raw_refs: bool = False) -> dict[str, Any]:
+    """Build a read-only sanitized JSON-serializable snapshot from the existing SQLite DB."""
+    bounded_limit = clamp_limit(limit)
+    uri = f"file:{os.path.abspath(db_path)}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        counts = table_counts(conn)
+        sections = {
+            "communityPresence": fetch_rows(conn, "community_presence", ["guild_id", "subject_key", "display_name", "first_seen_at", "last_seen_at", "source_lanes", "approved_channel_labels", "mention_count", "direct_interaction_count", "operator_mention_count", "active_windows", "category", "last_error_status", "evidence_snippets"], limit=bounded_limit, subject_key=subject_key, text_limit=300),
+            "entityProfileSnapshots": _profile_snapshots(conn, limit=bounded_limit, subject_key=subject_key),
+            "entityEvidenceEvents": fetch_rows(conn, "entity_evidence_events", ["subject_key", "subject_name", "matched_user_id", "source_type", "source_table", "source_label", "channel_name", "channel_policy", "visibility", "authority", "confidence", "relation_to_subject", "topic", "evidence_kind", "safe_summary", "public_safe_candidate", "review_only", "music_signal", "community_signal", "bnl_interaction", "dossier_relevance", "created_at", "observed_at", "updated_at", "raw_ref_json"], limit=bounded_limit, subject_key=subject_key, include_raw_refs=include_raw_refs, text_limit=500),
+            "entityIntelligenceEdges": fetch_rows(conn, "entity_intelligence_edges", ["subject_key", "object_key", "object_label", "relation_type", "source_type", "source_channel_policy", "visibility", "authority", "confidence", "first_seen_at", "last_seen_at", "evidence_count", "status"], limit=bounded_limit, subject_key=subject_key, text_limit=300),
+            "entityOpenQuestions": fetch_rows(conn, "entity_open_questions", ["subject_key", "question", "reason", "source_type", "visibility", "priority", "status", "created_at", "updated_at"], limit=bounded_limit, subject_key=subject_key, where_extra='status = ?' if table_exists(conn, "entity_open_questions") and "status" in table_columns(conn, "entity_open_questions") else "", params_extra=("open",), text_limit=500),
+            "memoryTierRiskSummary": _memory_risk_summary(conn),
+            "memoryTierSamples": _memory_samples(conn, limit=bounded_limit, include_samples=include_samples),
+            "sourceFileRefreshState": fetch_rows(conn, "source_file_refresh_state", ["subject_key", "subject_name", "last_refresh_started_at", "last_refresh_completed_at", "last_refresh_status", "last_failure_at", "last_error", "last_evidence_count", "cooldown_until", "updated_at"], limit=bounded_limit, subject_key=subject_key, text_limit=350),
+            "sourceFileRefreshQueue": fetch_rows(conn, "source_file_refresh_queue", ["subject_key", "subject_name", "status", "attempts", "reason", "last_error", "queued_at", "updated_at", "not_before_at", "last_attempt_at", "refresh_mode", "created_by"], limit=bounded_limit, subject_key=subject_key, text_limit=350),
+            "broadcastMemory": fetch_rows(conn, "broadcast_memory", ["episode_date", "cleaned_summary", "entry_type", "importance", "public_safe", "affects_next_show", "usage_scope", "status", "created_at", "updated_at"], limit=bounded_limit, text_limit=500),
+            "ambientLog": _ambient_log(conn, limit=bounded_limit, include_samples=include_samples),
+        }
+        return {
+            "snapshotVersion": SNAPSHOT_VERSION,
+            "exportedAt": utc_now_iso(),
+            "databaseName": sanitize_database_path(db_path),
+            "tableCounts": counts,
+            "rowLimits": {"default": bounded_limit, "max": MAX_LIMIT, "text": TEXT_LIMIT, "sampleText": SAMPLE_TEXT_LIMIT},
+            "redactionPolicy": "Secrets, auth material, long Discord IDs, mentions, emails, URLs, raw refs, and transcripts are redacted/truncated; relationship/journal/source-blind material is review-only.",
+            "filters": {"subject_key": subject_key or None, "include_samples": bool(include_samples), "include_raw_refs": bool(include_raw_refs)},
+            "sections": sections,
+            "warnings": _warnings(conn),
+        }
+    finally:
+        conn.close()

--- a/tests/test_memory_snapshot.py
+++ b/tests/test_memory_snapshot.py
@@ -1,0 +1,246 @@
+import asyncio
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from unittest import mock
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+from aiohttp.test_utils import make_mocked_request
+
+import bnl01_bot
+from bnl_memory_snapshot import build_bnl_memory_snapshot
+
+
+class MemorySnapshotTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.db_path = self.tmp.name
+        self.tmp.close()
+        self._create_db()
+
+    def tearDown(self):
+        try:
+            os.unlink(self.db_path)
+        except FileNotFoundError:
+            pass
+
+    def _create_db(self):
+        conn = sqlite3.connect(self.db_path)
+        c = conn.cursor()
+        c.execute("""
+            CREATE TABLE community_presence (
+                guild_id INTEGER, subject_key TEXT, display_name TEXT,
+                first_seen_at TEXT, last_seen_at TEXT, source_lanes TEXT,
+                approved_channel_labels TEXT, mention_count INTEGER,
+                direct_interaction_count INTEGER, operator_mention_count INTEGER,
+                active_windows TEXT, connection_notes TEXT, evidence_snippets TEXT,
+                category TEXT, last_error_status TEXT
+            )
+        """)
+        c.execute("""
+            CREATE TABLE entity_evidence_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER, subject_key TEXT,
+                subject_name TEXT, matched_user_id TEXT, source_type TEXT, source_table TEXT,
+                source_label TEXT, channel_name TEXT, channel_policy TEXT, visibility TEXT,
+                authority TEXT, confidence REAL, relation_to_subject TEXT, topic TEXT,
+                evidence_kind TEXT, safe_summary TEXT, public_safe_candidate INTEGER,
+                review_only INTEGER, music_signal INTEGER, community_signal INTEGER,
+                bnl_interaction INTEGER, dossier_relevance TEXT, raw_ref_json TEXT,
+                created_at TEXT, observed_at TEXT, updated_at TEXT
+            )
+        """)
+        c.execute("""
+            CREATE TABLE memory_tiers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, guild_id INTEGER,
+                tier TEXT, summary TEXT, salience REAL, mentions INTEGER, updated_at TEXT,
+                source_role TEXT, source_channel_policy TEXT, source_channel_name TEXT,
+                source_origin TEXT, source_trust TEXT
+            )
+        """)
+        c.execute("""
+            CREATE TABLE conversations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, user_name TEXT,
+                guild_id INTEGER, channel_name TEXT, channel_policy TEXT, role TEXT,
+                content TEXT, timestamp TEXT
+            )
+        """)
+        c.execute("""
+            CREATE TABLE source_file_refresh_state (
+                guild_id INTEGER, subject_key TEXT, subject_name TEXT,
+                last_refresh_started_at TEXT, last_refresh_completed_at TEXT,
+                last_refresh_status TEXT, last_recommendation_id TEXT,
+                last_evidence_hash TEXT, last_evidence_count INTEGER,
+                last_failure_at TEXT, last_error TEXT, cooldown_until TEXT, updated_at TEXT
+            )
+        """)
+        c.execute("""
+            CREATE TABLE source_file_refresh_queue (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER, subject_key TEXT,
+                subject_name TEXT, reason TEXT, evidence_source TEXT, evidence_count INTEGER,
+                priority INTEGER, status TEXT, queued_at TEXT, updated_at TEXT,
+                not_before_at TEXT, last_attempt_at TEXT, attempts INTEGER,
+                last_error TEXT, refresh_mode TEXT, created_by TEXT
+            )
+        """)
+        c.execute("""
+            CREATE TABLE entity_profile_snapshots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER, subject_key TEXT,
+                subject_name TEXT, summary_json TEXT, source_hash TEXT, created_at TEXT, updated_at TEXT
+            )
+        """)
+        c.execute("""
+            CREATE TABLE entity_intelligence_edges (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER, subject_key TEXT,
+                object_key TEXT, object_label TEXT, relation_type TEXT, source_type TEXT,
+                source_channel_policy TEXT, visibility TEXT, authority TEXT, confidence REAL,
+                first_seen_at TEXT, last_seen_at TEXT, evidence_count INTEGER, status TEXT
+            )
+        """)
+        c.execute("""
+            CREATE TABLE entity_open_questions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER, subject_key TEXT,
+                question TEXT, reason TEXT, source_type TEXT, visibility TEXT, priority INTEGER,
+                status TEXT, created_at TEXT, updated_at TEXT
+            )
+        """)
+        c.execute("""
+            CREATE TABLE broadcast_memory (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER, episode_date TEXT,
+                cleaned_summary TEXT, entry_type TEXT, importance TEXT, public_safe INTEGER,
+                affects_next_show INTEGER, usage_scope TEXT, status TEXT, created_at TEXT, updated_at TEXT
+            )
+        """)
+        c.execute("""
+            CREATE TABLE ambient_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER, channel_id INTEGER,
+                message TEXT, source_type TEXT, posted_at TEXT, timestamp TEXT
+            )
+        """)
+        c.execute(
+            "INSERT INTO community_presence VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (1, "crow", "Crow", "2026-01-01", "2026-01-02", '["community_presence"]', '["public_selective"]', 5, 2, 1, '["window"]', '["private note"]', json.dumps(["Crow public-safe snippet " + "x" * 900]), "community_regular_candidate", "none"),
+        )
+        c.execute(
+            """INSERT INTO entity_evidence_events
+            (guild_id, subject_key, subject_name, matched_user_id, source_type, source_table,
+             source_label, channel_name, channel_policy, visibility, authority, confidence,
+             relation_to_subject, topic, evidence_kind, safe_summary, public_safe_candidate,
+             review_only, music_signal, community_signal, bnl_interaction, dossier_relevance,
+             raw_ref_json, created_at, observed_at, updated_at)
+             VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (1, "crow", "Crow", "123456789012345678", "conversation", "conversations", "structured", "research-and-development", "private_internal", "review_only", "source_blind_memory", 0.7, "authored", "source-file", "summary", "Safe summary with API_KEY=supersecret and <@123456789012345678>", 0, 1, 1, 1, 1, "review", '{"raw":"full transcript DISCORD_TOKEN=abc.def.ghi"}', "2026", "2026", "2026"),
+        )
+        c.execute(
+            "INSERT INTO entity_evidence_events (guild_id, subject_key, subject_name, safe_summary, review_only, created_at) VALUES (?,?,?,?,?,?)",
+            (1, "other", "Other", "Other summary", 0, "2026"),
+        )
+        c.execute(
+            "INSERT INTO memory_tiers (user_id, guild_id, tier, summary, updated_at, source_role, source_channel_policy, source_channel_name, source_origin, source_trust) VALUES (?,?,?,?,?,?,?,?,?,?)",
+            (42, 1, "profile", "remembered summary", "2026", "user", "private_internal", "research-and-development", "legacy", "mixed_or_legacy_consolidated"),
+        )
+        long_secret_text = "hello BNL_MEMORY_SNAPSHOT_TOKEN=do-not-leak 123456789012345678 " + ("x" * 1200)
+        c.execute(
+            "INSERT INTO conversations (user_id, user_name, guild_id, channel_name, channel_policy, role, content, timestamp) VALUES (?,?,?,?,?,?,?,?)",
+            (42, "Crow", 1, "barcode-bot", "public_context", "user", long_secret_text, "2026-01-03"),
+        )
+        c.execute(
+            "INSERT INTO source_file_refresh_state VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (1, "crow", "Crow", "2026", "2026", "failed", "rec", "hash", 2, "2026", "Text field is too long: compact payload", "", "2026"),
+        )
+        c.execute(
+            "INSERT INTO source_file_refresh_queue (guild_id, subject_key, subject_name, reason, evidence_source, evidence_count, priority, status, queued_at, updated_at, attempts, last_error, refresh_mode, created_by) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (1, "crow", "Crow", "audit", "test", 1, 50, "queued", "2026", "2026", 4, "too long", "automatic", "test"),
+        )
+        c.execute("INSERT INTO entity_profile_snapshots (guild_id, subject_key, subject_name, summary_json, source_hash, created_at, updated_at) VALUES (?,?,?,?,?,?,?)", (1, "crow", "Crow", json.dumps({"summary": "ok", "action_items": ["review"], "openQuestions": ["q?"]}), "hash", "2026", "2026"))
+        c.execute("INSERT INTO entity_intelligence_edges (guild_id, subject_key, object_key, object_label, relation_type, source_type, source_channel_policy, visibility, authority, confidence, first_seen_at, last_seen_at, evidence_count, status) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)", (1, "crow", "barcode", "BARCODE", "mentions", "evidence", "public_context", "review_only", "public_context", 0.8, "2026", "2026", 1, "active"))
+        c.execute("INSERT INTO entity_open_questions (guild_id, subject_key, question, reason, source_type, visibility, priority, status, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?)", (1, "crow", "What is safe?", "audit", "evidence", "review_only", 10, "open", "2026", "2026"))
+        c.execute("INSERT INTO broadcast_memory (guild_id, episode_date, cleaned_summary, entry_type, importance, public_safe, affects_next_show, usage_scope, status, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?)", (1, "2026-01-09", "show summary", "show", "medium", 1, 0, "broadcast", "active", "2026", "2026"))
+        c.execute("INSERT INTO ambient_log (guild_id, channel_id, message, source_type, posted_at, timestamp) VALUES (?,?,?,?,?,?)", (1, 99, "ambient note secret=hide", "ambient", "2026", "2026"))
+        conn.commit()
+        conn.close()
+
+    def _table_counts(self):
+        conn = sqlite3.connect(self.db_path)
+        counts = {row[0]: row[1] for row in conn.execute("SELECT name, (SELECT COUNT(*) FROM sqlite_master) FROM sqlite_master WHERE type='table'")}
+        per_table = {}
+        for name in counts:
+            per_table[name] = conn.execute(f'SELECT COUNT(*) FROM "{name}"').fetchone()[0]
+        conn.close()
+        return per_table
+
+    def test_valid_snapshot_contains_counts_sections_and_redacts(self):
+        snapshot = build_bnl_memory_snapshot(self.db_path, limit=25)
+        self.assertEqual(snapshot["snapshotVersion"], 1)
+        self.assertEqual(snapshot["databaseName"], os.path.basename(self.db_path))
+        self.assertGreaterEqual(snapshot["tableCounts"]["community_presence"], 1)
+        self.assertEqual(snapshot["sections"]["communityPresence"][0]["subject_key"], "crow")
+        evidence = snapshot["sections"]["entityEvidenceEvents"][0]
+        self.assertNotIn("raw_ref_json", evidence)
+        self.assertNotIn("supersecret", json.dumps(snapshot))
+        self.assertNotIn("123456789012345678", json.dumps(snapshot))
+        sample_text = snapshot["sections"]["memoryTierSamples"][0]["content"]
+        self.assertLessEqual(len(sample_text), 500)
+        self.assertIn("[redacted-secret]", sample_text)
+        self.assertTrue(snapshot["sections"]["memoryTierRiskSummary"]["groups"])
+        self.assertIn("oversized compact payload failure appears in refresh state", snapshot["warnings"])
+
+    def test_subject_filter_and_limit_cap(self):
+        snapshot = build_bnl_memory_snapshot(self.db_path, limit=1000, subject_key="crow")
+        self.assertEqual(snapshot["rowLimits"]["default"], 100)
+        keys = {row["subject_key"] for row in snapshot["sections"]["entityEvidenceEvents"]}
+        self.assertEqual(keys, {"crow"})
+
+    def test_builder_is_read_only(self):
+        before = self._table_counts()
+        build_bnl_memory_snapshot(self.db_path, limit=5, include_raw_refs=True)
+        after = self._table_counts()
+        self.assertEqual(before, after)
+
+    def test_endpoint_rejects_missing_or_invalid_token(self):
+        old_db = bnl01_bot.DB_FILE
+        try:
+            bnl01_bot.DB_FILE = self.db_path
+            with mock.patch.dict(os.environ, {"BNL_MEMORY_SNAPSHOT_TOKEN": "snapshot-token"}):
+                missing = make_mocked_request("GET", bnl01_bot.BNL_MEMORY_SNAPSHOT_PATH)
+                missing_response = asyncio.run(bnl01_bot._handle_bnl_memory_snapshot(missing))
+                self.assertEqual(missing_response.status, 401)
+
+                invalid = make_mocked_request("GET", bnl01_bot.BNL_MEMORY_SNAPSHOT_PATH, headers={bnl01_bot.BNL_MEMORY_SNAPSHOT_TOKEN_HEADER: "wrong"})
+                invalid_response = asyncio.run(bnl01_bot._handle_bnl_memory_snapshot(invalid))
+                self.assertEqual(invalid_response.status, 401)
+        finally:
+            bnl01_bot.DB_FILE = old_db
+
+    def test_endpoint_valid_token_returns_json_without_side_effects(self):
+        old_db = bnl01_bot.DB_FILE
+        before = self._table_counts()
+        try:
+            bnl01_bot.DB_FILE = self.db_path
+            with mock.patch.dict(os.environ, {"BNL_MEMORY_SNAPSHOT_TOKEN": "snapshot-token"}), \
+                 mock.patch.object(bnl01_bot, "process_source_file_refresh_now") as refresh_now, \
+                 mock.patch.object(bnl01_bot, "send_dossier_recommendation") as send_recommendation:
+                request = make_mocked_request(
+                    "GET",
+                    bnl01_bot.BNL_MEMORY_SNAPSHOT_PATH + "?limit=1&subject_key=crow&include_samples=false",
+                    headers={bnl01_bot.BNL_MEMORY_SNAPSHOT_TOKEN_HEADER: "snapshot-token"},
+                )
+                response = asyncio.run(bnl01_bot._handle_bnl_memory_snapshot(request))
+                self.assertEqual(response.status, 200)
+                payload = json.loads(response.text)
+                self.assertEqual(payload["rowLimits"]["default"], 1)
+                self.assertEqual(payload["filters"]["subject_key"], "crow")
+                self.assertEqual(payload["sections"]["memoryTierSamples"], [])
+                self.assertIn("tableCounts", payload)
+                refresh_now.assert_not_called()
+                send_recommendation.assert_not_called()
+        finally:
+            bnl01_bot.DB_FILE = old_db
+        self.assertEqual(before, self._table_counts())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a safe internal, read-only way to inspect the bot's SQLite memory without SSH/file-copy, reusing the existing internal listener/auth patterns and preserving all existing bot behavior and side-effect guarantees.

### Description
- Added a read-only snapshot builder `bnl_memory_snapshot.py` that opens the existing DB in read-only mode and returns a sanitized JSON snapshot with metadata, `tableCounts`, row limits, redaction policy, warnings, and the requested sections (communityPresence, entityProfileSnapshots, entityEvidenceEvents, entityIntelligenceEdges, entityOpenQuestions, memoryTierRiskSummary, memoryTierSamples, sourceFileRefreshState, sourceFileRefreshQueue, broadcastMemory, ambientLog). 
- Implemented careful redaction and truncation rules for secrets, tokens, long Discord IDs, mentions, emails, URLs, and raw/ref JSON; hashed identifiers for matched_user_id; optional compacting/redacting of raw refs. 
- Added an internal HTTP handler and route `GET /internal/bnl/memory-snapshot` in the existing aiohttp listener that requires `BNL_MEMORY_SNAPSHOT_TOKEN` (header `x-bnl-memory-snapshot-token` or Bearer). The handler validates token, parses safe query params (`limit`, `subject_key`, `include_samples`, `include_raw_refs`), logs requests without echoing tokens, and returns the snapshot or conservative error codes. 
- Kept all operations read-only: database opened with `mode=ro`, no writes/enqueues/refreshes/calls performed. 
- Added unit tests `tests/test_memory_snapshot.py` covering token auth, valid JSON shape, table counts, redaction/truncation, subject filtering, limit caps, read-only behavior, and that no source-refresh/dossier side-effects are triggered. 

### Testing
- Ran `python -m unittest tests.test_memory_snapshot -v` (passed). 
- Ran `python -m unittest tests.test_source_file_refresh -v` (passed). 
- Ran `python -m unittest tests.test_source_file_archive -v` (passed). 
- Ran full test discovery `python -m unittest discover -s tests -v` (all tests passed). 
- Verified syntax with `python -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_source_file_refresh.py bnl_dossier_source_packets.py bnl_entity_intelligence.py bnl_source_file_enrichment.py bnl_memory_snapshot.py` (no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27887dd3f483219d181cbfaafae6d1)