### PR TITLE
Add insufficient-context state for unanswerable review cards

### DIFF
--- a/bnl_subject_memory_resolver.py
+++ b/bnl_subject_memory_resolver.py
@@ -327,7 +327,7 @@ def _universal_follow_up_for_claim(subject: str, claim_text: str, claim_type: st
             scope_label = obj; scope_known = True; confidence = "medium"
         else:
             question = "What AI/persona/project connection is this referring to? What AI, persona, project, character, bot, or universe is this referring to, and what was the subject’s actual connection to it? Should BNL mention it publicly, keep it internal, or ignore it?"
-        answer_type = "plain-language explanation of the interaction, AI/persona/project object, public/internal/ignore decision, and exact approved wording if public"
+        answer_type = "clarification of the AI/persona/project object, interaction, and subject role" if not obj else "plain-language explanation of the interaction, AI/persona/project object, public/internal/ignore decision, and exact approved wording if public"
         reason = "BNL found AI/persona/project wording but must not infer the object, interaction, or public permission from nearby context."
     elif category == "role_title":
         question = f"What exact public role or title may BNL use for {subject}, if any? Should BNL avoid giving {subject} a public role/title for now?"
@@ -355,15 +355,15 @@ def _universal_follow_up_for_claim(subject: str, claim_text: str, claim_type: st
         reason = "BNL must not turn queue/submission context into public dossier wording without admin/owner approval."
     elif category == "contest_event":
         question = f"What contest or event is this referring to? BNL found {scope_label or 'contest/event'} context near {subject}. Was {subject} a participant, submitter, link source, rules source, organizer, host, or just mentioned nearby? Should BNL mention it publicly, keep it internal, or ignore it?"
-        answer_type = "contest/event name plus subject role and public/internal/ignore decision"
+        answer_type = "clarification of the contest/event object, subject role, and whether it belongs in the dossier" if not scope_known else "contest/event name plus subject role and public/internal/ignore decision"
         reason = "BNL cannot infer contest/event role, host, organizer, or participation from proximity."
     elif category == "rules_instructions":
         question = f"What rules or instructions is this referring to, who were they for, and what was {subject}'s actual role with them? Should BNL mention this publicly, keep it internal, or ignore it?"
-        answer_type = "what the instructions were, who they were for, subject role, and public/internal/ignore decision"
+        answer_type = "clarification of the instruction source, audience, purpose, and subject role" if not scope_known else "what the instructions were, who they were for, subject role, and public/internal/ignore decision"
         reason = "BNL needs the instruction source, audience, purpose, and subject role before treating rules/instructions as dossier context."
     elif category == "theory_anomaly":
         question = f"What theory or anomaly is this referring to, and is it about {subject}, BARCODE lore, Orion, a recurring topic, a technical issue, or something unrelated? Should BNL use it publicly, keep it internal, or ignore it?"
-        answer_type = "scope of the theory/anomaly plus public/internal/ignore decision"
+        answer_type = "clarification of the theory/anomaly scope and whether it belongs in the dossier" if not scope_known else "scope of the theory/anomaly plus public/internal/ignore decision"
         reason = "BNL needs the theory/anomaly scope before deciding whether it belongs in a public dossier."
     elif category == "orion_context":
         question = f"Can BNL mention Orion in public {subject} context, or should Orion stay internal? If public, what exact wording is approved?"
@@ -371,7 +371,7 @@ def _universal_follow_up_for_claim(subject: str, claim_text: str, claim_type: st
         reason = "BNL needs an explicit public/internal boundary for Orion/context references."
     elif category == "lore_context":
         question = f"Is this {subject}'s own lore, BARCODE Network lore, Orion lore, Null TV lore, broadcast lore, recurring community context, or something else? Should BNL mention {subject}'s lore publicly, keep it internal, or ignore it?"
-        answer_type = "classification of the lore/context plus public/internal/ignore decision"
+        answer_type = "clarification of the lore/context scope and whether it belongs in the dossier" if not scope_known else "classification of the lore/context plus public/internal/ignore decision"
         reason = "BNL needs to classify lore/context before it can decide whether it belongs in the subject's public dossier."
     elif category == "public_summary":
         question = f"What short public summary is approved for {subject}, and what should BNL avoid inferring beyond that wording?"
@@ -379,7 +379,7 @@ def _universal_follow_up_for_claim(subject: str, claim_text: str, claim_type: st
         reason = "BNL needs owner/admin-approved summary direction and must not infer unsupported public copy."
     elif category == "unknown_context":
         question = "What is this item referring to, and should BNL use it publicly, keep it internal, or ignore it?"
-        answer_type = "plain-language context clarification and public/internal/ignore decision"
+        answer_type = "clarification of what this item refers to and whether it belongs in the dossier"
         reason = "BNL can tell the item is unclear context, so it needs classification before asking for proof or public wording."
         scope_label = "unclear context"; scope_known = False
     elif category == "admin_action":
@@ -390,13 +390,86 @@ def _universal_follow_up_for_claim(subject: str, claim_text: str, claim_type: st
         fallback = True
         not_enough = "BNL could not identify whether this is a role, link, lore, contest, relationship, queue, identity, AI/persona/project, source-blind, or public-boundary issue, so it needs proof or approved wording before using it publicly."
         question = GENERIC_FOLLOW_UP_FALLBACK
-        answer_type = "proof, correction, or approved public-safe wording"
+        answer_type = "clarification of what this item refers to and whether it belongs in the dossier"
         reason = not_enough
         scope_label = ""; scope_known = False; confidence = "low"
     return {
         "question": question, "audience": audience, "reason": reason, "answerType": answer_type,
         "confidence": confidence, "scopeKnown": bool(scope_known), "scopeLabel": scope_label,
         "category": category, "fallbackUsed": fallback, "notEnoughContextReason": not_enough,
+    }
+
+
+def _is_clarification_follow_up(follow_up: dict[str, Any] | None, actionability: str = "") -> bool:
+    if not follow_up:
+        return False
+    if follow_up.get("category") == "source_blind" or actionability == "source_blind_warning":
+        return False
+    question = str(follow_up.get("question") or "").lower()
+    answer_type = str(follow_up.get("answerType") or "").lower()
+    asks_scope = bool(re.search(r"\b(what|which|who|is this about|referring to|belongs? in|actual role|what .* role|scope)\b", question, re.I))
+    return (not bool(follow_up.get("scopeKnown"))) and ("clarification" in answer_type or asks_scope or bool(follow_up.get("fallbackUsed")))
+
+def _clarification_copy(subject: str, follow_up: dict[str, Any], fallback_question: str = "") -> dict[str, Any]:
+    question = str(follow_up.get("question") or fallback_question or "What is this item referring to?")
+    category = str(follow_up.get("category") or "")
+    reason = str(follow_up.get("reason") or follow_up.get("notEnoughContextReason") or "BNL cannot decide whether this belongs in the dossier until the missing context is provided.")
+    answer_type = str(follow_up.get("answerType") or "clarification of the item scope and whether it belongs in the dossier")
+    if "clarification" not in answer_type.lower():
+        if category == "rules_instructions":
+            answer_type = "clarification of the instruction source, audience, purpose, and subject role"
+            reason = "BNL cannot decide whether this belongs in the dossier until it knows what instructions are being referenced."
+        elif category == "theory_anomaly":
+            answer_type = "clarification of the theory/anomaly scope and whether it belongs in the dossier"
+            reason = "BNL cannot decide whether this is public, internal, or irrelevant until the theory/anomaly is identified."
+        elif category == "lore_context":
+            answer_type = "clarification of the lore/context scope and whether it belongs in the dossier"
+        elif category == "ai_persona_project":
+            answer_type = "clarification of the AI/persona/project object, interaction, and subject role"
+        elif category == "contest_event":
+            answer_type = "clarification of the contest/event object, subject role, and whether it belongs in the dossier"
+        else:
+            answer_type = "clarification of what this item refers to and whether it belongs in the dossier"
+    return {
+        "decisionState": "needs_clarification",
+        "actionability": "needs_clarification",
+        "suggestedDecision": "needs_clarification",
+        "publicSafe": False,
+        "hasSafePublicSuggestion": False,
+        "suggestedPublicWording": "",
+        "recommendedAction": "needs_clarification",
+        "recommendedActionReason": "BNL must clarify the item scope before any public/internal/reject Source File decision.",
+        "cannotSuggestPublicReason": "BNL does not know what this item refers to yet.",
+        "displayTitle": "Needs clarification before review",
+        "displayDecision": "What is this item referring to?",
+        "displayWhatIsBeingChecked": "You are not approving this as a fact yet. BNL needs the missing context before this can become a Source File decision.",
+        "displayWhyItExists": "BNL found a possible signal, but it does not know enough about the source, subject role, audience, or context to make a public/internal/reject decision.",
+        "displayWhyBNLFlaggedIt": "BNL found a possible signal, but it does not know enough about the source, subject role, audience, or context to make a public/internal/reject decision.",
+        "displayBNLRecommendation": "Ask for clarification or dismiss it as unusable. Do not approve public wording yet.",
+        "displayEvidenceSummary": "Possible signal only; the referenced source, subject role, audience, or context is not clear enough to review as a fact.",
+        "displaySafetyDefault": "Do not use this in public wording until the missing context is clear.",
+        "displaySafeDefault": "Do not use this in public wording until the missing context is clear.",
+        "displayApprovalInstruction": "Do not approve public wording from this card. First clarify what this refers to.",
+        "confirmationTarget": "admin",
+        "primaryActionLabel": "Add clarification question",
+        "secondaryActionLabels": ["Keep as internal note", "Reject / not useful"],
+        "verificationPacketQuestion": question,
+        "verificationPacketQuestions": [question],
+        "verificationPacketAudience": str(follow_up.get("audience") or "admin"),
+        "recommendedFollowUpQuestion": question,
+        "recommendedFollowUpAudience": str(follow_up.get("audience") or "admin"),
+        "recommendedFollowUpReason": reason,
+        "bestGuessConfidence": str(follow_up.get("confidence") or "low"),
+        "suggestedConfirmationQuestion": question,
+        "suggestedConfirmationAudience": str(follow_up.get("audience") or "admin"),
+        "suggestedConfirmationReason": reason,
+        "suggestedConfirmationAnswerType": answer_type,
+        "suggestedMissingInfoQuestion": question,
+        "followUpCategory": category,
+        "fallbackUsed": bool(follow_up.get("fallbackUsed")),
+        "notEnoughContextReason": str(follow_up.get("notEnoughContextReason") or reason),
+        "followUpScopeKnown": False,
+        "followUpScopeLabel": str(follow_up.get("scopeLabel") or ""),
     }
 
 def _scoped_follow_up_for_claim(subject: str, claim_text: str, claim_type: str, lane: str, actionability: str, scope: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -1032,6 +1105,8 @@ def _review_display_copy(subject: str, claim_text: str, claim_type: str, lane: s
             question = str(follow_up.get("question") or question)
             audience = str(follow_up.get("audience") or audience)
             why = str(follow_up.get("reason") or why)
+    if _is_clarification_follow_up(follow_up, actionability):
+        return {k: _display_clean(v) if isinstance(v, str) else v for k, v in _clarification_copy(subject, follow_up, question).items()}
     answer_type = str((follow_up or {}).get("answerType") or "plain-language approval, correction, or public-safe wording")
     confidence = str((follow_up or {}).get("confidence") or ("medium" if public_safe else ("low" if actionability in {"source_blind_warning", "weak_label"} else "medium")))
     return {k: _display_clean(v) if isinstance(v, str) else v for k, v in {
@@ -1121,8 +1196,13 @@ def _readiness_question_for_section(subject: str, section: str) -> tuple[str, st
 
 def _build_dossier_readiness(subject: str, reviewable_claims: list[dict[str, Any]], missing: list[dict[str, Any]], blind_insights: list[str]) -> dict[str, Any]:
     buckets: dict[tuple[str, str], dict[str, Any]] = {}
-    def add(section: str, claim_id: str = "") -> None:
+    def add(section: str, claim_id: str = "", clarification_question: str = "") -> None:
         audience, question, why, priority, safety = _readiness_question_for_section(subject, section)
+        if clarification_question:
+            question = clarification_question
+            why = "Clarification needed before BNL can draft this part of the dossier."
+            safety = "needs_clarification"
+            priority = "high"
         key = (section, audience)
         item = buckets.setdefault(key, {"audience": audience, "question": question, "whyItMatters": why, "dossierSection": section, "priority": priority, "relatedReviewClaimIds": [], "sourceSafety": safety})
         if claim_id and claim_id not in item["relatedReviewClaimIds"]:
@@ -1133,7 +1213,10 @@ def _build_dossier_readiness(subject: str, reviewable_claims: list[dict[str, Any
         section = _dossier_section_for_claim_type(str(c.get("claimType") or ""), " ".join(str(c.get(k) or "") for k in ("claimText", "displayTitle", "displayDecision")))
         if c.get("reviewLane") == "source_blind" and section == "unknown":
             continue
-        add(section, f"reviewableClaims[{idx}]")
+        clar_q = ""
+        if c.get("decisionState") == "needs_clarification":
+            clar_q = str(c.get("recommendedFollowUpQuestion") or c.get("verificationPacketQuestion") or "Clarification needed before BNL can draft this part of the dossier")
+        add(section, f"reviewableClaims[{idx}]", clar_q)
     for txt in blind_insights:
         if "orion" in txt.lower() or "relay" in txt.lower():
             add("orion")
@@ -1299,6 +1382,8 @@ def _review_guidance(subject: str, claim_text: str, claim_type: str, lane: str, 
         return guidance
     if actionability == "source_blind_warning":
         guidance.update({
+            "decisionState": "source_blind_blocked",
+            "hasSafePublicSuggestion": False,
             "recommendedAction": "needs_public_source",
             "suggestedInternalNote": f"BNL found source-blind context for {subject}. Keep this internal until a public source or owner-approved wording is provided.",
             "suggestedMissingInfoQuestion": "Can an owner/admin provide public-safe replacement wording for this context, or should BNL keep it internal?",
@@ -1361,6 +1446,8 @@ def _make_reviewable_claim(subject: str, claim_text: str, claim_type: str, lane:
         "suggestedDecision": "confirm_public" if public_safe else ("keep_boundary" if lane in {"source_blind", "private_internal_withheld"} else "needs_more_info"),
         "why": _text(why, 220),
         "publicSafe": bool(public_safe),
+        "hasSafePublicSuggestion": bool(public_safe),
+        "decisionState": "decidable" if public_safe else ("source_blind_blocked" if lane == "source_blind" else "decidable"),
         "confidence": confidence,
         "safeEvidenceSummary": _text(evidence or why, 240),
         "blockedBy": blocked or ([] if public_safe else ["missing owner/admin confirmation", "missing public-safe provenance"]),
@@ -1613,6 +1700,8 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
         if line not in review_claims:
             review_claims.append(line)
             claim = _make_reviewable_claim(subject, line, ctype, "needs_confirmation", f"Review-only subject memory mentions {ctype.replace('_', ' ')} context.", False, "low", humanize_internal_label(_safe_evidence_example(txt, subject)))
+            if claim.get("decisionState") == "needs_clarification" and not re.search(r"\b(what|which|who|referring to|about)\b", str(claim.get("recommendedFollowUpQuestion") or ""), re.I):
+                continue
             if conflict_corr:
                 claim.update(_admin_conflict_fields(subject, txt, conflict_corr))
             if ctype.startswith("contest_"):

--- a/tests/test_subject_memory_resolver.py
+++ b/tests/test_subject_memory_resolver.py
@@ -66,16 +66,16 @@ class SubjectMemoryResolverTests(unittest.TestCase):
             "queue": _review_guidance("Crow", "Crow queue submission history needs confirmation", "queue_submission", "admin", False),
         }
         self.assertEqual(cases["link"]["displayTitle"], "Confirm approved public links")
-        self.assertEqual(cases["contest"]["displayTitle"], "Confirm contest relationship")
-        self.assertEqual(cases["ai"]["displayTitle"], "Confirm project relationship")
+        self.assertEqual(cases["contest"]["displayTitle"], "Needs clarification before review")
+        self.assertEqual(cases["ai"]["displayTitle"], "Needs clarification before review")
         self.assertEqual(cases["role"]["displayTitle"], "Confirm public role")
         self.assertEqual(cases["orion"]["displayTitle"], "Confirm Orion/context use")
         self.assertEqual(cases["queue"]["displayTitle"], "Confirm queue/submission history")
         summaries = {name: item["displayEvidenceSummary"] for name, item in cases.items()}
         safe_defaults = {name: item["displaySafeDefault"] for name, item in cases.items()}
         questions = {name: item["verificationPacketQuestion"] for name, item in cases.items()}
-        self.assertEqual(len(set(summaries.values())), len(summaries))
-        self.assertEqual(len(set(safe_defaults.values())), len(safe_defaults))
+        self.assertGreaterEqual(len(set(summaries.values())), 5)
+        self.assertGreaterEqual(len(set(safe_defaults.values())), 5)
         self.assertIn("Which Crow links, music links, or social links", questions["link"])
         self.assertIn("What contest or event is this referring", questions["contest"])
         self.assertIn("AI/persona/project connection", questions["ai"])
@@ -345,7 +345,7 @@ class SubjectMemoryResolverTests(unittest.TestCase):
         unknown_lore = _review_guidance("Crow", "lore-heavy context only", "relationship", "needs_confirmation", False)
         self.assertIn("BARCODE Network lore", unknown_lore["verificationPacketQuestion"])
         theory = _review_guidance("Crow", "theory/anomaly-heavy context", "relationship", "needs_confirmation", False)
-        self.assertEqual(theory["displayTitle"], "Clarify theory/anomaly context")
+        self.assertEqual(theory["displayTitle"], "Needs clarification before review")
         self.assertIn("What theory or anomaly", theory["verificationPacketQuestion"])
 
     def test_admin_corrections_block_roles_reuse_facts_and_resolve_missing_info(self):
@@ -427,11 +427,11 @@ class DossierReadinessPacketTests(unittest.TestCase):
     def test_scoped_follow_up_populates_current_and_legacy_fields(self):
         generic = "What proof or approved wording should BNL use before saying this publicly?"
         cases = [
-            ("ai", _review_guidance("Crow", "Crow appears near AI persona project context", "relationship", "needs_confirmation", False), "AI/persona/project connection", "plain-language explanation of the interaction"),
-            ("lore", _review_guidance("Crow", "lore-heavy context only", "relationship", "needs_confirmation", False), "BARCODE Network lore", "classification of the lore/context"),
-            ("theory", _review_guidance("Crow", "unknown theory anomaly near Crow", "relationship", "needs_confirmation", False), "What theory or anomaly", "scope of the theory/anomaly"),
-            ("rules", _review_guidance("Crow", "unclear rules and instructions near Crow", "rules_instructions_context", "needs_confirmation", False), "What rules or instructions", "what the instructions were"),
-            ("contest", _review_guidance("Crow", "Crow appeared near contest rules", "contest_rules_poster", "needs_confirmation", False), "What contest or event", "contest/event name plus subject role"),
+            ("ai", _review_guidance("Crow", "Crow appears near AI persona project context", "relationship", "needs_confirmation", False), "AI/persona/project connection", "clarification of the AI/persona/project"),
+            ("lore", _review_guidance("Crow", "lore-heavy context only", "relationship", "needs_confirmation", False), "BARCODE Network lore", "clarification of the lore/context"),
+            ("theory", _review_guidance("Crow", "unknown theory anomaly near Crow", "relationship", "needs_confirmation", False), "What theory or anomaly", "clarification of the theory/anomaly"),
+            ("rules", _review_guidance("Crow", "unclear rules and instructions near Crow", "rules_instructions_context", "needs_confirmation", False), "What rules or instructions", "clarification of the instruction source"),
+            ("contest", _review_guidance("Crow", "Crow appeared near contest rules", "contest_rules_poster", "needs_confirmation", False), "What contest or event", "clarification of the contest/event"),
         ]
         for _name, card, expected, answer_type in cases:
             question = card["recommendedFollowUpQuestion"]
@@ -450,6 +450,14 @@ class DossierReadinessPacketTests(unittest.TestCase):
         self.assertEqual(blind["suggestedConfirmationQuestion"], "Can an owner/admin provide public-safe replacement wording for this context, or should BNL keep it internal?")
         self.assertIn("public-safe replacement wording", blind["suggestedConfirmationAnswerType"])
         self.assertNotIn("secret room", blind["suggestedConfirmationQuestion"].lower())
+
+        for _name, card, _expected, _answer_type in cases:
+            self.assertEqual(card["decisionState"], "needs_clarification")
+            self.assertFalse(card["publicSafe"])
+            self.assertFalse(card["hasSafePublicSuggestion"])
+            self.assertEqual(card["primaryActionLabel"], "Add clarification question")
+            self.assertNotIn("Confirm exact public-safe wording before use", json.dumps(card))
+            self.assertNotIn("approve_public", json.dumps(card))
 
         fallback = _review_guidance("Crow", "unclassified possible claim", "missing_confirmation", "needs_confirmation", False)
         self.assertEqual(fallback["suggestedMissingInfoQuestion"], generic)


### PR DESCRIPTION
### Motivation

- Some review cards ask clear questions that reveal the card lacks the context needed to decide, so admins were being prompted to approve/reject items that are not yet scoping decisions. 
- The intent is to add a universal insufficient-context classification so BNL marks those cards as clarification-only and does not present them as normal public-fact approval items.

### Description

- Added clarification detection and copy by introducing `_is_clarification_follow_up(...)` and `_clarification_copy(...)`, and by returning clarification-oriented review display copy when a follow-up is scope-seeking and `scopeKnown` is false.
- Converted unknown-scope follow-up `answerType`s (AI/persona/project, contest/event, rules/instructions, theory/anomaly, lore/context, unknown/fallback) to clarification variants when `scopeKnown` is false so questions ask "what/which/who is this referring to?" rather than requesting public wording.
- Introduced `decisionState: "needs_clarification"`, `actionability: "needs_clarification"`, `publicSafe: false`, `hasSafePublicSuggestion: false`, and suppressed suggested public wording for clarification cards; preserved `source_blind_blocked` behavior for source-blind items.
- Updated reviewable-claim construction (`_make_reviewable_claim`) and review guidance (`_review_guidance`/`_review_display_copy`) so known-scope/public-safe items remain `decidable`, source-blind items remain `source_blind_blocked`, and clarification cards present only clarification actions (`Add clarification question`, `Keep as internal note`, `Reject / not useful`).
- Fed clarification questions into the dossier readiness packet as high-priority clarification blockers via an extended `_build_dossier_readiness` `add` signature so readiness explicitly notes "Clarification needed before BNL can draft this part of the dossier."
- Suppressed extremely vague generated claims by skipping human-visible review claims when a clarification card cannot produce a meaningful scope-seeking question, and updated tests to cover these behaviors.

### Testing

- Ran byte-compile check: `python3 -m py_compile bnl_source_file_enrichment.py bnl_dossier_draft.py bnl01_bot.py bnl_subject_memory_resolver.py`, which succeeded.
- Ran resolver and generator unit tests: `python3 -m pytest tests/test_subject_memory_resolver.py -q` and `python3 -m pytest tests/test_dossier_draft_generator.py -q`, and source-file tests: `python3 -m pytest tests/test_source_file_enrichment.py tests/test_source_file_archive.py tests/test_source_file_refresh.py -q`; all test collections completed successfully (final run: 140 passed, 5 warnings).
- Updated `tests/test_subject_memory_resolver.py` to assert clarification card behavior for unknown-scope AI/persona/project, contest/event, rules/instructions, lore/context, and theory/anomaly scenarios.

Commit SHA: `0bac08130f0a23d514effcab083d06216b527c49`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a325e47eba48321ad158459d20db475)