### PR TITLE
Make Source Files memory-first dossier readouts

### DIFF
--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -944,10 +944,22 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
         for item in _strings(analyst.get("missingInfoQuestions"), max_items=5):
             if item not in missing:
                 missing.append(item)
+        if analyst.get("readyForDraft") is True:
+            blocked_sections = {str(x).lower() for x in _strings(analyst.get("dossierBlockedBy"), max_items=5)}
+            if blocked_sections:
+                missing = [
+                    item for item in missing
+                    if any(section in item.lower() for section in blocked_sections)
+                ][:3]
+            else:
+                missing = [
+                    item for item in missing
+                    if not re.search(r"\b(orion|lore|source[-_ ]blind|internal)\b", item, re.I)
+                ][:5]
     if thin:
         missing.insert(0, "Add more public-safe facts before this draft is treated as rich dossier copy.")
     if _dict(packet.get("identityAliasStatus")).get("needsConfirmation") is not False:
-        missing.append("Confirm what identity authority, if any, may be stated publicly.")
+        missing.append("Confirm preferred public display name and what identity authority, if any, may be stated publicly.")
 
     owner_warnings = _strings(packet.get("ownerReviewRules"), max_items=8) + _strings(packet.get("reviewOnlyWarnings"), max_items=8)
     owner_warnings.append("Owner Review must approve identity, role, category, links, and public wording before publication.")

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -2973,6 +2973,7 @@ def build_source_file_brief_v2(packet: dict[str, Any], *, archive_id: str | None
     """Build a compact, human-readable admin brief for the full Source File archive."""
 
     source_file = packet.get("sourceFile") if isinstance(packet.get("sourceFile"), dict) else {}
+    analyst = packet.get("subjectAnalystReadV1") if isinstance(packet.get("subjectAnalystReadV1"), dict) else {}
     sections = packet.get("sections") if isinstance(packet.get("sections"), dict) else {}
     subject_name = _brief_text(packet.get("subject") or _first(source_file, ("name", "sourceFileName", "subject", "displayName", "title", "normalizedName")) or "Unknown subject", 140)
     subject_key = _subject_key(subject_name or _first(source_file, ("normalizedName", "subjectKey", "slug")))
@@ -3010,15 +3011,29 @@ def build_source_file_brief_v2(packet: dict[str, Any], *, archive_id: str | None
         max_items=BRIEF_V2_LIST_MAX_ITEMS,
         limit=220,
     )
-    if public_notes:
+    if analyst.get("readyForDraft") is True:
+        action = _brief_text(analyst.get("draftReadinessReason") or "BNL can prepare a cautious Proposed Dossier from public-safe claims and omit unresolved/internal details.", 220)
+    elif analyst.get("dossierBlockedBy"):
+        action = _brief_text(analyst.get("draftReadinessReason") or "Resolve the true draft blocker(s) before drafting.", 220)
+    elif public_notes:
         action = "Review public-safe notes and decide whether a short Proposed Dossier is justified."
     elif packet.get("qualityStatus") in {"too_thin", "forced_low_confidence"}:
         action = "Keep as Source File only; not ready for Proposed Dossier."
     else:
         action = "Review Identity Check before drafting."
-    one_line = _brief_text(f"{subject_name} is a Source File subject in the {match_kind} lane with {len(evidence_items)} concise evidence item{'s' if len(evidence_items) != 1 else ''} ready for admin review.", 220)
+    worthiness = analyst.get("dossierWorthiness")
+    one_line = _brief_text(
+        analyst.get("currentRead")
+        or f"{subject_name} is a Source File subject in the {match_kind} lane with {len(evidence_items)} concise evidence item{'s' if len(evidence_items) != 1 else ''} ready for admin review.",
+        220,
+    )
     admin_summary = _brief_text(
-        f"BNL has a review-only Source File for {subject_name}. The packet preserves the underlying evidence, while this brief pulls out the useful admin read: what appears supported, what may be safe to draft from, and what still needs human review. Treat this as internal guidance, not a public claim or identity decision.",
+        (
+            f"BNL memory-first read: {worthiness}. {analyst.get('internalRead')} "
+            f"{analyst.get('dossierReadinessSummary')}"
+            if analyst
+            else f"BNL has a review-only Source File for {subject_name}. The packet preserves the underlying evidence, while this brief pulls out the useful admin read: what appears supported, what may be safe to draft from, and what still needs human review. Treat this as internal guidance, not a public claim or identity decision."
+        ),
         900,
     )
     archive_refs = {
@@ -4969,6 +4984,8 @@ def build_source_file_case_report_v1(subject_memory_packet: dict[str, Any]) -> d
 _SUBJECT_ANALYST_READ_KEYS = (
     "subjectName",
     "internalRead",
+    "currentRead",
+    "dossierWorthiness",
     "likelySubjectType",
     "confidence",
     "publicDraftPosture",
@@ -5142,11 +5159,20 @@ def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[s
         case_report["subjectAnalystReadV1"] = subject_analyst_read
         if subject_analyst_read.get("internalRead"):
             case_report["caseSummary"] = _case_text(f"{case_report.get('caseSummary')} BNL analyst read: {subject_analyst_read.get('internalRead')}", 900)
+        if subject_analyst_read.get("dossierWorthiness") or subject_analyst_read.get("dossierReadinessSummary"):
+            case_report["dossierUse"] = _case_text(
+                f"Use this Source File as BNL's admin/mod readout, not as a checklist. Fit read: {subject_analyst_read.get('dossierWorthiness') or 'unknown'}. {subject_analyst_read.get('dossierReadinessSummary') or ''} {subject_analyst_read.get('draftReadinessReason') or ''}",
+                700,
+            )
         case_report["recommendedNextSteps"] = _case_list([*(subject_analyst_read.get("recommendedAdminActions") or []), *(case_report.get("recommendedNextSteps") or [])], limit=10, item_limit=280)
-        case_report["reviewBlockers"] = _case_list([*(subject_analyst_read.get("missingInfoQuestions") or []), *(subject_analyst_read.get("doNotSayPublicly") or []), *(case_report.get("reviewBlockers") or [])], limit=12, item_limit=280)
+        if subject_analyst_read.get("readyForDraft") is True and not subject_analyst_read.get("dossierBlockedBy"):
+            case_report["reviewBlockers"] = []
+        else:
+            case_report["reviewBlockers"] = _case_list([*(subject_analyst_read.get("dossierBlockedBy") or []), *(case_report.get("reviewBlockers") or [])], limit=5, item_limit=220)
         case_report["confidenceNotes"] = _case_list([*(subject_analyst_read.get("provenanceSummary") or []), *(case_report.get("confidenceNotes") or [])], limit=12, item_limit=320)
         case_report["publicSafeClaims"] = _case_list([*(subject_analyst_read.get("publicSafeClaims") or []), *(case_report.get("publicSafeClaims") or [])], limit=10, item_limit=280)
         case_report["evidenceSummary"] = _case_list([*(subject_analyst_read.get("strongestSignals") or []), *(subject_analyst_read.get("provenanceSummary") or []), *(case_report.get("evidenceSummary") or [])], limit=12, item_limit=320)
+        case_report["internalOnlyNotes"] = _case_list([*(subject_analyst_read.get("privateOrInternalExclusions") or []), *(subject_analyst_read.get("sourceBlindInsights") or []), *(subject_analyst_read.get("doNotSayPublicly") or []), *(case_report.get("internalOnlyNotes") or [])], limit=10, item_limit=280)
     admin_summary = build_admin_summary({**packet, "subjectName": subject, "subjectKey": subject_key, "sourceLanes": ["source_file_enrichment"] + list(packet.get("sourceTypes") or [])})
     envelope = {
         "candidateId": _sanitize_archive_value(candidate_id) if candidate_id else None,
@@ -5159,7 +5185,7 @@ def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[s
         "publicSafetyNotes": _sanitize_archive_value(_section_text(sections, "Public-Safe Notes", limit=10) or packet.get("publicSafetyNotes") or ""),
         "doNotSay": _sanitize_archive_value(_section_text(sections, "Do Not Say", limit=10) or packet.get("doNotSay") or ""),
         "evidenceReceiptSummary": _sanitize_archive_value(receipt),
-        "sourceFileBriefV2": _sanitize_archive_value(build_source_file_brief_v2(packet, archive_id=packet.get("archiveId") or "")),
+        "sourceFileBriefV2": _sanitize_archive_value(build_source_file_brief_v2({**packet, "subjectAnalystReadV1": subject_analyst_read}, archive_id=packet.get("archiveId") or "")),
         "subjectAnalystReadV1": subject_analyst_read,
         "sourceFileClassificationV1": _sanitize_archive_value(source_file_classification),
         "subjectMemoryPacketV1": subject_memory_packet,

--- a/bnl_subject_memory_resolver.py
+++ b/bnl_subject_memory_resolver.py
@@ -2967,6 +2967,93 @@ def _withheld_audit(subject: str, resolved_memory: dict[str, Any], private: int,
     }
     return {"totalWithheld": private + blind + review, "categories": cats}
 
+
+def _memory_first_dossier_fit(subject: str, resolved_memory: dict[str, Any], public_claims: list[str], review_sources: list[str], blind_insights: list[str], counts: dict[str, Any]) -> dict[str, Any]:
+    """Form BNL's internal dossier-fit opinion before field output.
+
+    This is intentionally a compact readout helper, not a workflow/checklist. It
+    can count internal/review-only signals as fit evidence, but it only treats
+    sanitized public claims as public copy.
+    """
+
+    signal_texts = []
+    for key in (
+        "publicSafeFacts",
+        "publicCommunitySignals",
+        "publicCreativeMusicSignals",
+        "publicRoleSignals",
+        "queueOrSubmissionSignals",
+        "relationshipOrContextSignals",
+        "sourceLanes",
+        "broadcastMemorySignals",
+        "communityContext",
+        "musicCreativeContext",
+        "relationshipContext",
+        "queueSubmissionContext",
+    ):
+        value = resolved_memory.get(key)
+        if isinstance(value, list):
+            signal_texts.extend(str(v.get("summary") if isinstance(v, dict) else v) for v in value)
+        elif value:
+            signal_texts.append(str(value))
+    signal_texts.extend(review_sources)
+    signal_texts.extend(blind_insights)
+    hay = " ".join(signal_texts).lower()
+    ps = int(counts.get("publicSafe") or 0)
+    review = int(counts.get("reviewOnly") or 0)
+    blind = int(counts.get("sourceBlind") or 0)
+    scanned = int(counts.get("totalScanned") or 0)
+    public_count = len(public_claims)
+    has_engagement = bool(re.search(r"\b(repeated|recurring|active|engagement|interaction|community|discord|barcode|bnl|radio|broadcast|show)\b", hay))
+    has_queue = bool(re.search(r"\b(queue|submission|submitted|submitter|track)\b", hay))
+    has_relationship = bool(re.search(r"\b(relationship|collab|collaboration|orion|relay|introduced|connection)\b", hay))
+    has_music = bool(re.search(r"\b(music|artist|producer|song|track|suno|album|dj)\b", hay))
+    has_internal_only = bool(re.search(r"\b(internal only|do not say|private|source[-_ ]blind|orion|lore|relay)\b", hay)) or bool(blind)
+    score = public_count * 3 + min(ps, 5) + min(review, 4) + min(blind, 2)
+    for flag in (has_engagement, has_queue, has_relationship, has_music):
+        if flag:
+            score += 2
+    if public_count == 0 and ps == 0 and review == 0:
+        worthiness = "internal_only_for_now" if (blind or has_internal_only) else "not_a_dossier_fit_yet"
+    elif public_count >= 2 and (has_engagement or has_music or has_queue):
+        worthiness = "strong_fit"
+    elif public_count >= 1 and score >= 5:
+        worthiness = "possible_fit"
+    elif score >= 4 and has_internal_only:
+        worthiness = "internal_only_for_now"
+    elif scanned or score:
+        worthiness = "weak_fit_needs_more_signal"
+    else:
+        worthiness = "not_a_dossier_fit_yet"
+    signals = []
+    if public_count:
+        signals.append(f"{public_count} public-safe claim(s) can support cautious dossier copy.")
+    if has_engagement:
+        signals.append("Engagement/Discord/BARCODE context supports BNL's internal fit read.")
+    if has_queue:
+        signals.append("Queue/submission signals contribute to internal dossier fit, but need a public boundary before copy.")
+    if has_relationship:
+        signals.append("Relationship/collaboration/lore context matters internally and needs careful public-safe wording or omission.")
+    if blind:
+        signals.append("Source-blind memory can guide internal judgment but cannot prove public claims.")
+    if not signals:
+        signals.append("BNL has little signal beyond the subject name.")
+    can_draft = public_count >= 1 and worthiness in {"strong_fit", "possible_fit", "weak_fit_needs_more_signal"}
+    if worthiness == "not_a_dossier_fit_yet":
+        reason = "BNL does not have a safe identity/fit reason yet, so a public dossier draft would be mostly guesses."
+    elif worthiness == "internal_only_for_now" and not public_count:
+        reason = "BNL sees internal pattern signal, but no public-safe dossier claim is available yet."
+    elif can_draft:
+        reason = "BNL can draft a cautious public-safe dossier now using available claims and omitting unresolved links, role labels, collaboration, queue, or lore details."
+    else:
+        reason = "BNL needs one public-safe identity or dossier reason before drafting."
+    return {
+        "dossierWorthiness": worthiness,
+        "signals": signals[:6],
+        "canDraftCautiously": can_draft,
+        "reason": reason,
+    }
+
 def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any], packet: dict[str, Any] | None = None) -> dict[str, Any]:
     """Synthesize resolver output into internal/read-review/public-draft buckets.
 
@@ -3139,6 +3226,9 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
             if line not in review_claims:
                 review_claims.append(line)
         reviewable_claims.append(_make_reviewable_claim(subject, txt, ctype, "source_blind", "Context lacks public-safe provenance and must not be public copy.", False, "low", _safe_evidence_example(txt, subject), ["source-blind provenance", "missing public source"]))
+    memory_fit = _memory_first_dossier_fit(subject, resolved_memory, public_claims, review_sources, blind_insights, counts)
+    internal = f"BNL memory-first dossier fit: {memory_fit['dossierWorthiness']}. {internal} {memory_fit['reason']}"
+    current_read = f"{subject} Source File readout: BNL currently sees {memory_fit['dossierWorthiness'].replace('_', ' ')}. " + " ".join(memory_fit["signals"][:3])
     exclusions = []
     if private:
         exclusions.append(f"Excluded {private} protected/private memory item(s) from public and provenance text; see withheldEvidenceAudit category counts for safe details.")
@@ -3189,6 +3279,22 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
     readiness = _build_dossier_readiness(subject, reviewable_claims, missing, blind_insights)
     if dossier_clarification_needs:
         readiness = _build_dossier_readiness_from_clarifications(readiness, dossier_clarification_needs)
+    true_blockers = []
+    if identity_needs_review and not public_claims:
+        true_blockers.append("identity")
+    if not public_claims and memory_fit["dossierWorthiness"] in {"internal_only_for_now", "not_a_dossier_fit_yet"}:
+        true_blockers.append("public_dossier_reason")
+    if memory_fit["canDraftCautiously"] and public_claims:
+        readiness["blockedBy"] = []
+        readiness["readyForDraft"] = True
+        readiness["reason"] = memory_fit["reason"]
+        readiness["summary"] = f"BNL formed a memory-first {memory_fit['dossierWorthiness']} read and can draft cautiously from public-safe claims while omitting unresolved details."
+        readiness["questions"] = [q for q in readiness.get("questions", []) if q.get("dossierSection") in set(true_blockers)][:3]
+    else:
+        readiness["blockedBy"] = list(dict.fromkeys(true_blockers or readiness.get("blockedBy") or []))[:3]
+        readiness["readyForDraft"] = not readiness["blockedBy"]
+        readiness["reason"] = memory_fit["reason"]
+        readiness["summary"] = f"BNL formed a memory-first {memory_fit['dossierWorthiness']} read. {memory_fit['reason']}"
     resolution_context = normalize_source_file_resolution_context(packet)
     resolution_audit: dict[str, Any] = {}
     if resolution_context.get("hasContext"):
@@ -3230,6 +3336,8 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
             "unresolvedAfterResolutionCount": unresolved_count,
         }
     actions = [q["question"] for q in readiness["questions"] if q.get("priority") == "high"]
+    if not actions and readiness.get("readyForDraft") and missing:
+        actions = [m["question"] for m in missing[:3]]
     withheld_audit = _withheld_audit(subject, resolved_memory, private, blind, review) if (private or blind or review) else {}
     source_file_ingredients = []
     for item in [internal, *strongest[:6], *public_claims, *review_claims, *blind_insights, *actions, *missing_lines]:
@@ -3246,6 +3354,8 @@ def build_subject_analyst_read(subject_name: str, resolved_memory: dict[str, Any
     analyst_read = {
         "subjectName": subject,
         "internalRead": internal,
+        "currentRead": current_read,
+        "dossierWorthiness": memory_fit["dossierWorthiness"],
         "likelySubjectType": likely_type,
         "confidence": confidence,
         "publicDraftPosture": posture,

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -718,3 +718,26 @@ class DossierDraftReadinessMemoryTests(unittest.TestCase):
         public = json.dumps(result["draft"]).lower()
         for forbidden in ("dossierreadinessquestions", "draftreadinessreason", "readyfordraft", "which links are signal fox"):
             self.assertNotIn(forbidden, public)
+
+class DossierDraftMemoryFirstTests(unittest.TestCase):
+    def test_draft_uses_public_safe_claims_not_internal_judgment(self):
+        packet = pr217_packet(
+            publicSafeFacts=["Signal Fox is connected to BARCODE public community context."],
+            publicSafeNotes=[],
+            subjectAnalystReadV1={
+                "readyForDraft": True,
+                "dossierWorthiness": "possible_fit",
+                "internalRead": "Strong Discord queue engagement and Orion lore make this internally interesting.",
+                "publicSafeClaims": ["Signal Fox is connected to BARCODE public community context."],
+                "draftIngredients": ["Signal Fox is connected to BARCODE public community context."],
+                "missingInfoQuestions": ["Confirm public links", "Confirm Orion lore use"],
+                "dossierBlockedBy": [],
+                "draftReadinessReason": "Draft cautiously and omit unresolved links/lore.",
+            },
+        )
+        result = draft.generate_dossier_draft(packet)["draft"]
+        public = " ".join(str(result[k]) for k in PUBLIC_FIELD_KEYS)
+        self.assertIn("BARCODE", public)
+        self.assertNotIn("Orion", public)
+        self.assertNotIn("Discord queue", public)
+        self.assertNotIn("Confirm Orion", json.dumps(result["missingInfoQuestions"]))

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -1397,3 +1397,37 @@ class SourceFileEntityIntelligenceIntegrationTests(unittest.TestCase):
         self.assertNotIn("subjectMemoryPacketV1", compact)
         self.assertNotIn("sourceFileCaseReportV1", compact)
         self.assertIn("compactRecommendationNotice", compact)
+
+class SourceFileMemoryFirstReadoutTests(unittest.TestCase):
+    def test_archive_case_report_and_brief_carry_memory_first_judgment(self):
+        packet = {
+            "subject": "Crow",
+            "sourceFile": {"id": "sf_crow", "name": "Crow", "status": "active"},
+            "sections": {},
+            "subjectAnalystReadV1": {
+                "subjectName": "Crow",
+                "internalRead": "BNL memory-first dossier fit: possible_fit. Internal engagement is strong; keep Orion internal.",
+                "currentRead": "Crow Source File readout: possible fit with public-safe community context.",
+                "dossierWorthiness": "possible_fit",
+                "publicSafeClaims": ["Crow is connected to BARCODE public community context."],
+                "strongestSignals": ["Discord/queue engagement supports the internal fit read."],
+                "dossierReadinessSummary": "BNL can draft cautiously with omissions.",
+                "readyForDraft": True,
+                "draftReadinessReason": "Draft using public-safe claims; omit unresolved public link and Orion context.",
+                "dossierBlockedBy": [],
+                "recommendedAdminActions": [],
+                "privateOrInternalExclusions": ["Keep Orion context internal."],
+                "sourceBlindInsights": ["Source-blind context exists but is not public proof."],
+                "doNotSayPublicly": ["Do not mention Orion publicly."],
+            },
+        }
+        archive = enrich.build_source_file_archive_payload(packet)
+        analyst = archive["subjectAnalystReadV1"]
+        report = archive["sourceFileCaseReportV1"]
+        brief = archive["sourceFileBriefV2"]
+        self.assertEqual(analyst["dossierWorthiness"], "possible_fit")
+        self.assertTrue(analyst["readyForDraft"])
+        self.assertIn("possible_fit", report["dossierUse"])
+        self.assertEqual(report["reviewBlockers"], [])
+        self.assertIn("possible_fit", brief["adminSummary"])
+        self.assertIn("omit", brief["recommendedNextAction"].lower())

--- a/tests/test_subject_memory_resolver.py
+++ b/tests/test_subject_memory_resolver.py
@@ -882,9 +882,39 @@ class RoleVsActivitySemanticsTests(unittest.TestCase):
                             self.assertNotIn(term.lower(), low, f"{key}: {item}")
         self.assertNotIn("SECRET", json.dumps(cards[1]))
 
+    def test_memory_first_fit_allows_cautious_draft_with_internal_signals_and_omissions(self):
+        memory = {
+            "publicSafeFacts": ["Crow is connected to BARCODE public community context."],
+            "reviewOnlyEvidence": [
+                {"summary": "Crow has repeated Discord engagement and queue submission history needing public boundary."},
+                {"summary": "Crow has Orion lore/internal relay context that should stay internal."},
+                {"summary": "Crow may have a public link but ownership is unclear."},
+            ],
+            "queueOrSubmissionSignals": ["Crow queue submission history exists but is review-only."],
+            "relationshipOrContextSignals": ["Crow references Orion relay context internally."],
+            "sourceSafetyWarnings": ["source-blind internal lore exists"],
+            "evidenceCounts": {"publicSafe": 1, "reviewOnly": 3, "privateOrInternal": 0, "sourceBlind": 1, "totalScanned": 5},
+        }
+        analyst = build_subject_analyst_read("Crow", memory)
+        self.assertIn(analyst["dossierWorthiness"], {"strong_fit", "possible_fit"})
+        self.assertTrue(analyst["readyForDraft"])
+        self.assertEqual(analyst["dossierBlockedBy"], [])
+        self.assertIn("omit", analyst["draftReadinessReason"].lower())
+        self.assertNotIn("Orion", " ".join(analyst["publicSafeClaims"]))
+        self.assertLessEqual(len(analyst["dossierReadinessQuestions"]), 3)
 
-if __name__ == '__main__':
-    unittest.main()
+    def test_memory_first_fit_blocks_when_no_public_identity_or_public_reason(self):
+        memory = {
+            "sourceSafetyWarnings": ["source-blind private lore says token abcdefghijklmnopqrstuvwxyz and user id 123456789012345678"],
+            "evidenceCounts": {"publicSafe": 0, "reviewOnly": 0, "privateOrInternal": 1, "sourceBlind": 1, "totalScanned": 1},
+        }
+        analyst = build_subject_analyst_read("Unknown Subject", memory)
+        self.assertFalse(analyst["readyForDraft"])
+        self.assertIn("public_dossier_reason", analyst["dossierBlockedBy"])
+        blob = json.dumps(analyst)
+        self.assertNotIn("123456789012345678", blob)
+        self.assertNotIn("abcdefghijklmnopqrstuvwxyz", blob)
+
 
 class DossierReadinessPacketTests(unittest.TestCase):
     def test_dossier_readiness_packet_collapses_generic_review_questions(self):
@@ -960,3 +990,6 @@ class DossierReadinessPacketTests(unittest.TestCase):
 
         fallback = _review_guidance("Crow", "unclassified possible claim", "missing_confirmation", "needs_confirmation", False)
         self.assertEqual(fallback["suggestedMissingInfoQuestion"], generic)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Make the Source File an admin/mod readout driven by BNL memory-first judgment so BNL forms an opinion before emitting Source File output and does not treat the Source File like a workspace or checklist.
- Let BNL decide dossier fit from memory, engagement, queue/Discord/broadcast signals, source lanes and existing dossier patterns, then populate existing analyst/case/draft fields with that judgment while keeping internal-only signals out of public claims.

### Description
- Added a compact memory-first dossier-fit pass in `bnl_subject_memory_resolver.py` that emits `dossierWorthiness` (one of `strong_fit`, `possible_fit`, `weak_fit_needs_more_signal`, `internal_only_for_now`, `not_a_dossier_fit_yet`) plus `canDraftCautiously` and a human-readable `reason`, and wired those outputs into the analyst read (`internalRead`, `currentRead`, `dossierWorthiness`, `draftReadinessReason`, `readyForDraft`, `dossierBlockedBy`).
- Implemented question-reduction and draft-readiness logic so public-safe claims can enable a cautious draft while unresolved internal/source-blind/route-only signals become omissions not blockers; identity and true public-dossier reasons remain actual blockers.
- Propagated memory-first judgment into archive/brief/case-report helpers in `bnl_source_file_enrichment.py` so `sourceFileBriefV2` and `sourceFileCaseReportV1` present BNL’s read as an admin summary and keep internal-only notes separate.
- Updated `bnl_dossier_draft.py` to honor BNL readiness when building proposed drafts: keep identity/link questions but filter internal-only/source-blind/lore noise from public missing-info when a cautious draft is allowed.
- Tests added/updated to cover memory-first fit behavior, cautious drafting with omissions, question-reduction, safety boundaries (no private IDs/tokens/payment data leaked), and propagation into brief/case-report: modified tests in `tests/test_subject_memory_resolver.py`, `tests/test_source_file_enrichment.py`, and `tests/test_dossier_draft_generator.py`.

### Testing
- Ran byte-compile: `python3 -m py_compile bnl_source_file_enrichment.py bnl_dossier_draft.py bnl01_bot.py bnl_subject_memory_resolver.py` (succeeded).
- Ran unit tests: `python3 -m pytest tests/test_subject_memory_resolver.py -q`, `python3 -m pytest tests/test_dossier_draft_generator.py -q`, and `python3 -m pytest tests/test_source_file_enrichment.py tests/test_source_file_archive.py tests/test_source_file_refresh.py -q`; all tests passed (full suite passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33cce436fc832181ad92e45dd1cffc)