### PR TITLE
Add public-safe dossier draft evidence retrieval

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -3516,13 +3516,13 @@ async def _handle_dossier_draft(request: web.Request) -> web.Response:
         return web.json_response({"ok": False, "error": "validation_error", "details": errors}, status=400)
 
     try:
-        result = await asyncio.to_thread(generate_dossier_draft, payload)
+        result = await asyncio.to_thread(generate_dossier_draft, payload, DB_FILE)
     except Exception as exc:
         logging.warning("dossier_draft_generation_fallback reason=%s", _safe_force_pull_error(exc))
         fallback_payload = dict(payload) if isinstance(payload, dict) else {}
         fallback_payload["publicSafeFacts"] = []
         fallback_payload["publicSafeNotes"] = []
-        result = generate_dossier_draft(fallback_payload)
+        result = generate_dossier_draft(fallback_payload, DB_FILE)
         result["draft"]["ownerReviewWarnings"].insert(0, "BNL could not generate a rich draft and returned a deterministic fallback for admin review.")
         result["draft"]["missingInfoQuestions"].insert(0, "Retry draft generation or add more public-safe source detail.")
     return web.json_response(result, status=200)

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -3516,13 +3516,19 @@ async def _handle_dossier_draft(request: web.Request) -> web.Response:
         return web.json_response({"ok": False, "error": "validation_error", "details": errors}, status=400)
 
     try:
-        result = await asyncio.to_thread(generate_dossier_draft, payload, DB_FILE)
+        public_read_model = await asyncio.to_thread(fetch_bnl_read_model, False)
+    except Exception as exc:
+        logging.warning("dossier_draft_read_model_unavailable reason=%s", _safe_force_pull_error(exc))
+        public_read_model = None
+
+    try:
+        result = await asyncio.to_thread(generate_dossier_draft, payload, DB_FILE, public_read_model)
     except Exception as exc:
         logging.warning("dossier_draft_generation_fallback reason=%s", _safe_force_pull_error(exc))
         fallback_payload = dict(payload) if isinstance(payload, dict) else {}
         fallback_payload["publicSafeFacts"] = []
         fallback_payload["publicSafeNotes"] = []
-        result = generate_dossier_draft(fallback_payload, DB_FILE)
+        result = generate_dossier_draft(fallback_payload, DB_FILE, public_read_model)
         result["draft"]["ownerReviewWarnings"].insert(0, "BNL could not generate a rich draft and returned a deterministic fallback for admin review.")
         result["draft"]["missingInfoQuestions"].insert(0, "Retry draft generation or add more public-safe source detail.")
     return web.json_response(result, status=200)

--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -38,7 +38,7 @@ _NOTES_LIMIT = 900
 _PUBLIC_EVIDENCE_LIMIT = 8
 _PUBLIC_POLICIES = {"public_home", "public_context", "public_selective", "broadcast_memory", "public"}
 _PUBLIC_VISIBILITIES = {"public", "public_safe", "dossier_safe", "public_candidate", "public_use"}
-_PUBLIC_AUTHORITIES = {"public", "public_safe", "dossier_safe", "broadcast_memory", "public_conversation"}
+_PUBLIC_AUTHORITIES = {"public", "public_safe", "dossier_safe", "broadcast_memory", "public_conversation", "owner_confirmed", "official_public_dossier", "public_discord_observed", "queue_submission_confirmed"}
 
 
 def _as_list(value: Any) -> list[Any]:
@@ -190,6 +190,10 @@ def _matches_subject(text: str, terms: list[str]) -> bool:
     return any(term and term.lower() in low for term in terms)
 
 
+def _subject_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", (value or "").lower()).strip("_")
+
+
 def _add_bundle_item(bundle: dict[str, Any], key: str, value: str, *, max_items: int = _PUBLIC_EVIDENCE_LIMIT) -> None:
     clean = _text(value, 260)
     if not clean or _unsafe_reasons(clean):
@@ -215,7 +219,94 @@ def _classify_public_evidence(bundle: dict[str, Any], text: str) -> None:
     _add_bundle_item(bundle, "notablePublicSignals", text, max_items=5)
 
 
