### PR TITLE
Add internal BNL proposed dossier draft generator

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -97,6 +97,13 @@ from bnl_population_recommender import (
     parse_population_scan_command,
     run_population_scan,
 )
+from bnl_dossier_draft import (
+    DRAFT_ENDPOINT_PATH,
+    DRAFT_TOKEN_HEADER,
+    generate_dossier_draft,
+    is_dossier_draft_token_valid,
+    validate_dossier_draft_packet,
+)
 from bnl_source_file_refresh import (
     DEFAULT_MAX_AUTOMATIC_PER_CYCLE,
     DEFAULT_MAX_SITE_REQUESTS_PER_CYCLE,
@@ -3491,6 +3498,36 @@ async def _handle_force_pull(request: web.Request) -> web.Response:
     }, status=202)
 
 
+async def _handle_dossier_draft(request: web.Request) -> web.Response:
+    provided_token = request.headers.get(DRAFT_TOKEN_HEADER) or request.headers.get(DRAFT_TOKEN_HEADER.lower())
+    if not is_dossier_draft_token_valid(provided_token):
+        logging.warning("dossier_draft_auth_failed reason=missing_or_invalid_token")
+        return web.json_response({"ok": False, "error": "unauthorized"}, status=401)
+
+    try:
+        payload = await request.json()
+    except Exception:
+        logging.warning("dossier_draft_failed reason=invalid_json")
+        return web.json_response({"ok": False, "error": "invalid_json"}, status=400)
+
+    errors = validate_dossier_draft_packet(payload)
+    if errors:
+        logging.warning("dossier_draft_failed reason=validation_error errors=%s", ",".join(errors))
+        return web.json_response({"ok": False, "error": "validation_error", "details": errors}, status=400)
+
+    try:
+        result = await asyncio.to_thread(generate_dossier_draft, payload)
+    except Exception as exc:
+        logging.warning("dossier_draft_generation_fallback reason=%s", _safe_force_pull_error(exc))
+        fallback_payload = dict(payload) if isinstance(payload, dict) else {}
+        fallback_payload["publicSafeFacts"] = []
+        fallback_payload["publicSafeNotes"] = []
+        result = generate_dossier_draft(fallback_payload)
+        result["draft"]["ownerReviewWarnings"].insert(0, "BNL could not generate a rich draft and returned a deterministic fallback for admin review.")
+        result["draft"]["missingInfoQuestions"].insert(0, "Retry draft generation or add more public-safe source detail.")
+    return web.json_response(result, status=200)
+
+
 async def _handle_source_file_refresh_now(request: web.Request) -> web.Response:
     provided_token = request.headers.get(SOURCE_REFRESH_NOW_TOKEN_HEADER) or request.headers.get(
         SOURCE_REFRESH_NOW_TOKEN_HEADER.lower()
@@ -3551,6 +3588,7 @@ async def start_force_pull_listener():
     app = web.Application()
     app.router.add_post("/force-pull", _handle_force_pull)
     app.router.add_post(SOURCE_REFRESH_NOW_PATH, _handle_source_file_refresh_now)
+    app.router.add_post(DRAFT_ENDPOINT_PATH, _handle_dossier_draft)
     force_pull_runner = web.AppRunner(app)
     await force_pull_runner.setup()
     site = web.TCPSite(force_pull_runner, host="0.0.0.0", port=BNL_FORCE_PULL_PORT)

--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -16,10 +16,24 @@ DRAFT_TOKEN_ENV = "BNL_DOSSIER_DRAFT_GENERATOR_TOKEN"
 REQUEST_TYPE = "bnl_proposed_dossier_draft"
 VERSION = "1.0"
 
+VALID_STATUSES = {"ACTIVE", "INACTIVE", "ARCHIVED", "PENDING", "UNKNOWN"}
+VALID_CLEARANCES = {"PUBLIC", "INTERNAL", "RESTRICTED"}
+VALID_ORIGINS = {"KNOWN", "UNKNOWN", "UNVERIFIED", "WITHHELD"}
+VALID_IDENTITY_AUTHORITIES = {
+    "barcode_controlled",
+    "community_owned",
+    "external_system",
+    "sponsor_controlled",
+    "mixed_or_unclear",
+}
+
 _PAYMENT_RE = re.compile(r"\b(stripe|checkout|payment|paid|purchase|purchased|customer|priority\s*signal|priority)\b", re.I)
-_INTERNAL_RE = re.compile(r"\b(memory_tiers|rd_context|broadcast_memory|relationship_state|redis|database|table|json|diagnostic|evidence\s*id|recommendation\s*id|source\s*row|raw\s*source\s*lane|sourceFileSummary)\b", re.I)
+_INTERNAL_RE = re.compile(r"\b(memory_tiers|rd_context|broadcast_memory|relationship_state|redis|database|table|json|diagnostic|diagnostics|evidence\s*id|recommendation\s*id|source\s*row|raw\s*source\s*lane|sourceFileSummary|source\s*lane)\b", re.I)
 _ALIAS_RE = re.compile(r"\b(internal\s+alias|alias\s+count|confirmed\s+alias|private\s+alias)\b", re.I)
-_FINAL_RE = re.compile(r"\b(published|official|approved|live|complete|final)\b", re.I)
+_FINAL_RE = re.compile(r"\b(approved|published|live|final|complete|official)\b", re.I)
+_ROLE_LIMIT = 80
+_SUMMARY_LIMIT = 700
+_NOTES_LIMIT = 900
 
 
 def _as_list(value: Any) -> list[Any]:
@@ -43,7 +57,7 @@ def _strings(value: Any, *, limit_each: int = 260, max_items: int = 12) -> list[
     out: list[str] = []
     for item in _as_list(value):
         if isinstance(item, dict):
-            candidate = item.get("text") or item.get("summary") or item.get("note") or item.get("value") or item.get("label")
+            candidate = item.get("text") or item.get("summary") or item.get("note") or item.get("body") or item.get("value") or item.get("label")
         else:
             candidate = item
         s = _text(candidate, limit_each)
@@ -52,6 +66,10 @@ def _strings(value: Any, *, limit_each: int = 260, max_items: int = 12) -> list[
         if len(out) >= max_items:
             break
     return out
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
 
 
 def is_dossier_draft_token_valid(provided_token: str | None, *, environ: dict[str, str] | None = None) -> bool:
@@ -79,44 +97,33 @@ def validate_dossier_draft_packet(packet: Any) -> list[str]:
             errors.append("missing_candidate.subjectName")
     if not isinstance(packet.get("stylePacket"), dict):
         errors.append("missing_stylePacket")
-    if not isinstance(packet.get("fieldRequirements"), dict):
+    field_requirements = packet.get("fieldRequirements")
+    if not isinstance(field_requirements, list) or not any(isinstance(item, str) and item.strip() for item in field_requirements):
         errors.append("missing_fieldRequirements")
+    safe_classification = packet.get("safeClassification")
+    if safe_classification is not None and not isinstance(safe_classification, dict):
+        errors.append("invalid_safeClassification")
     return errors
 
 
-def _candidate_public_values(candidate: dict[str, Any], safe_classification: dict[str, Any]) -> dict[str, str]:
-    def pick(*keys: str, default: str = "") -> str:
-        for key in keys:
-            value = _text(candidate.get(key) or safe_classification.get(key), 120)
-            if value:
-                return value
-        return default
-
-    return {
-        "name": pick("subjectName", "name", default="Unnamed Source File subject"),
-        "category": pick("category", default="Source File candidate"),
-        "kind": pick("kind", default="proposed_dossier"),
-        "ecosystemLane": pick("ecosystemLane", "lane", default="community"),
-        "identityAuthority": pick("identityAuthority", default="unconfirmed"),
-        "status": pick("status", default="proposed"),
-        "clearance": pick("clearance", default="owner_review_required"),
-        "origin": pick("origin", default="BNL Source File draft request"),
-    }
+def _unsafe_reasons(text: str) -> list[str]:
+    reasons: list[str] = []
+    if _PAYMENT_RE.search(text):
+        reasons.append("payment/Priority material")
+    if _INTERNAL_RE.search(text):
+        reasons.append("internal provenance or diagnostics")
+    if _ALIAS_RE.search(text):
+        reasons.append("internal alias material")
+    if _FINAL_RE.search(text):
+        reasons.append("final/published status wording")
+    return reasons
 
 
 def _reject_unsafe_public(texts: list[str]) -> tuple[list[str], list[str]]:
     safe: list[str] = []
     rejected: list[str] = []
     for s in texts:
-        reasons = []
-        if _PAYMENT_RE.search(s):
-            reasons.append("payment/Priority material")
-        if _INTERNAL_RE.search(s):
-            reasons.append("internal provenance or diagnostics")
-        if _ALIAS_RE.search(s):
-            reasons.append("internal alias material")
-        if _FINAL_RE.search(s):
-            reasons.append("final/published status wording")
+        reasons = _unsafe_reasons(s)
         if reasons:
             rejected.append(f"Rejected {', '.join(reasons)} from public draft wording.")
         else:
@@ -124,42 +131,248 @@ def _reject_unsafe_public(texts: list[str]) -> tuple[list[str], list[str]]:
     return safe, rejected
 
 
-def _infer_role(facts: list[str], notes: list[str], category: str, kind: str) -> str:
-    haystack = " ".join(facts + notes + [category, kind]).lower()
-    if any(term in haystack for term in ("artist", "music", "musician", "producer", "track", "album", "song", "dj")):
-        return "Artist / music community subject"
+def _strip_unsafe_sentence(sentence: str) -> str:
+    return "" if _unsafe_reasons(sentence) else sentence
+
+
+def _sentences(texts: list[str], *, max_count: int = 4) -> list[str]:
+    out: list[str] = []
+    for text in texts:
+        for part in re.split(r"(?<=[.!?])\s+", text):
+            s = _strip_unsafe_sentence(part.strip())
+            if s and s not in out:
+                out.append(s)
+            if len(out) >= max_count:
+                return out
+    return out
+
+
+def _candidate_name(candidate: dict[str, Any]) -> str:
+    return _text(candidate.get("subjectName") or candidate.get("name"), 120) or "Unnamed Source File subject"
+
+
+def _classification_value(safe_classification: dict[str, Any], key: str, default: str) -> str:
+    return _text(safe_classification.get(key), 120) or default
+
+
+def _identity_authority(packet: dict[str, Any], safe_classification: dict[str, Any]) -> str:
+    raw = _text(safe_classification.get("identityAuthority") or _dict(packet.get("identityAliasStatus")).get("identityAuthority"), 80)
+    normalized = raw.strip().lower().replace(" ", "_").replace("-", "_")
+    aliases = {
+        "barcode": "barcode_controlled",
+        "barcode_controlled": "barcode_controlled",
+        "community": "community_owned",
+        "community_owned": "community_owned",
+        "external": "external_system",
+        "external_system": "external_system",
+        "sponsor": "sponsor_controlled",
+        "sponsor_controlled": "sponsor_controlled",
+    }
+    return aliases.get(normalized, "mixed_or_unclear")
+
+
+def _clearance(packet: dict[str, Any]) -> str:
+    boundary = " ".join(_strings(packet.get("sourceBoundaryRules"), max_items=20)).lower()
+    if "restricted" in boundary or "withheld" in boundary or "private" in boundary:
+        return "RESTRICTED"
+    if "internal" in boundary and "public" not in boundary:
+        return "INTERNAL"
+    return "PUBLIC"
+
+
+def _origin(packet: dict[str, Any]) -> str:
+    alias_status = _dict(packet.get("identityAliasStatus"))
+    raw = _text(alias_status.get("status"), 80).lower()
+    labels = " ".join(_strings(alias_status.get("publicSafeIdentityLabels"), max_items=10)).lower()
+    if alias_status.get("needsConfirmation") is True:
+        return "UNVERIFIED"
+    if any(term in raw or term in labels for term in ("known", "confirmed", "verified")) and not _FINAL_RE.search(raw + " " + labels):
+        return "KNOWN"
+    if "withheld" in raw or "withheld" in labels:
+        return "WITHHELD"
+    if "unknown" in raw:
+        return "UNKNOWN"
+    return "UNVERIFIED"
+
+
+def _category_kind_lane(safe_classification: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        _classification_value(safe_classification, "category", "Unknown"),
+        _classification_value(safe_classification, "kind", "Unknown"),
+        _classification_value(safe_classification, "ecosystemLane", "Unknown"),
+    )
+
+
+def _role_from_context(facts: list[str], notes: list[str], category: str, kind: str, lane: str) -> str:
+    haystack = " ".join(facts + notes + [category, kind, lane]).lower()
+    if any(term in haystack for term in ("moderator", "mod", "personnel", "staff")):
+        return "Community moderator"
+    if "sponsor" in haystack:
+        return "Sponsor record"
+    if any(term in haystack for term in ("interface", "system", "tool", "tech")):
+        return "Systems interface"
+    if any(term in haystack for term in ("producer", "production", "broadcast", "radio")):
+        return "Production collaborator"
+    if any(term in haystack for term in ("artist", "music", "musician", "track", "album", "song", "dj")):
+        return "Music artist"
+    if "collaborator" in haystack:
+        return "Community collaborator"
     if any(term in haystack for term in ("community", "server", "participant", "member")):
-        return "Community subject"
-    return "Source File subject pending owner classification"
+        return "Community member"
+    return "Review pending"
+
+
+def _length_guide(style_packet: dict[str, Any]) -> dict[str, Any]:
+    guide = _dict(style_packet.get("authoringGuideSummary"))
+    return {
+        "length": _text(guide.get("lengthGuide"), 500),
+        "tone": _text(guide.get("toneGuide"), 500),
+        "rules": _strings(guide.get("draftingRules"), max_items=8),
+        "has_examples": bool(style_packet.get("representativePublicDossierExamples") or style_packet.get("categorySpecificExamples")),
+    }
+
+
+def _word_count(text: str) -> int:
+    return len(re.findall(r"\b\w+\b", text))
+
+
+def _summary(name: str, role: str, facts: list[str], notes: list[str], style_packet: dict[str, Any]) -> str:
+    guide = _length_guide(style_packet)
+    source_sentences = _sentences(facts, max_count=3)
+    if source_sentences:
+        summary = " ".join(source_sentences)
+        if _word_count(summary) < 25 and notes:
+            extra = _sentences(notes, max_count=1)
+            if extra:
+                summary = f"{summary} {extra[0]}"
+    else:
+        summary = f"{name} is a proposed dossier subject awaiting owner review and stronger public-safe source detail."
+    if _word_count(summary) > 85:
+        words = summary.split()
+        summary = " ".join(words[:80]).rstrip(" ,;:") + "."
+    if guide["length"] and _word_count(summary) < 25 and source_sentences:
+        summary = f"{summary} This draft keeps the public copy compact while owner review confirms the remaining dossier fields."
+    return summary[:_SUMMARY_LIMIT].strip()
+
+
+def _notes(public_notes: list[str], facts: list[str]) -> str:
+    note_sentences = _sentences(public_notes, max_count=2)
+    if note_sentences:
+        notes = " ".join(note_sentences[:2])
+    elif len(facts) < 2:
+        notes = "Public-safe notes are limited; admin review should confirm wording before use."
+    else:
+        notes = "Owner Review should verify the public framing before this draft moves forward."
+    return notes[:_NOTES_LIMIT].strip()
+
+
+def _canonical_registry(style_packet: dict[str, Any]) -> set[str]:
+    guidance = style_packet.get("tagRegistryGuidance")
+    tags: set[str] = set()
+
+    def add_tag(value: Any) -> None:
+        s = _text(value, 80).lower().strip().replace(" ", "-")
+        if s and not _unsafe_reasons(s):
+            tags.add(s)
+
+    def walk(value: Any) -> None:
+        if isinstance(value, str):
+            add_tag(value)
+        elif isinstance(value, list):
+            for item in value:
+                walk(item)
+        elif isinstance(value, dict):
+            for key in ("canonicalTags", "existingTags", "allowedTags", "registry", "tags", "publicTags"):
+                if key in value:
+                    walk(value[key])
+            if "tag" in value:
+                add_tag(value["tag"])
+            if "name" in value and len(value) <= 3:
+                add_tag(value["name"])
+    walk(guidance)
+    return tags
+
+
+def _tag_candidates(category: str, kind: str, lane: str, facts: list[str], notes: list[str], packet: dict[str, Any]) -> list[str]:
+    haystack = " ".join([category, kind, lane] + facts + notes).lower()
+    candidates: list[str] = []
+    mapping = [
+        (("artist", "music", "musician"), "artist"),
+        (("collaborator",), "collaborator"),
+        (("community", "member"), "community"),
+        (("community", "member"), "member"),
+        (("personnel", "moderator", "mod"), "mod"),
+        (("sponsor",), "sponsor"),
+        (("interface", "system"), "systems"),
+        (("interface", "system", "tech"), "tech"),
+        (("production", "broadcast"), "broadcast"),
+        (("radio",), "radio"),
+        (("producer",), "producer"),
+    ]
+    for needles, tag in mapping:
+        if any(needle in haystack for needle in needles) and tag not in candidates:
+            candidates.append(tag)
+    for tag in _strings(packet.get("proposedTags"), limit_each=60, max_items=10):
+        normalized = tag.lower().replace(" ", "-")
+        if not _unsafe_reasons(normalized) and normalized not in candidates:
+            candidates.append(normalized)
+    return candidates
+
+
+def _split_tags(packet: dict[str, Any], style_packet: dict[str, Any], category: str, kind: str, lane: str, facts: list[str], notes: list[str]) -> tuple[list[str], list[str]]:
+    registry = _canonical_registry(style_packet)
+    candidates = _tag_candidates(category, kind, lane, facts, notes, packet)
+    confirmed: list[str] = []
+    proposed: list[str] = []
+    for tag in candidates:
+        if _unsafe_reasons(tag):
+            continue
+        if tag in registry:
+            if tag not in confirmed:
+                confirmed.append(tag)
+        elif tag not in proposed:
+            proposed.append(tag)
+    return confirmed[:8], proposed[:8]
 
 
 def _first_link(packet: dict[str, Any]) -> dict[str, Any] | None:
     for item in _as_list(packet.get("publicSafeLinks") or packet.get("links")):
         if isinstance(item, dict):
             url = _text(item.get("url"), 500)
-            if url and not (_PAYMENT_RE.search(url) or _INTERNAL_RE.search(url)):
-                return {"label": _text(item.get("label") or item.get("title") or "Primary link", 120), "url": url}
+            label = _text(item.get("label") or item.get("title") or "Primary link", 120)
+            if url and not (_unsafe_reasons(url) or _unsafe_reasons(label)):
+                return {"label": label, "url": url}
     return None
 
 
+def _source_usage_summary(packet: dict[str, Any]) -> str:
+    usage = _dict(packet.get("sourceUsageSummary"))
+    note_count = len(_as_list(usage.get("sourceFileNoteIds")))
+    recommendation_count = len(_as_list(usage.get("recommendationIds")))
+    lane_count = len(_as_list(usage.get("sourceLanes")))
+    parts = ["BNL drafted from public-safe facts, public-safe notes, safe classification, style guidance, field requirements, and boundary rules only."]
+    if note_count or recommendation_count:
+        parts.append(f"The packet referenced {note_count} source note(s) and {recommendation_count} recommendation reference(s) for admin traceability; raw IDs and lanes were not copied into public fields.")
+    if lane_count:
+        parts.append("Source lane details were treated as boundary context, not public copy.")
+    return " ".join(parts)
+
+
 def generate_dossier_draft(packet: dict[str, Any]) -> dict[str, Any]:
-    candidate = packet.get("candidate") if isinstance(packet.get("candidate"), dict) else {}
-    safe_classification = packet.get("safeClassification") if isinstance(packet.get("safeClassification"), dict) else {}
+    candidate = _dict(packet.get("candidate"))
+    safe_classification = _dict(packet.get("safeClassification"))
+    style_packet = _dict(packet.get("stylePacket"))
+    name = _candidate_name(candidate)
+    category, kind, lane = _category_kind_lane(safe_classification)
     public_facts, rejected_facts = _reject_unsafe_public(_strings(packet.get("publicSafeFacts"), max_items=16))
     public_notes, rejected_notes = _reject_unsafe_public(_strings(packet.get("publicSafeNotes"), max_items=12))
-    vals = _candidate_public_values(candidate, safe_classification)
-    role = _infer_role(public_facts, public_notes, vals["category"], vals["kind"])
+    role = _role_from_context(public_facts, public_notes, category, kind, lane)[:_ROLE_LIMIT]
     thin = len(public_facts) + len(public_notes) < 2
-
-    summary = " ".join(public_facts[:2]) if public_facts else f"{vals['name']} is a proposed dossier subject awaiting owner review and stronger public-safe source detail."
-    notes = " ".join(public_notes[:3]) if public_notes else "Public-safe notes are limited; admin review should confirm wording before use."
-    tags = [t.lower().replace(" ", "-")[:40] for t in _strings(candidate.get("tags") or safe_classification.get("tags"), limit_each=60, max_items=8)]
-    proposed = [t.lower().replace(" ", "-")[:40] for t in _strings(packet.get("proposedTags") or packet.get("stylePacket", {}).get("suggestedTags"), limit_each=60, max_items=8)]
 
     missing = _strings(packet.get("missingInfo"), max_items=8)
     if thin:
         missing.insert(0, "Add more public-safe facts before this draft is treated as rich dossier copy.")
-    if vals["identityAuthority"].lower() in {"", "unconfirmed", "unknown", "bnl_inferred"}:
+    if _dict(packet.get("identityAliasStatus")).get("needsConfirmation") is not False:
         missing.append("Confirm what identity authority, if any, may be stated publicly.")
 
     owner_warnings = _strings(packet.get("ownerReviewRules"), max_items=8) + _strings(packet.get("reviewOnlyWarnings"), max_items=8)
@@ -168,21 +381,40 @@ def generate_dossier_draft(packet: dict[str, Any]) -> dict[str, Any]:
     public_warnings.append("Public fields use only publicSafeFacts, publicSafeNotes, safeClassification, stylePacket, and fieldRequirements.")
 
     rejected = rejected_facts + rejected_notes
-    for unsafe_key in ("doNotSayNotes", "reviewOnlyWarnings", "sourceBoundaryNotes"):
+    for unsafe_key in ("doNotSayNotes", "reviewOnlyWarnings", "forbiddenPublicCopyPatterns"):
         if _strings(packet.get(unsafe_key), max_items=4):
             rejected.append(f"Did not use {unsafe_key} as public-facing dossier copy.")
-    if packet.get("internalAliasCount") or packet.get("internalAliases"):
+    alias_status = _dict(packet.get("identityAliasStatus"))
+    if alias_status.get("internalAliasCount") or packet.get("internalAliasCount") or packet.get("internalAliases"):
         rejected.append("Did not expose internal aliases or alias counts.")
+    if style_packet.get("representativePublicDossierExamples") or style_packet.get("categorySpecificExamples"):
+        rejected.append("Used existing public dossier examples only for structure, tone, field shape, length, and tag style; did not copy their facts.")
     if not rejected:
         rejected.append("No unsafe supplied material was needed for public-facing fields.")
 
+    tags, proposed_tags = _split_tags(packet, style_packet, category, kind, lane, public_facts, public_notes)
+
     draft = {
-        "name": vals["name"], "category": vals["category"], "kind": vals["kind"], "ecosystemLane": vals["ecosystemLane"],
-        "identityAuthority": vals["identityAuthority"], "status": vals["status"], "clearance": vals["clearance"], "origin": vals["origin"],
-        "role": role, "summary": summary[:700], "notes": notes[:900], "tags": tags, "proposedTags": proposed,
-        "primaryLink": _first_link(packet), "links": [], "files": [],
-        "missingInfoQuestions": missing[:10], "ownerReviewWarnings": owner_warnings[:12], "publicSafetyWarnings": public_warnings[:12],
-        "unsupportedClaimsRejected": rejected[:12],
-        "sourceUsageSummary": "BNL drafted from the packet's public-safe facts, public-safe notes, safe classification, style guidance, field requirements, and boundary rules only; review-only and do-not-say material was used only to form warnings or rejections.",
+        "name": name,
+        "category": category,
+        "kind": kind,
+        "ecosystemLane": lane,
+        "identityAuthority": _identity_authority(packet, safe_classification),
+        "status": "PENDING",
+        "clearance": _clearance(packet),
+        "origin": _origin(packet),
+        "role": role,
+        "summary": _summary(name, role, public_facts, public_notes, style_packet),
+        "notes": _notes(public_notes, public_facts),
+        "tags": tags,
+        "proposedTags": proposed_tags,
+        "primaryLink": _first_link(packet),
+        "links": [],
+        "files": [],
+        "missingInfoQuestions": missing[:10],
+        "ownerReviewWarnings": owner_warnings[:12],
+        "publicSafetyWarnings": public_warnings[:12],
+        "unsupportedClaimsRejected": rejected[:14],
+        "sourceUsageSummary": _source_usage_summary(packet),
     }
     return {"draft": draft}

--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -1,0 +1,188 @@
+"""BNL Proposed Dossier draft generator v1.
+
+Pure helpers for the internal site-to-BNL draft endpoint. These functions do not
+write Discord, memory, Source Files, candidates, or website state.
+"""
+from __future__ import annotations
+
+import hmac
+import os
+import re
+from typing import Any
+
+DRAFT_ENDPOINT_PATH = "/internal/dossiers/draft"
+DRAFT_TOKEN_HEADER = "X-BNL-DOSSIER-DRAFT-TOKEN"
+DRAFT_TOKEN_ENV = "BNL_DOSSIER_DRAFT_GENERATOR_TOKEN"
+REQUEST_TYPE = "bnl_proposed_dossier_draft"
+VERSION = "1.0"
+
+_PAYMENT_RE = re.compile(r"\b(stripe|checkout|payment|paid|purchase|purchased|customer|priority\s*signal|priority)\b", re.I)
+_INTERNAL_RE = re.compile(r"\b(memory_tiers|rd_context|broadcast_memory|relationship_state|redis|database|table|json|diagnostic|evidence\s*id|recommendation\s*id|source\s*row|raw\s*source\s*lane|sourceFileSummary)\b", re.I)
+_ALIAS_RE = re.compile(r"\b(internal\s+alias|alias\s+count|confirmed\s+alias|private\s+alias)\b", re.I)
+_FINAL_RE = re.compile(r"\b(published|official|approved|live|complete|final)\b", re.I)
+
+
+def _as_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if value is None:
+        return []
+    return [value]
+
+
+def _text(value: Any, limit: int = 500) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list)):
+        return ""
+    compact = re.sub(r"\s+", " ", str(value)).strip()
+    return compact[:limit].rstrip()
+
+
+def _strings(value: Any, *, limit_each: int = 260, max_items: int = 12) -> list[str]:
+    out: list[str] = []
+    for item in _as_list(value):
+        if isinstance(item, dict):
+            candidate = item.get("text") or item.get("summary") or item.get("note") or item.get("value") or item.get("label")
+        else:
+            candidate = item
+        s = _text(candidate, limit_each)
+        if s and s not in out:
+            out.append(s)
+        if len(out) >= max_items:
+            break
+    return out
+
+
+def is_dossier_draft_token_valid(provided_token: str | None, *, environ: dict[str, str] | None = None) -> bool:
+    env = environ if environ is not None else os.environ
+    expected = (env.get(DRAFT_TOKEN_ENV) or "").strip()
+    provided = (provided_token or "").strip()
+    return bool(expected and provided and hmac.compare_digest(provided, expected))
+
+
+def validate_dossier_draft_packet(packet: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(packet, dict):
+        return ["invalid_payload"]
+    if packet.get("requestType") != REQUEST_TYPE:
+        errors.append("invalid_requestType")
+    if str(packet.get("version") or "") != VERSION:
+        errors.append("invalid_version")
+    candidate = packet.get("candidate")
+    if not isinstance(candidate, dict):
+        errors.append("missing_candidate")
+    else:
+        if not _text(candidate.get("sourceFileId"), 160):
+            errors.append("missing_candidate.sourceFileId")
+        if not _text(candidate.get("subjectName"), 160):
+            errors.append("missing_candidate.subjectName")
+    if not isinstance(packet.get("stylePacket"), dict):
+        errors.append("missing_stylePacket")
+    if not isinstance(packet.get("fieldRequirements"), dict):
+        errors.append("missing_fieldRequirements")
+    return errors
+
+
+def _candidate_public_values(candidate: dict[str, Any], safe_classification: dict[str, Any]) -> dict[str, str]:
+    def pick(*keys: str, default: str = "") -> str:
+        for key in keys:
+            value = _text(candidate.get(key) or safe_classification.get(key), 120)
+            if value:
+                return value
+        return default
+
+    return {
+        "name": pick("subjectName", "name", default="Unnamed Source File subject"),
+        "category": pick("category", default="Source File candidate"),
+        "kind": pick("kind", default="proposed_dossier"),
+        "ecosystemLane": pick("ecosystemLane", "lane", default="community"),
+        "identityAuthority": pick("identityAuthority", default="unconfirmed"),
+        "status": pick("status", default="proposed"),
+        "clearance": pick("clearance", default="owner_review_required"),
+        "origin": pick("origin", default="BNL Source File draft request"),
+    }
+
+
+def _reject_unsafe_public(texts: list[str]) -> tuple[list[str], list[str]]:
+    safe: list[str] = []
+    rejected: list[str] = []
+    for s in texts:
+        reasons = []
+        if _PAYMENT_RE.search(s):
+            reasons.append("payment/Priority material")
+        if _INTERNAL_RE.search(s):
+            reasons.append("internal provenance or diagnostics")
+        if _ALIAS_RE.search(s):
+            reasons.append("internal alias material")
+        if _FINAL_RE.search(s):
+            reasons.append("final/published status wording")
+        if reasons:
+            rejected.append(f"Rejected {', '.join(reasons)} from public draft wording.")
+        else:
+            safe.append(s)
+    return safe, rejected
+
+
+def _infer_role(facts: list[str], notes: list[str], category: str, kind: str) -> str:
+    haystack = " ".join(facts + notes + [category, kind]).lower()
+    if any(term in haystack for term in ("artist", "music", "musician", "producer", "track", "album", "song", "dj")):
+        return "Artist / music community subject"
+    if any(term in haystack for term in ("community", "server", "participant", "member")):
+        return "Community subject"
+    return "Source File subject pending owner classification"
+
+
+def _first_link(packet: dict[str, Any]) -> dict[str, Any] | None:
+    for item in _as_list(packet.get("publicSafeLinks") or packet.get("links")):
+        if isinstance(item, dict):
+            url = _text(item.get("url"), 500)
+            if url and not (_PAYMENT_RE.search(url) or _INTERNAL_RE.search(url)):
+                return {"label": _text(item.get("label") or item.get("title") or "Primary link", 120), "url": url}
+    return None
+
+
+def generate_dossier_draft(packet: dict[str, Any]) -> dict[str, Any]:
+    candidate = packet.get("candidate") if isinstance(packet.get("candidate"), dict) else {}
+    safe_classification = packet.get("safeClassification") if isinstance(packet.get("safeClassification"), dict) else {}
+    public_facts, rejected_facts = _reject_unsafe_public(_strings(packet.get("publicSafeFacts"), max_items=16))
+    public_notes, rejected_notes = _reject_unsafe_public(_strings(packet.get("publicSafeNotes"), max_items=12))
+    vals = _candidate_public_values(candidate, safe_classification)
+    role = _infer_role(public_facts, public_notes, vals["category"], vals["kind"])
+    thin = len(public_facts) + len(public_notes) < 2
+
+    summary = " ".join(public_facts[:2]) if public_facts else f"{vals['name']} is a proposed dossier subject awaiting owner review and stronger public-safe source detail."
+    notes = " ".join(public_notes[:3]) if public_notes else "Public-safe notes are limited; admin review should confirm wording before use."
+    tags = [t.lower().replace(" ", "-")[:40] for t in _strings(candidate.get("tags") or safe_classification.get("tags"), limit_each=60, max_items=8)]
+    proposed = [t.lower().replace(" ", "-")[:40] for t in _strings(packet.get("proposedTags") or packet.get("stylePacket", {}).get("suggestedTags"), limit_each=60, max_items=8)]
+
+    missing = _strings(packet.get("missingInfo"), max_items=8)
+    if thin:
+        missing.insert(0, "Add more public-safe facts before this draft is treated as rich dossier copy.")
+    if vals["identityAuthority"].lower() in {"", "unconfirmed", "unknown", "bnl_inferred"}:
+        missing.append("Confirm what identity authority, if any, may be stated publicly.")
+
+    owner_warnings = _strings(packet.get("ownerReviewRules"), max_items=8) + _strings(packet.get("reviewOnlyWarnings"), max_items=8)
+    owner_warnings.append("Owner Review must approve identity, role, category, links, and public wording before publication.")
+    public_warnings = _strings(packet.get("sourceBoundaryRules"), max_items=8)
+    public_warnings.append("Public fields use only publicSafeFacts, publicSafeNotes, safeClassification, stylePacket, and fieldRequirements.")
+
+    rejected = rejected_facts + rejected_notes
+    for unsafe_key in ("doNotSayNotes", "reviewOnlyWarnings", "sourceBoundaryNotes"):
+        if _strings(packet.get(unsafe_key), max_items=4):
+            rejected.append(f"Did not use {unsafe_key} as public-facing dossier copy.")
+    if packet.get("internalAliasCount") or packet.get("internalAliases"):
+        rejected.append("Did not expose internal aliases or alias counts.")
+    if not rejected:
+        rejected.append("No unsafe supplied material was needed for public-facing fields.")
+
+    draft = {
+        "name": vals["name"], "category": vals["category"], "kind": vals["kind"], "ecosystemLane": vals["ecosystemLane"],
+        "identityAuthority": vals["identityAuthority"], "status": vals["status"], "clearance": vals["clearance"], "origin": vals["origin"],
+        "role": role, "summary": summary[:700], "notes": notes[:900], "tags": tags, "proposedTags": proposed,
+        "primaryLink": _first_link(packet), "links": [], "files": [],
+        "missingInfoQuestions": missing[:10], "ownerReviewWarnings": owner_warnings[:12], "publicSafetyWarnings": public_warnings[:12],
+        "unsupportedClaimsRejected": rejected[:12],
+        "sourceUsageSummary": "BNL drafted from the packet's public-safe facts, public-safe notes, safe classification, style guidance, field requirements, and boundary rules only; review-only and do-not-say material was used only to form warnings or rejections.",
+    }
+    return {"draft": draft}

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -8,21 +8,66 @@ import bnl01_bot
 import bnl_dossier_draft as draft
 
 
-def valid_packet(**overrides):
+def pr217_packet(**overrides):
     packet = {
         "requestType": "bnl_proposed_dossier_draft",
         "version": "1.0",
-        "candidate": {"sourceFileId": "sf_1", "subjectName": "Signal Fox", "category": "artist", "kind": "person"},
-        "stylePacket": {"suggestedTags": ["Music"]},
-        "fieldRequirements": {"summary": "required"},
-        "safeClassification": {"ecosystemLane": "music", "identityAuthority": "unconfirmed", "status": "proposed"},
-        "publicSafeFacts": ["Signal Fox is a music artist connected to the BARCODE community."],
-        "publicSafeNotes": ["Public materials frame the project around experimental electronic tracks."],
-        "ownerReviewRules": ["Owner must confirm links before publication."],
-        "sourceBoundaryRules": ["Do not use review-only material as public copy."],
+        "candidate": {
+            "sourceFileId": "sf_217",
+            "subjectName": "Signal Fox",
+            "sourceCandidateUpdatedAt": "2026-06-13T00:00:00.000Z",
+        },
+        "sourceFileSummary": "Internal admin summary that must not be copied.",
+        "publicSafeFacts": [
+            "Signal Fox is a music artist connected to the BARCODE community.",
+            "Public materials describe experimental electronic tracks and collaborative releases.",
+        ],
+        "publicSafeNotes": [
+            {"id": "note_1", "text": "Public-facing notes should stay concise and avoid identity certainty."},
+            {"id": "note_2", "note": "The available public copy supports an artist/community framing."},
+        ],
+        "reviewOnlyWarnings": ["Owner review must confirm identity labels before publication."],
+        "doNotSayNotes": ["Internal alias: SECRET HANDLE"],
+        "missingInfo": ["Confirm the preferred public link."],
+        "identityAliasStatus": {
+            "publicSafeIdentityLabels": ["artist"],
+            "internalAliasCount": 2,
+            "needsConfirmation": True,
+            "status": "needs_confirmation",
+        },
+        "sourceUsageSummary": {
+            "sourceFileNoteIds": ["note_1", "note_2"],
+            "recommendationIds": ["rec_1"],
+            "sourceLanes": ["internal_review", "public_safe"],
+        },
+        "currentDraft": None,
+        "safeClassification": {"category": "Artist", "kind": "Person", "ecosystemLane": "Music"},
+        "stylePacket": {
+            "representativePublicDossierExamples": [
+                {"name": "Example Star", "summary": "Example Star founded the copied-only Nebula Choir fact."}
+            ],
+            "categorySpecificExamples": [
+                {"category": "Artist", "role": "Music artist", "notes": "Short, concrete, public-safe."}
+            ],
+            "authoringGuideSummary": {
+                "lengthGuide": "Use one compact paragraph for summary and one or two short notes sentences.",
+                "toneGuide": "Clear BARCODE dossier style without lore fog.",
+                "draftingRules": ["Do not invent facts from examples."],
+            },
+            "tagRegistryGuidance": {
+                "canonicalTags": ["artist", "community", "member", "collaborator", "systems", "tech"],
+            },
+        },
+        "fieldRequirements": ["summary", "role", "tags", "ownerReviewWarnings"],
+        "forbiddenPublicCopyPatterns": ["internal alias", "payment", "Priority Signal"],
+        "ownerReviewRules": ["Owner Review must approve the draft before publication."],
+        "sourceBoundaryRules": ["Use public-safe facts and public-safe notes only."],
     }
     packet.update(overrides)
     return packet
+
+
+PUBLIC_FIELD_KEYS = ("role", "summary", "notes", "status", "sourceUsageSummary")
 
 
 class DossierDraftGeneratorTests(unittest.TestCase):
@@ -32,58 +77,114 @@ class DossierDraftGeneratorTests(unittest.TestCase):
         self.assertFalse(draft.is_dossier_draft_token_valid("wrong", environ=env))
         self.assertTrue(draft.is_dossier_draft_token_valid("secret", environ=env))
 
-    def test_valid_packet_returns_structured_draft(self):
-        result = draft.generate_dossier_draft(valid_packet())
-        self.assertIn("draft", result)
-        self.assertEqual(result["draft"]["name"], "Signal Fox")
-        self.assertIsInstance(result["draft"]["tags"], list)
-        self.assertEqual(result["draft"]["files"], [])
-        self.assertIn("sourceUsageSummary", result["draft"])
+    def test_realistic_pr217_packet_validates_successfully(self):
+        self.assertEqual(draft.validate_dossier_draft_packet(pr217_packet()), [])
+
+    def test_field_requirements_string_array_is_accepted(self):
+        packet = pr217_packet(fieldRequirements=["summary", "notes"])
+        self.assertEqual(draft.validate_dossier_draft_packet(packet), [])
+
+    def test_field_requirements_missing_or_empty_is_rejected(self):
+        missing = pr217_packet()
+        missing.pop("fieldRequirements")
+        self.assertIn("missing_fieldRequirements", draft.validate_dossier_draft_packet(missing))
+        self.assertIn("missing_fieldRequirements", draft.validate_dossier_draft_packet(pr217_packet(fieldRequirements=[])))
+        self.assertIn("missing_fieldRequirements", draft.validate_dossier_draft_packet(pr217_packet(fieldRequirements={})))
+
+    def test_returned_draft_uses_site_valid_enum_values(self):
+        result = draft.generate_dossier_draft(pr217_packet())["draft"]
+        self.assertIn(result["status"], draft.VALID_STATUSES)
+        self.assertIn(result["clearance"], draft.VALID_CLEARANCES)
+        self.assertIn(result["origin"], draft.VALID_ORIGINS)
+        self.assertIn(result["identityAuthority"], draft.VALID_IDENTITY_AUTHORITIES)
+        self.assertEqual(result["status"], "PENDING")
+        self.assertEqual(result["clearance"], "PUBLIC")
+        self.assertEqual(result["origin"], "UNVERIFIED")
+        self.assertEqual(result["identityAuthority"], "mixed_or_unclear")
+
+    def test_final_status_metadata_does_not_leak_and_returns_pending(self):
+        packet = pr217_packet(
+            candidate={
+                "sourceFileId": "sf_approved",
+                "subjectName": "Status Fox",
+                "status": "approved published live final complete",
+            },
+            publicSafeFacts=["Status Fox is a community artist with public music context."],
+            publicSafeNotes=[{"text": "Do not say this record is approved, published, live, final, or complete."}],
+            identityAliasStatus={"needsConfirmation": True, "status": "approved published live final complete"},
+        )
+        result = draft.generate_dossier_draft(packet)["draft"]
+        self.assertEqual(result["status"], "PENDING")
+        public = " ".join(str(result[k]) for k in PUBLIC_FIELD_KEYS).lower()
+        for forbidden in ("approved", "published", "live", "final", "complete"):
+            self.assertNotIn(forbidden, public)
 
     def test_internal_alias_and_do_not_say_terms_not_in_public_fields(self):
-        result = draft.generate_dossier_draft(valid_packet(
-            publicSafeFacts=["Signal Fox makes public music."],
-            doNotSayNotes=["Internal alias: SECRET HANDLE"],
-            internalAliasCount=3,
-        ))["draft"]
+        result = draft.generate_dossier_draft(pr217_packet())["draft"]
         public = " ".join(str(result[k]) for k in ("role", "summary", "notes"))
         self.assertNotIn("SECRET HANDLE", public)
         self.assertNotIn("Internal alias", public)
         self.assertTrue(any("internal aliases" in x for x in result["unsupportedClaimsRejected"]))
 
-    def test_payment_priority_terms_are_rejected_or_not_used(self):
-        result = draft.generate_dossier_draft(valid_packet(
-            publicSafeFacts=["Signal Fox paid through Stripe checkout for Priority Signal.", "Signal Fox makes public music."],
-            publicSafeNotes=["Priority purchase should not be public."]
+    def test_payment_priority_stripe_checkout_terms_are_rejected_or_excluded(self):
+        result = draft.generate_dossier_draft(pr217_packet(
+            publicSafeFacts=[
+                "Signal Fox paid through Stripe checkout for Priority Signal.",
+                "Signal Fox is a music artist connected to the BARCODE community.",
+            ],
+            publicSafeNotes=[{"text": "Priority purchase should not be public."}],
         ))["draft"]
         public = " ".join(str(result[k]) for k in ("role", "summary", "notes"))
-        self.assertNotIn("Stripe", public)
-        self.assertNotIn("Priority", public)
+        for forbidden in ("Stripe", "checkout", "Priority", "payment"):
+            self.assertNotIn(forbidden, public)
         self.assertTrue(any("payment/Priority" in x for x in result["unsupportedClaimsRejected"]))
 
-    def test_thin_packet_returns_conservative_draft_and_missing_info(self):
-        result = draft.generate_dossier_draft(valid_packet(publicSafeFacts=[], publicSafeNotes=[]))["draft"]
+    def test_thin_packet_returns_conservative_summary_and_missing_info(self):
+        result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]))["draft"]
         self.assertIn("awaiting owner review", result["summary"])
         self.assertTrue(result["missingInfoQuestions"])
+        self.assertIn("Add more public-safe facts", result["missingInfoQuestions"][0])
 
-    def test_public_safe_artist_music_packet_returns_music_wording(self):
-        result = draft.generate_dossier_draft(valid_packet())["draft"]
-        self.assertIn("music", result["role"].lower())
+    def test_public_safe_artist_music_packet_returns_artist_music_wording(self):
+        result = draft.generate_dossier_draft(pr217_packet())["draft"]
+        self.assertEqual(result["role"], "Music artist")
         self.assertIn("music artist", result["summary"].lower())
 
-    def test_endpoint_no_discord_send_or_memory_write(self):
+    def test_style_examples_used_for_shape_not_copied_facts(self):
+        result = draft.generate_dossier_draft(pr217_packet())["draft"]
+        combined = " ".join(str(result[k]) for k in ("role", "summary", "notes"))
+        self.assertNotIn("Example Star", combined)
+        self.assertNotIn("Nebula Choir", combined)
+        self.assertLessEqual(len(result["role"].split()), 8)
+        self.assertLessEqual(len(result["summary"].split()), 85)
+        self.assertTrue(any("examples only for structure" in x for x in result["unsupportedClaimsRejected"]))
+
+    def test_tag_registry_guidance_splits_existing_and_proposed_tags(self):
+        result = draft.generate_dossier_draft(pr217_packet(
+            safeClassification={"category": "Artist", "kind": "Collaborator", "ecosystemLane": "Music"},
+            stylePacket={
+                "tagRegistryGuidance": {"canonicalTags": ["artist", "collaborator"]},
+                "authoringGuideSummary": {"lengthGuide": "compact"},
+            },
+            proposedTags=["new-scene", "payment-vip"],
+        ))["draft"]
+        self.assertIn("artist", result["tags"])
+        self.assertIn("collaborator", result["tags"])
+        self.assertIn("new-scene", result["proposedTags"])
+        self.assertNotIn("payment-vip", result["tags"])
+        self.assertNotIn("payment-vip", result["proposedTags"])
+
+    def test_endpoint_causes_no_discord_send_or_memory_write(self):
         self.assertTrue(hasattr(bnl01_bot, "_handle_dossier_draft"))
-        self.assertIn(draft.DRAFT_ENDPOINT_PATH, bnl01_bot.DRAFT_ENDPOINT_PATH)
-        # The route delegates to pure draft generation only; no DB file, Discord client send, or memory writer is passed in.
-        result = draft.generate_dossier_draft(valid_packet())
+        self.assertEqual(draft.DRAFT_ENDPOINT_PATH, bnl01_bot.DRAFT_ENDPOINT_PATH)
+        result = draft.generate_dossier_draft(pr217_packet())
         self.assertIn("draft", result)
 
-    def test_validation_requires_contract_fields(self):
-        errors = draft.validate_dossier_draft_packet({"requestType": "bad"})
+    def test_validation_requires_candidate_and_style_packet(self):
+        errors = draft.validate_dossier_draft_packet({"requestType": "bad", "fieldRequirements": ["summary"]})
         self.assertIn("invalid_requestType", errors)
         self.assertIn("missing_candidate", errors)
         self.assertIn("missing_stylePacket", errors)
-        self.assertIn("missing_fieldRequirements", errors)
 
 
 if __name__ == "__main__":

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -1,0 +1,90 @@
+import os
+import unittest
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+
+import bnl01_bot
+import bnl_dossier_draft as draft
+
+
+def valid_packet(**overrides):
+    packet = {
+        "requestType": "bnl_proposed_dossier_draft",
+        "version": "1.0",
+        "candidate": {"sourceFileId": "sf_1", "subjectName": "Signal Fox", "category": "artist", "kind": "person"},
+        "stylePacket": {"suggestedTags": ["Music"]},
+        "fieldRequirements": {"summary": "required"},
+        "safeClassification": {"ecosystemLane": "music", "identityAuthority": "unconfirmed", "status": "proposed"},
+        "publicSafeFacts": ["Signal Fox is a music artist connected to the BARCODE community."],
+        "publicSafeNotes": ["Public materials frame the project around experimental electronic tracks."],
+        "ownerReviewRules": ["Owner must confirm links before publication."],
+        "sourceBoundaryRules": ["Do not use review-only material as public copy."],
+    }
+    packet.update(overrides)
+    return packet
+
+
+class DossierDraftGeneratorTests(unittest.TestCase):
+    def test_missing_and_invalid_token_reject(self):
+        env = {draft.DRAFT_TOKEN_ENV: "secret"}
+        self.assertFalse(draft.is_dossier_draft_token_valid(None, environ=env))
+        self.assertFalse(draft.is_dossier_draft_token_valid("wrong", environ=env))
+        self.assertTrue(draft.is_dossier_draft_token_valid("secret", environ=env))
+
+    def test_valid_packet_returns_structured_draft(self):
+        result = draft.generate_dossier_draft(valid_packet())
+        self.assertIn("draft", result)
+        self.assertEqual(result["draft"]["name"], "Signal Fox")
+        self.assertIsInstance(result["draft"]["tags"], list)
+        self.assertEqual(result["draft"]["files"], [])
+        self.assertIn("sourceUsageSummary", result["draft"])
+
+    def test_internal_alias_and_do_not_say_terms_not_in_public_fields(self):
+        result = draft.generate_dossier_draft(valid_packet(
+            publicSafeFacts=["Signal Fox makes public music."],
+            doNotSayNotes=["Internal alias: SECRET HANDLE"],
+            internalAliasCount=3,
+        ))["draft"]
+        public = " ".join(str(result[k]) for k in ("role", "summary", "notes"))
+        self.assertNotIn("SECRET HANDLE", public)
+        self.assertNotIn("Internal alias", public)
+        self.assertTrue(any("internal aliases" in x for x in result["unsupportedClaimsRejected"]))
+
+    def test_payment_priority_terms_are_rejected_or_not_used(self):
+        result = draft.generate_dossier_draft(valid_packet(
+            publicSafeFacts=["Signal Fox paid through Stripe checkout for Priority Signal.", "Signal Fox makes public music."],
+            publicSafeNotes=["Priority purchase should not be public."]
+        ))["draft"]
+        public = " ".join(str(result[k]) for k in ("role", "summary", "notes"))
+        self.assertNotIn("Stripe", public)
+        self.assertNotIn("Priority", public)
+        self.assertTrue(any("payment/Priority" in x for x in result["unsupportedClaimsRejected"]))
+
+    def test_thin_packet_returns_conservative_draft_and_missing_info(self):
+        result = draft.generate_dossier_draft(valid_packet(publicSafeFacts=[], publicSafeNotes=[]))["draft"]
+        self.assertIn("awaiting owner review", result["summary"])
+        self.assertTrue(result["missingInfoQuestions"])
+
+    def test_public_safe_artist_music_packet_returns_music_wording(self):
+        result = draft.generate_dossier_draft(valid_packet())["draft"]
+        self.assertIn("music", result["role"].lower())
+        self.assertIn("music artist", result["summary"].lower())
+
+    def test_endpoint_no_discord_send_or_memory_write(self):
+        self.assertTrue(hasattr(bnl01_bot, "_handle_dossier_draft"))
+        self.assertIn(draft.DRAFT_ENDPOINT_PATH, bnl01_bot.DRAFT_ENDPOINT_PATH)
+        # The route delegates to pure draft generation only; no DB file, Discord client send, or memory writer is passed in.
+        result = draft.generate_dossier_draft(valid_packet())
+        self.assertIn("draft", result)
+
+    def test_validation_requires_contract_fields(self):
+        errors = draft.validate_dossier_draft_packet({"requestType": "bad"})
+        self.assertIn("invalid_requestType", errors)
+        self.assertIn("missing_candidate", errors)
+        self.assertIn("missing_stylePacket", errors)
+        self.assertIn("missing_fieldRequirements", errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Implement the BNL Proposed Dossier Draft Generator v1 to satisfy the site-to-BNL contract and match barcode-network-site PR #217. 
- Provide a secure, token-gated internal endpoint that returns a structured, public-safe draft without mutating bot or website state. 
- Reuse the existing internal aiohttp listener used for force-pull / source-file refresh-now to avoid running a second web server.

### Description
- Add a pure helper module `bnl_dossier_draft.py` that validates the incoming packet, enforces drafting rules, rejects unsafe terms (internal aliases, payment/Priority terms, internal provenance, final/published wording), and returns the deterministic JSON draft shape. 
- Expose `POST /internal/dossiers/draft` on the existing internal listener and require header `X-BNL-DOSSIER-DRAFT-TOKEN` validated against env var `BNL_DOSSIER_DRAFT_GENERATOR_TOKEN`. 
- Validate the request contract (must have `requestType == bnl_proposed_dossier_draft`, `version == 1.0`, `candidate.sourceFileId`, `candidate.subjectName`, `stylePacket`, and `fieldRequirements`), return clear JSON errors for invalid/unauthorized requests, and return a fallback deterministic draft on generation errors. 
- Keep side-effect safety: the endpoint does not write to Discord, memory, Source Files, candidates, publish, merge identities, or expose internal aliases; it only returns the draft to the caller; tests added in `tests/test_dossier_draft_generator.py` cover the main checks.

### Testing
- Static checks and focused tests run: `python3 -m py_compile bnl01_bot.py`, `python3 -m py_compile bnl_dossier_draft.py`, and `python3 -m pytest tests/test_dossier_draft_generator.py` all succeeded. 
- Full test suite run: `python3 -m pytest -q` completed successfully (existing test suite passed). 
- Focused tests include token rejection, contract validation, structured draft output presence, rejection of internal/ payment/alias terms from public fields, conservative fallback for thin packets, music/artist wording inference, and ensuring no Discord/memory write occurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e06771218832189e938e750567b12)