### PR TITLE
Ground dossier drafts in public-safe page-plan material

### DIFF
--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -47,6 +47,15 @@ _PUBLIC_NOTE_META_RE = re.compile(
     re.I,
 )
 _SOURCE_USAGE_FORBIDDEN_RE = re.compile(r"\b(private|source[-_\s]*blind|review-only|review\s+only|internal|admin-only|admin\s+only|payment|priority|stripe|checkout|customer)\b", re.I)
+_NON_PUBLIC_COPY_RE = re.compile(
+    r"\b("
+    r"recurring\s+named\s+topic|may\s+inform\s+public[-\s]*safe\s+wording|topic\s+bucket|named\s+topic|"
+    r"generic\s+evidence\s+counts?|source[-\s]*blind|review[-\s]*only|admin[-\s]*only|"
+    r"clean\s+public\s+summary\s+needed|clean\s+role\s+needed|needs?\s+review\s+before\s+claiming|"
+    r"admin[-\s]*only\s+evidence\s+exists|placeholder[-\s]*like"
+    r")\b",
+    re.I,
+)
 _ROLE_LIMIT = 80
 _SUMMARY_LIMIT = 700
 _NOTES_LIMIT = 900
@@ -59,6 +68,11 @@ _ROLE_OR_TAXONOMY_LABELS = {
     "sponsor", "system", "interface", "production", "radio", "producer", "ai", "human", "hybrid",
     "unknown", "public", "internal", "restricted", "active", "pending", "person", "music",
     "tech", "systems", "broadcast", "participant", "dossier", "source", "source file",
+}
+_VALID_CLASSIFICATION_VALUES = {
+    "category": {"Unknown", "Artist", "Community", "Collaborator", "Sponsor", "System", "Entity", "Person", "Organization", "Project"},
+    "kind": {"Unknown", "Person", "Entity", "Organization", "Project", "Group", "System", "Collaborator"},
+    "ecosystemLane": {"Unknown", "Music", "BARCODE", "Community", "Tech", "Production", "Sponsor", "Systems"},
 }
 
 
@@ -142,6 +156,8 @@ def _unsafe_reasons(text: str) -> list[str]:
         reasons.append("internal alias material")
     if _FINAL_RE.search(text):
         reasons.append("final/published status wording")
+    if _NON_PUBLIC_COPY_RE.search(text):
+        reasons.append("topic-only or review-only material")
     return reasons
 
 
@@ -700,7 +716,40 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
 
 
 def _classification_value(safe_classification: dict[str, Any], key: str, default: str) -> str:
-    return _text(safe_classification.get(key), 120) or default
+    value = _text(safe_classification.get(key), 120) or default
+    allowed = _VALID_CLASSIFICATION_VALUES.get(key)
+    if allowed and value not in allowed:
+        return default
+    return value
+
+
+def _conservative_classification(packet: dict[str, Any], owner_warnings: list[str] | None = None) -> dict[str, str]:
+    safe = _dict(packet.get("safeClassification"))
+    source = _dict(packet.get("sourceFileClassificationV1"))
+    out = {
+        key: _classification_value(safe, key, "Unknown")
+        for key in ("category", "kind", "ecosystemLane")
+    }
+    source_out = {
+        key: _classification_value(source, key, "Unknown")
+        for key in ("category", "kind", "ecosystemLane")
+    }
+    for key in ("category", "kind", "ecosystemLane"):
+        raw_safe = _text(safe.get(key), 120)
+        raw_source = _text(source.get(key), 120)
+        if owner_warnings is not None and raw_safe and raw_safe != out[key]:
+            owner_warnings.append(f"Invalid safeClassification {key} value was treated as Unknown for public draft safety.")
+        if owner_warnings is not None and raw_source and raw_source != source_out[key]:
+            owner_warnings.append(f"Invalid sourceFileClassificationV1 {key} value was treated as Unknown for public draft safety.")
+        if raw_source and source_out[key] == "Unknown":
+            if raw_source and raw_safe and raw_source != raw_safe and owner_warnings is not None:
+                owner_warnings.append(f"Source File classification conflicts with safeClassification for {key}; used the more conservative value.")
+            out[key] = "Unknown"
+        elif raw_source and out[key] != "Unknown" and source_out[key] != out[key]:
+            out[key] = "Unknown"
+            if owner_warnings is not None:
+                owner_warnings.append(f"Source File classification conflicts with safeClassification for {key}; used the more conservative value.")
+    return out
 
 
 def _identity_authority(packet: dict[str, Any], safe_classification: dict[str, Any]) -> str:
