### PR TITLE
Add sourceFilePagePlanV1: full Source File page contract

### DIFF
--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -984,6 +984,33 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
     subject_dossier_state = _dict(packet.get("subjectDossierStateV1") or (analyst or {}).get("subjectDossierStateV1"))
     source_file_surface = _dict(packet.get("sourceFileSurfaceV1") or (analyst or {}).get("sourceFileSurfaceV1"))
     source_file_page_plan = _dict(packet.get("sourceFilePagePlanV1") or (analyst or {}).get("sourceFilePagePlanV1"))
+    page_plan_draft_plan = _dict(source_file_page_plan.get("draftOrUpdatePlan")) if source_file_page_plan else {}
+    page_plan_public_material_added = False
+    if source_file_page_plan:
+        page_plan_public_candidates = _strings(page_plan_draft_plan.get("useTheseMaterials"), max_items=8)
+        for material in source_file_page_plan.get("publicSafeMaterial") or []:
+            if not isinstance(material, dict):
+                continue
+            confidence = str(material.get("confidence") or "").lower()
+            text = _text(material.get("material"), 260)
+            if text and confidence != "none" and not re.search(r"\b(no public-safe|not ready|not enough public-safe)\b", text, re.I):
+                page_plan_public_candidates.append(text)
+        for item in page_plan_public_candidates:
+            safe_items, unsafe_items = _reject_unsafe_public([item])
+            for safe in safe_items:
+                if safe not in public_facts:
+                    public_facts.append(safe)
+                    page_plan_public_material_added = True
+            rejected_facts.extend(unsafe_items)
+        for item in _strings(page_plan_draft_plan.get("omitTheseMaterials"), max_items=10):
+            rejected_facts.append(f"Source File page plan says to omit from public draft: {item}")
+        internal_hold = _dict(source_file_page_plan.get("internalOmitHold"))
+        for bucket in ("keepInternal", "omitFromPublicDraft"):
+            for hold in internal_hold.get(bucket) or []:
+                if isinstance(hold, dict):
+                    title = _text(hold.get("material") or hold.get("whyInternal") or hold.get("whyOmitted"), 220)
+                    if title:
+                        rejected_facts.append(f"Source File page plan withheld {bucket}: {title}")
     if review_actionability:
         rejected_review_texts: list[str] = []
         for item in review_actionability.get("items") or []:
@@ -1017,7 +1044,7 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
             role = "Community participant"
         elif analyst.get("confidence") == "low" and role == "Review pending":
             role = "Dossier subject"
-    thin = len(public_facts) + len(public_notes) < 2
+    thin = len(public_facts) + len(public_notes) < 2 and not page_plan_public_material_added
 
     missing = _strings(packet.get("missingInfo"), max_items=8)
     if evidence:
@@ -1052,25 +1079,9 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
     owner_warnings = _strings(packet.get("ownerReviewRules"), max_items=8) + _strings(packet.get("reviewOnlyWarnings"), max_items=8)
     owner_warnings.append("Owner Review must approve identity, role, category, links, and public wording before publication.")
     if source_file_page_plan:
-        draft_plan = _dict(source_file_page_plan.get("draftOrUpdatePlan"))
-        for item in _strings(draft_plan.get("useTheseMaterials"), max_items=8):
-            safe_items, unsafe_items = _reject_unsafe_public([item])
-            for safe in safe_items:
-                if safe not in public_facts:
-                    public_facts.append(safe)
-            rejected_facts.extend(unsafe_items)
-        for item in _strings(draft_plan.get("omitTheseMaterials"), max_items=10):
-            rejected_facts.append(f"Source File page plan says to omit from public draft: {item}")
-        for item in _strings(draft_plan.get("ownerReviewWarnings"), max_items=8):
+        for item in _strings(page_plan_draft_plan.get("ownerReviewWarnings"), max_items=8):
             owner_warnings.append(f"Source File page plan warning: {item}")
-        internal_hold = _dict(source_file_page_plan.get("internalOmitHold"))
-        for bucket in ("keepInternal", "omitFromPublicDraft"):
-            for hold in internal_hold.get(bucket) or []:
-                if isinstance(hold, dict):
-                    title = _text(hold.get("material") or hold.get("whyInternal") or hold.get("whyOmitted"), 220)
-                    if title:
-                        rejected_facts.append(f"Source File page plan withheld {bucket}: {title}")
-        if draft_plan.get("canDraft") is False:
+        if page_plan_draft_plan.get("canDraft") is False:
             missing.append("Source File page plan says drafting is not recommended yet.")
     if subject_dossier_state:
         owner_warnings.append(f"Subject dossier state: {subject_dossier_state.get('state')} / {subject_dossier_state.get('recommendedNextAction')}.")

