### PR TITLE
Generate dossier readiness questions instead of review leftovers

### DIFF
--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -884,6 +884,9 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
         rejected_facts.extend(evidence_rejected)
     except Exception:
         evidence = None
+    supplied_analyst = _dict(packet.get("subjectAnalystReadV1") or packet.get("subjectAnalystRead") or packet.get("analystRead"))
+    if supplied_analyst and not analyst:
+        analyst = supplied_analyst
     if db_path:
         try:
             _, resolver_aliases = _subject_terms(packet)
@@ -1023,4 +1026,13 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
             if part
         ),
     }
-    return {"draft": draft}
+    readiness = {}
+    if analyst:
+        readiness = {
+            "dossierReadinessQuestions": analyst.get("dossierReadinessQuestions") or [],
+            "dossierReadinessSummary": _text(analyst.get("dossierReadinessSummary"), 500),
+            "dossierBlockedBy": _strings(analyst.get("dossierBlockedBy"), max_items=7),
+            "readyForDraft": bool(analyst.get("readyForDraft")),
+            "draftReadinessReason": _text(analyst.get("draftReadinessReason"), 500),
+        }
+    return {"draft": draft, "draftReadiness": readiness}

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -4767,6 +4767,11 @@ _SUBJECT_ANALYST_READ_KEYS = (
     "missingConfirmations",
     "recommendedAdminActions",
     "recommendedAdminActionCards",
+    "dossierReadinessQuestions",
+    "dossierReadinessSummary",
+    "dossierBlockedBy",
+    "readyForDraft",
+    "draftReadinessReason",
     "draftIngredients",
     "sourceFileIngredients",
     "provenanceSummary",
@@ -4837,6 +4842,11 @@ def _normalize_subject_analyst_read_v1(analyst: dict[str, Any]) -> dict[str, Any
     normalized["withheldEvidenceAudit"] = _sanitize_archive_value(analyst.get("withheldEvidenceAudit") or {}) if isinstance(analyst.get("withheldEvidenceAudit"), dict) else {}
     normalized["missingConfirmations"] = _sanitize_archive_value((analyst.get("missingConfirmations") or [])[:12]) if isinstance(analyst.get("missingConfirmations"), list) else []
     normalized["recommendedAdminActionCards"] = _sanitize_archive_value((analyst.get("recommendedAdminActionCards") or [])[:8]) if isinstance(analyst.get("recommendedAdminActionCards"), list) else []
+    normalized["dossierReadinessQuestions"] = _sanitize_archive_value((analyst.get("dossierReadinessQuestions") or [])[:7]) if isinstance(analyst.get("dossierReadinessQuestions"), list) else []
+    normalized["dossierBlockedBy"] = _case_list(analyst.get("dossierBlockedBy"), limit=7, item_limit=80)
+    normalized["readyForDraft"] = bool(analyst.get("readyForDraft"))
+    normalized["dossierReadinessSummary"] = _case_text(analyst.get("dossierReadinessSummary"), 500)
+    normalized["draftReadinessReason"] = _case_text(analyst.get("draftReadinessReason"), 500)
     for key in ("strongestSignals", "publicSafeClaims", "publicReadyClaims", "sourceBlindInsights", "privateOrInternalExclusions", "doNotSayPublicly", "missingInfoQuestions", "recommendedAdminActions", "draftIngredients", "provenanceSummary"):
         normalized[key] = _case_list(normalized.get(key), limit=12 if key != "draftIngredients" else 9, item_limit=360)
     normalized["subjectName"] = subject

--- a/bnl_subject_memory_resolver.py
+++ b/bnl_subject_memory_resolver.py
@@ -567,6 +567,18 @@ def _review_display_copy(subject: str, claim_text: str, claim_type: str, lane: s
         approval = ""
         target = "none"; audience = "none"; question = ""
         primary = "Keep as internal note"; secondary = ["Dismiss artifact"]
+    elif (not is_orion) and re.search(r"\blore[-\s]*heavy|\blore\b", low):
+        title = "Decide lore/public boundary"
+        decision = "Should this be used as public lore/context, kept internal, or rejected for this dossier?"
+        checked = "You are deciding whether lore-heavy context belongs in a concrete public dossier."
+        why = "BNL found lore-heavy context but needs a public/internal/reject decision, not a generic source request."
+        rec = "BNL recommends keeping this internal unless an admin approves it as public context."
+        evidence_summary = "Lore-heavy context exists without a specific public factual claim."
+        safe = "Keep as internal lore/context unless approved for public use."
+        approval = "Approve only public lore/context wording, keep internal, or reject as not useful."
+        target = "admin"; audience = "admin"
+        primary = "Decide public/internal/reject"; secondary = ["Keep internal", "Reject / not needed"]
+        question = "Should BNL describe this as public lore/context, keep it internal, or reject it for this dossier?"
     elif actionability == "source_blind_warning" or lane == "source_blind":
         title = "Needs public source"
         decision = "What public-safe source or owner-approved replacement wording supports this item?"
@@ -671,7 +683,80 @@ def _review_display_copy(subject: str, claim_text: str, claim_type: str, lane: s
         "secondaryActionLabels": secondary,
         "verificationPacketQuestion": question,
         "verificationPacketAudience": audience,
+        "recommendedFollowUpQuestion": question,
+        "recommendedFollowUpAudience": audience if audience in {"subject", "admin", "owner", "public_source"} else ("subject" if audience == "link_ownership" else ("admin" if audience == "none" else audience)),
+        "recommendedFollowUpReason": why,
+        "bestGuessConfidence": "low" if not public_safe else "medium",
     }.items()}
+
+
+def _dossier_question_id(section: str, audience: str, index: int) -> str:
+    return f"dossier-readiness-{section}-{audience}-{index}"
+
+
+def _dossier_section_for_claim_type(claim_type: str, text: str) -> str:
+    low = (text or "").lower()
+    if "orion" in low or "relay" in low:
+        return "orion"
+    if "lore" in low or "context" in low and "contest" not in low:
+        return "lore"
+    if claim_type in {"music_link", "public_link"} or re.search(r"\b(suno|music|song|track|link|social|url)\b", low):
+        return "links" if "music" not in low and "suno" not in low else "music"
+    if claim_type.startswith("contest_") or "contest" in low or "rules" in low:
+        return "contest"
+    if claim_type in {"role", "community_context"} or re.search(r"\b(role|title|artist|collaborator|participant|moderator)\b", low):
+        return "role"
+    if claim_type == "relationship" or "relationship" in low:
+        return "relationships"
+    if "display name" in low or "identity" in low:
+        return "identity"
+    return "unknown"
+
+
+def _readiness_question_for_section(subject: str, section: str) -> tuple[str, str, str, str, str]:
+    if section == "identity":
+        return ("subject", f"What exact public name may BNL use for {subject}?", "A public dossier needs an approved identity label before BNL writes summary copy.", "high", "needs_confirmation")
+    if section == "role":
+        return ("subject", f"What public role/title may BNL use for {subject}, if any?", "A public dossier needs a precise approved role instead of inferred labels.", "high", "needs_confirmation")
+    if section in {"links", "music"}:
+        return ("subject", f"Which links are {subject}’s and approved for BNL to mention publicly?", "BNL found possible link/music context but does not know ownership or approval.", "high", "needs_confirmation")
+    if section == "contest":
+        return ("subject", f"What was {subject}’s relationship to this contest: participant, submitter, rules poster, link source, host, organizer, or unrelated mention?", "BNL found contest/rules context but cannot safely infer the subject’s role.", "high", "needs_confirmation")
+    if section == "orion":
+        return ("admin", f"Can BNL mention Orion in {subject}’s public dossier, or should that stay internal?", "Orion/context references require an explicit public/internal boundary decision.", "high", "needs_confirmation")
+    if section == "lore":
+        return ("admin", "Should BNL describe this as public lore/context, keep it internal, or reject it for this dossier?", "BNL found lore-heavy context and needs a dossier decision, not a generic source request.", "medium", "internal_only")
+    if section == "relationships":
+        return ("subject", f"What public relationship to BARCODE/BNL, if any, is approved for BNL to state for {subject}?", "A public dossier needs approved relationship wording and public boundaries.", "high", "needs_confirmation")
+    return ("admin", f"What is still needed before BNL can write a complete public summary for {subject}?", "BNL has unresolved dossier-readiness context that does not fit a more specific section.", "low", "needs_confirmation")
+
+
+def _build_dossier_readiness(subject: str, reviewable_claims: list[dict[str, Any]], missing: list[dict[str, Any]], blind_insights: list[str]) -> dict[str, Any]:
+    buckets: dict[tuple[str, str], dict[str, Any]] = {}
+    def add(section: str, claim_id: str = "") -> None:
+        audience, question, why, priority, safety = _readiness_question_for_section(subject, section)
+        key = (section, audience)
+        item = buckets.setdefault(key, {"audience": audience, "question": question, "whyItMatters": why, "dossierSection": section, "priority": priority, "relatedReviewClaimIds": [], "sourceSafety": safety})
+        if claim_id and claim_id not in item["relatedReviewClaimIds"]:
+            item["relatedReviewClaimIds"].append(claim_id)
+    add("identity")
+    for m in missing:
+        add(_dossier_section_for_claim_type(str(m.get("relatedClaimType") or ""), str(m.get("question") or "")))
+    for idx, c in enumerate(reviewable_claims):
+        section = _dossier_section_for_claim_type(str(c.get("claimType") or ""), " ".join(str(c.get(k) or "") for k in ("claimText", "displayTitle", "displayDecision")))
+        if c.get("reviewLane") == "source_blind" and section == "unknown":
+            continue
+        add(section, f"reviewableClaims[{idx}]")
+    for txt in blind_insights:
+        if "orion" in txt.lower() or "relay" in txt.lower():
+            add("orion")
+    priority_rank = {"high": 0, "medium": 1, "low": 2}
+    questions = sorted(buckets.values(), key=lambda x: (priority_rank.get(x["priority"], 9), x["dossierSection"]) )[:7]
+    for i, q in enumerate(questions, 1):
+        q["id"] = _dossier_question_id(q["dossierSection"], q["audience"], i)
+    blocked = [q["dossierSection"] for q in questions if q["priority"] == "high"]
+    ready = not blocked
+    return {"questions": questions, "summary": f"BNL has {len(questions)} prioritized dossier-readiness question(s); {len(blocked)} block a complete public draft.", "blockedBy": blocked, "readyForDraft": ready, "reason": "Ready for draft with current public-safe facts." if ready else "Resolve high-priority identity, role, link/music, relationship, contest, or boundary questions before generating a concrete public dossier."}
 
 
 def _admin_action_card(action: str) -> dict[str, Any]:
@@ -1132,11 +1217,8 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
     resolved_types = _resolved_missing_info_types(admin_corrections)
     missing = [m for m in missing if m.get("relatedClaimType") not in resolved_types]
     missing_lines = [m["question"] + f" ({m['confirmationType'].replace('_', ' ')}.)" for m in missing]
-    actions = [
-        "Review each sourceFileReviewClaims line as an individual approve/reject/edit item; do not approve a whole bucket.",
-        "Promote only confirmed public-safe facts into the Source File before expanding public copy.",
-        "Attach owner-approved provenance for any role, link, music, queue, Orion/context, or relationship claim.",
-    ]
+    readiness = _build_dossier_readiness(subject, reviewable_claims, missing, blind_insights)
+    actions = [q["question"] for q in readiness["questions"] if q.get("priority") == "high"]
     withheld_audit = _withheld_audit(subject, resolved_memory, private, blind, review) if (private or blind or review) else {}
     source_file_ingredients = []
     for item in [internal, *strongest[:6], *public_claims, *review_claims, *blind_insights, *actions, *missing_lines]:
@@ -1170,6 +1252,11 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
         "missingConfirmations": missing,
         "recommendedAdminActions": actions,
         "recommendedAdminActionCards": [_admin_action_card(a) for a in actions],
+        "dossierReadinessQuestions": readiness["questions"],
+        "dossierReadinessSummary": readiness["summary"],
+        "dossierBlockedBy": readiness["blockedBy"],
+        "readyForDraft": readiness["readyForDraft"],
+        "draftReadinessReason": readiness["reason"],
         "draftIngredients": draft_ingredients,
         "sourceFileIngredients": source_file_ingredients[:18],
         "provenanceSummary": prov,

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -682,3 +682,19 @@ class DossierDraftGeneratorTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class DossierDraftReadinessMemoryTests(unittest.TestCase):
+    def test_readiness_memory_is_top_level_not_public_draft(self):
+        packet = pr217_packet(subjectAnalystReadV1={
+            "dossierReadinessQuestions": [{"id": "q1", "audience": "subject", "question": "Which links are Signal Fox’s and approved for BNL to mention publicly?", "whyItMatters": "Needed for links.", "dossierSection": "links", "priority": "high", "relatedReviewClaimIds": [], "sourceSafety": "needs_confirmation"}],
+            "dossierReadinessSummary": "One blocker remains.",
+            "dossierBlockedBy": ["links"],
+            "readyForDraft": False,
+            "draftReadinessReason": "Resolve link ownership first.",
+        })
+        result = draft.generate_dossier_draft(packet)
+        self.assertIn("draftReadiness", result)
+        self.assertEqual(result["draftReadiness"]["dossierBlockedBy"], ["links"])
+        public = json.dumps(result["draft"]).lower()
+        for forbidden in ("dossierreadinessquestions", "draftreadinessreason", "readyfordraft", "which links are signal fox"):
+            self.assertNotIn(forbidden, public)

--- a/tests/test_subject_memory_resolver.py
+++ b/tests/test_subject_memory_resolver.py
@@ -57,9 +57,8 @@ class SubjectMemoryResolverTests(unittest.TestCase):
         role = next(c for c in claims if c["claimType"] == "role")
         self.assertEqual(role["confirmationTarget"], "subject")
         cards = analyst["recommendedAdminActionCards"]
-        self.assertEqual(cards[0]["displayBNLRecommendation"], "Review each BNL claim separately.")
-        self.assertEqual(cards[1]["displayBNLRecommendation"], "Only say what we know is true.")
-        self.assertEqual(cards[2]["displayBNLRecommendation"], "Get proof or approval first.")
+        self.assertNotIn("sourceFileReviewClaims", " ".join(c["displayBNLRecommendation"] for c in cards))
+        self.assertTrue(any("public name" in c["displayBNLRecommendation"] or "public role" in c["displayBNLRecommendation"] for c in cards))
         display_keys = ("displayTitle", "displayDecision", "displayWhatIsBeingChecked", "displayWhyBNLFlaggedIt", "displayBNLRecommendation", "displayEvidenceSummary", "displaySafeDefault", "displayApprovalInstruction", "primaryActionLabel", "secondaryActionLabels", "verificationPacketQuestion")
         human_blob = json.dumps([{k: c.get(k) for k in display_keys} for c in [*claims, *cards]])
         for forbidden in ("sourceFileReviewClaims", "official_public_dossier", "public_safe", "source_blind", "review_only", "public_music_role", "queue_submission"):
@@ -370,3 +369,40 @@ class SubjectMemoryResolverTests(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+class DossierReadinessPacketTests(unittest.TestCase):
+    def test_dossier_readiness_packet_collapses_generic_review_questions(self):
+        packet = {
+            "reviewOnlyEvidence": [
+                {"summary": "Crow has Suno music link context needing public-safe provenance."},
+                {"summary": "Crow shared another music link that needs owner-approved wording."},
+                {"summary": "Crow appears near contest rules and submission link context."},
+                {"summary": "Crow may have artist role/title context needing confirmation."},
+                {"summary": "Crow has Orion relay context needing confirmation."},
+                {"summary": "Crow has lore-heavy context without a specific public fact."},
+                {"summary": "subject-owned/keyed local evidence exists"},
+            ],
+            "relationshipOrContextSignals": [{"summary": "Crow may reference Orion as AI/message relay context needing confirmation."}],
+            "sourceSafetyWarnings": ["Some subject memory lacked public-safe provenance"],
+            "evidenceCounts": {"publicSafe": 0, "reviewOnly": 7, "privateOrInternal": 0, "sourceBlind": 1, "totalScanned": 8},
+        }
+        analyst = build_subject_analyst_read("Crow", packet)
+        questions = analyst["dossierReadinessQuestions"]
+        self.assertLessEqual(len(questions), 7)
+        joined = " ".join(q["question"] for q in questions)
+        self.assertIn("Which links are Crow", joined)
+        self.assertIn("relationship to this contest", joined)
+        self.assertIn("public role/title", joined)
+        self.assertIn("Orion", joined)
+        self.assertIn("public lore/context, keep it internal, or reject", joined)
+        self.assertNotIn("What public-safe source or owner-approved wording supports this claim", joined)
+        self.assertIn("readyForDraft", analyst)
+        self.assertIn("draftReadinessReason", analyst)
+        self.assertFalse(analyst["readyForDraft"])
+        self.assertNotIn("sourceFileReviewClaims", " ".join(analyst["recommendedAdminActions"]))
+
+    def test_lore_heavy_card_uses_decision_copy_not_public_source(self):
+        card = _review_guidance("Crow", "Crow lore-heavy context only", "relationship", "needs_confirmation", False)
+        self.assertEqual(card["displayTitle"], "Decide lore/public boundary")
+        self.assertIn("public lore/context, keep it internal, or reject", card["verificationPacketQuestion"])
+        self.assertNotIn("public-safe source", card["verificationPacketQuestion"].lower())


### PR DESCRIPTION
### Motivation
- The verification/follow-up packet was emitting cleaned-up review-card leftovers instead of a small prioritized set of dossier-focused questions BNL needs to build a complete public-ready dossier. 
- Produce admin-only, subject-specific readiness questions that collapse redundant review items, avoid generic admin-task phrasing, and preserve public/private/source-blind protections.

### Description
- Add an admin-only `dossierReadinessQuestions` packet (with `id`, `audience`, `question`, `whyItMatters`, `dossierSection`, `priority`, `relatedReviewClaimIds`, `sourceSafety`) and supporting fields `dossierReadinessSummary`, `dossierBlockedBy`, `readyForDraft`, and `draftReadinessReason` to the Subject Analyst read and normalization paths. 
- Implement `_build_dossier_readiness` to map unresolved reviewable claims/missing confirmations/source-blind signals into a capped (3–7 default, max 7) prioritized set of dossier questions by section (identity, role, links/music, contest, lore, orion, relationships, unknown) and generate stable IDs. 
- Replace broad generic recommended admin actions with subject-specific high-priority readiness questions and add trustable follow-up metadata on review cards: `recommendedFollowUpQuestion`, `recommendedFollowUpAudience`, `recommendedFollowUpReason`, and `bestGuessConfidence`. 
- Improve handling of weak internal signals and lore-heavy context so non-actionable artifacts remain internal audit notes and lore-only items ask a public/internal/reject decision rather than a generic public-source question; surface readiness memory to the draft generator as top-level `draftReadiness` (internal only) while keeping the public `draft` free of admin-only fields. 

### Testing
- Ran static compile checks with `python3 -m py_compile bnl_source_file_enrichment.py bnl_dossier_draft.py bnl01_bot.py bnl_subject_memory_resolver.py` and they succeeded. 
- Ran unit tests for the subject resolver (`python3 -m pytest tests/test_subject_memory_resolver.py -q`) and dossier draft generator (`python3 -m pytest tests/test_dossier_draft_generator.py -q`) and they passed. 
- Ran the source file enrichment test group (`python3 -m pytest tests/test_source_file_enrichment.py tests/test_source_file_archive.py tests/test_source_file_refresh.py -q`) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a322a6a0f608321a04aebafb1d6bba1)