### PR TITLE
Add BNL subject memory evidence resolver and wire into dossier draft generation

### DIFF
--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -11,6 +11,8 @@ import re
 import sqlite3
 from typing import Any
 
+from bnl_subject_memory_resolver import resolve_subject_memory
+
 DRAFT_ENDPOINT_PATH = "/internal/dossiers/draft"
 DRAFT_TOKEN_HEADER = "X-BNL-DOSSIER-DRAFT-TOKEN"
 DRAFT_TOKEN_ENV = "BNL_DOSSIER_DRAFT_GENERATOR_TOKEN"
@@ -699,12 +701,12 @@ def _role_from_context(facts: list[str], notes: list[str], category: str, kind: 
         return "Sponsor record"
     if any(term in haystack for term in ("interface", "system", "tool", "tech")):
         return "Systems interface"
-    if any(term in haystack for term in ("producer", "production", "broadcast", "radio")):
-        if any(term in evidence_haystack for term in ("producer", "production", "broadcast", "radio")) or any(term in classification_haystack for term in ("producer", "production", "broadcast", "radio")):
-            return "Production collaborator"
     if any(term in haystack for term in ("artist", "music", "musician", "track", "album", "song", "dj")):
         if any(term in evidence_haystack for term in ("artist", "music", "musician", "track", "album", "song", "dj")) or any(term in classification_haystack for term in ("artist", "music")):
             return "Music artist"
+    if any(term in haystack for term in ("producer", "production", "broadcast", "radio")):
+        if any(term in evidence_haystack for term in ("producer", "production", "broadcast", "radio")) or any(term in classification_haystack for term in ("producer", "production", "broadcast", "radio")):
+            return "Production collaborator"
     if "collaborator" in haystack:
         return "Community collaborator"
     if any(term in haystack for term in ("community", "server", "participant", "member")):
@@ -859,6 +861,7 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
             clean_public_notes.append(note)
     public_notes = clean_public_notes
     evidence: dict[str, Any] | None = None
+    resolver: dict[str, Any] | None = None
     try:
         evidence = build_public_dossier_draft_evidence(packet, db_path, public_read_model=public_read_model)
         evidence_texts: list[str] = []
@@ -880,12 +883,38 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
         rejected_facts.extend(evidence_rejected)
     except Exception:
         evidence = None
+    if db_path:
+        try:
+            _, resolver_aliases = _subject_terms(packet)
+            resolver = resolve_subject_memory(name, db_path, aliases=resolver_aliases)
+            resolver_texts: list[str] = []
+            for key in (
+                "publicSafeFacts",
+                "publicSafeNotes",
+                "publicRoleSignals",
+                "publicCreativeMusicSignals",
+                "publicCommunitySignals",
+                "publicLinkSignals",
+                "relationshipOrContextSignals",
+            ):
+                resolver_texts.extend(_strings(resolver.get(key), max_items=8))
+            resolver_safe, resolver_rejected = _reject_unsafe_public(resolver_texts)
+            for item in resolver_safe:
+                if item not in public_facts:
+                    public_facts.append(item)
+            rejected_facts.extend(resolver_rejected)
+        except Exception:
+            resolver = None
     role = _role_from_context(public_facts, public_notes, category, kind, lane)[:_ROLE_LIMIT]
     thin = len(public_facts) + len(public_notes) < 2
 
     missing = _strings(packet.get("missingInfo"), max_items=8)
     if evidence:
         for item in _strings(evidence.get("missingInfoQuestions"), max_items=4):
+            if item not in missing:
+                missing.append(item)
+    if resolver:
+        for item in _strings(resolver.get("missingInfoQuestions"), max_items=4):
             if item not in missing:
                 missing.append(item)
     if thin:
@@ -904,6 +933,16 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
             owner_warnings.append(item)
         for item in _strings(evidence.get("thinReasons"), max_items=3):
             owner_warnings.append(item)
+    if resolver:
+        counts = _dict(resolver.get("evidenceCounts"))
+        if counts:
+            owner_warnings.append(
+                f"BNL subject memory resolver scanned {int(counts.get('totalScanned') or 0)} candidate memories: "
+                f"{int(counts.get('publicSafe') or 0)} public-safe, {int(counts.get('reviewOnly') or 0)} review-needed, "
+                f"{int(counts.get('privateOrInternal') or 0) + int(counts.get('sourceBlind') or 0)} withheld."
+            )
+        for item in _strings(resolver.get("sourceSafetyWarnings"), max_items=3):
+            owner_warnings.append(item)
 
     rejected = rejected_facts + rejected_notes
     for unsafe_key in ("doNotSayNotes", "reviewOnlyWarnings", "forbiddenPublicCopyPatterns"):
@@ -918,6 +957,12 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
         rejected.append("No unsafe supplied material was needed for public-facing fields.")
     if evidence and evidence.get("matchedAliasesUsedPrivately"):
         rejected.append("Used approved identity labels only as private matching hints; did not expose alias text in public fields.")
+    if resolver and resolver.get("matchedAliasesUsedPrivately"):
+        rejected.append("Used probable subject aliases only as private matching hints for BNL memory resolution; did not expose alias text in public fields.")
+    if resolver and _dict(resolver.get("evidenceCounts")).get("reviewOnly"):
+        rejected.append("BNL memory needing review was used only for owner-review metadata, not public dossier copy.")
+    if resolver and _dict(resolver.get("evidenceCounts")).get("sourceBlind"):
+        rejected.append("BNL memory without public-safe provenance was counted but not used as public dossier copy.")
     if evidence and evidence.get("publicDossierStyleGuidanceUsed"):
         rejected.append("Used public dossier examples for style and field shape only; unrelated example facts were not copied.")
 
@@ -952,6 +997,10 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
                     item
                     for item in (_strings(evidence.get("sourceSummariesUsed"), max_items=4) if evidence else [])
                     if not _SOURCE_USAGE_FORBIDDEN_RE.search(item)
+                ),
+                (
+                    f"Used {int(_dict(resolver.get('evidenceCounts')).get('publicSafe') or 0)} public-safe subject memory resolver items."
+                    if resolver and int(_dict(resolver.get('evidenceCounts')).get('publicSafe') or 0) else ""
                 ),
             ]
             if part