-def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | None) -> dict[str, Any]:
+def _style_guidance_used(style_packet: dict[str, Any]) -> list[str]:
+    fields = (
+        "representativePublicDossierExamples",
+        "categorySpecificExamples",
+        "goodRoleLineExamples",
+        "goodSummaryExamples",
+        "goodNotesExamples",
+        "authoringGuideSummary",
+        "taxonomyGuide",
+        "tagRegistryGuidance",
+    )
+    used = [field for field in fields if style_packet.get(field)]
+    if not used:
+        return []
+    return [f"Used site public dossier style guidance for structure, tone, length, taxonomy, and tag style only ({', '.join(used[:8])})."]
+
+
+def _read_model_public_dossier_items(read_model: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(read_model, dict):
+        return []
+    sections = read_model.get("sections") if isinstance(read_model.get("sections"), dict) else {}
+    dossiers_section = sections.get("dossiers") if sections.get("dossiers") is not None else read_model.get("dossiers")
+    candidates: list[Any] = []
+    if isinstance(dossiers_section, dict):
+        for key in ("items", "public", "dossiers", "publicDossiers"):
+            if isinstance(dossiers_section.get(key), list):
+                candidates.extend(dossiers_section[key])
+    elif isinstance(dossiers_section, list):
+        candidates.extend(dossiers_section)
+    for key in ("publicDossiers", "dossiers"):
+        if isinstance(read_model.get(key), list):
+            candidates.extend(read_model[key])
+    out: list[dict[str, Any]] = []
+    for item in candidates:
+        if isinstance(item, dict) and item not in out:
+            out.append(item)
+    return out
+
+
+def _dossier_public_texts(dossier: dict[str, Any]) -> list[str]:
+    bnl_context = _dict(dossier.get("bnlContext"))
+    texts = _strings(
+        [
+            dossier.get("role"),
+            dossier.get("summary") or dossier.get("description") or dossier.get("publicSummary"),
+            dossier.get("notes") or bnl_context.get("notes"),
+        ],
+        max_items=5,
+    )
+    texts += _strings(dossier.get("publicFacts"), max_items=6)
+    return [text for text in texts if not _unsafe_reasons(text)]
+
+
+def _matching_public_dossiers(packet: dict[str, Any], read_model: dict[str, Any] | None) -> list[dict[str, Any]]:
+    name, aliases = _subject_terms(packet)
+    candidate = _dict(packet.get("candidate"))
+    source_file_id = _text(candidate.get("sourceFileId"), 160)
+    terms = {name.lower(), _subject_key(name)}
+    terms.update(alias.lower() for alias in aliases)
+    terms.update(_subject_key(alias) for alias in aliases)
+    if source_file_id:
+        terms.add(source_file_id.lower())
+    matches: list[dict[str, Any]] = []
+    packet_contexts = []
+    for key in ("officialPublicDossierContext", "currentPublicDossierContext", "matchingPublicDossier", "publicDossierContext"):
+        value = packet.get(key)
+        if isinstance(value, dict):
+            packet_contexts.append(value)
+        elif isinstance(value, list):
+            packet_contexts.extend(item for item in value if isinstance(item, dict))
+    for dossier in packet_contexts + _read_model_public_dossier_items(read_model):
+        fields = [
+            dossier.get("name"),
+            dossier.get("title"),
+            dossier.get("slug"),
+            dossier.get("id"),
+            dossier.get("publicId"),
+            dossier.get("sourceFileId"),
+            dossier.get("subjectName"),
+        ]
+        keys = {str(field).strip().lower() for field in fields if field}
+        keys.update(_subject_key(str(field)) for field in fields if field)
+        if terms & keys:
+            matches.append(dossier)
+    return matches[:3]
+
+
+def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | None, public_read_model: dict[str, Any] | None = None) -> dict[str, Any]:
     """Build a temporary public-safe evidence bundle for draft authoring.
 
     This is read-only and intentionally narrow: the Source File packet provides
@@ -235,6 +326,9 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
         "publicRelationshipToBarcode": [],
         "recurringPublicTopics": [],
         "notablePublicSignals": [],
+        "officialPublicDossierContext": [],
+        "publicDossierStyleGuidanceUsed": _style_guidance_used(_dict(packet.get("stylePacket"))),
+        "publicDossierContextWarnings": [],
         "sourceSummariesUsed": [],
         "excludedSourceWarnings": [],
         "missingInfoQuestions": [],
@@ -245,6 +339,18 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
         _classify_public_evidence(bundle, fact)
     for note in _strings(packet.get("publicSafeNotes"), max_items=6):
         _classify_public_evidence(bundle, note)
+    matching_dossiers = _matching_public_dossiers(packet, public_read_model)
+    if matching_dossiers:
+        used = 0
+        for dossier in matching_dossiers:
+            for text in _dossier_public_texts(dossier):
+                _add_bundle_item(bundle, "officialPublicDossierContext", text, max_items=8)
+                _classify_public_evidence(bundle, text)
+                used += 1
+        if used:
+            bundle["sourceSummariesUsed"].append("Used matching current public dossier context as official public dossier authority.")
+    else:
+        bundle["publicDossierContextWarnings"].append("No matching current public dossier/read-model facts were available as a direct official source; style examples were used only for structure and tone.")
     if not db_path:
         bundle["excludedSourceWarnings"].append("Local BNL evidence database was not available; used the packet boundary only.")
     else:
@@ -257,7 +363,6 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
             conn.row_factory = sqlite3.Row
             try:
                 if _table_exists(conn, "entity_evidence_events"):
-                    cols = _table_columns(conn, "entity_evidence_events")
                     rows = conn.execute("SELECT * FROM entity_evidence_events ORDER BY COALESCE(updated_at, created_at, '') DESC LIMIT 250").fetchall()
                     used = 0
                     excluded = 0
@@ -289,7 +394,37 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
                         bundle["sourceSummariesUsed"].append(f"Used {used} public-safe structured entity evidence summarie(s).")
                     if excluded:
                         bundle["excludedSourceWarnings"].append("Excluded review-only or non-public structured entity evidence.")
+                if _table_exists(conn, "entity_intelligence_facts"):
+                    cols = _table_columns(conn, "entity_intelligence_facts")
+                    order_col = "last_seen_at" if "last_seen_at" in cols else ("updated_at" if "updated_at" in cols else "rowid")
+                    rows = conn.execute(f"SELECT * FROM entity_intelligence_facts ORDER BY {order_col} DESC LIMIT 250").fetchall()
+                    used = 0
+                    excluded = 0
+                    wanted_key = _subject_key(name)
+                    for row in rows:
+                        data = dict(row)
+                        row_subject_key = _subject_key(str(data.get("subject_key") or data.get("subject_name") or ""))
+                        subject_name = str(data.get("subject_name") or "")
+                        if row_subject_key != wanted_key and subject_name.lower() != name.lower():
+                            continue
+                        status = str(data.get("status") or "active").lower()
+                        visibility = str(data.get("visibility") or "").lower()
+                        authority = str(data.get("authority") or "").lower()
+                        public_safe = bool(data.get("public_safe"))
+                        review_only = bool(data.get("review_only"))
+                        if status != "active" or not public_safe or review_only or visibility not in _PUBLIC_VISIBILITIES or authority not in _PUBLIC_AUTHORITIES:
+                            excluded += 1
+                            continue
+                        text = _text(data.get("fact_value") or data.get("fact_label"), 260)
+                        if text and not _unsafe_reasons(text):
+                            _classify_public_evidence(bundle, text)
+                            used += 1
+                    if used:
+                        bundle["sourceSummariesUsed"].append(f"Used {used} public-safe entity intelligence fact(s).")
+                    if excluded:
+                        bundle["excludedSourceWarnings"].append("Excluded private, review-only, inactive, or non-public entity intelligence facts.")
                 if _table_exists(conn, "broadcast_memory"):
+                    bcols = _table_columns(conn, "broadcast_memory")
                     rows = conn.execute("SELECT * FROM broadcast_memory ORDER BY rowid DESC LIMIT 250").fetchall()
                     used = 0
                     excluded = 0
@@ -300,7 +435,8 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
                             continue
                         status = str(data.get("status") or "active").lower()
                         scope = str(data.get("usage_scope") or data.get("visibility") or "").lower()
-                        if not bool(data.get("public_safe")) or status != "active" or scope not in {"public", "public_safe", "broadcast_memory", "dossier_safe"}:
+                        has_scope = "usage_scope" in bcols or "visibility" in bcols
+                        if not bool(data.get("public_safe")) or status != "active" or (has_scope and scope not in {"public", "public_safe", "broadcast_memory", "dossier_safe"}):
                             excluded += 1
                             continue
                         if text and not _unsafe_reasons(text):
@@ -533,7 +669,7 @@ def _source_usage_summary(packet: dict[str, Any]) -> str:
     return " ".join(parts)
 
 
-def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None) -> dict[str, Any]:
+def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, public_read_model: dict[str, Any] | None = None) -> dict[str, Any]:
     candidate = _dict(packet.get("candidate"))
     safe_classification = _dict(packet.get("safeClassification"))
     style_packet = _dict(packet.get("stylePacket"))
@@ -543,7 +679,7 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None) -
     public_notes, rejected_notes = _reject_unsafe_public(_strings(packet.get("publicSafeNotes"), max_items=12))
     evidence: dict[str, Any] | None = None
     try:
-        evidence = build_public_dossier_draft_evidence(packet, db_path)
+        evidence = build_public_dossier_draft_evidence(packet, db_path, public_read_model=public_read_model)
         evidence_texts: list[str] = []
         for key in (
             "publicFacts",
@@ -553,6 +689,7 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None) -
             "publicCreativeMusicContext",
             "publicRelationshipToBarcode",
             "notablePublicSignals",
+            "officialPublicDossierContext",
         ):
             evidence_texts.extend(_strings(evidence.get(key), max_items=8))
         evidence_safe, evidence_rejected = _reject_unsafe_public(evidence_texts)
@@ -582,6 +719,8 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None) -
     if evidence:
         for item in _strings(evidence.get("excludedSourceWarnings"), max_items=5):
             owner_warnings.append(item)
+        for item in _strings(evidence.get("publicDossierContextWarnings"), max_items=3):
+            owner_warnings.append(item)
         for item in _strings(evidence.get("thinReasons"), max_items=3):
             owner_warnings.append(item)
 
@@ -598,6 +737,8 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None) -
         rejected.append("No unsafe supplied material was needed for public-facing fields.")
     if evidence and evidence.get("matchedAliasesUsedPrivately"):
         rejected.append("Used approved identity labels only as private matching hints; did not expose alias text in public fields.")
+    if evidence and evidence.get("publicDossierStyleGuidanceUsed"):
+        rejected.append("Used public dossier examples for style and field shape only; unrelated example facts were not copied.")
 
     tags, proposed_tags = _split_tags(packet, style_packet, category, kind, lane, public_facts, public_notes)
 
@@ -623,6 +764,8 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None) -
         "publicSafetyWarnings": public_warnings[:12],
         "unsupportedClaimsRejected": rejected[:14],
         "sourceUsageSummary": _source_usage_summary(packet)
-        + (" " + " ".join(_strings(evidence.get("sourceSummariesUsed"), max_items=4)) if evidence else ""),
+        + (" " + " ".join(_strings(evidence.get("sourceSummariesUsed"), max_items=4)) if evidence else "")
+        + (" " + " ".join(_strings(evidence.get("publicDossierStyleGuidanceUsed"), max_items=2)) if evidence else "")
+        + (" " + " ".join(_strings(evidence.get("publicDossierContextWarnings"), max_items=2)) if evidence else ""),
     }
     return {"draft": draft}

--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -39,6 +39,12 @@ _PUBLIC_EVIDENCE_LIMIT = 8
 _PUBLIC_POLICIES = {"public_home", "public_context", "public_selective", "broadcast_memory", "public"}
 _PUBLIC_VISIBILITIES = {"public", "public_safe", "dossier_safe", "public_candidate", "public_use"}
 _PUBLIC_AUTHORITIES = {"public", "public_safe", "dossier_safe", "broadcast_memory", "public_conversation", "owner_confirmed", "official_public_dossier", "public_discord_observed", "queue_submission_confirmed"}
+_ROLE_OR_TAXONOMY_LABELS = {
+    "artist", "member", "community", "collaborator", "mod", "moderator", "personnel", "staff",
+    "sponsor", "system", "interface", "production", "radio", "producer", "ai", "human", "hybrid",
+    "unknown", "public", "internal", "restricted", "active", "pending", "person", "music",
+    "tech", "systems", "broadcast", "participant", "dossier", "source", "source file",
+}
 
 
 def _as_list(value: Any) -> list[Any]:
@@ -156,6 +162,27 @@ def _candidate_name(candidate: dict[str, Any]) -> str:
     return _text(candidate.get("subjectName") or candidate.get("name"), 120) or "Unnamed Source File subject"
 
 
+def _identity_label_kind(label: str) -> str:
+    clean = _text(label, 100)
+    low = clean.lower().strip()
+    if not clean:
+        return "empty"
+    if low in _ROLE_OR_TAXONOMY_LABELS:
+        return "role_label"
+    if len(clean) < 3 or len(clean) > 80:
+        return "role_label"
+    words = re.findall(r"[A-Za-z0-9]+", clean)
+    if not words:
+        return "role_label"
+    if len(words) == 1 and clean.islower() and not any(ch.isdigit() for ch in clean):
+        return "role_label"
+    return "subject_alias"
+
+
+def _is_probable_subject_alias(label: str) -> bool:
+    return _identity_label_kind(label) == "subject_alias"
+
+
 def _subject_terms(packet: dict[str, Any]) -> tuple[str, list[str]]:
     candidate = _dict(packet.get("candidate"))
     name = _candidate_name(candidate)
@@ -165,7 +192,7 @@ def _subject_terms(packet: dict[str, Any]) -> tuple[str, list[str]]:
     labels += _strings(current.get("name"), limit_each=100, max_items=1)
     aliases: list[str] = []
     for label in labels:
-        if label and label.lower() != name.lower() and label not in aliases and not _unsafe_reasons(label):
+        if label and label.lower() != name.lower() and label not in aliases and not _unsafe_reasons(label) and _is_probable_subject_alias(label):
             aliases.append(label)
     return name, aliases[:8]
 
@@ -192,6 +219,54 @@ def _matches_subject(text: str, terms: list[str]) -> bool:
 
 def _subject_key(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "_", (value or "").lower()).strip("_")
+
+
+def _redact_private_match_terms(text: str, private_terms: list[str], public_subject_name: str) -> str:
+    clean = _text(text, 500)
+    replacement = _text(public_subject_name, 120) or "the subject"
+    for term in sorted({t for t in private_terms if t}, key=len, reverse=True):
+        if term.lower() == replacement.lower():
+            continue
+        clean = re.sub(re.escape(term), replacement, clean, flags=re.I)
+    return clean
+
+
+def _sql_subject_filter(cols: set[str], text_cols: list[str], name: str, aliases: list[str]) -> tuple[str, list[Any]]:
+    clauses: list[str] = []
+    params: list[Any] = []
+    key_terms = [_subject_key(name)] + [_subject_key(alias) for alias in aliases if alias]
+    exact_terms = [name] + aliases
+    if "subject_key" in cols:
+        placeholders = ",".join("?" for _ in key_terms)
+        clauses.append(f"LOWER(subject_key) IN ({placeholders})")
+        params.extend(key_terms)
+    if "subject_name" in cols:
+        placeholders = ",".join("?" for _ in exact_terms)
+        clauses.append(f"LOWER(subject_name) IN ({placeholders})")
+        params.extend(term.lower() for term in exact_terms)
+    for col in text_cols:
+        if col in cols:
+            for term in exact_terms:
+                clauses.append(f"{col} LIKE ?")
+                params.append(f"%{term}%")
+    return (" OR ".join(f"({clause})" for clause in clauses), params)
+
+
+def _fetch_subject_rows(
+    conn: sqlite3.Connection,
+    table: str,
+    *,
+    cols: set[str],
+    text_cols: list[str],
+    name: str,
+    aliases: list[str],
+    order_expr: str = "rowid DESC",
+    limit: int = 250,
+) -> list[sqlite3.Row]:
+    where, params = _sql_subject_filter(cols, text_cols, name, aliases)
+    if where:
+        return conn.execute(f"SELECT * FROM {table} WHERE {where} ORDER BY {order_expr} LIMIT ?", [*params, limit]).fetchall()
+    return conn.execute(f"SELECT * FROM {table} ORDER BY {order_expr} LIMIT ?", (limit,)).fetchall()
 
 
 def _add_bundle_item(bundle: dict[str, Any], key: str, value: str, *, max_items: int = _PUBLIC_EVIDENCE_LIMIT) -> None:
@@ -363,7 +438,25 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
             conn.row_factory = sqlite3.Row
             try:
                 if _table_exists(conn, "entity_evidence_events"):
-                    rows = conn.execute("SELECT * FROM entity_evidence_events ORDER BY COALESCE(updated_at, created_at, '') DESC LIMIT 250").fetchall()
+                    ecols = _table_columns(conn, "entity_evidence_events")
+                    if {"updated_at", "created_at"} <= ecols:
+                        order_expr = "COALESCE(updated_at, created_at, '') DESC"
+                    elif "updated_at" in ecols:
+                        order_expr = "updated_at DESC"
+                    elif "created_at" in ecols:
+                        order_expr = "created_at DESC"
+                    else:
+                        order_expr = "rowid DESC"
+                    rows = _fetch_subject_rows(
+                        conn,
+                        "entity_evidence_events",
+                        cols=ecols,
+                        text_cols=["safe_summary", "topic"],
+                        name=name,
+                        aliases=aliases,
+                        order_expr=order_expr,
+                        limit=250,
+                    )
                     used = 0
                     excluded = 0
                     for row in rows:
@@ -380,7 +473,7 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
                         if review_only or not (safe_flag or policy in _PUBLIC_POLICIES or visibility in _PUBLIC_VISIBILITIES or authority in _PUBLIC_AUTHORITIES):
                             excluded += 1
                             continue
-                        text = _text(data.get("safe_summary"), 260)
+                        text = _redact_private_match_terms(_text(data.get("safe_summary"), 260), matched, name)
                         for alias in matched:
                             if alias not in bundle["matchedAliasesUsedPrivately"]:
                                 bundle["matchedAliasesUsedPrivately"].append(alias)
@@ -397,15 +490,25 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
                 if _table_exists(conn, "entity_intelligence_facts"):
                     cols = _table_columns(conn, "entity_intelligence_facts")
                     order_col = "last_seen_at" if "last_seen_at" in cols else ("updated_at" if "updated_at" in cols else "rowid")
-                    rows = conn.execute(f"SELECT * FROM entity_intelligence_facts ORDER BY {order_col} DESC LIMIT 250").fetchall()
+                    rows = _fetch_subject_rows(
+                        conn,
+                        "entity_intelligence_facts",
+                        cols=cols,
+                        text_cols=["fact_value", "fact_label"],
+                        name=name,
+                        aliases=aliases,
+                        order_expr=f"{order_col} DESC",
+                        limit=250,
+                    )
                     used = 0
                     excluded = 0
-                    wanted_key = _subject_key(name)
+                    wanted_keys = {_subject_key(name), *(_subject_key(alias) for alias in aliases)}
+                    wanted_names = {name.lower(), *(alias.lower() for alias in aliases)}
                     for row in rows:
                         data = dict(row)
                         row_subject_key = _subject_key(str(data.get("subject_key") or data.get("subject_name") or ""))
                         subject_name = str(data.get("subject_name") or "")
-                        if row_subject_key != wanted_key and subject_name.lower() != name.lower():
+                        if row_subject_key not in wanted_keys and subject_name.lower() not in wanted_names:
                             continue
                         status = str(data.get("status") or "active").lower()
                         visibility = str(data.get("visibility") or "").lower()
@@ -415,7 +518,12 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
                         if status != "active" or not public_safe or review_only or visibility not in _PUBLIC_VISIBILITIES or authority not in _PUBLIC_AUTHORITIES:
                             excluded += 1
                             continue
-                        text = _text(data.get("fact_value") or data.get("fact_label"), 260)
+                        hay = " ".join(str(data.get(c) or "") for c in ("subject_name", "fact_value", "fact_label"))
+                        matched = [t for t in terms[1:] if _matches_subject(hay, [t])]
+                        text = _redact_private_match_terms(_text(data.get("fact_value") or data.get("fact_label"), 260), matched, name)
+                        for alias in matched:
+                            if alias not in bundle["matchedAliasesUsedPrivately"]:
+                                bundle["matchedAliasesUsedPrivately"].append(alias)
                         if text and not _unsafe_reasons(text):
                             _classify_public_evidence(bundle, text)
                             used += 1
@@ -425,14 +533,28 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
                         bundle["excludedSourceWarnings"].append("Excluded private, review-only, inactive, or non-public entity intelligence facts.")
                 if _table_exists(conn, "broadcast_memory"):
                     bcols = _table_columns(conn, "broadcast_memory")
-                    rows = conn.execute("SELECT * FROM broadcast_memory ORDER BY rowid DESC LIMIT 250").fetchall()
+                    rows = _fetch_subject_rows(
+                        conn,
+                        "broadcast_memory",
+                        cols=bcols,
+                        text_cols=["cleaned_summary", "summary", "raw_note"],
+                        name=name,
+                        aliases=aliases,
+                        order_expr="rowid DESC",
+                        limit=250,
+                    )
                     used = 0
                     excluded = 0
                     for row in rows:
                         data = dict(row)
-                        text = _text(data.get("cleaned_summary") or data.get("summary") or data.get("raw_note"), 260)
+                        raw_text = _text(data.get("cleaned_summary") or data.get("summary") or data.get("raw_note"), 260)
+                        matched = [t for t in terms[1:] if _matches_subject(raw_text, [t])]
+                        text = _redact_private_match_terms(raw_text, matched, name)
                         if not _matches_subject(text, terms):
                             continue
+                        for alias in matched:
+                            if alias not in bundle["matchedAliasesUsedPrivately"]:
+                                bundle["matchedAliasesUsedPrivately"].append(alias)
                         status = str(data.get("status") or "active").lower()
                         scope = str(data.get("usage_scope") or data.get("visibility") or "").lower()
                         has_scope = "usage_scope" in bcols or "visibility" in bcols

--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import hmac
 import os
 import re
+import sqlite3
 from typing import Any
 
 DRAFT_ENDPOINT_PATH = "/internal/dossiers/draft"
@@ -34,6 +35,10 @@ _FINAL_RE = re.compile(r"\b(approved|published|live|final|complete|official)\b",
 _ROLE_LIMIT = 80
 _SUMMARY_LIMIT = 700
 _NOTES_LIMIT = 900
+_PUBLIC_EVIDENCE_LIMIT = 8
+_PUBLIC_POLICIES = {"public_home", "public_context", "public_selective", "broadcast_memory", "public"}
+_PUBLIC_VISIBILITIES = {"public", "public_safe", "dossier_safe", "public_candidate", "public_use"}
+_PUBLIC_AUTHORITIES = {"public", "public_safe", "dossier_safe", "broadcast_memory", "public_conversation"}
 
 
 def _as_list(value: Any) -> list[Any]:
@@ -149,6 +154,176 @@ def _sentences(texts: list[str], *, max_count: int = 4) -> list[str]:
 
 def _candidate_name(candidate: dict[str, Any]) -> str:
     return _text(candidate.get("subjectName") or candidate.get("name"), 120) or "Unnamed Source File subject"
+
+
+def _subject_terms(packet: dict[str, Any]) -> tuple[str, list[str]]:
+    candidate = _dict(packet.get("candidate"))
+    name = _candidate_name(candidate)
+    labels = _strings(_dict(packet.get("identityAliasStatus")).get("publicSafeIdentityLabels"), limit_each=100, max_items=8)
+    labels += _strings(packet.get("publicSafeIdentityLabels"), limit_each=100, max_items=8)
+    current = _dict(packet.get("currentDraft"))
+    labels += _strings(current.get("name"), limit_each=100, max_items=1)
+    aliases: list[str] = []
+    for label in labels:
+        if label and label.lower() != name.lower() and label not in aliases and not _unsafe_reasons(label):
+            aliases.append(label)
+    return name, aliases[:8]
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    try:
+        return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
+    except sqlite3.Error:
+        return set()
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    try:
+        row = conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)).fetchone()
+        return bool(row)
+    except sqlite3.Error:
+        return False
+
+
+def _matches_subject(text: str, terms: list[str]) -> bool:
+    low = (text or "").lower()
+    return any(term and term.lower() in low for term in terms)
+
+
+def _add_bundle_item(bundle: dict[str, Any], key: str, value: str, *, max_items: int = _PUBLIC_EVIDENCE_LIMIT) -> None:
+    clean = _text(value, 260)
+    if not clean or _unsafe_reasons(clean):
+        return
+    items = bundle.setdefault(key, [])
+    if clean not in items and len(items) < max_items:
+        items.append(clean)
+
+
+def _classify_public_evidence(bundle: dict[str, Any], text: str) -> None:
+    _add_bundle_item(bundle, "publicFacts", text)
+    low = text.lower()
+    if any(x in low for x in ("artist", "music", "track", "song", "radio", "show", "producer", "dj", "beat")):
+        _add_bundle_item(bundle, "publicCreativeMusicContext", text)
+    if any(x in low for x in ("barcode", "bnl", "dossier", "source file", "community")):
+        _add_bundle_item(bundle, "publicCommunityContext", text)
+    if any(x in low for x in ("bnl", "barcode", "community", "interact", "asked", "helps", "collaborat")):
+        _add_bundle_item(bundle, "publicRelationshipToBarcode", text)
+    if any(x in low for x in ("repeat", "recurring", "often", "regular", "again", "pattern")):
+        _add_bundle_item(bundle, "publicInteractionPatterns", text)
+    if any(x in low for x in ("role", "represents", "known for", "moderator", "artist", "collaborator", "member")):
+        _add_bundle_item(bundle, "publicRoleSignals", text)
+    _add_bundle_item(bundle, "notablePublicSignals", text, max_items=5)
+
+
+def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | None) -> dict[str, Any]:
+    """Build a temporary public-safe evidence bundle for draft authoring.
+
+    This is read-only and intentionally narrow: the Source File packet provides
+    subject/boundary/classification, while only explicitly public/dossier-safe
+    local lanes can add draft evidence.
+    """
+    name, aliases = _subject_terms(packet)
+    terms = [name] + aliases
+    bundle: dict[str, Any] = {
+        "subjectName": name,
+        "matchedAliasesUsedPrivately": [],
+        "publicFacts": [],
+        "publicRoleSignals": [],
+        "publicInteractionPatterns": [],
+        "publicCommunityContext": [],
+        "publicCreativeMusicContext": [],
+        "publicRelationshipToBarcode": [],
+        "recurringPublicTopics": [],
+        "notablePublicSignals": [],
+        "sourceSummariesUsed": [],
+        "excludedSourceWarnings": [],
+        "missingInfoQuestions": [],
+        "confidence": "low",
+        "thinReasons": [],
+    }
+    for fact in _strings(packet.get("publicSafeFacts"), max_items=8):
+        _classify_public_evidence(bundle, fact)
+    for note in _strings(packet.get("publicSafeNotes"), max_items=6):
+        _classify_public_evidence(bundle, note)
+    if not db_path:
+        bundle["excludedSourceWarnings"].append("Local BNL evidence database was not available; used the packet boundary only.")
+    else:
+        try:
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        except sqlite3.Error:
+            bundle["excludedSourceWarnings"].append("Local BNL evidence database could not be opened read-only; used the packet boundary only.")
+            conn = None
+        if conn is not None:
+            conn.row_factory = sqlite3.Row
+            try:
+                if _table_exists(conn, "entity_evidence_events"):
+                    cols = _table_columns(conn, "entity_evidence_events")
+                    rows = conn.execute("SELECT * FROM entity_evidence_events ORDER BY COALESCE(updated_at, created_at, '') DESC LIMIT 250").fetchall()
+                    used = 0
+                    excluded = 0
+                    for row in rows:
+                        data = dict(row)
+                        hay = " ".join(str(data.get(c) or "") for c in ("subject_name", "safe_summary", "topic", "relation_to_subject"))
+                        matched = [t for t in terms[1:] if _matches_subject(hay, [t])]
+                        if not _matches_subject(hay, terms):
+                            continue
+                        policy = str(data.get("channel_policy") or "").lower()
+                        visibility = str(data.get("visibility") or "").lower()
+                        authority = str(data.get("authority") or "").lower()
+                        safe_flag = bool(data.get("public_safe_candidate"))
+                        review_only = bool(data.get("review_only"))
+                        if review_only or not (safe_flag or policy in _PUBLIC_POLICIES or visibility in _PUBLIC_VISIBILITIES or authority in _PUBLIC_AUTHORITIES):
+                            excluded += 1
+                            continue
+                        text = _text(data.get("safe_summary"), 260)
+                        for alias in matched:
+                            if alias not in bundle["matchedAliasesUsedPrivately"]:
+                                bundle["matchedAliasesUsedPrivately"].append(alias)
+                        if text and not _unsafe_reasons(text):
+                            _classify_public_evidence(bundle, text)
+                            topic = _text(data.get("topic"), 120)
+                            if topic and not _unsafe_reasons(topic):
+                                _add_bundle_item(bundle, "recurringPublicTopics", topic, max_items=6)
+                            used += 1
+                    if used:
+                        bundle["sourceSummariesUsed"].append(f"Used {used} public-safe structured entity evidence summarie(s).")
+                    if excluded:
+                        bundle["excludedSourceWarnings"].append("Excluded review-only or non-public structured entity evidence.")
+                if _table_exists(conn, "broadcast_memory"):
+                    rows = conn.execute("SELECT * FROM broadcast_memory ORDER BY rowid DESC LIMIT 250").fetchall()
+                    used = 0
+                    excluded = 0
+                    for row in rows:
+                        data = dict(row)
+                        text = _text(data.get("cleaned_summary") or data.get("summary") or data.get("raw_note"), 260)
+                        if not _matches_subject(text, terms):
+                            continue
+                        status = str(data.get("status") or "active").lower()
+                        scope = str(data.get("usage_scope") or data.get("visibility") or "").lower()
+                        if not bool(data.get("public_safe")) or status != "active" or scope not in {"public", "public_safe", "broadcast_memory", "dossier_safe"}:
+                            excluded += 1
+                            continue
+                        if text and not _unsafe_reasons(text):
+                            _classify_public_evidence(bundle, text)
+                            used += 1
+                    if used:
+                        bundle["sourceSummariesUsed"].append(f"Used {used} active public-safe broadcast memory summarie(s).")
+                    if excluded:
+                        bundle["excludedSourceWarnings"].append("Excluded inactive, internal, or non-public broadcast memory.")
+                for unsafe in ("memory_tiers", "user_memory_facts", "relationship_journal", "member_activity_events"):
+                    if _table_exists(conn, unsafe):
+                        bundle["excludedSourceWarnings"].append(f"Excluded {unsafe} because it is private, source-blind, or review-only for this draft.")
+            finally:
+                conn.close()
+    total = len(bundle["publicFacts"])
+    if total >= 5:
+        bundle["confidence"] = "high"
+    elif total >= 2:
+        bundle["confidence"] = "medium"
+    else:
+        bundle["thinReasons"].append("Fewer than two public-safe evidence items were available after filtering.")
+        bundle["missingInfoQuestions"].append("Add approved public-safe subject evidence before treating this as a rich dossier.")
+    return bundle
 
 
 def _classification_value(safe_classification: dict[str, Any], key: str, default: str) -> str:
@@ -358,7 +533,7 @@ def _source_usage_summary(packet: dict[str, Any]) -> str:
     return " ".join(parts)
 
 
-def generate_dossier_draft(packet: dict[str, Any]) -> dict[str, Any]:
+def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None) -> dict[str, Any]:
     candidate = _dict(packet.get("candidate"))
     safe_classification = _dict(packet.get("safeClassification"))
     style_packet = _dict(packet.get("stylePacket"))
@@ -366,10 +541,35 @@ def generate_dossier_draft(packet: dict[str, Any]) -> dict[str, Any]:
     category, kind, lane = _category_kind_lane(safe_classification)
     public_facts, rejected_facts = _reject_unsafe_public(_strings(packet.get("publicSafeFacts"), max_items=16))
     public_notes, rejected_notes = _reject_unsafe_public(_strings(packet.get("publicSafeNotes"), max_items=12))
+    evidence: dict[str, Any] | None = None
+    try:
+        evidence = build_public_dossier_draft_evidence(packet, db_path)
+        evidence_texts: list[str] = []
+        for key in (
+            "publicFacts",
+            "publicRoleSignals",
+            "publicInteractionPatterns",
+            "publicCommunityContext",
+            "publicCreativeMusicContext",
+            "publicRelationshipToBarcode",
+            "notablePublicSignals",
+        ):
+            evidence_texts.extend(_strings(evidence.get(key), max_items=8))
+        evidence_safe, evidence_rejected = _reject_unsafe_public(evidence_texts)
+        for item in evidence_safe:
+            if item not in public_facts:
+                public_facts.append(item)
+        rejected_facts.extend(evidence_rejected)
+    except Exception:
+        evidence = None
     role = _role_from_context(public_facts, public_notes, category, kind, lane)[:_ROLE_LIMIT]
     thin = len(public_facts) + len(public_notes) < 2
 
     missing = _strings(packet.get("missingInfo"), max_items=8)
+    if evidence:
+        for item in _strings(evidence.get("missingInfoQuestions"), max_items=4):
+            if item not in missing:
+                missing.append(item)
     if thin:
         missing.insert(0, "Add more public-safe facts before this draft is treated as rich dossier copy.")
     if _dict(packet.get("identityAliasStatus")).get("needsConfirmation") is not False:
@@ -378,7 +578,12 @@ def generate_dossier_draft(packet: dict[str, Any]) -> dict[str, Any]:
     owner_warnings = _strings(packet.get("ownerReviewRules"), max_items=8) + _strings(packet.get("reviewOnlyWarnings"), max_items=8)
     owner_warnings.append("Owner Review must approve identity, role, category, links, and public wording before publication.")
     public_warnings = _strings(packet.get("sourceBoundaryRules"), max_items=8)
-    public_warnings.append("Public fields use only publicSafeFacts, publicSafeNotes, safeClassification, stylePacket, and fieldRequirements.")
+    public_warnings.append("Public fields use the Source File packet as the subject boundary plus approved public-safe BNL evidence.")
+    if evidence:
+        for item in _strings(evidence.get("excludedSourceWarnings"), max_items=5):
+            owner_warnings.append(item)
+        for item in _strings(evidence.get("thinReasons"), max_items=3):
+            owner_warnings.append(item)
 
     rejected = rejected_facts + rejected_notes
     for unsafe_key in ("doNotSayNotes", "reviewOnlyWarnings", "forbiddenPublicCopyPatterns"):
@@ -391,6 +596,8 @@ def generate_dossier_draft(packet: dict[str, Any]) -> dict[str, Any]:
         rejected.append("Used existing public dossier examples only for structure, tone, field shape, length, and tag style; did not copy their facts.")
     if not rejected:
         rejected.append("No unsafe supplied material was needed for public-facing fields.")
+    if evidence and evidence.get("matchedAliasesUsedPrivately"):
+        rejected.append("Used approved identity labels only as private matching hints; did not expose alias text in public fields.")
 
     tags, proposed_tags = _split_tags(packet, style_packet, category, kind, lane, public_facts, public_notes)
 
@@ -415,6 +622,7 @@ def generate_dossier_draft(packet: dict[str, Any]) -> dict[str, Any]:
         "ownerReviewWarnings": owner_warnings[:12],
         "publicSafetyWarnings": public_warnings[:12],
         "unsupportedClaimsRejected": rejected[:14],
-        "sourceUsageSummary": _source_usage_summary(packet),
+        "sourceUsageSummary": _source_usage_summary(packet)
+        + (" " + " ".join(_strings(evidence.get("sourceSummariesUsed"), max_items=4)) if evidence else ""),
     }
     return {"draft": draft}

--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -418,10 +418,19 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
     if matching_dossiers:
         used = 0
         for dossier in matching_dossiers:
+            dossier_haystack = " ".join(
+                _text(dossier.get(key), 180)
+                for key in ("name", "title", "slug", "id", "publicId", "sourceFileId", "subjectName", "role", "summary", "description", "publicSummary")
+            )
+            matched_aliases = [alias for alias in aliases if _matches_subject(dossier_haystack, [alias])]
             for text in _dossier_public_texts(dossier):
+                text = _redact_private_match_terms(text, matched_aliases, name)
                 _add_bundle_item(bundle, "officialPublicDossierContext", text, max_items=8)
                 _classify_public_evidence(bundle, text)
                 used += 1
+            for alias in matched_aliases:
+                if alias not in bundle["matchedAliasesUsedPrivately"]:
+                    bundle["matchedAliasesUsedPrivately"].append(alias)
         if used:
             bundle["sourceSummariesUsed"].append("Used matching current public dossier context as official public dossier authority.")
     else:

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -219,6 +219,36 @@ class DossierDraftGeneratorTests(unittest.TestCase):
             self.assertIn("public-safe structured entity evidence", combined)
             self.assertNotIn("awaiting owner review", result["summary"])
 
+    def test_matching_official_public_dossier_context_enriches_draft(self):
+        read_model = {
+            "sections": {
+                "dossiers": {
+                    "items": [
+                        {
+                            "name": "Signal Fox",
+                            "role": "Experimental electronic artist",
+                            "summary": "Signal Fox is an official public BARCODE dossier subject known for glitchy electronic collaborations.",
+                            "publicFacts": ["Signal Fox appears in the public dossier registry as a music collaborator."],
+                        },
+                        {
+                            "name": "Unrelated Star",
+                            "summary": "Unrelated Star founded the Nebula Choir.",
+                        },
+                    ]
+                }
+            }
+        }
+        result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]), public_read_model=read_model)["draft"]
+        combined = " ".join(str(result[k]) for k in ("summary", "notes", "sourceUsageSummary"))
+        self.assertIn("public dossier registry", combined)
+        self.assertIn("official public dossier authority", combined)
+        self.assertNotIn("Nebula Choir", combined)
+
+    def test_no_public_read_model_context_warns_without_failing(self):
+        result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]))["draft"]
+        self.assertTrue(any("No matching current public dossier/read-model facts" in x for x in result["ownerReviewWarnings"]))
+        self.assertIn("style examples were used only", result["sourceUsageSummary"])
+
     def test_private_alias_payment_and_source_blind_evidence_are_excluded(self):
         with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
             conn = sqlite3.connect(tmp.name)
@@ -249,6 +279,40 @@ class DossierDraftGeneratorTests(unittest.TestCase):
                 self.assertNotIn(forbidden, public)
             self.assertTrue(any("Excluded review-only" in x for x in evidence["excludedSourceWarnings"]))
             self.assertTrue(any("memory_tiers" in x for x in evidence["excludedSourceWarnings"]))
+
+    def test_entity_intelligence_public_safe_active_facts_enrich_and_private_excluded(self):
+        with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute(
+                "CREATE TABLE entity_intelligence_facts (subject_key TEXT, subject_name TEXT, fact_label TEXT, fact_value TEXT, visibility TEXT, authority TEXT, public_safe INTEGER, review_only INTEGER, status TEXT, last_seen_at TEXT)"
+            )
+            rows = [
+                ("signal_fox", "Signal Fox", "role", "Signal Fox runs public BARCODE listening-room collaborations.", "public_safe", "owner_confirmed", 1, 0, "active", "now"),
+                ("signal_fox", "Signal Fox", "private", "Signal Fox source_blind_memory private detail.", "review_only", "source_blind_memory", 0, 1, "active", "now"),
+                ("signal_fox", "Signal Fox", "payment", "Signal Fox Stripe checkout customer note.", "public_safe", "owner_confirmed", 1, 0, "active", "now"),
+            ]
+            conn.executemany("INSERT INTO entity_intelligence_facts VALUES (?,?,?,?,?,?,?,?,?,?)", rows)
+            conn.commit()
+            conn.close()
+            result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]), tmp.name)["draft"]
+            public = " ".join(str(result[k]) for k in ("role", "summary", "notes", "sourceUsageSummary"))
+            self.assertIn("listening-room collaborations", public)
+            self.assertIn("public-safe entity intelligence fact", public)
+            self.assertNotIn("source_blind_memory", public)
+            self.assertNotIn("Stripe", public)
+
+    def test_broadcast_memory_active_public_safe_without_scope_columns_is_usable(self):
+        with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute("CREATE TABLE broadcast_memory (cleaned_summary TEXT, public_safe INTEGER, status TEXT)")
+            conn.execute(
+                "INSERT INTO broadcast_memory VALUES (?,?,?)",
+                ("Signal Fox is mentioned in active public-safe BARCODE Radio broadcast memory.", 1, "active"),
+            )
+            conn.commit()
+            conn.close()
+            result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]), tmp.name)["draft"]
+            self.assertIn("BARCODE Radio broadcast memory", " ".join(str(result[k]) for k in ("summary", "sourceUsageSummary")))
 
     def test_thin_retrieved_evidence_adds_missing_questions_and_review_warnings(self):
         with tempfile.NamedTemporaryFile(suffix=".db") as tmp:

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -1,4 +1,6 @@
 import os
+import sqlite3
+import tempfile
 import unittest
 
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
@@ -179,6 +181,84 @@ class DossierDraftGeneratorTests(unittest.TestCase):
         self.assertEqual(draft.DRAFT_ENDPOINT_PATH, bnl01_bot.DRAFT_ENDPOINT_PATH)
         result = draft.generate_dossier_draft(pr217_packet())
         self.assertIn("draft", result)
+
+    def test_public_safe_evidence_retrieval_enriches_subject_specific_draft(self):
+        with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute(
+                "CREATE TABLE entity_evidence_events (subject_name TEXT, safe_summary TEXT, topic TEXT, relation_to_subject TEXT, channel_policy TEXT, visibility TEXT, authority TEXT, public_safe_candidate INTEGER, review_only INTEGER, updated_at TEXT, created_at TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO entity_evidence_events VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    "Signal Fox",
+                    "Signal Fox regularly shares experimental electronic tracks with the BARCODE community.",
+                    "Music/track-sharing discussion",
+                    "subject_direct_evidence",
+                    "public_home",
+                    "public",
+                    "public_safe",
+                    1,
+                    0,
+                    "2026-06-14",
+                    "2026-06-14",
+                ),
+            )
+            conn.execute(
+                "CREATE TABLE broadcast_memory (cleaned_summary TEXT, public_safe INTEGER, usage_scope TEXT, status TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO broadcast_memory VALUES (?,?,?,?)",
+                ("Signal Fox appears in active public BARCODE Radio notes as a recurring music collaborator.", 1, "public", "active"),
+            )
+            conn.commit()
+            conn.close()
+            result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]), tmp.name)["draft"]
+            combined = " ".join(str(result[k]) for k in ("role", "summary", "notes", "sourceUsageSummary"))
+            self.assertIn("experimental electronic tracks", combined)
+            self.assertIn("public-safe structured entity evidence", combined)
+            self.assertNotIn("awaiting owner review", result["summary"])
+
+    def test_private_alias_payment_and_source_blind_evidence_are_excluded(self):
+        with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute(
+                "CREATE TABLE entity_evidence_events (subject_name TEXT, safe_summary TEXT, topic TEXT, relation_to_subject TEXT, channel_policy TEXT, visibility TEXT, authority TEXT, public_safe_candidate INTEGER, review_only INTEGER, updated_at TEXT, created_at TEXT)"
+            )
+            rows = [
+                ("Secret Fox", "Secret Fox is a private alias that must never appear.", "alias", "matched", "public_home", "public", "public_safe", 1, 0, "now", "now"),
+                ("Signal Fox", "Signal Fox paid through Stripe checkout for Priority customer handling.", "payment", "matched", "public_home", "public", "public_safe", 1, 0, "now", "now"),
+                ("Signal Fox", "Signal Fox source-blind unknown-policy memory says private lore.", "memory", "matched", "source_blind", "review_only", "source_blind_memory", 0, 1, "now", "now"),
+                ("Signal Fox", "Signal Fox is publicly known for BARCODE community music discussions.", "community", "matched", "public_context", "public", "public_safe", 1, 0, "now", "now"),
+            ]
+            conn.executemany("INSERT INTO entity_evidence_events VALUES (?,?,?,?,?,?,?,?,?,?,?)", rows)
+            conn.execute("CREATE TABLE memory_tiers (summary TEXT)")
+            conn.execute("INSERT INTO memory_tiers VALUES (?)", ("Signal Fox private source-blind detail.",))
+            conn.commit()
+            conn.close()
+            packet = pr217_packet(
+                publicSafeFacts=[],
+                publicSafeNotes=[],
+                identityAliasStatus={"publicSafeIdentityLabels": ["Secret Fox"], "needsConfirmation": True},
+            )
+            evidence = draft.build_public_dossier_draft_evidence(packet, tmp.name)
+            result = draft.generate_dossier_draft(packet, tmp.name)["draft"]
+            public = " ".join(str(result[k]) for k in ("role", "summary", "notes"))
+            self.assertIn("Secret Fox", evidence["matchedAliasesUsedPrivately"])
+            for forbidden in ("Secret Fox", "Stripe", "checkout", "Priority", "private lore", "source-blind unknown-policy"):
+                self.assertNotIn(forbidden, public)
+            self.assertTrue(any("Excluded review-only" in x for x in evidence["excludedSourceWarnings"]))
+            self.assertTrue(any("memory_tiers" in x for x in evidence["excludedSourceWarnings"]))
+
+    def test_thin_retrieved_evidence_adds_missing_questions_and_review_warnings(self):
+        with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute("CREATE TABLE memory_tiers (summary TEXT)")
+            conn.commit()
+            conn.close()
+            result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]), tmp.name)["draft"]
+            self.assertTrue(any("Add approved public-safe subject evidence" in x for x in result["missingInfoQuestions"]))
+            self.assertTrue(any("Fewer than two public-safe evidence" in x for x in result["ownerReviewWarnings"]))
 
     def test_validation_requires_candidate_and_style_packet(self):
         errors = draft.validate_dossier_draft_packet({"requestType": "bad", "fieldRequirements": ["summary"]})

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -244,6 +244,28 @@ class DossierDraftGeneratorTests(unittest.TestCase):
         self.assertIn("official public dossier authority", combined)
         self.assertNotIn("Nebula Choir", combined)
 
+    def test_public_read_model_alias_match_redacts_alias_from_public_fields(self):
+        read_model = {
+            "sections": {
+                "dossiers": {
+                    "items": [
+                        {
+                            "name": "Secret Fox",
+                            "role": "Secret Fox listening-room host",
+                            "summary": "Secret Fox appears in official public dossier context for BARCODE listening sessions.",
+                            "publicFacts": ["Secret Fox is connected to public BARCODE listening-room sessions."],
+                        }
+                    ]
+                }
+            }
+        }
+        packet = pr217_packet(publicSafeFacts=[], publicSafeNotes=[], identityAliasStatus={"publicSafeIdentityLabels": ["Secret Fox"], "needsConfirmation": True})
+        result = draft.generate_dossier_draft(packet, public_read_model=read_model)["draft"]
+        public = " ".join(str(result[k]) for k in ("role", "summary", "notes", "sourceUsageSummary", "ownerReviewWarnings", "publicSafetyWarnings", "unsupportedClaimsRejected", "tags", "proposedTags"))
+        self.assertIn("Signal Fox", public)
+        self.assertIn("BARCODE listening", public)
+        self.assertNotIn("Secret Fox", public)
+
     def test_no_public_read_model_context_warns_without_failing(self):
         result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]))["draft"]
         self.assertTrue(any("No matching current public dossier/read-model facts" in x for x in result["ownerReviewWarnings"]))
@@ -297,6 +319,13 @@ class DossierDraftGeneratorTests(unittest.TestCase):
             public = " ".join(str(result[k]) for k in ("role", "summary", "notes"))
             self.assertNotIn("Other Person", public)
             self.assertNotIn("unrelated BARCODE activity", public)
+
+    def test_common_role_labels_are_all_excluded_from_alias_terms(self):
+        labels = ["artist", "member", "community", "collaborator", "mod", "system", "radio", "producer", "ai", "human", "active", "pending"]
+        for label in labels:
+            with self.subTest(label=label):
+                self.assertFalse(draft._is_probable_subject_alias(label))
+        self.assertTrue(draft._is_probable_subject_alias("Signal Fox Alt"))
 
     def test_name_like_alias_matches_and_is_redacted_from_public_fields(self):
         with tempfile.NamedTemporaryFile(suffix=".db") as tmp:

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -354,6 +354,23 @@ class DossierDraftGeneratorTests(unittest.TestCase):
                 self.assertFalse(draft._is_probable_subject_alias(label))
         self.assertTrue(draft._is_probable_subject_alias("Signal Fox Alt"))
 
+    def test_p1_review_thread_alias_rules_are_covered_directly(self):
+        packet = pr217_packet(
+            publicSafeFacts=[],
+            publicSafeNotes=[],
+            identityAliasStatus={"publicSafeIdentityLabels": ["artist", "Signal Fox Alt"], "needsConfirmation": True},
+        )
+        subject_name, aliases = draft._subject_terms(packet)
+        self.assertEqual(subject_name, "Signal Fox")
+        self.assertNotIn("artist", aliases)
+        self.assertIn("Signal Fox Alt", aliases)
+        redacted = draft._redact_private_match_terms(
+            "Signal Fox Alt appears in public BARCODE music context.",
+            aliases,
+            subject_name,
+        )
+        self.assertEqual(redacted, "Signal Fox appears in public BARCODE music context.")
+
     def test_name_like_alias_matches_and_is_redacted_from_public_fields(self):
         with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
             conn = sqlite3.connect(tmp.name)

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -280,6 +280,42 @@ class DossierDraftGeneratorTests(unittest.TestCase):
             self.assertTrue(any("Excluded review-only" in x for x in evidence["excludedSourceWarnings"]))
             self.assertTrue(any("memory_tiers" in x for x in evidence["excludedSourceWarnings"]))
 
+    def test_role_identity_label_is_not_used_as_subject_alias(self):
+        with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute(
+                "CREATE TABLE entity_evidence_events (subject_name TEXT, safe_summary TEXT, topic TEXT, relation_to_subject TEXT, channel_policy TEXT, visibility TEXT, authority TEXT, public_safe_candidate INTEGER, review_only INTEGER, updated_at TEXT, created_at TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO entity_evidence_events VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                ("Other Person", "Other Person is a public artist with unrelated BARCODE activity.", "artist", "matched", "public_home", "public", "public_safe", 1, 0, "2026-06-14", "2026-06-14"),
+            )
+            conn.commit()
+            conn.close()
+            packet = pr217_packet(publicSafeFacts=[], publicSafeNotes=[], identityAliasStatus={"publicSafeIdentityLabels": ["artist"], "needsConfirmation": True})
+            result = draft.generate_dossier_draft(packet, tmp.name)["draft"]
+            public = " ".join(str(result[k]) for k in ("role", "summary", "notes"))
+            self.assertNotIn("Other Person", public)
+            self.assertNotIn("unrelated BARCODE activity", public)
+
+    def test_name_like_alias_matches_and_is_redacted_from_public_fields(self):
+        with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute(
+                "CREATE TABLE entity_evidence_events (subject_name TEXT, safe_summary TEXT, topic TEXT, relation_to_subject TEXT, channel_policy TEXT, visibility TEXT, authority TEXT, public_safe_candidate INTEGER, review_only INTEGER, updated_at TEXT, created_at TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO entity_evidence_events VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                ("Secret Fox", "Secret Fox regularly hosts public BARCODE listening-room sessions.", "community", "matched", "public_home", "public", "public_safe", 1, 0, "2026-06-14", "2026-06-14"),
+            )
+            conn.commit()
+            conn.close()
+            packet = pr217_packet(publicSafeFacts=[], publicSafeNotes=[], identityAliasStatus={"publicSafeIdentityLabels": ["Secret Fox"], "needsConfirmation": True})
+            result = draft.generate_dossier_draft(packet, tmp.name)["draft"]
+            combined = " ".join(str(result[k]) for k in ("role", "summary", "notes", "sourceUsageSummary", "ownerReviewWarnings", "publicSafetyWarnings", "unsupportedClaimsRejected", "tags", "proposedTags"))
+            self.assertIn("Signal Fox regularly hosts public BARCODE listening-room sessions", combined)
+            self.assertNotIn("Secret Fox", combined)
+
     def test_entity_intelligence_public_safe_active_facts_enrich_and_private_excluded(self):
         with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
             conn = sqlite3.connect(tmp.name)
@@ -301,6 +337,46 @@ class DossierDraftGeneratorTests(unittest.TestCase):
             self.assertNotIn("source_blind_memory", public)
             self.assertNotIn("Stripe", public)
 
+    def test_subject_filtering_happens_before_entity_evidence_row_limit(self):
+        with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute(
+                "CREATE TABLE entity_evidence_events (subject_key TEXT, subject_name TEXT, safe_summary TEXT, topic TEXT, relation_to_subject TEXT, channel_policy TEXT, visibility TEXT, authority TEXT, public_safe_candidate INTEGER, review_only INTEGER, updated_at TEXT, created_at TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO entity_evidence_events VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+                ("signal_fox", "Signal Fox", "Signal Fox has older public-safe dossier-worthy source evidence.", "community", "matched", "public_home", "public", "public_safe", 1, 0, "2026-01-01", "2026-01-01"),
+            )
+            for idx in range(300):
+                conn.execute(
+                    "INSERT INTO entity_evidence_events VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+                    (f"other_{idx}", f"Other {idx}", f"Other {idx} public artist note.", "artist", "matched", "public_home", "public", "public_safe", 1, 0, f"2026-06-{idx % 28 + 1:02d}", f"2026-06-{idx % 28 + 1:02d}"),
+                )
+            conn.commit()
+            conn.close()
+            result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]), tmp.name)["draft"]
+            self.assertIn("older public-safe dossier-worthy", " ".join(str(result[k]) for k in ("summary", "sourceUsageSummary")))
+
+    def test_subject_filtering_happens_before_entity_intelligence_row_limit(self):
+        with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute(
+                "CREATE TABLE entity_intelligence_facts (subject_key TEXT, subject_name TEXT, fact_label TEXT, fact_value TEXT, visibility TEXT, authority TEXT, public_safe INTEGER, review_only INTEGER, status TEXT, last_seen_at TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO entity_intelligence_facts VALUES (?,?,?,?,?,?,?,?,?,?)",
+                ("signal_fox", "Signal Fox", "older", "Signal Fox has older public-safe entity intelligence evidence.", "public_safe", "owner_confirmed", 1, 0, "active", "2026-01-01"),
+            )
+            for idx in range(300):
+                conn.execute(
+                    "INSERT INTO entity_intelligence_facts VALUES (?,?,?,?,?,?,?,?,?,?)",
+                    (f"other_{idx}", f"Other {idx}", "newer", f"Other {idx} public artist intelligence.", "public_safe", "owner_confirmed", 1, 0, "active", f"2026-06-{idx % 28 + 1:02d}"),
+                )
+            conn.commit()
+            conn.close()
+            result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]), tmp.name)["draft"]
+            self.assertIn("older public-safe entity intelligence", " ".join(str(result[k]) for k in ("summary", "sourceUsageSummary")))
+
     def test_broadcast_memory_active_public_safe_without_scope_columns_is_usable(self):
         with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
             conn = sqlite3.connect(tmp.name)
@@ -313,6 +389,24 @@ class DossierDraftGeneratorTests(unittest.TestCase):
             conn.close()
             result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]), tmp.name)["draft"]
             self.assertIn("BARCODE Radio broadcast memory", " ".join(str(result[k]) for k in ("summary", "sourceUsageSummary")))
+
+    def test_subject_filtering_happens_before_broadcast_memory_row_limit(self):
+        with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute("CREATE TABLE broadcast_memory (cleaned_summary TEXT, public_safe INTEGER, status TEXT)")
+            conn.execute(
+                "INSERT INTO broadcast_memory VALUES (?,?,?)",
+                ("Signal Fox has older active public-safe broadcast memory.", 1, "active"),
+            )
+            for idx in range(300):
+                conn.execute(
+                    "INSERT INTO broadcast_memory VALUES (?,?,?)",
+                    (f"Other {idx} has newer active public-safe broadcast memory.", 1, "active"),
+                )
+            conn.commit()
+            conn.close()
+            result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]), tmp.name)["draft"]
+            self.assertIn("older active public-safe broadcast memory", " ".join(str(result[k]) for k in ("summary", "sourceUsageSummary")))
 
     def test_thin_retrieved_evidence_adds_missing_questions_and_review_warnings(self):
         with tempfile.NamedTemporaryFile(suffix=".db") as tmp:

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -320,6 +320,33 @@ class DossierDraftGeneratorTests(unittest.TestCase):
             self.assertNotIn("Other Person", public)
             self.assertNotIn("unrelated BARCODE activity", public)
 
+    def test_role_identity_labels_do_not_match_broadcast_or_entity_intelligence_text(self):
+        with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute(
+                "CREATE TABLE entity_intelligence_facts (subject_key TEXT, subject_name TEXT, fact_label TEXT, fact_value TEXT, visibility TEXT, authority TEXT, public_safe INTEGER, review_only INTEGER, status TEXT, last_seen_at TEXT)"
+            )
+            conn.execute("CREATE TABLE broadcast_memory (cleaned_summary TEXT, public_safe INTEGER, status TEXT)")
+            conn.execute(
+                "INSERT INTO entity_intelligence_facts VALUES (?,?,?,?,?,?,?,?,?,?)",
+                ("other_artist", "Other Artist", "artist", "Other Artist is a public community collaborator.", "public_safe", "owner_confirmed", 1, 0, "active", "now"),
+            )
+            conn.execute(
+                "INSERT INTO broadcast_memory VALUES (?,?,?)",
+                ("Other Artist appears in public radio broadcast memory as a community collaborator.", 1, "active"),
+            )
+            conn.commit()
+            conn.close()
+            packet = pr217_packet(
+                publicSafeFacts=[],
+                publicSafeNotes=[],
+                identityAliasStatus={"publicSafeIdentityLabels": ["artist", "community", "collaborator", "radio"], "needsConfirmation": True},
+            )
+            result = draft.generate_dossier_draft(packet, tmp.name)["draft"]
+            public = " ".join(str(result[k]) for k in ("role", "summary", "notes", "sourceUsageSummary"))
+            self.assertNotIn("Other Artist", public)
+            self.assertNotIn("public community collaborator", public)
+
     def test_common_role_labels_are_all_excluded_from_alias_terms(self):
         labels = ["artist", "member", "community", "collaborator", "mod", "system", "radio", "producer", "ai", "human", "active", "pending"]
         for label in labels:
@@ -344,6 +371,33 @@ class DossierDraftGeneratorTests(unittest.TestCase):
             combined = " ".join(str(result[k]) for k in ("role", "summary", "notes", "sourceUsageSummary", "ownerReviewWarnings", "publicSafetyWarnings", "unsupportedClaimsRejected", "tags", "proposedTags"))
             self.assertIn("Signal Fox regularly hosts public BARCODE listening-room sessions", combined)
             self.assertNotIn("Secret Fox", combined)
+
+    def test_alias_redaction_applies_to_broadcast_and_entity_intelligence_evidence(self):
+        with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute(
+                "CREATE TABLE entity_intelligence_facts (subject_key TEXT, subject_name TEXT, fact_label TEXT, fact_value TEXT, visibility TEXT, authority TEXT, public_safe INTEGER, review_only INTEGER, status TEXT, last_seen_at TEXT)"
+            )
+            conn.execute("CREATE TABLE broadcast_memory (cleaned_summary TEXT, public_safe INTEGER, status TEXT)")
+            conn.execute(
+                "INSERT INTO entity_intelligence_facts VALUES (?,?,?,?,?,?,?,?,?,?)",
+                ("secret_fox", "Secret Fox", "role", "Secret Fox hosts public BARCODE collaboration reviews.", "public_safe", "owner_confirmed", 1, 0, "active", "now"),
+            )
+            conn.execute(
+                "INSERT INTO broadcast_memory VALUES (?,?,?)",
+                ("Secret Fox appears in public-safe BARCODE Radio notes.", 1, "active"),
+            )
+            conn.commit()
+            conn.close()
+            packet = pr217_packet(publicSafeFacts=[], publicSafeNotes=[], identityAliasStatus={"publicSafeIdentityLabels": ["Secret Fox"], "needsConfirmation": True})
+            evidence = draft.build_public_dossier_draft_evidence(packet, tmp.name)
+            result = draft.generate_dossier_draft(packet, tmp.name)["draft"]
+            public = " ".join(str(result[k]) for k in ("role", "summary", "notes", "sourceUsageSummary", "ownerReviewWarnings", "publicSafetyWarnings", "unsupportedClaimsRejected", "tags", "proposedTags"))
+            evidence_text = " ".join(evidence["publicFacts"] + evidence["notablePublicSignals"])
+            self.assertIn("Signal Fox hosts public BARCODE collaboration reviews", public)
+            self.assertIn("Signal Fox appears in public-safe BARCODE Radio notes", public)
+            self.assertNotIn("Secret Fox", public)
+            self.assertNotIn("Secret Fox", evidence_text)
 
     def test_entity_intelligence_public_safe_active_facts_enrich_and_private_excluded(self):
         with tempfile.NamedTemporaryFile(suffix=".db") as tmp:


### PR DESCRIPTION
### Motivation
- Improve draft specificity by having BNL retrieve approved public-safe knowledge before authoring instead of drafting only from the site packet.
- Use the Source File packet as the subject/boundary/safety contract while allowing read-only BNL memory to enrich public-facing copy.
- Ensure no private/internal memory, aliases, or side-effecting writes are exposed or performed during draft generation.

### Description
- Added `build_public_dossier_draft_evidence(packet, db_path)` to `bnl_dossier_draft.py` to build a temporary, read-only public-safe evidence bundle containing public facts, role/community/music/interaction signals, matched aliases (kept private), source summaries, exclusion warnings, missing-info questions, and a confidence rating.
- Limited v1 retrieval to packet-provided `publicSafeFacts`/`publicSafeNotes`, subject-matched `entity_evidence_events` rows when explicitly public/dossier-safe, and active `broadcast_memory` marked public-safe, while excluding private/source-blind/review-only lanes and tables; added admin-safe exclusion warnings instead of leaking data.
- Merged retrieved public-safe evidence into `generate_dossier_draft` (now accepts `db_path`) so drafts combine the Source File safety contract, style packet, site public-safe fields, and filtered BNL evidence; aliases are used only as private matching hints and never inserted into public fields.
- Updated the HTTP flow in `bnl01_bot.py` to pass `DB_FILE` into `generate_dossier_draft` without changing endpoint paths, tokens, or fallback behavior.
- Added/updated unit tests in `tests/test_dossier_draft_generator.py` to cover enrichment by public-safe evidence, exclusion of private/payment/source-blind material, alias matching without public leakage, thin-evidence warnings, and retained smoke-test behavior.

### Testing
- Ran `python3 -m py_compile bnl01_bot.py` and `python3 -m py_compile bnl_dossier_draft.py` with no syntax errors; compilation succeeded.
- Ran `python3 -m pytest tests/test_dossier_draft_generator.py` and `python3 -m pytest -q`; all new and existing tests passed (test suite completed successfully).
- The endpoint behavior and deterministic fallback are preserved by design and validated by the updated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e10b1cac883219866e99a83537cd2)