--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -983,6 +983,7 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
     review_actionability = _dict(packet.get("reviewActionabilityV1") or (analyst or {}).get("reviewActionabilityV1"))
     subject_dossier_state = _dict(packet.get("subjectDossierStateV1") or (analyst or {}).get("subjectDossierStateV1"))
     source_file_surface = _dict(packet.get("sourceFileSurfaceV1") or (analyst or {}).get("sourceFileSurfaceV1"))
+    source_file_page_plan = _dict(packet.get("sourceFilePagePlanV1") or (analyst or {}).get("sourceFilePagePlanV1"))
     if review_actionability:
         rejected_review_texts: list[str] = []
         for item in review_actionability.get("items") or []:
@@ -1050,11 +1051,35 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
 
     owner_warnings = _strings(packet.get("ownerReviewRules"), max_items=8) + _strings(packet.get("reviewOnlyWarnings"), max_items=8)
     owner_warnings.append("Owner Review must approve identity, role, category, links, and public wording before publication.")
+    if source_file_page_plan:
+        draft_plan = _dict(source_file_page_plan.get("draftOrUpdatePlan"))
+        for item in _strings(draft_plan.get("useTheseMaterials"), max_items=8):
+            safe_items, unsafe_items = _reject_unsafe_public([item])
+            for safe in safe_items:
+                if safe not in public_facts:
+                    public_facts.append(safe)
+            rejected_facts.extend(unsafe_items)
+        for item in _strings(draft_plan.get("omitTheseMaterials"), max_items=10):
+            rejected_facts.append(f"Source File page plan says to omit from public draft: {item}")
+        for item in _strings(draft_plan.get("ownerReviewWarnings"), max_items=8):
+            owner_warnings.append(f"Source File page plan warning: {item}")
+        internal_hold = _dict(source_file_page_plan.get("internalOmitHold"))
+        for bucket in ("keepInternal", "omitFromPublicDraft"):
+            for hold in internal_hold.get(bucket) or []:
+                if isinstance(hold, dict):
+                    title = _text(hold.get("material") or hold.get("whyInternal") or hold.get("whyOmitted"), 220)
+                    if title:
+                        rejected_facts.append(f"Source File page plan withheld {bucket}: {title}")
+        if draft_plan.get("canDraft") is False:
+            missing.append("Source File page plan says drafting is not recommended yet.")
     if subject_dossier_state:
         owner_warnings.append(f"Subject dossier state: {subject_dossier_state.get('state')} / {subject_dossier_state.get('recommendedNextAction')}.")
     if source_file_surface:
         primary = _dict(source_file_surface.get("primaryAction"))
         owner_warnings.append(f"Source File surface primary action: {primary.get('label') or primary.get('actionKey')}.")
+    if source_file_page_plan:
+        worth = _dict(source_file_page_plan.get("dossierWorthItDecision"))
+        owner_warnings.append(f"Source File page plan decision: {worth.get('decision') or 'not supplied'} / readiness {worth.get('draftReadiness') or 'unknown'}.")
     public_warnings = _strings(packet.get("sourceBoundaryRules"), max_items=8)
     public_warnings.append("Public fields use the Source File packet as the subject boundary plus approved public-safe BNL evidence.")
     if evidence:

--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -5660,6 +5660,118 @@ def build_source_file_surface_v1(subject_state: dict[str, Any], review_actionabi
         "diagnosticsSummary": _case_text(f"Derived from subjectDossierStateV1 plus dossierCompletionReadV1/reviewActionabilityV1. Mode: {subject_state.get('recommendedSurfaceMode')}.", 220),
     })
 