--- a/bnl_subject_memory_resolver.py
+++ b/bnl_subject_memory_resolver.py
@@ -1,0 +1,229 @@
+"""Subject memory evidence resolver for BNL dossier/source-file drafting.
+
+The resolver is read-only and conservative: it scans known memory/evidence tables
+when they exist, classifies candidate subject memories by public-readiness, and
+only returns sanitized text in public-safe sections.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+from typing import Any
+
+LOG = logging.getLogger(__name__)
+
+_PAYMENT_RE = re.compile(r"\b(stripe|checkout|payment|paid|purchase|purchased|customer|priority\s*signal|priority)\b", re.I)
+_INTERNAL_RE = re.compile(r"\b(admin[-\s]*only|internal|private\s+alias|raw\s*id|discord\s*id|user\s*id|rowid|debug|diagnostic|database|table|source\s*row|memory_tiers|redis|dm|direct\s+message)\b", re.I)
+_SOURCE_BLIND_RE = re.compile(r"\b(source[-_\s]*blind|unknown[-_\s]*policy|no\s+provenance|unverified\s+source)\b", re.I)
+_REVIEW_RE = re.compile(r"\b(review[-\s]*only|needs?\s+confirmation|unconfirmed|uncertain|inferred|ambiguous|maybe|appears\s+to|queue|submission|relationship)\b", re.I)
+_PUBLIC_RE = re.compile(r"\b(public[-_\s]*safe|dossier[-_\s]*safe|public\s+context|public\s+home|public\s+discord|owner[-_\s]*confirmed|official\s+public|broadcast\s+memory)\b", re.I)
+_LINK_RE = re.compile(r"https?://\S+", re.I)
+_ROLE_OR_TAXONOMY_LABELS = {
+    "artist", "member", "community", "collaborator", "mod", "moderator", "personnel", "staff", "sponsor", "system", "interface", "production", "radio", "producer", "ai", "human", "hybrid", "unknown", "public", "internal", "restricted", "active", "pending", "person", "music", "tech", "systems", "broadcast", "participant", "dossier", "source", "source file",
+}
+_PUBLIC_POLICIES = {"public_home", "public_context", "public_selective", "broadcast_memory", "public"}
+_PUBLIC_VISIBILITIES = {"public", "public_safe", "dossier_safe", "public_candidate", "public_use"}
+_PUBLIC_AUTHORITIES = {"public", "public_safe", "dossier_safe", "broadcast_memory", "public_conversation", "owner_confirmed", "official_public_dossier", "public_discord_observed", "queue_submission_confirmed"}
+
+
+def _text(value: Any, limit: int = 320) -> str:
+    if value is None or isinstance(value, (dict, list)):
+        return ""
+    return re.sub(r"\s+", " ", str(value)).strip()[:limit].rstrip()
+
+
+def _subject_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", (value or "").lower()).strip("_")
+
+
+def _is_probable_subject_alias(label: str) -> bool:
+    clean = _text(label, 100)
+    low = clean.lower().strip()
+    if not clean or low in _ROLE_OR_TAXONOMY_LABELS or len(clean) < 3 or len(clean) > 80:
+        return False
+    words = re.findall(r"[A-Za-z0-9]+", clean)
+    return bool(words) and not (len(words) == 1 and clean.islower() and not any(ch.isdigit() for ch in clean))
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    try:
+        return bool(conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)).fetchone())
+    except sqlite3.Error:
+        return False
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    try:
+        return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
+    except sqlite3.Error:
+        return set()
+
+
+def _matches(text: str, terms: list[str]) -> bool:
+    low = (text or "").lower()
+    keys = {_subject_key(text)}
+    return any(term and (term.lower() in low or _subject_key(term) in keys or _subject_key(term) in _subject_key(text)) for term in terms)
+
+
+def _sanitize_public(text: str, subject: str, aliases: list[str]) -> str:
+    clean = _text(text, 260)
+    for alias in sorted([a for a in aliases if a.lower() != subject.lower()], key=len, reverse=True):
+        clean = re.sub(re.escape(alias), subject, clean, flags=re.I)
+    if _PAYMENT_RE.search(clean) or _INTERNAL_RE.search(clean):
+        return ""
+    return clean
+
+
+def _blank_result(subject: str, aliases: list[str]) -> dict[str, Any]:
+    return {
+        "subjectName": subject,
+        "matchedAliasesUsedPrivately": aliases[:8],
+        "publicSafeFacts": [], "publicSafeNotes": [], "reviewOnlyEvidence": [], "privateOrInternalEvidence": [],
+        "publicRoleSignals": [], "publicCreativeMusicSignals": [], "publicCommunitySignals": [], "publicLinkSignals": [],
+        "queueOrSubmissionSignals": [], "relationshipOrContextSignals": [], "sourceSafetyWarnings": [], "missingInfoQuestions": [],
+        "confidence": "low",
+        "evidenceCounts": {"publicSafe": 0, "reviewOnly": 0, "privateOrInternal": 0, "sourceBlind": 0, "totalScanned": 0},
+        "diagnostic": {"tablesScanned": [], "tablesContributed": {}, "classificationReasons": {}},
+    }
+
+
+def _public_ready(data: dict[str, Any], text: str) -> bool:
+    blob = " ".join(str(data.get(k) or "") for k in data)
+    return bool(data.get("public_safe") or data.get("public_safe_candidate") or _PUBLIC_RE.search(blob) or str(data.get("channel_policy") or "").lower() in _PUBLIC_POLICIES or str(data.get("visibility") or "").lower() in _PUBLIC_VISIBILITIES or str(data.get("authority") or "").lower() in _PUBLIC_AUTHORITIES) and not (_REVIEW_RE.search(blob) or _SOURCE_BLIND_RE.search(blob) or _PAYMENT_RE.search(text) or _INTERNAL_RE.search(text))
+
+
+def _classify(data: dict[str, Any], text: str) -> tuple[str, str]:
+    blob = " ".join(str(data.get(k) or "") for k in data)
+    if not text:
+        return "unusable", "empty_text"
+    if _PAYMENT_RE.search(blob) or _INTERNAL_RE.search(blob):
+        return "private_internal", "private_or_internal_terms"
+    if _SOURCE_BLIND_RE.search(blob):
+        return "source_blind", "missing_public_provenance"
+    if _REVIEW_RE.search(blob) or bool(data.get("review_only")):
+        return "review_only", "needs_review_or_confirmation"
+    if _public_ready(data, text):
+        return "public_safe", "explicit_public_safe_status"
+    return "source_blind", "no_public_safe_status"
+
+
+def _add_public_sections(result: dict[str, Any], text: str) -> None:
+    low = text.lower()
+    for key in ("publicSafeFacts", "publicSafeNotes"):
+        if text not in result[key] and len(result[key]) < 10:
+            result[key].append(text)
+    if any(w in low for w in ("artist", "member", "moderator", "producer", "dj", "role", "known for")):
+        result["publicRoleSignals"].append(text)
+    if any(w in low for w in ("music", "track", "song", "artist", "producer", "dj", "radio", "album")):
+        result["publicCreativeMusicSignals"].append(text)
+    if any(w in low for w in ("barcode", "bnl", "community", "source file", "dossier")):
+        result["publicCommunitySignals"].append(text)
+    if _LINK_RE.search(text):
+        result["publicLinkSignals"].append(text)
+    if any(w in low for w in ("relationship", "context", "barcode", "bnl", "community")):
+        result["relationshipOrContextSignals"].append(text)
+
+
+def _scan_table(conn: sqlite3.Connection, table: str, subject: str, aliases: list[str]) -> list[dict[str, Any]]:
+    cols = _table_columns(conn, table)
+    if not cols:
+        return []
+    text_cols = [c for c in ("safe_summary", "cleaned_summary", "summary", "fact_value", "fact_label", "note", "body", "message", "content", "text", "topic", "description", "public_summary") if c in cols]
+    terms = [subject] + aliases
+    key_terms = [_subject_key(t) for t in terms]
+    clauses, params = [], []
+    for col in ("subject_name", "entity_name", "name", "display_name"):
+        if col in cols:
+            clauses.extend([f"LOWER({col})=?" for _ in terms]); params.extend(t.lower() for t in terms)
+    for col in ("subject_key", "entity_key", "normalized_subject"):
+        if col in cols:
+            clauses.extend([f"LOWER({col})=?" for _ in key_terms]); params.extend(key_terms)
+    for col in text_cols:
+        for term in terms:
+            clauses.append(f"{col} LIKE ?"); params.append(f"%{term}%")
+    where = " OR ".join(f"({c})" for c in clauses) or "1=1"
+    try:
+        rows = conn.execute(f"SELECT * FROM {table} WHERE {where} ORDER BY rowid DESC LIMIT 300", params).fetchall()
+    except sqlite3.Error:
+        return []
+    out = []
+    for row in rows:
+        data = dict(row)
+        text = next((_text(data.get(c)) for c in text_cols if _text(data.get(c))), "")
+        hay = " ".join(_text(data.get(c), 120) for c in cols)
+        if text and _matches(hay, terms):
+            data["_resolver_text"] = text
+            out.append(data)
+    return out
+
+
+def resolve_subject_memory(subject_name: str, db_path: str, aliases: list[str] | None = None) -> dict[str, Any]:
+    subject = _text(subject_name, 120) or "Unnamed subject"
+    clean_aliases = []
+    for alias in aliases or []:
+        if _is_probable_subject_alias(alias) and alias.lower() != subject.lower() and alias not in clean_aliases:
+            clean_aliases.append(alias)
+    result = _blank_result(subject, clean_aliases)
+    if not db_path:
+        result["sourceSafetyWarnings"].append("No local BNL memory database was available for subject memory resolution.")
+        return result
+    tables = ["entity_evidence_events", "entity_intelligence_facts", "broadcast_memory", "source_file_enrichments", "bnl_source_file_enrichment", "dossier_candidates", "bnl_dossier_recommendations", "dossier_recommendations", "population_recommendations", "conversation_memory", "message_memory", "messages", "memory_tiers", "user_memory_facts", "relationship_journal", "member_activity_events"]
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True); conn.row_factory = sqlite3.Row
+    except sqlite3.Error:
+        result["sourceSafetyWarnings"].append("Local BNL memory database could not be opened read-only.")
+        return result
+    try:
+        for table in tables:
+            if not _table_exists(conn, table):
+                continue
+            result["diagnostic"]["tablesScanned"].append(table)
+            rows = _scan_table(conn, table, subject, clean_aliases)
+            if rows:
+                result["diagnostic"]["tablesContributed"][table] = len(rows)
+            for data in rows:
+                raw = data.get("_resolver_text") or ""
+                klass, reason = _classify(data, raw)
+                result["evidenceCounts"]["totalScanned"] += 1
+                result["diagnostic"]["classificationReasons"][reason] = result["diagnostic"]["classificationReasons"].get(reason, 0) + 1
+                if klass == "public_safe":
+                    safe = _sanitize_public(raw, subject, clean_aliases)
+                    if safe:
+                        _add_public_sections(result, safe); result["evidenceCounts"]["publicSafe"] += 1
+                elif klass == "review_only":
+                    result["reviewOnlyEvidence"].append({"table": table, "summary": "Subject memory needs owner/admin confirmation before public use.", "reason": reason})
+                    result["evidenceCounts"]["reviewOnly"] += 1
+                    if re.search(r"queue|submission", str(raw), re.I): result["queueOrSubmissionSignals"].append("Queue or submission context needs admin confirmation before public use.")
+                elif klass == "private_internal":
+                    result["privateOrInternalEvidence"].append({"table": table, "summary": "Private/internal memory was excluded from public copy.", "reason": reason})
+                    result["evidenceCounts"]["privateOrInternal"] += 1
+                elif klass == "source_blind":
+                    result["sourceSafetyWarnings"].append("Some subject memory lacked public-safe provenance and was not used as public copy.")
+                    result["evidenceCounts"]["sourceBlind"] += 1
+        ps = result["evidenceCounts"]["publicSafe"]
+        result["confidence"] = "high" if ps >= 5 else ("medium" if ps >= 2 else "low")
+        if ps == 0:
+            result["missingInfoQuestions"].append("Confirm at least one public-safe subject fact before drafting rich public dossier copy.")
+        if result["evidenceCounts"]["reviewOnly"] or result["evidenceCounts"]["sourceBlind"]:
+            result["missingInfoQuestions"].append("Review BNL subject memory and promote confirmed public-safe facts with provenance.")
+    finally:
+        conn.close()
+    LOG.debug("subject_memory_resolver subject=%s tables=%s publicSafe=%s reviewOnly=%s rejected=%s confidence=%s", subject, result["diagnostic"]["tablesScanned"], result["evidenceCounts"]["publicSafe"], result["evidenceCounts"]["reviewOnly"], result["evidenceCounts"]["privateOrInternal"] + result["evidenceCounts"]["sourceBlind"], result["confidence"])
+    return result
+
+
+def build_subject_memory_diagnostic(subject_name: str, db_path: str) -> dict[str, Any]:
+    resolved = resolve_subject_memory(subject_name, db_path)
+    counts = resolved["evidenceCounts"]
+    return {
+        "subjectName": resolved["subjectName"],
+        "candidateMemoriesFound": counts["totalScanned"],
+        "tablesScanned": resolved["diagnostic"]["tablesScanned"],
+        "tablesContributed": resolved["diagnostic"]["tablesContributed"],
+        "classificationCounts": counts,
+        "classificationReasons": resolved["diagnostic"]["classificationReasons"],
+        "safePublicSummary": resolved["publicSafeFacts"][:5],
+        "adminConfirmationNeeded": resolved["missingInfoQuestions"][:5],
+        "confidence": resolved["confidence"],
+    }

--- a/tests/test_subject_memory_resolver.py
+++ b/tests/test_subject_memory_resolver.py
@@ -1,0 +1,70 @@
+import sqlite3
+import tempfile
+import unittest
+
+import bnl_dossier_draft as draft
+from bnl_subject_memory_resolver import build_subject_memory_diagnostic, resolve_subject_memory
+
+
+class SubjectMemoryResolverTests(unittest.TestCase):
+    def test_resolver_finds_and_classifies_crow_memory_across_tables(self):
+        with tempfile.NamedTemporaryFile(suffix='.db') as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute("CREATE TABLE entity_evidence_events (subject_name TEXT, safe_summary TEXT, channel_policy TEXT, visibility TEXT, authority TEXT, public_safe_candidate INTEGER, review_only INTEGER)")
+            conn.execute("CREATE TABLE entity_intelligence_facts (subject_key TEXT, subject_name TEXT, fact_label TEXT, fact_value TEXT, visibility TEXT, authority TEXT, public_safe INTEGER, review_only INTEGER, status TEXT)")
+            conn.execute("CREATE TABLE broadcast_memory (cleaned_summary TEXT, public_safe INTEGER, status TEXT)")
+            conn.execute("INSERT INTO entity_evidence_events VALUES (?,?,?,?,?,?,?)", ("Crow", "Crow is publicly listed as a BARCODE community music artist.", "public_home", "public", "public_safe", 1, 0))
+            conn.execute("INSERT INTO entity_intelligence_facts VALUES (?,?,?,?,?,?,?,?,?)", ("crow", "Crow", "queue", "Crow queue submission may connect to Raven.", "review_only", "", 0, 1, "active"))
+            conn.execute("INSERT INTO broadcast_memory VALUES (?,?,?)", ("Crow unknown-policy source-blind music mention.", 0, "active"))
+            conn.commit(); conn.close()
+            result = resolve_subject_memory("Crow", tmp.name, aliases=["artist", "Crow Alt"])
+            self.assertEqual(result["evidenceCounts"]["publicSafe"], 1)
+            self.assertEqual(result["evidenceCounts"]["reviewOnly"], 1)
+            self.assertEqual(result["evidenceCounts"]["sourceBlind"], 1)
+            self.assertIn("Crow is publicly listed", " ".join(result["publicSafeFacts"]))
+            self.assertNotIn("artist", result["matchedAliasesUsedPrivately"])
+            diagnostic = build_subject_memory_diagnostic("Crow", tmp.name)
+            self.assertEqual(diagnostic["candidateMemoriesFound"], 3)
+
+    def test_private_payment_rejected_and_missing_tables_do_not_crash(self):
+        with tempfile.NamedTemporaryFile(suffix='.db') as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute("CREATE TABLE message_memory (subject_name TEXT, summary TEXT, visibility TEXT, public_safe INTEGER)")
+            conn.execute("INSERT INTO message_memory VALUES (?,?,?,?)", ("Crow", "Crow Stripe checkout Priority customer note.", "public_safe", 1))
+            conn.commit(); conn.close()
+            result = resolve_subject_memory("Crow", tmp.name)
+            self.assertEqual(result["evidenceCounts"]["privateOrInternal"], 1)
+            self.assertEqual(result["publicSafeFacts"], [])
+
+    def test_draft_uses_public_safe_resolver_memory_not_review_only_music(self):
+        with tempfile.NamedTemporaryFile(suffix='.db') as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute("CREATE TABLE entity_evidence_events (subject_name TEXT, safe_summary TEXT, channel_policy TEXT, visibility TEXT, authority TEXT, public_safe_candidate INTEGER, review_only INTEGER)")
+            conn.execute("INSERT INTO entity_evidence_events VALUES (?,?,?,?,?,?,?)", ("Crow", "Crow is an unconfirmed music artist from a review-only queue note.", "", "review_only", "", 0, 1))
+            conn.commit(); conn.close()
+            packet = draft.validate_dossier_draft_packet
+            p = {
+                "requestType": "bnl_proposed_dossier_draft", "version": "1.0",
+                "candidate": {"sourceFileId": "sf_crow", "subjectName": "Crow"},
+                "publicSafeFacts": [], "publicSafeNotes": [], "stylePacket": {}, "fieldRequirements": ["summary"],
+                "safeClassification": {"category": "Unknown", "kind": "Person", "ecosystemLane": "Unknown"},
+            }
+            result = draft.generate_dossier_draft(p, tmp.name)["draft"]
+            self.assertNotEqual(result["role"], "Music artist")
+            self.assertIn("limited public-safe source detail", result["summary"])
+            self.assertTrue(any("resolver scanned" in x for x in result["ownerReviewWarnings"]))
+
+    def test_draft_music_role_requires_public_safe_music(self):
+        with tempfile.NamedTemporaryFile(suffix='.db') as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute("CREATE TABLE entity_evidence_events (subject_name TEXT, safe_summary TEXT, channel_policy TEXT, visibility TEXT, authority TEXT, public_safe_candidate INTEGER, review_only INTEGER)")
+            conn.execute("INSERT INTO entity_evidence_events VALUES (?,?,?,?,?,?,?)", ("Crow", "Crow is a public-safe music artist connected to BARCODE Radio.", "public_home", "public", "public_safe", 1, 0))
+            conn.commit(); conn.close()
+            p = {"requestType": "bnl_proposed_dossier_draft", "version": "1.0", "candidate": {"sourceFileId": "sf_crow", "subjectName": "Crow"}, "publicSafeFacts": [], "publicSafeNotes": [], "stylePacket": {}, "fieldRequirements": ["summary"], "safeClassification": {"category": "Unknown", "kind": "Person", "ecosystemLane": "Unknown"}}
+            result = draft.generate_dossier_draft(p, tmp.name)["draft"]
+            self.assertEqual(result["role"], "Music artist")
+            self.assertIn("subject memory resolver", result["sourceUsageSummary"])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Crow-like subjects have lots of internal BNL memory but little clean public-safe evidence reaching the Source File / Dossier draft path; a resolver is needed to surface and classify what can safely be promoted into public draft fields. 
- The change centralizes subject memory scanning and classification in the bot so dossier drafting and later source-file refresh can reuse a single conservative resolver.

### Description
- Add `bnl_subject_memory_resolver.py` which exposes `resolve_subject_memory(subject_name: str, db_path: str, aliases: list[str] | None = None) -> dict` and `build_subject_memory_diagnostic(subject_name, db_path)`; it defensively probes many known tables, classifies rows as `public_safe`, `review_only`, `private_internal`, `source_blind`, or `unusable`, redacts private alias text, and emits sanitized public sections and diagnostics. 
- Resolver output includes `subjectName`, `matchedAliasesUsedPrivately`, `publicSafeFacts`, `publicSafeNotes`, `reviewOnlyEvidence`, `privateOrInternalEvidence`, signal buckets, `sourceSafetyWarnings`, `missingInfoQuestions`, `confidence`, and `evidenceCounts` (publicSafe, reviewOnly, privateOrInternal, sourceBlind, totalScanned). 
- Wire the resolver into `generate_dossier_draft` (in `bnl_dossier_draft.py`) so resolver public-safe facts/notes/signals are appended to draft evidence only when safe, while review-only / private / source-blind items are routed into owner-review warnings, `missingInfoQuestions`, `unsupportedClaimsRejected`, and `sourceUsageSummary` metadata (resolver counts are summarized for owner review). 
- Adjust role inference ordering so public-safe music evidence will produce a `Music artist` role only when resolver/evidence contains clean public-safe music signals, preserving conservatism for review-only mentions. 
- Add `tests/test_subject_memory_resolver.py` with resolver-focused cases (multi-table Crow-like resolution; alias filtering; payment/private rejection; missing-table tolerance; conservative draft when only review-only memory exists; and enrichment when clean public-safe music evidence exists). 

### Testing
- Ran `python3 -m py_compile bnl_dossier_draft.py bnl01_bot.py bnl_subject_memory_resolver.py` and compilation succeeded. 
- Ran `python3 -m pytest tests/test_dossier_draft_generator.py -q` and all existing dossier draft generator tests passed (35 passed, including subtests). 
- Ran `python3 -m pytest tests/test_subject_memory_resolver.py -q` and new resolver tests passed (4 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e2b45400c8321bc4c35eac97844f7)