### PR TITLE
Clean weak-evidence public fallback copy and filter review/process terms

### DIFF
--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -19,6 +19,9 @@ DRAFT_TOKEN_ENV = "BNL_DOSSIER_DRAFT_GENERATOR_TOKEN"
 REQUEST_TYPE = "bnl_proposed_dossier_draft"
 VERSION = "1.0"
 
+WEAK_EVIDENCE_FALLBACK_SUMMARY = "{name} is a BARCODE Network dossier subject with public-facing details still being confirmed."
+WEAK_EVIDENCE_FALLBACK_NOTES = "Public-facing context is limited; keep wording concise and confirmation-based."
+
 VALID_STATUSES = {"ACTIVE", "INACTIVE", "ARCHIVED", "PENDING", "UNKNOWN"}
 VALID_CLEARANCES = {"PUBLIC", "INTERNAL", "RESTRICTED"}
 VALID_ORIGINS = {"KNOWN", "UNKNOWN", "UNVERIFIED", "WITHHELD"}
@@ -89,8 +92,8 @@ _VALID_CLASSIFICATION_VALUES = {
 _CLASSIFICATION_DEFAULTS = {"category": "Entity", "kind": "entity", "ecosystemLane": "unknown"}
 _PUBLIC_FIELD_FORBIDDEN_RE = re.compile(
     r"\b("
-    r"internal|source\s+file|debug|source/debug|internal/source|review-only|source-blind|"
-    r"admin-only|owner\s+review|no\s+public-safe\s+material|page\s+plan|draft\s+generator|"
+    r"internal|source\s+file|debug|source/debug|internal/source|review\w*|review-only|source-blind|"
+    r"admin-only|owner\s+review|listed\s+for\s+review|no\s+public-safe\s+material|page\s+plan|draft\s+generator|"
     r"resolver|diagnostics?|validation|unsupported\s+claims?|rejected\s+material"
     r")\b",
     re.I,
@@ -870,7 +873,7 @@ def _summary(name: str, role: str, facts: list[str], notes: list[str], style_pac
             if extra:
                 summary = f"{summary} {extra[0]}"
     else:
-        summary = f"{name} is listed for review as a BARCODE Network dossier subject while public-facing details are still being confirmed."
+        summary = WEAK_EVIDENCE_FALLBACK_SUMMARY.format(name=name)
     if _word_count(summary) > 85:
         words = summary.split()
         summary = " ".join(words[:80]).rstrip(" ,;:") + "."
@@ -885,9 +888,9 @@ def _notes(public_notes: list[str], facts: list[str]) -> str:
     if note_sentences:
         notes = " ".join(note_sentences[:2])
     elif len(facts) < 2:
-        notes = "Public-facing context is limited; keep wording concise and confirmation-based."
+        notes = WEAK_EVIDENCE_FALLBACK_NOTES
     else:
-        notes = "Public-facing context is limited; keep wording concise and confirmation-based."
+        notes = WEAK_EVIDENCE_FALLBACK_NOTES
     return notes[:_NOTES_LIMIT].strip()
 
 
@@ -1000,8 +1003,11 @@ def _source_usage_summary(packet: dict[str, Any]) -> str:
 
 def _clean_public_field(value: str, fallback: str) -> str:
     clean = _text(value, 1000)
+    safe_fallback = _text(fallback, 1000)
+    if _PUBLIC_FIELD_FORBIDDEN_RE.search(safe_fallback):
+        safe_fallback = WEAK_EVIDENCE_FALLBACK_NOTES
     if not clean or _PUBLIC_FIELD_FORBIDDEN_RE.search(clean):
-        return fallback
+        return safe_fallback
     return clean
 
 
@@ -1252,11 +1258,11 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
 
     public_summary = _clean_public_field(
         _summary(name, role, public_facts, public_notes, style_packet),
-        f"{name} is listed for review as a BARCODE Network dossier subject while public-facing details are still being confirmed.",
+        WEAK_EVIDENCE_FALLBACK_SUMMARY.format(name=name),
     )
     public_notes_text = _clean_public_field(
         _notes(public_notes, public_facts),
-        "Public-facing context is limited; keep wording concise and confirmation-based.",
+        WEAK_EVIDENCE_FALLBACK_NOTES,
     )
     public_role = _clean_public_field(role, "Dossier subject")[:_ROLE_LIMIT]
     public_source_usage = _clean_public_field(

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -203,8 +203,8 @@ class DossierDraftGeneratorTests(unittest.TestCase):
 
     def test_thin_packet_returns_conservative_summary_and_missing_info(self):
         result = draft.generate_dossier_draft(pr217_packet(publicSafeFacts=[], publicSafeNotes=[]))["draft"]
-        self.assertIn("listed for review as a BARCODE Network dossier subject", result["summary"])
-        self.assertNotIn("owner review", result["summary"].lower())
+        self.assertEqual(result["summary"], "Signal Fox is a BARCODE Network dossier subject with public-facing details still being confirmed.")
+        self.assertNotIn("review", result["summary"].lower())
         self.assertTrue(result["missingInfoQuestions"])
         self.assertIn("Add more public-safe facts", result["missingInfoQuestions"][0])
 
@@ -556,7 +556,7 @@ class DossierDraftGeneratorTests(unittest.TestCase):
             conn.execute("CREATE TABLE broadcast_memory (cleaned_summary TEXT, public_safe INTEGER, status TEXT)")
             conn.execute(
                 "INSERT INTO entity_intelligence_facts VALUES (?,?,?,?,?,?,?,?,?,?)",
-                ("secret_fox", "Secret Fox", "role", "Secret Fox hosts public BARCODE collaboration reviews.", "public_safe", "owner_confirmed", 1, 0, "active", "now"),
+                ("secret_fox", "Secret Fox", "role", "Secret Fox hosts public BARCODE collaboration sessions.", "public_safe", "owner_confirmed", 1, 0, "active", "now"),
             )
             conn.execute(
                 "INSERT INTO broadcast_memory VALUES (?,?,?)",
@@ -569,7 +569,7 @@ class DossierDraftGeneratorTests(unittest.TestCase):
             result = draft.generate_dossier_draft(packet, tmp.name)["draft"]
             public = " ".join(str(result[k]) for k in ("role", "summary", "notes", "sourceUsageSummary", "ownerReviewWarnings", "publicSafetyWarnings", "unsupportedClaimsRejected", "tags", "proposedTags"))
             evidence_text = " ".join(evidence["publicFacts"] + evidence["notablePublicSignals"])
-            self.assertIn("Signal Fox hosts public BARCODE collaboration reviews", public)
+            self.assertIn("Signal Fox hosts public BARCODE collaboration sessions", public)
             self.assertIn("Signal Fox appears in public-safe BARCODE Radio notes", public)
             self.assertNotIn("Secret Fox", public)
             self.assertNotIn("Secret Fox", evidence_text)
@@ -694,7 +694,7 @@ class DossierDraftGeneratorTests(unittest.TestCase):
             public = " ".join(str(result[k]) for k in ("role", "summary", "notes", "sourceUsageSummary")).lower()
             for forbidden in ("owner", "admin", "review-only", "source-blind", "private", "internal", "stripe", "priority", "customer", "discord id"):
                 self.assertNotIn(forbidden, public)
-            self.assertIn("held 10 specific review-needed", result["sourceUsageSummary"])
+            self.assertNotIn("review", result["sourceUsageSummary"].lower())
             self.assertTrue(any("BNL internal subject read" in x and "recurring BARCODE-facing community subject" in x for x in result["ownerReviewWarnings"]))
             self.assertTrue(any("display name" in x.lower() for x in result["missingInfoQuestions"]))
             self.assertTrue(any("public links" in x.lower() for x in result["missingInfoQuestions"]))
@@ -896,10 +896,12 @@ class DossierDraftPagePlanGroundingTests(unittest.TestCase):
         self.assertEqual(result["role"], "Dossier subject")
         self.assertFalse(set(result["tags"]) | set(result["proposedTags"]))
         public = " ".join(str(result[k]) for k in ("role", "summary", "notes", "sourceUsageSummary", "tags", "proposedTags")).lower()
-        for forbidden in ("internal", "source file", "debug", "source/debug", "internal/source", "review-only", "source-blind", "admin-only", "owner review", "no public-safe material", "page plan", "draft generator", "resolver", "diagnostics", "validation", "unsupported claims", "rejected material", "bit’s"):
+        for forbidden in ("review", "owner review", "listed for review", "internal", "source file", "debug", "source/debug", "internal/source", "review-only", "source-blind", "admin-only", "no public-safe material", "page plan", "draft generator", "resolver", "diagnostics", "validation", "unsupported claims", "rejected material", "bit’s"):
             self.assertNotIn(forbidden, public)
-        self.assertIn("crow is listed for review as a barcode network dossier subject", result["summary"].lower())
+        self.assertEqual(result["summary"], "Crow is a BARCODE Network dossier subject with public-facing details still being confirmed.")
         self.assertEqual(result["notes"], "Public-facing context is limited; keep wording concise and confirmation-based.")
+        for key in ("role", "summary", "notes", "sourceUsageSummary"):
+            self.assertNotIn("review", str(result[key]).lower())
         metadata = " ".join(result["ownerReviewWarnings"] + result["publicSafetyWarnings"] + result["unsupportedClaimsRejected"] + result["missingInfoQuestions"]).lower()
         self.assertIn("internal", metadata)
         self.assertIn("source file", metadata)


### PR DESCRIPTION
### Motivation
- The post-#315 Crow smoke test still failed because the public fallback summary exposed review/process wording that trips the site public-copy guard. 
- Public-facing draft fields must never contain review/owner/source/process/debug wording, so the weak-evidence fallbacks must be replaced with clean, public-friendly copy and validated before emission.

### Description
- Introduce explicit weak-evidence fallbacks `WEAK_EVIDENCE_FALLBACK_SUMMARY` and `WEAK_EVIDENCE_FALLBACK_NOTES` and use them instead of the prior "listed for review" phrasing in `_summary` and `_notes`.
- Extend the public-field forbidden regex to catch `review` (and derived forms) and the requested process/source/debug terms, and apply that check to fallback text as well by hardening `_clean_public_field` to sanitize fallback values.
- Apply the cleaner-backed fallback summary/notes when constructing the public draft so the fallback itself is validated for forbidden terms before being used in `summary`, `notes`, `role`, and `sourceUsageSummary` public fields.
- Preserve the prior taxonomy fallbacks from #315 (`category` => `Entity`, `kind` => `entity`, `ecosystemLane` => `unknown`) and keep #314 topic-only filtering behavior unchanged.
- Files changed: `bnl_dossier_draft.py`, `tests/test_dossier_draft_generator.py`.

### Testing
- Ran compilation: `python3 -m py_compile bnl01_bot.py bnl_source_file_enrichment.py bnl_subject_memory_resolver.py bnl_dossier_draft.py bnl_dossier_candidate_discovery.py bnl_source_file_refresh.py` — PASS.
- Ran unit tests for the draft generator: `python3 -m pytest tests/test_dossier_draft_generator.py -q` — PASS (tests updated; all passed).
- Ran source-file enrichment tests: `python3 -m pytest tests/test_source_file_enrichment.py -q` — PASS.
- Result: all automated checks completed successfully (no failing tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a495c1bab5c8321a29034bfd5c08176)