+
+def _page_plan_control(kind: str, label: str, question: str = "", enabled: bool = True) -> dict[str, Any]:
+    return {"kind": kind, "label": _case_text(label, 120), "questionToCopy": _case_text(question, 260), "enabled": bool(enabled)}
+
+
+def _page_plan_item_id(prefix: str, text: str, idx: int) -> str:
+    base = _subject_key(text)[:42] or f"item-{idx}"
+    return f"{prefix}-{idx + 1}-{base}"
+
+
+def build_source_file_page_plan_v1(packet: dict[str, Any], analyst: dict[str, Any] | None = None, dossier_completion_read: dict[str, Any] | None = None, review_actionability: dict[str, Any] | None = None, subject_dossier_state: dict[str, Any] | None = None, source_file_surface: dict[str, Any] | None = None, case_report: dict[str, Any] | None = None, source_file_classification: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Full BNL-authored Source File page contract.
+
+    This object is intentionally verbose and filled with explanatory fallbacks so
+    the site can render a fixed Source File page without inventing copy or
+    exposing raw diagnostic/private material.
+    """
+
+    analyst = analyst or {}
+    dossier_completion_read = dossier_completion_read or {}
+    review_actionability = review_actionability or {}
+    subject_dossier_state = subject_dossier_state or {}
+    case_report = case_report or {}
+    source_file_classification = source_file_classification or {}
+    source_file = packet.get("sourceFile") if isinstance(packet.get("sourceFile"), dict) else {}
+    subject = _case_text(subject_dossier_state.get("subjectName") or dossier_completion_read.get("subjectName") or analyst.get("subjectName") or packet.get("subject") or _first(source_file, ("name", "displayName", "title")) or "this subject", 140)
+    subject_key = _subject_key(subject_dossier_state.get("subjectKey") or subject)
+    state = _case_text(subject_dossier_state.get("state") or "source_file_building", 80)
+    existing = "Existing public dossier context is available." if _has_existing_public_dossier_context(packet) else "No existing public dossier context is confirmed in this Source File."
+    header = {
+        "subject": subject,
+        "sourceFileStatus": _case_text(packet.get("qualityStatus") or packet.get("matchKind") or "Source File is available for internal review.", 140),
+        "bnlState": state,
+        "currentLane": _case_text(subject_dossier_state.get("recommendedWorkflow") or source_file_classification.get("currentLane") or packet.get("matchKind") or "source_file_review", 120),
+        "lastRefresh": _case_text(packet.get("runTime") or packet.get("lastRefresh") or packet.get("refreshedAt") or "No refresh timestamp was supplied.", 140),
+        "existingPublicDossier": existing,
+    }
+    public_items = [x for x in _case_list(subject_dossier_state.get("publicSafeToUseNow") or dossier_completion_read.get("publicSafeToUseNow") or analyst.get("publicSafeClaims") or analyst.get("publicReadyClaims"), limit=10, item_limit=260) if not re.search(r"\b(no public-safe|not confirmed|ready yet)\b", x, re.I)]
+    internal_items = _case_list(subject_dossier_state.get("keepInternal") or dossier_completion_read.get("keepInternal") or analyst.get("privateOrInternalExclusions") or analyst.get("sourceBlindInsights"), limit=10, item_limit=240)
+    omit_items = _case_list(subject_dossier_state.get("omitForNow") or dossier_completion_read.get("omitForNow") or analyst.get("doNotSayPublicly"), limit=10, item_limit=240)
+    required = _case_list(subject_dossier_state.get("requiredDecisions") or dossier_completion_read.get("requiredToDraft") or analyst.get("dossierBlockedBy"), limit=8, item_limit=240)
+    optional = _case_list(subject_dossier_state.get("optionalEnrichments") or dossier_completion_read.get("helpfulButOptional") or analyst.get("missingInfoQuestions"), limit=8, item_limit=240)
+    bnl_read = {
+        "overallRead": _case_text(analyst.get("currentRead") or analyst.get("internalRead") or subject_dossier_state.get("whyNow") or "BNL is treating this as a Source File that needs public-safe review before any dossier action.", 520),
+        "whatBnlThinksThisIs": _case_text(analyst.get("whatBnlThinksThisIs") or analyst.get("likelySubjectType") or subject_dossier_state.get("dossierAngle") or "A dossier candidate or existing-dossier update candidate under review.", 260),
+        "whyThisSourceFileExists": _case_text(case_report.get("caseSummary") or "This Source File exists to separate public-safe dossier material from review-only, internal, omitted, or still-uncertain material.", 360),
+        "whatSeemsUseful": _case_text("; ".join(public_items[:3] or _case_list(subject_dossier_state.get("whatBnlHas"), limit=3, item_limit=180)) or "BNL does not have enough public-safe material yet.", 420),
+        "whatSeemsWeak": _case_text("; ".join(required[:3] or omit_items[:3]) or "No single weak point is driving the current read, but Owner Review still controls public use.", 420),
+        "whatIsUncertain": _case_text("; ".join(optional[:3] or required[:3]) or "BNL does not have any decision-unlocking uncertainty right now.", 420),
+        "whatBnlIsWatching": _case_text(subject_dossier_state.get("recommendedNextAction") or "BNL is watching for public-safe confirmation, owner-approved wording, and evidence that changes draft readiness.", 360),
+        "confidence": _case_text(subject_dossier_state.get("confidence") or analyst.get("confidence") or "medium", 60),
+    }
+    needs = []
+    for idx, text in enumerate(required + optional):
+        req = idx < len(required)
+        kind = "ask_owner" if re.search(r"owner|identity|wording|display", text, re.I) else "ask_admin"
+        needs.append({"id": _page_plan_item_id("need", text, idx), "neededItem": text, "whyNeeded": "BNL needs this answered only if it unlocks safer public dossier wording or draft readiness.", "whoCanAnswer": "owner" if kind == "ask_owner" else "admin", "requiredOrOptional": "required" if req else "optional", "unlocks": "A safer draft/update decision or a justified omission.", "currentStatus": "missing" if req else "partial", "suggestedControl": _page_plan_control(kind, "Ask owner" if kind == "ask_owner" else "Ask admin", text)})
+    if not needs:
+        needs.append({"id": "need-1-not-needed", "neededItem": "No additional information needed right now.", "whyNeeded": "BNL has enough information for the current recommended state.", "whoCanAnswer": "BNL", "requiredOrOptional": "not_needed", "unlocks": "Nothing is currently blocked by an information request.", "currentStatus": "not_needed", "suggestedControl": _page_plan_control("none", "No control needed", "", False)})
+    public_material = [{"id": _page_plan_item_id("public", x, i), "material": x, "howBnlWouldUseIt": "Use only as cautious public dossier material after Owner Review approves wording.", "whySafeEnough": "BNL classified this as public-safe or public-ready input; it is not auto-approved for publication.", "confidence": "medium", "needsApproval": True} for i, x in enumerate(public_items)]
+    if not public_material:
+        public_material.append({"id": "public-1-not-ready", "material": "No public-safe dossier material is ready yet.", "howBnlWouldUseIt": "BNL would not use this Source File for public copy yet.", "whySafeEnough": "Not enough public-safe confirmation exists.", "confidence": "none", "needsApproval": True})
+    guidance = []
+    for idx, item in enumerate((review_actionability.get("items") or [])[:40]):
+        if not isinstance(item, dict):
+            continue
+        text = _case_text(item.get("claimText") or item.get("question") or item.get("recommendedAction") or "Review item", 260)
+        action = str(item.get("actionability") or "")
+        public_use = str(item.get("publicUse") or "")
+        if action == "approve_public_claim" or public_use == "public_safe":
+            decision, default, control = "use_publicly", "use_cautiously", "approve_public_copy"
+        elif action in {"needs_owner_wording", "true_blocker"}:
+            decision, default, control = "ask_owner", "ask_owner", "ask_owner"
+        elif action in {"required_to_finish", "needs_admin_confirmation"}:
+            decision, default, control = "ask_admin", "ask_admin", "ask_admin"
+        elif action == "already_resolved":
+            decision, default, control = "already_resolved", "ignore", "none"
+        elif action in {"keep_internal"} or public_use == "internal_only":
+            decision, default, control = "keep_internal", "keep_internal", "keep_internal"
+        elif action in {"omit_from_public", "diagnostic_only"} or public_use in {"omit", "not_public"}:
+            decision, default, control = "ignore_for_now" if action == "diagnostic_only" else "omit", "omit" if action != "diagnostic_only" else "ignore", "none"
+        else:
+            decision, default, control = "optional_enrichment", "watch", "none"
+        guidance.append({"id": _case_text(item.get("id") or _page_plan_item_id("review", text, idx), 120), "reviewIssue": text, "bnlDecision": decision, "bnlExplanation": _case_text(item.get("reason") or item.get("recommendedAction") or "BNL absorbed this review item into the page plan without treating it as public copy.", 320), "recommendedDefault": default, "stillActive": item.get("id") in set(review_actionability.get("activeReviewItemIds") or []), "neededToFinish": decision in {"ask_owner", "ask_admin", "blocks_draft"}, "suggestedControl": _page_plan_control(control, control.replace("_", " ").title() if control != "none" else "No control needed", item.get("question") or text, control != "none"), "sourceReviewRefs": [_case_text(item.get("id"), 120)] if item.get("id") else []})
+    if not guidance:
+        guidance.append({"id": "review-1-none", "reviewIssue": "No review-card issue is active right now.", "bnlDecision": "already_resolved", "bnlExplanation": "BNL does not have old review cards or claim decisions that require a separate action.", "recommendedDefault": "ignore", "stillActive": False, "neededToFinish": False, "suggestedControl": _page_plan_control("none", "No control needed", "", False), "sourceReviewRefs": []})
+    questions = []
+    for idx, q in enumerate((review_actionability.get("verificationPacketQuestions") or [])[:12]):
+        if isinstance(q, dict) and q.get("question"):
+            text = _case_text(q.get("question"), 260)
+            aud = "owner" if re.search(r"owner|identity|wording", text, re.I) else "admin"
+            questions.append({"id": _case_text(q.get("id") or _page_plan_item_id("question", text, idx), 120), "question": text, "audience": aud, "whyBnlIsAsking": "This question is included because it can unlock a safer dossier decision.", "whatAnswerWouldUnlock": "Owner/admin-approved public wording, a safer omission, or draft readiness.", "requiredOrOptional": "required"})
+    if not questions:
+        questions.append({"id": "question-1-not-needed", "question": "BNL does not have any decision-unlocking questions right now.", "audience": "internal_operator", "whyBnlIsAsking": "No outside answer is needed for the current Source File state.", "whatAnswerWouldUnlock": "Nothing is currently blocked by a question.", "requiredOrOptional": "not_needed"})
+    can_draft = bool(subject_dossier_state.get("canDraftNow") or subject_dossier_state.get("hasEnoughForTruthfulDossier")) and public_items and state not in {"blocked", "internal_only", "needs_owner_wording", "needs_admin_confirmation"}
+    decision = "update_existing_dossier" if state == "update_existing_public_dossier" else ("worth_drafting_now" if can_draft else ("blocked" if state == "blocked" else ("internal_only" if state == "internal_only" else "not_worth_it_yet")))
+    keep_internal = [{"id": _page_plan_item_id("internal", x, i), "material": "Internal/review-only material withheld from public copy.", "whyInternal": _case_text(x or "This material is not public-safe dossier copy.", 260), "couldBecomePublicLater": True, "whatWouldMakeItUsable": "Owner-approved/public evidence would be required before any public use."} for i, x in enumerate(internal_items)]
+    omit_public = [{"id": _page_plan_item_id("omit", x, i), "material": _case_text(x, 220), "whyOmitted": "BNL is omitting this from public draft copy unless stronger public-safe evidence appears.", "couldBecomePublicLater": True, "whatWouldMakeItUsable": "Public-safe confirmation and Owner Review approval."} for i, x in enumerate(omit_items)]
+    if not keep_internal:
+        keep_internal.append({"id": "internal-1-none", "material": "No internal-only material is driving the current decision.", "whyInternal": "BNL still withholds raw private/source-blind diagnostics by default.", "couldBecomePublicLater": False, "whatWouldMakeItUsable": "Nothing is needed because no specific internal material is being proposed."})
+    if not omit_public:
+        omit_public.append({"id": "omit-1-none", "material": "No omit-only public draft material is driving the current decision.", "whyOmitted": "BNL does not have a separate public omission beyond normal safety boundaries.", "couldBecomePublicLater": False, "whatWouldMakeItUsable": "Nothing is needed because no specific omitted public claim is being proposed."})
+    omit_titles = [x.get("material") for x in keep_internal + omit_public if x.get("material")]
+    plan = {
+        "version": "1", "subjectName": subject, "subjectKey": subject_key, "header": header, "bnlAnalystRead": bnl_read, "whatBnlNeeds": needs, "publicSafeMaterial": public_material, "bnlReviewGuidance": guidance, "questionsToAsk": questions,
+        "dossierWorthItDecision": {"worthADossier": "yes" if can_draft else ("blocked" if state == "blocked" else ("maybe" if public_items else "no")), "decision": decision, "why": _case_text(subject_dossier_state.get("whyNow") or subject_dossier_state.get("recommendedNextAction") or "BNL has not found enough public-safe material for a public dossier yet.", 420), "possibleDossierType": _case_text(subject_dossier_state.get("dossierAngle") or dossier_completion_read.get("likelyDossierAngle") or "public dossier", 160), "draftReadiness": "ready" if can_draft else ("blocked" if state == "blocked" else "not_ready"), "whatWouldChangeTheDecision": _case_text("; ".join(required[:3]) or "Better public-safe evidence, owner-approved wording, or a clearer dossier angle would change this decision.", 360)},
+        "internalOmitHold": {"keepInternal": keep_internal, "omitFromPublicDraft": omit_public},
+        "draftOrUpdatePlan": {"canDraft": bool(can_draft), "draftType": "update_existing" if state == "update_existing_public_dossier" else ("new_dossier" if can_draft else "none_yet"), "suggestedAngle": _case_text(subject_dossier_state.get("dossierAngle") if can_draft else "Not enough material to choose a public dossier angle yet.", 220), "useTheseMaterials": [x["material"] for x in public_material if x.get("confidence") != "none"], "omitTheseMaterials": omit_titles[:12], "ownerReviewWarnings": ["Owner Review must approve public wording before publication."] + ([] if can_draft else ["Drafting is not recommended yet because the dossier angle or public-safe material is not clear."])},
+        "diagnosticsSummary": {"rawArchiveAvailable": True, "caseReportAvailable": bool(case_report), "interimBriefAvailable": bool(packet.get("sourceFileBriefV2") or packet.get("interimBrief")), "blueprintAvailable": bool(packet.get("blueprint") or packet.get("dossierBlueprint")), "legacyClaimReviewCount": len(review_actionability.get("items") or []), "absorbedReviewCount": len(guidance), "hiddenDiagnosticCount": len(internal_items) + len(omit_items), "safetyNotes": ["Diagnostics are support material only, not public copy.", "Private/source-blind/internal evidence is summarized without raw disclosure.", "No publishing, owner-review bypass, identity merge, or auto-approval is requested."]},
+    }
+    return _sanitize_archive_value(plan)
+
 def _source_package_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     """Build the full review-only archive package without compact-card trimming."""
 
@@ -5698,6 +5810,7 @@ def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[s
     review_actionability = build_review_actionability_v1(packet, subject_analyst_read, dossier_completion_read, case_report, source_file_classification) if subject_analyst_read and dossier_completion_read else {}
     subject_dossier_state = build_subject_dossier_state_v1(packet, subject_analyst_read, dossier_completion_read, review_actionability, case_report, source_file_classification) if subject_analyst_read and dossier_completion_read else {}
     source_file_surface = build_source_file_surface_v1(subject_dossier_state, review_actionability) if subject_dossier_state else {}
+    source_file_page_plan = build_source_file_page_plan_v1(packet, subject_analyst_read, dossier_completion_read, review_actionability, subject_dossier_state, source_file_surface, case_report, source_file_classification) if subject_analyst_read and dossier_completion_read else {}
     if subject_analyst_read and dossier_completion_read:
         subject_analyst_read["dossierCompletionReadV1"] = dossier_completion_read
         if review_actionability:
@@ -5706,6 +5819,8 @@ def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[s
             subject_analyst_read["subjectDossierStateV1"] = subject_dossier_state
         if source_file_surface:
             subject_analyst_read["sourceFileSurfaceV1"] = source_file_surface
+        if source_file_page_plan:
+            subject_analyst_read["sourceFilePagePlanV1"] = source_file_page_plan
         for key, target in (("publicReadyClaims", "publicSafeClaims"), ("draftIngredients", "publicSafeToUseNow"), ("sourceFileIngredients", "whatBnlHas")):
             merged = _case_list([*(subject_analyst_read.get(key) or []), *(dossier_completion_read.get(target) or [])], limit=12, item_limit=300)
             subject_analyst_read[key] = merged
@@ -5722,6 +5837,8 @@ def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[s
             case_report["subjectDossierStateV1"] = subject_dossier_state
         if source_file_surface:
             case_report["sourceFileSurfaceV1"] = source_file_surface
+        if source_file_page_plan:
+            case_report["sourceFilePagePlanV1"] = source_file_page_plan
         if subject_analyst_read.get("internalRead"):
             case_report["caseSummary"] = _case_text(f"{case_report.get('caseSummary')} BNL analyst read: {subject_analyst_read.get('internalRead')}", 900)
         if subject_analyst_read.get("dossierWorthiness") or subject_analyst_read.get("dossierReadinessSummary"):
@@ -5756,6 +5873,7 @@ def build_source_file_archive_payload(packet: dict[str, Any], *, environ: dict[s
         "reviewActionabilityV1": review_actionability,
         "subjectDossierStateV1": subject_dossier_state,
         "sourceFileSurfaceV1": source_file_surface,
+        "sourceFilePagePlanV1": source_file_page_plan,
         "sourceFileClassificationV1": _sanitize_archive_value(source_file_classification),
         "subjectMemoryPacketV1": subject_memory_packet,
         "sourceFileCaseReportV1": case_report,

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -806,3 +806,40 @@ class DossierDraftSourceFilePagePlanTests(unittest.TestCase):
         self.assertIn("Source File page plan says drafting is not recommended yet.", result["missingInfoQuestions"])
         self.assertTrue(any("page plan warning" in x.lower() for x in result["ownerReviewWarnings"]))
         self.assertTrue(any("Private queue note" in x for x in result["unsupportedClaimsRejected"]))
+
+    def test_page_plan_material_informs_role_and_thin_check_before_missing_info(self):
+        packet = pr217_packet(
+            publicSafeFacts=[],
+            publicSafeNotes=[],
+            missingInfo=[],
+            safeClassification={"category": "Unknown", "kind": "Unknown", "ecosystemLane": "Unknown"},
+            sourceFilePagePlanV1={
+                "publicSafeMaterial": [
+                    {"material": "Signal Fox is publicly described as a community moderator for BARCODE events.", "confidence": "high", "needsApproval": True},
+                ],
+                "draftOrUpdatePlan": {
+                    "canDraft": True,
+                    "useTheseMaterials": ["Signal Fox has public BARCODE community moderator context."],
+                    "omitTheseMaterials": ["Private DJ set note"],
+                    "ownerReviewWarnings": ["Owner Review must approve the page-plan wording."],
+                },
+                "internalOmitHold": {
+                    "keepInternal": [{"material": "Internal source-blind music artist diagnostic"}],
+                    "omitFromPublicDraft": [{"material": "Private DJ set note"}],
+                },
+                "diagnosticsSummary": {
+                    "safetyNotes": ["Diagnostics say music artist but must not become public copy."],
+                },
+                "dossierWorthItDecision": {"decision": "worth_drafting_now", "draftReadiness": "ready"},
+            },
+        )
+        result = draft.generate_dossier_draft(packet)["draft"]
+        public = " ".join(str(result[k]) for k in PUBLIC_FIELD_KEYS)
+        self.assertEqual(result["role"], "Community moderator")
+        self.assertNotIn("Review pending", result["role"])
+        self.assertFalse(any("more public-safe facts" in q.lower() for q in result["missingInfoQuestions"]))
+        self.assertNotIn("DJ", public)
+        self.assertNotIn("source-blind music artist", public.lower())
+        self.assertNotIn("diagnostics say music artist", public.lower())
+        self.assertTrue(any("page-plan wording" in x for x in result["ownerReviewWarnings"]))
+        self.assertTrue(any("Private DJ set note" in x for x in result["unsupportedClaimsRejected"]))

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -783,3 +783,26 @@ class DossierDraftMemoryFirstTests(unittest.TestCase):
         self.assertNotIn("Orion", public)
         self.assertNotIn("Discord queue", public)
         self.assertNotIn("Confirm Orion", json.dumps(result["missingInfoQuestions"]))
+
+class DossierDraftSourceFilePagePlanTests(unittest.TestCase):
+    def test_draft_consumes_source_file_page_plan_safely(self):
+        packet = pr217_packet(
+            publicSafeFacts=[],
+            sourceFilePagePlanV1={
+                "draftOrUpdatePlan": {
+                    "canDraft": False,
+                    "useTheseMaterials": ["Signal Fox has public BARCODE music context."],
+                    "omitTheseMaterials": ["Private queue note"],
+                    "ownerReviewWarnings": ["Drafting is not recommended yet."],
+                },
+                "internalOmitHold": {"keepInternal": [{"material": "Internal/source-blind material withheld"}], "omitFromPublicDraft": []},
+                "dossierWorthItDecision": {"decision": "not_worth_it_yet", "draftReadiness": "not_ready"},
+            },
+        )
+        result = draft.generate_dossier_draft(packet)["draft"]
+        public = " ".join(str(result[k]) for k in PUBLIC_FIELD_KEYS)
+        self.assertIn("BARCODE", public)
+        self.assertNotIn("Private queue note", public)
+        self.assertIn("Source File page plan says drafting is not recommended yet.", result["missingInfoQuestions"])
+        self.assertTrue(any("page plan warning" in x.lower() for x in result["ownerReviewWarnings"]))
+        self.assertTrue(any("Private queue note" in x for x in result["unsupportedClaimsRejected"]))

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -1624,3 +1624,58 @@ class SourceFileMemoryFirstReadoutTests(unittest.TestCase):
         self.assertEqual(report["reviewBlockers"], [])
         self.assertIn("possible_fit", brief["adminSummary"])
         self.assertIn("omit", brief["recommendedNextAction"].lower())
+
+class SourceFilePagePlanV1Tests(unittest.TestCase):
+    def test_archive_emits_complete_page_plan_everywhere_and_keeps_legacy_outputs(self):
+        packet = {
+            "subject": "Page Plan Fox",
+            "matchKind": "candidate_intake",
+            "runTime": "2026-06-18T00:00:00Z",
+            "sourceFile": {"id": "sf_page", "name": "Page Plan Fox"},
+            "sections": {},
+            "subjectAnalystReadV1": {
+                "subjectName": "Page Plan Fox",
+                "currentRead": "Full read: public music context, owner wording need, vague contest note, and internal queue boundary.",
+                "publicSafeClaims": ["Page Plan Fox has public BARCODE music context."],
+                "missingInfoQuestions": ["What owner-approved public role may BNL use?"],
+                "readyForDraft": False,
+                "dossierBlockedBy": [],
+                "privateOrInternalExclusions": ["Queue note contains private context."],
+                "reviewableClaims": [
+                    {"id": "contest", "claimText": "Possible contest/event connection.", "claimType": "contest", "publicSafe": False},
+                    {"id": "public", "claimText": "Page Plan Fox has public BARCODE music context.", "publicSafe": True},
+                ],
+            },
+        }
+        archive = enrich.build_source_file_archive_payload(packet)
+        plan = archive["sourceFilePagePlanV1"]
+        self.assertIn("sourceFilePagePlanV1", archive["subjectAnalystReadV1"])
+        self.assertIn("sourceFilePagePlanV1", archive["sourceFileCaseReportV1"])
+        for key in ("dossierCompletionReadV1", "reviewActionabilityV1", "subjectDossierStateV1", "sourceFileSurfaceV1"):
+            self.assertIn(key, archive)
+        self.assertNotIn("mainAction", plan)
+        self.assertNotIn("primaryAction", plan)
+        self.assertLess(list(plan.keys()).index("questionsToAsk"), list(plan.keys()).index("dossierWorthItDecision"))
+        for key in ("header", "bnlAnalystRead", "whatBnlNeeds", "publicSafeMaterial", "bnlReviewGuidance", "questionsToAsk", "dossierWorthItDecision", "internalOmitHold", "draftOrUpdatePlan", "diagnosticsSummary"):
+            self.assertTrue(plan[key])
+        for key in ("subject", "sourceFileStatus", "bnlState", "currentLane", "lastRefresh", "existingPublicDossier"):
+            self.assertTrue(plan["header"][key])
+        self.assertIsInstance(plan["whatBnlNeeds"], list)
+        text = json.dumps(plan).lower()
+        self.assertIn("full read", text)
+        self.assertIn("contest/event", text)
+        self.assertTrue(any(i["bnlDecision"] in {"ignore_for_now", "omit"} for i in plan["bnlReviewGuidance"] if "contest" in i["reviewIssue"].lower()))
+        self.assertIn("public barcode music context", text)
+        self.assertIn("owner-approved public role", text)
+        self.assertNotIn("private context", json.dumps(plan["publicSafeMaterial"]).lower())
+        self.assertIn("internal/review-only material withheld", json.dumps(plan["internalOmitHold"]).lower())
+
+    def test_page_plan_fills_not_needed_and_not_ready_fallbacks(self):
+        archive = enrich.build_source_file_archive_payload({"subject": "Quiet Fox", "sourceFile": {"name": "Quiet Fox"}, "sections": {}, "subjectAnalystReadV1": {"subjectName": "Quiet Fox", "publicSafeClaims": [], "readyForDraft": False, "dossierBlockedBy": []}})
+        plan = archive["sourceFilePagePlanV1"]
+        self.assertEqual(plan["whatBnlNeeds"][0]["requiredOrOptional"], "not_needed")
+        self.assertEqual(plan["whatBnlNeeds"][0]["suggestedControl"]["kind"], "none")
+        self.assertEqual(plan["publicSafeMaterial"][0]["confidence"], "none")
+        self.assertEqual(plan["questionsToAsk"][0]["requiredOrOptional"], "not_needed")
+        self.assertFalse(plan["draftOrUpdatePlan"]["canDraft"])
+        self.assertEqual(plan["draftOrUpdatePlan"]["draftType"], "none_yet")


### PR DESCRIPTION
### Motivation

- Provide a stable, explicit, fully-filled page contract so the Site can render a complete Source File page without guessing or exposing raw diagnostics. 
- `sourceFileSurfaceV1` is too compact to drive a full page; the page needs explicit BNL-written sections and fallbacks for every area. 
- Ensure the draft generator and archive payloads can consume page-level guidance safely while preserving existing outputs.

### Description

- Add `build_source_file_page_plan_v1` to `bnl_source_file_enrichment.py` to produce a verbose `sourceFilePagePlanV1` object containing the required ten sections (header, BNL Analyst Read, What BNL Needs, Public-Safe Material, BNL Review Guidance, Questions To Ask, Dossier Worth-It Decision, Internal/Omit/Hold, Draft/Update Plan, Diagnostics Summary) and explicit plain-English fallbacks. 
- Wire `sourceFilePagePlanV1` into the archive flow so it is emitted at the top-level archive payload and embedded into `subjectAnalystReadV1` and `sourceFileCaseReportV1` while keeping existing outputs (`dossierCompletionReadV1`, `reviewActionabilityV1`, `subjectDossierStateV1`, `sourceFileSurfaceV1`). 
- Update `bnl_dossier_draft.py` to safely consume `sourceFilePagePlanV1` (use `draftOrUpdatePlan.useTheseMaterials`, respect `omitTheseMaterials`, apply `ownerReviewWarnings`, record internal/omit holds in rejected/owner warnings, and treat `canDraft: false` as a missing-info/owner-warning rather than public copy). 
- Add regression tests: new `SourceFilePagePlanV1Tests` in `tests/test_source_file_enrichment.py` and `DossierDraftSourceFilePagePlanTests` in `tests/test_dossier_draft_generator.py` to validate emission, filled fallbacks, section ordering, review-card absorption, public-safe/omit behavior, and draft-generator consumption.

### Testing

- Compiled modules with `python3 -m py_compile bnl_source_file_enrichment.py bnl_dossier_draft.py bnl01_bot.py bnl_subject_memory_resolver.py bnl_dossier_candidate_discovery.py bnl_source_file_refresh.py` which succeeded. 
- Ran unit tests: `pytest tests/test_subject_memory_resolver.py`, `pytest tests/test_dossier_draft_generator.py`, and `pytest tests/test_source_file_enrichment.py tests/test_source_file_archive.py tests/test_source_file_refresh.py`; all tests passed (total test run: 154 passed, 5 warnings).
- Verified the new page plan appears in the archive payload and is embedded in `subjectAnalystReadV1` and `sourceFileCaseReportV1`, that every section is populated or contains explicit fallback text, and that the draft generator consumes page-plan guidance without exposing internal/raw evidence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347e988cac83219a6660f8b28c4947)