### PR TITLE
Cap compact Source File recommendations

### DIFF
--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -33,6 +33,24 @@ SITE_RAW_PROVENANCE_JSON_LIMIT = 20000
 SITE_RAW_PROVENANCE_JSON_TARGET = 18000
 SITE_LIST_ITEM_LIMIT = 500
 SITE_LIST_MAX_ITEMS = 25
+COMPACT_RECOMMENDATION_LIST_MAX_ITEMS = 8
+COMPACT_RECOMMENDATION_LIST_ITEM_LIMIT = 220
+COMPACT_RECOMMENDATION_TEXT_FIELD_LIMITS = {
+    "reason": 700,
+    "evidenceSummary": SITE_EVIDENCE_SUMMARY_TARGET,
+    "publicSafetyNotes": 500,
+    "doNotSay": 500,
+    "missingInfo": 500,
+    "suggestedAction": 500,
+    "queueSubmissionNote": 500,
+    "recentActivitySummary": 500,
+    "authoredVsMentionedSummary": 500,
+}
+COMPACT_RECOMMENDATION_JSON_FIELD_LIMITS = {
+    "entityIntelligenceProfile": 3000,
+    "rawProvenance": 3000,
+}
+COMPACT_RECOMMENDATION_ARCHIVE_NOTICE = "Full Source File archive available internally."
 SITE_RAW_FRAGMENT_MAX_ITEMS = 4
 SITE_RAW_FRAGMENT_TEXT_LIMIT = 500
 SITE_SOURCE_COVERAGE_ALLOWED_KEYS = {"source", "count", "counts", "status"}
@@ -2035,6 +2053,129 @@ def _compact_raw_provenance_for_site(raw: Any) -> dict[str, Any]:
     return compact
 
 
