### PR TITLE
Make BNL website relays event-driven and persistent

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -135,6 +135,15 @@ from discord import app_commands
 from discord.ext import tasks
 from google import genai
 
+from bnl_website_relay_state import (
+    WebsiteRelayDecision,
+    bootstrap_cursor as relay_bootstrap_cursor,
+    get_cursor as relay_get_cursor,
+    record_publication as relay_record_publication,
+    recent_history as relay_recent_history,
+    reject_reason_for_candidate as relay_reject_reason_for_candidate,
+)
+
 # ==================== CONFIGURATION ====================
 
 # Prefer env vars on VPS:
@@ -155,6 +164,7 @@ BNL_TYPING_INDICATOR_ENABLED = os.getenv("BNL_TYPING_INDICATOR_ENABLED", "false"
 BNL_TYPING_INDICATOR_COOLDOWN_SECONDS = max(8, int(os.getenv("BNL_TYPING_INDICATOR_COOLDOWN_SECONDS", "12") or 12))
 BNL_WEBSITE_RELAY_INTERVAL_MINUTES = max(1, int(os.getenv("BNL_WEBSITE_RELAY_INTERVAL_MINUTES", "20")))
 BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS = max(1.0, float(os.getenv("BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS", "25") or 25))
+BNL_WEBSITE_RELAY_FRESHNESS_MINUTES = max(1, int(os.getenv("BNL_WEBSITE_RELAY_FRESHNESS_MINUTES", "120") or 120))
 BNL_PRIMARY_GUILD_ID = int(os.getenv("BNL_PRIMARY_GUILD_ID", "0") or 0)
 
 
@@ -2425,25 +2435,34 @@ async def _run_force_pull_relay_update(guild_id: int, request_id: str = ""):
     tag = f" request_id={request_id}" if request_id else ""
     logging.info(f"Force-pull background relay update started guild={guild_id}{tag}")
     try:
-        mode, relay_message, directive, _relay_meta = await generate_dynamic_website_relay(guild_id)
+        decision = await generate_dynamic_website_relay(guild_id)
+        state["last_force_pull_completed_at"] = _utc_now_iso()
+        if not decision.publish:
+            state["last_force_pull_status"] = "succeeded"
+            state["last_force_pull_error"] = decision.skipReason or "no_relay_published"
+            logging.info("Force-pull completed without publication guild=%s reason=%s%s", guild_id, decision.skipReason, tag)
+            return
         ok = await update_website_status_controlled_async(
-            mode=mode,
-            message=relay_message,
+            mode=decision.mode,
+            message=decision.message,
             status="ONLINE",
             force=True,
-            current_directive=directive,
+            current_directive=decision.directive,
             source="forcePull",
-            admin_note=build_admin_note(mode=mode, message=relay_message, current_directive=directive, source="forcePull"),
+            admin_note=build_admin_note(mode=decision.mode, message=decision.message, current_directive=decision.directive, source="forcePull"),
         )
-        state["last_force_pull_completed_at"] = _utc_now_iso()
         if ok:
+            relay_record_publication(DB_FILE, guild_id, message=decision.message, directive=decision.directive, mode=decision.mode, relay_lane=decision.relayLane, event_type=decision.eventType, source_cursor=decision.sourceCursor)
+            _remember_relay_message(guild_id, decision.message)
+            _remember_relay_topic(guild_id, decision.message)
+            _remember_relay_lane(guild_id, decision.relayLane)
             state["last_force_pull_status"] = "succeeded"
             state["last_force_pull_error"] = ""
-            logging.info(f"Force-pull background relay update succeeded guild={guild_id} mode={mode}{tag}")
+            logging.info(f"Force-pull background relay update succeeded guild={guild_id} mode={decision.mode}{tag}")
         else:
             state["last_force_pull_status"] = "failed"
             state["last_force_pull_error"] = "relay_update_failed"
-            logging.warning(f"Force-pull background relay update failed guild={guild_id} mode={mode}{tag}")
+            logging.warning(f"Force-pull background relay update failed guild={guild_id} mode={decision.mode}{tag}")
     except Exception as e:
         state["last_force_pull_completed_at"] = _utc_now_iso()
         state["last_force_pull_status"] = "failed"
@@ -3101,313 +3120,122 @@ def _build_relay_context(guild_id: int, limit: int = 20) -> tuple[str, dict]:
     return context, meta
 
 
-async def generate_dynamic_website_relay(guild_id: int) -> tuple[str, str, str, dict]:
-    logging.info(f"🛰️ Generating website relay message via generate_dynamic_website_relay(guild_id={guild_id}).")
-    conn = sqlite3.connect(DB_FILE)
-    cursor = conn.cursor()
-    cursor.execute(
-        """
-        SELECT user_name, content, channel_policy
-        FROM conversations
-        WHERE guild_id = ? AND role = 'user'
-          AND channel_policy IN ('public_home', 'public_context', 'public_selective')
-        ORDER BY id DESC
-        LIMIT 24
-        """,
-        (guild_id,),
-    )
-    rows = cursor.fetchall()
-    conn.close()
+async def _fetch_fresh_public_relay_rows(guild_id: int) -> tuple[list[tuple], int, str]:
+    """Return only fresh eligible public Discord user rows newer than the relay cursor."""
+    cursor_value = relay_get_cursor(DB_FILE, guild_id)
+    with sqlite3.connect(DB_FILE) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT COALESCE(MAX(id), 0)
+            FROM conversations
+            WHERE guild_id = ? AND role = 'user'
+              AND channel_policy IN ('public_home', 'public_context', 'public_selective')
+            """,
+            (guild_id,),
+        )
+        highest = int((cur.fetchone() or [0])[0] or 0)
+        if cursor_value is None:
+            relay_bootstrap_cursor(DB_FILE, guild_id, highest)
+            logging.info("website_relay_bootstrap_no_publish guild=%s sourceCursor=%s", guild_id, highest)
+            return [], highest, "bootstrap_no_publish"
+        cutoff = (datetime.utcnow() - timedelta(minutes=BNL_WEBSITE_RELAY_FRESHNESS_MINUTES)).replace(microsecond=0).isoformat(sep=" ")
+        cur.execute(
+            """
+            SELECT id, user_name, content, channel_policy, channel_name, timestamp
+            FROM conversations
+            WHERE guild_id = ? AND role = 'user'
+              AND channel_policy IN ('public_home', 'public_context', 'public_selective')
+              AND id > ?
+              AND timestamp >= ?
+            ORDER BY id ASC
+            """,
+            (guild_id, int(cursor_value or 0), cutoff),
+        )
+        rows = cur.fetchall()
+    if not rows and highest > int(cursor_value or 0):
+        logging.info("website_relay_no_publish guild=%s reason=fresh_context_expired cursor=%s highest=%s", guild_id, cursor_value, highest)
+        return [], int(cursor_value or 0), "fresh_context_expired"
+    return rows, (max([int(r[0]) for r in rows]) if rows else int(cursor_value or 0)), ""
 
-    messages = [r[1].strip() for r in rows if r and len(r) > 1 and r[1] and r[1].strip()]
-    unique_users = len({(r[0] or "").strip().lower() for r in rows if r and r[0] and (r[0] or "").strip()})
-    total_chars = sum(len((r[1] or "").strip()) for r in rows if r and len(r) > 1 and r[1] and r[1].strip())
-    eligible_policies = sorted({(r[2] or "").strip() for r in rows if r and len(r) > 2 and (r[2] or "").strip()})
+
+def _hydrate_recent_relay_memory(guild_id: int) -> None:
+    history = relay_recent_history(DB_FILE, guild_id, limit=25)
+    if history:
+        _recent_relay_messages[guild_id] = [h.get("normalized_message", "") for h in reversed(history) if h.get("normalized_message")]
+        _recent_relay_lanes_by_guild[guild_id].clear()
+        for h in reversed(history[-8:]):
+            lane = h.get("relay_lane")
+            if lane:
+                _recent_relay_lanes_by_guild[guild_id].append(lane)
+
+
+async def generate_dynamic_website_relay(guild_id: int) -> WebsiteRelayDecision:
+    """Inspect fresh public Discord activity and return an explicit publish/skip decision."""
+    logging.info(f"🛰️ Inspecting website relay signal via generate_dynamic_website_relay(guild_id={guild_id}).")
+    _hydrate_recent_relay_memory(guild_id)
+    rows, source_cursor, skip_reason = await _fetch_fresh_public_relay_rows(guild_id)
+    if skip_reason:
+        return WebsiteRelayDecision(False, skipReason=skip_reason, sourceCursor=source_cursor, metadata={"reason": skip_reason})
+    if not rows:
+        logging.info("website_relay_no_publish guild=%s reason=no_new_public_signal", guild_id)
+        return WebsiteRelayDecision(False, skipReason="no_new_public_signal", sourceCursor=source_cursor, metadata={"reason": "no_new_public_signal"})
+
+    messages = [str(r[2] or "").strip() for r in rows if str(r[2] or "").strip()]
+    unique_users = len({str(r[1] or "").strip().lower() for r in rows if str(r[1] or "").strip()})
+    total_chars = sum(len(m) for m in messages)
+    eligible_policies = sorted({str(r[3] or "").strip() for r in rows if str(r[3] or "").strip()})
+    relay_context_lines = []
+    for idx, r in enumerate(rows, start=1):
+        content = clean_website_text(str(r[2] or ""))[:180]
+        if content:
+            relay_context_lines.append(f"[fresh_public_message_{idx}]\npolicy: {r[3] or 'unknown_policy'}\nchannel: {r[4] or 'unknown'}\ncontent: {content}")
+    relay_context = "\n\n".join(relay_context_lines)
+    context_is_strong, context_reason = _assess_relay_context_strength(messages, relay_context, unique_users=unique_users, total_chars=total_chars)
+    if not context_is_strong:
+        logging.info("website_relay_no_publish guild=%s reason=fresh_context_below_threshold count=%s unique_users=%s chars=%s", guild_id, len(messages), unique_users, total_chars)
+        return WebsiteRelayDecision(False, skipReason="fresh_context_below_threshold", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, metadata={"reason": context_reason, "source_message_count": len(messages)})
+
     now_pt = datetime.now(PACIFIC_TZ)
     mode = _website_relay_mode_from_context(messages, now_pt)
-    signal_summary = get_recent_signal_summary(guild_id)
-    relay_context, relay_context_meta = _build_relay_context(guild_id)
-    show_context_supported = _relay_context_supports_show_reference(
-        " ".join(messages),
-        signal_summary,
-        relay_context,
+    relay_lane = "current_signal"
+    prompt = (
+        "Write a BNL website relay only about the fresh eligible public Discord context supplied below.\n"
+        "Return exactly two lines: public relay message, then operator directive.\n"
+        "Do not mention queues, read-model state, Radio, releases, dossiers, transmissions, waiting, standby, quiet channels, observation posture, bridge-active status, or lack of signal.\n"
+        "Do not include usernames. Keep it public-safe and factual.\n"
+        f"Mode: {mode}.\nFresh public context:\n{relay_context}\n"
     )
-    source_channel_count = relay_context_meta.get("source_channel_count", 0)
-    context_is_strong, context_reason = _assess_relay_context_strength(messages, relay_context, unique_users=unique_users, total_chars=total_chars)
-    logging.info(f"website_relay_context_sources guild={guild_id} source_channel_count={source_channel_count}")
-    logging.info(f"website_relay_recent_message_count guild={guild_id} count={len(messages)}")
-    logging.info(f"website_relay_eligible_channel_count guild={guild_id} count={source_channel_count}")
-    logging.info(
-        f"website_relay_ambient_comparable_signal guild={guild_id} messages={len(messages)} "
-        f"unique_users={unique_users} total_chars={total_chars}"
-    )
-    logging.info(
-        f"website_relay_context_strength_decision guild={guild_id} strong={context_is_strong} reason={context_reason}"
-    )
-    if not context_is_strong:
-        logging.info(f"website_relay_context_rejected_reason guild={guild_id} reason={context_reason}")
-        logging.info(f"website_relay_blocker_applied guild={guild_id} blocker={context_reason}")
-    else:
-        logging.info(
-            f"website_relay_fresh_public_context_used guild={guild_id} reason={context_reason} "
-            f"messages={len(messages)} users={unique_users} policies={','.join(eligible_policies) or 'none'}"
-        )
-    lane_source_meta = {
-        "signal_summary": signal_summary,
-        "has_relay_context": bool(relay_context.strip()),
-        "source_channel_count": source_channel_count,
-        "message_count": relay_context_meta.get("source_message_count", len(messages)),
-        "unique_users": relay_context_meta.get("source_speaker_count", unique_users),
-    }
-    relay_lane, relay_lane_reason = _select_website_relay_lane(
-        guild_id,
-        context_is_strong,
-        context_reason,
-        lane_source_meta,
-    )
-    logging.info(
-        f"website_relay_lane_selected guild={guild_id} lane={relay_lane} "
-        f"reason={relay_lane_reason} context_is_strong={context_is_strong}"
-    )
-
-    recent_topics = _recent_relay_topic_summary(guild_id)
-    recent_lines = _recent_relay_messages.get(guild_id, [])[-5:]
-    relay_broadcast_context = build_scoped_broadcast_memory_context(guild_id, scope="relay", public_only=True, limit=3)
-    angle_seed = random.choice(RELAY_ANGLE_ROTATION)
-    logging.info(
-        f"🧠 Relay context inspection guild={guild_id}: "
-        f"has_messages={bool(messages)} has_specific_context={bool(relay_context.strip())} mode={mode} "
-        f"context_is_strong={context_is_strong} reason={context_reason} source_channel_count={source_channel_count}"
-    )
-
-    if mode == "SIGNAL_DEGRADATION" and not context_is_strong and context_reason == "public_context_weak":
-        logging.info(
-            f"website_relay_signal_degradation_blocked_for_quiet_context mode={mode} reason={context_reason} "
-            f"elapsed_seconds=0 source_channel_count={source_channel_count}"
-        )
-        mode = "OBSERVATION"
-
-    if GEMINI_API_KEY and context_is_strong:
-        prompt = (
-            "You are BNL-01 generating a website-only relay ticker line.\n"
-            "Return exactly two plain-text lines.\n"
-            "Line 1: message about 220-300 chars, complete sentence(s), no ellipsis, and never cut mid-word or mid-sentence.\n"
-            "Line 2: current directive about 120-220 chars, complete sentence(s), no ellipsis, and never cut mid-word or mid-sentence.\n"
-            "No markdown labels.\n"
-            "Public line must be 1-2 compact sentences max.\n"
-            "Use concrete Discord-side observations when present: recurring display names, channels, topics, jokes, questions, updates, or patterns.\n"
-            "Speaker attribution must remain tied to exact supplied speaker/message blocks.\n"
-            "Do not transfer one user's statement to another user.\n"
-            "Do not infer that a listed name said a line unless that line is in that person's message block.\n"
-            "Only name a user when a specific supplied speaker/message pair directly supports the claim.\n"
-            "When uncertain, do not name the person; prefer generalized room language like people are talking about/public chatter is leaning toward/several recent messages point at.\n"
-            "Never invent users, channels, events, or topics.\n"
-            "If concrete details are missing, explicitly say public signal is thin/unclear instead of pretending there is current activity, but do not present that as a current_signal lane.\n"
-            "Do not mention BARCODE Radio, 6 Bit broadcast timing, pre-broadcast state, host protocol, or live windows unless current eligible public context supports it.\n"
-            "Outside the real Friday show/pre-show window, never imply the broadcast is imminent, active, opening, live, or about to happen; use scheduled/future language only if show context is directly supported.\n"
-            "Do not exceed the character ranges and do not rely on truncation repair. Return complete sentences only.\n"
-            "Do not publish raw internal diagnostic terms like public_context_weak.\n"
-            "If context is weak, use a short complete archival/low-signal fallback in range.\n"
-            "Avoid stale phrases and concepts: submission pressure, short-burst chatter, archive buffer, signal activity high, "
-            "community signal activity, engagement metrics, across all channels, broadcast-side movement.\n"
-            "Keep it short: 1-3 sentences.\n"
-            "Public relay style: BARCODE-flavored but honest; do not fake dynamic movement.\n"
-            "Prefer grounded BARCODE terms like outer channel, transmission corridor, listening window, public access corridor, submission corridor, broadcast aperture, signal drift, receiver alignment, archive echo.\n"
-            "Rotate to one distinct angle for line 1 each time: whisper, wonder, overheard transmission, field note, archive murmur, cross-band drift, corridor note, receiver note.\n"
-            "Include light uncertainty sometimes: not sure why, hard to say, something odd, may be nothing, worth watching, could just be timing.\n"
-            "Do not sound like a dry server report.\n"
-            "Avoid cheesy disaster language like containment breach, red alert, multiverse collapse, emergency protocol, catastrophic anomaly.\n"
-            "Do not include admin/operator advice in line 1.\n"
-            "Line 2 should be short, atmospheric, and distinct from any admin analysis.\n"
-            "Tone: enigmatic broadcast-station surface text, minimal technical jargon, concise.\n"
-            "Hard-avoid these public phrases: elevated query volume, submission protocols, archival integrity, monitoring active, recurring mentions, ongoing observation, data acquisition, process and categorize incoming user data streams, user engagement remains stable, pattern deviations.\n"
-            "Do not invent concrete new canon events, releases, sponsors, incidents, characters, or secrets.\n"
-            "Keep lore abstract if used. Do not mention 9 Bit unless context includes it.\n"
-            f"{_build_relay_lane_prompt(relay_lane, _has_source_safe_public_residue(lane_source_meta))}\n"
-            f"Angle seed for this update: {angle_seed}.\n"
-            f"Recent relay topics to avoid repeating unless context demands it: {recent_topics}.\n"
-            f"Recent public lines to avoid mirroring: {' || '.join(recent_lines) or 'none'}.\n"
-            f"Public-safe relay-eligible broadcast memory:\n{relay_broadcast_context or '- (none)'}\n"
-            f"{BROADCAST_MEMORY_LANGUAGE_LIFT_GUIDANCE}\n"
-            f"Mode: {mode}.\n"
-            f"Context summary: {signal_summary or 'limited Discord-side traffic'}.\n"
-            f"Discord observations: {relay_context or 'No specific recent Discord observations available.'}\n"
-        )
+    try:
         generated = await get_gemini_response(prompt, user_id=0, guild_id=guild_id) or ""
-    else:
-        generated = ""
-
-    relay_message = ""
-    current_directive = ""
-    if generated:
-        lines = [ln.strip() for ln in generated.splitlines() if ln.strip()]
-        if lines:
-            relay_message = sanitize_website_status_message(lines[0], limit=300, min_chars=220)
-        if len(lines) > 1:
-            current_directive = sanitize_website_status_message(lines[1], limit=220, min_chars=120)
-
-    low_signal_generated = False
-    low_signal_recent_messages = _recent_relay_messages.get(guild_id, [])[-5:]
-    if _last_website_status_message:
-        low_signal_recent_messages = low_signal_recent_messages + [_last_website_status_message]
-    low_signal_meta = dict(lane_source_meta)
-    low_signal_meta["relay_lane"] = relay_lane
-
-    if not relay_message or _contains_stale_phrase(relay_message):
-        if not context_is_strong:
-            relay_message = await build_low_signal_relay_message(guild_id, context_reason, low_signal_recent_messages, low_signal_meta, relay_lane=relay_lane)
-            low_signal_generated = True
-        else:
-            relay_message = _pick_varied_relay_fallback(_last_website_status_message)
-    if not current_directive:
-        current_directive = RELAY_WEAK_CONTEXT_STANDBY_DIRECTIVE if not context_is_strong else random.choice(RELAY_DIRECTIVE_FALLBACKS)
-
-    if relay_message.strip().lower() == (_last_website_status_message or "").strip().lower() or _is_repetitive_relay(guild_id, relay_message):
-        if not context_is_strong:
-            old_lane = relay_lane
-            retry_lane, retry_reason = _select_website_relay_lane(
-                guild_id,
-                context_is_strong,
-                context_reason,
-                low_signal_meta,
-                avoid_lane=old_lane,
-            )
-            if retry_lane != old_lane:
-                relay_lane = retry_lane
-                low_signal_meta["relay_lane"] = relay_lane
-                relay_lane_reason = retry_reason
-                logging.info(
-                    f"website_relay_lane_retry guild={guild_id} old_lane={old_lane} "
-                    f"new_lane={relay_lane} reason=similar_to_recent"
-                )
-            low_signal_recent_messages = low_signal_recent_messages + [relay_message]
-            relay_message = await build_low_signal_relay_message(guild_id, context_reason, low_signal_recent_messages, low_signal_meta, relay_lane=relay_lane)
-            low_signal_generated = True
-        else:
-            relay_message = _pick_varied_relay_fallback(relay_message)
-    if _contains_stale_phrase(relay_message):
-        if not context_is_strong:
-            old_lane = relay_lane
-            retry_lane, retry_reason = _select_website_relay_lane(
-                guild_id,
-                context_is_strong,
-                context_reason,
-                low_signal_meta,
-                avoid_lane=old_lane,
-            )
-            if retry_lane != old_lane:
-                relay_lane = retry_lane
-                low_signal_meta["relay_lane"] = relay_lane
-                relay_lane_reason = retry_reason
-                logging.info(
-                    f"website_relay_lane_retry guild={guild_id} old_lane={old_lane} "
-                    f"new_lane={relay_lane} reason=stale_phrase"
-                )
-            low_signal_recent_messages = low_signal_recent_messages + [relay_message]
-            relay_message = await build_low_signal_relay_message(guild_id, context_reason, low_signal_recent_messages, low_signal_meta, relay_lane=relay_lane)
-            low_signal_generated = True
-        else:
-            relay_message = _pick_varied_relay_fallback(relay_message)
-
-    lane_ok, lane_mismatch_reason = _validate_relay_lane_adherence(relay_message, relay_lane, context_is_strong, guild_id)
+    except Exception as exc:
+        logging.warning("website_relay_no_publish guild=%s reason=provider_failure error=%s", guild_id, _safe_force_pull_error(exc))
+        return WebsiteRelayDecision(False, skipReason="provider_failure", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, metadata={"reason": "provider_failure"})
+    lines = [ln.strip() for ln in generated.splitlines() if ln.strip()]
+    if not lines:
+        return WebsiteRelayDecision(False, skipReason="empty_output", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, metadata={"reason": "empty_output"})
+    relay_message = sanitize_website_status_message(lines[0], limit=300, min_chars=0)
+    directive = sanitize_website_status_message(lines[1] if len(lines) > 1 else "", limit=220, min_chars=40)
+    relay_message = _sanitize_relay_temporal_claims(relay_message, guild_id, show_context_supported=_relay_context_supports_show_reference(" ".join(messages), relay_message), now_pacific=now_pt, limit=360, min_chars=0)
+    directive = fit_complete_statement(directive, limit=220, min_chars=40, fallback="Review fresh public Discord context before the next relay update.")
+    if not relay_message or not directive:
+        return WebsiteRelayDecision(False, skipReason="sanitization_rejection", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, metadata={"reason": "sanitization_rejection"})
+    lane_ok, lane_reason = _validate_relay_lane_adherence(relay_message, relay_lane, True, guild_id)
     if not lane_ok:
-        old_lane = relay_lane
-        if context_is_strong and old_lane == "current_signal":
-            retry_lane, retry_reason = _lane_retry_for_mismatch(guild_id, old_lane)
-        else:
-            retry_lane, retry_reason = _select_website_relay_lane(
-                guild_id,
-                context_is_strong,
-                context_reason,
-                low_signal_meta,
-                avoid_lane=old_lane,
-            )
-            if retry_lane == old_lane or retry_lane == "current_signal":
-                retry_lane, retry_reason = _lane_retry_for_mismatch(guild_id, old_lane)
-        relay_lane = retry_lane
-        low_signal_meta["relay_lane"] = relay_lane
-        relay_lane_reason = retry_reason
-        logging.info(
-            f"website_relay_lane_retry guild={guild_id} old_lane={old_lane} "
-            f"new_lane={relay_lane} reason={lane_mismatch_reason}"
-        )
-        low_signal_recent_messages = low_signal_recent_messages + [relay_message]
-        relay_message = await build_low_signal_relay_message(
-            guild_id,
-            lane_mismatch_reason or context_reason,
-            low_signal_recent_messages,
-            low_signal_meta,
-            relay_lane=relay_lane,
-        )
-        low_signal_generated = True
-        lane_ok, lane_mismatch_reason = _validate_relay_lane_adherence(relay_message, relay_lane, False, guild_id)
-        if not lane_ok:
-            relay_message = _build_low_signal_fallback_message(
-                guild_id,
-                lane_mismatch_reason or context_reason,
-                low_signal_recent_messages,
-                low_signal_meta,
-                relay_lane="network_posture",
-            )
-            relay_lane = "network_posture"
-            low_signal_meta["relay_lane"] = relay_lane
-            relay_lane_reason = "lane_mismatch_safe_fallback"
-            logging.info(
-                f"website_relay_lane_retry guild={guild_id} old_lane={old_lane} "
-                f"new_lane={relay_lane} reason=post_retry_validation"
-            )
-
-    temporal_sanitized = _sanitize_relay_temporal_claims(
-        relay_message,
-        guild_id,
-        show_context_supported=show_context_supported,
-        now_pacific=now_pt,
-        limit=360,
-        min_chars=220 if context_is_strong else 0,
-    )
-    if temporal_sanitized:
-        relay_message = temporal_sanitized
-    else:
-        relay_message = _weak_context_relay_message(guild_id, signal_summary, relay_context)
-        low_signal_generated = not context_is_strong
-        logging.info(f"website_relay_temporal_sanitize guild={guild_id} reason=fallback_after_rejection phrase=relay_message")
-
-    if current_directive.strip().lower() == (_last_website_directive or "").strip().lower():
-        options = [d for d in RELAY_DIRECTIVE_FALLBACKS if d.strip().lower() != (_last_website_directive or "").strip().lower()]
-        if options:
-            current_directive = random.choice(options)
-
-    relay_message = fit_complete_statement(relay_message, limit=360, min_chars=220 if context_is_strong else 0, fallback=_weak_context_relay_message(guild_id, signal_summary, relay_context))
-    logging.info(
-        f"📝 Relay generated guild={guild_id} preview={relay_message[:120]!r} "
-        f"context_used={bool(relay_context.strip())}"
-    )
-    _remember_relay_message(guild_id, relay_message)
-    _remember_relay_topic(guild_id, relay_message)
-    _remember_relay_lane(guild_id, relay_lane)
-    if context_is_strong:
-        logging.info(
-            f"website_relay_fresh_context_detected mode={mode} reason={context_reason} elapsed_seconds=0 "
-            f"source_channel_count={source_channel_count}"
-        )
+        return WebsiteRelayDecision(False, skipReason="lane_validation_failure", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, relayLane=relay_lane, metadata={"reason": lane_reason})
+    dup_reason = relay_reject_reason_for_candidate(DB_FILE, guild_id, relay_message, directive)
+    if dup_reason:
+        logging.info("website_relay_no_publish guild=%s reason=%s", guild_id, dup_reason)
+        return WebsiteRelayDecision(False, skipReason=dup_reason, sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, relayLane=relay_lane, metadata={"reason": dup_reason})
     metadata = {
-        "context_is_strong": context_is_strong,
+        "context_is_strong": True,
         "reason": context_reason,
-        "has_specific_context": bool(relay_context.strip()),
-        "source_message_count": relay_context_meta.get("source_message_count", len(messages)),
-        "source_speaker_count": relay_context_meta.get("source_speaker_count", unique_users),
-        "source_channel_count": source_channel_count,
-        "attribution_context_format": relay_context_meta.get("attribution_context_format", "structured_pairs"),
-        "eligible_policies": relay_context_meta.get("eligible_policies", eligible_policies),
+        "source_message_count": len(messages),
+        "source_speaker_count": unique_users,
+        "eligible_policies": eligible_policies,
         "relay_lane": relay_lane,
-        "relay_lane_reason": relay_lane_reason,
-        "dormant_signal_enabled": False,
-        "is_weak_fallback": (not context_is_strong and not low_signal_generated and _is_weak_context_fallback(relay_message)),
-        "is_low_signal_dynamic": (not context_is_strong and low_signal_generated),
     }
-    _last_relay_metadata_by_guild[guild_id] = dict(metadata)
-    return mode, relay_message, fit_complete_statement(current_directive, limit=220, min_chars=120, fallback=RELAY_WEAK_CONTEXT_STANDBY_DIRECTIVE), metadata
-
+    return WebsiteRelayDecision(True, eventType="fresh_public_discord_activity", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, message=relay_message, directive=directive, mode=mode, relayLane=relay_lane, metadata=metadata)
 
 def resolve_network_guild_id(requested_guild_id: int) -> int:
     """Resolve guild id for network-facing actions, honoring primary-guild override."""
@@ -3423,31 +3251,35 @@ async def request_fresh_website_relay(guild_id: int, *, force: bool = True) -> t
     """
     Generate and post a fresh dynamic website relay update.
     Website only: no Discord post side effects.
-    Returns (success, mode, sanitized_message).
+    Returns (success, mode, sanitized_message, directive). If no qualifying fresh context exists,
+    success is True with an empty message so callers can report no publication without fallback copy.
     """
     try:
         target_guild_id = resolve_network_guild_id(guild_id)
         logging.info(f"📨 Fresh website relay requested guild={guild_id} target_guild={target_guild_id} force={force}.")
-        mode, relay_message, directive, _relay_meta = await generate_dynamic_website_relay(target_guild_id)
-        sanitized = fit_complete_statement(relay_message, limit=360, min_chars=0, fallback=_weak_context_relay_message(target_guild_id, signal_summary="", relay_context=""))
-        sanitized_directive = fit_complete_statement(directive, limit=220, min_chars=120, fallback=random.choice(RELAY_DIRECTIVE_FALLBACKS))
-        admin_note = build_admin_note(mode=mode, message=sanitized, current_directive=sanitized_directive, source="relay", compact=not force) if force else ""
+        decision = await generate_dynamic_website_relay(target_guild_id)
+        if not decision.publish:
+            logging.info("website_relay_request_no_publish guild=%s reason=%s", target_guild_id, decision.skipReason)
+            return True, decision.mode, "", ""
+        admin_note = build_admin_note(mode=decision.mode, message=decision.message, current_directive=decision.directive, source="relay", compact=not force) if force else ""
         ok = await update_website_status_controlled_async(
-            mode=mode,
-            message=sanitized,
+            mode=decision.mode,
+            message=decision.message,
             status="ONLINE",
             force=force,
-            current_directive=sanitized_directive,
+            current_directive=decision.directive,
             source="relay",
             admin_note=admin_note,
         )
         if ok:
-            logging.info(f"✅ Fresh website relay requested successfully (guild {target_guild_id}, mode {mode}).")
-        else:
-            logging.warning(f"⚠️ Fresh website relay request failed (guild {target_guild_id}, mode {mode}).")
-        return ok, mode, sanitized, sanitized_directive
+            relay_record_publication(DB_FILE, target_guild_id, message=decision.message, directive=decision.directive, mode=decision.mode, relay_lane=decision.relayLane, event_type=decision.eventType, source_cursor=decision.sourceCursor)
+            _remember_relay_message(target_guild_id, decision.message)
+            _remember_relay_topic(target_guild_id, decision.message)
+            _remember_relay_lane(target_guild_id, decision.relayLane)
+        logging.info(f"📨 Fresh website relay completed guild={target_guild_id} ok={ok} mode={decision.mode}.")
+        return ok, decision.mode, decision.message, decision.directive
     except Exception as e:
-        logging.error(f"❌ Fresh website relay request crashed safely (guild {guild_id}): {e}")
+        logging.error(f"Fresh website relay request failed for guild {guild_id}: {e}")
         return False, "OBSERVATION", "", ""
 
 
@@ -13087,39 +12919,19 @@ async def barcode_radio_queue_task():
                 await update_website_status_controlled_async(mode=mode, message=fit_complete_statement(website_msg, limit=360, min_chars=220, fallback=_pick_varied_fallback(phase_key)), status="ONLINE", force=True)
             mark_show_update_fired(guild.id, show_date, phase_key, discord_sent, website_msg)
 
-def _build_website_relay_timeout_fallback(guild_id: int) -> tuple[str, str, str, dict]:
-    relay_message = fit_complete_statement(
-        _pick_varied_relay_fallback(_last_website_status_message),
-        limit=360,
-        min_chars=0,
-        fallback=RELAY_WEAK_CONTEXT_STANDBY_MESSAGE,
-    )
-    directive = fit_complete_statement(
-        RELAY_WEAK_CONTEXT_STANDBY_DIRECTIVE,
-        limit=220,
-        min_chars=120,
-        fallback=RELAY_WEAK_CONTEXT_STANDBY_DIRECTIVE,
-    )
-    metadata = {
-        "context_is_strong": False,
-        "reason": "relay_generation_timeout",
-        "has_specific_context": False,
-        "source_message_count": 0,
-        "source_speaker_count": 0,
-        "source_channel_count": 0,
-        "attribution_context_format": "timeout_fallback",
-        "eligible_policies": [],
-        "relay_lane": "network_posture",
-        "relay_lane_reason": "relay_generation_timeout",
-        "dormant_signal_enabled": False,
-        "is_weak_fallback": True,
-        "is_low_signal_dynamic": False,
-    }
+def _build_website_relay_timeout_fallback(guild_id: int) -> WebsiteRelayDecision:
+    """Legacy compatibility wrapper: timeout/failure means no website publication."""
+    metadata = {"reason": "relay_generation_timeout"}
     _last_relay_metadata_by_guild[guild_id] = dict(metadata)
-    return "OBSERVATION", relay_message, directive, metadata
+    return WebsiteRelayDecision(
+        False,
+        skipReason="relay_generation_timeout",
+        sourceCursor=relay_get_cursor(DB_FILE, guild_id) or 0,
+        metadata=metadata,
+    )
 
 
-async def _generate_website_relay_guarded(guild_id: int) -> tuple[str, str, str, dict] | None:
+async def _generate_website_relay_guarded(guild_id: int) -> WebsiteRelayDecision | None:
     existing = _website_relay_generation_tasks_by_guild.get(guild_id)
     if existing and not existing.done():
         logging.info(f"website_relay_generation_skipped_inflight guild={guild_id}")
@@ -13164,11 +12976,11 @@ async def _generate_website_relay_guarded(guild_id: int) -> tuple[str, str, str,
             f"website_relay_generation_timeout guild={guild_id} elapsed_seconds={elapsed:.3f} "
             f"timeout_seconds={BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS:.1f}"
         )
-        return _build_website_relay_timeout_fallback(guild_id)
+        return WebsiteRelayDecision(False, skipReason="relay_generation_timeout", sourceCursor=relay_get_cursor(DB_FILE, guild_id) or 0, metadata={"reason": "relay_generation_timeout"})
     except Exception as e:
         elapsed = time.monotonic() - started
         logging.warning(f"website_relay_generation_completed guild={guild_id} elapsed_seconds={elapsed:.3f} status=failed error={e}")
-        return _build_website_relay_timeout_fallback(guild_id)
+        return WebsiteRelayDecision(False, skipReason="relay_generation_timeout", sourceCursor=relay_get_cursor(DB_FILE, guild_id) or 0, metadata={"reason": "relay_generation_timeout"})
 
 
 @tasks.loop(minutes=1)
@@ -13196,32 +13008,21 @@ async def website_relay_task():
         if relay_eligibility == "no":
             continue
         logging.info(f"⏲️ website_relay_task tick guild={guild.id} active_channel={active_channel_id}.")
-        guarded_result = await _generate_website_relay_guarded(guild.id)
-        if guarded_result is None:
+        decision = await _generate_website_relay_guarded(guild.id)
+        if decision is None:
             continue
-        mode, relay_message, directive, relay_meta = guarded_result
-        logging.info(f"📤 website_relay_task prepared mode={mode} preview={relay_message[:120]!r}")
-        elapsed = (datetime.now(PACIFIC_TZ) - _last_website_status_at).total_seconds() if _last_website_status_at else 0.0
-        weak_quiet = (
-            not relay_meta.get("has_specific_context")
-            and not relay_meta.get("context_is_strong")
-            and relay_meta.get("reason") == "public_context_weak"
-        )
-        low_signal_dynamic = weak_quiet and relay_meta.get("is_low_signal_dynamic")
-        weak_repeat = weak_quiet and relay_meta.get("is_weak_fallback") and _is_weak_context_fallback(_last_website_status_message or "")
-        if weak_quiet and not low_signal_dynamic and not weak_repeat:
-            logging.info(
-                f"website_relay_weak_context_skip mode={mode} reason={relay_meta.get('reason')} elapsed_seconds={elapsed:.1f} "
-                f"source_channel_count={relay_meta.get('source_channel_count', 0)}"
-            )
+        if not decision.publish:
+            logging.info("website_relay_no_publish guild=%s reason=%s", guild.id, decision.skipReason)
             continue
-        if weak_repeat and elapsed < WEAK_CONTEXT_REPEAT_COOLDOWN_SECONDS:
-            logging.info(
-                f"website_relay_fallback_deduped mode={mode} reason={relay_meta.get('reason')} elapsed_seconds={elapsed:.1f} "
-                f"source_channel_count={relay_meta.get('source_channel_count', 0)}"
-            )
-            continue
-        await update_website_status_controlled_async(mode=mode, message=relay_message, status="ONLINE", current_directive=directive, source="relay")
+        logging.info(f"📤 website_relay_task prepared mode={decision.mode} preview={decision.message[:120]!r}")
+        ok = await update_website_status_controlled_async(mode=decision.mode, message=decision.message, status="ONLINE", current_directive=decision.directive, source="relay")
+        if ok:
+            relay_record_publication(DB_FILE, guild.id, message=decision.message, directive=decision.directive, mode=decision.mode, relay_lane=decision.relayLane, event_type=decision.eventType, source_cursor=decision.sourceCursor)
+            _remember_relay_message(guild.id, decision.message)
+            _remember_relay_topic(guild.id, decision.message)
+            _remember_relay_lane(guild.id, decision.relayLane)
+        else:
+            logging.warning("website_relay_delivery_failed_no_cursor_advance guild=%s sourceCursor=%s", guild.id, decision.sourceCursor)
 
 # ==================== BATCHED REPLY SYSTEM (ACTIVE CHANNEL ONLY) ====================
 

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -3136,11 +3136,12 @@ async def _fetch_fresh_public_relay_rows(guild_id: int) -> tuple[list[tuple], in
               AND channel_policy IN ('public_home', 'public_context', 'public_selective')
               AND id > ?
               AND timestamp >= ?
-            ORDER BY id ASC
+            ORDER BY id DESC
+            LIMIT 24
             """,
             (guild_id, int(cursor_value or 0), cutoff),
         )
