### PR TITLE
Make case-report backfill land in requesting site instance (honor callback base)

### DIFF
--- a/bnl_dossier_recommendations.py
+++ b/bnl_dossier_recommendations.py
@@ -14,11 +14,14 @@ import os
 import re
 import socket
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any
 
 DEFAULT_DOSSIER_INGEST_URL = "https://www.barcode-network.com/api/bnl/dossier-recommendations"
 DEFAULT_SOURCE_FILE_ARCHIVE_URL = "https://www.barcode-network.com/api/bnl/source-file-enrichments"
+DOSSIER_INGEST_PATH = "/api/bnl/dossier-recommendations"
+SOURCE_FILE_ARCHIVE_PATH = "/api/bnl/source-file-enrichments"
 DOSSIER_INGEST_TIMEOUT_SECONDS = 10
 SOURCE_FILE_ARCHIVE_TIMEOUT_SECONDS = 15
 SUPPORTED_PAYLOAD_FIELDS = {
@@ -89,12 +92,99 @@ VALID_DOSSIER_CATEGORIES = {"Entity", "Personnel", "Sponsor", "Interface", "Prod
 
 
 
-def get_dossier_ingest_url(environ: dict[str, str] | None = None) -> str:
-    """Return configured ingest URL or the production endpoint fallback."""
+def _safe_url_host(value: str) -> str:
+    try:
+        parsed = urllib.parse.urlparse(str(value or "").strip())
+        return (parsed.hostname or "").lower()[:180]
+    except Exception:
+        return ""
+
+
+def _configured_callback_hosts(environ: dict[str, str] | None = None) -> set[str]:
+    env = environ if environ is not None else os.environ
+    raw = env.get("BNL_TRUSTED_SITE_CALLBACK_HOSTS") or env.get("BNL_SITE_CALLBACK_ALLOWED_HOSTS") or ""
+    return {part.strip().lower() for part in re.split(r"[,\s]+", raw) if part.strip()}
+
+
+def is_trusted_site_callback_base_url(value: str | None, *, environ: dict[str, str] | None = None) -> bool:
+    """Return whether a site callback base URL is safe for BNL archive posts.
+
+    The callback target must be HTTPS and belong to the production BARCODE site,
+    a configured allowlist host, or a BARCODE Network Vercel preview host. This
+    intentionally rejects localhost and arbitrary external hosts by default.
+    """
+
+    text = str(value or "").strip()
+    if not text:
+        return False
+    try:
+        parsed = urllib.parse.urlparse(text)
+    except Exception:
+        return False
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or not host:
+        return False
+    if host == "www.barcode-network.com":
+        return True
+    for allowed in _configured_callback_hosts(environ):
+        if allowed.startswith("*.") and host.endswith(allowed[1:]):
+            return True
+        if host == allowed:
+            return True
+    # Vercel preview deployments for this project are allowed, while generic
+    # arbitrary Vercel/external hosts remain rejected.
+    if host.endswith(".vercel.app") and "barcode-network" in host:
+        return True
+    return False
+
+
+def normalize_trusted_site_callback_base_url(value: str | None, *, environ: dict[str, str] | None = None) -> str:
+    """Return a normalized trusted origin/base URL, or an empty string."""
+
+    if not is_trusted_site_callback_base_url(value, environ=environ):
+        return ""
+    parsed = urllib.parse.urlparse(str(value or "").strip())
+    return urllib.parse.urlunparse((parsed.scheme, parsed.netloc, "", "", "", "")).rstrip("/")
+
+
+def site_endpoint_url_from_callback_base(callback_base_url: str | None, path: str, *, environ: dict[str, str] | None = None) -> str:
+    """Build a site endpoint URL from a trusted callback base URL."""
+
+    base = normalize_trusted_site_callback_base_url(callback_base_url, environ=environ)
+    if not base:
+        return ""
+    return urllib.parse.urljoin(base.rstrip("/") + "/", path.lstrip("/"))
+
+
+def select_trusted_site_callback_base_url(payload: dict[str, Any] | None, *, environ: dict[str, str] | None = None) -> tuple[str, str]:
+    """Pick a trusted requesting-site callback base from a refresh payload.
+
+    Returns (base_url, source), where source is requesting_site_origin when a
+    trusted payload value is honored, otherwise env_default.
+    """
+
+    request = payload if isinstance(payload, dict) else {}
+    for key in ("sourceFileArchiveCallbackBaseUrl", "siteCallbackBaseUrl", "requestingSiteOrigin"):
+        base = normalize_trusted_site_callback_base_url(request.get(key), environ=environ)
+        if base:
+            return base, "requesting_site_origin"
+    return "", "env_default"
+
+
+def get_dossier_ingest_url(environ: dict[str, str] | None = None, *, callback_base_url: str | None = None) -> str:
+    """Return the selected ingest URL, honoring a trusted callback base first."""
 
     env = environ if environ is not None else os.environ
+    callback_url = site_endpoint_url_from_callback_base(callback_base_url, DOSSIER_INGEST_PATH, environ=env)
+    if callback_url:
+        return callback_url
     configured = (env.get("BNL_DOSSIER_INGEST_URL") or "").strip()
-    return configured or DEFAULT_DOSSIER_INGEST_URL
+    if configured:
+        return configured
+    base = normalize_trusted_site_callback_base_url(env.get("BNL_WEBSITE_BASE_URL") or env.get("BNL_SITE_BASE_URL"), environ=env)
+    if base:
+        return urllib.parse.urljoin(base.rstrip("/") + "/", DOSSIER_INGEST_PATH.lstrip("/"))
+    return DEFAULT_DOSSIER_INGEST_URL
 
 
 def is_dossier_ingest_token_configured(environ: dict[str, str] | None = None) -> bool:
@@ -104,12 +194,20 @@ def is_dossier_ingest_token_configured(environ: dict[str, str] | None = None) ->
     return bool((env.get("BNL_DOSSIER_INGEST_TOKEN") or "").strip())
 
 
-def get_source_file_archive_url(environ: dict[str, str] | None = None) -> str:
-    """Return configured Source File archive URL or production fallback."""
+def get_source_file_archive_url(environ: dict[str, str] | None = None, *, callback_base_url: str | None = None) -> str:
+    """Return the selected Source File archive URL, honoring a trusted callback base first."""
 
     env = environ if environ is not None else os.environ
+    callback_url = site_endpoint_url_from_callback_base(callback_base_url, SOURCE_FILE_ARCHIVE_PATH, environ=env)
+    if callback_url:
+        return callback_url
     configured = (env.get("BNL_SOURCE_FILE_ARCHIVE_URL") or "").strip()
-    return configured or DEFAULT_SOURCE_FILE_ARCHIVE_URL
+    if configured:
+        return configured
+    base = normalize_trusted_site_callback_base_url(env.get("BNL_WEBSITE_BASE_URL") or env.get("BNL_SITE_BASE_URL"), environ=env)
+    if base:
+        return urllib.parse.urljoin(base.rstrip("/") + "/", SOURCE_FILE_ARCHIVE_PATH.lstrip("/"))
+    return DEFAULT_SOURCE_FILE_ARCHIVE_URL
 
 
 def get_source_file_archive_token(environ: dict[str, str] | None = None) -> str:
@@ -279,7 +377,7 @@ def _safe_failure(error: str, status: int | None = None, duplicate: bool = False
     }
 
 
-def send_dossier_recommendation(payload: dict[str, Any], *, environ: dict[str, str] | None = None, opener=None) -> dict[str, Any]:
+def send_dossier_recommendation(payload: dict[str, Any], *, environ: dict[str, str] | None = None, opener=None, callback_base_url: str | None = None) -> dict[str, Any]:
     """POST a dossier recommendation to the configured site ingest endpoint."""
 
     env = environ if environ is not None else os.environ
@@ -288,7 +386,7 @@ def send_dossier_recommendation(payload: dict[str, Any], *, environ: dict[str, s
         logging.warning("dossier_recommendation_send_failed reason=missing_ingest_token")
         return _safe_failure("Dossier ingest token is not configured.")
 
-    url = get_dossier_ingest_url(env)
+    url = get_dossier_ingest_url(env, callback_base_url=callback_base_url)
     safe_payload = build_dossier_recommendation_payload(payload or {})
     logging.info(
         "dossier_recommendation_send_attempted "
@@ -374,7 +472,7 @@ def _safe_archive_failure(error: str, status: int | None = None) -> dict[str, An
     return {"ok": False, "archiveId": None, "error": error, "status": status}
 
 
-def send_source_file_archive_enrichment(payload: dict[str, Any], *, environ: dict[str, str] | None = None, opener=None) -> dict[str, Any]:
+def send_source_file_archive_enrichment(payload: dict[str, Any], *, environ: dict[str, str] | None = None, opener=None, callback_base_url: str | None = None) -> dict[str, Any]:
     """POST a full Source File enrichment envelope to the review-only archive endpoint.
 
     This sender is intentionally separate from send_dossier_recommendation() so
@@ -389,7 +487,7 @@ def send_source_file_archive_enrichment(payload: dict[str, Any], *, environ: dic
         logging.warning("source_file_archive_send_failed reason=missing_archive_token")
         return _safe_archive_failure("Source File archive token is not configured.")
 
-    url = get_source_file_archive_url(env)
+    url = get_source_file_archive_url(env, callback_base_url=callback_base_url)
     safe_payload = dict(payload or {})
     subject_key = _normalize_subject_key(str(safe_payload.get("subjectKey") or safe_payload.get("subjectName") or ""))
     logging.info("source_file_archive_send_attempted endpoint_configured=%s subject_key=%s", bool(url), subject_key)

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -8,6 +8,7 @@ endpoint. It never publishes, promotes, merges, or overwrites Source Files.
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
 import logging
 import re
@@ -3266,6 +3267,24 @@ def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: 
     return compact_payload
 
 
+
+def _call_site_sender(sender: Callable[..., dict[str, Any]], payload: dict[str, Any], *, environ: dict[str, str] | None = None, callback_base_url: str | None = None) -> dict[str, Any]:
+    """Call a site sender with routing kwargs when its signature supports them."""
+
+    kwargs: dict[str, Any] = {}
+    try:
+        sig = inspect.signature(sender)
+        params = sig.parameters
+        accepts_kwargs = any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values())
+        if accepts_kwargs or "environ" in params:
+            kwargs["environ"] = environ
+        if callback_base_url and (accepts_kwargs or "callback_base_url" in params):
+            kwargs["callback_base_url"] = callback_base_url
+    except (TypeError, ValueError):
+        kwargs = {}
+    return sender(payload, **kwargs) if kwargs else sender(payload)
+
+
 def run_source_file_enrichment(
     db_path: str,
     guild_id: int | None,
@@ -3281,6 +3300,7 @@ def run_source_file_enrichment(
     lookup_value: str | None = None,
     force: bool = False,
     diagnostics: bool = False,
+    callback_base_url: str | None = None,
 ) -> dict[str, Any]:
     canonical_key = lookup_key if lookup_key in {"subject", "alias", "candidateId", "normalizedName"} else "subject"
     target_value = (lookup_value if lookup_value is not None else subject) or ""
@@ -3415,9 +3435,11 @@ def run_source_file_enrichment(
         return packet
     archive_payload = build_source_file_archive_payload(packet, environ=environ)
     packet["archivePayload"] = archive_payload
+    packet["subjectMemoryPacketGenerated"] = bool((archive_payload or {}).get("subjectMemoryPacketV1"))
+    packet["caseReportGenerated"] = bool((archive_payload or {}).get("sourceFileCaseReportV1"))
     archive_required = is_source_file_archive_token_configured(environ)
     if archive_required:
-        archive_result = archive_sender(archive_payload)
+        archive_result = _call_site_sender(archive_sender, archive_payload, environ=environ, callback_base_url=callback_base_url)
     else:
         archive_result = {"ok": True, "archiveId": None, "error": "", "status": "not_configured_skipped"}
         logging.info("source_file_archive_send_skipped reason=archive_token_not_configured subject_key=%s", _subject_key(subject))
@@ -3429,7 +3451,7 @@ def run_source_file_enrichment(
 
     payload = sanitize_compact_recommendation_payload(payload, packet=packet, archive_id=packet.get("archiveId") or "")
     packet["payload"] = payload
-    send_result = sender(payload)
+    send_result = _call_site_sender(sender, payload, environ=environ, callback_base_url=callback_base_url)
     packet["sendResult"] = send_result
     packet["recommendationSent"] = bool((send_result or {}).get("ok"))
     packet["recommendationId"] = (send_result or {}).get("recommendationId") or (send_result or {}).get("id") or ""

--- a/bnl_source_file_refresh.py
+++ b/bnl_source_file_refresh.py
@@ -23,7 +23,15 @@ import urllib.request
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
 
-from bnl_dossier_recommendations import is_dossier_ingest_token_configured, is_source_file_archive_token_configured, send_dossier_recommendation
+from bnl_dossier_recommendations import (
+    get_dossier_ingest_url,
+    get_source_file_archive_url,
+    is_dossier_ingest_token_configured,
+    is_source_file_archive_token_configured,
+    select_trusted_site_callback_base_url,
+    send_dossier_recommendation,
+    _safe_url_host as _safe_callback_host,
+)
 from bnl_source_file_enrichment import run_source_file_enrichment
 from bnl_source_file_lookup import lookup_source_file
 from bnl_source_refresh_context import is_refresh_generation_subject, refresh_generation_context
@@ -522,6 +530,43 @@ def _case_report_backfill_trigger(*, explicit_site_request: bool = False, archiv
     return "none"
 
 
+def _select_and_log_source_refresh_callback_base(site_request: dict[str, Any], *, environ: dict[str, str]) -> tuple[str, str]:
+    """Select and log the safe site callback target for Source File sends."""
+
+    callback_base_url, source = select_trusted_site_callback_base_url(site_request, environ=environ)
+    selected = callback_base_url or get_source_file_archive_url(environ)
+    logging.info(
+        "source_refresh_callback_base_selected source=%s host=%s",
+        source,
+        _safe_callback_host(selected) or "none",
+    )
+    return callback_base_url, source
+
+
+
+def _result_case_report_generated(result: dict[str, Any]) -> bool:
+    if "caseReportGenerated" in result:
+        return bool(result.get("caseReportGenerated"))
+    archive_payload = result.get("archivePayload") if isinstance(result.get("archivePayload"), dict) else {}
+    return bool(result.get("sourceFileCaseReportV1") or archive_payload.get("sourceFileCaseReportV1"))
+
+
+def _result_subject_memory_packet_generated(result: dict[str, Any]) -> bool:
+    if "subjectMemoryPacketGenerated" in result:
+        return bool(result.get("subjectMemoryPacketGenerated"))
+    archive_payload = result.get("archivePayload") if isinstance(result.get("archivePayload"), dict) else {}
+    return bool(result.get("subjectMemoryPacketV1") or archive_payload.get("subjectMemoryPacketV1"))
+
+
+def _item_generation_status(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "caseReportGenerated": bool(item.get("caseReportGenerated")),
+        "subjectMemoryPacketGenerated": bool(item.get("subjectMemoryPacketGenerated")),
+        "caseReportBackfill": bool(item.get("caseReportBackfill")),
+        "caseReportBackfillTrigger": _safe_text(item.get("caseReportBackfillTrigger") or "none", 80),
+    }
+
+
 def _mark_current_cooldown_terminal(db_path: str, *, guild_id: int | None, subject_key: str, reason: str = "cooldown_current") -> None:
     conn = sqlite3.connect(db_path)
     try:
@@ -553,11 +598,12 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
     source = _safe_text(site_request.get("source") or "", 80)
     reason = _safe_text(site_request.get("reason") or "", 80)
     explicit_case_report_backfill = site_request_requires_case_report_backfill(site_request)
+    callback_base_url, callback_source = _select_and_log_source_refresh_callback_base(site_request, environ=env)
     logging.info("source_refresh_now_started request_id=%s subject_key=%s source=%s reason=%s", request_id or "none", skey or "none", source or "none", reason or "none")
     if explicit_case_report_backfill:
         logging.info("source_case_report_backfill_requested subject_key=%s trigger=%s reason=%s", skey or "none", "explicit_site_request", reason or CASE_REPORT_BACKFILL_REASON)
 
-    summary: dict[str, Any] = {"ok": True, "dryRun": dry_run, "requestId": request_id, "candidateId": candidate_id, "subject": subject or skey, "subjectKey": skey, "status": "skipped", "recommendationId": "", "recommendationSent": False, "archiveSent": False, "archiveStatus": None, "archiveId": "", "archiveError": "", "failureReason": ""}
+    summary: dict[str, Any] = {"ok": True, "dryRun": dry_run, "requestId": request_id, "candidateId": candidate_id, "subject": subject or skey, "subjectKey": skey, "status": "skipped", "recommendationId": "", "recommendationSent": False, "archiveSent": False, "archiveStatus": None, "archiveId": "", "archiveError": "", "failureReason": "", "callbackBaseSource": callback_source, "callbackBaseHost": _safe_callback_host(callback_base_url or get_source_file_archive_url(env))}
     if dry_run:
         summary.update({"status": "dry_run", "processed": 1})
         return summary
@@ -631,6 +677,7 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
         bypass_cooldown=explicit_case_report_backfill or report_missing or source in {"admin_manual_retry"} or reason in {"manual_retry", "file_not_updated"},
         refresh_mode=mode,
         subject_key=skey,
+        callback_base_url=callback_base_url or None,
     )
     item = (local.get("items") or [{}])[0]
     if not item:
@@ -676,6 +723,10 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
         "archiveStatus": item.get("archiveStatus"),
         "archiveId": archive_id,
         "archiveError": _safe_text(item.get("archiveError") or "", 180),
+        "caseReportGenerated": bool(item.get("caseReportGenerated")),
+        "subjectMemoryPacketGenerated": bool(item.get("subjectMemoryPacketGenerated")),
+        "caseReportBackfill": bool(item.get("caseReportBackfill")),
+        "caseReportBackfillTrigger": _safe_text(item.get("caseReportBackfillTrigger") or "none", 80),
         "failureReason": terminal_reason,
         "local": local,
     })
@@ -792,7 +843,7 @@ def _state_upsert(conn: sqlite3.Connection, *, guild_id: int | None, subject_key
         conn.execute(f"INSERT INTO {STATE_TABLE} ({cols}) VALUES ({placeholders})", list(base.values()))
 
 
-def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = None, dry_run: bool = False, max_items: int = DEFAULT_MAX_AUTOMATIC_PER_CYCLE, cooldown_minutes: int = DEFAULT_COOLDOWN_MINUTES, lookup_func: Callable[[dict[str, str]], dict[str, Any]] = lookup_source_file, sender: Callable[[dict[str, Any]], dict[str, Any]] = send_dossier_recommendation, environ: dict[str, str] | None = None, force: bool = False, bypass_cooldown: bool = False, refresh_mode: str = "automatic", subject_key: str | None = None) -> dict[str, Any]:
+def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = None, dry_run: bool = False, max_items: int = DEFAULT_MAX_AUTOMATIC_PER_CYCLE, cooldown_minutes: int = DEFAULT_COOLDOWN_MINUTES, lookup_func: Callable[[dict[str, str]], dict[str, Any]] = lookup_source_file, sender: Callable[[dict[str, Any]], dict[str, Any]] = send_dossier_recommendation, environ: dict[str, str] | None = None, force: bool = False, bypass_cooldown: bool = False, refresh_mode: str = "automatic", subject_key: str | None = None, callback_base_url: str | None = None) -> dict[str, Any]:
     now_dt = datetime.now(timezone.utc).replace(microsecond=0)
     now = now_dt.isoformat()
     env = environ if environ is not None else os.environ
@@ -866,6 +917,7 @@ def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = No
                         environ=env,
                         force=force,
                         diagnostics=False,
+                        callback_base_url=callback_base_url or None,
                     )
                 if result.get("status") == "no_target":
                     conn.execute(f"UPDATE {QUEUE_TABLE} SET status='skipped', updated_at=?, last_error='no_target' WHERE id=?", (utc_now(), row["id"]))
@@ -895,7 +947,7 @@ def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = No
                     if report_missing:
                         logging.info("source_case_report_backfill_succeeded subject_key=%s status=%s archive_id=%s trigger=%s", row["subject_key"], item_status, archive_id or "none", backfill_trigger)
                     summary["processed"] += 1
-                    summary["items"].append({"subject": row["subject_name"], "status": item_status, "reason": item_reason, "error": partial_reason, "partialSuccess": partial_success, "recommendationId": recommendation_id, "recommendationSent": bool(result.get("recommendationSent", bool(send_result.get("ok")))), "archiveSent": bool(result.get("archiveSent", bool(archive_result.get("ok")))), "archiveStatus": result.get("archiveStatus") or archive_result.get("status"), "archiveId": archive_id, "archiveError": _safe_text(result.get("archiveError") or archive_result.get("error") or "", 180), "caseReportBackfill": bool(report_missing)})
+                    summary["items"].append({"subject": row["subject_name"], "status": item_status, "reason": item_reason, "error": partial_reason, "partialSuccess": partial_success, "recommendationId": recommendation_id, "recommendationSent": bool(result.get("recommendationSent", bool(send_result.get("ok")))), "archiveSent": bool(result.get("archiveSent", bool(archive_result.get("ok")))), "archiveStatus": result.get("archiveStatus") or archive_result.get("status"), "archiveId": archive_id, "archiveError": _safe_text(result.get("archiveError") or archive_result.get("error") or "", 180), "caseReportBackfill": bool(report_missing), "caseReportBackfillTrigger": backfill_trigger, "caseReportGenerated": _result_case_report_generated(result), "subjectMemoryPacketGenerated": _result_subject_memory_packet_generated(result)})
                 else:
                     archive_result = result.get("archiveResult") or {}
                     send_result = result.get("sendResult") or {}
@@ -912,7 +964,7 @@ def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = No
                     if report_missing:
                         logging.warning("source_case_report_backfill_failed subject_key=%s error=%s trigger=%s", row["subject_key"], err, backfill_trigger)
                     summary["failed"] += 1
-                    summary["items"].append({"subject": row["subject_name"], "status": "failed", "reason": CASE_REPORT_BACKFILL_REASON if report_missing else "", "error": err, "recommendationSent": bool(result.get("recommendationSent")), "archiveSent": bool(result.get("archiveSent")), "archiveStatus": result.get("archiveStatus") or archive_result.get("status"), "archiveId": str(archive_result.get("archiveId") or result.get("archiveId") or "")[:120], "archiveError": _safe_text(result.get("archiveError") or archive_result.get("error") or "", 180), "recommendationId": str(send_result.get("recommendationId") or result.get("recommendationId") or "")[:120], "caseReportBackfill": bool(report_missing)})
+                    summary["items"].append({"subject": row["subject_name"], "status": "failed", "reason": CASE_REPORT_BACKFILL_REASON if report_missing else "", "error": err, "recommendationSent": bool(result.get("recommendationSent")), "archiveSent": bool(result.get("archiveSent")), "archiveStatus": result.get("archiveStatus") or archive_result.get("status"), "archiveId": str(archive_result.get("archiveId") or result.get("archiveId") or "")[:120], "archiveError": _safe_text(result.get("archiveError") or archive_result.get("error") or "", 180), "recommendationId": str(send_result.get("recommendationId") or result.get("recommendationId") or "")[:120], "caseReportBackfill": bool(report_missing), "caseReportBackfillTrigger": backfill_trigger, "caseReportGenerated": _result_case_report_generated(result), "subjectMemoryPacketGenerated": _result_subject_memory_packet_generated(result)})
             except Exception as exc:
                 err = _safe_text(exc, 240)
                 conn.execute(f"UPDATE {QUEUE_TABLE} SET status='failed', updated_at=?, last_error=? WHERE id=?", (utc_now(), err, row["id"]))
@@ -1005,6 +1057,7 @@ def process_site_refresh_requests(db_path: str, *, guild_id: int | None = None, 
             summary["failed"] += 1
             summary["items"].append({"subject": subject or skey, "subjectKey": skey, "requestId": request_id, "status": "failed", "error": reason})
             continue
+        callback_base_url, callback_source = _select_and_log_source_refresh_callback_base(site_request, environ=env)
         enqueue_source_file_refresh(
             db_path,
             guild_id=guild_id,
@@ -1027,6 +1080,7 @@ def process_site_refresh_requests(db_path: str, *, guild_id: int | None = None, 
             bypass_cooldown=explicit_case_report_backfill or report_missing or (mode == "site_manual_request"),
             refresh_mode=mode,
             subject_key=skey,
+            callback_base_url=callback_base_url or None,
         )
         item = (local.get("items") or [{}])[0]
         status = item.get("status")

--- a/tests/test_dossier_recommendations.py
+++ b/tests/test_dossier_recommendations.py
@@ -261,6 +261,40 @@ class DossierRecommendationSenderTests(unittest.TestCase):
         self.assertEqual(request.get_header("Authorization"), "Bearer secret-token")
         self.assertNotIn("secret-token", json.dumps(result))
 
+    def test_trusted_site_callback_base_overrides_archive_and_recommendation_urls(self):
+        base = "https://barcode-network-site-git-case-report-6-bit-01.vercel.app/source-files/x"
+        self.assertTrue(dossier.is_trusted_site_callback_base_url(base))
+        self.assertEqual(
+            dossier.get_source_file_archive_url({"BNL_SOURCE_FILE_ARCHIVE_URL": "https://prod.test/archive"}, callback_base_url=base),
+            "https://barcode-network-site-git-case-report-6-bit-01.vercel.app/api/bnl/source-file-enrichments",
+        )
+        self.assertEqual(
+            dossier.get_dossier_ingest_url({"BNL_DOSSIER_INGEST_URL": "https://prod.test/recommend"}, callback_base_url=base),
+            "https://barcode-network-site-git-case-report-6-bit-01.vercel.app/api/bnl/dossier-recommendations",
+        )
+
+    def test_untrusted_site_callback_base_is_ignored(self):
+        self.assertFalse(dossier.is_trusted_site_callback_base_url("https://evil.example.test"))
+        self.assertFalse(dossier.is_trusted_site_callback_base_url("http://localhost:3000"))
+        self.assertEqual(
+            dossier.get_source_file_archive_url({"BNL_SOURCE_FILE_ARCHIVE_URL": "https://prod.test/archive"}, callback_base_url="https://evil.example.test"),
+            "https://prod.test/archive",
+        )
+
+    def test_archive_send_posts_to_selected_callback_base_url(self):
+        opener = FakeOpener(FakeResponse(200, '{"ok": true, "archiveId": "arc_preview"}'))
+        result = dossier.send_source_file_archive_enrichment(
+            {"subjectName": "Signal Fox", "subjectKey": "signal-fox"},
+            environ={"BNL_SOURCE_FILE_ARCHIVE_TOKEN": "archive-token", "BNL_SOURCE_FILE_ARCHIVE_URL": "https://prod.test/archive"},
+            opener=opener,
+            callback_base_url="https://barcode-network-site-git-case-report-6-bit-01.vercel.app/admin/source-files",
+        )
+        request, timeout = opener.requests[0]
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["archiveId"], "arc_preview")
+        self.assertEqual(timeout, dossier.SOURCE_FILE_ARCHIVE_TIMEOUT_SECONDS)
+        self.assertEqual(request.full_url, "https://barcode-network-site-git-case-report-6-bit-01.vercel.app/api/bnl/source-file-enrichments")
+
     def test_duplicate_response_returns_duplicate_true(self):
         opener = FakeOpener(FakeResponse(200, '{"ok": true, "duplicate": true, "id": "rec_1"}'))
         result = dossier.send_dossier_recommendation(

--- a/tests/test_source_file_refresh.py
+++ b/tests/test_source_file_refresh.py
@@ -310,6 +310,59 @@ class SourceFileRefreshTests(unittest.TestCase):
         self.assertTrue(refresh.site_request_requires_case_report_backfill({"reason": "operator_case_report_backfill_retry"}))
         self.assertFalse(refresh.site_request_requires_case_report_backfill({"caseReportMissing": False, "reason": "opened_source_file"}))
 
+    def test_refresh_now_passes_trusted_callback_base_url_to_enrichment(self):
+        opener = FakeOpener({"ok": True, "requests": []})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}, "latestArchive": {"sourceCounts": {"conversations": 1}}}
+        result_packet = {
+            "sent": True,
+            "recommendationSent": True,
+            "archiveSent": True,
+            "sendResult": {"recommendationId": "rec_preview", "ok": True},
+            "archiveResult": {"archiveId": "arc_preview", "ok": True, "status": 200},
+            "archivePayload": {"subjectMemoryPacketV1": {"subjectName": "Signal Fox"}, "sourceFileCaseReportV1": {"subjectName": "Signal Fox"}},
+            "sourceCounts": {"conversations": 1},
+            "subject": "Signal Fox",
+        }
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value=result_packet) as mocked:
+            result = refresh.process_source_file_refresh_now(
+                self.db,
+                {
+                    "requestId": "req_preview",
+                    "subjectName": "Signal Fox",
+                    "normalizedSubjectKey": "signal-fox",
+                    "caseReportMissing": True,
+                    "source": "admin_source_file_open",
+                    "requestingSiteOrigin": "https://barcode-network-site-git-case-report-6-bit-01.vercel.app",
+                },
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://www.barcode-network.com", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+        self.assertEqual(mocked.call_args.kwargs.get("callback_base_url"), "https://barcode-network-site-git-case-report-6-bit-01.vercel.app")
+        self.assertEqual(result["callbackBaseSource"], "requesting_site_origin")
+        self.assertEqual(result["callbackBaseHost"], "barcode-network-site-git-case-report-6-bit-01.vercel.app")
+        self.assertTrue(result["caseReportGenerated"])
+        self.assertTrue(result["subjectMemoryPacketGenerated"])
+        self.assertTrue(result["caseReportBackfill"])
+        self.assertEqual(result["caseReportBackfillTrigger"], "explicit_site_request")
+
+    def test_refresh_now_ignores_untrusted_callback_base_url(self):
+        opener = FakeOpener({"ok": True, "requests": []})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}, "latestArchive": {"sourceCounts": {"conversations": 1}}}
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value={"sent": True, "recommendationSent": True, "archiveSent": True, "sendResult": {"recommendationId": "rec_default", "ok": True}, "archiveResult": {"archiveId": "arc_default", "ok": True, "status": 200}, "sourceCounts": {"conversations": 1}, "subject": "Signal Fox"}) as mocked:
+            result = refresh.process_source_file_refresh_now(
+                self.db,
+                {"requestId": "req_bad", "subjectName": "Signal Fox", "normalizedSubjectKey": "signal-fox", "caseReportMissing": True, "requestingSiteOrigin": "https://evil.example.test"},
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://www.barcode-network.com", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+        self.assertIsNone(mocked.call_args.kwargs.get("callback_base_url"))
+        self.assertEqual(result["callbackBaseSource"], "env_default")
+        self.assertEqual(result["callbackBaseHost"], "www.barcode-network.com")
+
     def test_refresh_now_explicit_case_report_missing_forces_backfill_without_archive_fields(self):
         opener = FakeOpener({"ok": True, "requests": []})
         lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}


### PR DESCRIPTION
### Motivation
- Ensure Source File case-report backfill archives are posted to the same site instance that requested the refresh so preview deployments and production do not get crossed wires.
- Only accept trusted callback origins and preserve existing environment/default routing when no trusted callback is provided.
- Surface explicit archive/send generation metadata to the site immediate-refresh response so the site can distinguish generation/send/visibility outcomes.
- Preserve existing security constraints: no report synthesis on site, no identity auto-confirm, and no new public memory endpoints.

### Description
- Add trusted callback helpers and allowlist logic in `bnl_dossier_recommendations.py` including `is_trusted_site_callback_base_url`, `normalize_trusted_site_callback_base_url`, `site_endpoint_url_from_callback_base`, and `select_trusted_site_callback_base_url` and conservative defaults for Vercel preview hosts and configured allowlists.
- Change URL selection to honor a trusted requesting-site callback base first for both dossier ingest and Source File archive endpoints by extending `get_dossier_ingest_url` and `get_source_file_archive_url` to accept `callback_base_url` and fall back to configured env/default behavior.
- Update senders to accept and use `callback_base_url` (`send_dossier_recommendation` and `send_source_file_archive_enrichment`) so BNL can post to the requesting site instance when trusted.
- Add `_call_site_sender` in `bnl_source_file_enrichment.py` and thread `callback_base_url` through `run_source_file_enrichment` so both the archive send and paired compact recommendation send use the selected callback base when available, and mark `subjectMemoryPacketGenerated` / `caseReportGenerated` booleans on the enrichment packet without leaking full reports into the compact payload.
- In `bnl_source_file_refresh.py`, select and log the callback base for each immediate or polled site request via `_select_and_log_source_refresh_callback_base`, pass `callback_base_url` into the refresh/enrichment/send path, and add immediate response/read-model fields (`caseReportGenerated`, `subjectMemoryPacketGenerated`, `archiveSent`, `archiveId`, `archiveStatus`, `caseReportBackfill`, and `caseReportBackfillTrigger`) so the site can distinguish generation vs send vs visibility failures.
- Update queue/item records and worker responses to include generation/send/backfill metadata and safe host logging (`source_refresh_callback_base_selected`).
- Add tests to cover trusted callback override, untrusted callback rejection, archive send target selection, callback propagation into immediate refresh, and immediate response/backfill metadata handling.

### Testing
- Compiled key modules: `python3 -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_source_file_refresh.py bnl_dossier_source_packets.py bnl_entity_intelligence.py bnl_source_file_enrichment.py` which succeeded.
- Ran the full test suite with `PYTHONPATH=. pytest -q` and all tests passed: 459 passed (with warnings noted), including new regression tests added for callback routing and immediate-refresh metadata.
- Ran the focused site/bot tests during development (`tests/test_dossier_recommendations.py` and `tests/test_source_file_refresh.py`) and validated the new behaviors and logging entries, all passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29baf6fa4c83218f1444979fca2948)