### PR TITLE
Wire subject analyst read into Source File enrichment

### DIFF
--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -25,6 +25,7 @@ from bnl_entity_intelligence import build_entity_intelligence_profile, resolve_e
 from bnl_evidence_ownership import classify_evidence_ownership, subject_owned_text_fragments
 from bnl_source_file_lookup import lookup_source_file
 from bnl_source_refresh_context import refresh_generation_context
+from bnl_subject_memory_resolver import build_subject_analyst_read, resolve_subject_memory
 
 ENRICHMENT_INGEST_SOURCE = "bnl_source_file_enrichment"
 FALLBACK_INGEST_SOURCE = "bnl_source_knowledge_bridge"
@@ -4746,10 +4747,98 @@ def build_source_file_case_report_v1(subject_memory_packet: dict[str, Any]) -> d
     }
     return _sanitize_archive_value(report)
 
+
+_SUBJECT_ANALYST_READ_KEYS = (
+    "subjectName",
+    "internalRead",
+    "likelySubjectType",
+    "confidence",
+    "publicDraftPosture",
+    "strongestSignals",
+    "publicSafeClaims",
+    "sourceFileReviewClaims",
+    "sourceBlindInsights",
+    "privateOrInternalExclusions",
+    "doNotSayPublicly",
+    "missingInfoQuestions",
+    "recommendedAdminActions",
+    "draftIngredients",
+    "sourceFileIngredients",
+    "provenanceSummary",
+)
+
+
+def _subject_analyst_aliases(packet: dict[str, Any]) -> list[str]:
+    source_file = packet.get("sourceFile") if isinstance(packet.get("sourceFile"), dict) else {}
+    identity = packet.get("subjectIdentity") if isinstance(packet.get("subjectIdentity"), dict) else {}
+    aliases: list[str] = []
+
+    def add(value: Any) -> None:
+        if isinstance(value, str):
+            for part in re.split(r"[,|;/]+", value):
+                clean = _safe_text(part, 120)
+                if clean and clean not in aliases:
+                    aliases.append(clean)
+        elif isinstance(value, (list, tuple, set)):
+            for item in value:
+                add(item)
+        elif isinstance(value, dict):
+            for key in ("name", "label", "alias", "displayName", "preferredName", "normalizedName", "value"):
+                add(value.get(key))
+
+    for key in ("aliases", "alias", "matchedAlias", "confirmedAliases", "proposedAliases", "possibleAliases", "identityLinks", "identity_links", "possibleConnections", "displayName", "preferredName", "normalizedName"):
+        add(source_file.get(key))
+    for key in ("aliasLabels", "matchedIdentityLabels", "confirmedAliases", "aliases"):
+        add(identity.get(key))
+    return aliases[:12]
+
+
+def _normalize_subject_analyst_read_v1(analyst: dict[str, Any]) -> dict[str, Any]:
+    review_claims = analyst.get("sourceFileReviewClaims")
+    if review_claims is None:
+        review_claims = analyst.get("reviewNeededClaims")
+    source_file_ingredients = analyst.get("sourceFileIngredients")
+    if not source_file_ingredients:
+        source_file_ingredients = _case_list([
+            analyst.get("internalRead"),
+            *(analyst.get("strongestSignals") or []),
+            *(analyst.get("publicSafeClaims") or []),
+            *(review_claims or []),
+            *(analyst.get("sourceBlindInsights") or []),
+            *(analyst.get("recommendedAdminActions") or []),
+            *(analyst.get("missingInfoQuestions") or []),
+        ], limit=18, item_limit=320)
+    normalized = {key: analyst.get(key) for key in _SUBJECT_ANALYST_READ_KEYS}
+    normalized["sourceFileReviewClaims"] = _case_list(review_claims, limit=10, item_limit=320)
+    normalized["sourceFileIngredients"] = _case_list(source_file_ingredients, limit=18, item_limit=320)
+    for key in ("strongestSignals", "publicSafeClaims", "sourceBlindInsights", "privateOrInternalExclusions", "doNotSayPublicly", "missingInfoQuestions", "recommendedAdminActions", "draftIngredients", "provenanceSummary"):
+        normalized[key] = _case_list(normalized.get(key), limit=12 if key != "draftIngredients" else 9, item_limit=360)
+    normalized["subjectName"] = _case_text(normalized.get("subjectName"), 140)
+    normalized["internalRead"] = _case_text(normalized.get("internalRead"), 700)
+    normalized["likelySubjectType"] = _case_text(normalized.get("likelySubjectType"), 80)
+    normalized["confidence"] = _case_text(normalized.get("confidence"), 40)
+    normalized["publicDraftPosture"] = _case_text(normalized.get("publicDraftPosture"), 80)
+    return _sanitize_archive_value(normalized)
+
+
+def build_source_file_subject_analyst_read_v1(packet: dict[str, Any], db_path: str | None = None) -> dict[str, Any]:
+    """Resolve subject memory and return the Source File-ready analyst read."""
+
+    source_file = packet.get("sourceFile") if isinstance(packet.get("sourceFile"), dict) else {}
+    subject = _safe_text(packet.get("subject") or _first(source_file, ("name", "sourceFileName", "subject", "displayName", "title", "normalizedName")), 140)
+    existing = packet.get("subjectAnalystReadV1") if isinstance(packet.get("subjectAnalystReadV1"), dict) else {}
+    if existing:
+        return _normalize_subject_analyst_read_v1(existing)
+    resolved = packet.get("resolvedSubjectMemoryV1") if isinstance(packet.get("resolvedSubjectMemoryV1"), dict) else None
+    if resolved is None:
+        resolved = resolve_subject_memory(subject, db_path or "", aliases=_subject_analyst_aliases(packet))
+    return _normalize_subject_analyst_read_v1(build_subject_analyst_read(subject, resolved, packet))
+
+
 def _source_package_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     """Build the full review-only archive package without compact-card trimming."""
 
