### PR TITLE
Add BNL suggested review wording for Source Files

### DIFF
--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -25,7 +25,7 @@ from bnl_entity_intelligence import build_entity_intelligence_profile, resolve_e
 from bnl_evidence_ownership import classify_evidence_ownership, subject_owned_text_fragments
 from bnl_source_file_lookup import lookup_source_file
 from bnl_source_refresh_context import refresh_generation_context
-from bnl_subject_memory_resolver import build_subject_analyst_read, resolve_subject_memory
+from bnl_subject_memory_resolver import build_subject_analyst_read, resolve_subject_memory, _review_guidance
 
 ENRICHMENT_INGEST_SOURCE = "bnl_source_file_enrichment"
 FALLBACK_INGEST_SOURCE = "bnl_source_knowledge_bridge"
@@ -4815,12 +4815,29 @@ def _normalize_subject_analyst_read_v1(analyst: dict[str, Any]) -> dict[str, Any
     normalized = {key: analyst.get(key) for key in _SUBJECT_ANALYST_READ_KEYS}
     normalized["sourceFileReviewClaims"] = _case_list(review_claims, limit=10, item_limit=320)
     normalized["sourceFileIngredients"] = _case_list(source_file_ingredients, limit=18, item_limit=320)
-    normalized["reviewableClaims"] = _sanitize_archive_value((analyst.get("reviewableClaims") or [])[:14]) if isinstance(analyst.get("reviewableClaims"), list) else []
+    subject = _case_text(analyst.get("subjectName") or "Unnamed subject", 140)
+    normalized_claims: list[dict[str, Any]] = []
+    if isinstance(analyst.get("reviewableClaims"), list):
+        for raw in (analyst.get("reviewableClaims") or [])[:14]:
+            if not isinstance(raw, dict):
+                continue
+            item = dict(raw)
+            claim_text = _case_text(item.get("claimText") or item.get("claim") or item.get("summary"), 300)
+            if not claim_text:
+                continue
+            item["claimText"] = claim_text
+            claim_type = _case_text(item.get("claimType") or "missing_confirmation", 80)
+            lane = _case_text(item.get("reviewLane") or "needs_confirmation", 80)
+            public_safe = bool(item.get("publicSafe") is True)
+            for key, value in _review_guidance(subject, claim_text, claim_type, lane, public_safe).items():
+                item.setdefault(key, value)
+            normalized_claims.append(item)
+    normalized["reviewableClaims"] = _sanitize_archive_value(normalized_claims)
     normalized["withheldEvidenceAudit"] = _sanitize_archive_value(analyst.get("withheldEvidenceAudit") or {}) if isinstance(analyst.get("withheldEvidenceAudit"), dict) else {}
     normalized["missingConfirmations"] = _sanitize_archive_value((analyst.get("missingConfirmations") or [])[:12]) if isinstance(analyst.get("missingConfirmations"), list) else []
     for key in ("strongestSignals", "publicSafeClaims", "publicReadyClaims", "sourceBlindInsights", "privateOrInternalExclusions", "doNotSayPublicly", "missingInfoQuestions", "recommendedAdminActions", "draftIngredients", "provenanceSummary"):
         normalized[key] = _case_list(normalized.get(key), limit=12 if key != "draftIngredients" else 9, item_limit=360)
-    normalized["subjectName"] = _case_text(normalized.get("subjectName"), 140)
+    normalized["subjectName"] = subject
     normalized["internalRead"] = _case_text(normalized.get("internalRead"), 700)
     normalized["likelySubjectType"] = _case_text(normalized.get("likelySubjectType"), 80)
     normalized["confidence"] = _case_text(normalized.get("confidence"), 40)

--- a/bnl_subject_memory_resolver.py
+++ b/bnl_subject_memory_resolver.py
@@ -350,6 +350,114 @@ def _claim_prefix(claim_type: str) -> str:
     }.get(claim_type, "Possible review claim")
 
 
