### PR TITLE
Tighten source-owned evidence gate and prevent authority over-promotion

### DIFF
--- a/bnl_evidence_ownership.py
+++ b/bnl_evidence_ownership.py
@@ -25,6 +25,29 @@ REVIEW_ONLY_SCOPES = {
 }
 OWNERSHIP_SCOPES = (*OWNED_SCOPES, *REVIEW_ONLY_SCOPES)
 
+_DERIVED_OR_BROAD_LANES = {
+    "knowncontext",
+    "relationshipsignals",
+    "communitycontext",
+    "relationshipcontext",
+    "publicsafecandidatefacts",
+    "sourcecoverage",
+    "topicbreakdown",
+    "toptopicdetails",
+    "conversationthemes",
+    "topicthemes",
+    "missinginfo",
+    "sourceauthority",
+}
+_EXPLICIT_SUBJECT_FIELD_KEYS = (
+    "subject", "subjectName", "subject_name", "subjectKey", "subject_key", "entity", "entityName",
+    "normalizedName", "sourceFileName", "source_file_name", "profileSubject", "profileName", "publicProfileSubject",
+)
+_QUEUE_SUBJECT_FIELD_KEYS = (
+    "queueSubject", "queueSubjectName", "queue_subject", "queue_subject_name", "submitter", "submitterName",
+    "artist", "artistName", "queueArtistName", "submissionSubject",
+)
+
 # This ownership classifier is the shared gate for BNL memory.
 # Source File intelligence, Discord memory retrieval, website/dossier context,
 # queue/submission context, and future canonical entity profiles should all pass
