### PR TITLE
Bot PR #269 — Generate Structured Admin Source File Summaries

### DIFF
--- a/bnl_admin_summaries.py
+++ b/bnl_admin_summaries.py
@@ -1,0 +1,425 @@
+"""Structured admin-only summary builders for BNL internal review records.
+
+The helpers in this module sit on top of existing Source File, Dossier Update,
+and recommendation evidence. They do not replace raw evidence storage and they
+never create public dossier copy or trigger publishing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+ADMIN_SUMMARY_VERSION = "admin_summary_v1"
+DOSSIER_UPDATE_SUMMARY_VERSION = "dossier_update_summary_v1"
+RECOMMENDATION_CLUSTER_SUMMARY_VERSION = "recommendation_cluster_summary_v1"
+GENERATED_BY = "BNL"
+INSUFFICIENT_EVIDENCE_SUMMARY = "BNL summary needed: insufficient evidence."
+THIN_EVIDENCE_NOTE = "Known evidence is thin; review before routing."
+
+ADMIN_SUMMARY_SCHEMA_FIELDS = (
+    "summaryVersion",
+    "generatedAt",
+    "generatedBy",
+    "subjectName",
+    "subjectKey",
+    "subjectType",
+    "confidence",
+    "operatorSummary",
+    "whyTheyMatter",
+    "knownContext",
+    "notableEvidence",
+    "relationshipToBARCODE",
+    "currentStatus",
+    "missingInfo",
+    "recommendedNextAction",
+    "routingRecommendation",
+    "publicSafetyNotes",
+    "doNotSay",
+    "rawEvidenceRefs",
+    "sourceLanes",
+    "stale",
+    "inputHash",
+)
+
+DOSSIER_UPDATE_SUMMARY_FIELDS = (
+    "summaryVersion",
+    "generatedAt",
+    "generatedBy",
+    "subjectName",
+    "subjectKey",
+    "updateSummary",
+    "whatChanged",
+    "whatAlreadyExists",
+    "whatNeedsReview",
+    "safePublicUpdateCandidate",
+    "recommendedAdminNextAction",
+    "rawEvidenceRefs",
+    "sourceLanes",
+    "stale",
+    "inputHash",
+)
+
+RECOMMENDATION_CLUSTER_SUMMARY_FIELDS = (
+    "summaryVersion",
+    "generatedAt",
+    "generatedBy",
+    "subjectName",
+    "subjectKey",
+    "clusterSummary",
+    "whyClusterExists",
+    "appearsToBelongTo",
+    "recommendedDisposition",
+    "confidence",
+    "missingInfo",
+    "rawEvidenceRefs",
+    "sourceLanes",
+    "stale",
+    "inputHash",
+)
+
+_RAW_KEY_RE = re.compile(r"\b(?:relationship_journal|local_profile_observed|rawRefJson|sourceRowId|source_row_id|sourceLabel|source_label|memory_tiers|entity_evidence_events|user_profiles|user_memory_facts|broadcast_memory|rd_context)\b", re.I)
+_UNKNOWN_CHAIN_RE = re.compile(r"\bunknown\s*(?:->|→)\s*unknown\b", re.I)
+_LONG_ID_RE = re.compile(r"\b\d{15,22}\b")
+_DISCORD_MENTION_RE = re.compile(r"<@!?\d+>|<@&\d+>|<#\d+>")
+_URL_RE = re.compile(r"https?://\S+", re.I)
+_ALIAS_VALUE_RE = re.compile(r"\b(?:alias(?:es)?|aka|known as|identity link)\s*[:=]\s*[^.;,|]+", re.I)
+_SAFE_LANE_RE = re.compile(r"[^a-z0-9_-]+")
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    try:
+        return json.dumps(value, sort_keys=True, default=str)
+    except Exception:
+        return str(value)
+
+
+def _clean_public_admin_text(value: Any, limit: int = 320) -> str:
+    """Return concise admin prose without raw storage keys or alias values."""
+
+    text = re.sub(r"\s+", " ", _text(value)).strip()
+    text = _DISCORD_MENTION_RE.sub("[redacted-mention]", text)
+    text = _LONG_ID_RE.sub("[redacted-id]", text)
+    text = _URL_RE.sub("[redacted-url]", text)
+    text = _UNKNOWN_CHAIN_RE.sub("", text)
+    text = _RAW_KEY_RE.sub("internal evidence", text)
+    text = _ALIAS_VALUE_RE.sub("alias/identity signal kept internal", text)
+    text = text.replace("[object Object]", "").strip(" -|;,")
+    if not text:
+        return ""
+    return text[:limit].rstrip()
+
+
+def _list(value: Any, *, limit: int = 6, item_limit: int = 220) -> list[str]:
+    if value is None:
+        raw: list[Any] = []
+    elif isinstance(value, dict):
+        raw = []
+        for key, item in value.items():
+            if item in (None, "", [], {}):
+                continue
+            raw.append(f"{key}: {_text(item)}")
+    elif isinstance(value, (list, tuple, set)):
+        raw = list(value)
+    else:
+        raw = [value]
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        text = _clean_public_admin_text(item, item_limit)
+        if not text or text.lower() in seen:
+            continue
+        seen.add(text.lower())
+        cleaned.append(text)
+        if len(cleaned) >= limit:
+            break
+    return cleaned
+
+
+def _subject_key(name: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", str(name or "").strip().lower()).strip("-")
+    return normalized or "unknown-subject"
+
+
+def _source_lanes(record: dict[str, Any]) -> list[str]:
+    raw = record.get("sourceLanes") or record.get("sourceTypes") or []
+    if isinstance(raw, str):
+        parts = re.split(r"[,\s]+", raw)
+    elif isinstance(raw, (list, tuple, set)):
+        parts = list(raw)
+    else:
+        parts = []
+    lanes: list[str] = []
+    seen: set[str] = set()
+    for part in parts:
+        lane = _SAFE_LANE_RE.sub("_", str(part or "").strip().lower()).strip("_")
+        if lane and lane not in seen:
+            lanes.append(lane[:48])
+            seen.add(lane)
+    return lanes or ["unknown"]
+
+
+def _raw_evidence_refs(record: dict[str, Any]) -> list[str]:
+    refs: list[str] = []
+
+    def add(value: Any) -> None:
+        if len(refs) >= 24:
+            return
+        text = _clean_public_admin_text(value, 160)
+        if text and text not in refs:
+            refs.append(text)
+
+    for key in ("rawEvidenceRefs", "sourceRefs", "sourceCoverage", "representativeEvidence", "bestEvidenceToReview", "evidenceDetails"):
+        value = record.get(key)
+        if isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    add(item.get("sourceRef") or item.get("source") or item.get("lane") or item.get("summary") or item)
+                else:
+                    add(item)
+        elif value:
+            add(value)
+    raw_provenance = record.get("rawProvenance")
+    if isinstance(raw_provenance, dict):
+        for key, value in raw_provenance.items():
+            if isinstance(value, (list, tuple, set)):
+                add(f"{key}: {len(value)} evidence item(s)")
+            else:
+                add(f"{key}: present")
+    if not refs:
+        for lane in _source_lanes(record):
+            add(f"lane:{lane}")
+    return refs
+
+
+def _input_hash(record: dict[str, Any], *, summary_kind: str) -> str:
+    material = {
+        "summaryKind": summary_kind,
+        "subjectName": record.get("subjectName") or record.get("subject") or record.get("name"),
+        "subjectKey": record.get("subjectKey"),
+        "sourceLanes": _source_lanes(record),
+        "sourceCounts": record.get("sourceCounts"),
+        "sourceTypes": record.get("sourceTypes"),
+        "qualityScore": record.get("qualityScore"),
+        "qualityStatus": record.get("qualityStatus"),
+        "knownContext": record.get("knownContext"),
+        "usefulEvidence": record.get("usefulEvidence") or record.get("evidenceDetails"),
+        "representativeEvidence": record.get("representativeEvidence"),
+        "bestEvidenceToReview": record.get("bestEvidenceToReview"),
+        "relationshipSignals": record.get("relationshipSignals"),
+        "missingInfo": record.get("missingInfo"),
+        "publicSafetyNotes": record.get("publicSafetyNotes"),
+        "doNotSay": record.get("doNotSay"),
+        "reason": record.get("reason"),
+        "evidenceSummary": record.get("evidenceSummary"),
+        "rawEvidenceRefs": record.get("rawEvidenceRefs"),
+    }
+    encoded = json.dumps(material, sort_keys=True, default=str, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _evidence_count(record: dict[str, Any]) -> int:
+    count = 0
+    source_counts = record.get("sourceCounts")
+    if isinstance(source_counts, dict):
+        count += sum(int(v or 0) for v in source_counts.values() if str(v or "").isdigit() or isinstance(v, int))
+    for key in ("knownContext", "usefulEvidence", "evidenceDetails", "representativeEvidence", "bestEvidenceToReview", "conversationHighlights", "reason", "evidenceSummary"):
+        value = record.get(key)
+        if isinstance(value, (list, tuple, set, dict)) and value:
+            count += len(value)
+        elif str(value or "").strip():
+            count += 1
+    return count
+
+
+def _confidence(record: dict[str, Any], evidence_count: int) -> str:
+    explicit = str(record.get("confidence") or "").strip().lower()
+    if explicit in {"low", "medium", "high"}:
+        return explicit
+    status = str(record.get("qualityStatus") or "").lower()
+    if evidence_count < 2 or status in {"too_thin", "forced_low_confidence", "suppressed_too_thin"}:
+        return "low"
+    score = record.get("qualityScore")
+    try:
+        if int(score) >= 80:
+            return "high"
+        if int(score) >= 45:
+            return "medium"
+    except Exception:
+        pass
+    return "medium" if evidence_count >= 3 else "low"
+
+
+def _first_nonempty(record: dict[str, Any], keys: tuple[str, ...], default: str = "") -> str:
+    for key in keys:
+        value = record.get(key)
+        if isinstance(value, list) and value:
+            text = _clean_public_admin_text(value[0])
+        else:
+            text = _clean_public_admin_text(value)
+        if text:
+            return text
+    return default
+
+
+def build_admin_summary(record: dict[str, Any] | None, *, generated_at: str | None = None, stale: bool = False) -> dict[str, Any]:
+    """Build the admin-only Source File summary object from existing evidence."""
+
+    source = dict(record or {})
+    subject = _clean_public_admin_text(source.get("subjectName") or source.get("subject") or source.get("name") or "Unknown subject", 140) or "Unknown subject"
+    subject_key = _clean_public_admin_text(source.get("subjectKey"), 120) or _subject_key(subject)
+    lanes = _source_lanes(source)
+    refs = _raw_evidence_refs(source)
+    evidence_count = _evidence_count(source)
+    confidence = _confidence(source, evidence_count)
+    input_hash = _input_hash(source, summary_kind="admin")
+    generated = generated_at or utc_now()
+
+    if evidence_count <= 0:
+        operator = INSUFFICIENT_EVIDENCE_SUMMARY
+        why = THIN_EVIDENCE_NOTE
+        known = ["No usable stored evidence was available for this admin summary."]
+        notable = []
+        missing = ["Add or review Source File notes, recommendation evidence, source lanes, or conversation evidence before routing."]
+        routing = "remain_review_only"
+        next_action = "Collect or attach evidence, then regenerate the admin summary."
+    else:
+        known = _list(source.get("knownContext") or source.get("conversationHighlights") or source.get("observedChannels"), limit=5) or ["Some stored evidence exists, but BNL could not extract a clean fact list. Review raw evidence before routing."]
+        notable = _list(source.get("usefulEvidence") or source.get("evidenceDetails") or source.get("representativeEvidence") or source.get("bestEvidenceToReview") or source.get("evidenceSummary"), limit=6)
+        why = _first_nonempty(source, ("whyTheyMatter", "reason", "activityFrequencySummary", "recentActivitySummary"), THIN_EVIDENCE_NOTE)
+        if confidence == "low":
+            why = f"{why} Evidence is low-confidence and needs admin review."
+        uncertainty = " Facts above are evidence-grounded; relationship, identity, alias, and public biography claims remain unconfirmed unless separately verified."
+        operator = _clean_public_admin_text(f"BNL found review-only evidence for {subject} across {', '.join(lanes)}. {why}.{uncertainty}", 620)
+        missing = _list(source.get("missingInfo"), limit=5) or ["Confirm public-safe identity, role, source ownership, relationships, and routing before drafting public copy."]
+        routing = _clean_public_admin_text(source.get("routingRecommendation") or source.get("suggestedAction") or source.get("recommendedAction") or "Review for Source File or Dossier Update routing; do not publish automatically.", 260)
+        next_action = _clean_public_admin_text(source.get("recommendedNextAction") or source.get("suggestedAction") or source.get("recommendedAction") or "Admin should review evidence refs, confirm routing, and regenerate after adding missing evidence.", 260)
+
+    relationship = _list(source.get("relationshipSignals"), limit=4) or ["No public relationship claim is confirmed by this summary; treat relationship signals as internal review evidence only."]
+    public_safety = _list(source.get("publicSafetyNotes"), limit=5) or ["Admin-only summary. Do not turn this into public dossier copy without review."]
+    do_not_say = _list(source.get("doNotSay"), limit=6) or [
+        "Do not publish raw evidence, private context, internal aliases, relationship guesses, or identity links as public facts.",
+        "Do not claim queue, payment, submission, role, relationship, or biography details without separate confirmation.",
+    ]
+
+    return {
+        "summaryVersion": ADMIN_SUMMARY_VERSION,
+        "generatedAt": generated,
+        "generatedBy": GENERATED_BY,
+        "subjectName": subject,
+        "subjectKey": subject_key,
+        "subjectType": _clean_public_admin_text(source.get("subjectType") or source.get("recommendedKind") or source.get("recommendedCategory") or "source_file_subject", 80),
+        "confidence": confidence,
+        "operatorSummary": operator,
+        "whyTheyMatter": why,
+        "knownContext": known,
+        "notableEvidence": notable,
+        "relationshipToBARCODE": relationship,
+        "currentStatus": _clean_public_admin_text(source.get("currentStatus") or source.get("qualityStatus") or source.get("matchKind") or "review_only", 120),
+        "missingInfo": missing,
+        "recommendedNextAction": next_action,
+        "routingRecommendation": routing,
+        "publicSafetyNotes": public_safety,
+        "doNotSay": do_not_say,
+        "rawEvidenceRefs": refs,
+        "sourceLanes": lanes,
+        "stale": bool(stale),
+        "inputHash": input_hash,
+    }
+
+
+def build_dossier_update_summary(record: dict[str, Any] | None, *, generated_at: str | None = None, stale: bool = False) -> dict[str, Any]:
+    source = dict(record or {})
+    base = build_admin_summary(source, generated_at=generated_at, stale=stale)
+    evidence_count = _evidence_count(source)
+    if evidence_count <= 0:
+        update_summary = INSUFFICIENT_EVIDENCE_SUMMARY
+        what_changed = []
+        safe = "no"
+    else:
+        update_summary = _clean_public_admin_text(f"BNL found internal review evidence for a possible Dossier Update to {base['subjectName']}. This is not public copy and needs admin review.", 420)
+        what_changed = _list(source.get("whatChanged") or source.get("usefulEvidence") or source.get("evidenceDetails") or source.get("evidenceSummary"), limit=5)
+        safe = "maybe" if base["confidence"] != "low" else "no"
+    return {
+        "summaryVersion": DOSSIER_UPDATE_SUMMARY_VERSION,
+        "generatedAt": base["generatedAt"],
+        "generatedBy": GENERATED_BY,
+        "subjectName": base["subjectName"],
+        "subjectKey": base["subjectKey"],
+        "updateSummary": update_summary,
+        "whatChanged": what_changed,
+        "whatAlreadyExists": _list(source.get("whatAlreadyExists") or source.get("knownContext"), limit=5),
+        "whatNeedsReview": base["missingInfo"],
+        "safePublicUpdateCandidate": _clean_public_admin_text(source.get("safePublicUpdateCandidate") or safe, 20).lower() if evidence_count > 0 else "no",
+        "recommendedAdminNextAction": base["recommendedNextAction"],
+        "rawEvidenceRefs": base["rawEvidenceRefs"],
+        "sourceLanes": base["sourceLanes"],
+        "stale": bool(stale),
+        "inputHash": _input_hash(source, summary_kind="dossier_update"),
+    }
+
+
+def build_recommendation_cluster_summary(cluster: dict[str, Any] | None, *, generated_at: str | None = None, stale: bool = False) -> dict[str, Any]:
+    source = dict(cluster or {})
+    base = build_admin_summary(source, generated_at=generated_at, stale=stale)
+    evidence_count = _evidence_count(source)
+    if evidence_count <= 0:
+        why = INSUFFICIENT_EVIDENCE_SUMMARY
+        disposition = "remain_review_only"
+    else:
+        why = _clean_public_admin_text(source.get("whyClusterExists") or source.get("reason") or f"Evidence items in {', '.join(base['sourceLanes'])} appear to point at the same review subject.", 360)
+        suggested = str(source.get("suggestedAction") or source.get("recommendedDisposition") or "").lower()
+        if "update" in suggested or source.get("targetDossierId"):
+            disposition = "dossier_update_review"
+        elif "source file" in suggested or source.get("targetCandidateId"):
+            disposition = "source_file_review"
+        else:
+            disposition = "remain_review_only" if base["confidence"] == "low" else "source_file_review"
+    return {
+        "summaryVersion": RECOMMENDATION_CLUSTER_SUMMARY_VERSION,
+        "generatedAt": base["generatedAt"],
+        "generatedBy": GENERATED_BY,
+        "subjectName": base["subjectName"],
+        "subjectKey": base["subjectKey"],
+        "clusterSummary": _clean_public_admin_text(f"Recommendation cluster for {base['subjectName']}: {why}", 460) if evidence_count > 0 else INSUFFICIENT_EVIDENCE_SUMMARY,
+        "whyClusterExists": why,
+        "appearsToBelongTo": base["subjectName"],
+        "recommendedDisposition": disposition,
+        "confidence": base["confidence"],
+        "missingInfo": base["missingInfo"],
+        "rawEvidenceRefs": base["rawEvidenceRefs"],
+        "sourceLanes": base["sourceLanes"],
+        "stale": bool(stale),
+        "inputHash": _input_hash(source, summary_kind="recommendation_cluster"),
+    }
+
+
+def mark_summary_stale_if_evidence_changed(summary: dict[str, Any] | None, record: dict[str, Any] | None, *, summary_kind: str = "admin") -> dict[str, Any]:
+    """Return a copy of summary with stale=true when current evidence hash differs."""
+
+    current = dict(summary or {})
+    if not current:
+        return current
+    expected = _input_hash(dict(record or {}), summary_kind=summary_kind)
+    if current.get("inputHash") != expected:
+        current["stale"] = True
+    return current
+
+
+def attach_admin_summary(record: dict[str, Any] | None, *, stale: bool = False) -> dict[str, Any]:
+    updated = dict(record or {})
+    updated["adminSummary"] = build_admin_summary(updated, stale=stale)
+    return updated

--- a/bnl_dossier_candidate_discovery.py
+++ b/bnl_dossier_candidate_discovery.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from collections import Counter
 from typing import Any, Callable
 
+from bnl_admin_summaries import build_recommendation_cluster_summary
 from bnl_dossier_recommendations import VALID_DOSSIER_CATEGORIES, build_dossier_recommendation_payload
 from bnl_community_scouting import COMMUNITY_PRESENCE_LANE, community_category_taxonomy
 from bnl_dossier_source_packets import (
@@ -567,6 +568,17 @@ def discover_candidate_recommendations(
         evidence_summary = _evidence_summary(acc.evidence)
         evidence_hash = hashlib.sha256(f"{reason}\n{evidence_summary}".encode("utf-8")).hexdigest()[:8]
         taxonomy = _payload_taxonomy(acc)
+        cluster_summary = build_recommendation_cluster_summary({
+            **taxonomy,
+            "subjectName": acc.subject_name,
+            "subjectKey": subject_key(acc.subject_name),
+            "reason": reason,
+            "evidenceSummary": evidence_summary,
+            "sourceLanes": lane_list,
+            "suggestedAction": DEFAULT_SUGGESTED_ACTION,
+            "confidence": confidence,
+            "rawEvidenceRefs": [item.get("sourceRef") or item.get("source") or item.get("summary") for item in acc.evidence],
+        })
         payload = build_dossier_recommendation_payload(
             {
                 **taxonomy,
@@ -586,6 +598,7 @@ def discover_candidate_recommendations(
                 "confidence": confidence,
                 "createdBy": "bnl",
                 "ingestSource": DISCOVERY_INGEST_SOURCE,
+                "recommendationClusterSummary": cluster_summary,
                 "ingestKey": f"bnl:dossier:{DISCOVERY_INGEST_SOURCE}:{acc.category}:{subject_key(acc.subject_name)}:{'-'.join(lane_list)}:{evidence_hash}",
             }
         )

--- a/bnl_dossier_recommendations.py
+++ b/bnl_dossier_recommendations.py
@@ -86,6 +86,9 @@ SUPPORTED_PAYLOAD_FIELDS = {
     "queueSubmissionStatus",
     "queueSubmissionNote",
     "entityIntelligenceProfile",
+    "adminSummary",
+    "updateSummary",
+    "recommendationClusterSummary",
 }
 _SAFE_LANE_PATTERN = re.compile(r"[^a-z0-9_-]+")
 VALID_DOSSIER_CATEGORIES = {"Entity", "Personnel", "Sponsor", "Interface", "Production"}

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -17,6 +17,7 @@ from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from typing import Any, Callable
 
+from bnl_admin_summaries import build_admin_summary, build_dossier_update_summary
 from bnl_dossier_recommendations import build_dossier_recommendation_payload, is_source_file_archive_token_configured, send_dossier_recommendation, send_source_file_archive_enrichment
 from bnl_entity_activity_summary import build_entity_activity_summary, refresh_entity_evidence_for_subject
 from bnl_entity_evidence import _website_safe_payload_text
@@ -2138,6 +2139,8 @@ def sanitize_compact_recommendation_payload(payload: dict[str, Any], *, packet: 
     compact = dict(payload or {})
     compact.pop("subjectMemoryPacketV1", None)
     compact.pop("sourceFileCaseReportV1", None)
+    compact.pop("adminSummary", None)
+    compact.pop("updateSummary", None)
     packet = packet or {}
     existing_summary = str(compact.get("evidenceSummary") or "")
     pointer_summary = build_compact_source_file_recommendation_summary(packet, compact, archive_id=archive_id)
@@ -2233,6 +2236,8 @@ def compact_enrichment_payload_for_site(payload: dict[str, Any]) -> dict[str, An
     compact = dict(payload or {})
     compact.pop("subjectMemoryPacketV1", None)
     compact.pop("sourceFileCaseReportV1", None)
+    compact.pop("adminSummary", None)
+    compact.pop("updateSummary", None)
     compact["evidenceSummary"] = _site_safe_text(compact.get("evidenceSummary"), SITE_EVIDENCE_SUMMARY_TARGET)
     for key in SITE_BOUND_LIST_FIELDS:
         if key in compact:
@@ -4771,6 +4776,7 @@ def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[s
     }
     subject_memory_packet = build_subject_memory_packet_v1(packet)
     case_report = build_source_file_case_report_v1(subject_memory_packet)
+    admin_summary = build_admin_summary({**packet, "subjectName": subject, "subjectKey": subject_key, "sourceLanes": ["source_file_enrichment"] + list(packet.get("sourceTypes") or [])})
     envelope = {
         "candidateId": _sanitize_archive_value(candidate_id) if candidate_id else None,
         "subjectName": subject,
@@ -4785,6 +4791,8 @@ def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[s
         "sourceFileBriefV2": _sanitize_archive_value(build_source_file_brief_v2(packet, archive_id=packet.get("archiveId") or "")),
         "subjectMemoryPacketV1": subject_memory_packet,
         "sourceFileCaseReportV1": case_report,
+        "adminSummary": admin_summary,
+        "updateSummary": build_dossier_update_summary({**packet, "subjectName": subject, "subjectKey": subject_key, "sourceLanes": ["source_file_enrichment"] + list(packet.get("sourceTypes") or [])}) if str(packet.get("matchKind") or "") in {"active_source_file", "existing_dossier_update", "candidate_intake"} else None,
         "sourcePackage": _source_package_from_packet(packet),
     }
     return envelope
@@ -4846,6 +4854,8 @@ def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: 
         "queueSubmissionStatus": packet.get("queueSubmissionStatus") or "not_connected",
         "queueSubmissionNote": packet.get("queueSubmissionNote") or QUEUE_NOT_CONNECTED_NOTE,
         "entityIntelligenceProfile": dict(packet.get("entityIntelligenceProfile") or {}),
+        "adminSummary": build_admin_summary(packet),
+        "updateSummary": build_dossier_update_summary(packet) if match_kind in {"active_source_file", "existing_dossier_update", "candidate_intake"} else None,
         "linkSignalDiagnostics": dict(packet.get("linkSignalDiagnostics") or {}),
         "rawProvenance": dict(packet.get("rawProvenance") or {}),
         "visibilityLabels": ["internal_review_only", "admin_review_required"],

--- a/tests/test_admin_summaries.py
+++ b/tests/test_admin_summaries.py
@@ -1,0 +1,129 @@
+import unittest
+
+from bnl_admin_summaries import (
+    ADMIN_SUMMARY_SCHEMA_FIELDS,
+    DOSSIER_UPDATE_SUMMARY_FIELDS,
+    RECOMMENDATION_CLUSTER_SUMMARY_FIELDS,
+    build_admin_summary,
+    build_dossier_update_summary,
+    build_recommendation_cluster_summary,
+    mark_summary_stale_if_evidence_changed,
+)
+from bnl_dossier_candidate_discovery import discover_candidate_recommendations
+from bnl_source_file_enrichment import build_enrichment_recommendation_payload, build_source_file_archive_payload
+
+
+class AdminSummaryTests(unittest.TestCase):
+    def sample_record(self):
+        return {
+            "subjectName": "Signal Fox",
+            "subjectKey": "signal-fox",
+            "matchKind": "existing_dossier_update",
+            "confidence": "medium",
+            "sourceLanes": ["source_file_notes", "relationship_journal", "local_profile_observed"],
+            "sourceTypes": ["conversations"],
+            "sourceCounts": {"conversations": 2},
+            "knownContext": ["Signal Fox appears in BARCODE Radio planning notes as a recurring review subject."],
+            "usefulEvidence": ["Admin note says Signal Fox may need a Source File follow-up after repeated BARCODE mentions."],
+            "relationshipSignals": ["relationship_journal: unknown -> unknown via local_profile_observed blob"],
+            "missingInfo": ["Confirm role and whether any public links are owned by the subject."],
+            "publicSafetyNotes": ["Keep internal aliases private until owner/admin confirmation."],
+            "doNotSay": ["Do not publish alias: Fox Internal Handle as a public fact."],
+            "rawEvidenceRefs": ["relationship_journal/42", "local_profile_observed/7"],
+            "reason": "Repeated review-only BARCODE context; not public copy.",
+        }
+
+    def test_admin_summary_schema_exists(self):
+        self.assertIn("operatorSummary", ADMIN_SUMMARY_SCHEMA_FIELDS)
+        self.assertIn("rawEvidenceRefs", ADMIN_SUMMARY_SCHEMA_FIELDS)
+        self.assertIn("inputHash", ADMIN_SUMMARY_SCHEMA_FIELDS)
+        self.assertIn("updateSummary", DOSSIER_UPDATE_SUMMARY_FIELDS)
+        self.assertIn("clusterSummary", RECOMMENDATION_CLUSTER_SUMMARY_FIELDS)
+
+    def test_source_file_refresh_payload_can_produce_admin_summary_and_preserve_refs(self):
+        record = self.sample_record()
+        archive = build_source_file_archive_payload({
+            "subject": "Signal Fox",
+            "matchKind": "existing_dossier_update",
+            "sections": {"Missing Info": ["Confirm role."], "Do Not Say": ["Do not publish aliases."], "Public-Safe Notes": ["Review first."]},
+            **record,
+        })
+        self.assertIn("adminSummary", archive)
+        self.assertEqual(archive["adminSummary"]["generatedBy"], "BNL")
+        self.assertFalse(archive["adminSummary"]["stale"])
+        self.assertTrue(archive["adminSummary"]["rawEvidenceRefs"])
+        self.assertIn("sourcePackage", archive)
+
+    def test_dossier_update_workspace_refresh_can_produce_update_summary(self):
+        summary = build_dossier_update_summary(self.sample_record())
+        self.assertEqual(summary["summaryVersion"], "dossier_update_summary_v1")
+        self.assertIn("possible Dossier Update", summary["updateSummary"])
+        self.assertIn(summary["safePublicUpdateCandidate"], {"yes", "no", "maybe"})
+        archive = build_source_file_archive_payload({"subject": "Signal Fox", "matchKind": "existing_dossier_update", "sections": {}, **self.sample_record()})
+        self.assertIn("updateSummary", archive)
+        self.assertIn("adminSummary", archive)
+
+    def test_recommendation_cluster_summary_can_be_produced_from_stored_evidence(self):
+        summary = build_recommendation_cluster_summary({
+            "subjectName": "Signal Fox",
+            "reason": "BNL dynamic discovery found Signal Fox in approved source-safe lanes as a new source file candidate.",
+            "evidenceSummary": "R&D context: Signal Fox should have a source file for recurring BARCODE mentions.",
+            "sourceLanes": ["rd_context"],
+            "confidence": "medium",
+        })
+        self.assertEqual(summary["summaryVersion"], "recommendation_cluster_summary_v1")
+        self.assertEqual(summary["recommendedDisposition"], "source_file_review")
+        self.assertEqual(summary["appearsToBelongTo"], "Signal Fox")
+
+    def test_discovery_payload_includes_recommendation_cluster_summary(self):
+        result = discover_candidate_recommendations(
+            123,
+            ["rd_context"],
+            rd_context=[{"main_subject": "Signal Fox", "user_request": "Signal Fox needs a source file", "response_summary": "recurring BARCODE review subject"}],
+        )
+        self.assertGreaterEqual(result["candidateCount"], 1)
+        payload = result["payloads"][0]
+        self.assertIn("recommendationClusterSummary", payload)
+        self.assertEqual(payload["recommendationClusterSummary"]["generatedBy"], "BNL")
+
+    def test_raw_blobs_unknown_chains_and_internal_alias_values_not_dumped(self):
+        summary = build_admin_summary(self.sample_record())
+        text = " ".join([
+            summary["operatorSummary"],
+            summary["whyTheyMatter"],
+            " ".join(summary["knownContext"]),
+            " ".join(summary["relationshipToBARCODE"]),
+            " ".join(summary["doNotSay"]),
+        ]).lower()
+        self.assertNotIn("relationship_journal", text)
+        self.assertNotIn("local_profile_observed", text)
+        self.assertNotIn("unknown -> unknown", text)
+        self.assertNotIn("fox internal handle", text)
+        self.assertIn("unconfirmed", summary["operatorSummary"].lower())
+
+    def test_missing_evidence_creates_insufficient_summary_instead_of_hallucination(self):
+        summary = build_admin_summary({"subjectName": "Empty Subject", "sourceLanes": []})
+        self.assertEqual(summary["operatorSummary"], "BNL summary needed: insufficient evidence.")
+        self.assertEqual(summary["confidence"], "low")
+        self.assertIn("Collect or attach evidence", summary["recommendedNextAction"])
+
+    def test_summary_becomes_stale_when_source_evidence_changes_and_can_regenerate(self):
+        record = self.sample_record()
+        summary = build_admin_summary(record)
+        changed = {**record, "usefulEvidence": record["usefulEvidence"] + ["New admin evidence was added."]}
+        stale = mark_summary_stale_if_evidence_changed(summary, changed)
+        self.assertTrue(stale["stale"])
+        regenerated = build_admin_summary(changed)
+        self.assertFalse(regenerated["stale"])
+        self.assertNotEqual(summary["inputHash"], regenerated["inputHash"])
+
+    def test_public_copy_and_publish_actions_are_not_emitted(self):
+        archive = build_source_file_archive_payload({"subject": "Signal Fox", "matchKind": "none", "sections": {}, **self.sample_record()})
+        serialized = str(archive).lower()
+        self.assertNotIn("publishnow", serialized)
+        self.assertNotIn("publicdossiertext", serialized)
+        self.assertIn("internal/review-only", archive["sourcePackage"]["archiveNotice"].lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Admin-facing Source File / Dossier Update rows currently expose raw evidence blobs and noisy fields; the site must show concise admin-readable summaries instead of raw "sludge." 
- Create an admin-only structured summary layer that can be attached to internal records and used by the site for review routing while preserving raw evidence separately. 
- Ensure summaries are safe (scrub internal keys/blobs, redact ids/mentions/urls), explicit about uncertainty, and mark stale when evidence changes.

### Description

- Add `bnl_admin_summaries.py` which implements the admin-only summary schema and builders: `build_admin_summary`, `build_dossier_update_summary`, `build_recommendation_cluster_summary`, `mark_summary_stale_if_evidence_changed`, and `attach_admin_summary` with `inputHash`/`stale` handling and sanitization rules. 
- Wire summaries into enrichment/archive and recommendation codepaths by attaching `adminSummary` and (where appropriate) `updateSummary` to the Source File archive envelope and by adding `recommendationClusterSummary` to discovery payloads. 
- Keep raw evidence separate (preserve `subjectMemoryPacketV1`, `sourceFileCaseReportV1`, `sourcePackage`, `rawProvenance`) and remove admin fields from compact/site recommendation payloads so the compact card does not carry full admin blobs. 
- Add `tests/test_admin_summaries.py` and update enrichment/discovery modules to validate: schema presence, archive payloads include `adminSummary`/`updateSummary`, discovery payloads include cluster summaries, raw evidence refs are preserved, raw blobs/unknown->unknown chains/alias values are scrubbed from operator prose, insufficient evidence produces conservative summary, stale detection/regeneration works, and no public dossier or publish actions are emitted.

### Testing

- Ran unit suites with `python3 -m unittest discover -s tests` and the full test run completed successfully: all tests passed (502 tests, OK). 
- Ran focused test commands during development: `python3 -m unittest tests.test_admin_summaries`, `python3 -m unittest tests.test_source_file_archive tests.test_source_file_enrichment tests.test_source_file_refresh tests.test_dossier_recommendations` and these succeeded. 
- Verified interpreter checks with `python3 -m py_compile bnl01_bot.py` and compiled changed modules with `python3 -m py_compile bnl01_bot.py bnl_admin_summaries.py bnl_source_file_enrichment.py bnl_dossier_candidate_discovery.py bnl_dossier_recommendations.py`, all of which passed. 
- Summary: automated tests and byte-compile checks passed; changes add admin-only summaries, preserve raw evidence, scrub noisy internal material, and do not alter public dossier text or trigger publishing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b536ae96c8321b36847e7d8bbbf59)