+def _claim_actionability(claim_text: str, claim_type: str, lane: str, public_safe: bool) -> str:
+    low = (claim_text or "").lower()
+    if "subject-owned/keyed local evidence exists" in low or "local/keyed evidence" in low:
+        return "non_actionable_artifact"
+    if "lacked public-safe provenance" in low or "source-blind" in low or lane == "source_blind":
+        return "source_blind_warning"
+    if claim_text.strip().lower() in {"contest organizer", "organizer", "participant", "artist", "member"} or "contest organizer" in low:
+        return "weak_label"
+    if "?" in claim_text or "confirm" in low or "can bnl" in low:
+        return "missing_confirmation"
+    if public_safe:
+        return "actionable_claim"
+    if claim_type in {"relationship", "music_link", "public_link", "queue_submission", "role", "community_context"}:
+        return "actionable_claim"
+    return "evidence_signal"
+
+
+def _suggested_public_wording(subject: str, claim_text: str, claim_type: str, public_safe: bool) -> str:
+    if not public_safe:
+        return ""
+    text = _sanitize_public(claim_text, subject, [])
+    low = text.lower()
+    if not text:
+        return ""
+    if claim_type == "identity":
+        return subject
+    if claim_type in {"role", "community_context"}:
+        if "radio" in low:
+            return f"{subject} is a BARCODE Radio viewer/community participant."
+        if re.search(r"\b(member|community|barcode|bnl|participant)\b", low):
+            return f"{subject} is a BARCODE Network community member."
+    if claim_type in {"music_link", "public_link"} and _LINK_RE.search(text):
+        return f"{subject} has an approved public music link: {_LINK_RE.search(text).group(0)}."
+    if claim_type == "relationship" and "orion" in low:
+        return f"{subject} has recurring Orion-related BARCODE lore/context."
+    if claim_type == "queue_submission":
+        return f"{subject} has submitted music to BARCODE Radio."
+    return text if not re.search(r"\b(may|possible|unconfirmed|needs confirmation|source-blind|internal)\b", low) else ""
+
+
+def _review_guidance(subject: str, claim_text: str, claim_type: str, lane: str, public_safe: bool) -> dict[str, str]:
+    actionability = _claim_actionability(claim_text, claim_type, lane, public_safe)
+    low = (claim_text or "").lower()
+    guidance: dict[str, str] = {"actionability": actionability}
+    public_wording = _suggested_public_wording(subject, claim_text, claim_type, public_safe)
+    if public_wording:
+        guidance.update({
+            "suggestedPublicWording": public_wording,
+            "recommendedAction": "approve_public",
+            "recommendedActionReason": "BNL found public-safe or owner/admin-confirmed support for exact public wording.",
+        })
+        return guidance
+    if actionability == "non_actionable_artifact":
+        guidance.update({
+            "recommendedAction": "reject",
+            "suggestedRejectionReason": "This is a technical evidence artifact, not a reviewable Source File fact.",
+            "suggestedInternalNote": f"BNL found local/keyed evidence for {subject}, but it is not specific enough to become a public or internal claim without more context.",
+            "cannotSuggestPublicReason": "No concrete public-safe claim was identified.",
+            "recommendedActionReason": "The item is audit metadata rather than a subject fact.",
+        })
+        return guidance
+    if actionability == "weak_label":
+        label = _text(claim_text, 80)
+        if "contest organizer" in low:
+            label = "contest organizer"
+        guidance.update({
+            "recommendedAction": "keep_internal",
+            "suggestedInternalNote": f"BNL found a weak pattern label: \"{label}\". Keep internal only if useful; reject it if inaccurate.",
+            "suggestedMissingInfoQuestion": f"Is the label \"{label}\" accurate and useful for {subject}, or should it be rejected?",
+            "suggestedRejectionReason": "This label is too thin to approve without supporting public-safe context.",
+            "cannotSuggestPublicReason": "The label is not specific enough to become public copy.",
+            "recommendedActionReason": "Weak labels need supporting context before approval.",
+        })
+        return guidance
+    if actionability == "source_blind_warning":
+        guidance.update({
+            "recommendedAction": "needs_public_source",
+            "suggestedInternalNote": f"BNL found source-blind context for {subject}. Keep this internal until a public source or owner-approved wording is provided.",
+            "suggestedMissingInfoQuestion": "What public-safe source or owner-approved wording supports this source-blind context?",
+            "cannotSuggestPublicReason": "Source-blind memory cannot become public copy by itself.",
+            "recommendedActionReason": "Source-blind context needs separate public-safe provenance or owner/admin confirmation.",
+        })
+        return guidance
+    if claim_type in {"music_link", "public_link"}:
+        note = f"BNL found repeated music/link context for {subject}, but public ownership/use is not confirmed. Keep this internal until owner/admin approves links or wording."
+        question = f"Which {subject} links are owned or approved for public reference?"
+    elif claim_type == "relationship" and "orion" in low:
+        note = f"BNL found Orion-related context for {subject}. Keep this internal unless owner/admin confirms it may be referenced publicly."
+        question = f"Can BNL mention Orion in public {subject} context, or should Orion stay internal?"
+    elif claim_type == "queue_submission":
+        note = f"BNL found possible queue/submission context for {subject}. Keep this internal unless admin confirms it may be referenced publicly."
+        question = f"Can {subject}'s queue/submission history be referenced publicly, or should it stay internal?"
+    elif claim_type in {"role", "community_context"}:
+        note = f"BNL found possible role/community context for {subject}. Keep this internal until public wording is confirmed."
+        question = f"What public role/title may BNL use for {subject}, if any?"
+    else:
+        note = f"BNL found review-only context for {subject}. Keep this internal until a public source or owner-approved wording is provided."
+        question = "What public-safe source or owner-approved wording supports this claim?"
+    guidance.update({
+        "recommendedAction": "needs_more_info",
+        "recommendedActionReason": "BNL cannot safely suggest public wording until the missing confirmation is resolved.",
+        "suggestedInternalNote": note,
+        "suggestedMissingInfoQuestion": question,
+        "cannotSuggestPublicReason": "No confirmed public-safe wording or provenance was identified.",
+    })
+    return guidance
+
+
 def _safe_evidence_example(text: str, subject: str) -> str:
     clean = _redact_review_evidence_summary(text, subject)
     clean = re.sub(r"\b(cus|sub|pi|ch|tok)_[A-Za-z0-9_\-]+\b", "[redacted token]", clean, flags=re.I)
