### PR TITLE
Guard stale media fallbacks and add repeat-output suppression

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -8527,6 +8527,9 @@ def save_user_message(user_id: int, user_name: str, guild_id: int, content: str,
     return decision
 
 def save_model_message(user_id: int, guild_id: int, content: str, channel_name: str = "", channel_policy: str = "unknown", channel_id: int = 0, route_mode: str = ROUTE_MODE_NORMAL_CHAT):
+    if should_exclude_from_prompt_history("model", content):
+        logging.info("memory_write_policy_skip_conversation role=model route_mode=%s reason=bare_media_fallback_transient", route_mode)
+        return MemoryWriteDecision(False, False, False, False, False, False, "bare_media_fallback_transient", context_visibility_for_policy(channel_policy))
     decision = decide_memory_write_policy(route_mode, channel_policy, "model", content, True)
     if not decision.save_conversation:
         logging.info("memory_write_policy_skip_conversation role=model route_mode=%s reason=%s", route_mode, decision.reason)
@@ -8556,6 +8559,106 @@ def save_model_message(user_id: int, guild_id: int, content: str, channel_name: 
         add_relationship_journal(user_id, guild_id, "support_response", f"BNL provided guidance: {(content or '')[:160]}")
     return decision
 
+
+
+BARE_MEDIA_FALLBACK_PATTERNS = (
+    r"\bi saw (?:your|[a-z0-9_. '\-]{1,80}'?s|someone'?s|their|his|her)?\s*recent\s+(?:gif|image|picture|photo|video|sticker|meme|media)\b.*\b(?:do not have|don['’]t have|lack)\b.*\bdetailed visual description\b",
+    r"\bi saw .*\bas\s+(?:gif|image|video|sticker|media).*(?:embed|preview|provider=|host=|preview=yes).*\bdetailed visual description\b",
+)
+
+def _normalize_response_for_repeat(text: str) -> str:
+    lowered = (text or "").lower()
+    lowered = re.sub(r"https?://\S+", " url ", lowered)
+    lowered = re.sub(r"[^a-z0-9]+", " ", lowered)
+    return re.sub(r"\s+", " ", lowered).strip()
+
+
+def is_bare_media_fallback_text(text: str) -> bool:
+    lowered = re.sub(r"\s+", " ", (text or "").strip().lower())
+    if not lowered:
+        return False
+    if any(re.search(pattern, lowered) for pattern in BARE_MEDIA_FALLBACK_PATTERNS):
+        return True
+    media_bits = ("recent gif" in lowered or "recent media" in lowered or "recent image" in lowered or "gif embed" in lowered or "link preview" in lowered)
+    thin_bits = "detailed visual description" in lowered and ("do not have" in lowered or "don't have" in lowered or "dont have" in lowered)
+    metadata_bits = any(token in lowered for token in ("provider=", "host=", "preview=yes", "embed_type=", "tenor", "giphy"))
+    return bool(media_bits and thin_bits and metadata_bits)
+
+
+def should_exclude_from_prompt_history(role: str, content: str) -> bool:
+    return (role or "").strip().lower() == "model" and is_bare_media_fallback_text(content)
+
+
+def current_batch_references_recent_media(text: str) -> bool:
+    return is_explicit_recent_media_followup(text)
+
+
+def _responses_near_duplicate(candidate: str, previous: str, *, threshold: float = 0.82) -> bool:
+    cand = _normalize_response_for_repeat(candidate)
+    prev = _normalize_response_for_repeat(previous)
+    if not cand or not prev:
+        return False
+    if cand == prev or cand in prev or prev in cand:
+        return True
+    cand_tokens = set(cand.split())
+    prev_tokens = set(prev.split())
+    if not cand_tokens or not prev_tokens:
+        return False
+    return (len(cand_tokens & prev_tokens) / max(1, len(cand_tokens | prev_tokens))) >= threshold
+
+
+def get_recent_model_responses(user_id: int, guild_id: int, channel_id: int = 0, limit: int = 6) -> list[str]:
+    if not user_id or not guild_id:
+        return []
+    safe_limit = max(1, min(int(limit or 6), 20))
+    conn = sqlite3.connect(DB_FILE)
+    cursor = conn.cursor()
+    try:
+        if channel_id:
+            cursor.execute(
+                """
+                SELECT content FROM conversations
+                WHERE guild_id = ? AND user_id = ? AND role = 'model' AND (channel_id = ? OR COALESCE(channel_id, 0) = 0)
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (guild_id, user_id, int(channel_id), safe_limit),
+            )
+        else:
+            cursor.execute(
+                """
+                SELECT content FROM conversations
+                WHERE guild_id = ? AND user_id = ? AND role = 'model'
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (guild_id, user_id, safe_limit),
+            )
+        return [(row[0] or "") for row in cursor.fetchall() if row and (row[0] or "").strip()]
+    finally:
+        conn.close()
+
+
+def recent_model_response_repeated(candidate: str, user_id: int, guild_id: int, channel_id: int = 0, limit: int = 6) -> bool:
+    return any(_responses_near_duplicate(candidate, previous) for previous in get_recent_model_responses(user_id, guild_id, channel_id=channel_id, limit=limit))
+
+
+def suppress_stale_media_fallback(candidate: str, *, current_text: str = "", current_has_media: bool = False, user_id: int = 0, guild_id: int = 0, channel_id: int = 0) -> str:
+    if not candidate:
+        return ""
+    references_media = current_batch_references_recent_media(current_text)
+    bare_media = is_bare_media_fallback_text(candidate)
+    repeated = recent_model_response_repeated(candidate, user_id, guild_id, channel_id=channel_id) if user_id and guild_id else False
+    if bare_media and (repeated or (not current_has_media and not references_media)):
+        logging.info(
+            "stale_media_fallback_suppressed guild_id=%s channel_id=%s user_id=%s current_has_media=%s current_references_media=%s repeated=%s",
+            guild_id, channel_id, user_id, int(current_has_media), int(references_media), int(repeated),
+        )
+        return ""
+    if repeated:
+        logging.info("repeat_response_suppressed guild_id=%s channel_id=%s user_id=%s", guild_id, channel_id, user_id)
+        return "The relay caught that twice. I’m holding the duplicate instead of echoing it again."
+    return candidate
 
 def _stringify_embed_value(value) -> list:
     parts = []
@@ -10120,6 +10223,8 @@ def get_conversation_history(user_id: int, guild_id: int, limit: int = 50):
     history = []
     for role_db, content in reversed(rows):
         role = "user" if role_db == "user" else "model"
+        if should_exclude_from_prompt_history(role, content):
+            continue
         history.append({"role": role, "parts": [content]})
     return history
 
@@ -10224,6 +10329,8 @@ def get_recent_channel_context(guild_id: int, channel_id: int, limit: int = 12, 
         content = (row[3] or "").strip()
         if not content:
             continue
+        if should_exclude_from_prompt_history((row[2] or "").strip(), content):
+            continue
         context_rows.append({
             "id": row[0],
             "user_name": (row[1] or "").strip(),
@@ -10264,7 +10371,7 @@ def format_room_context_for_prompt(rows: list[dict], current_user_name: str = ""
     return "\n".join(rendered)
 
 
-def build_room_first_direct_context(guild_id: int, channel_id: int, channel_name: str, channel_policy: str, current_user_name: str, route: str = "direct") -> str:
+def build_room_first_direct_context(guild_id: int, channel_id: int, channel_name: str, channel_policy: str, current_user_name: str, route: str = "direct", current_text: str = "", current_has_media: bool = False) -> str:
     rows = get_recent_channel_context(
         guild_id,
         channel_id,
@@ -10274,7 +10381,9 @@ def build_room_first_direct_context(guild_id: int, channel_id: int, channel_name
         channel_policy=channel_policy,
     )
     formatted = format_room_context_for_prompt(rows, current_user_name=current_user_name) if rows else ""
-    recent_media = build_recent_media_context_for_prompt(guild_id, channel_id, channel_policy, current_user_name=current_user_name, limit=5)
+    recent_media = ""
+    if current_has_media or current_batch_references_recent_media(current_text):
+        recent_media = build_recent_media_context_for_prompt(guild_id, channel_id, channel_policy, current_user_name=current_user_name, limit=5)
     if recent_media:
         formatted = (formatted + "\n" + recent_media).strip() if formatted else recent_media
     if formatted:
@@ -13882,7 +13991,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             )
             if recent_room_prompt:
                 prompt += "\n\n" + recent_room_prompt + "\n"
-            recent_media_prompt = build_recent_media_context_for_prompt(guild_id, channel_id, channel_policy, limit=5)
+            recent_media_prompt = ""
+            if active_packet.get("media_present") or current_batch_references_recent_media(combined_text):
+                recent_media_prompt = build_recent_media_context_for_prompt(guild_id, channel_id, channel_policy, limit=5)
             if recent_media_prompt:
                 prompt += "\n\n" + recent_media_prompt + "\n"
                 _log_batch_event(logging.INFO, "recent_media_context_used", guild_id, channel_id, len(collapsed_items), f"recent_media_context_found=1;recent_media_used_in_prompt=1;channel_policy={channel_policy}")
@@ -13932,6 +14043,15 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             _log_batch_event(logging.INFO, "generation_typing_started", guild_id, channel_id, len(collapsed_items), f"payload_count={len(active_packet['payload_items'])};elapsed_seconds={generation_elapsed:.2f};selected_wait_seconds={selected_wait_seconds:.2f}")
             if True:  # typing indicator disabled: Discord 429 was aborting bot replies
                 response = await get_gemini_response(prompt, user_id=first_uid, guild_id=channel.guild.id, route=generation_route)
+
+            response = suppress_stale_media_fallback(
+                response,
+                current_text=combined_text,
+                current_has_media=bool(active_packet.get("media_present")),
+                user_id=first_uid,
+                guild_id=guild_id,
+                channel_id=channel_id,
+            )
 
             if not response:
                 latest_result = GenerationResult(
@@ -14972,6 +15092,7 @@ async def _generate_direct_payload_session(session_key, reason: str):
         session.get("channel_policy", "unknown"),
         session["requester_display_name"],
         route="direct_payload_session",
+        current_text=direct_content,
     )
     website_read_model_context = maybe_build_bnl_read_model_context(direct_content, session.get("channel_policy", "unknown"))
     source_context_block = await maybe_build_source_context_for_direct_message(
@@ -15022,6 +15143,15 @@ async def _generate_direct_payload_session(session_key, reason: str):
                 if fallback_lines:
                     response = ((response or "").strip() + "\n\n" + fallback_lines).strip()
                     logging.info(f"direct_payload_completion_fallback_appended missing_count={len(missing_items)}")
+
+    response = suppress_stale_media_fallback(
+        response,
+        current_text=direct_content,
+        current_has_media=False,
+        user_id=session["requester_user_id"],
+        guild_id=session["guild_id"],
+        channel_id=session.get("channel_id", 0),
+    )
 
     fallback_response_sent = False
     if not response:
@@ -15642,6 +15772,15 @@ async def on_message(message: discord.Message):
                 f"Operator request: {clean_content}"
             )
             response = await get_gemini_response(ops_prompt, message.author.id, message.guild.id, route="internal_operations_brief")
+            response = suppress_stale_media_fallback(
+                response,
+                current_text=clean_content,
+                current_has_media=bool(build_message_media_context(message).get("present", False)),
+                user_id=message.author.id,
+                guild_id=message.guild.id,
+                channel_id=message.channel.id,
+            )
+
             if not response:
                 result = GenerationResult(False, "", _last_generation_status.get("error_category") or GENERATION_ERROR_PROVIDER_UNKNOWN, _last_generation_status.get("provider_error_code") or "", "", "internal_operations_brief", 0.0, GEMINI_MODEL)
                 log_response_generation_failed(route="internal_operations_brief", channel=message.channel, channel_policy=channel_policy, conversation_surface=conversation_surface, directness="command_only", result=result)
@@ -15941,6 +16080,8 @@ async def on_message(message: discord.Message):
                 channel_policy,
                 message.author.display_name,
                 route="direct_active",
+                current_text=direct_content,
+                current_has_media=bool(build_message_media_context(message).get("present", False)),
             )
             website_read_model_context = maybe_build_bnl_read_model_context(direct_content, channel_policy)
             source_context_block = await maybe_build_source_context_for_direct_message(
@@ -15994,6 +16135,15 @@ async def on_message(message: discord.Message):
                             response = (response + "\n\n" + fallback_lines).strip() if response else fallback_lines
                             logging.info(f"direct_payload_completion_fallback_appended missing_count={len(missing_items)}")
             logging.info(f"direct_payload_generation_complete payload_count={len(direct_payload_items)}")
+
+            response = suppress_stale_media_fallback(
+                response,
+                current_text=direct_content,
+                current_has_media=bool(build_message_media_context(message).get("present", False)),
+                user_id=message.author.id,
+                guild_id=message.guild.id,
+                channel_id=message.channel.id,
+            )
 
             if not response:
                 if show_state_ctx:
@@ -16159,6 +16309,8 @@ async def on_message(message: discord.Message):
             channel_policy,
             message.author.display_name,
             route="direct",
+            current_text=direct_content,
+            current_has_media=bool(build_message_media_context(message).get("present", False)),
         )
         website_read_model_context = maybe_build_bnl_read_model_context(direct_content, channel_policy)
         source_context_block = await maybe_build_source_context_for_direct_message(
@@ -16225,6 +16377,15 @@ async def on_message(message: discord.Message):
                         response = (response + "\n\n" + fallback_lines).strip() if response else fallback_lines
                         logging.info(f"direct_payload_completion_fallback_appended missing_count={len(missing_items)}")
         logging.info(f"direct_payload_generation_complete payload_count={len(direct_payload_items)}")
+
+        response = suppress_stale_media_fallback(
+            response,
+            current_text=direct_content,
+            current_has_media=bool(build_message_media_context(message).get("present", False)),
+            user_id=message.author.id,
+            guild_id=message.guild.id,
+            channel_id=message.channel.id,
+        )
 
         if not response:
             if show_state_ctx:
@@ -16356,6 +16517,8 @@ async def on_message(message: discord.Message):
             channel_policy,
             message.author.display_name,
             route="direct",
+            current_text=direct_content,
+            current_has_media=bool(build_message_media_context(message).get("present", False)),
         )
         website_read_model_context = maybe_build_bnl_read_model_context(direct_content, channel_policy)
         source_context_block = await maybe_build_source_context_for_direct_message(
@@ -16422,6 +16585,15 @@ async def on_message(message: discord.Message):
                         response = (response + "\n\n" + fallback_lines).strip() if response else fallback_lines
                         logging.info(f"direct_payload_completion_fallback_appended missing_count={len(missing_items)}")
         logging.info(f"direct_payload_generation_complete payload_count={len(direct_payload_items)}")
+
+        response = suppress_stale_media_fallback(
+            response,
+            current_text=direct_content,
+            current_has_media=bool(build_message_media_context(message).get("present", False)),
+            user_id=message.author.id,
+            guild_id=message.guild.id,
+            channel_id=message.channel.id,
+        )
 
         if not response:
             if show_state_ctx:

--- a/tests/test_route_memory_governance.py
+++ b/tests/test_route_memory_governance.py
@@ -877,6 +877,110 @@ class RecentMediaRoomContextTests(unittest.TestCase):
         self.assertEqual(event["visibility"], "public_home_transient")
         self.assertNotIn("durable", event["visibility"])
 
+
+    def test_bare_media_fallback_detection_and_suppression_without_current_media(self):
+        fallback = "I saw your recent gif as gif embed (embed_type=gifv; provider=Tenor; preview=yes); gif link preview (host=tenor.com), but I do not have a detailed visual description stored for that one."
+        self.assertTrue(bnl01_bot.is_bare_media_fallback_text(fallback))
+        self.assertEqual(
+            bnl01_bot.suppress_stale_media_fallback(
+                fallback,
+                current_text="what is BARCODE Radio doing next?",
+                current_has_media=False,
+            ),
+            "",
+        )
+
+    def test_current_media_reference_can_acknowledge_once_but_not_repeat(self):
+        fallback = "I saw your recent gif as gif embed (provider=Tenor; preview=yes), but I do not have a detailed visual description stored for that one."
+        old_db = bnl01_bot.DB_FILE
+        with tempfile.NamedTemporaryFile(delete=True) as tmp:
+            bnl01_bot.DB_FILE = tmp.name
+            bnl01_bot.init_db()
+            try:
+                self.assertEqual(
+                    bnl01_bot.suppress_stale_media_fallback(
+                        fallback,
+                        current_text="what was that gif?",
+                        current_has_media=False,
+                        user_id=101,
+                        guild_id=1,
+                        channel_id=2,
+                    ),
+                    fallback,
+                )
+                with bnl01_bot.sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+                    conn.execute(
+                        "INSERT INTO conversations (user_id, user_name, guild_id, channel_id, role, content) VALUES (?, ?, ?, ?, ?, ?)",
+                        (101, "BNL-01", 1, 2, "model", fallback),
+                    )
+                self.assertEqual(
+                    bnl01_bot.suppress_stale_media_fallback(
+                        fallback,
+                        current_text="what was that gif?",
+                        current_has_media=False,
+                        user_id=101,
+                        guild_id=1,
+                        channel_id=2,
+                    ),
+                    "",
+                )
+            finally:
+                bnl01_bot.DB_FILE = old_db
+
+    def test_bare_media_fallback_model_rows_excluded_from_history_and_room_context(self):
+        fallback = "I saw your recent gif as gif embed (provider=Tenor; preview=yes), but I do not have a detailed visual description stored for that one."
+        old_db = bnl01_bot.DB_FILE
+        with tempfile.NamedTemporaryFile(delete=True) as tmp:
+            bnl01_bot.DB_FILE = tmp.name
+            bnl01_bot.init_db()
+            try:
+                bnl01_bot.save_user_message(101, "Crow", 1, "what is the current signal?", channel_name="general", channel_policy="public_home", channel_id=2)
+                bnl01_bot.save_model_message(101, 1, fallback, channel_name="general", channel_policy="public_home", channel_id=2)
+                history_text = "\n".join(part for msg in bnl01_bot.get_conversation_history(101, 1) for part in msg.get("parts", []))
+                room_rows = bnl01_bot.get_recent_channel_context(1, 2, channel_name="general", channel_policy="public_home")
+                self.assertNotIn("recent gif", history_text.lower())
+                self.assertFalse(any("recent gif" in row["content"].lower() for row in room_rows))
+            finally:
+                bnl01_bot.DB_FILE = old_db
+
+    def test_recent_media_prompt_context_requires_current_media_or_reference(self):
+        bnl01_bot.record_recent_media_event(
+            guild_id=1, channel_id=2, author_id=101, author_display_name="Crow",
+            text="", media_context={"items": ["gif embed (provider=Tenor; preview=yes)"]},
+            channel_policy="public_home", conversation_surface="free_speak_public_home", response_state="observed",
+        )
+        self.assertFalse(bnl01_bot.current_batch_references_recent_media("what time is the show?"))
+        self.assertTrue(bnl01_bot.current_batch_references_recent_media("what was that gif?"))
+        old_db = bnl01_bot.DB_FILE
+        with tempfile.NamedTemporaryFile(delete=True) as tmp:
+            bnl01_bot.DB_FILE = tmp.name
+            bnl01_bot.init_db()
+            try:
+                no_ref = bnl01_bot.build_room_first_direct_context(1, 2, "general", "public_home", "Crow", current_text="what time is the show?")
+                with_ref = bnl01_bot.build_room_first_direct_context(1, 2, "general", "public_home", "Crow", current_text="what was that gif?")
+            finally:
+                bnl01_bot.DB_FILE = old_db
+        self.assertNotIn("Recent media context", no_ref)
+        self.assertIn("Recent media context", with_ref)
+
+    def test_repeat_guard_replaces_non_media_duplicate(self):
+        old_db = bnl01_bot.DB_FILE
+        with tempfile.NamedTemporaryFile(delete=True) as tmp:
+            bnl01_bot.DB_FILE = tmp.name
+            bnl01_bot.init_db()
+            try:
+                previous = "The relay is stable; answer the text normally."
+                with bnl01_bot.sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+                    conn.execute(
+                        "INSERT INTO conversations (user_id, user_name, guild_id, channel_id, role, content) VALUES (?, ?, ?, ?, ?, ?)",
+                        (101, "BNL-01", 1, 2, "model", previous),
+                    )
+                replacement = bnl01_bot.suppress_stale_media_fallback(previous, current_text="repeat?", user_id=101, guild_id=1, channel_id=2)
+                self.assertNotEqual(replacement, previous)
+                self.assertNotIn("gif", replacement.lower())
+            finally:
+                bnl01_bot.DB_FILE = old_db
+
     def test_active_media_reaction_after_other_user_text_escalates(self):
         bnl01_bot.record_recent_room_event_from_message(
             guild_id=1, channel_id=2, author_id=202, author_display_name="Six", text="that plan is extremely logical",


### PR DESCRIPTION
### Motivation

- Prevent stale GIF/embed/media fallback replies from reappearing as active answers or poisoning later prompt/context while preserving legitimate current-message media handling.
- Avoid repeating the same canned media acknowledgement repeatedly and ensure provider-failure fallbacks do not resurrect stale media context.

### Description

- Detect thin/bare media-fallback responses with `is_bare_media_fallback_text(...)` and treat them as transient so model-side rows are excluded from prompt history via `should_exclude_from_prompt_history(...)` and `save_model_message` early-exit logic. 
- Add recent-response deduplication helpers (`_normalize_response_for_repeat`, `_responses_near_duplicate`, `get_recent_model_responses`, `recent_model_response_repeated`) and a suppression helper `suppress_stale_media_fallback(...)` that (a) blocks bare-media fallbacks when the current batch does not reference media, and (b) replaces/suppresses near-duplicate model outputs. 
- Stop injecting recent-media context into prompts unless the current batch contains media or the user text explicitly references recent media by gating with `current_batch_references_recent_media(...)` in `build_room_first_direct_context` and the batched prompt assembly. 
- Exclude bare-media fallback rows from conversation-history reads and same-channel room-context selection by filtering `get_conversation_history` and `get_recent_channel_context`. 
- Apply suppression before sending generated or fallback responses in the main batch flow, direct payload path, and internal operations/direct routes so provider failures/regenerations cannot resurrect stale media replies. 
- Add regression tests to `tests/test_route_memory_governance.py` for detection/suppression, one-time explicit acknowledgement behavior, history/context exclusion, recent-media prompt gating, and duplicate-response replacement.

### Testing

- Compiled key modules with `python3 -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_source_file_refresh.py bnl_dossier_source_packets.py bnl_entity_intelligence.py bnl_source_file_enrichment.py` (succeeded).
- Ran unit tests with `PYTHONPATH=. pytest -q` and all tests passed: `434 passed, 5 warnings, 31 subtests passed`.
- Note: a plain `pytest -q` run without `PYTHONPATH=.` initially showed import-collection failures due to environment path; the documented runner uses `PYTHONPATH=.` and that run passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28f09d9d7083218d62ab03d59a619a)