@@ -877,9 +926,12 @@ def _tag_candidates(category: str, kind: str, lane: str, facts: list[str], notes
         for item in _as_list(source_classification.get("blockedPublicTags"))
         if isinstance(item, dict)
     )
+    supported_tag_text = haystack
     for tag in _strings(packet.get("proposedTags"), limit_each=60, max_items=10):
         normalized = tag.lower().replace(" ", "-")
         if normalized in blocked_classification_tags:
+            continue
+        if normalized in {"artist", "community", "member", "mod", "moderator"} and normalized not in supported_tag_text:
             continue
         if not _unsafe_reasons(normalized) and normalized not in candidates:
             candidates.append(normalized)
@@ -928,7 +980,9 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
     safe_classification = _dict(packet.get("safeClassification"))
     style_packet = _dict(packet.get("stylePacket"))
     name = _candidate_name(candidate)
-    category, kind, lane = _category_kind_lane(safe_classification)
+    classification_warnings: list[str] = []
+    conservative_classification = _conservative_classification(packet, classification_warnings)
+    category, kind, lane = _category_kind_lane(conservative_classification)
     public_facts, rejected_facts = _reject_unsafe_public(_strings(packet.get("publicSafeFacts"), max_items=16))
     raw_public_notes = _strings(packet.get("publicSafeNotes"), max_items=12)
     public_notes, rejected_notes = _reject_unsafe_public(raw_public_notes)
@@ -987,6 +1041,8 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
     page_plan_draft_plan = _dict(source_file_page_plan.get("draftOrUpdatePlan")) if source_file_page_plan else {}
     page_plan_public_material_added = False
     if source_file_page_plan:
+        public_facts = []
+        public_notes = []
         page_plan_public_candidates = _strings(page_plan_draft_plan.get("useTheseMaterials"), max_items=8)
         for material in source_file_page_plan.get("publicSafeMaterial") or []:
             if not isinstance(material, dict):
@@ -1030,20 +1086,25 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
             rejected_facts.extend(rejected_review_texts[:6])
     if subject_dossier_state:
         for item in _strings(subject_dossier_state.get("publicSafeToUseNow"), max_items=5):
-            if item not in public_facts:
-                public_facts.append(item)
+            safe_items, unsafe_items = _reject_unsafe_public([item])
+            for safe in safe_items:
+                if not source_file_page_plan and safe not in public_facts:
+                    public_facts.append(safe)
+            rejected_facts.extend(unsafe_items)
         for item in _strings(subject_dossier_state.get("keepInternal"), max_items=4) + _strings(subject_dossier_state.get("omitForNow"), max_items=4):
             if item:
                 rejected_facts.append(item)
     role = _role_from_context(public_facts, public_notes, category, kind, lane)[:_ROLE_LIMIT]
     if analyst:
         analyst_public = " ".join(_strings(analyst.get("draftIngredients"), max_items=9) + _strings(analyst.get("publicSafeClaims"), max_items=6)).lower()
-        if re.search(r"\b(music|artist|musician|track|song|album|producer|dj)\b", analyst_public):
+        if not source_file_page_plan and re.search(r"\b(music|artist|musician|track|song|album|producer|dj)\b", analyst_public):
             role = "Music artist"
         elif analyst.get("likelySubjectType") == "community_participant" and analyst.get("publicDraftPosture") in {"confident", "conservative"}:
             role = "Community participant"
         elif analyst.get("confidence") == "low" and role == "Review pending":
             role = "Dossier subject"
+    if role == "Review pending" or (source_file_page_plan and not page_plan_public_material_added):
+        role = "Dossier subject"
     thin = len(public_facts) + len(public_notes) < 2 and not page_plan_public_material_added
 
     missing = _strings(packet.get("missingInfo"), max_items=8)