@@ -40,8 +63,17 @@ def classify_evidence_ownership(raw_item: Any, subject_name: str, subject_key: s
     subject_tokens = _subject_tokens(subject_name, subject_key, confirmed_aliases)
     subject_hit = _any_token(haystack, subject_tokens)
     author_tokens = _field_values(raw_item, ("author", "authorName", "author_name", "username", "userName", "displayName", "memberName", "sender", "speaker", "createdBy", "owner", "ownerName"))
-    subject_field_tokens = _field_values(raw_item, ("subject", "subjectName", "subject_name", "subjectKey", "subject_key", "entity", "entityName", "normalizedName"))
+    subject_field_tokens = _field_values(raw_item, _EXPLICIT_SUBJECT_FIELD_KEYS)
+    queue_subject_tokens = _field_values(raw_item, _QUEUE_SUBJECT_FIELD_KEYS)
     relationship_tokens = _field_values(raw_item, ("from", "to", "source", "target", "subjectA", "subjectB", "endpointA", "endpointB", "relatedName", "relatedSubject"))
+    explicit_subject_match = _field_matches(subject_field_tokens, subject_tokens)
+    queue_subject_match = _field_matches(queue_subject_tokens, subject_tokens)
+    author_match = _field_matches(author_tokens, subject_tokens)
+    alias_match = _field_matches(author_tokens, [_norm(a) for a in confirmed_aliases if a])
+    relationship_match = bool(relationship_tokens and _field_matches(relationship_tokens, subject_tokens))
+    direct_match = _direct_address_to_subject(raw_item, haystack, subject_tokens)
+    text_subject_match = _text_starts_as_subject(text, subject_tokens)
+    derived_or_broad = _is_derived_or_broad_lane(raw_item)
 
     def result(ownership: str, confidence: str, reason: str) -> dict[str, str]:
         return {
@@ -52,30 +84,49 @@ def classify_evidence_ownership(raw_item: Any, subject_name: str, subject_key: s
             "sourceType": source_type,
             "visibility": visibility,
             "authority": authority,
+            "sourceLane": _source_lane(raw_item),
         }
 
     if _has_source_blind_marker(raw_item, haystack):
         return result("source_blind_legacy", "weak", "source-blind or legacy memory trace lacks item-level ownership metadata")
     if _has_generated_marker(raw_item, haystack):
         return result("generated_or_taxonomy", "weak", "generated report/taxonomy/system wording is not source evidence")
-    if _has_queue_marker(raw_item, haystack) and _visibility_safe(haystack, visibility):
-        return result("queue_authoritative", "strong" if subject_hit else "moderate", "queue/submission authority marker is present and visibility-safe")
-    if _has_site_marker(raw_item, haystack) and _visibility_safe(haystack, visibility):
-        return result("site_authoritative", "strong" if subject_hit else "moderate", "site/source-file authority marker is present and visibility-safe")
-    if _has_broadcast_marker(raw_item, haystack) and _visibility_safe(haystack, visibility):
-        return result("broadcast_memory_authoritative", "strong" if subject_hit else "moderate", "broadcast memory authority marker is present and visibility-safe")
-    if _field_matches(author_tokens, subject_tokens):
+
+    # Subject ownership outranks generic authority. Authority markers are only
+    # allowed after explicit author/subject/endpoint/direct evidence has been
+    # checked so broad Source File context cannot over-promote nearby entities.
+    if author_match:
         return result("owned", "strong", "author/user metadata matches the subject or confirmed alias")
-    if _field_matches(subject_field_tokens, subject_tokens):
+    if explicit_subject_match:
         return result("owned", "strong", "subject metadata matches the requested subject")
-    if _field_matches(author_tokens, [_norm(a) for a in confirmed_aliases if a]):
+    if alias_match:
         return result("confirmed_alias", "strong", "author/user metadata matches a confirmed subject alias")
-    if relationship_tokens and _field_matches(relationship_tokens, subject_tokens):
+    if relationship_match:
         return result("explicit_relationship", "moderate", "relationship endpoint metadata includes the subject")
-    if _direct_address_to_subject(raw_item, haystack, subject_tokens):
+    if direct_match:
         return result("direct_address", "moderate", "item is addressed directly to the subject")
-    if _text_starts_as_subject(text, subject_tokens):
+    if text_subject_match and not derived_or_broad:
         return result("owned", "moderate", "text is written as subject-authored/action evidence")
+
+    if derived_or_broad:
+        if _has_generated_marker(raw_item, haystack):
+            return result("generated_or_taxonomy", "weak", "derived/generated lane is not source-owned evidence")
+        if subject_hit or _co_mention_marker(raw_item, haystack):
+            return result("co_mention", "weak", "derived/broad context lane lacks explicit subject ownership metadata")
+        return result("shared_topic", "weak", "derived/broad context lane is review-only without explicit subject ownership metadata")
+
+    if _has_queue_marker(raw_item, haystack) and _visibility_safe(haystack, visibility):
+        if explicit_subject_match or queue_subject_match:
+            return result("queue_authoritative", "strong", "queue/submission authority marker has an explicit matching subject field")
+        return result("shared_topic", "weak", "queue/submission authority marker lacks explicit matching subject metadata")
+    if _has_site_marker(raw_item, haystack) and _visibility_safe(haystack, visibility):
+        if explicit_subject_match and (_has_strict_site_authority_marker(raw_item, haystack) or _has_subject_attached_source_note(raw_item, haystack)):
+            return result("site_authoritative", "strong", "site/source-file authority marker is explicitly attached to the requested subject")
+        return result("shared_topic", "weak", "generic site/source-file/profile wording lacks explicit matching subject authority")
+    if _has_broadcast_marker(raw_item, haystack) and _visibility_public_safe(haystack, visibility):
+        if explicit_subject_match:
+            return result("broadcast_memory_authoritative", "strong", "public-safe broadcast memory is explicitly attached to the requested subject")
+        return result("shared_topic", "weak", "broadcast/show/BARCODE wording lacks explicit matching subject metadata")
     if subject_hit and _shared_topic_marker(raw_item, haystack):
         return result("shared_topic", "weak", "subject appears in topic/community context without ownership metadata")
     if subject_hit or _co_mention_marker(raw_item, haystack):
@@ -112,6 +163,7 @@ def subject_owned_text_fragments(memory: dict[str, Any], subject_name: str, subj
         "coMentionExamples": _texts(fragments.get("co_mention", []), 5),
         "sourceBlindWarnings": [f"Source-blind legacy memory was quarantined: {t}" for t in _texts(fragments.get("source_blind_legacy", []), 4)],
         "routingWarnings": [],
+        "ownershipRoutingDiagnostics": _ownership_routing_diagnostics(review_items),
     }
     if counts["co_mention"] or counts["shared_topic"]:
         summary["routingWarnings"].append("Co-mentioned/shared-topic evidence is review context only and must not become subject facts.")
@@ -199,6 +251,14 @@ def _source_type(raw: Any) -> str:
     return "unknown"
 
 
+
+def _source_lane(raw: Any) -> str:
+    if isinstance(raw, dict):
+        for key in ("sourceLane", "lane", "field", "contextLane"):
+            if raw.get(key):
+                return _clean(str(raw.get(key)), 90)
+    return "unknown"
+
 def _visibility(raw: Any) -> str:
     if isinstance(raw, dict):
         for key in ("visibility", "channelPolicy", "policy", "publicSafe", "privacy"):
@@ -246,6 +306,77 @@ def _field_values(raw: Any, keys: tuple[str, ...]) -> list[str]:
 def _field_matches(values: list[str], tokens: list[str]) -> bool:
     return any(v == token or _any_token(v, [token]) for v in values for token in tokens if v and token)
 
+
+
+def _is_derived_or_broad_lane(raw_item: Any) -> bool:
+    if not isinstance(raw_item, dict):
+        return False
+    lane_values = [str(raw_item.get(key) or "") for key in ("sourceLane", "lane", "field", "contextLane", "sourceType", "type")]
+    normalized = {_norm(value).replace(" ", "") for value in lane_values if value}
+    return any(value in _DERIVED_OR_BROAD_LANES for value in normalized)
+
+
+def _visibility_public_safe(haystack: str, visibility: str) -> bool:
+    lowered = f"{haystack} {visibility}".lower()
+    unsafe = ("private" in lowered or "internal_review_only" in lowered or "publicsafe false" in _norm(lowered) or "public safe false" in _norm(lowered))
+    return not unsafe and ("public" in lowered or "approved" in lowered or "broadcast" in lowered)
+
+
+def _has_strict_site_authority_marker(raw: Any, haystack: str) -> bool:
+    if isinstance(raw, dict):
+        authority = _norm(str(raw.get("authority") or raw.get("sourceAuthority") or raw.get("authorityType") or raw.get("sourceAuthorityType") or ""))
+        source_type = _norm(str(raw.get("sourceType") or raw.get("type") or raw.get("origin") or ""))
+        if any(marker in authority for marker in ("site authoritative", "site_authoritative", "source file authoritative", "public profile")):
+            return True
+        if any(marker in source_type for marker in ("site authoritative", "public profile record", "source file note")):
+            return True
+    return any(t in haystack for t in ("site_authoritative", "site authoritative"))
+
+
+def _has_subject_attached_source_note(raw: Any, haystack: str) -> bool:
+    if not isinstance(raw, dict):
+        return False
+    lane = _norm(str(raw.get("sourceLane") or raw.get("sourceType") or raw.get("type") or ""))
+    if any(marker in lane for marker in ("source file note", "source note", "public profile record")):
+        return True
+    return bool(raw.get("sourceFileNote") or raw.get("sourceNote") or raw.get("publicProfileRecord"))
+
+
+def _ownership_routing_diagnostics(review_items: list[dict[str, Any]]) -> dict[str, Any]:
+    blocked: list[dict[str, str]] = []
+    warnings: list[str] = []
+    seen: set[tuple[str, str]] = set()
+    authority_warning_terms = ("source file", "identity check", "public profile", "dossier", "queue", "submission", "broadcast", "radio", "barcode")
+    for item in review_items:
+        classification = item.get("classification", {}) if isinstance(item, dict) else {}
+        text = str(item.get("text") or classification.get("safeSummary") or "")
+        lowered = text.lower()
+        reason = str(classification.get("reason") or "review-only evidence lacks explicit subject ownership metadata")
+        routed_as = str(classification.get("ownership") or "unknown")
+        source_lane = str(classification.get("sourceLane") or classification.get("sourceType") or "unknown")
+        attempted = "namedAnchors/subject-owned intelligence" if any(term in lowered for term in ("orion", "bnl", "barcode", "network", "edge", "interface", "archive", "ai")) else "subject-owned intelligence"
+        terms = []
+        for term in ("Orion", "BNL", "BNL-01", "BARCODE", "Network", "EDGE", "Interface", "Archive", "AI"):
+            pattern = re.escape(term).replace("\\ ", r"\s+")
+            if re.search(rf"(?<![-A-Za-z0-9]){pattern}(?![-A-Za-z0-9])", text, flags=re.I):
+                terms.append(term)
+        if not terms:
+            terms = re.findall(r"(?<![-A-Za-z0-9])[A-Z][A-Za-z0-9'’-]{2,}(?:-[A-Za-z0-9'’-]+)*\b", text)[:3]
+        for term in terms[:4]:
+            key = (term.lower(), source_lane)
+            if key in seen:
+                continue
+            seen.add(key)
+            blocked.append({"term": term, "sourceLane": source_lane, "attemptedScope": attempted, "routedAs": routed_as, "reason": reason})
+            if len(blocked) >= 20:
+                break
+        if any(term in lowered for term in authority_warning_terms) and routed_as not in OWNED_SCOPES:
+            warning = f"Strict authority gate kept {source_lane} as {routed_as}: {reason}"
+            if warning not in warnings:
+                warnings.append(warning)
+        if len(blocked) >= 20:
+            break
+    return {"overpromotedCandidatesBlocked": blocked[:20], "strictAuthorityWarnings": warnings[:12]}
 
 def _visibility_safe(haystack: str, visibility: str) -> bool:
     lowered = f"{haystack} {visibility}".lower()

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -3315,6 +3315,9 @@ def _topic_buckets(memory: dict[str, Any], ownership: dict[str, Any] | None = No
         topic_tokens = [part for part in re.split(r"[^a-z0-9]+", key) if len(part) >= 3]
         signals = [text for text in evidence_texts if any(token in text.lower() for token in topic_tokens[:3])][:3]
         review_signals = [text for text in review_only_texts if any(token in text.lower() for token in topic_tokens[:3])][:2]
+        if ownership and evidence_texts and not signals and any(term in key for term in ("orion", "interface", "lore", "source file", "dossier", "relationship", "bnl")):
+            # Keep broad/derived labels from becoming subject-owned shape evidence.
+            continue
         if count is None:
             count = len(signals) or None
         strength = "weak"
@@ -3513,15 +3516,19 @@ def _signals_from(memory: dict[str, Any], fields: tuple[str, ...], fallback: str
     return deduped or [fallback]
 
 
-def _brief_signal_text(memory: dict[str, Any], topics: list[dict[str, Any]], anchors: list[dict[str, Any]], channels: list[dict[str, Any]] | None = None) -> str:
+def _brief_signal_text(memory: dict[str, Any], topics: list[dict[str, Any]], anchors: list[dict[str, Any]], channels: list[dict[str, Any]] | None = None, ownership: dict[str, Any] | None = None) -> str:
     context = _brief_context(memory)
-    shape_fields = (
-        "conversationThemes", "topicThemes", "topTopicDetails", "topicBreakdown", "knownContext", "usefulEvidence",
-        "bestEvidenceToReview", "bnlInteractionSignals", "musicSignals", "communitySignals", "relationshipSignals",
-        "evidenceDetails", "representativeEvidence", "topChannels", "recentActivitySummary", "authoredVsMentionedSummary",
-    )
-    values = [topics, anchors, channels or [], memory.get("representativeMoments")]
-    values.extend(context.get(field) for field in shape_fields)
+    if ownership:
+        owned_texts = [item.get("text") for item in ownership.get("owned", [])]
+        values = [topics, anchors, channels or [], owned_texts]
+    else:
+        shape_fields = (
+            "conversationThemes", "topicThemes", "topTopicDetails", "topicBreakdown", "knownContext", "usefulEvidence",
+            "bestEvidenceToReview", "bnlInteractionSignals", "musicSignals", "communitySignals", "relationshipSignals",
+            "evidenceDetails", "representativeEvidence", "topChannels", "recentActivitySummary", "authoredVsMentionedSummary",
+        )
+        values = [topics, anchors, channels or [], memory.get("representativeMoments")]
+        values.extend(context.get(field) for field in shape_fields)
     fragments = []
     for text in _case_flatten_text_values(values, max_items=160, item_limit=300):
         lowered = text.lower()
@@ -3535,8 +3542,8 @@ def _queue_connected(memory: dict[str, Any]) -> bool:
     return str(_brief_context(memory).get("queueSubmissionStatus") or "not_connected").lower() not in {"", "not_connected", "unknown", "none"}
 
 
-def _subject_archetype_read(subject: str, memory: dict[str, Any], profile: dict[str, Any], topics: list[dict[str, Any]], anchors: list[dict[str, Any]], channels: list[dict[str, Any]]) -> dict[str, Any]:
-    body = _brief_signal_text(memory, topics, anchors, channels)
+def _subject_archetype_read(subject: str, memory: dict[str, Any], profile: dict[str, Any], topics: list[dict[str, Any]], anchors: list[dict[str, Any]], channels: list[dict[str, Any]], ownership: dict[str, Any] | None = None) -> dict[str, Any]:
+    body = _brief_signal_text(memory, topics, anchors, channels, ownership)
     total = _as_int(profile.get("totalEvidenceScanned")) or _as_int(profile.get("totalApprovedPublicAuthoredItems")) or len(memory.get("representativeMoments") or [])
     queue_connected = _queue_connected(memory)
     has_bnl = any(term in body for term in ("bnl-01", "bnl", "threshold", "boundary", "operational"))
@@ -3756,6 +3763,35 @@ def _source_file_gaps(memory: dict[str, Any], anchors: list[dict[str, Any]]) -> 
     return _case_list([*gaps, *base], limit=10, item_limit=240)
 
 
+
+def _brief_ownership_routing_diagnostics(ownership: dict[str, Any], nearby_context: list[dict[str, Any]]) -> dict[str, Any]:
+    summary = ownership.get("summary", {}) if isinstance(ownership, dict) else {}
+    diagnostics = summary.get("ownershipRoutingDiagnostics") if isinstance(summary, dict) else None
+    if not isinstance(diagnostics, dict):
+        diagnostics = {"overpromotedCandidatesBlocked": [], "strictAuthorityWarnings": []}
+    blocked = list(diagnostics.get("overpromotedCandidatesBlocked") or [])
+    seen = {(str(item.get("term") or "").lower(), str(item.get("sourceLane") or "")) for item in blocked if isinstance(item, dict)}
+    for item in nearby_context or []:
+        if not isinstance(item, dict) or not item.get("name"):
+            continue
+        key = (str(item.get("name")).lower(), "nearbyContextSignals")
+        if key in seen:
+            continue
+        blocked.append({
+            "term": str(item.get("name")),
+            "sourceLane": "nearbyContextSignals",
+            "attemptedScope": "namedAnchors/subject-owned intelligence",
+            "routedAs": "co_mention",
+            "reason": str(item.get("warning") or item.get("reason") or "nearby context only; not subject-owned evidence"),
+        })
+        seen.add(key)
+        if len(blocked) >= 20:
+            break
+    return {
+        "overpromotedCandidatesBlocked": blocked[:20],
+        "strictAuthorityWarnings": _case_list(diagnostics.get("strictAuthorityWarnings") or [], limit=12, item_limit=240),
+    }
+
 def build_subject_intelligence_brief_v1(memory: dict[str, Any]) -> dict[str, Any]:
     subject = _case_text(memory.get("subjectName") or "this subject", 140)
     subject_key = _case_text(memory.get("subjectKey") or _subject_key(subject), 140)
@@ -3766,7 +3802,7 @@ def build_subject_intelligence_brief_v1(memory: dict[str, Any]) -> dict[str, Any
     topics = _topic_buckets(memory, ownership)
     anchors, ignored_noise, nearby_context = _named_anchor_extraction(memory, ownership)
     behavioral_signature = _behavioral_signature_v1(subject, ownership)
-    archetype = _subject_archetype_read(subject, memory, profile, topics, anchors, channels)
+    archetype = _subject_archetype_read(subject, memory, profile, topics, anchors, channels, ownership)
     distinguishing = _distinguishing_read(archetype)
     music = _signals_from(memory, ("musicSignals", "bestEvidenceToReview", "representativeEvidence"), "No specific music/link signal is confirmed in the current packet; do not infer submissions or ownership.")
     relationship = _signals_from(memory, ("relationshipSignals",), "No relationship signal is confirmed; keep any relationship interpretation review-only.")
@@ -3787,6 +3823,7 @@ def build_subject_intelligence_brief_v1(memory: dict[str, Any]) -> dict[str, Any
         "namedAnchors": anchors,
         "nearbyContextSignals": nearby_context,
         "evidenceOwnershipSummary": ownership.get("summary", {}),
+        "ownershipRoutingDiagnostics": _brief_ownership_routing_diagnostics(ownership, nearby_context),
         "behavioralSignatureV1": behavioral_signature,
         "ignoredExtractionNoise": ignored_noise,
         "interactionPatterns": _signals_from(memory, ("bnlInteractionSignals", "communitySignals", "conversationThemes"), "No specific interaction pattern is exposed beyond the representative evidence."),

--- a/tests/test_evidence_ownership.py
+++ b/tests/test_evidence_ownership.py
@@ -1,0 +1,50 @@
+import unittest
+
+from bnl_evidence_ownership import classify_evidence_ownership, subject_owned_text_fragments
+
+
+class EvidenceOwnershipStrictGateTests(unittest.TestCase):
+    def classify(self, item, subject="Antigrain"):
+        return classify_evidence_ownership(item, subject, subject.lower(), [])
+
+    def test_source_file_marker_without_subject_fields_is_not_site_authoritative(self):
+        classified = self.classify({"summary": "Source File note says Orion is nearby in public context.", "visibility": "public_context"})
+        self.assertNotEqual(classified["ownership"], "site_authoritative")
+        self.assertIn(classified["ownership"], {"shared_topic", "co_mention", "unknown", "generated_or_taxonomy"})
+
+    def test_identity_or_public_profile_marker_without_subject_fields_is_not_site_authoritative(self):
+        for text in ("Identity check found a public profile near Orion.", "Public profile dossier mentions Orion in broad context."):
+            with self.subTest(text=text):
+                classified = self.classify({"summary": text, "visibility": "public_context"})
+                self.assertNotEqual(classified["ownership"], "site_authoritative")
+                self.assertIn(classified["ownership"], {"shared_topic", "co_mention", "unknown", "generated_or_taxonomy"})
+
+    def test_derived_relationship_lane_without_subject_metadata_is_review_only(self):
+        classified = self.classify({"summary": "Orion appears near Antigrain in relationship context.", "sourceLane": "relationshipSignals", "visibility": "public_context"})
+        self.assertNotIn(classified["ownership"], {"owned", "site_authoritative", "queue_authoritative", "broadcast_memory_authoritative"})
+        self.assertIn(classified["ownership"], {"co_mention", "shared_topic", "generated_or_taxonomy"})
+
+    def test_authority_requires_explicit_subject_match(self):
+        missing_subject_items = [
+            {"summary": "Queue submission missing status for a nearby public profile.", "visibility": "public_context"},
+            {"summary": "Site authoritative source file note mentions Orion broadly.", "visibility": "public_context"},
+            {"summary": "Broadcast memory says BARCODE Radio played on a public episode.", "visibility": "public_context"},
+        ]
+        for item in missing_subject_items:
+            with self.subTest(item=item):
+                self.assertNotIn(self.classify(item)["ownership"], {"queue_authoritative", "site_authoritative", "broadcast_memory_authoritative"})
+
+        # Explicit subject fields are still subject-owned evidence and therefore allowed
+        # through the owned gate before generic authority checks run.
+        owned = self.classify({"summary": "Source note attached to Antigrain.", "subjectName": "Antigrain", "sourceFileNote": True, "visibility": "public_context"})
+        self.assertIn(owned["ownership"], {"owned", "site_authoritative"})
+
+    def test_subject_fragments_include_overpromotion_diagnostics(self):
+        memory = {"sourceIntelligenceContext": {"relationshipSignals": ["Orion appears near Antigrain in broad relationship context only."]}}
+        fragments = subject_owned_text_fragments(memory, "Antigrain", "antigrain")
+        diagnostics = fragments["summary"]["ownershipRoutingDiagnostics"]
+        self.assertTrue(any(item.get("term") == "Orion" for item in diagnostics["overpromotedCandidatesBlocked"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_source_file_archive.py
+++ b/tests/test_source_file_archive.py
@@ -584,6 +584,28 @@ class SourceFileArchiveTests(unittest.TestCase):
         self.assertIn("orion/archive-facing", brief["bnlTake"].lower())
         self.assertIn("review-only", brief["bnlTake"].lower())
 
+
+    def test_evidence_ownership_shortybabe_nearby_orion_not_promoted(self):
+        brief = self._subject_brief_for(
+            "ShortyBabe",
+            sourceCounts={"conversations": 6},
+            topChannels=[{"channel": "#barcode-bot", "count": 4, "summary": "ShortyBabe challenges BNL repeatedly."}],
+            topTopicDetails=[{"topic": "BNL challenge and pushback", "count": 4}],
+            usefulEvidence=[
+                {"summary": "ShortyBabe challenges BNL-01 and pushes back on the Source File boundary.", "authorName": "ShortyBabe", "sourceType": "Discord conversation", "visibility": "public_context"},
+                {"summary": "ShortyBabe teases BNL and provokes BNL-01 about the rules.", "authorName": "ShortyBabe", "sourceType": "Discord conversation", "visibility": "public_context"},
+            ],
+            knownContext=["Orion appears in broad nearby context around ShortyBabe but is not attached to ShortyBabe evidence."],
+            relationshipSignals=["Orion appears near ShortyBabe in relationship/context evidence only; meaning unconfirmed."],
+            representativeEvidence=[{"summary": "ShortyBabe challenged BNL-01 and pushed back at the rules.", "authorName": "ShortyBabe", "channelName": "#barcode-bot", "sourceType": "Discord conversation", "visibility": "public_context"}],
+        )
+        self.assertNotIn("Orion", {item.get("name") for item in brief["namedAnchors"]})
+        self.assertNotIn("orion-linked", brief["bnlTake"].lower())
+        self.assertNotIn("orion/archive-facing", brief["bnlTake"].lower())
+        self.assertTrue(any(item.get("name") == "Orion" for item in brief["nearbyContextSignals"]))
+        diagnostics = brief["ownershipRoutingDiagnostics"]
+        self.assertTrue(any(item.get("term") == "Orion" and item.get("routedAs") in {"co_mention", "shared_topic"} for item in diagnostics["overpromotedCandidatesBlocked"]))
+
     def test_evidence_ownership_shortybabe_bnl_challenger_signature(self):
         brief = self._subject_brief_for(
             "ShortyBabe",


### PR DESCRIPTION
### Motivation
- Fix over-promotion where broad Source File / relationship / context language (e.g., "source file", "identity check", "public profile", or nearby/co-mention lanes) was being upgraded into subject-owned facts and named anchors (Orion showing up on unrelated subjects). 
- Ensure only explicit subject-owned/author/alias/relationship/endpoint evidence, or strictly-attached queue/site/broadcast records, can drive namedAnchors, behavioralSignatureV1, subjectArchetypeRead, subjectRead, and bnlTake. 
- Provide internal diagnostics so blocked over-promotion cases are visible for review without weakening privacy/public-safety rules.

### Description
- Reordered the ownership classifier in `bnl_evidence_ownership.py` so explicit author/subject/confirmed-alias/relationship/direct/text-start matches are checked before queue/site/broadcast authority, and source-blind/generated markers still reject early. 
- Added derived-lane detection and quarantine via `_DERIVED_OR_BROAD_LANES` and `_is_derived_or_broad_lane`, and classify derived lanes as `co_mention`/`shared_topic`/`generated_or_taxonomy` unless explicit subject ownership metadata is present. 
- Made `queue_authoritative`, `site_authoritative`, and `broadcast_memory_authoritative` strict: they now require explicit subject-match fields or an attached subject source note/strict authority marker or be public-safe and explicitly subject-attached. 
- Prevented broad context lanes from seeding subject-owned topic/anchor extraction by modifying topic/anchor extraction and `_brief_signal_text` to prefer owned evidence and skip broad derived labels when ownership is absent. 
- Added ownership routing diagnostics (`_ownership_routing_diagnostics`) and surfaced `ownershipRoutingDiagnostics` in `subject_owned_text_fragments` and `subjectIntelligenceBriefV1` (via `_brief_ownership_routing_diagnostics`) so blocked over-promotion candidates and strict-authority warnings are visible. 
- Tests: added `tests/test_evidence_ownership.py` with focused classifier assertions and extended `tests/test_source_file_archive.py` with a ShortyBabe nearby-Orion regression to ensure nearby/co-mention Orion is routed to nearbyContextSignals and diagnostics not namedAnchors.

### Testing
- Ran static compile: `python3 -m py_compile bnl_evidence_ownership.py bnl01_bot.py bnl_dossier_recommendations.py bnl_source_file_refresh.py bnl_dossier_source_packets.py bnl_entity_intelligence.py bnl_source_file_enrichment.py` with no syntax errors. 
- Ran focused new tests: `PYTHONPATH=. pytest -q tests/test_evidence_ownership.py` and Source File regression tests; all focused tests passed. 
- Ran full suite: `PYTHONPATH=. pytest -q` and observed the full test suite success (476 passed, 5 warnings, subtests included).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a12761108832197674b1aeb7e0e21)