+def truncate_compact_text_field(value: Any, max_length: int, *, field_name: str = "compact_field") -> str:
+    """Deterministically cap compact recommendation text while preserving useful boundaries."""
+
+    text = _site_safe_text(value, max(max_length * 4, max_length))
+    original_length = len(text)
+    if original_length <= max_length:
+        logging.info("compact_recommendation_field_length field=%s original=%s capped=%s truncated=false", field_name, original_length, original_length)
+        return text
+    suffix = "… [truncated; full Source File archive available internally]"
+    budget = max(0, max_length - len(suffix))
+    candidate = text[:budget].rstrip()
+    boundary = max(candidate.rfind("\n- "), candidate.rfind(". "), candidate.rfind("; "), candidate.rfind("\n"))
+    if boundary >= max(80, int(budget * 0.55)):
+        candidate = candidate[: boundary + (1 if candidate[boundary:boundary + 1] == "." else 0)].rstrip()
+    capped = f"{candidate}{suffix}" if candidate else suffix[-max_length:]
+    logging.info("compact_recommendation_field_length field=%s original=%s capped=%s truncated=true", field_name, original_length, len(capped))
+    return capped
+
+
+def _compact_json_value_for_recommendation(value: Any, *, field_name: str, max_json_length: int) -> Any:
+    compact = _compact_value_for_site(value, text_limit=COMPACT_RECOMMENDATION_LIST_ITEM_LIMIT)
+    original_length = len(json.dumps(value, sort_keys=True, default=str)) if value not in (None, "") else 0
+    capped_length = len(json.dumps(compact, sort_keys=True, default=str))
+    if capped_length <= max_json_length:
+        logging.info("compact_recommendation_field_length field=%s original=%s capped=%s truncated=%s", field_name, original_length, capped_length, str(original_length != capped_length).lower())
+        return compact
+    if isinstance(compact, dict):
+        reduced: dict[str, Any] = {}
+        for key in ("subjectKey", "qualityScore", "qualityStatus", "diagnostics", "rowScopeCounts", "sourceCounts", "warningCounts", "summary"):
+            if key in compact:
+                reduced[key] = compact[key]
+        reduced.setdefault("summary", COMPACT_RECOMMENDATION_ARCHIVE_NOTICE)
+        compact = reduced
+    elif isinstance(compact, list):
+        compact = compact[:2]
+    capped_length = len(json.dumps(compact, sort_keys=True, default=str))
+    if capped_length > max_json_length:
+        compact = {"summary": COMPACT_RECOMMENDATION_ARCHIVE_NOTICE}
+        capped_length = len(json.dumps(compact, sort_keys=True, default=str))
+    logging.info("compact_recommendation_field_length field=%s original=%s capped=%s truncated=true", field_name, original_length, capped_length)
+    return compact
+
+
+def build_compact_source_file_recommendation_summary(packet: dict[str, Any], payload: dict[str, Any] | None = None, *, archive_id: str | None = None) -> str:
+    """Build a short pointer-style card for compact dossier recommendations."""
+
+    source = payload or {}
+    subject = str(source.get("subjectName") or packet.get("subject") or "").strip()
+    subject_key = _subject_key(subject or source.get("subjectKey") or packet.get("subjectKey") or "unknown-subject")
+    recommendation_type = str(source.get("type") or "source_file_review").strip() or "source_file_review"
+    confidence = str(source.get("confidence") or "unknown").strip() or "unknown"
+    quality_score = packet.get("qualityScore", source.get("qualityScore"))
+    quality_status = str(packet.get("qualityStatus") or source.get("qualityStatus") or "unknown").strip() or "unknown"
+    match_kind = str(packet.get("matchKind") or "none").strip() or "none"
+    source_counts = packet.get("sourceCounts") or source.get("sourceCounts") or {}
+    if isinstance(source_counts, dict) and source_counts:
+        count_text = ", ".join(f"{_site_safe_text(k, 40)}={int(v or 0) if isinstance(v, (int, float)) else _site_safe_text(v, 20)}" for k, v in list(source_counts.items())[:4])
+    else:
+        count_text = "no compact counts"
+    archive_ref = archive_id or packet.get("archiveId") or source.get("archiveId") or "pending/not returned"
+    lines = [
+        "Source File compact review pointer.",
+        f"- Subject key: {subject_key}",
+        f"- Recommendation type: {recommendation_type}",
+        f"- Confidence: {confidence}; priority/quality: {quality_status} ({quality_score if quality_score is not None else 'n/a'}).",
+        f"- Why review: BNL refreshed Source File intelligence for match target {match_kind}; admin review may update dossier context without publishing or identity-link changes.",
+        f"- Compact source counts: {count_text}.",
+        f"- Archive id: {_site_safe_text(archive_ref, 160)}.",
+        f"- {COMPACT_RECOMMENDATION_ARCHIVE_NOTICE}",
+    ]
+    return truncate_compact_text_field("\n".join(lines), COMPACT_RECOMMENDATION_TEXT_FIELD_LIMITS["evidenceSummary"], field_name="evidenceSummary")
+
+
+def sanitize_compact_recommendation_payload(payload: dict[str, Any], *, packet: dict[str, Any] | None = None, archive_id: str | None = None) -> dict[str, Any]:
+    """Apply centralized Source File compact recommendation caps before site send."""
+
+    compact = dict(payload or {})
+    packet = packet or {}
+    existing_summary = str(compact.get("evidenceSummary") or "")
+    pointer_summary = build_compact_source_file_recommendation_summary(packet, compact, archive_id=archive_id)
+    if len(existing_summary) <= COMPACT_RECOMMENDATION_TEXT_FIELD_LIMITS["evidenceSummary"] and not archive_id:
+        compact["evidenceSummary"] = existing_summary
+    else:
+        compact["evidenceSummary"] = pointer_summary
+    match_kind = str(packet.get("matchKind") or "none")
+    compact["reason"] = truncate_compact_text_field(
+        f"Review-only Source File compact pointer for subject_key={_subject_key(compact.get('subjectName') or packet.get('subject') or '')}; match target={match_kind}. {COMPACT_RECOMMENDATION_ARCHIVE_NOTICE} No publishing, promotion, merge, or alias confirmation is requested.",
+        COMPACT_RECOMMENDATION_TEXT_FIELD_LIMITS["reason"],
+        field_name="reason",
+    )
+    for key, limit in COMPACT_RECOMMENDATION_TEXT_FIELD_LIMITS.items():
+        if key in {"reason", "evidenceSummary"}:
+            continue
+        if key in compact:
+            compact[key] = truncate_compact_text_field(compact.get(key), limit, field_name=key)
+    for key in SITE_BOUND_LIST_FIELDS:
+        if key in compact:
+            if key in SITE_CONTRACT_READOUT_FIELDS:
+                compact[key] = _normalize_readout_field_for_site(key, compact.get(key))
+                if isinstance(compact[key], list):
+                    compact[key] = _compact_list_for_site(compact[key], max_items=COMPACT_RECOMMENDATION_LIST_MAX_ITEMS, item_limit=COMPACT_RECOMMENDATION_LIST_ITEM_LIMIT)
+                elif isinstance(compact[key], str):
+                    compact[key] = truncate_compact_text_field(compact[key], COMPACT_RECOMMENDATION_LIST_ITEM_LIMIT, field_name=key)
+            else:
+                compact[key] = _compact_list_for_site(compact.get(key), max_items=COMPACT_RECOMMENDATION_LIST_MAX_ITEMS, item_limit=COMPACT_RECOMMENDATION_LIST_ITEM_LIMIT)
+    if "entityIntelligenceProfile" in compact:
+        profile = compact.get("entityIntelligenceProfile") if isinstance(compact.get("entityIntelligenceProfile"), dict) else {}
+        diagnostics = profile.get("diagnostics") if isinstance(profile, dict) else {}
+        profile_pointer = {"summary": COMPACT_RECOMMENDATION_ARCHIVE_NOTICE, "subjectKey": profile.get("subjectKey") or _subject_key(compact.get("subjectName") or packet.get("subject") or ""), "diagnostics": diagnostics}
+        for keep_key in ("roles", "relationships", "themes", "behaviorPosture", "eventContest", "dossierUsefulness"):
+            if keep_key in profile:
+                profile_pointer[keep_key] = _compact_list_for_site(profile.get(keep_key), max_items=4, item_limit=120)
+        compact["entityIntelligenceProfile"] = _compact_json_value_for_recommendation(
+            profile_pointer,
+            field_name="entityIntelligenceProfile",
+            max_json_length=COMPACT_RECOMMENDATION_JSON_FIELD_LIMITS["entityIntelligenceProfile"],
+        )
+    if "rawProvenance" in compact:
+        compact["rawProvenance"] = _compact_json_value_for_recommendation(compact.get("rawProvenance"), field_name="rawProvenance", max_json_length=COMPACT_RECOMMENDATION_JSON_FIELD_LIMITS["rawProvenance"])
+    compact["compactRecommendationNotice"] = COMPACT_RECOMMENDATION_ARCHIVE_NOTICE
+    return compact
+
+
 def build_compact_enrichment_evidence_summary(packet: dict[str, Any]) -> str:
     classification = packet.get("classification") or {}
     sections = packet.get("sections") or {}