@@ -358,7 +466,7 @@ def _safe_evidence_example(text: str, subject: str) -> str:
 
 
 def _make_reviewable_claim(subject: str, claim_text: str, claim_type: str, lane: str, why: str, public_safe: bool, confidence: str, evidence: str = "", blocked: list[str] | None = None) -> dict[str, Any]:
-    return {
+    item = {
         "claimText": _text(claim_text, 300),
         "claimType": claim_type,
         "reviewLane": lane,
@@ -369,6 +477,8 @@ def _make_reviewable_claim(subject: str, claim_text: str, claim_type: str, lane:
         "safeEvidenceSummary": _text(evidence or why, 240),
         "blockedBy": blocked or ([] if public_safe else ["missing owner/admin confirmation", "missing public-safe provenance"]),
     }
+    item.update(_review_guidance(subject, item["claimText"], claim_type, lane, public_safe))
+    return item
 
 
 def _withheld_audit(subject: str, resolved_memory: dict[str, Any], private: int, blind: int, review: int) -> dict[str, Any]:
@@ -443,6 +553,11 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
     public_claims = draft_ingredients[:6]
     reviewable_claims: list[dict[str, Any]] = []
     review_claims: list[str] = []
+    for txt in public_claims[:6]:
+        ctype = _claim_type_from_text(txt)
+        if ctype == "missing_confirmation":
+            ctype = "community_context" if re.search(r"\b(barcode|bnl|community|radio)\b", txt, re.I) else "role"
+        reviewable_claims.append(_make_reviewable_claim(subject, txt, ctype, "public_safe", "Public-safe subject memory supports this Source File fact.", True, confidence, _safe_evidence_example(txt, subject), []))
     review_sources: list[str] = []
     for ev in resolved_memory.get("reviewOnlyEvidence") or []:
         if isinstance(ev, dict):

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -1,4 +1,5 @@
 import os
+import json
 import sqlite3
 import tempfile
 import unittest
@@ -140,6 +141,24 @@ class DossierDraftGeneratorTests(unittest.TestCase):
         for forbidden in ("Stripe", "checkout", "Priority", "payment"):
             self.assertNotIn(forbidden, public)
         self.assertTrue(any("payment/Priority" in x for x in result["unsupportedClaimsRejected"]))
+
+    def test_public_draft_does_not_emit_review_helper_fields_or_source_blind_terms(self):
+        packet = pr217_packet(
+            publicSafeFacts=["Signal Fox is a BARCODE Network community member."],
+            publicSafeNotes=[],
+            reviewableClaims=[{
+                "claimText": "Some subject memory lacked public-safe provenance",
+                "suggestedInternalNote": "BNL found source-blind context for Signal Fox.",
+                "suggestedMissingInfoQuestion": "What public-safe source or owner-approved wording supports this source-blind context?",
+                "recommendedAction": "needs_public_source",
+                "actionability": "source_blind_warning",
+            }],
+            withheldEvidenceAudit={"source_blind": {"count": 1}},
+        )
+        result = draft.generate_dossier_draft(packet)["draft"]
+        public = json.dumps(result).lower()
+        for forbidden in ("reviewableclaims", "suggestedinternalnote", "suggestedmissinginfoquestion", "recommendedaction", "actionability", "withheldevidenceaudit", "source-blind", "source_blind"):
+            self.assertNotIn(forbidden, public)
 
     def test_thin_packet_returns_conservative_summary_and_missing_info(self):
         result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]))["draft"]

