### PR TITLE
Align dossier draft taxonomy with site contract and sanitize public fields

### DIFF
--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -69,11 +69,32 @@ _ROLE_OR_TAXONOMY_LABELS = {
     "unknown", "public", "internal", "restricted", "active", "pending", "person", "music",
     "tech", "systems", "broadcast", "participant", "dossier", "source", "source file",
 }
-_VALID_CLASSIFICATION_VALUES = {
-    "category": {"Unknown", "Artist", "Community", "Collaborator", "Sponsor", "System", "Entity", "Person", "Organization", "Project"},
-    "kind": {"Unknown", "Person", "Entity", "Organization", "Project", "Group", "System", "Collaborator"},
-    "ecosystemLane": {"Unknown", "Music", "BARCODE", "Community", "Tech", "Production", "Sponsor", "Systems"},
+VALID_DOSSIER_CATEGORIES = {"Entity", "Personnel", "Artist", "Collaborator", "Community", "Sponsor", "Interface", "Production"}
+VALID_DOSSIER_KINDS = {
+    "program", "interface", "platform", "system", "entity", "artist", "sponsor_character",
+    "story_arc", "technical_component", "archive_record", "core_entity", "network_operator",
+    "network_staff", "moderator", "collaborator", "community_member", "radio_regular",
+    "radio_entity", "unknown",
 }
+VALID_DOSSIER_ECOSYSTEM_LANES = {
+    "core_team", "network_operator", "network_staff", "community_mod", "radio_support",
+    "technical_operator", "artist", "collaborator", "community_member", "radio_regular",
+    "sponsor", "radio_entity", "infrastructure", "production", "external_platform", "unknown",
+}
+_VALID_CLASSIFICATION_VALUES = {
+    "category": VALID_DOSSIER_CATEGORIES,
+    "kind": VALID_DOSSIER_KINDS,
+    "ecosystemLane": VALID_DOSSIER_ECOSYSTEM_LANES,
+}
+_CLASSIFICATION_DEFAULTS = {"category": "Entity", "kind": "entity", "ecosystemLane": "unknown"}
+_PUBLIC_FIELD_FORBIDDEN_RE = re.compile(
+    r"\b("
+    r"internal|source\s+file|debug|source/debug|internal/source|review-only|source-blind|"
+    r"admin-only|owner\s+review|no\s+public-safe\s+material|page\s+plan|draft\s+generator|"
+    r"resolver|diagnostics?|validation|unsupported\s+claims?|rejected\s+material"
+    r")\b",
+    re.I,
+)
 
 
 def _as_list(value: Any) -> list[Any]:
@@ -715,11 +736,12 @@ def build_public_dossier_draft_evidence(packet: dict[str, Any], db_path: str | N
     return bundle
 
 
-def _classification_value(safe_classification: dict[str, Any], key: str, default: str) -> str:
-    value = _text(safe_classification.get(key), 120) or default
+def _classification_value(safe_classification: dict[str, Any], key: str, default: str | None = None) -> str:
+    fallback = default or _CLASSIFICATION_DEFAULTS[key]
+    value = _text(safe_classification.get(key), 120) or fallback
     allowed = _VALID_CLASSIFICATION_VALUES.get(key)
     if allowed and value not in allowed:
-        return default
+        return fallback
     return value
 
 
@@ -727,28 +749,29 @@ def _conservative_classification(packet: dict[str, Any], owner_warnings: list[st
     safe = _dict(packet.get("safeClassification"))
     source = _dict(packet.get("sourceFileClassificationV1"))
     out = {
-        key: _classification_value(safe, key, "Unknown")
+        key: _classification_value(safe, key)
         for key in ("category", "kind", "ecosystemLane")
     }
     source_out = {
-        key: _classification_value(source, key, "Unknown")
+        key: _classification_value(source, key)
         for key in ("category", "kind", "ecosystemLane")
     }
     for key in ("category", "kind", "ecosystemLane"):
         raw_safe = _text(safe.get(key), 120)
         raw_source = _text(source.get(key), 120)
+        fallback = _CLASSIFICATION_DEFAULTS[key]
         if owner_warnings is not None and raw_safe and raw_safe != out[key]:
-            owner_warnings.append(f"Invalid safeClassification {key} value was treated as Unknown for public draft safety.")
+            owner_warnings.append(f"Invalid safeClassification {key} value was treated as {fallback} for site taxonomy compatibility.")
         if owner_warnings is not None and raw_source and raw_source != source_out[key]:
-            owner_warnings.append(f"Invalid sourceFileClassificationV1 {key} value was treated as Unknown for public draft safety.")
-        if raw_source and source_out[key] == "Unknown":
-            if raw_source and raw_safe and raw_source != raw_safe and owner_warnings is not None:
-                owner_warnings.append(f"Source File classification conflicts with safeClassification for {key}; used the more conservative value.")
-            out[key] = "Unknown"
-        elif raw_source and out[key] != "Unknown" and source_out[key] != out[key]:
-            out[key] = "Unknown"
+            owner_warnings.append(f"Invalid sourceFileClassificationV1 {key} value was treated as {fallback} for site taxonomy compatibility.")
+        if raw_source and source_out[key] == fallback and raw_source not in _VALID_CLASSIFICATION_VALUES[key]:
+            if raw_safe and raw_source != raw_safe and owner_warnings is not None:
+                owner_warnings.append(f"Source File classification conflicts with safeClassification for {key}; used the conservative site-compatible fallback.")
+            out[key] = fallback
+        elif raw_source and out[key] != fallback and source_out[key] != out[key]:
+            out[key] = fallback
             if owner_warnings is not None:
-                owner_warnings.append(f"Source File classification conflicts with safeClassification for {key}; used the more conservative value.")
+                owner_warnings.append(f"Source File classification conflicts with safeClassification for {key}; used the conservative site-compatible fallback.")
     return out
 
 
@@ -794,9 +817,9 @@ def _origin(packet: dict[str, Any]) -> str:
 
 def _category_kind_lane(safe_classification: dict[str, Any]) -> tuple[str, str, str]:
     return (
-        _classification_value(safe_classification, "category", "Unknown"),
-        _classification_value(safe_classification, "kind", "Unknown"),
-        _classification_value(safe_classification, "ecosystemLane", "Unknown"),
+        _classification_value(safe_classification, "category"),
+        _classification_value(safe_classification, "kind"),
+        _classification_value(safe_classification, "ecosystemLane"),
     )
 
 
@@ -847,12 +870,12 @@ def _summary(name: str, role: str, facts: list[str], notes: list[str], style_pac
             if extra:
                 summary = f"{summary} {extra[0]}"
     else:
-        summary = f"{name} is a proposed dossier subject with limited public-safe source detail."
+        summary = f"{name} is listed for review as a BARCODE Network dossier subject while public-facing details are still being confirmed."
     if _word_count(summary) > 85:
         words = summary.split()
         summary = " ".join(words[:80]).rstrip(" ,;:") + "."
     if guide["length"] and _word_count(summary) < 25 and source_sentences:
-        summary = f"{summary} Public-facing context stays concise and source-backed."
+        summary = f"{summary} Public-facing context stays concise and confirmation-based."
     return summary[:_SUMMARY_LIMIT].strip()
 
 
@@ -862,9 +885,9 @@ def _notes(public_notes: list[str], facts: list[str]) -> str:
     if note_sentences:
         notes = " ".join(note_sentences[:2])
     elif len(facts) < 2:
-        notes = "Public-safe context is limited; add stronger confirmed public details before publication."
+        notes = "Public-facing context is limited; keep wording concise and confirmation-based."
     else:
-        notes = "Public-facing context is limited; keep the wording concise and source-backed."
+        notes = "Public-facing context is limited; keep wording concise and confirmation-based."
     return notes[:_NOTES_LIMIT].strip()
 
 
@@ -900,7 +923,7 @@ def _tag_candidates(category: str, kind: str, lane: str, facts: list[str], notes
     candidates: list[str] = []
     mapping = [
         (("artist", "music", "musician"), "artist"),
-        (("collaborator",), "collaborator"),
+        (("collaborat",), "collaborator"),
         (("community", "member"), "community"),
         (("community", "member"), "member"),
         (("personnel", "moderator", "mod"), "mod"),
@@ -971,8 +994,15 @@ def _first_link(packet: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def _source_usage_summary(packet: dict[str, Any]) -> str:
-    parts = ["Used supplied public-safe packet facts, notes, safe classification, and site style guidance as draft boundary context."]
+    parts = ["Used supplied public-facing facts, notes, site-compatible classification, and site style guidance as draft boundary context."]
     return " ".join(part for part in parts if not _SOURCE_USAGE_FORBIDDEN_RE.search(part))
+
+
+def _clean_public_field(value: str, fallback: str) -> str:
+    clean = _text(value, 1000)
+    if not clean or _PUBLIC_FIELD_FORBIDDEN_RE.search(clean):
+        return fallback
+    return clean
 
 
 def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, public_read_model: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -1103,7 +1133,12 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
             role = "Community participant"
         elif analyst.get("confidence") == "low" and role == "Review pending":
             role = "Dossier subject"
-    if role == "Review pending" or (source_file_page_plan and not page_plan_public_material_added):
+    if source_file_page_plan and not page_plan_public_material_added:
+        category, kind, lane = _CLASSIFICATION_DEFAULTS["category"], _CLASSIFICATION_DEFAULTS["kind"], _CLASSIFICATION_DEFAULTS["ecosystemLane"]
+        public_facts = []
+        public_notes = []
+        role = "Dossier subject"
+    elif role == "Review pending":
         role = "Dossier subject"
     thin = len(public_facts) + len(public_notes) < 2 and not page_plan_public_material_added
 
@@ -1215,6 +1250,36 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
 
     tags, proposed_tags = _split_tags(packet, style_packet, category, kind, lane, public_facts, public_notes)
 
+    public_summary = _clean_public_field(
+        _summary(name, role, public_facts, public_notes, style_packet),
+        f"{name} is listed for review as a BARCODE Network dossier subject while public-facing details are still being confirmed.",
+    )
+    public_notes_text = _clean_public_field(
+        _notes(public_notes, public_facts),
+        "Public-facing context is limited; keep wording concise and confirmation-based.",
+    )
+    public_role = _clean_public_field(role, "Dossier subject")[:_ROLE_LIMIT]
+    public_source_usage = _clean_public_field(
+        " ".join(
+            part
+            for part in [
+                _source_usage_summary(packet),
+                *(
+                    item
+                    for item in (_strings(evidence.get("sourceSummariesUsed"), max_items=4) if evidence else [])
+                    if not (_SOURCE_USAGE_FORBIDDEN_RE.search(item) or _PUBLIC_FIELD_FORBIDDEN_RE.search(item))
+                ),
+                *(
+                    item
+                    for item in (_strings(analyst.get("provenanceSummary"), max_items=3) if analyst else [])
+                    if not (_SOURCE_USAGE_FORBIDDEN_RE.search(item) or _PUBLIC_FIELD_FORBIDDEN_RE.search(item))
+                ),
+            ]
+            if part
+        ),
+        "Used supplied public-facing facts, notes, site-compatible classification, and site style guidance as draft boundary context.",
+    )
+
     draft = {
         "name": name,
         "category": category,
@@ -1224,9 +1289,9 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
         "status": "PENDING",
         "clearance": _clearance(packet),
         "origin": _origin(packet),
-        "role": role,
-        "summary": _summary(name, role, public_facts, public_notes, style_packet),
-        "notes": _notes(public_notes, public_facts),
+        "role": public_role,
+        "summary": public_summary,
+        "notes": public_notes_text,
         "tags": tags,
         "proposedTags": proposed_tags,
         "primaryLink": _first_link(packet),
@@ -1236,23 +1301,7 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
         "ownerReviewWarnings": owner_warnings[:12],
         "publicSafetyWarnings": public_warnings[:12],
         "unsupportedClaimsRejected": rejected[:14],
-        "sourceUsageSummary": " ".join(
-            part
-            for part in [
-                _source_usage_summary(packet),
-                *(
-                    item
-                    for item in (_strings(evidence.get("sourceSummariesUsed"), max_items=4) if evidence else [])
-                    if not _SOURCE_USAGE_FORBIDDEN_RE.search(item)
-                ),
-                *(
-                    item
-                    for item in (_strings(analyst.get("provenanceSummary"), max_items=3) if analyst else [])
-                    if not _SOURCE_USAGE_FORBIDDEN_RE.search(item)
-                ),
-            ]
-            if part
-        ),
+        "sourceUsageSummary": public_source_usage,
     }
     readiness = {}
     if analyst:

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -203,7 +203,7 @@ class DossierDraftGeneratorTests(unittest.TestCase):
 
     def test_thin_packet_returns_conservative_summary_and_missing_info(self):
         result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]))["draft"]
-        self.assertIn("limited public-safe source detail", result["summary"])
+        self.assertIn("listed for review as a BARCODE Network dossier subject", result["summary"])
         self.assertNotIn("owner review", result["summary"].lower())
         self.assertTrue(result["missingInfoQuestions"])
         self.assertIn("Add more public-safe facts", result["missingInfoQuestions"][0])
@@ -694,7 +694,7 @@ class DossierDraftGeneratorTests(unittest.TestCase):
             public = " ".join(str(result[k]) for k in ("role", "summary", "notes", "sourceUsageSummary")).lower()
             for forbidden in ("owner", "admin", "review-only", "source-blind", "private", "internal", "stripe", "priority", "customer", "discord id"):
                 self.assertNotIn(forbidden, public)
-            self.assertIn("reduced them to", result["sourceUsageSummary"])
+            self.assertIn("held 10 specific review-needed", result["sourceUsageSummary"])
             self.assertTrue(any("BNL internal subject read" in x and "recurring BARCODE-facing community subject" in x for x in result["ownerReviewWarnings"]))
             self.assertTrue(any("display name" in x.lower() for x in result["missingInfoQuestions"]))
             self.assertTrue(any("public links" in x.lower() for x in result["missingInfoQuestions"]))
@@ -874,6 +874,55 @@ class DossierDraftPagePlanGroundingTests(unittest.TestCase):
         review_text = " ".join(result["ownerReviewWarnings"] + result["unsupportedClaimsRejected"])
         self.assertIn("topic-only or review-only material", review_text)
 
+
+    def test_weak_crow_page_plan_uses_site_taxonomy_and_clean_public_fallbacks(self):
+        packet = pr217_packet(
+            candidate={"sourceFileId": "sf_crow", "subjectName": "Crow"},
+            publicSafeFacts=[],
+            publicSafeNotes=[],
+            proposedTags=["artist", "community", "member", "mod", "moderator"],
+            safeClassification={"category": "Internal only", "kind": "Unknown", "ecosystemLane": "Unknown"},
+            sourceFileClassificationV1={"category": "Unknown", "kind": "Person", "ecosystemLane": "BARCODE"},
+            sourceFilePagePlanV1={
+                "publicSafeMaterial": [{"material": "No public-safe material is ready; internal/source review-only page plan.", "confidence": "none"}],
+                "draftOrUpdatePlan": {"canDraft": False, "useTheseMaterials": ["Recurring named topic: Bit’s source-blind review-only signal."], "ownerReviewWarnings": ["Source File is internal-only and needs owner review."]},
+                "dossierWorthItDecision": {"decision": "not_worth_it_yet", "draftReadiness": "not_ready"},
+            },
+        )
+        result = draft.generate_dossier_draft(packet)["draft"]
+        self.assertEqual(result["category"], "Entity")
+        self.assertEqual(result["kind"], "entity")
+        self.assertEqual(result["ecosystemLane"], "unknown")
+        self.assertEqual(result["role"], "Dossier subject")
+        self.assertFalse(set(result["tags"]) | set(result["proposedTags"]))
+        public = " ".join(str(result[k]) for k in ("role", "summary", "notes", "sourceUsageSummary", "tags", "proposedTags")).lower()
+        for forbidden in ("internal", "source file", "debug", "source/debug", "internal/source", "review-only", "source-blind", "admin-only", "owner review", "no public-safe material", "page plan", "draft generator", "resolver", "diagnostics", "validation", "unsupported claims", "rejected material", "bit’s"):
+            self.assertNotIn(forbidden, public)
+        self.assertIn("crow is listed for review as a barcode network dossier subject", result["summary"].lower())
+        self.assertEqual(result["notes"], "Public-facing context is limited; keep wording concise and confirmation-based.")
+        metadata = " ".join(result["ownerReviewWarnings"] + result["publicSafetyWarnings"] + result["unsupportedClaimsRejected"] + result["missingInfoQuestions"]).lower()
+        self.assertIn("internal", metadata)
+        self.assertIn("source file", metadata)
+
+    def test_site_taxonomy_never_emits_known_invalid_values(self):
+        invalid_packets = [
+            {"category": "Unknown", "kind": "Unknown", "ecosystemLane": "Unknown"},
+            {"category": "Internal only", "kind": "Person", "ecosystemLane": "BARCODE"},
+            {"category": "System", "kind": "entity", "ecosystemLane": "Music"},
+            {"category": "Person", "kind": "Person", "ecosystemLane": "Unknown"},
+            {"category": "Organization", "kind": "entity", "ecosystemLane": "BARCODE"},
+            {"category": "Project", "kind": "entity", "ecosystemLane": "Music"},
+        ]
+        for safe in invalid_packets:
+            with self.subTest(safe=safe):
+                result = draft.generate_dossier_draft(pr217_packet(safeClassification=safe, sourceFileClassificationV1=safe))["draft"]
+                self.assertIn(result["category"], draft.VALID_DOSSIER_CATEGORIES)
+                self.assertIn(result["kind"], draft.VALID_DOSSIER_KINDS)
+                self.assertIn(result["ecosystemLane"], draft.VALID_DOSSIER_ECOSYSTEM_LANES)
+                self.assertNotIn(result["category"], {"Unknown", "Internal only", "System", "Person", "Organization", "Project"})
+                self.assertNotIn(result["kind"], {"Unknown", "Person"})
+                self.assertNotIn(result["ecosystemLane"], {"Unknown", "BARCODE", "Music"})
+
     def test_page_plan_public_safe_material_drives_draft(self):
         packet = pr217_packet(
             publicSafeFacts=[],
@@ -912,9 +961,9 @@ class DossierDraftPagePlanGroundingTests(unittest.TestCase):
             },
         )
         result = draft.generate_dossier_draft(packet)["draft"]
-        self.assertEqual(result["category"], "Unknown")
-        self.assertEqual(result["kind"], "Unknown")
-        self.assertEqual(result["ecosystemLane"], "Unknown")
+        self.assertEqual(result["category"], "Entity")
+        self.assertEqual(result["kind"], "entity")
+        self.assertEqual(result["ecosystemLane"], "unknown")
         self.assertEqual(result["role"], "Dossier subject")
         emitted = json.dumps(result)
         self.assertNotIn("internal_only", emitted)


### PR DESCRIPTION
### Motivation
- The Crow smoke test was failing because the draft generator still emitted site-invalid taxonomy values (e.g., `Unknown`, `Internal only`, `Person`, `BARCODE`, `Music`) and included internal/source/debug wording in public-facing summary fields, causing site validation to reject drafts. 
- The intent is to make the BNL proposed-dossier output self-contained and site-compatible so the site no longer needs to normalize enum values or reject drafts for internal wording.

### Description
- Replace the local classification allow-list with the exact site-compatible taxonomy sets and conservative fallbacks, namely category fallback `Entity`, kind fallback `entity`, and ecosystemLane fallback `unknown`; category values: `Entity`, `Personnel`, `Artist`, `Collaborator`, `Community`, `Sponsor`, `Interface`, `Production`; kind values: `program`, `interface`, `platform`, `system`, `entity`, `artist`, `sponsor_character`, `story_arc`, `technical_component`, `archive_record`, `core_entity`, `network_operator`, `network_staff`, `moderator`, `collaborator`, `community_member`, `radio_regular`, `radio_entity`, `unknown`; ecosystemLane values: `core_team`, `network_operator`, `network_staff`, `community_mod`, `radio_support`, `technical_operator`, `artist`, `collaborator`, `community_member`, `radio_regular`, `sponsor`, `radio_entity`, `infrastructure`, `production`, `external_platform`, `unknown`. 
- Prevent internal/source/debug/process wording from reaching public fields by adding a public-field forbidden regex and applying `_clean_public_field` to `role`, `summary`, `notes`, and `sourceUsageSummary`, while routing any source/process limitations into non-public metadata such as `ownerReviewWarnings`, `publicSafetyWarnings`, `unsupportedClaimsRejected`, and `missingInfoQuestions`.
- Make page-plan/weak-evidence behavior conservative and public-safe by clearing public facts/notes and forcing conservative outputs when no usable `publicSafeMaterial` exists, including `role: Dossier subject`, `category: Entity`, `kind: entity`, `ecosystemLane: unknown`, `summary: "<Name> is listed for review as a BARCODE Network dossier subject while public-facing details are still being confirmed."`, and `notes: "Public-facing context is limited; keep wording concise and confirmation-based."`.
- Preserve and extend existing protections from PR #314 (topic-only filtering and recurring named topic blocking) and filter per-part source-usage/provenance entries so unsafe process language cannot contaminate the public `sourceUsageSummary` or tags.

### Testing
- Ran static compile: `python3 -m py_compile bnl01_bot.py bnl_source_file_enrichment.py bnl_subject_memory_resolver.py bnl_dossier_draft.py bnl_dossier_candidate_discovery.py bnl_source_file_refresh.py` (passed). 
- Ran dossier generator tests: `python3 -m pytest tests/test_dossier_draft_generator.py -q` (50 passed, 5 warnings, 18 subtests passed). 
- Ran source file enrichment tests: `python3 -m pytest tests/test_source_file_enrichment.py -q` (70 passed, 5 warnings). 
- Files changed: `bnl_dossier_draft.py` (taxonomy, fallbacks, public-field filtering, public fallback copy, page-plan logic), and `tests/test_dossier_draft_generator.py` (added/adjusted tests covering Crow-style weak page-plan material, forbidden public wording, taxonomy contract and fallback behavior).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4956ddaf088321a9f867a958b18af9)