@@ -1077,6 +1138,7 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
         missing.append("Confirm preferred public display name and what identity authority, if any, may be stated publicly.")
 
     owner_warnings = _strings(packet.get("ownerReviewRules"), max_items=8) + _strings(packet.get("reviewOnlyWarnings"), max_items=8)
+    owner_warnings.extend(classification_warnings)
     owner_warnings.append("Owner Review must approve identity, role, category, links, and public wording before publication.")
     if source_file_page_plan:
         for item in _strings(page_plan_draft_plan.get("ownerReviewWarnings"), max_items=8):

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -843,3 +843,80 @@ class DossierDraftSourceFilePagePlanTests(unittest.TestCase):
         self.assertNotIn("diagnostics say music artist", public.lower())
         self.assertTrue(any("page-plan wording" in x for x in result["ownerReviewWarnings"]))
         self.assertTrue(any("Private DJ set note" in x for x in result["unsupportedClaimsRejected"]))
+
+class DossierDraftPagePlanGroundingTests(unittest.TestCase):
+    def test_topic_only_page_plan_does_not_become_public_copy(self):
+        topic_line = "Recurring named topic: Bit’s may inform public-safe wording only after owner and admin review."
+        packet = pr217_packet(
+            publicSafeFacts=[],
+            publicSafeNotes=[],
+            proposedTags=["artist", "community", "member", "mod"],
+            safeClassification={"category": "Unknown", "kind": "Person", "ecosystemLane": "Unknown"},
+            sourceFileClassificationV1={"category": "Unknown", "kind": "Person", "ecosystemLane": "Unknown"},
+            sourceFilePagePlanV1={
+                "publicSafeMaterial": [{"material": topic_line, "confidence": "low"}],
+                "draftOrUpdatePlan": {
+                    "canDraft": False,
+                    "useTheseMaterials": [topic_line, "clean public summary needed", "clean role needed"],
+                    "omitTheseMaterials": ["admin-only evidence exists"],
+                    "ownerReviewWarnings": ["needs review before claiming"],
+                },
+                "dossierWorthItDecision": {"decision": "not_worth_it_yet", "draftReadiness": "not_ready"},
+            },
+        )
+        result = draft.generate_dossier_draft(packet)["draft"]
+        public = " ".join(str(result[k]) for k in ("role", "summary", "notes", "tags", "proposedTags"))
+        self.assertNotIn("Recurring named topic", public)
+        self.assertNotIn("may inform public-safe wording", public)
+        self.assertNotEqual(result["role"], "Music artist")
+        self.assertEqual(result["role"], "Dossier subject")
+        self.assertFalse({"artist", "community", "member", "mod"} & (set(result["tags"]) | set(result["proposedTags"])))
+        review_text = " ".join(result["ownerReviewWarnings"] + result["unsupportedClaimsRejected"])
+        self.assertIn("topic-only or review-only material", review_text)
+
+    def test_page_plan_public_safe_material_drives_draft(self):
+        packet = pr217_packet(
+            publicSafeFacts=[],
+            publicSafeNotes=[],
+            safeClassification={"category": "Community", "kind": "Person", "ecosystemLane": "BARCODE"},
+            sourceFileClassificationV1={"category": "Community", "kind": "Person", "ecosystemLane": "BARCODE"},
+            sourceFilePagePlanV1={
+                "publicSafeMaterial": [
+                    {"material": "Crow is publicly documented as a BARCODE community moderator for event discussions.", "confidence": "high"}
+                ],
+                "draftOrUpdatePlan": {
+                    "canDraft": True,
+                    "useTheseMaterials": ["Crow helps moderate public BARCODE community event discussions."],
+                    "ownerReviewWarnings": ["Owner Review must approve public moderator wording."],
+                },
+                "dossierWorthItDecision": {"decision": "worth_drafting_now", "draftReadiness": "ready"},
+            },
+        )
+        result = draft.generate_dossier_draft(packet)["draft"]
+        public = " ".join(str(result[k]) for k in ("role", "summary", "notes", "tags", "proposedTags"))
+        self.assertEqual(result["role"], "Community moderator")
+        self.assertIn("BARCODE", public)
+        self.assertIn("moderator", public.lower())
+        self.assertTrue(any("moderator wording" in x for x in result["ownerReviewWarnings"]))
+
+    def test_invalid_and_conflicting_classification_is_conservative(self):
+        packet = pr217_packet(
+            publicSafeFacts=[],
+            publicSafeNotes=[],
+            safeClassification={"category": "Artist", "kind": "internal_only", "ecosystemLane": "Music"},
+            sourceFileClassificationV1={"category": "Unknown", "kind": "kind", "ecosystemLane": "ecosystemLane"},
+            sourceFilePagePlanV1={
+                "publicSafeMaterial": [],
+                "draftOrUpdatePlan": {"canDraft": False, "useTheseMaterials": []},
+                "dossierWorthItDecision": {"decision": "not_worth_it_yet", "draftReadiness": "not_ready"},
+            },
+        )
+        result = draft.generate_dossier_draft(packet)["draft"]
+        self.assertEqual(result["category"], "Unknown")
+        self.assertEqual(result["kind"], "Unknown")
+        self.assertEqual(result["ecosystemLane"], "Unknown")
+        self.assertEqual(result["role"], "Dossier subject")
+        emitted = json.dumps(result)
+        self.assertNotIn("internal_only", emitted)
+        self.assertNotIn('"kind"', result["kind"])
+        self.assertTrue(any("classification" in x.lower() for x in result["ownerReviewWarnings"]))


