### PR TITLE
Improve BNL subject analyst review claims and withheld-evidence audit

### DIFF
--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -4756,11 +4756,15 @@ _SUBJECT_ANALYST_READ_KEYS = (
     "publicDraftPosture",
     "strongestSignals",
     "publicSafeClaims",
+    "publicReadyClaims",
     "sourceFileReviewClaims",
+    "reviewableClaims",
     "sourceBlindInsights",
     "privateOrInternalExclusions",
+    "withheldEvidenceAudit",
     "doNotSayPublicly",
     "missingInfoQuestions",
+    "missingConfirmations",
     "recommendedAdminActions",
     "draftIngredients",
     "sourceFileIngredients",
@@ -4811,7 +4815,10 @@ def _normalize_subject_analyst_read_v1(analyst: dict[str, Any]) -> dict[str, Any
     normalized = {key: analyst.get(key) for key in _SUBJECT_ANALYST_READ_KEYS}
     normalized["sourceFileReviewClaims"] = _case_list(review_claims, limit=10, item_limit=320)
     normalized["sourceFileIngredients"] = _case_list(source_file_ingredients, limit=18, item_limit=320)
-    for key in ("strongestSignals", "publicSafeClaims", "sourceBlindInsights", "privateOrInternalExclusions", "doNotSayPublicly", "missingInfoQuestions", "recommendedAdminActions", "draftIngredients", "provenanceSummary"):
+    normalized["reviewableClaims"] = _sanitize_archive_value((analyst.get("reviewableClaims") or [])[:14]) if isinstance(analyst.get("reviewableClaims"), list) else []
+    normalized["withheldEvidenceAudit"] = _sanitize_archive_value(analyst.get("withheldEvidenceAudit") or {}) if isinstance(analyst.get("withheldEvidenceAudit"), dict) else {}
+    normalized["missingConfirmations"] = _sanitize_archive_value((analyst.get("missingConfirmations") or [])[:12]) if isinstance(analyst.get("missingConfirmations"), list) else []
+    for key in ("strongestSignals", "publicSafeClaims", "publicReadyClaims", "sourceBlindInsights", "privateOrInternalExclusions", "doNotSayPublicly", "missingInfoQuestions", "recommendedAdminActions", "draftIngredients", "provenanceSummary"):
         normalized[key] = _case_list(normalized.get(key), limit=12 if key != "draftIngredients" else 9, item_limit=360)
     normalized["subjectName"] = _case_text(normalized.get("subjectName"), 140)
     normalized["internalRead"] = _case_text(normalized.get("internalRead"), 700)

--- a/bnl_subject_memory_resolver.py
+++ b/bnl_subject_memory_resolver.py
@@ -135,6 +135,22 @@ def _redact_review_evidence_summary(text: str, subject: str) -> str:
         return "Review-needed evidence exists, but the raw detail was withheld for privacy."
     return clean[:240].rstrip()
 
+
+def _source_blind_warning_from_summary(summary: str, subject: str) -> str:
+    """Return only category-level safe wording for source-blind warnings."""
+    low = _text(summary, 360).lower()
+    if "orion" in low or "relay" in low:
+        return f"Source-blind Orion/context evidence exists for {subject}, but raw details were withheld."
+    if "queue" in low or "submission" in low:
+        return f"Source-blind queue/submission context exists for {subject}, but raw details were withheld."
+    if "suno" in low or "music" in low or "song" in low or "track" in low or "link" in low or "url" in low or _LINK_RE.search(summary or ""):
+        return f"Source-blind music/link context exists for {subject}, but raw details were withheld."
+    if "relationship" in low or "context" in low:
+        return f"Source-blind Orion/context evidence exists for {subject}, but raw details were withheld."
+    if "barcode" in low or "bnl" in low or "community" in low:
+        return f"Source-blind community context exists for {subject}, but raw details were withheld."
+    return "Some subject memory lacked public-safe provenance and was not used as public copy."
+
 def _blank_result(subject: str, aliases: list[str]) -> dict[str, Any]:
     return {
         "subjectName": subject,
@@ -157,10 +173,12 @@ def _classify(data: dict[str, Any], text: str) -> tuple[str, str]:
     blob = " ".join(str(data.get(k) or "") for k in data)
     if not text:
         return "unusable", "empty_text"
-    if _PAYMENT_RE.search(blob) or _INTERNAL_RE.search(blob):
+    if _PAYMENT_RE.search(blob):
         return "private_internal", "private_or_internal_terms"
     if _SOURCE_BLIND_RE.search(blob):
         return "source_blind", "missing_public_provenance"
+    if _INTERNAL_RE.search(blob):
+        return "private_internal", "private_or_internal_terms"
     if _REVIEW_RE.search(blob) or bool(data.get("review_only")):
         return "review_only", "needs_review_or_confirmation"
     if _public_ready(data, text):
@@ -262,12 +280,9 @@ def resolve_subject_memory(subject_name: str, db_path: str, aliases: list[str] |
                     result["privateOrInternalEvidence"].append({"table": table, "summary": "Private/internal memory was excluded from public copy.", "reason": reason})
                     result["evidenceCounts"]["privateOrInternal"] += 1
                 elif klass == "source_blind":
-                    safe_blind = _redact_review_evidence_summary(raw, subject)
-                    warning = "Some subject memory lacked public-safe provenance and was not used as public copy."
-                    if safe_blind and re.search(r"relationship|context|orion|relay|references|through|music|link|queue|submission|barcode|community", safe_blind, re.I):
-                        warning = f"Source-blind/internal context for review only: {safe_blind}"
-                        if re.search(r"relationship|context|orion|relay|references|through", safe_blind, re.I):
-                            result["relationshipOrContextSignals"].append(safe_blind)
+                    warning = _source_blind_warning_from_summary(raw, subject)
+                    if re.search(r"relationship|context|orion|relay|references|through", str(raw), re.I):
+                        result["relationshipOrContextSignals"].append(warning)
                     result["sourceSafetyWarnings"].append(warning)
                     result["evidenceCounts"]["sourceBlind"] += 1
         ps = result["evidenceCounts"]["publicSafe"]

--- a/bnl_subject_memory_resolver.py
+++ b/bnl_subject_memory_resolver.py
@@ -192,14 +192,23 @@ def resolve_subject_memory(subject_name: str, db_path: str, aliases: list[str] |
                     if safe:
                         _add_public_sections(result, safe); result["evidenceCounts"]["publicSafe"] += 1
                 elif klass == "review_only":
-                    result["reviewOnlyEvidence"].append({"table": table, "summary": "Subject memory needs owner/admin confirmation before public use.", "reason": reason})
+                    safe_review = _sanitize_public(raw, subject, clean_aliases) or "Subject memory needs owner/admin confirmation before public use."
+                    result["reviewOnlyEvidence"].append({"table": table, "summary": safe_review, "reason": reason})
                     result["evidenceCounts"]["reviewOnly"] += 1
-                    if re.search(r"queue|submission", str(raw), re.I): result["queueOrSubmissionSignals"].append("Queue or submission context needs admin confirmation before public use.")
+                    if re.search(r"queue|submission", str(raw), re.I): result["queueOrSubmissionSignals"].append(safe_review if safe_review else "Queue or submission context needs admin confirmation before public use.")
+                    if re.search(r"relationship|context|orion|relay|references|through", str(raw), re.I) and safe_review:
+                        result["relationshipOrContextSignals"].append(safe_review)
                 elif klass == "private_internal":
                     result["privateOrInternalEvidence"].append({"table": table, "summary": "Private/internal memory was excluded from public copy.", "reason": reason})
                     result["evidenceCounts"]["privateOrInternal"] += 1
                 elif klass == "source_blind":
-                    result["sourceSafetyWarnings"].append("Some subject memory lacked public-safe provenance and was not used as public copy.")
+                    safe_blind = _sanitize_public(raw, subject, clean_aliases)
+                    warning = "Some subject memory lacked public-safe provenance and was not used as public copy."
+                    if safe_blind and re.search(r"relationship|context|orion|relay|references|through|music|link|queue|submission|barcode|community", safe_blind, re.I):
+                        warning = f"Source-blind/internal context for review only: {safe_blind}"
+                        if re.search(r"relationship|context|orion|relay|references|through", safe_blind, re.I):
+                            result["relationshipOrContextSignals"].append(safe_blind)
+                    result["sourceSafetyWarnings"].append(warning)
                     result["evidenceCounts"]["sourceBlind"] += 1
         ps = result["evidenceCounts"]["publicSafe"]
         result["confidence"] = "high" if ps >= 5 else ("medium" if ps >= 2 else "low")
@@ -236,6 +245,74 @@ def _dedupe_by_pattern(items: list[str], subject: str, limit: int = 9) -> list[s
     return out
 
 
+
+def _claim_type_from_text(text: str) -> str:
+    low = (text or "").lower()
+    if any(w in low for w in ("do not", "never state", "must not")):
+        return "do_not_say"
+    if any(w in low for w in ("queue", "submission")):
+        return "queue_submission"
+    if any(w in low for w in ("suno", "music link", "social link", "http", "link")):
+        return "music_link" if any(w in low for w in ("suno", "music", "song", "track")) else "public_link"
+    if any(w in low for w in ("orion", "relationship", "relay", "references", "through", "context")):
+        return "relationship"
+    if any(w in low for w in ("artist", "participant", "member", "role", "collaborator", "moderator", "producer", "dj")):
+        return "role"
+    if any(w in low for w in ("barcode", "bnl", "community")):
+        return "community_context"
+    return "missing_confirmation"
+
+
+def _claim_prefix(claim_type: str) -> str:
+    return {
+        "role": "Possible role claim",
+        "relationship": "Possible relationship/context claim",
+        "music_link": "Possible music/link claim",
+        "public_link": "Possible public-link claim",
+        "queue_submission": "Possible queue/submission claim",
+        "community_context": "Possible community/context claim",
+        "source_blind_context": "Source-blind context claim",
+    }.get(claim_type, "Possible review claim")
+
+
+def _safe_evidence_example(text: str, subject: str) -> str:
+    clean = _text(text, 180)
+    clean = _LINK_RE.sub("[redacted public link]", clean)
+    clean = re.sub(r"\b\d{6,}\b", "[redacted id]", clean)
+    clean = re.sub(r"\b(cus|sub|pi|ch|tok)_[A-Za-z0-9_\-]+\b", "[redacted token]", clean, flags=re.I)
+    clean = re.sub(r"\b(stripe|checkout|payment|paid|purchase|purchased|customer|priority\s*signal|priority)\b", "[redacted protected category]", clean, flags=re.I)
+    return clean or f"Redacted protected memory about {subject}."
+
+
+def _make_reviewable_claim(subject: str, claim_text: str, claim_type: str, lane: str, why: str, public_safe: bool, confidence: str, evidence: str = "", blocked: list[str] | None = None) -> dict[str, Any]:
+    return {
+        "claimText": _text(claim_text, 300),
+        "claimType": claim_type,
+        "reviewLane": lane,
+        "suggestedDecision": "confirm_public" if public_safe else ("keep_boundary" if lane in {"source_blind", "private_internal_withheld"} else "needs_more_info"),
+        "why": _text(why, 220),
+        "publicSafe": bool(public_safe),
+        "confidence": confidence,
+        "safeEvidenceSummary": _text(evidence or why, 240),
+        "blockedBy": blocked or ([] if public_safe else ["missing owner/admin confirmation", "missing public-safe provenance"]),
+    }
+
+
+def _withheld_audit(subject: str, resolved_memory: dict[str, Any], private: int, blind: int, review: int) -> dict[str, Any]:
+    private_examples = [_safe_evidence_example(x.get("summary", ""), subject) for x in (resolved_memory.get("privateOrInternalEvidence") or [])[:2] if isinstance(x, dict)]
+    blind_examples = [_safe_evidence_example(x, subject) for x in (resolved_memory.get("sourceSafetyWarnings") or [])[:2] if isinstance(x, str)]
+    review_examples = [_safe_evidence_example(x.get("summary", ""), subject) for x in (resolved_memory.get("reviewOnlyEvidence") or [])[:2] if isinstance(x, dict)]
+    cats = {
+        "private_internal": {"count": private, "reason": "Private/internal, payment/customer, raw-ID, DM, database-row, or operational content is never public draft evidence.", "safeExamples": private_examples},
+        "payment_customer_priority": {"count": private, "reason": "Protected payment/customer/Priority signals are counted only as withheld safety evidence.", "safeExamples": private_examples[:1]},
+        "raw_ids_or_database_rows": {"count": private, "reason": "Raw IDs, tokens, and database-row style content are redacted and withheld.", "safeExamples": []},
+        "source_blind": {"count": blind, "reason": "Source-blind memory can guide internal review but cannot prove public claims.", "safeExamples": blind_examples},
+        "unsafe_public_copy": {"count": review, "reason": "Review-only claims may be meaningful but need confirmation before public use.", "safeExamples": review_examples},
+        "duplicate_or_repetitive": {"count": 0, "reason": "Repetitive public-safe items are deduped before draft ingredients.", "safeExamples": []},
+        "low_value_context": {"count": 0, "reason": "Thin context is kept out of public copy until it supports a specific claim.", "safeExamples": []},
+    }
+    return {"totalWithheld": private + blind + review, "categories": cats}
+
 def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any], packet: dict[str, Any] | None = None) -> dict[str, Any]:
     """Synthesize resolver output into internal/read-review/public-draft buckets.
 
@@ -245,7 +322,7 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
     subject = _text(subject_name, 120) or _text(resolved_memory.get("subjectName"), 120) or "Unnamed subject"
     counts = resolved_memory.get("evidenceCounts") if isinstance(resolved_memory.get("evidenceCounts"), dict) else {}
     public_items: list[str] = []
-    for key in ("publicSafeFacts", "publicSafeNotes", "publicCommunitySignals", "relationshipOrContextSignals", "publicCreativeMusicSignals", "publicRoleSignals", "publicLinkSignals"):
+    for key in ("publicSafeFacts", "publicSafeNotes", "publicCommunitySignals", "publicCreativeMusicSignals", "publicRoleSignals", "publicLinkSignals"):
         for item in resolved_memory.get(key) or []:
             clean = _sanitize_public(str(item), subject, resolved_memory.get("matchedAliasesUsedPrivately") or [])
             if clean and clean not in public_items:
@@ -291,32 +368,88 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
     if review or blind:
         internal += " Inferred role, link, queue, relationship, or source-blind claims should stay in owner/admin review rather than public copy."
     public_claims = draft_ingredients[:6]
-    review_claims = []
-    if review:
-        review_claims.append("Possible role, queue/submission, link, or relationship claims require owner/admin confirmation before public use.")
-    blind_insights = ["Source-blind memory indicates possible additional subject context, but it is not public-copy provenance."] if blind else []
+    reviewable_claims: list[dict[str, Any]] = []
+    review_claims: list[str] = []
+    review_sources: list[str] = []
+    for ev in resolved_memory.get("reviewOnlyEvidence") or []:
+        if isinstance(ev, dict):
+            txt = _sanitize_public(str(ev.get("summary") or ""), subject, resolved_memory.get("matchedAliasesUsedPrivately") or [])
+            if txt and txt not in review_sources:
+                review_sources.append(txt)
+    for item in (resolved_memory.get("queueOrSubmissionSignals") or []) + (resolved_memory.get("relationshipOrContextSignals") or []):
+        txt = _sanitize_public(str(item), subject, resolved_memory.get("matchedAliasesUsedPrivately") or [])
+        if txt and txt not in review_sources and txt not in draft_ingredients:
+            review_sources.append(txt)
+    if review and not review_sources:
+        review_sources.append(f"{subject} may have role, link, queue/submission, music, or relationship context, but BNL needs confirmation before public use.")
+    for txt in review_sources[:10]:
+        ctype = _claim_type_from_text(txt)
+        if ctype == "community_context" and not ps:
+            ctype = "role"
+        if ctype == "relationship" and "orion" in txt.lower():
+            line = f"Possible relationship/context claim: {subject} references Orion as an AI or message relay context. Confirm whether this may be used publicly or should remain internal community context."
+        elif ctype == "queue_submission":
+            line = f"Possible queue/submission claim: {subject} may have queue/submission history, but public use needs confirmation. Evidence context: {txt}"
+        elif ctype in {"music_link", "public_link"}:
+            line = f"Possible music/link claim: {subject} may have public music or link context, but ownership/use needs confirmation. Evidence context: {txt}"
+        elif ctype == "role":
+            role_hint = "recurring BARCODE community participant" if re.search(r"barcode|community|participant|recurring", txt, re.I) else "a role or title BNL should not state publicly yet"
+            line = f"Possible role claim: {subject} may be {role_hint}. Evidence context: {txt}"
+        else:
+            line = f"{_claim_prefix(ctype)}: {txt} Confirm the exact public-safe wording before use."
+        if line not in review_claims:
+            review_claims.append(line)
+            reviewable_claims.append(_make_reviewable_claim(subject, line, ctype, "needs_confirmation", f"Review-only subject memory mentions {ctype.replace('_', ' ')} context.", False, "low", _safe_evidence_example(txt, subject)))
+    blind_insights = []
+    if blind:
+        for warn in resolved_memory.get("sourceSafetyWarnings") or []:
+            clean = _text(str(warn), 260)
+            if clean and clean not in blind_insights:
+                blind_insights.append(clean if clean.startswith("Source-blind") else f"Source-blind/internal context: {clean}")
+    if blind and not blind_insights:
+        blind_insights = ["Source-blind memory indicates possible additional subject context, but it is not public-copy provenance."]
+    for txt in blind_insights[:5]:
+        ctype = "source_blind_context"
+        if "orion" in txt.lower() or "relay" in txt.lower():
+            ctype = "relationship"
+            line = f"Possible relationship/context claim: {subject} references Orion or relay context in source-blind memory. Keep internal unless admin confirms public-safe provenance."
+            if line not in review_claims:
+                review_claims.append(line)
+        reviewable_claims.append(_make_reviewable_claim(subject, txt, ctype, "source_blind", "Context lacks public-safe provenance and must not be public copy.", False, "low", _safe_evidence_example(txt, subject), ["source-blind provenance", "missing public source"]))
     exclusions = []
     if private:
-        exclusions.append(f"Excluded {private} private/internal/payment/customer/raw-ID memory item(s) from public and provenance text.")
-    do_not = ["Do not state artist/music role, owned links, formal BARCODE role, queue/submission history, or relationships unless confirmed public-safe evidence supports it."]
+        exclusions.append(f"Excluded {private} protected/private memory item(s) from public and provenance text; see withheldEvidenceAudit category counts for safe details.")
+    do_not = ["Do not state artist/music role, owned links, formal BARCODE role, queue/submission history, or relationships unless confirmed public-safe evidence supports that exact claim."]
     if private:
-        do_not.append("Do not expose private, payment, customer, DM, raw ID, token, database-row, or internal operational details.")
-    missing = ["Confirm the subject's preferred public display name and identity boundary.", "Confirm the public role/title that may be stated.", "Confirm which public links, if any, are owned or approved for the dossier."]
+        do_not.append("Do not expose private, payment, customer, DM, raw ID, token, database-row, private alias, or internal operational details.")
+    missing = [
+        {"question": f"Confirm preferred public display name: What exact name may BNL use for {subject}?", "confirmationType": "needs_owner_confirmation", "suggestedReviewer": "owner_or_admin", "why": "Identity wording should be owner-approved before public promotion.", "canAutoResolve": False, "relatedClaimType": "identity"},
+        {"question": f"Confirm public role/title: Is {subject} a community participant, artist, collaborator, or something else?", "confirmationType": "needs_admin_confirmation", "suggestedReviewer": "admin", "why": "Role wording is only public when backed by clean public evidence or admin-confirmed Source File fact.", "canAutoResolve": bool(has_community or has_music), "relatedClaimType": "role"},
+        {"question": f"Confirm public links: Which {subject}/Suno/music/social links are owned or approved for public reference?", "confirmationType": "needs_owner_confirmation", "suggestedReviewer": "owner_or_admin", "why": "Link ownership/use must be explicit before public dossier use.", "canAutoResolve": False, "relatedClaimType": "music_link"},
+    ]
+    if any("orion" in x.lower() or "relay" in x.lower() for x in review_claims + blind_insights):
+        missing.append({"question": f"Confirm Orion context: Can BNL mention Orion as {subject}'s AI/message relay context, or keep it internal?", "confirmationType": "needs_admin_confirmation", "suggestedReviewer": "admin", "why": "Named relationship/context should not become public copy without permission and provenance.", "canAutoResolve": False, "relatedClaimType": "relationship"})
     if review or re.search(r"queue|submission", " ".join(str(x) for x in resolved_memory.get("queueOrSubmissionSignals") or []), re.I):
-        missing.append("Confirm whether queue/submission history may be referenced publicly.")
-    actions = ["Promote only confirmed public-safe facts into the Source File before expanding public copy.", "Attach owner-approved provenance for any role, link, music, queue, or relationship claim."]
+        missing.append({"question": f"Confirm queue/submission history: Can {subject}'s queue or submission history be referenced publicly?", "confirmationType": "needs_admin_confirmation", "suggestedReviewer": "admin", "why": "Queue/submission evidence is review-only unless explicitly confirmed public-safe.", "canAutoResolve": False, "relatedClaimType": "queue_submission"})
+    missing_lines = [m["question"] + f" ({m['confirmationType'].replace('_', ' ')}.)" for m in missing]
+    actions = [
+        "Review each sourceFileReviewClaims line as an individual approve/reject/edit item; do not approve a whole bucket.",
+        "Promote only confirmed public-safe facts into the Source File before expanding public copy.",
+        "Attach owner-approved provenance for any role, link, music, queue, Orion/context, or relationship claim.",
+    ]
+    withheld_audit = _withheld_audit(subject, resolved_memory, private, blind, review) if (private or blind or review) else {}
     source_file_ingredients = []
-    for item in [internal, *strongest[:6], *public_claims, *review_claims, *blind_insights, *actions, *missing]:
+    for item in [internal, *strongest[:6], *public_claims, *review_claims, *blind_insights, *actions, *missing_lines]:
         clean = _text(item, 320)
         if clean and clean not in source_file_ingredients:
             source_file_ingredients.append(clean)
     prov = [f"BNL subject memory resolver reviewed {scanned} subject-memory matches and reduced them to {len(draft_ingredients)} public-safe draft ingredients."]
     if review:
-        prov.append("BNL held inferred role/link/music/queue/relationship claims out of public copy.")
+        prov.append(f"BNL held {len(review_claims) or review} specific review-needed role/link/music/queue/relationship claim(s) out of public copy pending confirmation.")
     if ps > len(draft_ingredients):
         prov.append("BNL treated repetitive public context as internal pattern evidence, not public dossier prose.")
     if private or blind:
-        prov.append(f"BNL withheld {private + blind} private/internal or source-unproven item(s) from public draft copy.")
+        prov.append(f"BNL withheld {private + blind} private/internal or source-unproven item(s) from public draft copy; audit categories contain only redacted summaries.")
     return {
         "subjectName": subject,
         "internalRead": internal,
@@ -325,11 +458,15 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
         "publicDraftPosture": posture,
         "strongestSignals": strongest[:6],
         "publicSafeClaims": public_claims,
+        "publicReadyClaims": public_claims,
         "reviewNeededClaims": review_claims,
+        "reviewableClaims": reviewable_claims[:14],
         "sourceBlindInsights": blind_insights,
         "privateOrInternalExclusions": exclusions,
+        "withheldEvidenceAudit": withheld_audit,
         "doNotSayPublicly": do_not,
-        "missingInfoQuestions": missing,
+        "missingInfoQuestions": missing_lines,
+        "missingConfirmations": missing,
         "recommendedAdminActions": actions,
         "draftIngredients": draft_ingredients,
         "sourceFileIngredients": source_file_ingredients[:18],

--- a/bnl_subject_memory_resolver.py
+++ b/bnl_subject_memory_resolver.py
@@ -19,6 +19,13 @@ _SOURCE_BLIND_RE = re.compile(r"\b(source[-_\s]*blind|unknown[-_\s]*policy|no\s+
 _REVIEW_RE = re.compile(r"\b(review[-\s]*only|needs?\s+confirmation|unconfirmed|uncertain|inferred|ambiguous|maybe|appears\s+to|queue|submission|relationship)\b", re.I)
 _PUBLIC_RE = re.compile(r"\b(public[-_\s]*safe|dossier[-_\s]*safe|public\s+context|public\s+home|public\s+discord|owner[-_\s]*confirmed|official\s+public|broadcast\s+memory)\b", re.I)
 _LINK_RE = re.compile(r"https?://\S+", re.I)
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I)
+_PHONE_RE = re.compile(r"(?<!\w)(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}(?!\w)")
+_RAW_ID_RE = re.compile(r"\b\d{15,22}\b|\b(?:discord|user|channel|message|guild|member)[-_\s]*(?:id)?\s*[:=#]?\s*\d+\b", re.I)
+_SECRET_RE = re.compile(r"\b(?:api[_-]?key|token|secret|authorization|bearer|password)\b\s*[:=]?\s*[A-Za-z0-9_./+\-=]{8,}|\b[A-Za-z0-9_-]{24,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}\b", re.I)
+_CONTACT_RE = re.compile(r"\b(?:email|e-mail|phone|telephone|contact me|contact info|address|sms|text me)\b", re.I)
+_PRIVATE_ALIAS_RE = re.compile(r"\b(?:private alias|alias privately|known privately as|legal name|real name)\b", re.I)
+_DB_ROW_RE = re.compile(r"\b(?:rowid|source row|database row|raw json|raw payload|table row|memory_tiers|entity_evidence_events)\b", re.I)
 _ROLE_OR_TAXONOMY_LABELS = {
     "artist", "member", "community", "collaborator", "mod", "moderator", "personnel", "staff", "sponsor", "system", "interface", "production", "radio", "producer", "ai", "human", "hybrid", "unknown", "public", "internal", "restricted", "active", "pending", "person", "music", "tech", "systems", "broadcast", "participant", "dossier", "source", "source file",
 }
@@ -70,10 +77,63 @@ def _sanitize_public(text: str, subject: str, aliases: list[str]) -> str:
     clean = _text(text, 260)
     for alias in sorted([a for a in aliases if a.lower() != subject.lower()], key=len, reverse=True):
         clean = re.sub(re.escape(alias), subject, clean, flags=re.I)
-    if _PAYMENT_RE.search(clean) or _INTERNAL_RE.search(clean):
+    if (_PAYMENT_RE.search(clean) or _INTERNAL_RE.search(clean) or _EMAIL_RE.search(clean) or _PHONE_RE.search(clean) or _RAW_ID_RE.search(clean) or _SECRET_RE.search(clean) or _CONTACT_RE.search(clean) or _PRIVATE_ALIAS_RE.search(clean) or _DB_ROW_RE.search(clean)):
         return ""
     return clean
 
+
+
+def _redact_review_evidence_summary(text: str, subject: str) -> str:
+    """Return a privacy-safe review/source-blind evidence summary.
+
+    Unlike _sanitize_public, this is for non-public metadata: it may preserve
+    coarse claim category (Orion/context, queue/submission, music/link) but must
+    not preserve raw contact details, private aliases, IDs, URLs, tokens, payment
+    details, or database-row wording.
+    """
+    original = _text(text, 360)
+    low = original.lower()
+    if not original:
+        return f"Review-needed evidence exists for {subject}, but the raw detail was withheld for privacy."
+    payment = bool(_PAYMENT_RE.search(original))
+    unsafe = bool(
+        payment
+        or _EMAIL_RE.search(original)
+        or _PHONE_RE.search(original)
+        or _RAW_ID_RE.search(original)
+        or _SECRET_RE.search(original)
+        or _CONTACT_RE.search(original)
+        or _INTERNAL_RE.search(original)
+        or _PRIVATE_ALIAS_RE.search(original)
+        or _DB_ROW_RE.search(original)
+        or _LINK_RE.search(original)
+    )
+    if unsafe:
+        if payment:
+            return "Private/payment-related evidence was counted but withheld."
+        if "source-blind" in low or "source blind" in low or "unknown-policy" in low or "no provenance" in low:
+            if "orion" in low:
+                return f"Source-blind Orion/context evidence exists for {subject}, but raw details were withheld."
+            return "Source-blind context exists, but raw details were withheld."
+        if "orion" in low:
+            return f"{subject} has recurring Orion-related context. Raw supporting detail withheld for privacy/source safety."
+        if "queue" in low or "submission" in low:
+            return f"{subject} has possible queue/submission context. Raw supporting detail withheld for privacy/source safety."
+        if "suno" in low or "music" in low or "link" in low or "url" in low:
+            return f"{subject} has possible music/link context. Raw supporting detail withheld for privacy/source safety."
+        if "relationship" in low or "relay" in low or "context" in low:
+            return f"{subject} has possible relationship/context evidence. Raw supporting detail withheld for privacy/source safety."
+        return "Review-needed evidence exists, but the raw detail was withheld for privacy."
+    clean = original
+    clean = _EMAIL_RE.sub("[redacted email]", clean)
+    clean = _PHONE_RE.sub("[redacted phone]", clean)
+    clean = _RAW_ID_RE.sub("[redacted id]", clean)
+    clean = _SECRET_RE.sub("[redacted secret]", clean)
+    clean = _LINK_RE.sub("[redacted link]", clean)
+    clean = re.sub(r"\s+", " ", clean).strip()
+    if _EMAIL_RE.search(clean) or _PHONE_RE.search(clean) or _RAW_ID_RE.search(clean) or _SECRET_RE.search(clean) or _LINK_RE.search(clean):
+        return "Review-needed evidence exists, but the raw detail was withheld for privacy."
+    return clean[:240].rstrip()
 
 def _blank_result(subject: str, aliases: list[str]) -> dict[str, Any]:
     return {
@@ -192,7 +252,7 @@ def resolve_subject_memory(subject_name: str, db_path: str, aliases: list[str] |
                     if safe:
                         _add_public_sections(result, safe); result["evidenceCounts"]["publicSafe"] += 1
                 elif klass == "review_only":
-                    safe_review = _sanitize_public(raw, subject, clean_aliases) or "Subject memory needs owner/admin confirmation before public use."
+                    safe_review = _redact_review_evidence_summary(raw, subject) or "Subject memory needs owner/admin confirmation before public use."
                     result["reviewOnlyEvidence"].append({"table": table, "summary": safe_review, "reason": reason})
                     result["evidenceCounts"]["reviewOnly"] += 1
                     if re.search(r"queue|submission", str(raw), re.I): result["queueOrSubmissionSignals"].append(safe_review if safe_review else "Queue or submission context needs admin confirmation before public use.")
@@ -202,7 +262,7 @@ def resolve_subject_memory(subject_name: str, db_path: str, aliases: list[str] |
                     result["privateOrInternalEvidence"].append({"table": table, "summary": "Private/internal memory was excluded from public copy.", "reason": reason})
                     result["evidenceCounts"]["privateOrInternal"] += 1
                 elif klass == "source_blind":
-                    safe_blind = _sanitize_public(raw, subject, clean_aliases)
+                    safe_blind = _redact_review_evidence_summary(raw, subject)
                     warning = "Some subject memory lacked public-safe provenance and was not used as public copy."
                     if safe_blind and re.search(r"relationship|context|orion|relay|references|through|music|link|queue|submission|barcode|community", safe_blind, re.I):
                         warning = f"Source-blind/internal context for review only: {safe_blind}"
@@ -276,11 +336,9 @@ def _claim_prefix(claim_type: str) -> str:
 
 
 def _safe_evidence_example(text: str, subject: str) -> str:
-    clean = _text(text, 180)
-    clean = _LINK_RE.sub("[redacted public link]", clean)
-    clean = re.sub(r"\b\d{6,}\b", "[redacted id]", clean)
+    clean = _redact_review_evidence_summary(text, subject)
     clean = re.sub(r"\b(cus|sub|pi|ch|tok)_[A-Za-z0-9_\-]+\b", "[redacted token]", clean, flags=re.I)
-    clean = re.sub(r"\b(stripe|checkout|payment|paid|purchase|purchased|customer|priority\s*signal|priority)\b", "[redacted protected category]", clean, flags=re.I)
+    clean = re.sub(r"\b\d{6,}\b", "[redacted id]", clean)
     return clean or f"Redacted protected memory about {subject}."
 
 
@@ -373,11 +431,11 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
     review_sources: list[str] = []
     for ev in resolved_memory.get("reviewOnlyEvidence") or []:
         if isinstance(ev, dict):
-            txt = _sanitize_public(str(ev.get("summary") or ""), subject, resolved_memory.get("matchedAliasesUsedPrivately") or [])
+            txt = _redact_review_evidence_summary(str(ev.get("summary") or ""), subject)
             if txt and txt not in review_sources:
                 review_sources.append(txt)
     for item in (resolved_memory.get("queueOrSubmissionSignals") or []) + (resolved_memory.get("relationshipOrContextSignals") or []):
-        txt = _sanitize_public(str(item), subject, resolved_memory.get("matchedAliasesUsedPrivately") or [])
+        txt = _redact_review_evidence_summary(str(item), subject)
         if txt and txt not in review_sources and txt not in draft_ingredients:
             review_sources.append(txt)
     if review and not review_sources:
@@ -403,7 +461,7 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
     blind_insights = []
     if blind:
         for warn in resolved_memory.get("sourceSafetyWarnings") or []:
-            clean = _text(str(warn), 260)
+            clean = _redact_review_evidence_summary(str(warn), subject)
             if clean and clean not in blind_insights:
                 blind_insights.append(clean if clean.startswith("Source-blind") else f"Source-blind/internal context: {clean}")
     if blind and not blind_insights:

--- a/tests/test_subject_memory_resolver.py
+++ b/tests/test_subject_memory_resolver.py
@@ -80,6 +80,36 @@ class SubjectMemoryResolverTests(unittest.TestCase):
             self.assertNotIn("queue", public_blob)
             self.assertNotIn("stripe", public_blob)
 
+
+    def test_review_and_source_blind_contact_details_are_redacted(self):
+        with tempfile.NamedTemporaryFile(suffix='.db') as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute("CREATE TABLE entity_evidence_events (subject_name TEXT, safe_summary TEXT, channel_policy TEXT, visibility TEXT, authority TEXT, public_safe_candidate INTEGER, review_only INTEGER)")
+            conn.execute("CREATE TABLE broadcast_memory (cleaned_summary TEXT, public_safe INTEGER, status TEXT)")
+            conn.execute("CREATE TABLE message_memory (subject_name TEXT, summary TEXT, visibility TEXT, public_safe INTEGER)")
+            conn.execute("INSERT INTO entity_evidence_events VALUES (?,?,?,?,?,?,?)", ("Crow", "Crow relationship context: Orion relay details at crow.private@example.com and phone 555-123-4567 need confirmation.", "", "review_only", "", 0, 1))
+            conn.execute("INSERT INTO broadcast_memory VALUES (?,?,?)", ("Crow source-blind Orion context mentions private contact crow.blind@example.com and Discord ID 123456789012345678.", 0, "active"))
+            conn.execute("INSERT INTO message_memory VALUES (?,?,?,?)", ("Crow", "Crow Stripe customer cus_123 paid Priority signal contact crow.pay@example.com raw Discord ID 123456789012345678.", "public_safe", 1))
+            conn.commit(); conn.close()
+            resolved = resolve_subject_memory("Crow", tmp.name)
+            analyst = build_subject_analyst_read("Crow", resolved)
+            combined = " ".join([
+                str(resolved["sourceSafetyWarnings"]),
+                str(analyst["reviewNeededClaims"]),
+                str(analyst["reviewableClaims"]),
+                str(analyst["sourceBlindInsights"]),
+                str(analyst["withheldEvidenceAudit"]),
+            ]).lower()
+            for leaked in ("crow.private@example.com", "crow.blind@example.com", "crow.pay@example.com", "555-123-4567", "123456789012345678", "cus_123"):
+                self.assertNotIn(leaked, combined)
+            self.assertTrue(any("Orion" in claim for claim in analyst["reviewNeededClaims"]))
+            self.assertTrue(any("withheld" in c.get("safeEvidenceSummary", "").lower() for c in analyst["reviewableClaims"]))
+            audit = analyst["withheldEvidenceAudit"]
+            self.assertGreaterEqual(audit["categories"]["payment_customer_priority"]["count"], 1)
+            public_blob = " ".join(analyst["publicSafeClaims"] + analyst["draftIngredients"]).lower()
+            self.assertNotIn("example.com", public_blob)
+            self.assertNotIn("orion", public_blob)
+
     def test_private_payment_rejected_and_missing_tables_do_not_crash(self):
         with tempfile.NamedTemporaryFile(suffix='.db') as tmp:
             conn = sqlite3.connect(tmp.name)

--- a/tests/test_subject_memory_resolver.py
+++ b/tests/test_subject_memory_resolver.py
@@ -50,6 +50,36 @@ class SubjectMemoryResolverTests(unittest.TestCase):
                 self.assertNotIn(forbidden, public_blob)
             self.assertTrue(any("role" in x.lower() or "queue" in x.lower() for x in analyst["reviewNeededClaims"] + analyst["doNotSayPublicly"]))
 
+
+    def test_analyst_outputs_specific_claims_orion_and_safe_withheld_audit(self):
+        with tempfile.NamedTemporaryFile(suffix='.db') as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute("CREATE TABLE entity_evidence_events (subject_name TEXT, safe_summary TEXT, channel_policy TEXT, visibility TEXT, authority TEXT, public_safe_candidate INTEGER, review_only INTEGER)")
+            conn.execute("CREATE TABLE message_memory (subject_name TEXT, summary TEXT, visibility TEXT, public_safe INTEGER)")
+            conn.execute("INSERT INTO entity_evidence_events VALUES (?,?,?,?,?,?,?)", ("Crow", "Crow may be a recurring BARCODE community participant who references Orion as an AI/message relay context.", "", "review_only", "", 0, 1))
+            conn.execute("INSERT INTO entity_evidence_events VALUES (?,?,?,?,?,?,?)", ("Crow", "Crow may have public Suno/music links and queue submission history needing confirmation.", "", "review_only", "", 0, 1))
+            conn.execute("INSERT INTO message_memory VALUES (?,?,?,?)", ("Crow", "Crow Stripe customer cus_123 paid Priority signal with raw Discord ID 123456789012345678.", "public_safe", 1))
+            conn.commit(); conn.close()
+            analyst = build_subject_analyst_read("Crow", resolve_subject_memory("Crow", tmp.name))
+            review_blob = "\n".join(analyst["reviewNeededClaims"])
+            self.assertIn("Possible relationship/context claim", review_blob)
+            self.assertIn("Orion", review_blob)
+            self.assertIn("Possible queue/submission claim", review_blob)
+            self.assertNotIn("Possible role, queue/submission, link, or relationship claims require", review_blob)
+            self.assertTrue(analyst["reviewableClaims"])
+            self.assertTrue(any(c["claimType"] in {"relationship", "queue_submission", "music_link"} for c in analyst["reviewableClaims"]))
+            self.assertTrue(any("Confirm Orion context" in q for q in analyst["missingInfoQuestions"]))
+            audit = analyst["withheldEvidenceAudit"]
+            self.assertGreaterEqual(audit["totalWithheld"], 1)
+            self.assertGreaterEqual(audit["categories"]["private_internal"]["count"], 1)
+            audit_blob = str(audit).lower()
+            self.assertNotIn("cus_123", audit_blob)
+            self.assertNotIn("123456789012345678", audit_blob)
+            public_blob = " ".join(analyst["publicSafeClaims"] + analyst["draftIngredients"]).lower()
+            self.assertNotIn("orion", public_blob)
+            self.assertNotIn("queue", public_blob)
+            self.assertNotIn("stripe", public_blob)
+
     def test_private_payment_rejected_and_missing_tables_do_not_crash(self):
         with tempfile.NamedTemporaryFile(suffix='.db') as tmp:
             conn = sqlite3.connect(tmp.name)

--- a/tests/test_subject_memory_resolver.py
+++ b/tests/test_subject_memory_resolver.py
@@ -110,6 +110,24 @@ class SubjectMemoryResolverTests(unittest.TestCase):
             self.assertNotIn("example.com", public_blob)
             self.assertNotIn("orion", public_blob)
 
+
+    def test_source_blind_warnings_are_category_only_for_sensitive_fragments(self):
+        with tempfile.NamedTemporaryFile(suffix='.db') as tmp:
+            conn = sqlite3.connect(tmp.name)
+            conn.execute("CREATE TABLE broadcast_memory (cleaned_summary TEXT, public_safe INTEGER, status TEXT)")
+            conn.execute("INSERT INTO broadcast_memory VALUES (?,?,?)", ("Crow source-blind Orion context email crow.orion@example.com Discord ID 123456789012345678.", 0, "active"))
+            conn.execute("INSERT INTO broadcast_memory VALUES (?,?,?)", ("Crow source-blind music link context at https://private.example/song and phone 555-222-3333.", 0, "active"))
+            conn.execute("INSERT INTO broadcast_memory VALUES (?,?,?)", ("Crow source-blind queue submission context for user ID 987654321098765432.", 0, "active"))
+            conn.commit(); conn.close()
+            resolved = resolve_subject_memory("Crow", tmp.name)
+            warnings = "\n".join(resolved["sourceSafetyWarnings"])
+            warning_blob = warnings.lower()
+            for leaked in ("crow.orion@example.com", "https://private.example/song", "555-222-3333", "123456789012345678", "987654321098765432"):
+                self.assertNotIn(leaked, warning_blob)
+            self.assertIn("Source-blind Orion/context evidence exists for Crow, but raw details were withheld.", warnings)
+            self.assertIn("Source-blind music/link context exists for Crow, but raw details were withheld.", warnings)
+            self.assertIn("Source-blind queue/submission context exists for Crow, but raw details were withheld.", warnings)
+
     def test_private_payment_rejected_and_missing_tables_do_not_crash(self):
         with tempfile.NamedTemporaryFile(suffix='.db') as tmp:
             conn = sqlite3.connect(tmp.name)


### PR DESCRIPTION
### Motivation

- Replace a single vague review-needed bucket with specific, reviewable claims so site admins can approve/reject/edit discrete items. 
- Provide actionable missing-confirmation prompts and structured claim metadata to make review controls (PR #221) usable without changing site workflows. 
- Surface Orion/relationship/context and music/queue/link signals as review-only context while preserving public-boundary protections and avoiding raw private leakage.

### Description

- Update `bnl_subject_memory_resolver.py` to sanitize review-only/source-blind evidence, capture relationship/context signals (including Orion) without promoting them to public draft ingredients, and produce per-evidence review sources. 
- Add helpers and structured outputs in the resolver: `_claim_type_from_text`, `_make_reviewable_claim`, `_safe_evidence_example`, and `_withheld_audit`, and emit `reviewableClaims`, `withheldEvidenceAudit`, `missingConfirmations`, and `publicReadyClaims` from `build_subject_analyst_read`. 
- Extend `bnl_source_file_enrichment.py` normalization to preserve the new keys (`publicReadyClaims`, `reviewableClaims`, `withheldEvidenceAudit`, `missingConfirmations`) safely for archive/enrichment payloads and keep site-compatible string arrays (`reviewNeededClaims`, `missingInfoQuestions`) intact. 
- Add/adjust unit tests in `tests/test_subject_memory_resolver.py` to assert specific claim wording, Orion/context behavior, withheld-audit redaction, and that public draft fields remain free of review-only/private terms.

### Testing

- Ran compilation: `python3 -m py_compile bnl_source_file_enrichment.py bnl_dossier_draft.py bnl01_bot.py bnl_subject_memory_resolver.py` and it succeeded. 
- Ran unit tests: `python3 -m pytest tests/test_subject_memory_resolver.py -q`, `python3 -m pytest tests/test_dossier_draft_generator.py -q`, and `python3 -m pytest tests/test_source_file_enrichment.py tests/test_source_file_archive.py tests/test_source_file_refresh.py -q` and all tests passed (final run: 140 passed). 
- Modified files: `bnl_subject_memory_resolver.py`, `bnl_source_file_enrichment.py`, and updated `tests/test_subject_memory_resolver.py` for the new coverage. 
- Latest commit SHA: `df348fa8b0dd605143b9aa77691c5150b714b3da`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f8125182c8321b49ee1812dfa2a24)