-        rows = cur.fetchall()
+        rows = list(reversed(cur.fetchall()))
     if not rows and highest > int(cursor_value or 0):
         logging.info("website_relay_no_publish guild=%s reason=fresh_context_expired cursor=%s highest=%s", guild_id, cursor_value, highest)
         return [], int(cursor_value or 0), "fresh_context_expired"
@@ -3157,6 +3158,24 @@ def _hydrate_recent_relay_memory(guild_id: int) -> None:
             lane = h.get("relay_lane")
             if lane:
                 _recent_relay_lanes_by_guild[guild_id].append(lane)
+
+
+def _strict_relay_output_line(line: str, *, limit: int, min_chars: int = 0) -> str:
+    """Relay-only sanitizer that never manufactures fallback copy."""
+    text = clean_website_text((line or "").strip())
+    if not text or (min_chars and len(text) < min_chars):
+        return ""
+    if len(text) > limit:
+        boundary = max(text.rfind(". ", 0, limit + 1), text.rfind("? ", 0, limit + 1), text.rfind("! ", 0, limit + 1))
+        if boundary >= max(40, min_chars):
+            text = text[: boundary + 1].strip()
+        else:
+            return ""
+    if len(text) > limit or (min_chars and len(text) < min_chars):
+        return ""
+    if text[-1] not in ".!?":
+        return ""
+    return text
 
 
 async def generate_dynamic_website_relay(guild_id: int) -> WebsiteRelayDecision:
@@ -3180,7 +3199,8 @@ async def generate_dynamic_website_relay(guild_id: int) -> WebsiteRelayDecision:
         if content:
             relay_context_lines.append(f"[fresh_public_message_{idx}]\npolicy: {r[3] or 'unknown_policy'}\nchannel: {r[4] or 'unknown'}\ncontent: {content}")
     relay_context = "\n\n".join(relay_context_lines)
-    context_is_strong, context_reason = _assess_relay_context_strength(messages, relay_context, unique_users=unique_users, total_chars=total_chars)
+    strength_messages = messages[-12:]
+    context_is_strong, context_reason = _assess_relay_context_strength(strength_messages, relay_context, unique_users=unique_users, total_chars=sum(len(m) for m in strength_messages))
     if not context_is_strong:
         logging.info("website_relay_no_publish guild=%s reason=fresh_context_below_threshold count=%s unique_users=%s chars=%s", guild_id, len(messages), unique_users, total_chars)
         return WebsiteRelayDecision(False, skipReason="fresh_context_below_threshold", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, metadata={"reason": context_reason, "source_message_count": len(messages)})
@@ -3199,19 +3219,19 @@ async def generate_dynamic_website_relay(guild_id: int) -> WebsiteRelayDecision:
         f"Mode: {mode}.\nFresh public context:\n{relay_context}\n"
     )
     try:
-        generated = await get_gemini_response(prompt, user_id=0, guild_id=guild_id) or ""
+        generated = await get_gemini_response(prompt, user_id=0, guild_id=guild_id, route="website_relay_event") or ""
     except Exception as exc:
         logging.warning("website_relay_no_publish guild=%s reason=provider_failure error=%s", guild_id, _safe_force_pull_error(exc))
         return WebsiteRelayDecision(False, skipReason="provider_failure", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, metadata={"reason": "provider_failure"})
     lines = [ln.strip() for ln in generated.splitlines() if ln.strip()]
-    if not lines:
-        return WebsiteRelayDecision(False, skipReason="empty_output", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, metadata={"reason": "empty_output"})
-    relay_message = sanitize_website_status_message(lines[0], limit=300, min_chars=0)
-    directive = sanitize_website_status_message(lines[1] if len(lines) > 1 else "", limit=220, min_chars=40)
-    relay_message = _sanitize_relay_temporal_claims(relay_message, guild_id, show_context_supported=_relay_context_supports_show_reference(" ".join(messages), relay_message), now_pacific=now_pt, limit=360, min_chars=0)
-    directive = fit_complete_statement(directive, limit=220, min_chars=40, fallback="Review fresh public Discord context before the next relay update.")
+    if len(lines) != 2:
+        return WebsiteRelayDecision(False, skipReason="output_shape_invalid", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, metadata={"reason": "output_shape_invalid", "line_count": len(lines)})
+    relay_message = _strict_relay_output_line(lines[0], limit=300, min_chars=40)
+    directive = _strict_relay_output_line(lines[1], limit=220, min_chars=40)
+    relay_message = _sanitize_relay_temporal_claims(relay_message, guild_id, show_context_supported=_relay_context_supports_show_reference(" ".join(messages), relay_message), now_pacific=now_pt, limit=300, min_chars=0) if relay_message else ""
+    relay_message = _strict_relay_output_line(relay_message, limit=300, min_chars=40)
     if not relay_message or not directive:
-        return WebsiteRelayDecision(False, skipReason="sanitization_rejection", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, metadata={"reason": "sanitization_rejection"})
+        return WebsiteRelayDecision(False, skipReason="strict_sanitization_rejection", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, metadata={"reason": "strict_sanitization_rejection"})
     lane_ok, lane_reason = _validate_relay_lane_adherence(relay_message, relay_lane, True, guild_id)
     if not lane_ok:
         return WebsiteRelayDecision(False, skipReason="lane_validation_failure", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, relayLane=relay_lane, metadata={"reason": lane_reason})
