### PR TITLE
Source File: add dossier-completion readout and public-dossier style context for drafts

### DIFF
--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -369,7 +369,12 @@ def _read_model_public_dossier_items(read_model: dict[str, Any] | None) -> list[
             candidates.extend(read_model[key])
     out: list[dict[str, Any]] = []
     for item in candidates:
-        if isinstance(item, dict) and item not in out:
+        if not isinstance(item, dict):
+            continue
+        visibility = str(item.get("visibility") or item.get("clearance") or item.get("status") or item.get("publicationStatus") or "public").lower()
+        if any(term in visibility for term in ("draft", "private", "owner", "internal", "restricted")):
+            continue
+        if item not in out:
             out.append(item)
     return out
 
@@ -387,6 +392,55 @@ def _dossier_public_texts(dossier: dict[str, Any]) -> list[str]:
     texts += _strings(dossier.get("publicFacts"), max_items=6)
     return [text for text in texts if not _unsafe_reasons(text)]
 
+
+
+def _public_dossier_style_context(packet: dict[str, Any], read_model: dict[str, Any] | None) -> dict[str, Any]:
+    """Summarize current public dossier corpus for house-style matching.
+
+    Defensive input contract: callers may pass bounded style/context in the packet
+    (`stylePacket.publicDossierStyleContext`, `currentPublicDossierContext`) or in
+    the public read model. Only already-public items are consumed; draft/private/
+    owner-only/internal items are ignored.
+    """
+    style_packet = _dict(packet.get("stylePacket"))
+    inline: list[Any] = []
+    for key in ("publicDossierStyleContext", "currentPublicDossierContext", "publicDossierCorpus", "representativePublicDossierExamples", "categorySpecificExamples"):
+        value = style_packet.get(key) if key in style_packet else packet.get(key)
+        if isinstance(value, list):
+            inline.extend(value)
+        elif isinstance(value, dict):
+            inline.append(value)
+            for inner in ("items", "examples", "dossiers", "patterns"):
+                if isinstance(value.get(inner), list):
+                    inline.extend(value.get(inner) or [])
+    items = [x for x in inline if isinstance(x, dict)] + _read_model_public_dossier_items(read_model)
+    clean: list[dict[str, Any]] = []
+    for item in items:
+        visibility = str(item.get("visibility") or item.get("clearance") or item.get("status") or item.get("publicationStatus") or "public").lower()
+        if any(term in visibility for term in ("draft", "private", "owner", "internal", "restricted")):
+            continue
+        if item not in clean:
+            clean.append(item)
+        if len(clean) >= 10:
+            break
+    role_hay = " ".join(_strings(packet.get("publicSafeFacts"), max_items=8) + _strings(packet.get("publicSafeNotes"), max_items=4)).lower()
+    if any(t in role_hay for t in ("artist", "music", "track", "song", "producer", "dj")):
+        nearest = "artist/music public dossier pattern"
+    elif any(t in role_hay for t in ("collaborator", "broadcast", "radio", "production")):
+        nearest = "collaborator/production public dossier pattern"
+    else:
+        nearest = "community/member public dossier pattern"
+    notes: list[str] = []
+    for item in clean:
+        for key in ("styleNotes", "toneNotes", "structureNotes", "pattern", "type", "role"):
+            notes.extend(_strings(item.get(key), max_items=2))
+    return {
+        "available": bool(clean),
+        "count": len(clean),
+        "nearestPattern": nearest,
+        "styleNotes": notes[:6] or _style_guidance_used(style_packet),
+        "warning": "No current public dossier corpus/style context was supplied; site should pass bounded public dossier context for stronger house-style matching." if not clean else "",
+    }
 
 def _matching_public_dossiers(packet: dict[str, Any], read_model: dict[str, Any] | None) -> list[dict[str, Any]]:
     name, aliases = _subject_terms(packet)
@@ -431,6 +485,7 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
     """
     name, aliases = _subject_terms(packet)
     terms = [name] + aliases
+    style_context = _public_dossier_style_context(packet, public_read_model)
     bundle: dict[str, Any] = {
         "subjectName": name,
         "matchedAliasesUsedPrivately": [],
@@ -445,6 +500,7 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
         "officialPublicDossierContext": [],
         "publicDossierStyleGuidanceUsed": _style_guidance_used(_dict(packet.get("stylePacket"))),
         "publicDossierContextWarnings": [],
+        "publicDossierStyleContext": style_context,
         "sourceSummariesUsed": [],
         "excludedSourceWarnings": [],
         "missingInfoQuestions": [],
@@ -481,6 +537,10 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
             bundle["sourceSummariesUsed"].append(f"Used matching current public dossier context as official public dossier authority for {name}.")
     else:
         bundle["publicDossierContextWarnings"].append("No matching current public dossier/read-model facts were available as a direct official source; style examples were used only for structure and tone.")
+    if style_context.get("available"):
+        bundle["sourceSummariesUsed"].append(f"Compared draft against {style_context.get('count')} current public dossier style/context item(s); closest house pattern: {style_context.get('nearestPattern')}.")
+    elif style_context.get("warning"):
+        bundle["publicDossierContextWarnings"].append(style_context.get("warning"))
     if not db_path:
         bundle["excludedSourceWarnings"].append("Local BNL evidence database was not available; used the packet boundary only.")
     else:
@@ -983,6 +1043,9 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
         for item in _strings(resolver.get("sourceSafetyWarnings"), max_items=3):
             owner_warnings.append(item)
     if analyst:
+        completion = _dict(analyst.get("dossierCompletionReadV1"))
+        if completion:
+            owner_warnings.append(f"Dossier-completion read: {completion.get('completionStatus')} / {completion.get('likelyDossierAngle')} using {completion.get('nearestPublicDossierPattern')}.")
         if _text(analyst.get("internalRead"), 500):
             owner_warnings.append(f"BNL internal subject read: {_text(analyst.get('internalRead'), 460)}")
         for item in _strings(analyst.get("recommendedAdminActions"), max_items=3):
@@ -1014,8 +1077,11 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
             rejected.append(item)
         for item in _strings(analyst.get("sourceBlindInsights"), max_items=2):
             rejected.append(item)
+    style_context = _dict(evidence.get("publicDossierStyleContext")) if evidence else {}
     if evidence and evidence.get("publicDossierStyleGuidanceUsed"):
         rejected.append("Used public dossier examples for style and field shape only; unrelated example facts were not copied.")
+    if style_context.get("available"):
+        rejected.append(f"Matched current public dossier house style via {style_context.get('nearestPattern')}; did not copy existing dossier text in bulk.")
 
     tags, proposed_tags = _split_tags(packet, style_packet, category, kind, lane, public_facts, public_notes)
 

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -5121,6 +5121,108 @@ def build_source_file_subject_analyst_read_v1(packet: dict[str, Any], db_path: s
     return _normalize_subject_analyst_read_v1(build_subject_analyst_read(subject, resolved, packet))
 
 
+
+def _public_dossier_context_items(packet: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return bounded current-public-dossier style/context items supplied by site.
+
+    Defensive input contract: Source File refresh may pass `publicDossierStyleContext`,
+    `currentPublicDossierContext`, or `publicDossierCorpus` as a bounded list/dict of
+    already-public dossier summaries/examples. Draft/private/owner-only rows are ignored.
+    """
+    candidates: list[Any] = []
+    for key in ("publicDossierStyleContext", "currentPublicDossierContext", "publicDossierCorpus", "publicDossiers"):
+        value = packet.get(key)
+        if isinstance(value, dict):
+            for inner in ("items", "examples", "dossiers", "publicDossiers", "patterns"):
+                if isinstance(value.get(inner), list):
+                    candidates.extend(value.get(inner) or [])
+            candidates.append(value)
+        elif isinstance(value, list):
+            candidates.extend(value)
+    out: list[dict[str, Any]] = []
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        visibility = str(item.get("visibility") or item.get("clearance") or item.get("status") or item.get("publicationStatus") or "public").lower()
+        if any(term in visibility for term in ("draft", "private", "owner", "internal", "restricted")):
+            continue
+        if item not in out:
+            out.append(item)
+        if len(out) >= 8:
+            break
+    return out
+
+
+def _dossier_type_from_text(text: str) -> str:
+    low = text.lower()
+    if re.search(r"\b(artist|music|track|song|producer|dj|album)\b", low):
+        return "artist dossier"
+    if re.search(r"\b(collaborator|production|radio|broadcast|contributor)\b", low):
+        return "collaborator dossier"
+    if re.search(r"\b(queue|submission|submitter)\b", low):
+        return "queue participant dossier"
+    if re.search(r"\b(community|member|participant|listener|supporter)\b", low):
+        return "community member dossier"
+    if re.search(r"\b(internal|source|contact)\b", low):
+        return "internal-only contact/source context"
+    return "community/music-adjacent dossier"
+
+
+def build_dossier_completion_read_v1(packet: dict[str, Any], analyst: dict[str, Any], case_report: dict[str, Any] | None = None) -> dict[str, Any]:
+    subject = _case_text(analyst.get("subjectName") or packet.get("subject") or "this subject", 140)
+    public_claims = _case_list(analyst.get("publicReadyClaims") or analyst.get("publicSafeClaims") or packet.get("publicSafePossibilities"), limit=8, item_limit=260)
+    strongest = _case_list(analyst.get("strongestSignals"), limit=6, item_limit=260)
+    internal_support = _case_list([*(analyst.get("sourceBlindInsights") or []), *(analyst.get("privateOrInternalExclusions") or []), *((case_report or {}).get("queueSubmissionContext") if isinstance((case_report or {}).get("queueSubmissionContext"), list) else [(case_report or {}).get("queueSubmissionContext")])], limit=8, item_limit=260)
+    omit = _case_list([*(analyst.get("doNotSayPublicly") or []), *(analyst.get("privateOrInternalExclusions") or []), *(analyst.get("sourceBlindInsights") or [])], limit=8, item_limit=260)
+    missing = _case_list(analyst.get("missingInfoQuestions") or analyst.get("missingConfirmations"), limit=5, item_limit=220)
+    hay = " ".join([subject, analyst.get("likelySubjectType") or "", analyst.get("dossierWorthiness") or "", *public_claims, *strongest])
+    draft_angle = _dossier_type_from_text(hay)
+    public_items = _public_dossier_context_items(packet)
+    matched_types: list[str] = []
+    structure_notes: list[str] = []
+    tone_notes: list[str] = []
+    style_notes: list[str] = []
+    pattern = "No current public dossier corpus was supplied; site should pass bounded public dossier style/context for house-style comparison."
+    if public_items:
+        scored: list[tuple[int, dict[str, Any]]] = []
+        angle_terms = set(re.findall(r"[a-z]+", draft_angle.lower()))
+        for item in public_items:
+            item_text = " ".join(_case_list([item.get(k) for k in ("type", "category", "role", "title", "summary", "structureNotes", "toneNotes", "styleNotes")], limit=10, item_limit=180))
+            typ = _dossier_type_from_text(item_text)
+            if typ not in matched_types:
+                matched_types.append(typ)
+            score = len(angle_terms & set(re.findall(r"[a-z]+", item_text.lower())))
+            scored.append((score, item))
+            for key, target in (("structureNotes", structure_notes), ("toneNotes", tone_notes), ("styleNotes", style_notes)):
+                for txt in _case_list(item.get(key), limit=2, item_limit=180):
+                    if txt not in target:
+                        target.append(txt)
+        best = max(scored, key=lambda x: x[0])[1] if scored else public_items[0]
+        pattern = _case_text(best.get("pattern") or best.get("type") or best.get("category") or best.get("role") or _dossier_type_from_text(" ".join(_case_list(best, limit=8))), 180)
+    ready = bool(analyst.get("readyForDraft"))
+    blocked = _case_list(analyst.get("dossierBlockedBy"), limit=5, item_limit=120)
+    status = "ready now" if ready and not blocked else ("ready with omissions" if public_claims and not blocked else ("internal-only" if not public_claims and internal_support else "blocked"))
+    return _sanitize_archive_value({
+        "version": "1",
+        "subjectName": subject,
+        "completionStatus": status,
+        "likelyDossierAngle": draft_angle,
+        "nearestPublicDossierPattern": pattern,
+        "matchedPublicDossierTypes": matched_types[:5] or [draft_angle],
+        "whatBnlHas": _case_list([*strongest, *public_claims, *internal_support], limit=10, item_limit=240),
+        "publicSafeToUseNow": public_claims or ["No public-safe claim is confirmed yet."],
+        "keepInternal": internal_support or ["Queue/Discord/broadcast/source-blind context stays internal unless separately approved for public wording."],
+        "omitForNow": omit or ["Omit unresolved identity, role, relationship, queue, lore, collaboration, private, and source-blind details unless approved."],
+        "requiredToDraft": [m for m in missing if re.search(r"display name|identity", m, re.I)][:3],
+        "helpfulButOptional": [m for m in missing if not re.search(r"display name|identity", m, re.I)][:5],
+        "blockedByPublicSafety": blocked,
+        "styleNotes": style_notes[:5] or ["Use supplied current public dossier examples only for house style; do not copy facts or wording."],
+        "structureNotes": structure_notes[:5] or ["Follow the closest supplied public dossier structure when available; otherwise keep a concise role, summary, notes, tags shape."],
+        "toneNotes": tone_notes[:5] or ["Match current public dossier tone when supplied; avoid generic assistant-profile language."],
+        "draftCompositionPlan": _case_text(f"Draft a cautious {draft_angle} for {subject} from public-safe claims, keep internal support out of public copy, and omit optional unresolved role/link/lore/queue/collaboration details.", 420),
+        "publicDossierComparisonSummary": _case_text(f"Compared against {len(public_items)} supplied current public dossier style/context item(s). Closest pattern: {pattern}.", 320),
+    })
+
 def _source_package_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     """Build the full review-only archive package without compact-card trimming."""
 
@@ -5155,8 +5257,19 @@ def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[s
     source_file_classification = packet.get("sourceFileClassificationV1") if isinstance(packet.get("sourceFileClassificationV1"), dict) else {}
     if subject_analyst_read and source_file_classification:
         subject_analyst_read["sourceFileClassificationSummaryV1"] = _classification_summary_for_analyst(source_file_classification)
+    dossier_completion_read = build_dossier_completion_read_v1(packet, subject_analyst_read, case_report) if subject_analyst_read else {}
+    if subject_analyst_read and dossier_completion_read:
+        subject_analyst_read["dossierCompletionReadV1"] = dossier_completion_read
+        for key, target in (("publicReadyClaims", "publicSafeClaims"), ("draftIngredients", "publicSafeToUseNow"), ("sourceFileIngredients", "whatBnlHas")):
+            merged = _case_list([*(subject_analyst_read.get(key) or []), *(dossier_completion_read.get(target) or [])], limit=12, item_limit=300)
+            subject_analyst_read[key] = merged
+        subject_analyst_read["currentRead"] = _case_text(f"{subject_analyst_read.get('currentRead') or ''} Dossier-completion read: {dossier_completion_read.get('completionStatus')} as {dossier_completion_read.get('likelyDossierAngle')}; closest public pattern: {dossier_completion_read.get('nearestPublicDossierPattern')}.", 700)
+        subject_analyst_read["dossierReadinessSummary"] = _case_text(f"{subject_analyst_read.get('dossierReadinessSummary') or ''} BNL has: {'; '.join((dossier_completion_read.get('whatBnlHas') or [])[:3])}. Public-use now: {'; '.join((dossier_completion_read.get('publicSafeToUseNow') or [])[:3])}. Omit: {'; '.join((dossier_completion_read.get('omitForNow') or [])[:3])}.", 700)
+        subject_analyst_read["recommendedAdminActions"] = _case_list([*(dossier_completion_read.get("requiredToDraft") or []), *(dossier_completion_read.get("helpfulButOptional") or []), *(subject_analyst_read.get("recommendedAdminActions") or [])], limit=5, item_limit=220)
     if subject_analyst_read:
         case_report["subjectAnalystReadV1"] = subject_analyst_read
+        if dossier_completion_read:
+            case_report["dossierCompletionReadV1"] = dossier_completion_read
         if subject_analyst_read.get("internalRead"):
             case_report["caseSummary"] = _case_text(f"{case_report.get('caseSummary')} BNL analyst read: {subject_analyst_read.get('internalRead')}", 900)
         if subject_analyst_read.get("dossierWorthiness") or subject_analyst_read.get("dossierReadinessSummary"):
@@ -5187,6 +5300,7 @@ def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[s
         "evidenceReceiptSummary": _sanitize_archive_value(receipt),
         "sourceFileBriefV2": _sanitize_archive_value(build_source_file_brief_v2({**packet, "subjectAnalystReadV1": subject_analyst_read}, archive_id=packet.get("archiveId") or "")),
         "subjectAnalystReadV1": subject_analyst_read,
+        "dossierCompletionReadV1": dossier_completion_read,
         "sourceFileClassificationV1": _sanitize_archive_value(source_file_classification),
         "subjectMemoryPacketV1": subject_memory_packet,
         "sourceFileCaseReportV1": case_report,

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -74,6 +74,24 @@ PUBLIC_FIELD_KEYS = ("role", "summary", "notes", "status", "sourceUsageSummary")
 
 
 class DossierDraftGeneratorTests(unittest.TestCase):
+
+    def test_draft_uses_public_dossier_style_context_and_filters_private_examples(self):
+        packet = pr217_packet(
+            stylePacket={
+                "publicDossierStyleContext": [
+                    {"status": "PUBLIC", "type": "artist dossier", "toneNotes": ["tight BARCODE public voice"], "structureNotes": ["role then compact summary"]},
+                    {"status": "OWNER_DRAFT", "type": "private draft", "toneNotes": ["secret owner style"]},
+                ],
+                "tagRegistryGuidance": {"canonicalTags": ["artist", "community"]},
+            }
+        )
+        result = draft.generate_dossier_draft(packet)["draft"]
+        combined = json.dumps(result)
+        self.assertIn("closest house pattern", result["sourceUsageSummary"])
+        self.assertIn("artist/music public dossier pattern", combined)
+        self.assertNotIn("secret owner style", combined)
+        self.assertNotIn("Example Star founded the copied-only Nebula Choir fact", combined)
+
     def test_missing_and_invalid_token_reject(self):
         env = {draft.DRAFT_TOKEN_ENV: "secret"}
         self.assertFalse(draft.is_dossier_draft_token_valid(None, environ=env))

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -1386,6 +1386,43 @@ class SourceFileEntityIntelligenceIntegrationTests(unittest.TestCase):
         self.assertNotIn("cus_123", json.dumps(analyst).lower())
         self.assertNotIn("123456789012345678", json.dumps(analyst))
 
+
+    def test_archive_adds_dossier_completion_public_pattern_context(self):
+        packet = {
+            "subject": "Crow",
+            "sourceFile": {"id": "sf_crow", "name": "Crow", "status": "active"},
+            "sections": {},
+            "publicDossierStyleContext": {
+                "items": [
+                    {"status": "PUBLIC", "type": "community member dossier", "pattern": "community/music-adjacent subject", "toneNotes": ["concise public-safe BARCODE voice"], "structureNotes": ["role, summary, notes, tags pacing"], "styleNotes": ["short section rhythm"]},
+                    {"status": "DRAFT", "type": "private owner draft", "styleNotes": ["must not appear"]},
+                ]
+            },
+            "subjectAnalystReadV1": {
+                "subjectName": "Crow",
+                "internalRead": "Queue and Discord engagement support fit but stay internal.",
+                "currentRead": "Crow has public-safe community context.",
+                "dossierWorthiness": "possible_fit",
+                "publicSafeClaims": ["Crow is connected to BARCODE public community context."],
+                "strongestSignals": ["Internal queue engagement supports the fit read."],
+                "missingInfoQuestions": ["What public role/title may BNL use, if any?", "Is there an approved public link?"],
+                "dossierReadinessSummary": "BNL can draft cautiously.",
+                "readyForDraft": True,
+                "draftReadinessReason": "Use public-safe claims and omit unresolved role/link.",
+                "dossierBlockedBy": [],
+                "privateOrInternalExclusions": ["Keep queue history internal."],
+                "sourceBlindInsights": ["Source-blind context stays internal."],
+                "doNotSayPublicly": ["Do not mention queue history publicly."],
+            },
+        }
+        archive = enrich.build_source_file_archive_payload(packet)
+        completion = archive["dossierCompletionReadV1"]
+        self.assertEqual(completion["completionStatus"], "ready now")
+        self.assertIn("community", completion["nearestPublicDossierPattern"])
+        self.assertIn("concise public-safe BARCODE voice", json.dumps(completion))
+        self.assertNotIn("private owner draft", json.dumps(completion).lower())
+        self.assertIn("dossierCompletionReadV1", archive["sourceFileCaseReportV1"])
+
     def test_compact_recommendation_payload_excludes_full_memory_packet_and_case_report(self):
         payload = {
             "subjectName": "Signal Fox",


### PR DESCRIPTION
### Motivation
- Make Source File refresh and proposed-dossier generation dossier-focused by producing a short dossier-completion assessment before any review-question output. 
- Ensure drafts follow the existing house public-dossier style and avoid treating Source Files as evidence-audit or workspace outputs.

### Description
- Add `build_dossier_completion_read_v1` and helpers (`_public_dossier_context_items`, `_dossier_type_from_text`) to produce a `dossierCompletionReadV1` that states likely dossier angle, nearest public dossier pattern, what BNL has, what is public-safe, what to omit, required vs optional missing items, and a draft composition plan (changes in `bnl_source_file_enrichment.py`).
- Wire the completion read into archive outputs and `subjectAnalystReadV1` so completion context augments `currentRead`, readiness summaries, `publicReadyClaims`/`draftIngredients`/`sourceFileIngredients`, and `recommendedAdminActions` (changes in `bnl_source_file_enrichment.py`).
- Add bounded public-dossier style/context handling for draft evidence and draft generation, filtering out draft/private/owner-only/internal examples, reporting nearest house pattern, and placing style notes into draft evidence (changes in `bnl_dossier_draft.py`).
- Use the supplied or read-model public dossier corpus only for style/structure/tone guidance and avoid copying existing dossier text as facts; surface warnings when no bounded public corpus is provided (changes in `bnl_dossier_draft.py`).
- Add owner-review and draft protections so private, source-blind, or review-only signals are kept internal and do not leak into public draft fields (changes in both modules and reflected in draft assembly).
- Files changed: `bnl_source_file_enrichment.py`, `bnl_dossier_draft.py`, `tests/test_dossier_draft_generator.py`, and `tests/test_source_file_enrichment.py`.

### Testing
- Ran static compile: `python3 -m py_compile bnl_source_file_enrichment.py bnl_dossier_draft.py bnl01_bot.py bnl_subject_memory_resolver.py`, which succeeded.
- Ran unit tests: `python3 -m pytest tests/test_subject_memory_resolver.py -q`, `python3 -m pytest tests/test_dossier_draft_generator.py -q`, and `python3 -m pytest tests/test_source_file_enrichment.py tests/test_source_file_archive.py tests/test_source_file_refresh.py -q`, and the suite passed (final run: `146 passed`, `5 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a343cdd8b5083218439b33e68ebe4a0)