### PR DESCRIPTION
### Motivation
- Crow smoke test exposed that recurring topic labels and review-only placeholder wording from Source File page plans were being included verbatim in public-facing draft fields, causing incorrect roles/tags and placeholder-like summaries.
- The generator must only create public copy from validated public-safe materials and otherwise fall back to conservative owner-review warnings or withhold public claims.
- Classification values and source-file classifications must be validated and reconciled conservatively to avoid inventing stronger public roles from invalid inputs.

### Description
- Added a non-public-copy pattern filter (`_NON_PUBLIC_COPY_RE`) and treated matches as unsafe so recurring-topic, review-only, placeholder, source-blind, and similar strings are rejected from public fields and recorded as unsupported/rejected material.
- When `sourceFilePagePlanV1` is present the draft rebuilds public inputs from `draftOrUpdatePlan.useTheseMaterials` plus non-`none` `publicSafeMaterial`, clears weaker accumulated facts/notes, and records omitted/internal holds as rejected claims instead of public prose.
- Introduced conservative classification validation via `_VALID_CLASSIFICATION_VALUES` and `_conservative_classification` that downgrades invalid or conflicting `category`/`kind`/`ecosystemLane` values to `Unknown` and emits owner-review warnings when conflicts or invalid values are encountered.
- Prevented inferring `Music artist` from music-adjacent fragments when a page plan is present or when page-plan material is insufficient, made role fallback to `Dossier subject` for weak evidence, and tightened proposed tag acceptance so sensitive tags like `artist`, `community`, `member`, and `mod` require explicit supporting material.

### Testing
- Ran compilation: `python3 -m py_compile bnl01_bot.py bnl_source_file_enrichment.py bnl_subject_memory_resolver.py bnl_dossier_draft.py bnl_dossier_candidate_discovery.py bnl_source_file_refresh.py` which passed.
- Ran unit tests: `python3 -m pytest tests/test_dossier_draft_generator.py -q` and `python3 -m pytest tests/test_source_file_enrichment.py -q`, both suites passed (new tests included and all tests green).
- Added tests in `tests/test_dossier_draft_generator.py` proving that Crow-style topic-only page-plan material does not appear in `role`, `summary`, `notes`, `tags`, or `proposedTags`, that page-plan `publicSafeMaterial` drives positive drafts, and that invalid/conflicting classification values are made conservative.

Files changed
- `bnl_dossier_draft.py`
- `tests/test_dossier_draft_generator.py`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36eef0c3c88321a4b7e87d209b0058)