### PR TITLE
Return HTTP 200 for source refresh `partial_success`

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -3584,7 +3584,7 @@ async def _handle_source_file_refresh_now(request: web.Request) -> web.Response:
         return web.json_response({"ok": False, "status": "failed", "failureReason": safe_error}, status=500)
 
     status = result.get("status") or ("success" if result.get("ok") else "failed")
-    http_status = 200 if status in {"success", "skipped", "dry_run"} else 500
+    http_status = 200 if status in {"success", "skipped", "dry_run", "partial_success"} else 500
     return web.json_response(result, status=http_status)
 
 async def start_force_pull_listener():

--- a/tests/test_source_file_refresh.py
+++ b/tests/test_source_file_refresh.py
@@ -1,3 +1,5 @@
+import asyncio
+import json
 import os
 import sqlite3
 import tempfile
@@ -8,6 +10,7 @@ os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
 
 import bnl_source_file_refresh as refresh
+import bnl01_bot
 from bnl_entity_evidence import upsert_entity_evidence_event
 
 
@@ -41,6 +44,22 @@ class FakeOpener:
             self.posts.append(json.loads((request.data or b"{}").decode("utf-8")))
             return FakeResponse({"ok": True})
         return FakeResponse(self.get_payload)
+
+
+class FakeRefreshNowRequest:
+    def __init__(self, payload=None, headers=None, json_exc=None):
+        self._payload = payload
+        self.headers = headers or {}
+        self._json_exc = json_exc
+
+    async def json(self):
+        if self._json_exc:
+            raise self._json_exc
+        return self._payload
+
+
+def decode_json_response(response):
+    return json.loads(response.text)
 
 
 class SourceFileRefreshTests(unittest.TestCase):
@@ -941,6 +960,53 @@ class SourceFileRefreshTests(unittest.TestCase):
             source = handle.read()
         for forbidden in ("publish_public", "queue_payment", "artist_account", "canonical_profile_merge", "identity_alias"):
             self.assertNotIn(forbidden, source)
+
+
+class SourceFileRefreshNowRouteTests(unittest.TestCase):
+    def call_handler(self, result):
+        request = FakeRefreshNowRequest(
+            {
+                "requestId": "req_route",
+                "subjectName": "Crow",
+                "normalizedSubjectKey": "crow",
+                "reason": "opened_source_file",
+                "source": "admin_source_file_open",
+            },
+            headers={bnl01_bot.SOURCE_REFRESH_NOW_TOKEN_HEADER: "secret"},
+        )
+        with mock.patch.object(bnl01_bot, "is_source_refresh_now_token_valid", return_value=True), \
+             mock.patch.object(bnl01_bot, "_resolve_force_pull_guild", return_value=123), \
+             mock.patch.object(bnl01_bot, "process_source_file_refresh_now", return_value=result):
+            return asyncio.run(bnl01_bot._handle_source_file_refresh_now(request))
+
+    def test_route_returns_200_for_partial_success_with_failure_reason(self):
+        result = {
+            "ok": True,
+            "status": "partial_success",
+            "failureReason": "compact_recommendation_rejected",
+            "reason": "compact_recommendation_rejected",
+            "recommendation_id": None,
+            "archive_id": "arc_crow",
+            "archiveSent": True,
+        }
+
+        response = self.call_handler(result)
+        body = decode_json_response(response)
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(body["status"], "partial_success")
+        self.assertEqual(body["failureReason"], "compact_recommendation_rejected")
+        self.assertEqual(body["reason"], "compact_recommendation_rejected")
+        self.assertIsNone(body["recommendation_id"])
+        self.assertEqual(body["archive_id"], "arc_crow")
+
+    def test_route_still_returns_500_for_failed_status(self):
+        response = self.call_handler({"ok": False, "status": "failed", "failureReason": "archive_rejected"})
+        body = decode_json_response(response)
+
+        self.assertEqual(response.status, 500)
+        self.assertEqual(body["status"], "failed")
+        self.assertEqual(body["failureReason"], "archive_rejected")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- The route `_handle_source_file_refresh_now` treated `partial_success` as an error because `partial_success` was not included in the HTTP 200 status set.  
- As a result Crow Source File could be stuck on “Loading BNL Source File” when the archive send succeeded but the compact recommendation send was rejected, because the endpoint returned HTTP 500 even though an archive was available.  

### Description
- Fixed the exact route bug by including `"partial_success"` in the set that maps to HTTP 200 in `_handle_source_file_refresh_now`.  
- The route now returns HTTP 200 for statuses `success`, `skipped`, `dry_run`, and `partial_success`, while `failed`/error statuses continue to return HTTP 500 and auth/payload/guild failures keep their original 401/400/503 behaviors.  
- The JSON payload returned by the route is unchanged for `partial_success` and still includes `status: partial_success`, any `failureReason`/`reason`, `recommendation_id` (which may be `null`), and `archive_id`/archive fields when present.  
- Added route-level tests to `tests/test_source_file_refresh.py` that mock `process_source_file_refresh_now` and assert that a `partial_success` result yields HTTP 200 and preserves the failure reason and archive fields, and that a full `failed` status still yields HTTP 500.  
- Files changed: `bnl01_bot.py`, `tests/test_source_file_refresh.py`.  

### Testing
- Compiled files: `python3 -m py_compile bnl01_bot.py bnl_source_file_refresh.py` — passed.  
- Unit tests: `python3 -m pytest tests/test_source_file_refresh.py -q` — passed (`50 passed, 5 warnings`).  
- Unit tests: `python3 -m pytest tests/test_source_file_archive.py -q` — passed (`37 passed`).  
- Route tests added/ran verify that `partial_success` returns HTTP 200 and preserves `failureReason` and archive fields, and that `failed` still returns HTTP 500.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a510d6c63a883218656d6308a3c4778)