--- a/tests/test_subject_memory_resolver.py
+++ b/tests/test_subject_memory_resolver.py
@@ -110,6 +110,49 @@ class SubjectMemoryResolverTests(unittest.TestCase):
             self.assertNotIn("example.com", public_blob)
             self.assertNotIn("orion", public_blob)
 
+    def test_reviewable_claim_suggestions_cover_public_internal_source_blind_artifacts_and_weak_labels(self):
+        public_claim = build_subject_analyst_read("Crow", {
+            "subjectName": "Crow",
+            "matchedAliasesUsedPrivately": [],
+            "publicSafeFacts": ["Crow is a public-safe recurring BARCODE community member."],
+            "publicSafeNotes": [],
+            "publicCommunitySignals": [],
+            "publicCreativeMusicSignals": [],
+            "publicRoleSignals": [],
+            "publicLinkSignals": [],
+            "reviewOnlyEvidence": [
+                {"summary": "Crow may have public Suno/music links and repeated music link context needing confirmation."},
+                {"summary": "Crow may reference Orion as AI/message relay context needing confirmation."},
+                {"summary": "subject-owned/keyed local evidence exists"},
+                {"summary": "contest organizer"},
+            ],
+            "queueOrSubmissionSignals": ["Crow queue submission history needs confirmation."],
+            "relationshipOrContextSignals": [],
+            "sourceSafetyWarnings": ["Some subject memory lacked public-safe provenance"],
+            "privateOrInternalEvidence": [],
+            "evidenceCounts": {"publicSafe": 1, "reviewOnly": 4, "privateOrInternal": 0, "sourceBlind": 1, "totalScanned": 6},
+        })
+        claims = public_claim["reviewableClaims"]
+        self.assertTrue(any(c.get("suggestedPublicWording") == "Crow is a BARCODE Network community member." for c in claims))
+        music = next(c for c in claims if c["claimType"] == "music_link")
+        self.assertIn("repeated music/link context", music["suggestedInternalNote"])
+        self.assertIn("Which Crow links are owned", music["suggestedMissingInfoQuestion"])
+        self.assertNotIn("suggestedPublicWording", music)
+        orion = next(c for c in claims if c["claimType"] == "relationship")
+        self.assertIn("Orion-related context", orion["suggestedInternalNote"])
+        self.assertIn("Can BNL mention Orion", orion["suggestedMissingInfoQuestion"])
+        blind = next(c for c in claims if c.get("actionability") == "source_blind_warning")
+        self.assertEqual(blind["recommendedAction"], "needs_public_source")
+        self.assertIn("Source-blind memory cannot become public copy", blind["cannotSuggestPublicReason"])
+        artifact = next(c for c in claims if c.get("actionability") == "non_actionable_artifact")
+        self.assertEqual(artifact["recommendedAction"], "reject")
+        self.assertIn("technical evidence artifact", artifact["suggestedRejectionReason"])
+        self.assertNotIn("suggestedPublicWording", artifact)
+        weak = next(c for c in claims if c.get("actionability") == "weak_label")
+        self.assertIn(weak["recommendedAction"], {"keep_internal", "reject"})
+        self.assertIn('weak pattern label: "contest organizer"', weak["suggestedInternalNote"])
+        self.assertTrue(any("Can Crow's queue/submission history" in c.get("suggestedMissingInfoQuestion", "") for c in claims))
+
 
     def test_source_blind_warnings_are_category_only_for_sensitive_fragments(self):
         with tempfile.NamedTemporaryFile(suffix='.db') as tmp:


### PR DESCRIPTION
### Motivation

- The site now renders Source File review cards, but BNL sometimes returns vague review items that do not give admins actionable approve/reject/edit guidance.  
- The analyst/enrichment layer should try harder to produce concrete suggested wording, internal notes, and recommended actions for `reviewableClaims` while preserving public/private/source-blind protections.  
- Changes must live in BNL (not the site), preserve Site PR #222 compatibility, and avoid leaking private/payment/contact/raw-ID/source-blind data.

### Description

- Add actionability classification and review-guidance helpers in `bnl_subject_memory_resolver.py`, including `_claim_actionability`, `_suggested_public_wording`, and `_review_guidance` to compute `actionability` and populate new review-helper fields.  
- Extend each `reviewableClaims` item to optionally include `suggestedPublicWording`, `suggestedInternalNote`, `suggestedMissingInfoQuestion`, `suggestedRejectionReason`, `recommendedAction`, `recommendedActionReason`, `cannotSuggestPublicReason`, and `actionability`, while keeping existing fields (`claimText`, `claimType`, `reviewLane`, `suggestedDecision`, `why`, `publicSafe`, `confidence`, `safeEvidenceSummary`, `blockedBy`).  
- Implement concrete safe-public wording rules for common cases (community/role, BARCODE Radio participant, approved music link, Orion/context when public-safe, queue/submission wording) and conservative internal-note / missing-info generation for source-blind, music/link without ownership, Orion, queue/submission, and weak labels.  
- Backfill and normalize guidance into the enrichment output by updating `bnl_source_file_enrichment.py` to run `_review_guidance` when normalizing `reviewableClaims`, and ensure public dossier draft generation (`bnl_dossier_draft.py` tests) does not emit admin-only helper fields.

### Testing

- Ran compilation: `python3 -m py_compile bnl_source_file_enrichment.py bnl_dossier_draft.py bnl01_bot.py bnl_subject_memory_resolver.py`, which completed successfully.  
- Ran unit tests that exercise the resolver and enrichment changes: `python3 -m pytest tests/test_subject_memory_resolver.py -q` and `python3 -m pytest tests/test_source_file_enrichment.py tests/test_source_file_archive.py tests/test_source_file_refresh.py -q`, and `python3 -m pytest tests/test_dossier_draft_generator.py -q`; all tests passed.  
- Added/updated regression tests that assert safe public wording is produced when appropriate, internal notes and missing-info questions are produced when public wording is unsafe, vague artifacts are classified as `non_actionable_artifact` and recommended for rejection or internal audit, weak labels are classified as `weak_label`, and that public dossier draft output does not include admin-only review-helper fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30185b06748321a293f9459f1632dd)