### PR TITLE
Reject generic source-count dossier public copy

### DIFF
--- a/bnl_dossier_draft.py
+++ b/bnl_dossier_draft.py
@@ -123,6 +123,29 @@ _BACKEND_COPY_TERMS_RE = re.compile(
     re.I,
 )
 _SOURCE_LABEL_RE = re.compile(r"(?:^|[\n;|])\s*(?:source|source\s+file|source\s+lane|evidence)\s*[:#-]", re.I)
+_GENERIC_SOURCE_COUNT_SUMMARY_RE = re.compile(
+    r"(?:"
+    r"mentions\s+without\s+link\s+claims|without\s+link\s+claims|"
+    r"(?:music\s+)?discussion\s+only|feedback\s+requests?|"
+    r"song\s*/\s*track\s*/\s*demo\s*/\s*wip|"
+    r"source[-\s]*(?:count|counts|stat|stats|statistics|summary)|"
+    r"count[-\s]*(?:summary|summaries)|topic\s+buckets?"
+    r")",
+    re.I,
+)
+_COUNT_SUMMARY_CHAIN_RE = re.compile(
+    r"(?:\b[A-Za-z][A-Za-z0-9'’/ -]{1,48}:\s*\d+\b[;,.]?\s*){3,}",
+    re.I,
+)
+
+
+def _generic_source_count_summary_reason(value: Any) -> str | None:
+    clean = _text(value, 2000)
+    if not clean:
+        return None
+    if _GENERIC_SOURCE_COUNT_SUMMARY_RE.search(clean) or _COUNT_SUMMARY_CHAIN_RE.search(clean):
+        return "generic_source_count_summary"
+    return None
 
 
 def _has_repeated_public_lines(text: str) -> bool:
@@ -138,6 +161,8 @@ def contains_dossier_public_copy_junk(value: Any) -> bool:
         return False
     if _PUBLIC_FIELD_FORBIDDEN_RE.search(clean) or _SITE_PUBLIC_COPY_JUNK_RE.search(clean):
         return True
+    if _generic_source_count_summary_reason(clean):
+        return True
     if len(_SOURCE_LABEL_RE.findall(clean)) >= 2:
         return True
     if _has_repeated_public_lines(str(value)):
@@ -150,14 +175,17 @@ def contains_dossier_public_copy_junk(value: Any) -> bool:
     return False
 
 
-def _sanitize_public_field(value: str, fallback: str) -> tuple[str, bool]:
+def _sanitize_public_field(value: str, fallback: str) -> tuple[str, bool, str | None]:
     clean = _text(value, 1000)
     safe_fallback = _text(fallback, 1000)
     if contains_dossier_public_copy_junk(safe_fallback):
         safe_fallback = WEAK_EVIDENCE_FALLBACK_NOTES
-    if not clean or contains_dossier_public_copy_junk(clean):
-        return safe_fallback, bool(clean)
-    return clean, False
+    if not clean:
+        return safe_fallback, False, None
+    generic_reason = _generic_source_count_summary_reason(clean)
+    if contains_dossier_public_copy_junk(clean):
+        return safe_fallback, True, generic_reason or "site_rejected_source_process_copy"
+    return clean, False, None
 
 
 def _as_list(value: Any) -> list[Any]:
@@ -242,6 +270,8 @@ def _unsafe_reasons(text: str) -> list[str]:
         reasons.append("final/published status wording")
     if _NON_PUBLIC_COPY_RE.search(text):
         reasons.append("topic-only or review-only material")
+    if _generic_source_count_summary_reason(text):
+        reasons.append("generic source/count summary")
     return reasons
 
 
@@ -1311,16 +1341,16 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
     tags, proposed_tags = _split_tags(packet, style_packet, category, kind, lane, public_facts, public_notes)
 
     summary_raw = _summary(name, role, public_facts, public_notes, style_packet)
