### PR TITLE
Shared evidence ownership routing for Source File intelligence

### DIFF
--- a/bnl_evidence_ownership.py
+++ b/bnl_evidence_ownership.py
@@ -1,0 +1,307 @@
+"""Shared evidence ownership/source routing helpers for BNL memory."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from typing import Any
+
+OWNED_SCOPES = {
+    "owned",
+    "direct_address",
+    "confirmed_alias",
+    "explicit_relationship",
+    "queue_authoritative",
+    "site_authoritative",
+    "broadcast_memory_authoritative",
+}
+REVIEW_ONLY_SCOPES = {
+    "co_mention",
+    "shared_topic",
+    "generated_or_taxonomy",
+    "source_blind_legacy",
+    "unknown",
+}
+OWNERSHIP_SCOPES = (*OWNED_SCOPES, *REVIEW_ONLY_SCOPES)
+
+# This ownership classifier is the shared gate for BNL memory.
+# Source File intelligence, Discord memory retrieval, website/dossier context,
+# queue/submission context, and future canonical entity profiles should all pass
+# through ownership/source/visibility classification before BNL treats evidence
+# as subject knowledge.
+def classify_evidence_ownership(raw_item: Any, subject_name: str, subject_key: str, confirmed_aliases: list[str] | None = None) -> dict[str, str]:
+    confirmed_aliases = confirmed_aliases or []
+    text = _safe_summary(raw_item)
+    haystack = _jsonish(raw_item).lower()
+    source_type = _source_type(raw_item)
+    visibility = _visibility(raw_item)
+    authority = _authority(raw_item)
+    subject_tokens = _subject_tokens(subject_name, subject_key, confirmed_aliases)
+    subject_hit = _any_token(haystack, subject_tokens)
+    author_tokens = _field_values(raw_item, ("author", "authorName", "author_name", "username", "userName", "displayName", "memberName", "sender", "speaker", "createdBy", "owner", "ownerName"))
+    subject_field_tokens = _field_values(raw_item, ("subject", "subjectName", "subject_name", "subjectKey", "subject_key", "entity", "entityName", "normalizedName"))
+    relationship_tokens = _field_values(raw_item, ("from", "to", "source", "target", "subjectA", "subjectB", "endpointA", "endpointB", "relatedName", "relatedSubject"))
+
+    def result(ownership: str, confidence: str, reason: str) -> dict[str, str]:
+        return {
+            "ownership": ownership,
+            "confidence": confidence,
+            "reason": reason,
+            "safeSummary": text,
+            "sourceType": source_type,
+            "visibility": visibility,
+            "authority": authority,
+        }
+
+    if _has_source_blind_marker(raw_item, haystack):
+        return result("source_blind_legacy", "weak", "source-blind or legacy memory trace lacks item-level ownership metadata")
+    if _has_generated_marker(raw_item, haystack):
+        return result("generated_or_taxonomy", "weak", "generated report/taxonomy/system wording is not source evidence")
+    if _has_queue_marker(raw_item, haystack) and _visibility_safe(haystack, visibility):
+        return result("queue_authoritative", "strong" if subject_hit else "moderate", "queue/submission authority marker is present and visibility-safe")
+    if _has_site_marker(raw_item, haystack) and _visibility_safe(haystack, visibility):
+        return result("site_authoritative", "strong" if subject_hit else "moderate", "site/source-file authority marker is present and visibility-safe")
+    if _has_broadcast_marker(raw_item, haystack) and _visibility_safe(haystack, visibility):
+        return result("broadcast_memory_authoritative", "strong" if subject_hit else "moderate", "broadcast memory authority marker is present and visibility-safe")
+    if _field_matches(author_tokens, subject_tokens):
+        return result("owned", "strong", "author/user metadata matches the subject or confirmed alias")
+    if _field_matches(subject_field_tokens, subject_tokens):
+        return result("owned", "strong", "subject metadata matches the requested subject")
+    if _field_matches(author_tokens, [_norm(a) for a in confirmed_aliases if a]):
+        return result("confirmed_alias", "strong", "author/user metadata matches a confirmed subject alias")
+    if relationship_tokens and _field_matches(relationship_tokens, subject_tokens):
+        return result("explicit_relationship", "moderate", "relationship endpoint metadata includes the subject")
+    if _direct_address_to_subject(raw_item, haystack, subject_tokens):
+        return result("direct_address", "moderate", "item is addressed directly to the subject")
+    if _text_starts_as_subject(text, subject_tokens):
+        return result("owned", "moderate", "text is written as subject-authored/action evidence")
+    if subject_hit and _shared_topic_marker(raw_item, haystack):
+        return result("shared_topic", "weak", "subject appears in topic/community context without ownership metadata")
+    if subject_hit or _co_mention_marker(raw_item, haystack):
+        return result("co_mention", "weak", "subject or another named entity appears nearby without ownership metadata")
+    if _shared_topic_marker(raw_item, haystack):
+        return result("shared_topic", "weak", "topic/community context lacks subject ownership metadata")
+    return result("unknown", "weak", "no reliable ownership/source scope metadata was available")
+
+
+def subject_owned_text_fragments(memory: dict[str, Any], subject_name: str, subject_key: str, confirmed_aliases: list[str] | None = None) -> dict[str, Any]:
+    fragments: dict[str, list[dict[str, Any]]] = {scope: [] for scope in OWNERSHIP_SCOPES}
+    for raw in _iter_memory_evidence(memory):
+        classified = classify_evidence_ownership(raw, subject_name, subject_key, confirmed_aliases)
+        scope = classified["ownership"]
+        if classified.get("safeSummary"):
+            fragments.setdefault(scope, []).append({"text": classified["safeSummary"], "classification": classified})
+    counts = Counter({scope: len(fragments.get(scope, [])) for scope in OWNERSHIP_SCOPES})
+    owned_items = [item for scope in OWNED_SCOPES for item in fragments.get(scope, [])]
+    review_items = [item for scope in REVIEW_ONLY_SCOPES for item in fragments.get(scope, [])]
+    summary = {
+        "ownedEvidenceCount": counts["owned"],
+        "directAddressEvidenceCount": counts["direct_address"],
+        "confirmedAliasEvidenceCount": counts["confirmed_alias"],
+        "explicitRelationshipEvidenceCount": counts["explicit_relationship"],
+        "siteAuthoritativeEvidenceCount": counts["site_authoritative"],
+        "queueAuthoritativeEvidenceCount": counts["queue_authoritative"],
+        "broadcastMemoryAuthoritativeEvidenceCount": counts["broadcast_memory_authoritative"],
+        "coMentionEvidenceCount": counts["co_mention"],
+        "sharedTopicEvidenceCount": counts["shared_topic"],
+        "generatedOrNoiseEvidenceCount": counts["generated_or_taxonomy"],
+        "sourceBlindLegacyEvidenceCount": counts["source_blind_legacy"],
+        "unknownEvidenceCount": counts["unknown"],
+        "ownedEvidenceExamples": _texts(owned_items, 5),
+        "coMentionExamples": _texts(fragments.get("co_mention", []), 5),
+        "sourceBlindWarnings": [f"Source-blind legacy memory was quarantined: {t}" for t in _texts(fragments.get("source_blind_legacy", []), 4)],
+        "routingWarnings": [],
+    }
+    if counts["co_mention"] or counts["shared_topic"]:
+        summary["routingWarnings"].append("Co-mentioned/shared-topic evidence is review context only and must not become subject facts.")
+    if counts["generated_or_taxonomy"]:
+        summary["routingWarnings"].append("Generated/taxonomy/report labels were ignored for subject-owned claims.")
+    if counts["unknown"]:
+        summary["routingWarnings"].append("Unknown ownership evidence needs review before public-safe subject claims.")
+    if counts["source_blind_legacy"]:
+        summary["routingWarnings"].append("Source-blind legacy memory is quarantined from owned subject facts.")
+    return {"owned": owned_items, "reviewOnly": review_items, "byOwnership": fragments, "summary": summary}
+
+
+def _iter_memory_evidence(memory: dict[str, Any]):
+    context = memory.get("sourceIntelligenceContext") if isinstance(memory.get("sourceIntelligenceContext"), dict) else {}
+    evidence_fields = (
+        "representativeEvidence", "evidenceDetails", "bestEvidenceToReview", "usefulEvidence", "conversationHighlights",
+        "bnlInteractionSignals", "musicSignals", "communitySignals", "relationshipSignals", "knownContext",
+    )
+    generated_fields = (
+        "subjectRead", "bnlTake", "confidenceRead", "queueSubmissionRead", "queueSubmissionNote", "sourceFileGaps",
+        "recommendedAdminActions", "doNotSayPubliclyYet", "sourceCoverage", "topTopicDetails", "topicBreakdown", "topicThemes",
+        "conversationThemes", "publicUseCandidates", "reviewOnlyEvidence", "missingInfo", "sourceAuthority", "sourceCounts",
+        "sourceTypes", "archivePayloadMetadata",
+    )
+    for field in evidence_fields:
+        yield from _wrap_items(context.get(field), field)
+    raw_meta = context.get("archivePayloadMetadata") if isinstance(context.get("archivePayloadMetadata"), dict) else {}
+    yield from _wrap_items(raw_meta.get("representativeFragments"), "representativeFragments")
+    yield from _wrap_items(memory.get("representativeMoments"), "representativeMoments")
+    for field in ("communityContext", "musicCreativeContext", "relationshipContext", "publicSafeCandidateFacts"):
+        yield from _wrap_items(memory.get(field), field)
+    for field in generated_fields:
+        yield from _wrap_items(context.get(field), field, generated=True)
+    for path in (("memory_tiers",), ("source_blind_memory_trace",), ("memoryTiers",), ("sourceBlindMemoryTrace",)):
+        cur: Any = memory
+        for key in path:
+            cur = cur.get(key) if isinstance(cur, dict) else None
+        if cur:
+            yield from _wrap_items(cur, "/".join(path), source_blind=True)
+
+
+def _wrap_items(value: Any, lane: str, *, generated: bool = False, source_blind: bool = False):
+    if value in (None, "", [], {}):
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from _wrap_items(item, lane, generated=generated, source_blind=source_blind)
+    elif isinstance(value, dict):
+        item = dict(value)
+        item.setdefault("sourceLane", lane)
+        if generated:
+            item.setdefault("generatedReportField", True)
+        if source_blind:
+            item.setdefault("sourceBlindLegacy", True)
+        yield item
+    else:
+        yield {"summary": str(value), "sourceLane": lane, **({"generatedReportField": True} if generated else {}), **({"sourceBlindLegacy": True} if source_blind else {})}
+
+
+def _safe_summary(raw: Any) -> str:
+    if isinstance(raw, dict):
+        for key in ("summary", "safeSummary", "detail", "evidenceSummary", "claim", "text", "message", "note", "explanation", "snippet", "topic", "theme", "label"):
+            if raw.get(key):
+                return _clean(str(raw.get(key)), 360)
+        return _clean(json.dumps({k: v for k, v in raw.items() if k not in {"id", "rowId", "sourceRowId", "userId", "channelId", "rawRefJson"}}, default=str), 360)
+    return _clean(str(raw or ""), 360)
+
+
+def _clean(text: str, limit: int) -> str:
+    return re.sub(r"\s+", " ", text).strip()[:limit]
+
+
+def _jsonish(raw: Any) -> str:
+    try:
+        return json.dumps(raw, default=str)
+    except Exception:
+        return str(raw)
+
+
+def _source_type(raw: Any) -> str:
+    if isinstance(raw, dict):
+        for key in ("sourceType", "sourceLane", "source", "lane", "table", "sourceTable", "origin", "type"):
+            if raw.get(key):
+                return _clean(str(raw.get(key)), 90)
+    return "unknown"
+
+
+def _visibility(raw: Any) -> str:
+    if isinstance(raw, dict):
+        for key in ("visibility", "channelPolicy", "policy", "publicSafe", "privacy"):
+            if raw.get(key) is not None:
+                return _clean(str(raw.get(key)), 80)
+    return "unknown"
+
+
+def _authority(raw: Any) -> str:
+    if isinstance(raw, dict):
+        for key in ("authority", "sourceAuthority", "authorityType", "sourceAuthorityType"):
+            if raw.get(key):
+                return _clean(str(raw.get(key)), 90)
+    return "unverified"
+
+
+def _norm(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", str(value or "").lower()).strip()
+
+
+def _subject_tokens(subject_name: str, subject_key: str, aliases: list[str]) -> list[str]:
+    vals = [subject_name, subject_key, str(subject_key or "").replace("-", " "), *aliases]
+    return [v for v in {_norm(v) for v in vals if _norm(v)}]
+
+
+def _any_token(haystack: str, tokens: list[str]) -> bool:
+    normalized = _norm(haystack)
+    return any(re.search(rf"(?<![a-z0-9]){re.escape(token)}(?![a-z0-9])", normalized) for token in tokens if token)
+
+
+def _field_values(raw: Any, keys: tuple[str, ...]) -> list[str]:
+    out: list[str] = []
+    if isinstance(raw, dict):
+        for key in keys:
+            value = raw.get(key)
+            if isinstance(value, dict):
+                out.extend(str(v) for v in value.values() if v)
+            elif isinstance(value, (list, tuple, set)):
+                out.extend(str(v) for v in value if v)
+            elif value:
+                out.append(str(value))
+    return [_norm(v) for v in out if _norm(v)]
+
+
+def _field_matches(values: list[str], tokens: list[str]) -> bool:
+    return any(v == token or _any_token(v, [token]) for v in values for token in tokens if v and token)
+
+
+def _visibility_safe(haystack: str, visibility: str) -> bool:
+    lowered = f"{haystack} {visibility}".lower()
+    return "public" in lowered or "visibility safe" in lowered or "approved" in lowered or "review" not in lowered
+
+
+def _has_source_blind_marker(raw: Any, haystack: str) -> bool:
+    return "source_blind" in haystack or "sourceblind" in haystack or "memory_tiers" in haystack or (isinstance(raw, dict) and raw.get("sourceBlindLegacy"))
+
+
+def _has_generated_marker(raw: Any, haystack: str) -> bool:
+    lane = str(raw.get("sourceLane") if isinstance(raw, dict) else "").lower()
+    return bool(isinstance(raw, dict) and raw.get("generatedReportField")) or any(t in haystack or t in lane for t in ("generated", "taxonomy", "report label", "classification label", "topicbreakdown", "toptopicdetails", "sourcecoverage"))
+
+
+def _has_queue_marker(raw: Any, haystack: str) -> bool:
+    return any(t in haystack for t in ("queue_authoritative", "queue authoritative", "queue submission", "submission_id", "submitted track"))
+
+
+def _has_site_marker(raw: Any, haystack: str) -> bool:
+    return any(t in haystack for t in ("site_authoritative", "site authoritative", "source file", "identity check", "public profile", "site_visibility"))
+
+
+def _has_broadcast_marker(raw: Any, haystack: str) -> bool:
+    return any(t in haystack for t in ("broadcast_memory_authoritative", "broadcast authoritative", "broadcast memory", "played on", "radio episode"))
+
+
+def _direct_address_to_subject(raw: Any, haystack: str, subject_tokens: list[str]) -> bool:
+    targets = _field_values(raw, ("target", "targetName", "recipient", "addressedTo", "mentions"))
+    return _field_matches(targets, subject_tokens) or any(f"@{token}" in haystack for token in subject_tokens)
+
+
+def _text_starts_as_subject(text: str, subject_tokens: list[str]) -> bool:
+    normalized = _norm(text[:120])
+    return any(normalized.startswith(token + " ") or normalized.startswith(token + "s ") for token in subject_tokens)
+
+
+def _shared_topic_marker(raw: Any, haystack: str) -> bool:
+    lane = str(raw.get("sourceLane") if isinstance(raw, dict) else "").lower()
+    return any(t in haystack or t in lane for t in ("topic", "theme", "community", "knowncontext", "relationshipsignals", "musicsignals"))
+
+
+def _co_mention_marker(raw: Any, haystack: str) -> bool:
+    lane = str(raw.get("sourceLane") if isinstance(raw, dict) else "").lower()
+    return "mention" in haystack or "near" in haystack or "appears in" in haystack or "relationshipsignals" in lane
+
+
+def _texts(items: list[dict[str, Any]], limit: int) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        text = _clean(str(item.get("text") or item.get("classification", {}).get("safeSummary") or ""), 240)
+        key = text.lower()
+        if text and key not in seen:
+            out.append(text)
+            seen.add(key)
+        if len(out) >= limit:
+            break
+    return out

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -21,6 +21,7 @@ from bnl_dossier_recommendations import build_dossier_recommendation_payload, is
 from bnl_entity_activity_summary import build_entity_activity_summary, refresh_entity_evidence_for_subject
 from bnl_entity_evidence import _website_safe_payload_text
 from bnl_entity_intelligence import build_entity_intelligence_profile, resolve_entity_context_for_surface, safe_text as _entity_safe_text
+from bnl_evidence_ownership import subject_owned_text_fragments
 from bnl_source_file_lookup import lookup_source_file
 from bnl_source_refresh_context import refresh_generation_context
 
@@ -3283,7 +3284,7 @@ def _topic_explanation(topic: str, detail: str, signals: list[str]) -> str:
         return _case_text(detail or "The subject reads primarily through community presence and conversation/support patterns; do not upgrade that into artist, submitter, or lore identity without stronger evidence.", 320)
     return _case_text(detail or f"Extracted evidence points at {topic.lower()}, but the packet has limited subject-specific detail behind that label.", 320)
 
-def _topic_buckets(memory: dict[str, Any]) -> list[dict[str, Any]]:
+def _topic_buckets(memory: dict[str, Any], ownership: dict[str, Any] | None = None) -> list[dict[str, Any]]:
     context = _brief_context(memory)
     candidates: list[Any] = []
     for field in ("topTopicDetails", "topicBreakdown", "topicThemes", "conversationThemes"):
@@ -3292,7 +3293,12 @@ def _topic_buckets(memory: dict[str, Any]) -> list[dict[str, Any]]:
             candidates.extend(value)
     buckets: list[dict[str, Any]] = []
     seen: set[str] = set()
-    evidence_texts = _case_flatten_text_values([context.get("knownContext"), context.get("usefulEvidence"), context.get("bestEvidenceToReview"), context.get("evidenceDetails"), memory.get("representativeMoments")], max_items=40)
+    if ownership:
+        evidence_texts = _case_flatten_text_values([item.get("text") for item in ownership.get("owned", [])], max_items=80)
+        review_only_texts = _case_flatten_text_values([item.get("text") for item in ownership.get("reviewOnly", [])], max_items=80)
+    else:
+        evidence_texts = _case_flatten_text_values([context.get("knownContext"), context.get("usefulEvidence"), context.get("bestEvidenceToReview"), context.get("evidenceDetails"), memory.get("representativeMoments")], max_items=40)
+        review_only_texts = []
     for item in candidates:
         if isinstance(item, dict):
             topic = _clean_topic_label(item.get("topic") or item.get("label") or item.get("theme") or item.get("name"))
@@ -3306,18 +3312,22 @@ def _topic_buckets(memory: dict[str, Any]) -> list[dict[str, Any]]:
         if not topic or key in seen:
             continue
         seen.add(key)
-        signals = [text for text in evidence_texts if key.split(" ")[0] and key.split(" ")[0] in text.lower()][:3]
+        topic_tokens = [part for part in re.split(r"[^a-z0-9]+", key) if len(part) >= 3]
+        signals = [text for text in evidence_texts if any(token in text.lower() for token in topic_tokens[:3])][:3]
+        review_signals = [text for text in review_only_texts if any(token in text.lower() for token in topic_tokens[:3])][:2]
         if count is None:
             count = len(signals) or None
         strength = "weak"
-        if count is not None and count >= 5:
+        if signals and count is not None and count >= 5:
             strength = "strong"
-        elif count is not None and count >= 2:
+        elif signals and count is not None and count >= 2:
             strength = "moderate"
         elif re.search(r"\bnoise|generic|unclear\b", topic, re.I):
             strength = "noise"
         explanation = _topic_explanation(topic, detail, signals)
-        buckets.append({"topic": topic, "strength": strength, **({"evidenceCount": count} if count is not None else {}), "explanation": explanation, **({"exampleSignals": signals[:3]} if signals else {})})
+        if review_signals and not signals:
+            explanation = _case_text(f"Review-only/co-mentioned topic signal; do not treat as subject-owned fact. {explanation}", 340)
+        buckets.append({"topic": topic, "strength": strength, **({"evidenceCount": count} if count is not None else {}), "explanation": explanation, **({"exampleSignals": signals[:3] or review_signals[:2]} if (signals or review_signals) else {})})
         if len(buckets) >= 10:
             break
     if not buckets:
@@ -3381,8 +3391,14 @@ def _domain_anchor_type(name: str) -> str:
     return _anchor_type(name)
 
 
-def _named_anchor_extraction(memory: dict[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    evidence_texts, generated_texts = _anchor_text_fragments(memory)
+def _named_anchor_extraction(memory: dict[str, Any], ownership: dict[str, Any] | None = None) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    if ownership:
+        evidence_texts = _case_flatten_text_values([item.get("text") for item in ownership.get("owned", [])], max_items=120)
+        review_texts = _case_flatten_text_values([item.get("text") for item in ownership.get("reviewOnly", [])], max_items=120)
+        _raw_evidence_texts, generated_texts = _anchor_text_fragments(memory)
+    else:
+        evidence_texts, generated_texts = _anchor_text_fragments(memory)
+        review_texts = []
     ignored_noise = _extract_ignored_anchor_noise(evidence_texts, generated_texts)
     counts: dict[str, int] = {}
     fragments: dict[str, set[int]] = {}
@@ -3415,8 +3431,9 @@ def _named_anchor_extraction(memory: dict[str, Any]) -> tuple[list[dict[str, Any
 
     anchors: list[dict[str, Any]] = []
     subject_key = _anchor_noise_key(str(memory.get("subjectName") or ""))
+    subject_parts = {part for part in subject_key.split() if len(part) >= 3}
     for key, count in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
-        if _is_anchor_noise_key(key) or key == subject_key or key == f"{subject_key} s":
+        if _is_anchor_noise_key(key) or key == subject_key or key == f"{subject_key} s" or key in subject_parts:
             continue
         qs = qualifiers.get(key, set())
         distinct = len(fragments.get(key, set()))
@@ -3446,11 +3463,42 @@ def _named_anchor_extraction(memory: dict[str, Any]) -> tuple[list[dict[str, Any
         anchors.append({"name": name, "type": anchor_type, "strength": strength, "note": note})
         if len(anchors) >= 12:
             break
-    return anchors, ignored_noise
+    nearby = _nearby_context_signals(review_texts, set(counts.keys()), subject_key)
+    return anchors, ignored_noise, nearby
+
+
+def _nearby_context_signals(review_texts: list[str], owned_anchor_keys: set[str], subject_key: str) -> list[dict[str, Any]]:
+    signals: dict[str, dict[str, Any]] = {}
+
+    def add(name: str, reason: str) -> None:
+        clean = _case_text(name, 120).strip(".,;:()[]{}<>\"'")
+        key = _anchor_noise_key(clean)
+        if not key or key in owned_anchor_keys or key == subject_key or _is_anchor_noise_key(key):
+            return
+        item = signals.setdefault(key, {
+            "name": clean,
+            "reason": reason,
+            "confidence": "weak",
+            "warning": "Nearby/co-mentioned/shared-topic context only; do not treat as a subject-owned anchor or fact without owned/explicit evidence.",
+        })
+        if item["confidence"] == "weak" and key in _MEANINGFUL_ANCHOR_TYPES:
+            item["confidence"] = "moderate"
+
+    for text in review_texts:
+        for known in _MEANINGFUL_ANCHOR_TYPES:
+            pattern = re.escape(known).replace("\\ ", r"\s+")
+            if re.search(rf"(?<![-A-Za-z0-9]){pattern}(?![-A-Za-z0-9])", text, flags=re.I):
+                display = "BNL-01" if known == "bnl-01" else ("BNL" if known == "bnl" else ("BARCODE" if known == "barcode" else ("EDGE" if known == "edge" else known[:1].upper() + known[1:])))
+                add(display, "appears only in co-mentioned/shared-topic/review-only evidence")
+        for match in re.findall(r"(?<![-A-Za-z0-9])[A-Z][A-Za-z0-9'’-]{2,}(?:-[A-Za-z0-9'’-]+)*\b", text):
+            add(match, "appears only in co-mentioned/shared-topic/review-only evidence")
+        if len(signals) >= 12:
+            break
+    return list(signals.values())[:12]
 
 
 def _named_anchors(memory: dict[str, Any]) -> list[dict[str, Any]]:
-    anchors, _ignored_noise = _named_anchor_extraction(memory)
+    anchors, _ignored_noise, _nearby = _named_anchor_extraction(memory)
     return anchors
 
 
@@ -3575,19 +3623,33 @@ def _distinguishing_read(archetype: dict[str, Any]) -> str:
     return "Distinctive mainly by recurring community participation; current evidence does not support a narrower artist, lore, or submitter read."
 
 
-def _build_subject_read(subject: str, profile: dict[str, Any], topics: list[dict[str, Any]], channels: list[dict[str, Any]], archetype: dict[str, Any]) -> str:
+def _build_subject_read(subject: str, profile: dict[str, Any], topics: list[dict[str, Any]], channels: list[dict[str, Any]], archetype: dict[str, Any], behavioral_signature: dict[str, Any] | None = None) -> str:
     topic_names = ", ".join(bucket.get("topic", "") for bucket in topics[:4] if bucket.get("topic")) or "not enough extracted topic detail"
     primary = next((ch for ch in channels if ch.get("role") == "primary"), channels[0] if channels else {})
     where = primary.get("channelName") or "unknown channel coverage"
     missing = "; ".join((archetype.get("notEnoughEvidenceFor") or [])[:2])
-    return _case_text(f"BNL reads {subject} as {archetype.get('archetype')} ({archetype.get('confidence')} confidence) based on {profile.get('activityLevel', 'unknown activity')} evidence. What makes this file different is: {_distinguishing_read(archetype)} The evidence pattern runs through {topic_names}, with the clearest safe channel read at {where}. BNL is not allowed to assume {missing or 'public identity, role, relationship meaning, or queue history'} yet.", 900)
+    signature = behavioral_signature.get("signatureRead") if isinstance(behavioral_signature, dict) else ""
+    signature_note = f" Subject-owned behavior note: {signature}" if signature else ""
+    return _case_text(f"BNL reads {subject} as {archetype.get('archetype')} ({archetype.get('confidence')} confidence) based on {profile.get('activityLevel', 'unknown activity')} evidence. What makes this file different is: {_distinguishing_read(archetype)} The evidence pattern runs through {topic_names}, with the clearest safe channel read at {where}.{signature_note} BNL is not allowed to assume {missing or 'public identity, role, relationship meaning, or queue history'} yet.", 1100)
 
 
-def _build_bnl_take(subject: str, memory: dict[str, Any], topics: list[dict[str, Any]], anchors: list[dict[str, Any]], archetype: dict[str, Any]) -> str:
+def _build_bnl_take(subject: str, memory: dict[str, Any], topics: list[dict[str, Any]], anchors: list[dict[str, Any]], archetype: dict[str, Any], behavioral_signature: dict[str, Any] | None = None, nearby_context: list[dict[str, Any]] | None = None) -> str:
     name = str(archetype.get("archetype") or "weak/unknown subject")
     missing = "; ".join((archetype.get("notEnoughEvidenceFor") or [])[:3])
     signals = ", ".join((archetype.get("distinguishingSignals") or [])[:3])
-    if "BNL-facing lore/interface" in name:
+    sig = behavioral_signature or {}
+    sig_read = str(sig.get("signatureRead") or "")
+    bnl_stance = (sig.get("stanceTowardBNL") or {}).get("stance") if isinstance(sig.get("stanceTowardBNL"), dict) else ""
+    network_stance = (sig.get("stanceTowardNetwork") or {}).get("stance") if isinstance(sig.get("stanceTowardNetwork"), dict) else ""
+    unusual_subjects = [item.get("subject") for item in (sig.get("unusualRecurringSubjects") or []) if isinstance(item, dict)]
+    nearby_names = [item.get("name") for item in (nearby_context or []) if isinstance(item, dict)]
+    if "orion" in sig_read.lower() and ("archive" in sig_read.lower() or "ai" in sig_read.lower()):
+        text = f"BNL reads {subject} as an Orion/archive-facing subject when the owned evidence frames Orion as an AI, speaker, archive, or connected intelligence. This is review-only: relationship meaning and canon status still need explicit confirmation."
+    elif bnl_stance in {"antagonistic", "playful_challenger"}:
+        text = f"BNL reads {subject} as a BNL-facing antagonist or playful challenger because subject-owned evidence shows repeated challenge, pushback, teasing, or provocation toward BNL. That distinguishes the file from generic community chatter, but tone and public wording need review."
+    elif unusual_subjects or network_stance in {"questioning", "skeptical"}:
+        text = f"BNL reads {subject} as a weird-topic community participant whose owned evidence includes unusual recurring subjects{(': ' + ', '.join(unusual_subjects[:3])) if unusual_subjects else ''} and Network skepticism/questioning when supported by the cited fragments. Nearby context such as {', '.join(nearby_names[:3]) if nearby_names else 'other entities'} stays quarantined unless owned evidence supports it."
+    elif "BNL-facing lore/interface" in name:
         text = f"BNL reads {subject} as a recurring BARCODE-side participant whose activity is unusually BNL-facing. The strongest pattern is not ordinary artist submission behavior; it is interface/lore-style interaction around {signals}. That makes {subject} more useful as a community/lore/interface subject than as a confirmed artist profile until queue history, public music ownership, and anchor meaning are confirmed."
     elif "music-link" in name:
         text = f"BNL reads {subject} as a music-link sharer: the useful signal is the presence of music platforms, tracks, songs, or link-sharing language. The packet should not turn those links into owned music, queue submissions, played tracks, or an artist profile unless connected queue data or public ownership evidence is added."
@@ -3602,6 +3664,83 @@ def _build_bnl_take(subject: str, memory: dict[str, Any], topics: list[dict[str,
     else:
         text = f"BNL reads {subject} as {name}. The useful pattern is {signals or 'the available subject evidence'}, but the packet still cannot support {missing or 'public identity, role, relationship meaning, or queue history'} without admin confirmation."
     return _case_text(text, 980)
+
+
+def _behavioral_signature_v1(subject: str, ownership: dict[str, Any]) -> dict[str, Any]:
+    owned_texts = _case_list([item.get("text") for item in ownership.get("owned", [])], limit=80, item_limit=260)
+    body = "\n".join(owned_texts).lower()
+
+    def matches(pattern: str) -> list[str]:
+        return [text for text in owned_texts if re.search(pattern, text, flags=re.I)][:4]
+
+    recurring: list[dict[str, Any]] = []
+    unusual: list[dict[str, Any]] = []
+
+    def add_behavior(label: str, evidence: list[str], note: str) -> None:
+        if not evidence:
+            return
+        recurring.append({
+            "behavior": label,
+            "strength": "strong" if len(evidence) >= 3 else ("moderate" if len(evidence) >= 2 else "weak"),
+            "evidenceCount": len(evidence),
+            "exampleSignals": evidence[:3],
+            "note": note,
+        })
+
+    add_behavior("BNL challenge / pushback", matches(r"\b(antagoniz|challenge|push(?:es|ed)? back|teas(?:e|es|ed)|provok|argu(?:e|es|ed)|calls? out|tests? bnl)\b"), "Subject-owned evidence shows repeated BNL-facing challenge/pushback; keep tone review-only.")
+    add_behavior("Orion/archive/AI framing", matches(r"\b(orion|archive|my ai|his ai|her ai|speaks? (?:for|through)|ai[- ]proxy|interface)\b"), "Subject-owned evidence uses Orion/archive/AI or interface language; relationship meaning remains review-only unless explicitly confirmed.")
+    add_behavior("Network motive questioning", matches(r"\b(network|barcode network|barcode)\b.*\b(why|motive|intent|trust|skeptic|question|what does|what are they)\b|\b(question|skeptic|doubt|trust)\w*\b.*\b(network|barcode network)\b"), "Subject-owned evidence questions Network/BARCODE motives or intent.")
+
+    concrete_patterns = [
+        ("vibrating beds", r"\bvibrating beds?\b"),
+        ("unusual physical/object/environment references", r"\b(vibrating|bed|mattress|object|physical|weird concrete|environment|room|device)\b"),
+    ]
+    for label, pattern in concrete_patterns:
+        ev = matches(pattern)
+        if ev:
+            unusual.append({"subject": label, "evidenceCount": len(ev), "exampleSignals": ev[:3], "note": "Unusual concrete recurring subject appears in subject-owned evidence."})
+
+    bnl_ev = matches(r"\b(bnl|bnl-01)\b")
+    challenger_ev = matches(r"\b(antagoniz|challenge|push(?:es|ed)? back|teas(?:e|es|ed)|provok|argu(?:e|es|ed)|calls? out)\b")
+    supportive_ev = matches(r"\b(support|thanks|help(?:s|ed)?|appreciat|boost)\b.*\b(bnl|bnl-01)\b")
+    if challenger_ev:
+        bnl_stance = "playful_challenger" if matches(r"\b(teas(?:e|es|ed)|playful|joke|provok)\b") else "antagonistic"
+        bnl_conf = "strong" if len(challenger_ev) >= 3 else "moderate"
+        bnl_note = "Subject-owned evidence shows direct challenge, antagonism, teasing, or pushback toward BNL."
+        bnl_evidence = challenger_ev
+    elif supportive_ev:
+        bnl_stance, bnl_conf, bnl_note, bnl_evidence = "supportive", "moderate", "Subject-owned evidence has supportive BNL-facing language.", supportive_ev
+    elif bnl_ev:
+        bnl_stance, bnl_conf, bnl_note, bnl_evidence = "BNL-facing", "moderate", "Subject-owned evidence addresses or references BNL.", bnl_ev
+    else:
+        bnl_stance, bnl_conf, bnl_note, bnl_evidence = "unknown", "weak", "No subject-owned BNL stance is clear.", []
+
+    network_question_ev = matches(r"\b(network|barcode network|barcode)\b.*\b(why|motive|intent|trust|skeptic|question|what does|what are they)\b|\b(question|skeptic|doubt|trust)\w*\b.*\b(network|barcode network)\b")
+    network_lore_ev = matches(r"\b(network|barcode|edge|lardcode)\b")
+    if network_question_ev:
+        stance = "skeptical" if matches(r"\b(skeptic|doubt|trust)\w*\b") else "questioning"
+        network = {"stance": stance, "confidence": "strong" if len(network_question_ev) >= 3 else "moderate", "evidence": network_question_ev, "note": "Subject-owned evidence questions Network/BARCODE motives or intent."}
+    elif network_lore_ev:
+        network = {"stance": "lore-engaged", "confidence": "moderate", "evidence": network_lore_ev[:3], "note": "Subject-owned evidence engages Network/BARCODE lore without a clear trust/skepticism stance."}
+    else:
+        network = {"stance": "unknown", "confidence": "weak", "evidence": [], "note": "No subject-owned Network stance is clear."}
+
+    if not recurring and unusual:
+        add_behavior("unusual concrete topic recurrence", [sig for item in unusual for sig in item.get("exampleSignals", [])], "Subject-owned evidence includes unusual concrete recurring topics.")
+    if not recurring:
+        add_behavior("general subject-owned participation", owned_texts[:2], "Subject-owned evidence exists but does not yet form a sharper behavioral pattern.")
+
+    if "orion" in body and ("archive" in body or "ai" in body):
+        read = f"BNL reads {subject}'s owned evidence as Orion/archive/AI-facing; relationship meaning remains review-only unless confirmed."
+    elif challenger_ev:
+        read = f"BNL reads {subject}'s owned evidence as BNL-facing challenge or playful antagonism rather than generic community chatter."
+    elif unusual or network_question_ev:
+        read = f"BNL reads {subject}'s owned evidence as unusual concrete-topic participation with Network skepticism/questioning when supported by the cited fragments."
+    elif owned_texts:
+        read = f"BNL has subject-owned evidence for {subject}, but the behavioral signature is still limited and review-only."
+    else:
+        read = f"BNL does not have enough subject-owned evidence to form a behavioral signature for {subject}."
+    return {"signatureRead": _case_text(read, 420), "recurringBehaviors": recurring[:6], "stanceTowardBNL": {"stance": bnl_stance, "confidence": bnl_conf, "evidence": bnl_evidence[:4], "note": bnl_note}, "stanceTowardNetwork": network, "unusualRecurringSubjects": unusual[:6]}
 
 
 def _source_file_gaps(memory: dict[str, Any], anchors: list[dict[str, Any]]) -> list[str]:
@@ -3619,10 +3758,14 @@ def _source_file_gaps(memory: dict[str, Any], anchors: list[dict[str, Any]]) -> 
 
 def build_subject_intelligence_brief_v1(memory: dict[str, Any]) -> dict[str, Any]:
     subject = _case_text(memory.get("subjectName") or "this subject", 140)
+    subject_key = _case_text(memory.get("subjectKey") or _subject_key(subject), 140)
+    confirmed_aliases = _case_list(memory.get("confirmedAliases") or memory.get("aliases"), limit=12, item_limit=120)
+    ownership = subject_owned_text_fragments(memory, subject, subject_key, confirmed_aliases)
     profile = _subject_activity_profile(memory)
     channels = _channel_breakdown(memory)
-    topics = _topic_buckets(memory)
-    anchors, ignored_noise = _named_anchor_extraction(memory)
+    topics = _topic_buckets(memory, ownership)
+    anchors, ignored_noise, nearby_context = _named_anchor_extraction(memory, ownership)
+    behavioral_signature = _behavioral_signature_v1(subject, ownership)
     archetype = _subject_archetype_read(subject, memory, profile, topics, anchors, channels)
     distinguishing = _distinguishing_read(archetype)
     music = _signals_from(memory, ("musicSignals", "bestEvidenceToReview", "representativeEvidence"), "No specific music/link signal is confirmed in the current packet; do not infer submissions or ownership.")
@@ -3634,14 +3777,17 @@ def build_subject_intelligence_brief_v1(memory: dict[str, Any]) -> dict[str, Any
     confidence = _case_text(f"Archetype confidence is {archetype.get('confidence')} for the internal shape read. Safety remains strict: identity, public role, relationship meaning, queue/submission claims, payment/Priority status, and public-safe anchor meaning stay unconfirmed until admin review connects source links. This brief is admin-facing and review-only.", 520)
     gaps = _source_file_gaps(memory, anchors)
     return _sanitize_archive_value({
-        "subjectRead": _build_subject_read(subject, profile, topics, channels, archetype),
-        "bnlTake": _build_bnl_take(subject, memory, topics, anchors, archetype),
+        "subjectRead": _build_subject_read(subject, profile, topics, channels, archetype, behavioral_signature),
+        "bnlTake": _build_bnl_take(subject, memory, topics, anchors, archetype, behavioral_signature, nearby_context),
         "subjectArchetypeRead": archetype,
         "distinguishingRead": distinguishing,
         "activityProfile": profile,
         "channelBreakdown": channels,
         "topicBuckets": topics,
         "namedAnchors": anchors,
+        "nearbyContextSignals": nearby_context,
+        "evidenceOwnershipSummary": ownership.get("summary", {}),
+        "behavioralSignatureV1": behavioral_signature,
         "ignoredExtractionNoise": ignored_noise,
         "interactionPatterns": _signals_from(memory, ("bnlInteractionSignals", "communitySignals", "conversationThemes"), "No specific interaction pattern is exposed beyond the representative evidence."),
         "musicAndLinkSignals": music,

--- a/tests/test_source_file_archive.py
+++ b/tests/test_source_file_archive.py
@@ -542,3 +542,91 @@ class SourceFileArchiveTests(unittest.TestCase):
         self.assertIn("queue/submission memory is not connected", body)
         self.assertIn("does not auto-confirm identity", body)
 
+
+    def test_evidence_ownership_antigrain_quarantines_nearby_orion(self):
+        brief = self._subject_brief_for(
+            "Antigrain",
+            sourceCounts={"conversations": 8},
+            topChannels=[{"channel": "#general", "count": 5, "summary": "Antigrain asks odd concrete questions and talks about the Network."}],
+            topTopicDetails=[{"topic": "vibrating beds and Network motives", "count": 3, "summary": "Owned evidence includes vibrating beds and questioning Network motives."}],
+            usefulEvidence=[
+                {"summary": "Antigrain asks why the BARCODE Network wants vibrating beds in the room.", "authorName": "Antigrain", "sourceType": "Discord conversation", "visibility": "public_context"},
+                {"summary": "Antigrain questions the Network's motives and intent around weird physical objects.", "authorName": "Antigrain", "sourceType": "Discord conversation", "visibility": "public_context"},
+            ],
+            relationshipSignals=["Orion appears near Antigrain in broader community context; meaning unconfirmed."],
+            representativeEvidence=[{"summary": "Antigrain asked about vibrating beds and questioned Network motives in #general.", "authorName": "Antigrain", "channelName": "#general", "sourceType": "Discord conversation", "visibility": "public_context"}],
+        )
+        self.assertTrue(any("vibrating" in item.get("subject", "").lower() for item in brief["behavioralSignatureV1"]["unusualRecurringSubjects"]))
+        self.assertIn(brief["behavioralSignatureV1"]["stanceTowardNetwork"]["stance"], {"questioning", "skeptical"})
+        self.assertIn("unusual recurring subjects", brief["bnlTake"].lower())
+        self.assertIn("network skepticism", brief["bnlTake"].lower())
+        self.assertNotIn("Orion", {item.get("name") for item in brief["namedAnchors"]})
+        self.assertIn("Orion", {item.get("name") for item in brief["nearbyContextSignals"]})
+        self.assertTrue(any("warning" in item and "not treat" in item["warning"].lower() for item in brief["nearbyContextSignals"]))
+
+    def test_evidence_ownership_crow_owned_orion_archive_ai_can_anchor(self):
+        brief = self._subject_brief_for(
+            "Crow",
+            sourceCounts={"conversations": 7},
+            topChannels=[{"channel": "#barcode-bot", "count": 5, "summary": "Crow addresses BNL with Orion archive language."}],
+            topTopicDetails=[{"topic": "Orion archive AI language", "count": 4}],
+            usefulEvidence=[
+                {"summary": "Crow says Orion is my AI and speaks through the archive interface.", "authorName": "Crow", "sourceType": "Discord conversation", "visibility": "public_context"},
+                {"summary": "Crow frames the archive as Orion speaking through a connected intelligence.", "authorName": "Crow", "sourceType": "Discord conversation", "visibility": "public_context"},
+            ],
+            representativeEvidence=[{"summary": "Crow told BNL-01 that Orion is my AI and the archive speaks through Orion.", "authorName": "Crow", "channelName": "#barcode-bot", "sourceType": "Discord conversation", "visibility": "public_context"}],
+        )
+        self.assertIn("Orion", {item.get("name") for item in brief["namedAnchors"]})
+        body = json.dumps(brief["behavioralSignatureV1"], sort_keys=True).lower()
+        self.assertIn("archive", body)
+        self.assertIn("orion", body)
+        self.assertIn("ai", body)
+        self.assertIn("orion/archive-facing", brief["bnlTake"].lower())
+        self.assertIn("review-only", brief["bnlTake"].lower())
+
+    def test_evidence_ownership_shortybabe_bnl_challenger_signature(self):
+        brief = self._subject_brief_for(
+            "ShortyBabe",
+            sourceCounts={"conversations": 6},
+            topChannels=[{"channel": "#barcode-bot", "count": 4, "summary": "ShortyBabe challenges BNL repeatedly."}],
+            topTopicDetails=[{"topic": "BNL challenge and pushback", "count": 4}],
+            usefulEvidence=[
+                {"summary": "ShortyBabe challenges BNL-01 and pushes back on the Source File boundary.", "authorName": "ShortyBabe", "sourceType": "Discord conversation", "visibility": "public_context"},
+                {"summary": "ShortyBabe teases BNL and provokes BNL-01 about the rules.", "authorName": "ShortyBabe", "sourceType": "Discord conversation", "visibility": "public_context"},
+            ],
+            representativeEvidence=[{"summary": "ShortyBabe challenged BNL-01 and pushed back at the rules.", "authorName": "ShortyBabe", "channelName": "#barcode-bot", "sourceType": "Discord conversation", "visibility": "public_context"}],
+        )
+        self.assertIn(brief["behavioralSignatureV1"]["stanceTowardBNL"]["stance"], {"antagonistic", "playful_challenger"})
+        self.assertIn("challenge", json.dumps(brief["behavioralSignatureV1"], sort_keys=True).lower())
+        self.assertIn("generic community chatter", brief["bnlTake"].lower())
+
+    def test_co_mention_only_named_entity_routes_to_nearby_context(self):
+        brief = self._subject_brief_for(
+            "Signal Fox",
+            relationshipSignals=["Nova Artifact appears near Signal Fox in co-mentioned archive context only."],
+            representativeEvidence=[{"summary": "Signal Fox discussed community topics without adding the nearby entity as owned evidence.", "authorName": "Signal Fox", "sourceType": "Discord conversation", "visibility": "public_context"}],
+        )
+        self.assertNotIn("Nova", {item.get("name") for item in brief["namedAnchors"]})
+        self.assertTrue(any(item.get("name") in {"Nova", "Artifact"} for item in brief["nearbyContextSignals"]))
+
+    def test_source_blind_legacy_is_quarantined_from_owned_claims(self):
+        packet = self.large_packet()
+        packet.update({"subject": "Legacy Fox", "representativeEvidence": [], "memory_tiers": {"source_blind_memory_trace": ["Legacy Fox may be tied to Orion from old memory_tiers/source_blind_memory_trace."]}})
+        memory = enrichment.build_subject_memory_packet_v1(packet)
+        memory["memory_tiers"] = packet["memory_tiers"]
+        brief = enrichment.build_subject_intelligence_brief_v1(memory)
+        self.assertGreaterEqual(brief["evidenceOwnershipSummary"]["sourceBlindLegacyEvidenceCount"], 1)
+        self.assertTrue(brief["evidenceOwnershipSummary"]["sourceBlindWarnings"])
+        self.assertNotIn("Orion", {item.get("name") for item in brief["namedAnchors"]})
+
+    def test_generated_taxonomy_labels_remain_ignored_noise_not_anchors(self):
+        brief = self._subject_brief_for(
+            "Taxonomy Fox",
+            topTopicDetails=[{"topic": "internal classification source file relationship taxonomy", "count": 5}],
+            sourceCoverage=["ENTITY", "LOCAL", "SOURCE FILE", "RELATIONSHIP", "INTERNAL"],
+            representativeEvidence=[{"summary": "Taxonomy Fox had one generic public chat item.", "authorName": "Taxonomy Fox", "sourceType": "Discord conversation", "visibility": "public_context"}],
+        )
+        anchors = {item.get("name") for item in brief["namedAnchors"]}
+        self.assertNotIn("Internal", anchors)
+        noise_terms = {item.get("term") for item in brief["ignoredExtractionNoise"]}
+        self.assertTrue({"internal", "source file", "relationship"} & noise_terms)


### PR DESCRIPTION
### Motivation
- Prevent nearby/co-mentioned/shared-topic/system-generated evidence from being treated as subject-owned facts by classifying each evidence fragment by ownership/authority before use.
- Provide a reusable ownership gate that future memory, dossier, website, and queue context can call so subject claims are only driven by truly owned/authoritative evidence.
- Surface subject-owned behavioral signatures (e.g., Antigrain concrete topics, Crow Orion/archive framing, ShortyBabe BNL-challenger behavior) while quarantining nearby context as review-only.

### Description
- Add `bnl_evidence_ownership.py` with `classify_evidence_ownership(raw_item, subject_name, subject_key, confirmed_aliases=None)` and `subject_owned_text_fragments(memory, subject_name, subject_key, confirmed_aliases=None)` implementing the ownership scopes and a shared architecture comment for future reuse.
- Integrate ownership routing into `bnl_source_file_enrichment.py` so `build_subject_intelligence_brief_v1` now builds `ownership = subject_owned_text_fragments(...)`, uses ownership to drive `_topic_buckets(...)` and `_named_anchor_extraction(...)`, and exposes `evidenceOwnershipSummary`, `nearbyContextSignals`, and `behavioralSignatureV1` in `subjectIntelligenceBriefV1` while preserving `ignoredExtractionNoise`.
- Add `_behavioral_signature_v1(...)` and wire its output into `_build_subject_read` and `_build_bnl_take` so behavioral signatures are constructed from subject-owned fragments only and nearby/co-mention names are quarantined to `nearbyContextSignals` with explicit warnings.
- Update named-anchor and topic extraction logic to prefer owned/authoritative fragments, treat co-mention/shared-topic/generated/system/source-blind traces as review-only (not anchors), and avoid promoting nearby entities into `namedAnchors`.
- Add focused tests in `tests/test_source_file_archive.py` covering Antigrain-like, Crow-like, ShortyBabe-like, co-mention-only routing, source-blind legacy quarantine, and generated/taxonomy noise handling.

### Testing
- Ran syntax checks: `python3 -m py_compile bnl_evidence_ownership.py bnl_source_file_enrichment.py` and full module compile: `python3 -m py_compile bnl01_bot.py bnl_dossier_recommendations.py bnl_source_file_refresh.py bnl_dossier_source_packets.py bnl_entity_intelligence.py bnl_source_file_enrichment.py`, which succeeded.
- Ran unit tests: `PYTHONPATH=. pytest -q` which completed successfully with the full suite passing: 470 passed (31 subtests passed) and no failing tests.
- Also exercised the focused `tests/test_source_file_archive.py` during development; the new ownership and behavioral signature assertions passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a0c73bb988321adf072b5fe356a94)