@@ -2564,6 +2705,7 @@ def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: 
     }
     _validate_source_payload_fields(payload)
     compact_payload = compact_enrichment_payload_for_site(build_dossier_recommendation_payload(payload))
+    compact_payload = sanitize_compact_recommendation_payload(compact_payload, packet=packet)
     _validate_source_payload_fields(compact_payload)
     compact_payload["siteValidationIssues"] = validate_enrichment_payload_for_site(compact_payload)
     if not compact_payload["siteValidationIssues"]:
@@ -2732,6 +2874,8 @@ def run_source_file_enrichment(
     packet["archiveId"] = (archive_result or {}).get("archiveId") or ""
     packet["archiveError"] = _safe_text((archive_result or {}).get("error") or "", 240)
 
+    payload = sanitize_compact_recommendation_payload(payload, packet=packet, archive_id=packet.get("archiveId") or "")
+    packet["payload"] = payload
     send_result = sender(payload)
     packet["sendResult"] = send_result
     packet["recommendationSent"] = bool((send_result or {}).get("ok"))
@@ -2740,8 +2884,10 @@ def run_source_file_enrichment(
     if packet["sent"]:
         packet["status"] = "sent"
     elif (packet["archiveSent"] or not archive_required) and not packet["recommendationSent"]:
-        packet["status"] = "recommendation_send_failed"
-        logging.warning("source_enrichment_compact_recommendation_failed archive_ok=true subject_key=%s", _subject_key(subject))
+        packet["status"] = "partial_success" if packet["archiveSent"] else "recommendation_send_failed"
+        packet["partialSuccess"] = bool(packet["archiveSent"])
+        packet["partialSuccessReason"] = "compact_recommendation_rejected"
+        logging.warning("source_enrichment_compact_recommendation_failed archive_ok=%s compact_recommendation_ok=false reason=compact_recommendation_rejected subject_key=%s", str(bool(packet["archiveSent"])).lower(), _subject_key(subject))
     elif packet["recommendationSent"] and not packet["archiveSent"]:
         packet["status"] = "archive_send_failed"
         logging.warning("source_enrichment_archive_failed recommendation_ok=true subject_key=%s", _subject_key(subject))

--- a/bnl_source_file_refresh.py
+++ b/bnl_source_file_refresh.py
@@ -366,8 +366,9 @@ def _site_refresh_lookup_parts(site_request: dict[str, Any]) -> tuple[str, str]:
 
 def _site_status_for_local_item(item: dict[str, Any]) -> tuple[str, str]:
     status = str(item.get("status") or "").lower()
-    if status in {"succeeded", "current", "already_current"}:
-        return "completed", ""
+    if status in {"succeeded", "current", "already_current", "partial_success"}:
+        reason = _safe_text(item.get("reason") or "", 240) if status == "partial_success" else ""
+        return "completed", reason
     if status in {"skipped", "cooldown", "deferred", "no_target", "dry_run"}:
         return "skipped", _safe_text(item.get("reason") or item.get("error") or status, 240)
     return "failed", _safe_text(item.get("error") or item.get("reason") or status or "send_failed", 240)
@@ -403,7 +404,7 @@ def _state_has_current_success(state: dict[str, Any] | sqlite3.Row | None) -> bo
     completed = parse_iso(completed_value)
     cooldown_until = parse_iso(cooldown_value)
     now_dt = datetime.now(timezone.utc).replace(microsecond=0)
-    return status == "succeeded" and completed is not None and cooldown_until is not None and cooldown_until > now_dt
+    return status in {"succeeded", "partial_success"} and completed is not None and cooldown_until is not None and cooldown_until > now_dt
 
 
 def _mark_current_cooldown_terminal(db_path: str, *, guild_id: int | None, subject_key: str, reason: str = "cooldown_current") -> None:
@@ -545,7 +546,7 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
     archive_id = _safe_text(item.get("archiveId") or "", 120)
     summary.update({
         "ok": site_status in {"completed", "skipped"},
-        "status": "success" if site_status == "completed" else site_status,
+        "status": "partial_success" if str(item.get("status") or "").lower() == "partial_success" else ("success" if site_status == "completed" else site_status),
         "recommendationId": rec_id,
         "recommendationSent": bool(item.get("recommendationSent") or rec_id),
         "archiveSent": bool(item.get("archiveSent")),
@@ -735,19 +736,25 @@ def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = No
                     logging.info("source_refresh_skipped subject_key=%s reason=no_target", row["subject_key"])
                     summary["skipped"] += 1
                     summary["items"].append({"subject": row["subject_name"], "status": "skipped", "reason": "no_target", "error": "no_target"})
-                elif result.get("sent"):
+                elif result.get("sent") or (result.get("archiveSent") and not result.get("recommendationSent") and result.get("status") == "partial_success"):
                     send_result = result.get("sendResult") or {}
                     recommendation_id = str(send_result.get("recommendationId") or send_result.get("recommendation_id") or result.get("recommendationId") or send_result.get("id") or "")[:120]
                     archive_result = result.get("archiveResult") or {}
                     archive_id = str(archive_result.get("archiveId") or result.get("archiveId") or "")[:120]
                     cooldown_until_text = _cooldown_until_from(now_dt, cooldown_minutes)
                     evidence_count = sum(int(v or 0) for v in (result.get("sourceCounts") or {}).values()) if isinstance(result.get("sourceCounts"), dict) else int(row["evidence_count"] or 0)
+                    partial_success = bool(result.get("archiveSent") and not result.get("recommendationSent") and result.get("status") == "partial_success")
+                    item_status = "partial_success" if partial_success else "succeeded"
+                    partial_reason = "compact_recommendation_rejected" if partial_success else ""
                     conn.execute(f"UPDATE {QUEUE_TABLE} SET status='succeeded', updated_at=?, last_error=NULL WHERE id=?", (utc_now(), row["id"]))
-                    _state_upsert(conn, guild_id=row["guild_id"], subject_key=row["subject_key"], subject_name=row["subject_name"], fields={"last_refresh_completed_at": utc_now(), "last_refresh_status": "succeeded", "last_recommendation_id": recommendation_id, "last_evidence_hash": _evidence_hash_for_result(result), "last_evidence_count": evidence_count, "last_error": None, "cooldown_until": cooldown_until_text})
+                    _state_upsert(conn, guild_id=row["guild_id"], subject_key=row["subject_key"], subject_name=row["subject_name"], fields={"last_refresh_completed_at": utc_now(), "last_refresh_status": item_status, "last_recommendation_id": recommendation_id, "last_evidence_hash": _evidence_hash_for_result(result), "last_evidence_count": evidence_count, "last_error": partial_reason or None, "cooldown_until": cooldown_until_text})
                     conn.commit()
-                    logging.info("source_refresh_succeeded subject_key=%s recommendation_id=%s archive_id=%s", row["subject_key"], recommendation_id or "none", archive_id or "none")
+                    if partial_success:
+                        logging.warning("source_refresh_partial_success subject_key=%s archive_ok=true compact_recommendation_ok=false reason=compact_recommendation_rejected archive_id=%s", row["subject_key"], archive_id or "none")
+                    else:
+                        logging.info("source_refresh_succeeded subject_key=%s recommendation_id=%s archive_id=%s", row["subject_key"], recommendation_id or "none", archive_id or "none")
                     summary["processed"] += 1
-                    summary["items"].append({"subject": row["subject_name"], "status": "succeeded", "recommendationId": recommendation_id, "recommendationSent": bool(result.get("recommendationSent", bool(send_result.get("ok")))), "archiveSent": bool(result.get("archiveSent", bool(archive_result.get("ok")))), "archiveStatus": result.get("archiveStatus") or archive_result.get("status"), "archiveId": archive_id, "archiveError": _safe_text(result.get("archiveError") or archive_result.get("error") or "", 180)})
+                    summary["items"].append({"subject": row["subject_name"], "status": item_status, "reason": partial_reason, "error": partial_reason, "partialSuccess": partial_success, "recommendationId": recommendation_id, "recommendationSent": bool(result.get("recommendationSent", bool(send_result.get("ok")))), "archiveSent": bool(result.get("archiveSent", bool(archive_result.get("ok")))), "archiveStatus": result.get("archiveStatus") or archive_result.get("status"), "archiveId": archive_id, "archiveError": _safe_text(result.get("archiveError") or archive_result.get("error") or "", 180)})
                 else:
                     archive_result = result.get("archiveResult") or {}
                     send_result = result.get("sendResult") or {}

--- a/tests/test_source_file_archive.py
+++ b/tests/test_source_file_archive.py
@@ -142,7 +142,9 @@ class SourceFileArchiveTests(unittest.TestCase):
         self.assertTrue(result["archiveSent"])
         self.assertFalse(result["recommendationSent"])
         self.assertFalse(result["sent"])
-        self.assertEqual(result["status"], "recommendation_send_failed")
+        self.assertEqual(result["status"], "partial_success")
+        self.assertTrue(result["partialSuccess"])
+        self.assertEqual(result["partialSuccessReason"], "compact_recommendation_rejected")
         self.assertIn("sourcePackage", archive_calls[0])
         self.assertNotIn("sourcePackage", rec_calls[0])
 
@@ -163,3 +165,25 @@ class SourceFileArchiveTests(unittest.TestCase):
         body = json.dumps(archive_payload, sort_keys=True).lower()
         for forbidden in ("publish_public", "draft_create", "tag_create", "identity_merge", "queue_payment", "alias_confirm"):
             self.assertNotIn(forbidden, body)
+
+    def test_oversized_compact_recommendation_fields_are_capped_with_archive_preserved(self):
+        packet = self.large_packet()
+        huge = "\n".join(f"full evidence dump row {i} " + ("x" * 200) for i in range(200))
+        packet["entityIntelligenceProfile"] = {"subjectKey": "6-bit", "body": huge, "diagnostics": {"rowScopeCounts": {"subject_owned": 200}}}
+        packet["bestEvidenceToReview"] = [huge for _ in range(20)]
+        packet["conversationHighlights"] = [huge for _ in range(20)]
+        archive_payload = enrichment.build_source_file_archive_payload(packet)
+        compact_payload = enrichment.build_enrichment_recommendation_payload(packet)
+        archive_body = json.dumps(archive_payload, sort_keys=True)
+        compact_body = json.dumps(compact_payload, sort_keys=True)
+        self.assertIn("full evidence dump row 13", archive_body)
+        self.assertNotIn("full evidence dump row 199", compact_body)
+        self.assertLessEqual(len(compact_payload["evidenceSummary"]), enrichment.COMPACT_RECOMMENDATION_TEXT_FIELD_LIMITS["evidenceSummary"])
+        self.assertLessEqual(len(json.dumps(compact_payload["entityIntelligenceProfile"], sort_keys=True)), enrichment.COMPACT_RECOMMENDATION_JSON_FIELD_LIMITS["entityIntelligenceProfile"])
+        self.assertIn("Full Source File archive available internally", compact_payload["compactRecommendationNotice"])
+
+    def test_compact_summary_can_include_archive_id_after_archive_send(self):
+        packet = self.large_packet()
+        payload = enrichment.build_enrichment_recommendation_payload(packet)
+        compact = enrichment.sanitize_compact_recommendation_payload(payload, packet=packet, archive_id="arc_6bit")
+        self.assertIn("arc_6bit", compact["evidenceSummary"])

--- a/tests/test_source_file_refresh.py
+++ b/tests/test_source_file_refresh.py
@@ -480,10 +480,10 @@ class SourceFileRefreshTests(unittest.TestCase):
         self.assertEqual([p["status"] for p in opener.posts], ["claimed", "failed"])
         self.assertIn("archive rejected", opener.posts[-1]["failureReason"])
 
-    def test_refresh_now_compact_recommendation_failure_still_reports_failure(self):
+    def test_refresh_now_compact_recommendation_failure_reports_partial_success(self):
         opener = FakeOpener({"ok": True, "requests": []})
         lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
-        with mock.patch.object(refresh, "run_source_file_enrichment", return_value={"sent": False, "recommendationSent": False, "archiveSent": True, "sendResult": {"ok": False, "error": "compact rejected"}, "archiveResult": {"ok": True, "archiveId": "arc_partial", "status": 200}, "status": "recommendation_send_failed"}):
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value={"sent": False, "recommendationSent": False, "archiveSent": True, "sendResult": {"ok": False, "error": "compact rejected"}, "archiveResult": {"ok": True, "archiveId": "arc_partial", "status": 200}, "status": "partial_success", "partialSuccess": True, "partialSuccessReason": "compact_recommendation_rejected"}):
             result = refresh.process_source_file_refresh_now(
                 self.db,
                 {"requestId": "req_compact", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "reason": "manual_retry", "source": "admin_manual_retry"},
@@ -492,12 +492,12 @@ class SourceFileRefreshTests(unittest.TestCase):
                 opener=opener,
                 lookup_func=lookup,
             )
-        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["status"], "partial_success")
+        self.assertTrue(result["ok"])
         self.assertTrue(result["archiveSent"])
         self.assertEqual(result["archiveId"], "arc_partial")
-        self.assertIn("compact rejected", result["failureReason"])
-        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "failed"])
-        self.assertIn("compact rejected", opener.posts[-1]["failureReason"])
+        self.assertEqual(result["failureReason"], "compact_recommendation_rejected")
+        self.assertEqual([p["status"] for p in opener.posts], ["claimed", "completed"])
 
     def test_refresh_now_no_target_does_not_stay_claimed(self):
         opener = FakeOpener({"ok": True, "requests": []})


