### PR TITLE
Generate human-facing Source File review copy

### DIFF
--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -4766,6 +4766,7 @@ _SUBJECT_ANALYST_READ_KEYS = (
     "missingInfoQuestions",
     "missingConfirmations",
     "recommendedAdminActions",
+    "recommendedAdminActionCards",
     "draftIngredients",
     "sourceFileIngredients",
     "provenanceSummary",
@@ -4835,6 +4836,7 @@ def _normalize_subject_analyst_read_v1(analyst: dict[str, Any]) -> dict[str, Any
     normalized["reviewableClaims"] = _sanitize_archive_value(normalized_claims)
     normalized["withheldEvidenceAudit"] = _sanitize_archive_value(analyst.get("withheldEvidenceAudit") or {}) if isinstance(analyst.get("withheldEvidenceAudit"), dict) else {}
     normalized["missingConfirmations"] = _sanitize_archive_value((analyst.get("missingConfirmations") or [])[:12]) if isinstance(analyst.get("missingConfirmations"), list) else []
+    normalized["recommendedAdminActionCards"] = _sanitize_archive_value((analyst.get("recommendedAdminActionCards") or [])[:8]) if isinstance(analyst.get("recommendedAdminActionCards"), list) else []
     for key in ("strongestSignals", "publicSafeClaims", "publicReadyClaims", "sourceBlindInsights", "privateOrInternalExclusions", "doNotSayPublicly", "missingInfoQuestions", "recommendedAdminActions", "draftIngredients", "provenanceSummary"):
         normalized[key] = _case_list(normalized.get(key), limit=12 if key != "draftIngredients" else 9, item_limit=360)
     normalized["subjectName"] = subject

--- a/bnl_subject_memory_resolver.py
+++ b/bnl_subject_memory_resolver.py
@@ -517,6 +517,161 @@ def _claim_type_from_text(text: str) -> str:
     return "missing_confirmation"
 
 
+
+
+def _display_clean(text: str) -> str:
+    text = _text(text, 500)
+    replacements = {
+        "sourceFileReviewClaims": "BNL claims",
+        "official_public_dossier": "public dossier",
+        "public_safe": "approved for public use",
+        "source_blind": "without a public source",
+        "source-blind": "without a public source",
+        "review_only": "for review only",
+        "review-only": "for review only",
+        "public_music_role": "public music role",
+        "queue_submission": "queue or submission",
+    }
+    for old, new in replacements.items():
+        text = re.sub(re.escape(old), new, text, flags=re.I)
+    text = re.sub(r"\b[A-Za-z]+(?:[A-Z][a-z0-9]+)+\b", lambda m: "BNL item" if m.group(0) != "BNL" else m.group(0), text)
+    return text
+
+
+def _review_display_copy(subject: str, claim_text: str, claim_type: str, lane: str, public_safe: bool, actionability: str) -> dict[str, Any]:
+    low = (claim_text or "").lower()
+    title = "Review BNL claim"
+    decision = f"Is this claim approved for public use, internal use only, or should it be rejected?"
+    checked = "You are checking whether this claim is true and approved for public use."
+    why = "BNL found context that needs a human decision before it can be used publicly."
+    rec = "BNL recommends asking for confirmation before using this in public copy."
+    safe = "Keep this out of public copy until approved."
+    approval = "Approve only the exact wording that can be safely used publicly."
+    target = "admin"
+    audience = "admin"
+    primary = "Add to admin follow-up"
+    secondary = ["Reject / not needed"]
+    question = "Is this claim approved for public use, internal use only, or should it be rejected?"
+
+    if actionability == "non_actionable_artifact":
+        title = "Internal evidence artifact"
+        decision = "Should this vague evidence marker be kept internally or dismissed?"
+        checked = "This is not a public-ready claim. It only shows that BNL found subject-linked evidence that was not specific enough to approve."
+        why = "BNL flagged this because it is audit context, not a fact about the subject."
+        rec = "BNL recommends keeping this only as internal audit context or dismissing it."
+        safe = "Do not turn this into public wording."
+        approval = "Do not approve public wording from this artifact."
+        target = "none"; audience = "none"; question = ""
+        primary = "Keep as internal audit note"; secondary = ["Dismiss artifact"]
+    elif actionability == "source_blind_warning" or lane == "source_blind":
+        title = "Needs public source"
+        decision = "What public-safe source or owner-approved wording supports this claim?"
+        checked = "BNL found context, but it cannot be used publicly until it has a public source or owner-approved wording."
+        why = "BNL flagged this because the available context is not enough public proof by itself."
+        rec = "BNL recommends requesting a public source or owner-approved wording before approval."
+        target = "public_source"; audience = "public_source"
+        primary = "Request public source"; secondary = ["Ask for owner-approved wording", "Reject / not needed"]
+        question = "What public-safe source supports this claim?"
+    elif actionability == "weak_label":
+        title = "Check weak label"
+        label = "contest organizer" if "contest organizer" in low else _text(claim_text, 80)
+        decision = f"Is the label \"{label}\" accurate and useful for {subject}, or should it be rejected?"
+        checked = "You are checking whether a thin label has enough support to keep internally or approve later."
+        why = "BNL flagged this because the label was too vague to approve as public copy."
+        rec = "BNL recommends keeping this internal only if it helps review, otherwise reject it."
+        target = "admin"; audience = "admin"; primary = "Save BNL internal note"; secondary = ["Reject weak label"]
+        question = decision
+    elif claim_type in {"music_link", "public_link", "contest_music_context"}:
+        title = "Confirm approved public links"
+        decision = f"Which links, if any, may BNL publicly associate with {subject}?"
+        checked = f"You are checking whether these links belong to {subject} and whether BNL may mention them publicly."
+        why = "BNL found repeated link or music context but does not yet have approval to use it publicly."
+        rec = "BNL recommends asking who owns the links and which ones are approved for public reference."
+        target = "link_ownership"; audience = "subject"; primary = "Ask who owns these links"; secondary = ["Add to subject verification packet", "Reject / not needed"]
+        question = "Which music or contest-related links are yours and approved for public reference?"
+    elif claim_type.startswith("contest_"):
+        title = "Confirm contest relationship"
+        decision = f"What was {subject}’s relationship to this contest context?"
+        checked = f"You are checking whether {subject} was a participant, submitter, rules poster, link source, host, organizer, or only mentioned near the contest."
+        why = "BNL found contest context, but context alone does not prove a specific role."
+        rec = "BNL recommends confirming the exact relationship before writing public copy."
+        target = "subject"; audience = "subject"; primary = "Add to subject verification packet"; secondary = ["Use BNL suggested question", "Reject / not needed"]
+        question = "What was your relationship to this contest context: participant, submitter, rules poster, link source, host, organizer, or unrelated mention?"
+    elif claim_type in {"role", "community_context"}:
+        title = "Confirm public role"
+        decision = f"What public role/title may BNL use for {subject}, if any?"
+        checked = "You are checking whether this role is true and approved for public use."
+        why = "BNL found possible role context but does not have approved public wording yet."
+        rec = "BNL recommends asking for the exact approved public role or title."
+        target = "subject"; audience = "subject"; primary = "Add to subject verification packet"; secondary = ["Use BNL suggested question", "Reject / not needed"]
+        question = "What public role/title should BNL use for you, if any?"
+    elif claim_type == "relationship" and "orion" in low:
+        title = "Confirm relationship context"
+        decision = f"Can BNL mention Orion in public {subject} context?"
+        checked = f"You are checking whether Orion/context may be mentioned publicly for {subject}, or should stay internal."
+        why = "BNL found relationship or context language that needs approval before public use."
+        rec = "BNL recommends subject or owner confirmation before public wording."
+        target = "subject"; audience = "subject"; primary = "Add to subject verification packet"; secondary = ["Ask for owner-approved wording", "Reject / not needed"]
+        question = f"Can BNL mention Orion in public {subject} context, or should that stay internal?"
+    elif claim_type == "queue_submission":
+        title = "Confirm queue or submission history"
+        decision = f"May BNL publicly mention {subject}’s queue or submission history?"
+        checked = "You are checking whether queue or submission history is approved for public use."
+        why = "BNL found queue or submission context that needs approval before public wording."
+        rec = "BNL recommends admin confirmation before public use."
+        target = "admin"; audience = "admin"; primary = "Add to admin follow-up"; secondary = ["Reject / not needed"]
+        question = "Is this claim approved for public use, internal use only, or should it be rejected?"
+    return {k: _display_clean(v) if isinstance(v, str) else v for k, v in {
+        "displayTitle": title,
+        "displayDecision": decision,
+        "displayWhatIsBeingChecked": checked,
+        "displayWhyBNLFlaggedIt": why,
+        "displayBNLRecommendation": rec,
+        "displayEvidenceSummary": "No public approval has been provided yet." if not public_safe else "BNL found approved public wording for this item.",
+        "displaySafeDefault": safe,
+        "displayApprovalInstruction": approval,
+        "confirmationTarget": target,
+        "primaryActionLabel": primary,
+        "secondaryActionLabels": secondary,
+        "verificationPacketQuestion": question,
+        "verificationPacketAudience": audience,
+    }.items()}
+
+
+def _admin_action_card(action: str) -> dict[str, Any]:
+    raw = str(action or "")
+    title = "Admin follow-up task"
+    display = _display_clean(raw)
+    explanation = "This is an admin workflow task, not a public claim approval."
+    if "sourceFileReviewClaims" in raw:
+        display = "Review each BNL claim separately."
+        explanation = "Do not approve a whole group of claims at once. Each claim needs its own approve, edit, reject, or confirmation decision."
+    elif "Promote only confirmed" in raw:
+        display = "Only say what we know is true."
+        explanation = "BNL should not use guesses in public text. Approve the fact first, then BNL can use it."
+    elif "Attach owner-approved provenance" in raw:
+        display = "Get proof or approval first."
+        explanation = "If the claim involves someone’s role, links, music, queue history, Orion/context, or relationships, BNL needs a public source or owner-approved wording before using it publicly."
+    return {
+        "claimText": raw,
+        "claimType": "admin_task",
+        "reviewLane": "admin_follow_up",
+        "displayTitle": title,
+        "displayDecision": "What follow-up should happen before this Source File is used for public copy?",
+        "displayWhatIsBeingChecked": "This is an admin workflow task, not a public claim approval.",
+        "displayWhyBNLFlaggedIt": explanation,
+        "displayBNLRecommendation": display,
+        "displayEvidenceSummary": explanation,
+        "displaySafeDefault": "Do not use this task as public copy.",
+        "displayApprovalInstruction": "Complete this follow-up before approving related public wording.",
+        "confirmationTarget": "admin",
+        "primaryActionLabel": "Add to admin follow-up",
+        "secondaryActionLabels": ["Reject / not needed"],
+        "verificationPacketQuestion": "Is this follow-up complete, still needed, or not needed?",
+        "verificationPacketAudience": "admin",
+    }
+
+
 def _claim_prefix(claim_type: str) -> str:
     return {
         "role": "Possible role claim",
@@ -587,6 +742,7 @@ def _review_guidance(subject: str, claim_text: str, claim_type: str, lane: str, 
             "recommendedAction": "approve_public",
             "recommendedActionReason": "BNL found public-safe or owner/admin-confirmed support for exact public wording.",
         })
+        guidance.update(_review_display_copy(subject, claim_text, claim_type, lane, public_safe, actionability))
         return guidance
     if actionability == "non_actionable_artifact":
         guidance.update({
@@ -596,6 +752,7 @@ def _review_guidance(subject: str, claim_text: str, claim_type: str, lane: str, 
             "cannotSuggestPublicReason": "No concrete public-safe claim was identified.",
             "recommendedActionReason": "The item is audit metadata rather than a subject fact.",
         })
+        guidance.update(_review_display_copy(subject, claim_text, claim_type, lane, public_safe, actionability))
         return guidance
     if actionability == "weak_label":
         label = _text(claim_text, 80)
@@ -609,6 +766,7 @@ def _review_guidance(subject: str, claim_text: str, claim_type: str, lane: str, 
             "cannotSuggestPublicReason": "The label is not specific enough to become public copy.",
             "recommendedActionReason": "Weak labels need supporting context before approval.",
         })
+        guidance.update(_review_display_copy(subject, claim_text, claim_type, lane, public_safe, actionability))
         return guidance
     if actionability == "source_blind_warning":
         guidance.update({
@@ -618,6 +776,7 @@ def _review_guidance(subject: str, claim_text: str, claim_type: str, lane: str, 
             "cannotSuggestPublicReason": "Source-blind memory cannot become public copy by itself.",
             "recommendedActionReason": "Source-blind context needs separate public-safe provenance or owner/admin confirmation.",
         })
+        guidance.update(_review_display_copy(subject, claim_text, claim_type, lane, public_safe, actionability))
         return guidance
     if claim_type == "contest_music_context":
         note = f"BNL found contest-related music/link context for {subject}. This does not prove {subject} hosted or organized a contest. Keep internal until links and role are confirmed."
@@ -647,6 +806,7 @@ def _review_guidance(subject: str, claim_text: str, claim_type: str, lane: str, 
         "suggestedMissingInfoQuestion": question,
         "cannotSuggestPublicReason": "Contest role is ambiguous and needs owner/admin confirmation." if claim_type.startswith("contest_") and claim_type not in {"contest_host", "contest_organizer"} else "No confirmed public-safe wording or provenance was identified.",
     })
+    guidance.update(_review_display_copy(subject, claim_text, claim_type, lane, public_safe, actionability))
     return guidance
 
 
@@ -658,8 +818,10 @@ def _safe_evidence_example(text: str, subject: str) -> str:
 
 
 def _make_reviewable_claim(subject: str, claim_text: str, claim_type: str, lane: str, why: str, public_safe: bool, confidence: str, evidence: str = "", blocked: list[str] | None = None) -> dict[str, Any]:
+    actionability = _claim_actionability(claim_text, claim_type, lane, public_safe)
+    display_claim_text = "Vague internal evidence marker" if actionability == "non_actionable_artifact" else claim_text
     item = {
-        "claimText": _text(claim_text, 300),
+        "claimText": _text(display_claim_text, 300),
         "claimType": claim_type,
         "reviewLane": lane,
         "suggestedDecision": "confirm_public" if public_safe else ("keep_boundary" if lane in {"source_blind", "private_internal_withheld"} else "needs_more_info"),
@@ -669,14 +831,14 @@ def _make_reviewable_claim(subject: str, claim_text: str, claim_type: str, lane:
         "safeEvidenceSummary": _text(evidence or why, 240),
         "blockedBy": blocked or ([] if public_safe else ["missing owner/admin confirmation", "missing public-safe provenance"]),
     }
-    item.update(_review_guidance(subject, item["claimText"], claim_type, lane, public_safe))
+    item.update(_review_guidance(subject, claim_text, claim_type, lane, public_safe))
     return item
 
 
 
 def _admin_blocked_claim(subject: str, claim_text: str, claim_type: str, correction: dict[str, Any]) -> dict[str, Any]:
     label = str(correction.get("label") or _detect_blocked_label(claim_text) or claim_type.replace("_", " "))
-    return {
+    item = {
         "claimText": _text(claim_text, 300),
         "claimType": claim_type,
         "reviewLane": "admin_correction",
@@ -695,10 +857,14 @@ def _admin_blocked_claim(subject: str, claim_text: str, claim_type: str, correct
         "rejectedLabel": label,
         "blockedInference": f"Admin rejected {label} for {subject}.",
     }
+    item.update(_review_display_copy(subject, item["claimText"], claim_type, item["reviewLane"], False, "weak_label"))
+    item["displayTitle"] = "Check weak label"
+    item["primaryActionLabel"] = "Reject weak label"
+    return item
 
 def _admin_conflict_fields(subject: str, evidence: str, correction: dict[str, Any]) -> dict[str, Any]:
     label = str(correction.get("label") or _detect_blocked_label(evidence) or "this label")
-    return {
+    fields = {
         "reviewLane": "admin_correction_conflict",
         "recommendedAction": "needs_more_info",
         "suggestedDecision": "needs_more_info",
@@ -708,6 +874,8 @@ def _admin_conflict_fields(subject: str, evidence: str, correction: dict[str, An
         "suggestedMissingInfoQuestion": "Admin previously rejected this label. Is there new owner-approved evidence that changes it?",
         "recommendedActionReason": "New evidence appears to conflict with an admin correction; do not override silently.",
     }
+    fields.update(_review_display_copy(subject, fields["claimText"], "role", fields["reviewLane"], False, "missing_confirmation"))
+    return fields
 
 def _resolved_missing_info_types(corrections: list[dict[str, Any]]) -> set[str]:
     resolved: set[str] = set()
@@ -965,6 +1133,7 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
         "missingInfoQuestions": missing_lines,
         "missingConfirmations": missing,
         "recommendedAdminActions": actions,
+        "recommendedAdminActionCards": [_admin_action_card(a) for a in actions],
         "draftIngredients": draft_ingredients,
         "sourceFileIngredients": source_file_ingredients[:18],
         "provenanceSummary": prov,

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -148,6 +148,9 @@ class DossierDraftGeneratorTests(unittest.TestCase):
             publicSafeNotes=[],
             reviewableClaims=[{
                 "claimText": "Some subject memory lacked public-safe provenance",
+                "displayTitle": "Needs public source",
+                "displayDecision": "What public-safe source or owner-approved wording supports this claim?",
+                "verificationPacketQuestion": "What public-safe source supports this claim?",
                 "suggestedInternalNote": "BNL found source-blind context for Signal Fox.",
                 "suggestedMissingInfoQuestion": "What public-safe source or owner-approved wording supports this source-blind context?",
                 "recommendedAction": "needs_public_source",
@@ -157,7 +160,7 @@ class DossierDraftGeneratorTests(unittest.TestCase):
         )
         result = draft.generate_dossier_draft(packet)["draft"]
         public = json.dumps(result).lower()
-        for forbidden in ("reviewableclaims", "suggestedinternalnote", "suggestedmissinginfoquestion", "recommendedaction", "actionability", "withheldevidenceaudit", "source-blind", "source_blind"):
+        for forbidden in ("reviewableclaims", "displaytitle", "displaydecision", "verificationpacketquestion", "suggestedinternalnote", "suggestedmissinginfoquestion", "recommendedaction", "actionability", "withheldevidenceaudit", "source-blind", "source_blind"):
             self.assertNotIn(forbidden, public)
 
     def test_thin_packet_returns_conservative_summary_and_missing_info(self):

--- a/tests/test_subject_memory_resolver.py
+++ b/tests/test_subject_memory_resolver.py
@@ -1,12 +1,67 @@
 import sqlite3
 import tempfile
 import unittest
+import json
 
 import bnl_dossier_draft as draft
 from bnl_subject_memory_resolver import build_subject_analyst_read, build_subject_memory_diagnostic, resolve_subject_memory
 
 
 class SubjectMemoryResolverTests(unittest.TestCase):
+
+    def test_review_cards_include_human_display_copy_and_clean_questions(self):
+        packet = {
+            "publicSafeFacts": ["Crow is a BARCODE Network community member."],
+            "publicCreativeMusicSignals": [],
+            "publicRoleSignals": [],
+            "publicLinkSignals": [],
+            "reviewOnlyEvidence": [
+                {"summary": "Crow may have public Suno/music links and repeated music link context needing confirmation."},
+                {"summary": "Crow has contest-related music/link context and contest rules links but the relationship is unclear."},
+                {"summary": "Crow may be an artist role/title but needs confirmation."},
+                {"summary": "subject-owned/keyed local evidence exists"},
+            ],
+            "queueOrSubmissionSignals": ["Crow queue submission history needs confirmation."],
+            "relationshipOrContextSignals": [{"summary": "Crow may reference Orion as AI/message relay context needing confirmation."}],
+            "sourceSafetyWarnings": ["Some subject memory lacked public-safe provenance"],
+            "privateOrInternalEvidence": [],
+            "evidenceCounts": {"publicSafe": 1, "reviewOnly": 5, "privateOrInternal": 0, "sourceBlind": 1, "totalScanned": 7},
+        }
+        analyst = build_subject_analyst_read("Crow", packet)
+        claims = analyst["reviewableClaims"]
+        music = next(c for c in claims if c["claimType"] == "music_link")
+        self.assertEqual(music["displayTitle"], "Confirm approved public links")
+        self.assertEqual(music["displayDecision"], "Which links, if any, may BNL publicly associate with Crow?")
+        self.assertEqual(music["confirmationTarget"], "link_ownership")
+        self.assertEqual(music["primaryActionLabel"], "Ask who owns these links")
+        self.assertEqual(music["verificationPacketQuestion"], "Which music or contest-related links are yours and approved for public reference?")
+        contest = next(c for c in claims if c["claimType"] == "contest_music_context")
+        self.assertEqual(contest["displayTitle"], "Confirm approved public links")
+        self.assertEqual(contest["verificationPacketAudience"], "subject")
+        self.assertIn("Which music or contest-related links", contest["verificationPacketQuestion"])
+        blind = next(c for c in claims if c.get("actionability") == "source_blind_warning")
+        self.assertEqual(blind["displayTitle"], "Needs public source")
+        self.assertEqual(blind["confirmationTarget"], "public_source")
+        self.assertEqual(blind["primaryActionLabel"], "Request public source")
+        artifact = next(c for c in claims if c.get("actionability") == "non_actionable_artifact")
+        self.assertEqual(artifact["claimText"], "Vague internal evidence marker")
+        self.assertEqual(artifact["displayTitle"], "Internal evidence artifact")
+        self.assertEqual(artifact["primaryActionLabel"], "Keep as internal audit note")
+        self.assertEqual(artifact["secondaryActionLabels"], ["Dismiss artifact"])
+        self.assertNotIn("suggestedPublicWording", artifact)
+        queue = next(c for c in claims if c["claimType"] == "queue_submission")
+        self.assertEqual(queue["confirmationTarget"], "admin")
+        role = next(c for c in claims if c["claimType"] == "role")
+        self.assertEqual(role["confirmationTarget"], "subject")
+        cards = analyst["recommendedAdminActionCards"]
+        self.assertEqual(cards[0]["displayBNLRecommendation"], "Review each BNL claim separately.")
+        self.assertEqual(cards[1]["displayBNLRecommendation"], "Only say what we know is true.")
+        self.assertEqual(cards[2]["displayBNLRecommendation"], "Get proof or approval first.")
+        display_keys = ("displayTitle", "displayDecision", "displayWhatIsBeingChecked", "displayWhyBNLFlaggedIt", "displayBNLRecommendation", "displayEvidenceSummary", "displaySafeDefault", "displayApprovalInstruction", "primaryActionLabel", "secondaryActionLabels", "verificationPacketQuestion")
+        human_blob = json.dumps([{k: c.get(k) for k in display_keys} for c in [*claims, *cards]])
+        for forbidden in ("sourceFileReviewClaims", "official_public_dossier", "public_safe", "source_blind", "review_only", "public_music_role", "queue_submission"):
+            self.assertNotIn(forbidden, human_blob)
+
     def test_resolver_finds_and_classifies_crow_memory_across_tables(self):
         with tempfile.NamedTemporaryFile(suffix='.db') as tmp:
             conn = sqlite3.connect(tmp.name)


### PR DESCRIPTION
### Motivation

- The analyst/review output layer previously emitted internal/system-style notes that required the site to translate them for admins, so BNL should produce clear human-facing review cards directly.
- Admin workflows must get copy-ready titles, decisions, verification questions, and action labels while preserving structured fields and strict public/private boundaries.

### Description

- Added admin-facing display fields (`displayTitle`, `displayDecision`, `displayWhatIsBeingChecked`, `displayWhyBNLFlaggedIt`, `displayBNLRecommendation`, `displayEvidenceSummary`, `displaySafeDefault`, `displayApprovalInstruction`, `confirmationTarget`, `primaryActionLabel`, `secondaryActionLabels`, `verificationPacketQuestion`, and `verificationPacketAudience`) and a `recommendedAdminActionCards` array in the subject analyst read. 
- Implemented `_review_display_copy` and `_admin_action_card` helpers and integrated them into `_review_guidance`, `_make_reviewable_claim`, admin-correction handling, and the subject analyst read so reviewable claims and admin tasks carry clean human copy. 
- Improved artifact handling by replacing raw artifact claim text with a neutral `Vague internal evidence marker` and added a `_display_clean` sanitizer that rewrites/removes camelCase/snake_case/internal enum names from any display strings. 
- Kept existing structured compatibility fields (e.g., `claimText`, `claimType`, `reviewLane`, `suggestedDecision`, `suggestedPublicWording`, `suggestedMissingInfoQuestion`, `recommendedAction`, `recommendedActionReason`, `cannotSuggestPublicReason`, `actionability`) and extended the enrichment normalization to include `recommendedAdminActionCards` so admin cards survive archive/enrichment output. 

### Testing

- Ran `python3 -m py_compile bnl_source_file_enrichment.py bnl_dossier_draft.py bnl01_bot.py bnl_subject_memory_resolver.py` with no syntax errors. 
- Ran `pytest` for updated units: `tests/test_subject_memory_resolver.py`, `tests/test_dossier_draft_generator.py`, and the source-file enrichment suites via `python3 -m pytest tests/test_source_file_enrichment.py tests/test_source_file_archive.py tests/test_source_file_refresh.py`, and all tests passed. 
- Added regression coverage that asserts human-facing display copy for music/link, contest, source-needed, artifact, admin-task rewriting, confirmation-target mapping, technical-term filtering, and that public dossier drafts do not leak admin/display fields. 
- Latest commit SHA: `1cf82a42a597047a7a31de0f72b717055c7fcc4a`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31f119615483218de54f4accc9a9c3)