-    excluded = {"payload", "sendResult", "archiveResult", "sourcePackage", "subjectMemoryPacketV1", "sourceFileCaseReportV1"}
+    excluded = {"payload", "sendResult", "archiveResult", "sourcePackage", "subjectMemoryPacketV1", "sourceFileCaseReportV1", "resolvedSubjectMemoryV1", "dbPath"}
     package = {key: value for key, value in (packet or {}).items() if key not in excluded}
     package["archiveNotice"] = "Internal/review-only Source File archive package. No public publishing, draft creation, tag creation, queue/payment action, identity merge, or alias confirmation is requested."
     return _sanitize_archive_value(package)
@@ -4776,6 +4865,16 @@ def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[s
     }
     subject_memory_packet = build_subject_memory_packet_v1(packet)
     case_report = build_source_file_case_report_v1(subject_memory_packet)
+    subject_analyst_read = build_source_file_subject_analyst_read_v1(packet, (environ or {}).get("BNL_DB_PATH") or packet.get("dbPath") or "")
+    if subject_analyst_read:
+        case_report["subjectAnalystReadV1"] = subject_analyst_read
+        if subject_analyst_read.get("internalRead"):
+            case_report["caseSummary"] = _case_text(f"{case_report.get('caseSummary')} BNL analyst read: {subject_analyst_read.get('internalRead')}", 900)
+        case_report["recommendedNextSteps"] = _case_list([*(subject_analyst_read.get("recommendedAdminActions") or []), *(case_report.get("recommendedNextSteps") or [])], limit=10, item_limit=280)
+        case_report["reviewBlockers"] = _case_list([*(subject_analyst_read.get("missingInfoQuestions") or []), *(subject_analyst_read.get("doNotSayPublicly") or []), *(case_report.get("reviewBlockers") or [])], limit=12, item_limit=280)
+        case_report["confidenceNotes"] = _case_list([*(subject_analyst_read.get("provenanceSummary") or []), *(case_report.get("confidenceNotes") or [])], limit=12, item_limit=320)
+        case_report["publicSafeClaims"] = _case_list([*(subject_analyst_read.get("publicSafeClaims") or []), *(case_report.get("publicSafeClaims") or [])], limit=10, item_limit=280)
+        case_report["evidenceSummary"] = _case_list([*(subject_analyst_read.get("strongestSignals") or []), *(subject_analyst_read.get("provenanceSummary") or []), *(case_report.get("evidenceSummary") or [])], limit=12, item_limit=320)
     admin_summary = build_admin_summary({**packet, "subjectName": subject, "subjectKey": subject_key, "sourceLanes": ["source_file_enrichment"] + list(packet.get("sourceTypes") or [])})
     envelope = {
         "candidateId": _sanitize_archive_value(candidate_id) if candidate_id else None,
@@ -4789,6 +4888,7 @@ def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[s
         "doNotSay": _sanitize_archive_value(_section_text(sections, "Do Not Say", limit=10) or packet.get("doNotSay") or ""),
         "evidenceReceiptSummary": _sanitize_archive_value(receipt),
         "sourceFileBriefV2": _sanitize_archive_value(build_source_file_brief_v2(packet, archive_id=packet.get("archiveId") or "")),
+        "subjectAnalystReadV1": subject_analyst_read,
         "subjectMemoryPacketV1": subject_memory_packet,
         "sourceFileCaseReportV1": case_report,
         "adminSummary": admin_summary,
@@ -4981,6 +5081,16 @@ def run_source_file_enrichment(
     with refresh_generation_context(str(effective_subject)):
         evidence = collect_source_enrichment_evidence(db_path, guild_id, str(effective_subject), rd_context=rd_context, lookup_result=lookup_result)
         entity_profile = build_entity_intelligence_profile(db_path, guild_id, str(effective_subject), refresh=True)
+        resolved_subject_memory = resolve_subject_memory(str(effective_subject), db_path, aliases=list((evidence.get("subjectIdentity") or {}).get("aliasLabels") or []))
+        subject_analyst_read = build_source_file_subject_analyst_read_v1(
+            {
+                "subject": str(effective_subject),
+                "sourceFile": source_file,
+                "subjectIdentity": evidence.get("subjectIdentity") or {},
+                "resolvedSubjectMemoryV1": resolved_subject_memory,
+            },
+            db_path,
+        )
     entity_resolver = resolve_entity_context_for_surface(entity_profile, "source_file", max_items=16)
     entity_diag_for_log = entity_profile.get("diagnostics") or {}
     scope_for_log = entity_diag_for_log.get("rowScopeCounts") or {}
@@ -5016,6 +5126,9 @@ def run_source_file_enrichment(
         "runTime": datetime.now(timezone.utc).isoformat(),
         "forced": bool(force),
         "diagnosticsRequested": bool(diagnostics),
+        "dbPath": db_path,
+        "resolvedSubjectMemoryV1": resolved_subject_memory,
+        "subjectAnalystReadV1": subject_analyst_read,
     }
     _copy_evidence_fields(packet, evidence)
     packet["subjectIntelligenceDiagnostics"] = evidence.get("subjectIntelligenceDiagnostics") or {}

--- a/bnl_subject_memory_resolver.py
+++ b/bnl_subject_memory_resolver.py
@@ -305,6 +305,11 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
     if review or re.search(r"queue|submission", " ".join(str(x) for x in resolved_memory.get("queueOrSubmissionSignals") or []), re.I):
         missing.append("Confirm whether queue/submission history may be referenced publicly.")
     actions = ["Promote only confirmed public-safe facts into the Source File before expanding public copy.", "Attach owner-approved provenance for any role, link, music, queue, or relationship claim."]
+    source_file_ingredients = []
+    for item in [internal, *strongest[:6], *public_claims, *review_claims, *blind_insights, *actions, *missing]:
+        clean = _text(item, 320)
+        if clean and clean not in source_file_ingredients:
+            source_file_ingredients.append(clean)
     prov = [f"BNL subject memory resolver reviewed {scanned} subject-memory matches and reduced them to {len(draft_ingredients)} public-safe draft ingredients."]
     if review:
         prov.append("BNL held inferred role/link/music/queue/relationship claims out of public copy.")
@@ -327,6 +332,7 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
         "missingInfoQuestions": missing,
         "recommendedAdminActions": actions,
         "draftIngredients": draft_ingredients,
+        "sourceFileIngredients": source_file_ingredients[:18],
         "provenanceSummary": prov,
     }
 

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -1240,6 +1240,72 @@ class SourceFileEntityIntelligenceIntegrationTests(unittest.TestCase):
         self.assertIsInstance(archive.get("sourceFileCaseReportV1"), dict)
         self.assertEqual(archive["subjectMemoryPacketV1"].get("subjectName"), "Signal Fox")
 
+    def test_source_file_archive_payload_includes_subject_analyst_read(self):
+        packet = {
+            "subject": "Crow",
+            "sourceFile": {"name": "Crow", "candidateId": "sf_crow"},
+            "sections": {"Subject Overview": ["Crow has review-only source evidence."]},
+            "sourceCounts": {"conversations": 1},
+            "sourceTypes": ["conversations"],
+            "warningCounts": {},
+            "warnings": [],
+            "qualityScore": 88,
+            "qualityStatus": "sendable",
+            "matchKind": "exact",
+            "runTime": "2026-06-10T00:00:00+00:00",
+            "subjectAnalystReadV1": {
+                "subjectName": "Crow",
+                "internalRead": "Crow appears to be a recurring BARCODE-facing community subject.",
+                "likelySubjectType": "community_participant",
+                "confidence": "medium",
+                "publicDraftPosture": "conservative",
+                "strongestSignals": ["Repeated public BARCODE/BNL/community context for Crow."],
+                "publicSafeClaims": ["Crow is mentioned in public BARCODE community context."],
+                "reviewNeededClaims": ["Possible role, queue/submission, link, or relationship claims require owner/admin confirmation before public use."],
+                "sourceBlindInsights": ["Source-blind memory indicates possible additional subject context, but it is not public-copy provenance."],
+                "privateOrInternalExclusions": ["Excluded 1 private/internal/payment/customer/raw-ID memory item(s) from public and provenance text."],
+                "doNotSayPublicly": ["Do not state artist/music role, owned links, formal BARCODE role, queue/submission history, or relationships unless confirmed public-safe evidence supports it."],
+                "missingInfoQuestions": ["Confirm the subject's preferred public display name and identity boundary."],
+                "recommendedAdminActions": ["Promote only confirmed public-safe facts into the Source File before expanding public copy."],
+                "draftIngredients": ["Crow is mentioned in public BARCODE community context."],
+                "provenanceSummary": ["BNL reviewed subject-memory matches and reduced them to public-safe draft ingredients."],
+            },
+        }
+        archive = enrich.build_source_file_archive_payload(packet)
+        analyst = archive["subjectAnalystReadV1"]
+        report = archive["sourceFileCaseReportV1"]
+        self.assertEqual(analyst["subjectName"], "Crow")
+        self.assertIn("subjectAnalystReadV1", report)
+        self.assertIn("sourceFileReviewClaims", analyst)
+        self.assertIn("sourceFileIngredients", analyst)
+        self.assertEqual(analyst["publicSafeClaims"], ["Crow is mentioned in public BARCODE community context."])
+        self.assertTrue(any("queue/submission" in item for item in analyst["sourceFileReviewClaims"]))
+        self.assertTrue(any("Source-blind" in item for item in analyst["sourceBlindInsights"]))
+        self.assertIn("Crow appears", report["caseSummary"])
+
+    def test_run_source_file_enrichment_builds_crow_like_subject_analyst_read(self):
+        c = self.conn.cursor()
+        c.execute("INSERT INTO broadcast_memory (guild_id, episode_date, cleaned_summary, entry_type, public_safe, usage_scope, status, created_at) VALUES (?,?,?,?,?,?,?,?)", (1, "2026-06-01", "Crow is a public-safe recurring BARCODE community subject discussed around BNL.", "recap", 1, "public_context", "active", "2026-06-01"))
+        c.execute("INSERT INTO memory_tiers (user_id, guild_id, tier, summary, salience, mentions, updated_at, source_trust, source_channel_policy) VALUES (?,?,?,?,?,?,?,?,?)", (1, 1, "review", "Crow may have an unconfirmed artist role, music link, queue submission, and relationship context.", 1.0, 1, "2026-06-01", "review_only", "public_context"))
+        c.execute("INSERT INTO memory_tiers (user_id, guild_id, tier, summary, salience, mentions, updated_at, source_trust, source_channel_policy) VALUES (?,?,?,?,?,?,?,?,?)", (1, 1, "legacy", "Crow has source-blind context that should remain internal review context.", 1.0, 1, "2026-06-01", "source-blind", "unknown"))
+        c.execute("INSERT INTO memory_tiers (user_id, guild_id, tier, summary, salience, mentions, updated_at, source_trust, source_channel_policy) VALUES (?,?,?,?,?,?,?,?,?)", (1, 1, "private", "Crow Stripe customer cus_123 paid Priority signal with raw Discord ID 123456789012345678.", 1.0, 1, "2026-06-01", "internal", "private"))
+        self.conn.commit()
+        with mock.patch.object(enrich, "build_subject_analyst_read", wraps=enrich.build_subject_analyst_read) as analyst_mock:
+            result = enrich.run_source_file_enrichment(self.db, 1, "Crow", dry_run=True, lookup_func=lambda query: {"ok": True, "found": True, "matchKind": "exact", "data": {"sourceFile": {"id": "sf_1", "name": query["lookupValue"], "status": "active", "candidateType": "entity"}}})
+        analyst = result["subjectAnalystReadV1"]
+        self.assertTrue(analyst_mock.called)
+        self.assertIn("Crow", analyst["internalRead"])
+        self.assertIn(analyst["likelySubjectType"], {"community_participant", "artist"})
+        self.assertTrue(analyst["publicSafeClaims"])
+        self.assertTrue(analyst["sourceFileReviewClaims"])
+        self.assertTrue(analyst["missingInfoQuestions"])
+        self.assertTrue(analyst["recommendedAdminActions"])
+        self.assertTrue(analyst["sourceBlindInsights"])
+        self.assertNotIn("artist role", json.dumps(analyst["publicSafeClaims"]).lower())
+        self.assertNotIn("stripe", json.dumps(analyst).lower())
+        self.assertNotIn("cus_123", json.dumps(analyst).lower())
+        self.assertNotIn("123456789012345678", json.dumps(analyst))
+
     def test_compact_recommendation_payload_excludes_full_memory_packet_and_case_report(self):
         payload = {
             "subjectName": "Signal Fox",


### PR DESCRIPTION
### Motivation
- Make BNL’s analyst layer the working intelligence for Source File refreshes so Source Files carry the reviewed/structured subject read rather than leaving it only in Proposed Dossier provenance.
- Reuse the existing subject-memory resolver and analyst helper to avoid duplicating resolver logic and to keep public vs review-only boundaries clear.

### Description
- Call `resolve_subject_memory(...)` and `build_subject_analyst_read(...)` during `run_source_file_enrichment(...)` and attach the result to the runtime packet as `subjectAnalystReadV1`.
- Add `build_source_file_subject_analyst_read_v1(...)`, `_subject_analyst_aliases(...)`, and `_normalize_subject_analyst_read_v1(...)` helpers to normalize/limit the analyst output and derive aliases from the packet.
- Embed the normalized `subjectAnalystReadV1` in the archive envelope root and inside `sourceFileCaseReportV1`, and improve `caseSummary`, `recommendedNextSteps`, `reviewBlockers`, `confidenceNotes`, `publicSafeClaims`, and `evidenceSummary` with analyst content.
- Extend the analyst shape by adding `sourceFileIngredients` to `build_subject_analyst_read(...)` while keeping `draftIngredients` for public-draft generation, and ensure `resolvedSubjectMemoryV1`/`dbPath` are excluded from the archived source package.

### Testing
- Ran Python compile and test suites with `python3 -m py_compile ...` and `pytest`; all automated tests passed including subject resolver and dossier draft tests.
- Executed `pytest tests/test_subject_memory_resolver.py` which passed (5 tests) and `pytest tests/test_dossier_draft_generator.py` which passed (37 tests + subtests).
- Executed `pytest tests/test_source_file_enrichment.py tests/test_source_file_archive.py tests/test_source_file_refresh.py` and all Source File enrichment/archive/refresh tests passed (full suite run: 140 passed, 5 warnings).
- Added integration tests in `tests/test_source_file_enrichment.py` that assert `subjectAnalystReadV1` is present in archive payload, contains `sourceFileReviewClaims` and `sourceFileIngredients`, and that a Crow-like memory produces the expected internal read and exclusions, and those tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e3ba9a9cc8321b5d5bfc6be6e54d8)