-    public_summary, summary_sanitized = _sanitize_public_field(
+    public_summary, summary_sanitized, summary_sanitize_reason = _sanitize_public_field(
         summary_raw,
         WEAK_EVIDENCE_FALLBACK_SUMMARY.format(name=name),
     )
     notes_raw = _notes(public_notes, public_facts)
-    public_notes_text, notes_sanitized = _sanitize_public_field(
+    public_notes_text, notes_sanitized, notes_sanitize_reason = _sanitize_public_field(
         notes_raw,
         WEAK_EVIDENCE_FALLBACK_NOTES,
     )
-    public_role, role_sanitized = _sanitize_public_field(role, "Dossier subject")
+    public_role, role_sanitized, role_sanitize_reason = _sanitize_public_field(role, "Dossier subject")
     public_role = public_role[:_ROLE_LIMIT]
     source_usage_raw = " ".join(
         part
@@ -1339,7 +1369,7 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
         ]
         if part
     )
-    public_source_usage, source_usage_sanitized = _sanitize_public_field(
+    public_source_usage, source_usage_sanitized, source_usage_sanitize_reason = _sanitize_public_field(
         source_usage_raw,
         "Draft used supplied public-facing facts, site-compatible classification, and style guidance.",
     )
@@ -1353,8 +1383,14 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
         rejected.append(warning)
     if tags_sanitized:
         rejected.append("Removed public tag candidates containing site-rejected source/process copy.")
+    sanitize_reasons = [
+        reason
+        for reason in (summary_sanitize_reason, role_sanitize_reason, notes_sanitize_reason, source_usage_sanitize_reason)
+        if reason
+    ]
+    sanitize_reason = "generic_source_count_summary" if "generic_source_count_summary" in sanitize_reasons else (sanitize_reasons[0] if sanitize_reasons else "none")
     logging.info(
-        "dossier_draft_public_copy_guard subject=%s category=%s kind=%s ecosystemLane=%s summary_sanitized=%s role_sanitized=%s notes_sanitized=%s sourceUsageSummary_sanitized=%s",
+        "dossier_draft_public_copy_guard subject=%s category=%s kind=%s ecosystemLane=%s summary_sanitized=%s role_sanitized=%s notes_sanitized=%s sourceUsageSummary_sanitized=%s reason=%s",
         re.sub(r"[^A-Za-z0-9 ._-]", "", name)[:80] or "Unknown",
         category,
         kind,
@@ -1363,6 +1399,7 @@ def generate_dossier_draft(packet: dict[str, Any], db_path: str | None = None, p
         role_sanitized,
         notes_sanitized,
         source_usage_sanitized,
+        sanitize_reason,
     )
 
     draft = {

--- a/tests/test_dossier_draft_generator.py
+++ b/tests/test_dossier_draft_generator.py
@@ -116,6 +116,61 @@ class DossierDraftGeneratorTests(unittest.TestCase):
         self.assertNotIn("candidateId", public)
         self.assertNotIn("source file", public.lower())
 
+
+    def test_generic_source_count_summary_is_rejected_with_safe_fallback_and_log_reason(self):
+        bad = "Song/track/demo/WIP mentions without link claims: 2 Music discussion only: 29 Feedback requests: 19"
+        packet = pr217_packet(
+            candidate={"sourceFileId": "sf_crow", "subjectName": "Crow"},
+            proposedTags=["community", "mentions without link claims: 2", "debug-count"],
+            subjectAnalystReadV1={"provenanceSummary": [bad]},
+        )
+        with (
+            mock.patch.object(draft, "_summary", return_value=bad),
+            mock.patch.object(draft, "_notes", return_value="Topic buckets: 2 Discussion only: 29 Feedback requests: 19"),
+            mock.patch.object(draft, "_source_usage_summary", return_value="A: 2 B: 29 C: 19"),
+            self.assertLogs(level="INFO") as logs,
+        ):
+            result = draft.generate_dossier_draft(packet)["draft"]
+
+        self.assertEqual(result["summary"], "Crow is a BARCODE Network dossier subject with public-facing details still being confirmed.")
+        self.assertEqual(result["notes"], "Public-facing context is limited; keep wording concise and confirmation-based.")
+        self.assertEqual(result["sourceUsageSummary"], "Draft used supplied public-facing facts, site-compatible classification, and style guidance.")
+        self.assertNotIn("mentions without link claims: 2", result["tags"] + result["proposedTags"])
+        self.assertNotIn("debug-count", result["tags"] + result["proposedTags"])
+        log_text = " ".join(logs.output)
+        self.assertIn("summary_sanitized=True", log_text)
+        self.assertIn("reason=generic_source_count_summary", log_text)
+        public = " ".join(str(result[k]) for k in ("role", "summary", "notes", "sourceUsageSummary", "tags", "proposedTags")).lower()
+        for forbidden in ("review", "internal", "source file", "debug", "candidateid", "workflow record", "mentions without link claims", "discussion only", "feedback requests"):
+            self.assertNotIn(forbidden, public)
+
+    def test_clean_page_plan_material_beats_generic_source_count_fallback(self):
+        bad = "Song/track/demo/WIP mentions without link claims: 2 Music discussion only: 29 Feedback requests: 19"
+        packet = pr217_packet(
+            candidate={"sourceFileId": "sf_crow", "subjectName": "Crow"},
+            publicSafeFacts=[],
+            publicSafeNotes=[],
+            sourceFilePagePlanV1={
+                "publicSafeMaterial": [
+                    {"material": bad, "confidence": "low"},
+                    {"material": "Crow is publicly connected to BARCODE community music discussions.", "confidence": "high"},
+                ],
+                "draftOrUpdatePlan": {
+                    "canDraft": True,
+                    "useTheseMaterials": ["Crow participates in public BARCODE music community conversations."],
+                    "ownerReviewWarnings": [],
+                },
+            },
+        )
+        result = draft.generate_dossier_draft(packet)["draft"]
+        self.assertNotEqual(result["summary"], "Crow is a BARCODE Network dossier subject with public-facing details still being confirmed.")
+        self.assertIn("Crow", result["summary"])
+        self.assertIn("BARCODE", result["summary"])
+        public = " ".join(str(result[k]) for k in ("role", "summary", "notes", "sourceUsageSummary", "tags", "proposedTags"))
+        self.assertNotIn("Song/track/demo/WIP", public)
+        self.assertNotIn("Recurring named topic: Bit’s", public)
+        self.assertNotIn("Lardcode", public)
+
     def test_draft_uses_public_dossier_style_context_and_filters_private_examples(self):
         packet = pr217_packet(
             stylePacket={


### PR DESCRIPTION
### Motivation
- The Crow smoke test (site PR #238) failed because the proposed public summary contained a source-count/debug readout: `Song/track/demo/WIP mentions without link claims: 2 Music discussion only: 29 Feedback requests: 19`, which the site flagged as `summary: generic_source_or_debug_copy` and rejected as forbidden internal/source copy. 
- That readout is not public-facing prose but an internal bucket/count dump and must be replaced with concise BNL-authored public prose or a conservative fallback before returning a draft. 
- The change enforces that the BNL Proposed Dossier draft generator never leaks generic source/count/stat summaries, topic-bucket dumps, or count-chain readouts into public fields. 

### Description
- Added detection for generic source/count/debug patterns via `_GENERIC_SOURCE_COUNT_SUMMARY_RE`, `_COUNT_SUMMARY_CHAIN_RE`, and `_generic_source_count_summary_reason`, and integrated them into the existing `contains_dossier_public_copy_junk` junk-guard. 
- Extended `_sanitize_public_field` to return a sanitization reason and used it for `summary`, `role`, `notes`, and `sourceUsageSummary`, while continuing to filter `tags` and `proposedTags` through the same junk-guard. 
- When a public field fails the guard the generator replaces values with safe fallbacks (`summary` => `"<Name> is a BARCODE Network dossier subject with public-facing details still being confirmed."`, `notes` => `"Public-facing context is limited; keep wording concise and confirmation-based."`, `role` => `"Dossier subject"`, `sourceUsageSummary` => `"Draft used supplied public-facing facts, site-compatible classification, and style guidance."`). 
- The generator preserves existing behavior so clean `sourceFilePagePlanV1.draftOrUpdatePlan.useTheseMaterials` or `publicSafeMaterial` will still produce richer concise BNL-authored public prose instead of the weak fallback. 
- Diagnostic logging was extended to include `reason=generic_source_count_summary` (without logging raw source text) whenever the generic source/count guard triggered; existing taxonomy fallbacks and topic-only filtering are unchanged. 
- Files changed: `bnl_dossier_draft.py`, `tests/test_dossier_draft_generator.py`. 
- New generic source/count patterns rejected include phrases like `mentions without link claims`, `without link claims`, `discussion only` / `music discussion only`, `feedback request(s)`, `song/track/demo/WIP`, `source count` / `source stat` / `source summary`, `count summary`, `topic bucket(s)`, and chained count summaries in the form `X: 2 Y: 29 Z: 19`. 

### Testing
- Ran compilation: `python3 -m py_compile bnl01_bot.py bnl_source_file_enrichment.py bnl_subject_memory_resolver.py bnl_dossier_draft.py bnl_dossier_candidate_discovery.py bnl_source_file_refresh.py` which passed. 
- Ran unit tests for the dossier draft generator: `python3 -m pytest tests/test_dossier_draft_generator.py -q` which passed (54 passed, 25 subtests passed). 
- Ran source-file enrichment tests: `python3 -m pytest tests/test_source_file_enrichment.py -q` which passed (70 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51207fb738832195543fc15e87f87e)