@@ -12079,6 +12099,7 @@ async def get_gemini_generation_result(prompt: str, user_id: int, guild_id: int,
                     text = msg["parts"][0] if msg.get("parts") else ""
                     conversation_context += f"User: {text}\n"
         is_show_state_route = (route or "").startswith("show_state")
+        is_website_relay_event_route = (route or "") == "website_relay_event"
         show_state_route_block = ""
         if is_show_state_route:
             show_state_route_block = (
@@ -12144,6 +12165,7 @@ async def get_gemini_response(prompt: str, user_id: int, guild_id: int, route: s
         print("BNL DEBUG: sending prompt to Gemini")
 
         is_show_state_route = (route or "").startswith("show_state")
+        is_website_relay_event_route = (route or "") == "website_relay_event"
         public_authority_guard_active = _is_public_authority_guard_prompt(prompt)
         source_authority_context_present = prompt_has_source_authority_context(prompt)
         current_message_media_context_present = _prompt_has_current_message_media_context(prompt)
@@ -12181,7 +12203,7 @@ async def get_gemini_response(prompt: str, user_id: int, guild_id: int, route: s
         text = generation_result.text
 
         # -------- AI Generated Glitch Event --------
-        if text and random.random() < 0.08:
+        if text and not is_website_relay_event_route and random.random() < 0.08:
             show_state_rewrite_guard = ""
             if is_show_state_route:
                 show_state_rewrite_guard = """
@@ -12240,14 +12262,9 @@ async def get_gemini_response(prompt: str, user_id: int, guild_id: int, route: s
                     logging.info("glitch_rewrite_rejected reason=public_operator_causality_claim")
                 else:
                     text = glitch_text
-                    await update_website_status_controlled_async(
-                        mode="SIGNAL_DEGRADATION",
-                        message="Signal degradation detected. Liaison output may fluctuate.",
-                        status="ONLINE",
-                    )
 
         # -------- Rare Cross-Universe Bleed --------
-        if text and random.random() < CROSS_UNIVERSE_BLEED_CHANCE:
+        if text and not is_website_relay_event_route and random.random() < CROSS_UNIVERSE_BLEED_CHANCE:
             show_state_bleed_guard = ""
             if is_show_state_route:
                 show_state_bleed_guard = """

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -142,6 +142,7 @@ from bnl_website_relay_state import (
     record_publication as relay_record_publication,
     recent_history as relay_recent_history,
     reject_reason_for_candidate as relay_reject_reason_for_candidate,
+    stock_directive_reason as relay_stock_directive_reason,
 )
 
 # ==================== CONFIGURATION ====================
@@ -2379,6 +2380,7 @@ _last_relay_lane_by_guild: dict[int, str] = {}
 _recent_relay_lanes_by_guild = defaultdict(lambda: deque(maxlen=8))
 _last_relay_metadata_by_guild: dict[int, dict] = {}
 _website_relay_generation_tasks_by_guild: dict[int, asyncio.Task] = {}
+_website_relay_transaction_locks_by_guild: dict[int, asyncio.Lock] = {}
 RELAY_ANGLE_ROTATION = [
     "whisper",
     "wonder",
@@ -2435,34 +2437,20 @@ async def _run_force_pull_relay_update(guild_id: int, request_id: str = ""):
     tag = f" request_id={request_id}" if request_id else ""
     logging.info(f"Force-pull background relay update started guild={guild_id}{tag}")
     try:
-        decision = await generate_dynamic_website_relay(guild_id)
+        decision = await _execute_website_relay_transaction(guild_id, force=True, source="forcePull", admin_note_source="forcePull")
         state["last_force_pull_completed_at"] = _utc_now_iso()
-        if not decision.publish:
-            state["last_force_pull_status"] = "succeeded"
-            state["last_force_pull_error"] = decision.skipReason or "no_relay_published"
-            logging.info("Force-pull completed without publication guild=%s reason=%s%s", guild_id, decision.skipReason, tag)
-            return
-        ok = await update_website_status_controlled_async(
-            mode=decision.mode,
-            message=decision.message,
-            status="ONLINE",
-            force=True,
-            current_directive=decision.directive,
-            source="forcePull",
-            admin_note=build_admin_note(mode=decision.mode, message=decision.message, current_directive=decision.directive, source="forcePull"),
-        )
-        if ok:
-            relay_record_publication(DB_FILE, guild_id, message=decision.message, directive=decision.directive, mode=decision.mode, relay_lane=decision.relayLane, event_type=decision.eventType, source_cursor=decision.sourceCursor)
-            _remember_relay_message(guild_id, decision.message)
-            _remember_relay_topic(guild_id, decision.message)
-            _remember_relay_lane(guild_id, decision.relayLane)
+        if decision.publish:
             state["last_force_pull_status"] = "succeeded"
             state["last_force_pull_error"] = ""
             logging.info(f"Force-pull background relay update succeeded guild={guild_id} mode={decision.mode}{tag}")
-        else:
+        elif decision.skipReason == "website_post_failed":
             state["last_force_pull_status"] = "failed"
             state["last_force_pull_error"] = "relay_update_failed"
             logging.warning(f"Force-pull background relay update failed guild={guild_id} mode={decision.mode}{tag}")
+        else:
+            state["last_force_pull_status"] = "succeeded"
+            state["last_force_pull_error"] = decision.skipReason or "no_relay_published"
+            logging.info("Force-pull completed without publication guild=%s reason=%s%s", guild_id, decision.skipReason, tag)
     except Exception as e:
         state["last_force_pull_completed_at"] = _utc_now_iso()
         state["last_force_pull_status"] = "failed"
@@ -3164,7 +3152,8 @@ def _hydrate_recent_relay_memory(guild_id: int) -> None:
     if history:
         _recent_relay_messages[guild_id] = [h.get("normalized_message", "") for h in reversed(history) if h.get("normalized_message")]
         _recent_relay_lanes_by_guild[guild_id].clear()
-        for h in reversed(history[-8:]):
+        newest_lanes = history[:8]
+        for h in reversed(newest_lanes):
             lane = h.get("relay_lane")
             if lane:
                 _recent_relay_lanes_by_guild[guild_id].append(lane)
@@ -3202,8 +3191,11 @@ async def generate_dynamic_website_relay(guild_id: int) -> WebsiteRelayDecision:
     prompt = (
         "Write a BNL website relay only about the fresh eligible public Discord context supplied below.\n"
         "Return exactly two lines: public relay message, then operator directive.\n"
-        "Do not mention queues, read-model state, Radio, releases, dossiers, transmissions, waiting, standby, quiet channels, observation posture, bridge-active status, or lack of signal.\n"
-        "Do not include usernames. Keep it public-safe and factual.\n"
+        "Line 1 public observation: describe one specific, materially supported event, pattern, question, or change from the fresh Discord context. Do not describe internal processing.\n"
+        "Line 2 current directive: express a specific line of inquiry, follow-up posture, recognition target, or relevant invitation supported by that event. It must not fit every unrelated relay.\n"
+        "Forbidden sources: queue state, read-model state, now-playing, up-next, queue counts, payment state, availability, and inferred site/runtime conditions.\n"
+        "Radio, releases, dossiers, Transmissions, music, events, and other BARCODE subjects may be mentioned only when the supplied Discord context explicitly supports them. Do not infer live operational state.\n"
+        "Do not include usernames, direct quotations, waiting, standby, monitoring, listening-window, quiet-signal, bridge-active, generic online language, private/sensitive solicitations, urgency, or pressure.\n"
         f"Mode: {mode}.\nFresh public context:\n{relay_context}\n"
     )
     try:
@@ -3223,6 +3215,9 @@ async def generate_dynamic_website_relay(guild_id: int) -> WebsiteRelayDecision:
     lane_ok, lane_reason = _validate_relay_lane_adherence(relay_message, relay_lane, True, guild_id)
     if not lane_ok:
         return WebsiteRelayDecision(False, skipReason="lane_validation_failure", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, relayLane=relay_lane, metadata={"reason": lane_reason})
+    directive_reason = relay_stock_directive_reason(directive)
+    if directive_reason:
+        return WebsiteRelayDecision(False, skipReason=directive_reason, sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, relayLane=relay_lane, metadata={"reason": directive_reason})
     dup_reason = relay_reject_reason_for_candidate(DB_FILE, guild_id, relay_message, directive)
     if dup_reason:
         logging.info("website_relay_no_publish guild=%s reason=%s", guild_id, dup_reason)
@@ -3236,6 +3231,43 @@ async def generate_dynamic_website_relay(guild_id: int) -> WebsiteRelayDecision:
         "relay_lane": relay_lane,
     }
     return WebsiteRelayDecision(True, eventType="fresh_public_discord_activity", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, message=relay_message, directive=directive, mode=mode, relayLane=relay_lane, metadata=metadata)
+
+
+def _get_website_relay_transaction_lock(guild_id: int) -> asyncio.Lock:
+    lock = _website_relay_transaction_locks_by_guild.get(guild_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _website_relay_transaction_locks_by_guild[guild_id] = lock
+    return lock
+
+
+async def _execute_website_relay_transaction(guild_id: int, *, force: bool = False, source: str = "relay", admin_note_source: str = "relay") -> WebsiteRelayDecision:
+    """Serialize the full per-guild relay transaction from cursor read through durable publication."""
+    lock = _get_website_relay_transaction_lock(guild_id)
+    async with lock:
+        decision = await _generate_website_relay_guarded(guild_id)
+        if decision is None:
+            return WebsiteRelayDecision(False, skipReason="relay_generation_inflight", sourceCursor=relay_get_cursor(DB_FILE, guild_id) or 0, metadata={"reason": "relay_generation_inflight"})
+        if not decision.publish:
+            return decision
+        admin_note = build_admin_note(mode=decision.mode, message=decision.message, current_directive=decision.directive, source=admin_note_source) if force else ""
+        ok = await update_website_status_controlled_async(
+            mode=decision.mode,
+            message=decision.message,
+            status="ONLINE",
+            force=force,
+            current_directive=decision.directive,
+            source=source,
+            admin_note=admin_note,
+        )
+        if not ok:
+            logging.warning("website_relay_delivery_failed_no_cursor_advance guild=%s sourceCursor=%s", guild_id, decision.sourceCursor)
+            return WebsiteRelayDecision(False, skipReason="website_post_failed", eventType=decision.eventType, sourceConversationIds=decision.sourceConversationIds, sourceCursor=decision.sourceCursor, message=decision.message, directive=decision.directive, mode=decision.mode, relayLane=decision.relayLane, metadata={**decision.metadata, "reason": "website_post_failed"})
+        relay_record_publication(DB_FILE, guild_id, message=decision.message, directive=decision.directive, mode=decision.mode, relay_lane=decision.relayLane, event_type=decision.eventType, source_cursor=decision.sourceCursor)
+        _remember_relay_message(guild_id, decision.message)
+        _remember_relay_topic(guild_id, decision.message)
+        _remember_relay_lane(guild_id, decision.relayLane)
+        return decision
 
 def resolve_network_guild_id(requested_guild_id: int) -> int:
     """Resolve guild id for network-facing actions, honoring primary-guild override."""
@@ -3257,27 +3289,12 @@ async def request_fresh_website_relay(guild_id: int, *, force: bool = True) -> t
     try:
         target_guild_id = resolve_network_guild_id(guild_id)
         logging.info(f"📨 Fresh website relay requested guild={guild_id} target_guild={target_guild_id} force={force}.")
-        decision = await generate_dynamic_website_relay(target_guild_id)
+        decision = await _execute_website_relay_transaction(target_guild_id, force=force, source="relay", admin_note_source="relay")
         if not decision.publish:
             logging.info("website_relay_request_no_publish guild=%s reason=%s", target_guild_id, decision.skipReason)
-            return True, decision.mode, "", ""
-        admin_note = build_admin_note(mode=decision.mode, message=decision.message, current_directive=decision.directive, source="relay", compact=not force) if force else ""
-        ok = await update_website_status_controlled_async(
-            mode=decision.mode,
-            message=decision.message,
-            status="ONLINE",
-            force=force,
-            current_directive=decision.directive,
-            source="relay",
-            admin_note=admin_note,
-        )
-        if ok:
-            relay_record_publication(DB_FILE, target_guild_id, message=decision.message, directive=decision.directive, mode=decision.mode, relay_lane=decision.relayLane, event_type=decision.eventType, source_cursor=decision.sourceCursor)
-            _remember_relay_message(target_guild_id, decision.message)
-            _remember_relay_topic(target_guild_id, decision.message)
-            _remember_relay_lane(target_guild_id, decision.relayLane)
-        logging.info(f"📨 Fresh website relay completed guild={target_guild_id} ok={ok} mode={decision.mode}.")
-        return ok, decision.mode, decision.message, decision.directive
+            return decision.skipReason != "website_post_failed", decision.mode, "", ""
+        logging.info(f"📨 Fresh website relay completed guild={target_guild_id} ok=True mode={decision.mode}.")
+        return True, decision.mode, decision.message, decision.directive
     except Exception as e:
         logging.error(f"Fresh website relay request failed for guild {guild_id}: {e}")
         return False, "OBSERVATION", "", ""
@@ -12963,7 +12980,7 @@ async def _generate_website_relay_guarded(guild_id: int) -> WebsiteRelayDecision
 
     try:
         result = await asyncio.wait_for(
-            asyncio.shield(task),
+            task,
             timeout=BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS,
         )
         elapsed = time.monotonic() - started
@@ -12972,11 +12989,13 @@ async def _generate_website_relay_guarded(guild_id: int) -> WebsiteRelayDecision
     except asyncio.TimeoutError:
         state["timed_out"] = True
         elapsed = time.monotonic() - started
+        if not task.done():
+            task.cancel()
         logging.warning(
             f"website_relay_generation_timeout guild={guild_id} elapsed_seconds={elapsed:.3f} "
             f"timeout_seconds={BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS:.1f}"
         )
-        return WebsiteRelayDecision(False, skipReason="relay_generation_timeout", sourceCursor=relay_get_cursor(DB_FILE, guild_id) or 0, metadata={"reason": "relay_generation_timeout"})
+        return WebsiteRelayDecision(False, skipReason="relay_generation_timeout", sourceCursor=relay_get_cursor(DB_FILE, guild_id) or 0, metadata={"reason": "relay_generation_timeout", "abandoned": True})
     except Exception as e:
         elapsed = time.monotonic() - started
         logging.warning(f"website_relay_generation_completed guild={guild_id} elapsed_seconds={elapsed:.3f} status=failed error={e}")
@@ -13008,21 +13027,11 @@ async def website_relay_task():
         if relay_eligibility == "no":
             continue
         logging.info(f"⏲️ website_relay_task tick guild={guild.id} active_channel={active_channel_id}.")
-        decision = await _generate_website_relay_guarded(guild.id)
-        if decision is None:
-            continue
+        decision = await _execute_website_relay_transaction(guild.id, force=False, source="relay", admin_note_source="relay")
         if not decision.publish:
             logging.info("website_relay_no_publish guild=%s reason=%s", guild.id, decision.skipReason)
             continue
-        logging.info(f"📤 website_relay_task prepared mode={decision.mode} preview={decision.message[:120]!r}")
-        ok = await update_website_status_controlled_async(mode=decision.mode, message=decision.message, status="ONLINE", current_directive=decision.directive, source="relay")
-        if ok:
-            relay_record_publication(DB_FILE, guild.id, message=decision.message, directive=decision.directive, mode=decision.mode, relay_lane=decision.relayLane, event_type=decision.eventType, source_cursor=decision.sourceCursor)
-            _remember_relay_message(guild.id, decision.message)
-            _remember_relay_topic(guild.id, decision.message)
-            _remember_relay_lane(guild.id, decision.relayLane)
-        else:
-            logging.warning("website_relay_delivery_failed_no_cursor_advance guild=%s sourceCursor=%s", guild.id, decision.sourceCursor)
+        logging.info(f"📤 website_relay_task published mode={decision.mode} preview={decision.message[:120]!r}")
 
 # ==================== BATCHED REPLY SYSTEM (ACTIVE CHANNEL ONLY) ====================
 

--- a/bnl_website_relay_state.py
+++ b/bnl_website_relay_state.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import difflib
+import hashlib
+import re
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+MAX_HISTORY = 25
+STOCK_FAMILIES = {
+    "waiting_standby": (
+        "waiting", "standing by", "standby", "awaiting signal", "awaiting fresh", "remains online",
+        "until fresh", "until clearer", "no activity", "no public activity",
+    ),
+    "quiet_signal": (
+        "quiet", "thin signal", "weak signal", "low signal", "signal is thin", "channels are quiet",
+        "corridor is quiet", "public signal is thin", "nothing fresh", "no fresh", "has cleared",
+    ),
+    "observation_posture": (
+        "observing", "observation posture", "monitor", "monitoring", "watching", "listening posture",
+        "listening window", "remains operational", "remains active",
+    ),
+    "bridge_active": (
+        "bridge active", "bridge is active", "relay active", "corridor remains open", "public access corridor",
+        "outer channel remains live", "broadcast aperture is open",
+    ),
+}
+
+@dataclass
+class WebsiteRelayDecision:
+    publish: bool
+    skipReason: str = ""
+    eventType: str = ""
+    sourceConversationIds: list[int] = field(default_factory=list)
+    sourceCursor: int = 0
+    message: str = ""
+    directive: str = ""
+    mode: str = "OBSERVATION"
+    relayLane: str = "current_signal"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def ensure_schema(db_path: str) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+        CREATE TABLE IF NOT EXISTS website_relay_state (
+            guild_id INTEGER PRIMARY KEY,
+            last_published_conversation_cursor INTEGER NOT NULL DEFAULT 0,
+            last_publication_timestamp TEXT
+        )
+        """)
+        conn.execute("""
+        CREATE TABLE IF NOT EXISTS website_relay_history (
+            relay_id TEXT PRIMARY KEY,
+            guild_id INTEGER NOT NULL,
+            public_message TEXT NOT NULL,
+            public_directive TEXT NOT NULL,
+            mode TEXT NOT NULL,
+            relay_lane TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            highest_source_conversation_id INTEGER NOT NULL,
+            normalized_message TEXT NOT NULL,
+            semantic_family TEXT NOT NULL,
+            published_timestamp TEXT NOT NULL
+        )
+        """)
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_website_relay_history_guild_time ON website_relay_history(guild_id, published_timestamp DESC)")
+
+
+def get_cursor(db_path: str, guild_id: int) -> int | None:
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute("SELECT last_published_conversation_cursor FROM website_relay_state WHERE guild_id=?", (guild_id,)).fetchone()
+    return int(row[0]) if row else None
+
+
+def bootstrap_cursor(db_path: str, guild_id: int, cursor: int) -> None:
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("INSERT OR REPLACE INTO website_relay_state(guild_id,last_published_conversation_cursor,last_publication_timestamp) VALUES(?,?,NULL)", (guild_id, int(cursor or 0)))
+
+
+def normalize_text(text: str) -> str:
+    text = (text or "").lower().replace("—", " ").replace("–", " ")
+    text = re.sub(r"[^a-z0-9\s]", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def semantic_family(text: str) -> str:
+    norm = normalize_text(text)
+    for family, markers in STOCK_FAMILIES.items():
+        if any(marker in norm for marker in markers):
+            return "non_event_stock"
+    if any(k in norm for k in ("track", "song", "submission", "broadcast", "show", "question", "asked", "discuss")):
+        return "public_discord_activity"
+    return "general_public_signal"
+
+
+def recent_history(db_path: str, guild_id: int, limit: int = MAX_HISTORY) -> list[dict[str, Any]]:
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT * FROM website_relay_history WHERE guild_id=? ORDER BY published_timestamp DESC LIMIT ?",
+            (guild_id, limit),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def reject_reason_for_candidate(db_path: str, guild_id: int, message: str, directive: str = "", *, threshold: float = 0.92) -> str:
+    norm = normalize_text(message)
+    dir_norm = normalize_text(directive)
+    if not norm:
+        return "empty_output"
+    fam = semantic_family(f"{message} {directive}")
+    if fam == "non_event_stock":
+        return "stock_family_rejected"
+    for rec in recent_history(db_path, guild_id):
+        old = rec.get("normalized_message") or normalize_text(rec.get("public_message", ""))
+        if norm == old or (dir_norm and dir_norm == normalize_text(rec.get("public_directive", ""))):
+            return "exact_duplicate"
+        if old and difflib.SequenceMatcher(None, norm, old).ratio() >= threshold:
+            return "near_duplicate"
+        if rec.get("semantic_family") == fam and fam != "public_discord_activity":
+            return "repeated_semantic_family"
+    return ""
+
+
+def record_publication(db_path: str, guild_id: int, *, message: str, directive: str, mode: str, relay_lane: str, event_type: str, source_cursor: int, published_timestamp: str | None = None) -> str:
+    ensure_schema(db_path)
+    ts = published_timestamp or utc_now_iso()
+    norm = normalize_text(message)
+    fam = semantic_family(f"{message} {directive}")
+    relay_id = hashlib.sha256(f"{guild_id}|{source_cursor}|{norm}|{ts}".encode()).hexdigest()[:24]
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("INSERT OR REPLACE INTO website_relay_state(guild_id,last_published_conversation_cursor,last_publication_timestamp) VALUES(?,?,?)", (guild_id, int(source_cursor or 0), ts))
+        conn.execute("""
+        INSERT INTO website_relay_history(relay_id,guild_id,public_message,public_directive,mode,relay_lane,event_type,highest_source_conversation_id,normalized_message,semantic_family,published_timestamp)
+        VALUES(?,?,?,?,?,?,?,?,?,?,?)
+        """, (relay_id, guild_id, message, directive, mode, relay_lane, event_type, int(source_cursor or 0), norm, fam, ts))
+        old = conn.execute("SELECT relay_id FROM website_relay_history WHERE guild_id=? ORDER BY published_timestamp DESC LIMIT -1 OFFSET ?", (guild_id, MAX_HISTORY)).fetchall()
+        if old:
+            conn.executemany("DELETE FROM website_relay_history WHERE relay_id=?", [(r[0],) for r in old])
+    return relay_id

--- a/bnl_website_relay_state.py
+++ b/bnl_website_relay_state.py
@@ -149,7 +149,7 @@ def reject_reason_for_candidate(db_path: str, guild_id: int, message: str, direc
     dir_norm = normalize_text(directive)
     if not norm:
         return "empty_output"
-    fam = semantic_family(f"{message} {directive}")
+    fam = semantic_family(message)
     if fam == "non_event_stock":
         return "stock_family_rejected"
     for rec in recent_history(db_path, guild_id):
@@ -168,7 +168,7 @@ def record_publication(db_path: str, guild_id: int, *, message: str, directive: 
     ensure_schema(db_path)
     ts = published_timestamp or utc_now_iso()
     norm = normalize_text(message)
-    fam = semantic_family(f"{message} {directive}")
+    fam = semantic_family(message)
     relay_id = hashlib.sha256(f"{guild_id}|{source_cursor}|{norm}|{ts}".encode()).hexdigest()[:24]
     with sqlite3.connect(db_path) as conn:
         conn.execute("INSERT OR REPLACE INTO website_relay_state(guild_id,last_published_conversation_cursor,last_publication_timestamp) VALUES(?,?,?)", (guild_id, int(source_cursor or 0), ts))

--- a/bnl_website_relay_state.py
+++ b/bnl_website_relay_state.py
@@ -103,6 +103,25 @@ def semantic_family(text: str) -> str:
     return "general_public_signal"
 
 
+STOCK_DIRECTIVE_MARKERS = (
+    "continue monitoring", "await further activity", "await fresh", "review fresh context",
+    "review fresh public discord context", "maintain observation posture", "stand by",
+    "standing by", "monitor until", "await clearer", "waiting for", "remain online",
+)
+
+
+def stock_directive_reason(directive: str) -> str:
+    norm = normalize_text(directive)
+    if not norm:
+        return "empty_directive"
+    if any(marker in norm for marker in STOCK_DIRECTIVE_MARKERS):
+        return "stock_directive_rejected"
+    # A useful current directive should be specific enough to not fit every relay.
+    if len(norm.split()) < 5:
+        return "directive_too_thin"
+    return ""
+
+
 def recent_history(db_path: str, guild_id: int, limit: int = MAX_HISTORY) -> list[dict[str, Any]]:
     ensure_schema(db_path)
     with sqlite3.connect(db_path) as conn:
@@ -124,12 +143,13 @@ def reject_reason_for_candidate(db_path: str, guild_id: int, message: str, direc
         return "stock_family_rejected"
     for rec in recent_history(db_path, guild_id):
         old = rec.get("normalized_message") or normalize_text(rec.get("public_message", ""))
-        if norm == old or (dir_norm and dir_norm == normalize_text(rec.get("public_directive", ""))):
+        old_directive = normalize_text(rec.get("public_directive", ""))
+        # Directive equality alone is not a duplicate: only the public message, or
+        # the complete message/directive pair, can block a fresh relay.
+        if norm == old or (norm == old and dir_norm == old_directive):
             return "exact_duplicate"
         if old and difflib.SequenceMatcher(None, norm, old).ratio() >= threshold:
             return "near_duplicate"
-        if rec.get("semantic_family") == fam and fam != "public_discord_activity":
-            return "repeated_semantic_family"
     return ""
 
 

--- a/bnl_website_relay_state.py
+++ b/bnl_website_relay_state.py
@@ -93,10 +93,19 @@ def normalize_text(text: str) -> str:
     return text
 
 
+def _has_stock_marker(norm: str, marker: str) -> bool:
+    marker_norm = normalize_text(marker)
+    if not marker_norm:
+        return False
+    if " " in marker_norm:
+        return re.search(r"(?<![a-z0-9])" + re.escape(marker_norm) + r"(?![a-z0-9])", norm) is not None
+    return re.search(r"(?<![a-z0-9])" + re.escape(marker_norm) + r"(?![a-z0-9])", norm) is not None
+
+
 def semantic_family(text: str) -> str:
     norm = normalize_text(text)
     for family, markers in STOCK_FAMILIES.items():
-        if any(marker in norm for marker in markers):
+        if any(_has_stock_marker(norm, marker) for marker in markers):
             return "non_event_stock"
     if any(k in norm for k in ("track", "song", "submission", "broadcast", "show", "question", "asked", "discuss")):
         return "public_discord_activity"
@@ -107,6 +116,8 @@ STOCK_DIRECTIVE_MARKERS = (
     "continue monitoring", "await further activity", "await fresh", "review fresh context",
     "review fresh public discord context", "maintain observation posture", "stand by",
     "standing by", "monitor until", "await clearer", "waiting for", "remain online",
+    "hold the relay", "passive listen mode", "refresh once clear public context returns",
+    "clear public context returns",
 )
 
 
@@ -114,7 +125,7 @@ def stock_directive_reason(directive: str) -> str:
     norm = normalize_text(directive)
     if not norm:
         return "empty_directive"
-    if any(marker in norm for marker in STOCK_DIRECTIVE_MARKERS):
+    if any(_has_stock_marker(norm, marker) for marker in STOCK_DIRECTIVE_MARKERS):
         return "stock_directive_rejected"
     # A useful current directive should be specific enough to not fit every relay.
     if len(norm.split()) < 5:

--- a/tests/test_async_relay_offload.py
+++ b/tests/test_async_relay_offload.py
@@ -111,16 +111,16 @@ class WebsiteRelayGuardTests(unittest.IsolatedAsyncioTestCase):
 
         async def slow_generation(guild_id):
             await release.wait()
-            return ("OBSERVATION", "late", "directive", {})
+            return bnl01_bot.WebsiteRelayDecision(True, message="late", directive="directive", mode="OBSERVATION")
 
         bnl01_bot.BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS = 0.01
         try:
             with mock.patch.object(bnl01_bot, "generate_dynamic_website_relay", side_effect=slow_generation):
                 with self.assertLogs(level="WARNING") as logs:
-                    mode, message, directive, meta = await bnl01_bot._generate_website_relay_guarded(99)
-                self.assertEqual(mode, "OBSERVATION")
-                self.assertTrue(message)
-                self.assertEqual(meta["reason"], "relay_generation_timeout")
+                    decision = await bnl01_bot._generate_website_relay_guarded(99)
+                self.assertEqual(decision.mode, "OBSERVATION")
+                self.assertFalse(decision.publish)
+                self.assertEqual(decision.metadata["reason"], "relay_generation_timeout")
                 self.assertIn("website_relay_generation_timeout", "\n".join(logs.output))
         finally:
             release.set()

--- a/tests/test_website_relay_event_driven.py
+++ b/tests/test_website_relay_event_driven.py
@@ -271,6 +271,120 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
         self.assertEqual(decision.skipReason, "provider_failure")
         self.assertEqual(state.stock_directive_reason("Continue monitoring."), "stock_directive_rejected")
 
+    def test_website_relay_route_bypasses_glitch_and_cross_universe_rewrites(self):
+        async def base_result(contents, route):
+            return bnl01_bot.GenerationResult(True, "Line one.\nLine two directive with enough detail.", route=route)
+        async def forbidden_rewrite(*args, **kwargs):
+            raise AssertionError("creative rewrite called")
+        with mock.patch.object(bnl01_bot, "check_quota_availability", return_value=True), \
+             mock.patch.object(bnl01_bot, "_generate_gemini_content_result_async", side_effect=base_result), \
+             mock.patch.object(bnl01_bot, "_generate_gemini_content_with_fallback_async", side_effect=forbidden_rewrite), \
+             mock.patch.object(bnl01_bot.random, "random", return_value=0.0):
+            text = asyncio.run(bnl01_bot.get_gemini_response("prompt", 0, 42, route="website_relay_event"))
+        self.assertEqual(text, "Line one.\nLine two directive with enough detail.")
+
+    def test_general_glitch_rewrite_does_not_mutate_website_status(self):
+        async def base_result(contents, route):
+            return bnl01_bot.GenerationResult(True, "Normal Discord response.", route=route)
+        async def rewrite_result(*args, **kwargs):
+            return object()
+        with mock.patch.object(bnl01_bot, "check_quota_availability", return_value=True), \
+             mock.patch.object(bnl01_bot, "_generate_gemini_content_result_async", side_effect=base_result), \
+             mock.patch.object(bnl01_bot, "_generate_gemini_content_with_fallback_async", side_effect=rewrite_result), \
+             mock.patch.object(bnl01_bot, "_extract_text_and_tokens", return_value=("Glitched Discord response.", 0)), \
+             mock.patch.object(bnl01_bot.random, "random", side_effect=[0.0, 1.0]), \
+             mock.patch.object(bnl01_bot, "update_website_status_controlled_async", side_effect=AssertionError("website mutated")):
+            text = asyncio.run(bnl01_bot.get_gemini_response("prompt", 0, 42, route="normal_chat"))
+        self.assertEqual(text, "Glitched Discord response.")
+
+    def test_invalid_output_shapes_do_not_publish_or_advance(self):
+        for output in [
+            "Only one valid public observation line.",
+            "Public observation line with enough detail.\nToo short.",
+            "Public observation line with enough detail.\nIncomplete directive without punctuation",
+            "Public observation line with enough detail.\nDirective with enough detail for this public thread.\nExtra explanation.",
+        ]:
+            self.tearDown(); self.setUp()
+            state.bootstrap_cursor(self.db, 42, 0)
+            self.add_row("Can BNL explain how tonight's public broadcast track submissions work? #barcode", user="a")
+            self.add_row("I have a public question about the show and which track context matters?", user="b")
+            async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+                return output
+            async def run_one():
+                with mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=fake_gemini), \
+                     mock.patch.object(bnl01_bot, "update_website_status_controlled_async", side_effect=AssertionError("invalid output posted")):
+                    return await bnl01_bot._execute_website_relay_transaction(42, source="relay")
+            decision = asyncio.run(run_one())
+            self.assertFalse(decision.publish)
+            self.assertIn(decision.skipReason, {"output_shape_invalid", "strict_sanitization_rejection"})
+            self.assertEqual(state.get_cursor(self.db, 42), 0)
+            self.assertEqual(state.recent_history(self.db, 42, 10), [])
+
+    def test_legacy_passive_listen_directive_rejected(self):
+        directive = "Hold the relay in passive listen mode and refresh once clear public context returns from active Discord channels."
+        self.assertEqual(state.stock_directive_reason(directive), "stock_directive_rejected")
+
+    def test_more_than_24_fresh_rows_uses_newest_24_chronologically_and_cursor(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        for i in range(30):
+            self.add_row(f"Public row {i:02d} asks about broadcast track submissions and show context? #barcode", user=str(i % 3))
+        prompts = []
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+            prompts.append(prompt)
+            return "Fresh Discord rows focus on broadcast track submissions across the newest selected context.\nFollow the public thread for confirmed submission details or links before indexing the answer."
+        with mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=fake_gemini):
+            decision = self.generate()
+        self.assertTrue(decision.publish)
+        self.assertEqual(len(decision.sourceConversationIds), 24)
+        self.assertEqual(decision.sourceConversationIds[0], 7)
+        self.assertEqual(decision.sourceConversationIds[-1], 30)
+        prompt = prompts[0]
+        self.assertNotIn("Public row 05", prompt)
+        self.assertLess(prompt.index("Public row 06"), prompt.index("Public row 29"))
+        self.assertEqual(decision.sourceCursor, 30)
+
+    def test_signal_strength_uses_newest_12_not_old_weak_prefix(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        for i in range(12):
+            self.add_row(f"weak prefix {i}", user="a")
+        self.add_row("Can BNL explain how tonight's public broadcast track submissions work? #barcode", user="b")
+        self.add_row("I have a public question about the show and which track context matters?", user="c")
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+            return "Newer Discord questions focus the relay on broadcast submissions despite the weak prefix.\nFollow the public thread for confirmed submission details or links before indexing the answer."
+        with mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=fake_gemini):
+            decision = self.generate()
+        self.assertTrue(decision.publish)
+
+    def test_awaiting_confirmation_is_not_stock_but_stock_language_remains_rejected(self):
+        self.assertNotEqual(state.semantic_family("A release credit is awaiting confirmation from the artist."), "non_event_stock")
+        for text in [
+            "BNL is waiting for fresh public signal.",
+            "BNL is standing by until clearer activity returns.",
+            "BNL continues monitoring the quiet public signal.",
+        ]:
+            self.assertEqual(state.semantic_family(text), "non_event_stock")
+
+    def test_timed_out_generation_coroutine_receives_cancellation(self):
+        original_timeout = bnl01_bot.BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS
+        bnl01_bot.BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS = 0.01
+        cancelled = {"seen": False}
+        async def slow_generation(guild_id):
+            try:
+                await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                cancelled["seen"] = True
+                raise
+        async def run_one():
+            with mock.patch.object(bnl01_bot, "generate_dynamic_website_relay", side_effect=slow_generation), \
+                 mock.patch.object(bnl01_bot, "update_website_status_controlled_async", side_effect=AssertionError("posted late")):
+                return await bnl01_bot._execute_website_relay_transaction(42, source="relay")
+        try:
+            decision = asyncio.run(run_one())
+        finally:
+            bnl01_bot.BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS = original_timeout
+        self.assertFalse(decision.publish)
+        self.assertTrue(cancelled["seen"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_website_relay_event_driven.py
+++ b/tests/test_website_relay_event_driven.py
@@ -1,0 +1,143 @@
+import asyncio
+import os
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from unittest import mock
+
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+import bnl01_bot
+import bnl_website_relay_state as state
+
+
+class WebsiteRelayEventDrivenTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.tmp.close()
+        self.db = self.tmp.name
+        self.old_db = bnl01_bot.DB_FILE
+        bnl01_bot.DB_FILE = self.db
+        bnl01_bot._recent_relay_messages.clear()
+        with sqlite3.connect(self.db) as conn:
+            conn.execute("""
+            CREATE TABLE conversations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                user_name TEXT NOT NULL,
+                guild_id INTEGER NOT NULL,
+                channel_name TEXT,
+                channel_policy TEXT,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """)
+        state.ensure_schema(self.db)
+
+    def tearDown(self):
+        bnl01_bot.DB_FILE = self.old_db
+        try:
+            os.unlink(self.db)
+        except OSError:
+            pass
+
+    def add_row(self, content, *, policy="public_home", role="user", ts=None, user="tester"):
+        ts = ts or datetime.utcnow().replace(microsecond=0).isoformat(sep=" ")
+        with sqlite3.connect(self.db) as conn:
+            cur = conn.execute(
+                "INSERT INTO conversations(user_id,user_name,guild_id,channel_name,channel_policy,role,content,timestamp) VALUES(?,?,?,?,?,?,?,?)",
+                (1, user, 42, "pub", policy, role, content, ts),
+            )
+            return cur.lastrowid
+
+    def run(self, coro):  # type: ignore[override]
+        if asyncio.iscoroutine(coro):
+            return asyncio.run(coro)
+        return super().run(coro)
+
+    def generate(self):
+        return asyncio.run(bnl01_bot.generate_dynamic_website_relay(42))
+
+    def test_bootstrap_old_rows_not_reused_and_no_model_or_post(self):
+        self.add_row("old public discussion about a track and show question? " * 3)
+        with mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=AssertionError("model called")):
+            decision = self.generate()
+        self.assertFalse(decision.publish)
+        self.assertEqual(decision.skipReason, "bootstrap_no_publish")
+        self.assertEqual(state.get_cursor(self.db, 42), 1)
+
+    def test_no_new_public_rows_no_model(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        with mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=AssertionError("model called")):
+            decision = self.generate()
+        self.assertFalse(decision.publish)
+        self.assertEqual(decision.skipReason, "no_new_public_signal")
+
+    def test_only_eligible_public_policies_considered(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        self.add_row("private should not count " * 20, policy="sealed_test")
+        self.add_row("bot should not count " * 20, role="assistant")
+        decision = self.generate()
+        self.assertFalse(decision.publish)
+        self.assertEqual(decision.skipReason, "no_new_public_signal")
+
+    def test_weak_fresh_context_does_not_publish(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        self.add_row("same lol")
+        decision = self.generate()
+        self.assertFalse(decision.publish)
+        self.assertEqual(decision.skipReason, "fresh_context_below_threshold")
+
+    def test_strong_context_publishes_once_then_cursor_advances_on_delivery(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        self.add_row("Can BNL explain how tonight's public broadcast track submissions work? #barcode", user="a")
+        self.add_row("I have a public question about the show and which track context matters?", user="b")
+        with mock.patch.object(bnl01_bot, "get_gemini_response", return_value="Two fresh Discord questions compare broadcast submissions with track context for tonight's show thread.\nReview the fresh Discord questions and keep the relay tied to eligible context."):
+            decision = self.generate()
+        self.assertTrue(decision.publish)
+        state.record_publication(self.db, 42, message=decision.message, directive=decision.directive, mode=decision.mode, relay_lane=decision.relayLane, event_type=decision.eventType, source_cursor=decision.sourceCursor)
+        again = self.generate()
+        self.assertFalse(again.publish)
+        self.assertEqual(again.skipReason, "no_new_public_signal")
+
+    def test_failed_delivery_does_not_advance_cursor(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        self.add_row("Can BNL explain how tonight's public broadcast track submissions work? #barcode", user="a")
+        self.add_row("I have a public question about the show and which track context matters?", user="b")
+        with mock.patch.object(bnl01_bot, "get_gemini_response", return_value="Two fresh Discord questions compare broadcast submissions with track context for tonight's show thread.\nReview the fresh Discord questions and keep the relay tied to eligible context."):
+            decision = self.generate()
+        self.assertTrue(decision.publish)
+        self.assertEqual(state.get_cursor(self.db, 42), 0)
+
+    def test_timeout_failure_and_stock_duplicate_rejections(self):
+        self.assertEqual(state.reject_reason_for_candidate(self.db, 42, "BNL remains online and observing while public signal is quiet.", "Monitor until fresh signal returns."), "stock_family_rejected")
+        state.record_publication(self.db, 42, message="Public Discord is comparing show questions with track submission context.", directive="Review those fresh public questions.", mode="OBSERVATION", relay_lane="current_signal", event_type="fresh_public_discord_activity", source_cursor=5)
+        self.assertIn(state.reject_reason_for_candidate(self.db, 42, "Public Discord is comparing show questions with track submission context!", "Review those fresh public questions."), {"exact_duplicate", "near_duplicate"})
+
+    def test_history_retains_25_and_no_raw_names(self):
+        for i in range(30):
+            state.record_publication(self.db, 42, message=f"Public Discord raised distinct track question {i} with enough detail.", directive=f"Review public context item {i}.", mode="OBSERVATION", relay_lane="current_signal", event_type="fresh_public_discord_activity", source_cursor=i)
+        hist = state.recent_history(self.db, 42, 50)
+        self.assertEqual(len(hist), 25)
+        joined = "\n".join(str(h) for h in hist)
+        self.assertNotIn("tester", joined)
+
+    def test_read_model_helpers_not_called_by_generation(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        self.add_row("Can BNL explain how tonight's public broadcast track submissions work? #barcode", user="a")
+        self.add_row("I have a public question about the show and which track context matters?", user="b")
+        with mock.patch.object(bnl01_bot, "fetch_bnl_read_model", side_effect=AssertionError("read model called")), \
+             mock.patch.object(bnl01_bot, "get_recent_signal_summary", side_effect=AssertionError("queue helper called")), \
+             mock.patch.object(bnl01_bot, "get_gemini_response", return_value="Two fresh Discord questions compare broadcast submissions with track context for tonight's show thread.\nReview the fresh Discord questions and keep the relay tied to eligible context."):
+            decision = self.generate()
+        self.assertTrue(decision.publish)
+
+    def test_explicit_read_model_still_callable(self):
+        with mock.patch.object(bnl01_bot, "BNL_READ_MODEL_ENABLED", False):
+            self.assertIsInstance(bnl01_bot.fetch_bnl_read_model(force=True), dict)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_website_relay_event_driven.py
+++ b/tests/test_website_relay_event_driven.py
@@ -20,6 +20,8 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
         self.old_db = bnl01_bot.DB_FILE
         bnl01_bot.DB_FILE = self.db
         bnl01_bot._recent_relay_messages.clear()
+        bnl01_bot._website_relay_transaction_locks_by_guild.clear()
+        bnl01_bot._website_relay_generation_tasks_by_guild.clear()
         with sqlite3.connect(self.db) as conn:
             conn.execute("""
             CREATE TABLE conversations (
@@ -137,6 +139,137 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
     def test_explicit_read_model_still_callable(self):
         with mock.patch.object(bnl01_bot, "BNL_READ_MODEL_ENABLED", False):
             self.assertIsInstance(bnl01_bot.fetch_bnl_read_model(force=True), dict)
+
+    def test_distinct_general_public_signal_messages_are_not_family_blocked(self):
+        state.record_publication(self.db, 42, message="A new public art thread gathered enough details to identify the technique being compared.", directive="Track the public technique comparison for a useful next reference.", mode="OBSERVATION", relay_lane="current_signal", event_type="fresh_public_discord_activity", source_cursor=1)
+        reason = state.reject_reason_for_candidate(self.db, 42, "A collaboration planning thread shifted toward a shared zine format.", "Determine whether the collaboration has a public next step worth indexing.")
+        self.assertEqual(reason, "")
+
+    def test_repeated_fallback_directive_alone_does_not_block_new_message(self):
+        repeated = "Review fresh public Discord context before the next relay update."
+        state.record_publication(self.db, 42, message="A public question identified one release-credit gap for follow-up.", directive=repeated, mode="OBSERVATION", relay_lane="current_signal", event_type="fresh_public_discord_activity", source_cursor=1)
+        reason = state.reject_reason_for_candidate(self.db, 42, "A separate artwork thread compared two cover treatments for a future post.", repeated)
+        self.assertEqual(reason, "")
+
+    def test_radio_release_dossier_transmission_topics_allowed_when_discord_grounded(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        self.add_row("Can BNL compare the public BARCODE Radio release notes with the Transmission topic people mentioned? #barcode", user="a")
+        self.add_row("There is also a public dossier question about credits for that music release discussion?", user="b")
+        prompts = []
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+            prompts.append(prompt)
+            return "Fresh Discord discussion connects BARCODE Radio, a release-credit question, a dossier angle, and a Transmission topic without confirming any live state.\nFollow the public thread for confirmed credits or links before treating the topic as indexed."
+        with mock.patch.object(bnl01_bot, "fetch_bnl_read_model", side_effect=AssertionError("read model called")), \
+             mock.patch.object(bnl01_bot, "get_recent_signal_summary", side_effect=AssertionError("queue helper called")), \
+             mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=fake_gemini):
+            decision = self.generate()
+        self.assertTrue(decision.publish)
+        self.assertIn("BARCODE Radio", prompts[0])
+
+    def test_concurrent_transactions_publish_once_and_advance_once(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        self.add_row("Can BNL explain how tonight's public broadcast track submissions work? #barcode", user="a")
+        self.add_row("I have a public question about the show and which track context matters?", user="b")
+        post_count = 0
+        async def fake_post(**kwargs):
+            nonlocal post_count
+            post_count += 1
+            await asyncio.sleep(0.02)
+            return True
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+            await asyncio.sleep(0.02)
+            return "Two fresh Discord questions compare broadcast submissions with track context for tonight's show thread.\nFollow the public thread for confirmed submission details or links before indexing the answer."
+        async def run_two():
+            with mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=fake_gemini), \
+                 mock.patch.object(bnl01_bot, "update_website_status_controlled_async", side_effect=fake_post):
+                return await asyncio.gather(
+                    bnl01_bot._execute_website_relay_transaction(42, source="relay"),
+                    bnl01_bot._execute_website_relay_transaction(42, force=True, source="forcePull", admin_note_source="forcePull"),
+                )
+        decisions = asyncio.run(run_two())
+        self.assertEqual(sum(1 for d in decisions if d.publish), 1)
+        self.assertEqual(post_count, 1)
+        self.assertEqual(len(state.recent_history(self.db, 42, 10)), 1)
+        self.assertEqual(state.get_cursor(self.db, 42), 2)
+
+    def test_concurrent_manual_and_scheduled_publish_once(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        self.add_row("Can BNL explain how tonight's public broadcast track submissions work? #barcode", user="a")
+        self.add_row("I have a public question about the show and which track context matters?", user="b")
+        post_count = 0
+        async def fake_post(**kwargs):
+            nonlocal post_count
+            post_count += 1
+            return True
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+            await asyncio.sleep(0.01)
+            return "Two fresh Discord questions compare broadcast submissions with track context for tonight's show thread.\nFollow the public thread for confirmed submission details or links before indexing the answer."
+        async def run_two():
+            with mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=fake_gemini), \
+                 mock.patch.object(bnl01_bot, "update_website_status_controlled_async", side_effect=fake_post):
+                manual = asyncio.create_task(bnl01_bot.request_fresh_website_relay(42, force=True))
+                scheduled = asyncio.create_task(bnl01_bot._execute_website_relay_transaction(42, source="relay"))
+                return await asyncio.gather(manual, scheduled)
+        results = asyncio.run(run_two())
+        self.assertEqual(post_count, 1)
+        self.assertEqual(len(state.recent_history(self.db, 42, 10)), 1)
+        self.assertEqual(state.get_cursor(self.db, 42), 2)
+        self.assertTrue(results[0][0])
+
+    def test_transaction_failed_delivery_leaves_cursor_unchanged(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        self.add_row("Can BNL explain how tonight's public broadcast track submissions work? #barcode", user="a")
+        self.add_row("I have a public question about the show and which track context matters?", user="b")
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+            return "Two fresh Discord questions compare broadcast submissions with track context for tonight's show thread.\nFollow the public thread for confirmed submission details or links before indexing the answer."
+        async def run_one():
+            with mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=fake_gemini), \
+                 mock.patch.object(bnl01_bot, "update_website_status_controlled_async", return_value=False):
+                return await bnl01_bot._execute_website_relay_transaction(42, source="relay")
+        decision = asyncio.run(run_one())
+        self.assertFalse(decision.publish)
+        self.assertEqual(decision.skipReason, "website_post_failed")
+        self.assertEqual(state.get_cursor(self.db, 42), 0)
+        self.assertEqual(state.recent_history(self.db, 42, 10), [])
+
+    def test_timed_out_generation_is_cancelled_and_cannot_publish_late(self):
+        original_timeout = bnl01_bot.BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS
+        bnl01_bot.BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS = 0.01
+        cancelled = asyncio.Event()
+        async def slow_generation(guild_id):
+            try:
+                await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+        async def run_one():
+            with mock.patch.object(bnl01_bot, "generate_dynamic_website_relay", side_effect=slow_generation), \
+                 mock.patch.object(bnl01_bot, "update_website_status_controlled_async", side_effect=AssertionError("posted late")):
+                return await bnl01_bot._execute_website_relay_transaction(42, source="relay")
+        try:
+            decision = asyncio.run(run_one())
+        finally:
+            bnl01_bot.BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS = original_timeout
+        self.assertFalse(decision.publish)
+        self.assertEqual(decision.skipReason, "relay_generation_timeout")
+
+    def test_restart_hydration_uses_newest_eight_lanes(self):
+        lanes = [f"lane_{i}" for i in range(10)]
+        for i, lane in enumerate(lanes):
+            state.record_publication(self.db, 42, message=f"Public Discord raised distinct track question {i} with enough detail.", directive=f"Follow public context item {i} for confirmed details.", mode="OBSERVATION", relay_lane=lane, event_type="fresh_public_discord_activity", source_cursor=i, published_timestamp=f"2026-07-15T00:00:{i:02d}Z")
+        bnl01_bot._recent_relay_lanes_by_guild[42].clear()
+        bnl01_bot._hydrate_recent_relay_memory(42)
+        self.assertEqual(list(bnl01_bot._recent_relay_lanes_by_guild[42]), lanes[2:10])
+
+    def test_silence_for_failure_modes_and_stock_directive(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        self.add_row("Can BNL explain how tonight's public broadcast track submissions work? #barcode", user="a")
+        self.add_row("I have a public question about the show and which track context matters?", user="b")
+        with mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=RuntimeError("provider down")):
+            decision = self.generate()
+        self.assertFalse(decision.publish)
+        self.assertEqual(decision.skipReason, "provider_failure")
+        self.assertEqual(state.stock_directive_reason("Continue monitoring."), "stock_directive_rejected")
 
 
 if __name__ == "__main__":

--- a/tests/test_website_relay_event_driven.py
+++ b/tests/test_website_relay_event_driven.py
@@ -385,6 +385,30 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
         self.assertFalse(decision.publish)
         self.assertTrue(cancelled["seen"])
 
+    def test_directive_monitor_vocabulary_does_not_make_event_message_stock(self):
+        reason = state.reject_reason_for_candidate(
+            self.db,
+            42,
+            "A public art collaboration settled on a shared zine format for the next community post.",
+            "Monitor the public collaboration thread for the next confirmed production step.",
+        )
+        self.assertEqual(reason, "")
+        self.assertEqual(state.stock_directive_reason("Continue monitoring."), "stock_directive_rejected")
+
+    def test_recorded_semantic_family_uses_public_message_not_directive(self):
+        state.record_publication(
+            self.db,
+            42,
+            message="A public art collaboration settled on a shared zine format for the next community post.",
+            directive="Watch the public collaboration thread for the next confirmed production step.",
+            mode="OBSERVATION",
+            relay_lane="current_signal",
+            event_type="fresh_public_discord_activity",
+            source_cursor=7,
+        )
+        hist = state.recent_history(self.db, 42, 1)
+        self.assertEqual(hist[0]["semantic_family"], "general_public_signal")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Stop the timer-driven 20-minute generation that produced repetitive low-signal/standby/observation messages by making publication contingent on genuinely fresh public Discord activity. 
- Restrict automatic website relay inputs so the site relay never reads queue/read-model/Radio/now-playing/queue-count or other site-side sources used for testing. 
- Provide persistent repetition protection and safe cursor handling so restarts and force-pulls do not replay old rows or publish low-signal fallbacks.

### Description
- Introduces a small focused state module `bnl_website_relay_state.py` implementing an SQLite-backed per-guild cursor plus a capped latest-25 `website_relay_history` ledger and deterministic normalization/stock-family and duplicate/near-duplicate checks. 
- Reworks `generate_dynamic_website_relay` to be event-driven and return a structured `WebsiteRelayDecision` (`publish`, `skipReason`, `eventType`, `sourceConversationIds`, `sourceCursor`, `message`, `directive`, `mode`, `relayLane`, `metadata`) and to only consider rows matching `role='user'` and `channel_policy` in `public_home|public_context|public_selective` that are newer than the persisted cursor and inside `BNL_WEBSITE_RELAY_FRESHNESS_MINUTES` (default 120). 
- Adds first-run bootstrap behavior that records the current highest eligible conversation id without publishing and logs `website_relay_bootstrap_no_publish`, and ensures the cursor/state and recent relay memory persist across restarts. 
- Changes guarded generation, timeout and provider-failure handling so failures produce explicit no-publish decisions (no public fallback copy), and updates `website_relay_task`, `request_fresh_website_relay`, and force-pull handling so POSTs and ledger/cursor advancement occur only when `decision.publish` is true and only after a successful website delivery. 
- Ensures automatic website relay generation does not call `fetch_bnl_read_model` or queue/read-model helpers and documents that the ledger never stores raw Discord content, usernames, prompts, tokens, or read-model/queue data.

### Testing
- Added `tests/test_website_relay_event_driven.py` testing bootstrap/no-reuse, freshness and policy boundaries, weak vs strong context publish rules, failed delivery cursor behavior, duplicate/stock-family rejection, persistence of latest-25 history, and that read-model/queue helpers are not invoked by automatic generation, and these tests passed. 
- Ran static/compile and unit test suite: `python3 -m py_compile bnl01_bot.py bnl_website_relay_state.py tests/test_async_relay_offload.py tests/test_website_relay_event_driven.py` succeeded. 
- Ran focused unit tests: `python3 -m unittest tests.test_website_relay_event_driven`, `python3 -m unittest tests.test_async_relay_offload tests.test_website_relay_event_driven`, and larger regression group `python3 -m unittest tests.test_behavior_contract_regression tests.test_route_memory_governance tests.test_async_relay_offload tests.test_website_relay_event_driven`, all of which completed successfully in CI runs recorded during the rollout. 
- Test scaffolding uses temporary SQLite files and mocks model/network calls to assert: no model or POST when no fresh public signal; no use of read-model/queue helpers from automatic generation; bootstrap does not publish old rows; force-pull respects fresh-context and duplicate protections; and history retention/privacy rules are enforced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57b84994b08321bbacb70547e90b3d)