### PR DESCRIPTION
### Motivation

- Compact dossier recommendation payloads were sometimes rejected by the site for oversized text fields, causing repeated refresh failures even when the full Source File archive succeeded.
- The full Source File archive must remain unchanged while compact recommendations stay pointer-style and safely under likely site limits.

### Description

- Add centralized compact recommendation limits and helpers: `COMPACT_RECOMMENDATION_TEXT_FIELD_LIMITS`, `COMPACT_RECOMMENDATION_LIST_MAX_ITEMS`, `COMPACT_RECOMMENDATION_JSON_FIELD_LIMITS`, `truncate_compact_text_field`, `_compact_json_value_for_recommendation`, `build_compact_source_file_recommendation_summary`, and `sanitize_compact_recommendation_payload` in `bnl_source_file_enrichment.py` to deterministically cap and log truncation of compact fields before sending.
- Ensure the full archive envelope and `sourcePackage` remain intact and are sent unchanged via the archive sender while compact payloads are replaced or summarized, and include an `archiveId` pointer when available.
- Treat archive-success plus compact-recommendation rejection as an explicit `partial_success` with `partialSuccessReason="compact_recommendation_rejected"` instead of a total failure, and update refresh worker/site-status handling so `partial_success` is terminal/completed; changes are in `bnl_source_file_enrichment.py` and `bnl_source_file_refresh.py`.
- Add/adjust unit tests to cover oversized compact payload truncation, archive preservation, inclusion of archive id in compact pointers, and partial-success reporting, and expose truncation/length diagnostic logging in the new helpers.

### Testing

- Compiled the modified modules with `python3 -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_source_file_refresh.py bnl_dossier_source_packets.py bnl_entity_intelligence.py bnl_source_file_enrichment.py` which succeeded.
- Ran the full test suite with `PYTHONPATH=. pytest -q` and all unit tests passed (tests complete; suite returned all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28f3985cfc8321bcf6f4f1e3d0d8ad)