### PR TITLE
Emit Source File classification profile v1

### DIFF
--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -805,8 +805,28 @@ def _tag_candidates(category: str, kind: str, lane: str, facts: list[str], notes
     for needles, tag in mapping:
         if any(needle in haystack for needle in needles) and tag not in candidates:
             candidates.append(tag)
+    source_classification = _dict(packet.get("sourceFileClassificationV1"))
+    blocked_classification_tags = {
+        tag.lower().replace(" ", "-")
+        for tag in _strings(source_classification.get("internalTags"), limit_each=80, max_items=20)
+        + _strings(source_classification.get("rejectedTagCandidates"), limit_each=80, max_items=20)
+        + _strings(source_classification.get("doNotPubliclyTagAs"), limit_each=80, max_items=20)
+    }
+    blocked_classification_tags.update(
+        _text(item.get("tag"), 80).lower().replace(" ", "-")
+        for item in _as_list(source_classification.get("blockedPublicTags"))
+        if isinstance(item, dict)
+    )
     for tag in _strings(packet.get("proposedTags"), limit_each=60, max_items=10):
         normalized = tag.lower().replace(" ", "-")
+        if normalized in blocked_classification_tags:
+            continue
+        if not _unsafe_reasons(normalized) and normalized not in candidates:
+            candidates.append(normalized)
+    for tag in _strings(source_classification.get("publicSafeTagCandidates"), limit_each=60, max_items=10):
+        normalized = tag.lower().replace(" ", "-")
+        if normalized in blocked_classification_tags:
+            continue
         if not _unsafe_reasons(normalized) and normalized not in candidates:
             candidates.append(normalized)
     return candidates

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -243,6 +243,56 @@ TOPIC_LABELS = {
     "unknown/no clear theme": "Unknown/no clear theme",
 }
 
+_CANONICAL_TAGS = {
+    "artist", "producer", "broadcaster", "moderator", "community-member",
+    "project", "collective", "event", "platform", "lore-entity",
+    "ai-persona", "music", "visual-art", "discord", "barcode-radio",
+    "queue", "contest", "collaboration", "internal-only", "source-blind",
+    "needs-public-proof", "owner-approved-wording-needed",
+    "identity-unconfirmed", "role-unconfirmed",
+}
+_PUBLIC_SAFE_ROLE_TAGS = {"artist", "producer", "broadcaster", "project", "collective", "event", "platform", "lore-entity", "ai-persona", "music", "visual-art", "discord", "barcode-radio", "contest", "collaboration"}
+_INTERNAL_ONLY_ROLE_TAGS = {"moderator", "community-member", "queue", "internal-only", "source-blind"}
+_CLASSIFICATION_SAFETY_RE = re.compile(r"\b(?:stripe|checkout|payment|paid|purchase|customer|cus_[A-Za-z0-9_]+|acct_[A-Za-z0-9_]+|token|secret|api[_-]?key|authorization|bearer|password|discord\s*id|user\s*id|\d{15,22}|[\w.+-]+@[\w.-]+\.[A-Za-z]{2,})\b", re.I)
+
+
+def _canon_tag(value: Any) -> str:
+    tag = re.sub(r"[^a-z0-9]+", "-", str(value or "").lower()).strip("-")
+    aliases = {"community": "community-member", "member": "community-member", "mod": "moderator", "radio": "barcode-radio", "broadcast": "barcode-radio", "lore": "lore-entity", "persona": "ai-persona", "submission": "queue"}
+    return aliases.get(tag, tag)
+
+
+def _class_safe_text(value: Any, limit: int = 220) -> str:
+    text = _safe_text(value, limit)
+    text = _EMAIL_RE.sub("[email redacted]", text)
+    text = _LONG_ID_RE.sub("[id redacted]", text)
+    text = re.sub(r"\b(?:cus|acct|pi|pm|sub|cs)_[A-Za-z0-9_]+\b", "[account redacted]", text)
+    text = re.sub(r"\b(?:token|secret|api[_-]?key|authorization|bearer|password)\b\s*[:=]?\s*\S+", "[secret redacted]", text, flags=re.I)
+    text = re.sub(r"\b(?:stripe|checkout|payment|paid|purchase|customer)\b", "private account", text, flags=re.I)
+    return _safe_text(text, limit)
+
+
+def _add_unique(items: list[str], value: Any) -> None:
+    tag = _canon_tag(value)
+    if tag in _CANONICAL_TAGS and tag not in items:
+        items.append(tag)
+
+
+def _classification_summary_for_analyst(classification: dict[str, Any]) -> dict[str, Any]:
+    if not classification:
+        return {}
+    return {
+        "version": classification.get("version") or "1.0",
+        "subjectType": classification.get("subjectType") or "unknown",
+        "publicDossierType": classification.get("publicDossierType") or "unknown",
+        "confidence": classification.get("confidence") or "low",
+        "publicSafeTagCandidates": list(classification.get("publicSafeTagCandidates") or [])[:8],
+        "needsReviewTagCandidates": list(classification.get("needsReviewTagCandidates") or [])[:8],
+        "routingTags": list(classification.get("routingTags") or [])[:8],
+        "sourceSafety": classification.get("sourceSafety") or "insufficient",
+        "classificationBlockedBy": list(classification.get("classificationBlockedBy") or [])[:6],
+    }
+
 _TOPIC_KEYWORDS = {
     "music submissions": ("submit", "submission", "song", "track", "beat", "demo", "queue"),
     "production": ("mix", "master", "produce", "producer", "fl studio", "ableton", "sample", "vocal"),
@@ -470,6 +520,168 @@ def classify_entity_activity(subject_identity: dict[str, Any] | None, evidence_b
         "engagementRead": _classification_plain_list(engagement_use, ENGAGEMENT_LABELS),
         "dossierRead": _format_dossier_read(dossier_use, primary_role),
         "relationshipRead": RELATIONSHIP_LABELS.get(relationship_use, relationship_use),
+    }
+
+
+def build_source_file_classification_v1(subject_identity: dict[str, Any] | None, evidence_bundle: dict[str, Any] | None, analyst_read: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Emit durable Source File classification/tag profile for site consumption.
+
+    The profile is admin/review metadata. It separates public-safe tag candidates
+    from internal-only/rejected/needs-review candidates and never promotes private
+    or source-blind evidence into public facts.
+    """
+
+    identity = subject_identity or {}
+    bundle = evidence_bundle or {}
+    legacy = bundle.get("classification") if isinstance(bundle.get("classification"), dict) else classify_entity_activity(identity, bundle)
+    sections = bundle.get("sections") if isinstance(bundle.get("sections"), dict) else {}
+    source_file = bundle.get("sourceFile") if isinstance(bundle.get("sourceFile"), dict) else {}
+    resolution = normalize_source_file_resolution_context(bundle if isinstance(bundle, dict) else {})
+    texts: list[str] = []
+    for key in ("candidateType", "sourceType", "type", "kind", "recommendedCategory", "knownFacts", "facts", "evidenceSummary", "summary", "publicSafetyNotes"):
+        if source_file.get(key) not in (None, "", [], {}):
+            texts.append(str(source_file.get(key)))
+    for key in ("Public-Safe Notes", "Known Facts", "History With BARCODE / BNL / Discord / BARCODE Radio", "Why This Subject Matters", "Do Not Say", "Missing Info"):
+        texts.extend(str(x) for x in (sections.get(key) or [])[:8])
+    if analyst_read:
+        for key in ("publicSafeClaims", "draftIngredients", "reviewNeededClaims", "sourceBlindInsights", "doNotSayPublicly", "strongestSignals"):
+            texts.extend(str(x) for x in (analyst_read.get(key) or [])[:5])
+    texts.extend(str(x) for x in bundle.get("publicSafeCandidates") or [])
+    texts.extend(str(x) for x in resolution.get("sourceFileResolvedFacts") or [])
+    hay = " ".join(texts).lower()
+
+    internal_tags: list[str] = []
+    public_tags: list[str] = []
+    needs_review: list[str] = []
+    rejected: list[str] = []
+    routing: list[str] = []
+    reasons: list[str] = []
+    evidence_signals: list[str] = []
+    blocked_public: list[dict[str, str]] = []
+    blocked_by: list[str] = []
+
+    def signal(text: str) -> None:
+        clean = _class_safe_text(text, 180)
+        if clean and not _CLASSIFICATION_SAFETY_RE.search(clean) and clean not in evidence_signals:
+            evidence_signals.append(clean)
+
+    def block(tag: str, reason: str) -> None:
+        tag = _canon_tag(tag)
+        if tag in _CANONICAL_TAGS:
+            if tag not in rejected:
+                rejected.append(tag)
+            if tag not in blocked_by:
+                blocked_by.append(tag)
+            rec = {"tag": tag, "reason": _class_safe_text(reason, 160)}
+            if rec not in blocked_public:
+                blocked_public.append(rec)
+
+    role_map = [
+        ("artist", r"\b(artist|musician|rapper|singer|dj|performer)\b"),
+        ("producer", r"\b(producer|production|produces|mix(?:es|ing)?|master(?:s|ing)?)\b"),
+        ("broadcaster", r"\b(broadcaster|host|show|episode|broadcast|barcode radio|radio)\b"),
+        ("moderator", r"\b(moderator|mod\b|staff role|admin role|team role)\b"),
+        ("community-member", r"\b(community member|community subject|participant|recurring community|discord community)\b"),
+        ("project", r"\b(project|collective|release|label)\b"),
+        ("event", r"\b(event|contest|challenge|tournament|showcase)\b"),
+        ("platform", r"\b(platform|discord|youtube|twitch|site)\b"),
+        ("lore-entity", r"\b(lore|entity|canon|character|persona|orion|null tv)\b"),
+        ("ai-persona", r"\b(ai persona|persona|bot persona)\b"),
+        ("music", r"\b(music|song|track|album|beat)\b"),
+        ("visual-art", r"\b(visual art|image|illustration|artwork)\b"),
+        ("discord", r"\b(discord|server|channel)\b"),
+        ("barcode-radio", r"\b(barcode radio|radio|broadcast)\b"),
+        ("queue", r"\b(queue|submission|submitted|submitter)\b"),
+        ("contest", r"\b(contest|challenge|competition|tournament)\b"),
+        ("collaboration", r"\b(collaboration|collaborator|featured|worked with)\b"),
+    ]
+    observed: list[str] = []
+    for tag, pattern in role_map:
+        if re.search(pattern, hay, re.I):
+            _add_unique(observed, tag)
+            signal(f"{tag.replace('-', ' ')} signal present in sanitized Source File context.")
+    for role in [legacy.get("primaryRole"), *(legacy.get("secondaryRoles") or [])]:
+        mapped = {"active_community_member": "community-member", "barcode_entity": "lore-entity", "submitter": "queue", "barcode_team": "internal-only"}.get(str(role), str(role))
+        _add_unique(observed, mapped)
+
+    public_hay = " ".join([*(sections.get("Public-Safe Notes") or []), *(bundle.get("publicSafeCandidates") or []), *(resolution.get("sourceFileResolvedFacts") or []), *((analyst_read or {}).get("publicSafeClaims") or []), *((analyst_read or {}).get("draftIngredients") or [])]).lower()
+    public_ok = bool(public_hay) and not re.search(r"\b(source[-_ ]blind|internal only|keep internal|not public|unconfirmed|needs confirmation|private)\b", public_hay, re.I)
+    has_source_blind = bool(re.search(r"\bsource[-_ ]blind\b", hay, re.I) or bundle.get("warningCounts", {}).get("source_blind_memory"))
+    if has_source_blind:
+        _add_unique(internal_tags, "source-blind"); _add_unique(routing, "source-blind")
+    if re.search(r"\b(queue|submission|submitted|moderator|staff role|team role|member status|confirmed_internal|internal only|keep internal)\b", hay, re.I):
+        _add_unique(internal_tags, "internal-only")
+
+    for key, tag in (("role_title", "role-unconfirmed"), ("identity_name", "identity-unconfirmed"), ("relationship_affiliation", "collaboration")):
+        if key in resolution.get("resolvedQuestionCategories", set()) and key not in resolution.get("publicSafeApprovedQuestionKeys", set()):
+            _add_unique(routing, tag)
+    for rec in resolution.get("resolvedByQuestionKey", {}).values():
+        decision = str(rec.get("decision") or "")
+        cat = str(rec.get("questionCategory") or "")
+        tag = "role-unconfirmed" if "role" in cat else "identity-unconfirmed" if "identity" in cat else "needs-public-proof"
+        if decision in {"rejected", "do_not_say", "boundary", "not_public", "unsafe_public"}:
+            block(tag, f"Workflow resolution marked {cat or 'claim'} as {decision}.")
+        elif decision in {"confirmed_internal", "internal", "internal_only", "keep_internal"}:
+            _add_unique(internal_tags, tag); block(tag, f"Workflow resolution keeps {cat or 'claim'} internal.")
+
+    for tag in observed:
+        if tag in _INTERNAL_ONLY_ROLE_TAGS:
+            _add_unique(internal_tags, tag)
+            if tag in {"moderator", "community-member", "queue"}:
+                block(tag, "Internal/admin context only unless public-safe evidence or owner-approved wording exists.")
+            continue
+        if tag in _PUBLIC_SAFE_ROLE_TAGS and public_ok and tag not in rejected:
+            _add_unique(public_tags, tag)
+        else:
+            _add_unique(needs_review, tag)
+            _add_unique(routing, "needs-public-proof")
+    if not public_tags and observed:
+        _add_unique(routing, "owner-approved-wording-needed")
+    if not observed:
+        _add_unique(routing, "needs-public-proof")
+        reasons.append("No durable public-safe role/category signal was available; classification remains unknown.")
+
+    primary_tags = public_tags[:6] or [t for t in observed if t not in rejected][:3]
+    secondary_tags = [t for t in observed if t not in primary_tags and t not in rejected][:8]
+    subject_type = "unknown"
+    for tag, st in (("artist", "artist"), ("producer", "producer"), ("broadcaster", "broadcaster"), ("moderator", "moderator"), ("community-member", "community_member"), ("project", "project"), ("event", "event"), ("platform", "platform"), ("lore-entity", "lore_entity")):
+        if tag in primary_tags or tag in public_tags or tag in internal_tags:
+            subject_type = st; break
+    public_type = "unknown"
+    if subject_type in {"artist", "producer", "broadcaster", "moderator", "community_member"}:
+        public_type = "person"
+    elif subject_type in {"project", "event", "platform"}:
+        public_type = subject_type
+    elif "collective" in public_tags:
+        public_type = "collective"
+    if internal_tags and not public_tags and not public_ok:
+        public_type = "internal_only"
+    source_safety = "public_safe" if public_tags and not internal_tags and not has_source_blind else "source_blind" if has_source_blind and not public_tags else "mixed" if public_tags and internal_tags else "internal_only" if internal_tags else "insufficient"
+    confidence = "high" if public_tags and public_ok and not needs_review and not blocked_public else "medium" if public_tags or (observed and not has_source_blind) else "low"
+    if public_ok:
+        reasons.append("Public-safe or owner-approved context supports the public tag candidates.")
+    if internal_tags:
+        reasons.append("Internal/admin-only signals were separated from public tag candidates.")
+    if blocked_public:
+        reasons.append("Workflow boundaries blocked corresponding public tags.")
+    return {
+        "version": "1.0",
+        "subjectType": subject_type,
+        "publicDossierType": public_type,
+        "confidence": confidence,
+        "primaryTags": primary_tags[:8],
+        "secondaryTags": secondary_tags[:8],
+        "internalTags": internal_tags[:10],
+        "doNotPubliclyTagAs": rejected[:10],
+        "routingTags": routing[:10],
+        "evidenceSignals": evidence_signals[:8],
+        "publicSafeTagCandidates": public_tags[:10],
+        "needsReviewTagCandidates": needs_review[:10],
+        "rejectedTagCandidates": rejected[:10],
+        "classificationReasons": reasons[:8],
+        "blockedPublicTags": blocked_public[:10],
+        "sourceSafety": source_safety,
+        "classificationBlockedBy": blocked_by[:10],
     }
 
 
@@ -1642,6 +1854,8 @@ def collect_source_enrichment_evidence(db_path: str, guild_id: int | None, subje
         "sourceCounts": dict(source_counts),
         "diagnostics": diagnostics,
         "sourceFile": sf_obj if lookup_result else {},
+        "sourceFileWorkflowContext": (sf_obj.get("sourceFileWorkflowContext") or sf_obj.get("workflowContext") or {}) if isinstance(sf_obj, dict) else {},
+        "resolvedQuestions": (sf_obj.get("resolvedQuestions") or sf_obj.get("sourceFileQuestionResolutions") or []) if isinstance(sf_obj, dict) else [],
         "matchKind": match_kind,
         "publicSafeCandidates": public_safe_candidates[:5],
         "channelActivity": {
@@ -1656,6 +1870,9 @@ def collect_source_enrichment_evidence(db_path: str, guild_id: int | None, subje
         },
     }
     classification = classify_entity_activity(safe_identity, classification_bundle)
+    classification_bundle["classification"] = classification
+    classification_bundle["warningCounts"] = dict(warning_counts)
+    source_file_classification = build_source_file_classification_v1(safe_identity, classification_bundle)
     diagnostics.update({
         "classificationPrimaryRole": classification["primaryRole"],
         "classificationActivityLevel": classification["activityLevel"],
@@ -1674,6 +1891,7 @@ def collect_source_enrichment_evidence(db_path: str, guild_id: int | None, subje
         "subjectIdentity": safe_identity,
         "diagnostics": diagnostics,
         "classification": classification,
+        "sourceFileClassificationV1": source_file_classification,
         "knownContext": list(entity_summary.get("knownContext") or [])[:6] if raw_provenance else [],
         "usefulEvidence": list(entity_summary.get("usefulEvidence") or [])[:6] if raw_provenance else [],
         "relationshipSignals": list(entity_summary.get("relationshipSignals") or [])[:4] if raw_provenance else [],
@@ -4917,6 +5135,9 @@ def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[s
     subject_memory_packet = build_subject_memory_packet_v1(packet)
     case_report = build_source_file_case_report_v1(subject_memory_packet)
     subject_analyst_read = build_source_file_subject_analyst_read_v1(packet, (environ or {}).get("BNL_DB_PATH") or packet.get("dbPath") or "")
+    source_file_classification = packet.get("sourceFileClassificationV1") if isinstance(packet.get("sourceFileClassificationV1"), dict) else {}
+    if subject_analyst_read and source_file_classification:
+        subject_analyst_read["sourceFileClassificationSummaryV1"] = _classification_summary_for_analyst(source_file_classification)
     if subject_analyst_read:
         case_report["subjectAnalystReadV1"] = subject_analyst_read
         if subject_analyst_read.get("internalRead"):
@@ -4940,6 +5161,7 @@ def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[s
         "evidenceReceiptSummary": _sanitize_archive_value(receipt),
         "sourceFileBriefV2": _sanitize_archive_value(build_source_file_brief_v2(packet, archive_id=packet.get("archiveId") or "")),
         "subjectAnalystReadV1": subject_analyst_read,
+        "sourceFileClassificationV1": _sanitize_archive_value(source_file_classification),
         "subjectMemoryPacketV1": subject_memory_packet,
         "sourceFileCaseReportV1": case_report,
         "adminSummary": admin_summary,
@@ -4979,6 +5201,7 @@ def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: 
         "sourceCoverage": list(packet.get("sourceCoverage") or []),
         "identityDiagnostics": dict(packet.get("diagnostics") or {}),
         "internalClassification": dict(packet.get("classification") or {}),
+        "sourceFileClassificationV1": dict(packet.get("sourceFileClassificationV1") or {}),
         "knownContext": list(packet.get("knownContext") or []),
         "usefulEvidence": list(packet.get("usefulEvidence") or packet.get("evidenceDetails") or []),
         "relationshipSignals": list(packet.get("relationshipSignals") or []),
@@ -5172,6 +5395,7 @@ def run_source_file_enrichment(
         "subjectIdentity": evidence.get("subjectIdentity") or {},
         "diagnostics": evidence.get("diagnostics") or {},
         "classification": evidence.get("classification") or {},
+        "sourceFileClassificationV1": evidence.get("sourceFileClassificationV1") or {},
         "sourceTypesChecked": (evidence.get("diagnostics") or {}).get("sourceTypesChecked", {}),
         "sourceTypesSkipped": (evidence.get("diagnostics") or {}).get("sourceTypesSkipped", {}),
         "runTime": datetime.now(timezone.utc).isoformat(),
@@ -5181,6 +5405,8 @@ def run_source_file_enrichment(
         "resolvedSubjectMemoryV1": resolved_subject_memory,
         "subjectAnalystReadV1": subject_analyst_read,
     }
+    if packet["sourceFileClassificationV1"] and packet["subjectAnalystReadV1"]:
+        packet["subjectAnalystReadV1"]["sourceFileClassificationSummaryV1"] = _classification_summary_for_analyst(packet["sourceFileClassificationV1"])
     _copy_evidence_fields(packet, evidence)
     packet["subjectIntelligenceDiagnostics"] = evidence.get("subjectIntelligenceDiagnostics") or {}
     packet["linkSignalDiagnostics"] = evidence.get("linkSignalDiagnostics") or {}

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -105,6 +105,26 @@ class DossierDraftGeneratorTests(unittest.TestCase):
         self.assertEqual(result["origin"], "UNVERIFIED")
         self.assertEqual(result["identityAuthority"], "mixed_or_unclear")
 
+    def test_source_file_classification_internal_and_rejected_tags_not_public_tags(self):
+        packet = pr217_packet(
+            publicSafeFacts=["Signal Fox is a public-safe music project."],
+            proposedTags=["moderator", "queue", "artist"],
+            sourceFileClassificationV1={
+                "version": "1.0",
+                "publicSafeTagCandidates": ["artist", "music"],
+                "internalTags": ["moderator", "queue"],
+                "rejectedTagCandidates": ["contest"],
+                "doNotPubliclyTagAs": ["moderator", "queue", "contest"],
+                "blockedPublicTags": [{"tag": "moderator", "reason": "internal only"}],
+            },
+        )
+        result = draft.generate_dossier_draft(packet)["draft"]
+        public_tags = set(result["tags"]) | set(result["proposedTags"])
+        self.assertNotIn("moderator", public_tags)
+        self.assertNotIn("queue", public_tags)
+        self.assertNotIn("contest", public_tags)
+        self.assertIn("artist", public_tags)
+
     def test_final_status_metadata_does_not_leak_and_returns_pending(self):
         packet = pr217_packet(
             candidate={

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -1240,6 +1240,86 @@ class SourceFileEntityIntelligenceIntegrationTests(unittest.TestCase):
         self.assertIsInstance(archive.get("sourceFileCaseReportV1"), dict)
         self.assertEqual(archive["subjectMemoryPacketV1"].get("subjectName"), "Signal Fox")
 
+    def test_source_file_classification_v1_separates_public_internal_and_rejected_tags(self):
+        packet = {
+            "sections": {
+                "Public-Safe Notes": ["Public-safe wording says Signal Fox is a music artist and producer."],
+                "Known Facts": ["Internal queue submission and moderator status are admin-only context."],
+            },
+            "sourceFile": {"name": "Signal Fox", "candidateType": "person"},
+            "sourceCounts": {"source_file_lookup": 1},
+            "warningCounts": {},
+            "publicSafeCandidates": ["Signal Fox is a public-safe music artist."],
+            "classification": {"primaryRole": "artist", "secondaryRoles": ["moderator", "submitter"], "sourceConfidence": "medium"},
+            "sourceFileWorkflowContext": {
+                "resolvedQuestions": [
+                    {"questionKey": "bnlq_role_title_moderator", "questionCategory": "role_title", "decision": "confirmed_internal", "claimText": "Moderator role is internal only.", "useInPublicDossier": False},
+                    {"questionKey": "bnlq_role_title_contest", "questionCategory": "role_title", "decision": "rejected", "claimText": "Contest organizer rejected.", "publicSafe": False},
+                ]
+            },
+        }
+        profile = enrich.build_source_file_classification_v1({}, packet)
+        self.assertEqual(profile["version"], "1.0")
+        self.assertEqual(profile["subjectType"], "artist")
+        self.assertIn("artist", profile["publicSafeTagCandidates"])
+        self.assertIn("producer", profile["publicSafeTagCandidates"])
+        self.assertIn("moderator", profile["internalTags"])
+        self.assertIn("queue", profile["internalTags"])
+        self.assertIn("moderator", profile["doNotPubliclyTagAs"])
+        self.assertTrue(profile["blockedPublicTags"])
+        self.assertNotIn("moderator", profile["publicSafeTagCandidates"])
+        self.assertNotRegex(json.dumps(profile).lower(), r"stripe|cus_123|token|123456789012345678|@")
+
+    def test_source_file_classification_v1_low_confidence_unknown_and_source_blind(self):
+        profile = enrich.build_source_file_classification_v1({}, {
+            "sections": {"Known Facts": ["Source-blind memory mentions a possible role but no public proof."]},
+            "warningCounts": {"source_blind_memory": 1},
+            "classification": {"primaryRole": "unknown", "secondaryRoles": [], "sourceConfidence": "low"},
+        })
+        self.assertEqual(profile["subjectType"], "unknown")
+        self.assertEqual(profile["confidence"], "low")
+        self.assertIn("source-blind", profile["internalTags"])
+        self.assertIn(profile["sourceSafety"], {"source_blind", "mixed"})
+        self.assertEqual(profile["publicSafeTagCandidates"], [])
+
+    def test_source_file_classification_v1_project_event_platform_and_crow_lore_routing(self):
+        profile = enrich.build_source_file_classification_v1({}, {
+            "sections": {"Public-Safe Notes": ["Public-safe context describes a Discord platform project, contest event, lore entity, and BARCODE Radio music collaboration."]},
+            "publicSafeCandidates": ["Owner-approved public wording exists for the project/event/platform context."],
+            "classification": {"primaryRole": "barcode_entity", "secondaryRoles": [], "sourceConfidence": "medium"},
+        })
+        for tag in ("project", "event", "platform", "lore-entity", "discord", "barcode-radio", "music", "collaboration"):
+            self.assertIn(tag, profile["publicSafeTagCandidates"])
+        self.assertTrue(all("source-blind" not in item.lower() for item in profile["evidenceSignals"]))
+
+    def test_source_file_archive_payload_includes_classification_and_compact_analyst_summary(self):
+        packet = {
+            "subject": "Crow",
+            "sourceFile": {"name": "Crow", "candidateId": "sf_crow"},
+            "sections": {"Public-Safe Notes": ["Crow is a public-safe BARCODE community subject."]},
+            "sourceCounts": {"conversations": 1},
+            "sourceTypes": ["conversations"],
+            "warningCounts": {},
+            "warnings": [],
+            "qualityScore": 88,
+            "qualityStatus": "sendable",
+            "matchKind": "exact",
+            "runTime": "2026-06-10T00:00:00+00:00",
+            "sourceFileClassificationV1": {
+                "version": "1.0", "subjectType": "community_member", "publicDossierType": "internal_only", "confidence": "low",
+                "primaryTags": ["community-member"], "secondaryTags": [], "internalTags": ["community-member"], "doNotPubliclyTagAs": ["community-member"],
+                "routingTags": ["needs-public-proof"], "evidenceSignals": ["Community signal present."], "publicSafeTagCandidates": [],
+                "needsReviewTagCandidates": ["community-member"], "rejectedTagCandidates": [], "classificationReasons": ["Separated internal context."],
+                "blockedPublicTags": [], "sourceSafety": "internal_only", "classificationBlockedBy": [],
+            },
+            "subjectAnalystReadV1": {"subjectName": "Crow", "internalRead": "Crow appears in community context.", "publicSafeClaims": [], "reviewNeededClaims": []},
+        }
+        archive = enrich.build_source_file_archive_payload(packet)
+        self.assertIn("sourceFileClassificationV1", archive)
+        summary = archive["subjectAnalystReadV1"]["sourceFileClassificationSummaryV1"]
+        self.assertLessEqual(len(json.dumps(summary)), 900)
+        self.assertNotIn("internalTags", summary)
+
     def test_source_file_archive_payload_includes_subject_analyst_read(self):
         packet = {
             "subject": "Crow",


### PR DESCRIPTION
### Motivation
- Provide a durable, canonical Source File classification and tag profile that the site can consume so classification/tag intelligence becomes a stable BNL output instead of ephemeral Crow-style heuristics. 
- Ensure public-safe tags are separated from internal/admin-only and rejected signals and that classification respects Source File workflow resolutions and does not leak private evidence.

### Description
- Added a canonical `sourceFileClassificationV1` generator (`build_source_file_classification_v1`) and helper utilities to `bnl_source_file_enrichment.py`, and included `sourceFileClassificationV1` in enrichment run results, archive payloads, and compact recommendation payloads. Changed files: `bnl_source_file_enrichment.py`, `bnl_dossier_draft.py`, `tests/test_source_file_enrichment.py`, and `tests/test_dossier_draft_generator.py`.
- The emitted profile follows the v1 shape including at least: `version`, `subjectType`, `publicDossierType`, `confidence`, `primaryTags`, `secondaryTags`, `internalTags`, `doNotPubliclyTagAs`, `routingTags`, `evidenceSignals`, `publicSafeTagCandidates`, `needsReviewTagCandidates`, `rejectedTagCandidates`, `classificationReasons`, `blockedPublicTags`, `sourceSafety`, and `classificationBlockedBy` (compact/administrative-safe values only). 
- Introduced a normalized tag vocabulary (examples: `artist`, `producer`, `broadcaster`, `moderator`, `community-member`, `project`, `collective`, `event`, `platform`, `lore-entity`, `ai-persona`, `music`, `visual-art`, `discord`, `barcode-radio`, `queue`, `contest`, `collaboration`, `internal-only`, `source-blind`, `needs-public-proof`, `owner-approved-wording-needed`, `identity-unconfirmed`, `role-unconfirmed`) and redaction/safety heuristics to avoid leaking emails, raw IDs, tokens, payment/customer strings, and other private evidence.
- Integrated workflow/context rules so confirmed_internal/rejected/boundary decisions and source-blind evidence are treated as internal or blocked for public tagging, and updated dossier draft tag selection to skip `internalTags`, `rejectedTagCandidates`, `doNotPubliclyTagAs`, and `blockedPublicTags` from the classification profile while allowing `publicSafeTagCandidates` to be considered.

### Testing
- Compiled modified modules with `python3 -m py_compile bnl_source_file_enrichment.py bnl_dossier_draft.py bnl01_bot.py bnl_subject_memory_resolver.py` and the compile step succeeded without syntax errors. 
- Ran unit tests: `pytest tests/test_subject_memory_resolver.py`, `pytest tests/test_dossier_draft_generator.py`, and `pytest tests/test_source_file_enrichment.py tests/test_source_file_archive.py tests/test_source_file_refresh.py`, and all suites passed (total tests covering changes: new/updated classification tests plus existing tests), with final result showing all tests green. 
- Added/updated tests that verify: public-safe vs internal/rejected tag separation, low-confidence/source-blind handling, project/event/platform/lore routing signals, inclusion of `sourceFileClassificationV1` in archive payloads, compact analyst summary mirroring, and that dossier draft generation never promotes internal/rejected classification tags into public tags.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33be912610832190277a5d3db19249)