### PR TITLE
Cut BNL website producer over to Presence/Relay Contract v2

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -18,6 +18,7 @@ from bnl_website_contract_v2 import (
     DeliveryResult,
     build_presence_envelope,
     build_relay_envelope,
+    canonical_payload_bytes,
     deliver_json as deliver_contract_v2_json,
     effective_contract_version,
     parse_status_relay,
@@ -159,6 +160,9 @@ from bnl_website_relay_state import (
     record_publication as relay_record_publication,
     prepare_attempt_relay as relay_prepare_attempt_relay,
     hydrate_publication as relay_hydrate_publication,
+    get_pending_v2_publication as relay_get_pending_v2_publication,
+    save_pending_v2_publication as relay_save_pending_v2_publication,
+    clear_pending_v2_publication as relay_clear_pending_v2_publication,
     normalize_text as relay_normalize_text,
     recent_history as relay_recent_history,
     reject_reason_for_candidate as relay_reject_reason_for_candidate,
@@ -2251,8 +2255,42 @@ def build_website_read_model_intent_response(intent: str, request_text: str) -> 
 _last_website_presence_result = {"status": "idle", "reason": "", "source": "", "time": ""}
 _last_website_relay_delivery_result = {"status": "idle", "reason": "", "prepared_relay_id": "", "accepted_relay_id": "", "published_at": "", "idempotent": False}
 
-def _new_stable_relay_id(attempt_id: str) -> str:
-    return validate_relay_id(f"bnl-{attempt_id}-{uuid.uuid4().hex[:16]}")
+def _new_stable_relay_id(*, guild_id: int, source_cursor: int, message: str, directive: str, source_class: str, trigger: str, source_conversation_fingerprint: str) -> str:
+    identity = "|".join([
+        str(int(guild_id or 0)),
+        str(int(source_cursor or 0)),
+        relay_normalize_text(message),
+        relay_normalize_text(directive),
+        source_class or "",
+        trigger or "",
+        source_conversation_fingerprint or "",
+    ])
+    return validate_relay_id("bnl-" + hashlib.sha256(identity.encode("utf-8")).hexdigest()[:32])
+
+def _relay_source_fingerprint(decision: WebsiteRelayDecision) -> str:
+    ids = ",".join(str(int(x)) for x in sorted(decision.sourceConversationIds or []))
+    return hashlib.sha256(f"{decision.sourceCursor}|{ids}|{decision.eventType}".encode("utf-8")).hexdigest()[:32]
+
+def _pending_envelope_from_row(row: dict) -> dict:
+    raw = row.get("canonical_json") or "{}"
+    try:
+        return json.loads(raw)
+    except Exception:
+        return {}
+
+def _delivery_failure_decision(decision: WebsiteRelayDecision, *, detailed_reason: str, prepared_relay_id: str = "") -> WebsiteRelayDecision:
+    return WebsiteRelayDecision(
+        False,
+        skipReason="website_post_failed",
+        eventType=decision.eventType,
+        sourceConversationIds=decision.sourceConversationIds,
+        sourceCursor=decision.sourceCursor,
+        message=decision.message,
+        directive=decision.directive,
+        mode=decision.mode,
+        relayLane=decision.relayLane,
+        metadata={**decision.metadata, "reason": detailed_reason or "website_post_failed", "delivery_failure": True, "prepared_relay_id": prepared_relay_id},
+    )
 
 def publish_website_presence_v2(*, source: str, status: str = "ONLINE", mode: str = "OBSERVATION") -> bool:
     if not BNL_API_KEY or not BNL_STATUS_URL:
@@ -2271,6 +2309,22 @@ def publish_website_relay_v2(*, relay_id: str, message: str, current_directive: 
     if not BNL_API_KEY or not BNL_STATUS_URL:
         return DeliveryResult(False, "delivery_failed", "not_configured", relay_id=relay_id)
     envelope = build_relay_envelope(relay_id, message, current_directive, source_class, trigger)
+    result = deliver_contract_v2_json(BNL_STATUS_URL, BNL_API_KEY, envelope, retries=1)
+    _last_website_relay_delivery_result.update({
+        "status": "published" if result.ok else "delivery_failed",
+        "reason": result.reason,
+        "prepared_relay_id": relay_id,
+        "accepted_relay_id": result.relay_id if result.ok else "",
+        "published_at": result.published_at if result.ok else "",
+        "idempotent": bool(result.idempotent),
+    })
+    return result
+
+def publish_website_relay_envelope_v2(envelope: dict):
+    relay = envelope.get("relay") if isinstance(envelope, dict) else {}
+    relay_id = relay.get("relayId", "") if isinstance(relay, dict) else ""
+    if not BNL_API_KEY or not BNL_STATUS_URL:
+        return DeliveryResult(False, "delivery_failed", "not_configured", relay_id=relay_id)
     result = deliver_contract_v2_json(BNL_STATUS_URL, BNL_API_KEY, envelope, retries=1)
     _last_website_relay_delivery_result.update({
         "status": "published" if result.ok else "delivery_failed",
@@ -2536,8 +2590,8 @@ async def _run_force_pull_relay_update(guild_id: int, request_id: str = ""):
             logging.info(f"Force-pull background relay update succeeded guild={guild_id} mode={decision.mode}{tag}")
         elif decision.skipReason == "website_post_failed":
             state["last_force_pull_status"] = "failed"
-            state["last_force_pull_error"] = "relay_update_failed"
-            logging.warning(f"Force-pull background relay update failed guild={guild_id} mode={decision.mode}{tag}")
+            state["last_force_pull_error"] = decision.metadata.get("reason") or "relay_update_failed"
+            logging.warning(f"Force-pull background relay update failed guild={guild_id} mode={decision.mode} reason={state['last_force_pull_error']}{tag}")
         else:
             state["last_force_pull_status"] = decision.skipReason or "no_publication"
             state["last_force_pull_error"] = decision.skipReason or "no_relay_published"
@@ -3589,6 +3643,40 @@ async def _execute_website_relay_transaction(guild_id: int, *, force: bool = Fal
         relay_complete_attempt(DB_FILE, attempt_id, source_class="none", outcome="disabled", reason="website_relay_disabled", aggregate_source_counts={}, cursor=initial_cursor, highest_eligible_conversation_id=initial_cursor)
         return WebsiteRelayDecision(False, skipReason="website_relay_disabled", sourceCursor=initial_cursor, metadata={"reason": "website_relay_disabled", "source_class": "none"})
     async with lock:
+        if BNL_WEBSITE_CONTRACT_VERSION == "2":
+            pending = relay_get_pending_v2_publication(DB_FILE, guild_id)
+            if pending:
+                envelope = _pending_envelope_from_row(pending)
+                prepared_relay_id = pending.get("relay_id") or ""
+                source_class = pending.get("source_class") or "none"
+                counts = json.loads(pending.get("aggregate_source_counts") or "{}")
+                source_cursor = int(pending.get("source_cursor") or 0)
+                highest = int(pending.get("highest_eligible_conversation_id") or source_cursor)
+                pending_decision = WebsiteRelayDecision(
+                    True,
+                    eventType=pending.get("event_type") or source_class,
+                    sourceCursor=source_cursor,
+                    message=pending.get("message") or "",
+                    directive=pending.get("current_directive") or "",
+                    mode=pending.get("mode") or "OBSERVATION",
+                    relayLane=pending.get("relay_lane") or "current_signal",
+                    metadata={"source_class": source_class, "pending_replay": True, "prepared_relay_id": prepared_relay_id},
+                )
+                relay_prepare_attempt_relay(DB_FILE, attempt_id, prepared_relay_id)
+                result = await asyncio.to_thread(publish_website_relay_envelope_v2, envelope)
+                reason = result.reason or ""
+                if not result.ok:
+                    relay_complete_attempt(DB_FILE, attempt_id, source_class=source_class, outcome="delivery_failed", reason=reason or "website_post_failed", aggregate_source_counts=counts, cursor=source_cursor, highest_eligible_conversation_id=highest, prepared_relay_id=prepared_relay_id)
+                    return _delivery_failure_decision(pending_decision, detailed_reason=reason or "website_post_failed", prepared_relay_id=prepared_relay_id)
+                relay_id = relay_record_publication(DB_FILE, guild_id, message=pending_decision.message, directive=pending_decision.directive, mode=pending_decision.mode, relay_lane=pending_decision.relayLane, event_type=pending_decision.eventType, source_cursor=source_cursor, published_timestamp=result.published_at, relay_id=result.relay_id)
+                relay_complete_attempt(DB_FILE, attempt_id, source_class=source_class, outcome="published", reason="idempotent_replay" if result.idempotent else "", aggregate_source_counts=counts, cursor=source_cursor, highest_eligible_conversation_id=highest, accepted_relay_id=relay_id, prepared_relay_id=prepared_relay_id, website_published_at=result.published_at, idempotent=result.idempotent)
+                relay_clear_pending_v2_publication(DB_FILE, guild_id, prepared_relay_id)
+                pending_decision.metadata.update({"accepted_relay_id": relay_id, "website_published_at": result.published_at, "website_idempotent": result.idempotent})
+                _remember_relay_message(guild_id, pending_decision.message)
+                _remember_relay_topic(guild_id, pending_decision.message)
+                _remember_relay_lane(guild_id, pending_decision.relayLane)
+                return pending_decision
+
         decision = await _generate_website_relay_guarded(guild_id, allow_quiet_sources=True)
         if decision is None:
             decision = WebsiteRelayDecision(False, skipReason="relay_generation_inflight", sourceCursor=relay_get_cursor(DB_FILE, guild_id) or 0, metadata={"reason": "relay_generation_inflight"})
@@ -3609,22 +3697,25 @@ async def _execute_website_relay_transaction(guild_id: int, *, force: bool = Fal
             if not ok:
                 logging.warning("website_relay_delivery_failed_no_cursor_advance guild=%s sourceCursor=%s", guild_id, decision.sourceCursor)
                 relay_complete_attempt(DB_FILE, attempt_id, source_class=source_class, outcome="delivery_failed", reason="website_post_failed", aggregate_source_counts=counts, cursor=decision.sourceCursor, highest_eligible_conversation_id=highest)
-                return WebsiteRelayDecision(False, skipReason="website_post_failed", eventType=decision.eventType, sourceConversationIds=decision.sourceConversationIds, sourceCursor=decision.sourceCursor, message=decision.message, directive=decision.directive, mode=decision.mode, relayLane=decision.relayLane, metadata={**decision.metadata, "reason": "website_post_failed"})
+                return WebsiteRelayDecision(False, skipReason="website_post_failed", eventType=decision.eventType, sourceConversationIds=decision.sourceConversationIds, sourceCursor=decision.sourceCursor, message=decision.message, directive=decision.directive, mode=decision.mode, relayLane=decision.relayLane, metadata={**decision.metadata, "reason": "website_post_failed", "delivery_failure": True})
             relay_id = relay_record_publication(DB_FILE, guild_id, message=decision.message, directive=decision.directive, mode=decision.mode, relay_lane=decision.relayLane, event_type=decision.eventType, source_cursor=decision.sourceCursor)
             relay_complete_attempt(DB_FILE, attempt_id, source_class=source_class, outcome="published", reason="", aggregate_source_counts=counts, cursor=decision.sourceCursor, highest_eligible_conversation_id=highest, accepted_relay_id=relay_id)
             decision.metadata["accepted_relay_id"] = relay_id
         else:
-            prepared_relay_id = _new_stable_relay_id(attempt_id)
+            source_fingerprint = _relay_source_fingerprint(decision)
+            prepared_relay_id = _new_stable_relay_id(guild_id=guild_id, source_cursor=decision.sourceCursor, message=decision.message, directive=decision.directive, source_class=source_class, trigger=trigger, source_conversation_fingerprint=source_fingerprint)
             relay_prepare_attempt_relay(DB_FILE, attempt_id, prepared_relay_id)
             try:
-                result = await asyncio.to_thread(
-                    publish_website_relay_v2,
-                    relay_id=prepared_relay_id,
-                    message=decision.message,
-                    current_directive=decision.directive,
-                    source_class=source_class,
-                    trigger=trigger,
+                envelope = build_relay_envelope(prepared_relay_id, decision.message, decision.directive, source_class, trigger)
+                relay = envelope["relay"]
+                canonical_json = canonical_payload_bytes(envelope).decode("utf-8")
+                relay_save_pending_v2_publication(
+                    DB_FILE, guild_id, relay_id=prepared_relay_id, message=relay["message"], current_directive=relay["currentDirective"],
+                    source_class=relay["sourceClass"], trigger=relay["trigger"], source_cursor=decision.sourceCursor,
+                    source_conversation_fingerprint=source_fingerprint, canonical_json=canonical_json, mode=decision.mode,
+                    relay_lane=decision.relayLane, event_type=decision.eventType, aggregate_source_counts=counts, highest_eligible_conversation_id=highest,
                 )
+                result = await asyncio.to_thread(publish_website_relay_envelope_v2, envelope)
             except ContractV2Error as exc:
                 result = None
                 reason = str(exc) or "contract_validation_failed"
@@ -3633,9 +3724,10 @@ async def _execute_website_relay_transaction(guild_id: int, *, force: bool = Fal
             if not result or not result.ok:
                 logging.warning("website_relay_delivery_failed_no_cursor_advance guild=%s sourceCursor=%s reason=%s", guild_id, decision.sourceCursor, reason)
                 relay_complete_attempt(DB_FILE, attempt_id, source_class=source_class, outcome="delivery_failed", reason=reason or "website_post_failed", aggregate_source_counts=counts, cursor=decision.sourceCursor, highest_eligible_conversation_id=highest, prepared_relay_id=prepared_relay_id)
-                return WebsiteRelayDecision(False, skipReason=reason or "website_post_failed", eventType=decision.eventType, sourceConversationIds=decision.sourceConversationIds, sourceCursor=decision.sourceCursor, message=decision.message, directive=decision.directive, mode=decision.mode, relayLane=decision.relayLane, metadata={**decision.metadata, "reason": reason or "website_post_failed", "prepared_relay_id": prepared_relay_id})
+                return _delivery_failure_decision(decision, detailed_reason=reason or "website_post_failed", prepared_relay_id=prepared_relay_id)
             relay_id = relay_record_publication(DB_FILE, guild_id, message=decision.message, directive=decision.directive, mode=decision.mode, relay_lane=decision.relayLane, event_type=decision.eventType, source_cursor=decision.sourceCursor, published_timestamp=result.published_at, relay_id=result.relay_id)
             relay_complete_attempt(DB_FILE, attempt_id, source_class=source_class, outcome="published", reason="idempotent_replay" if result.idempotent else "", aggregate_source_counts=counts, cursor=decision.sourceCursor, highest_eligible_conversation_id=highest, accepted_relay_id=relay_id, prepared_relay_id=prepared_relay_id, website_published_at=result.published_at, idempotent=result.idempotent)
+            relay_clear_pending_v2_publication(DB_FILE, guild_id, prepared_relay_id)
             decision.metadata["accepted_relay_id"] = relay_id
             decision.metadata["prepared_relay_id"] = prepared_relay_id
             decision.metadata["website_published_at"] = result.published_at

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -13,6 +13,17 @@
 
 from __future__ import annotations
 
+from bnl_website_contract_v2 import (
+    ContractV2Error,
+    DeliveryResult,
+    build_presence_envelope,
+    build_relay_envelope,
+    deliver_json as deliver_contract_v2_json,
+    effective_contract_version,
+    parse_status_relay,
+    validate_relay_id,
+)
+
 import os
 import re
 import asyncio
@@ -146,6 +157,8 @@ from bnl_website_relay_state import (
     bootstrap_cursor as relay_bootstrap_cursor,
     get_cursor as relay_get_cursor,
     record_publication as relay_record_publication,
+    prepare_attempt_relay as relay_prepare_attempt_relay,
+    hydrate_publication as relay_hydrate_publication,
     normalize_text as relay_normalize_text,
     recent_history as relay_recent_history,
     reject_reason_for_candidate as relay_reject_reason_for_candidate,
@@ -166,6 +179,7 @@ BNL_STATUS_URL = os.getenv("BNL_STATUS_URL")
 BNL_READ_MODEL_URL = os.getenv("BNL_READ_MODEL_URL", "").strip()
 BNL_READ_MODEL_ENABLED = os.getenv("BNL_READ_MODEL_ENABLED", "true").strip().lower() not in {"false", "0", "off"}
 
+BNL_WEBSITE_CONTRACT_VERSION = effective_contract_version(os.getenv("BNL_WEBSITE_CONTRACT_VERSION", "2"))
 BNL_WEBSITE_RELAY_ENABLED = os.getenv("BNL_WEBSITE_RELAY_ENABLED", "true").strip().lower() not in {"false", "0", "off"}
 BNL_ACTIVE_BATCHING_ENABLED = os.getenv("BNL_ACTIVE_BATCHING_ENABLED", "false").strip().lower() in {"true", "1", "on"}
 BNL_TYPING_INDICATOR_ENABLED = os.getenv("BNL_TYPING_INDICATOR_ENABLED", "false").strip().lower() in {"true", "1", "on"}
@@ -173,6 +187,7 @@ BNL_TYPING_INDICATOR_COOLDOWN_SECONDS = max(8, int(os.getenv("BNL_TYPING_INDICAT
 BNL_WEBSITE_RELAY_INTERVAL_MINUTES = max(1, int(os.getenv("BNL_WEBSITE_RELAY_INTERVAL_MINUTES", "20")))
 BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS = max(1.0, float(os.getenv("BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS", "25") or 25))
 BNL_WEBSITE_RELAY_FRESHNESS_MINUTES = max(1, int(os.getenv("BNL_WEBSITE_RELAY_FRESHNESS_MINUTES", "120") or 120))
+BNL_WEBSITE_HEARTBEAT_INTERVAL_MINUTES = max(1, int(os.getenv("BNL_WEBSITE_HEARTBEAT_INTERVAL_MINUTES", "5") or 5))
 BNL_PRIMARY_GUILD_ID = int(os.getenv("BNL_PRIMARY_GUILD_ID", "0") or 0)
 
 
@@ -2233,6 +2248,62 @@ def build_website_read_model_intent_response(intent: str, request_text: str) -> 
         return build_website_public_safe_candidate_response(read_model, request_text)
     return build_website_read_model_classifier_response(read_model, request_text)
 
+_last_website_presence_result = {"status": "idle", "reason": "", "source": "", "time": ""}
+_last_website_relay_delivery_result = {"status": "idle", "reason": "", "prepared_relay_id": "", "accepted_relay_id": "", "published_at": "", "idempotent": False}
+
+def _new_stable_relay_id(attempt_id: str) -> str:
+    return validate_relay_id(f"bnl-{attempt_id}-{uuid.uuid4().hex[:16]}")
+
+def publish_website_presence_v2(*, source: str, status: str = "ONLINE", mode: str = "OBSERVATION") -> bool:
+    if not BNL_API_KEY or not BNL_STATUS_URL:
+        _last_website_presence_result.update({"status": "skipped", "reason": "not_configured", "source": source, "time": _utc_now_iso()})
+        return False
+    try:
+        envelope = build_presence_envelope(status=status, mode=mode, source=source)
+        result = deliver_contract_v2_json(BNL_STATUS_URL, BNL_API_KEY, envelope, retries=0)
+        _last_website_presence_result.update({"status": "published" if result.ok else "delivery_failed", "reason": result.reason, "source": source, "time": _utc_now_iso()})
+        return result.ok
+    except Exception as exc:
+        _last_website_presence_result.update({"status": "delivery_failed", "reason": _safe_force_pull_error(exc), "source": source, "time": _utc_now_iso()})
+        return False
+
+def publish_website_relay_v2(*, relay_id: str, message: str, current_directive: str, source_class: str, trigger: str):
+    if not BNL_API_KEY or not BNL_STATUS_URL:
+        return DeliveryResult(False, "delivery_failed", "not_configured", relay_id=relay_id)
+    envelope = build_relay_envelope(relay_id, message, current_directive, source_class, trigger)
+    result = deliver_contract_v2_json(BNL_STATUS_URL, BNL_API_KEY, envelope, retries=1)
+    _last_website_relay_delivery_result.update({
+        "status": "published" if result.ok else "delivery_failed",
+        "reason": result.reason,
+        "prepared_relay_id": relay_id,
+        "accepted_relay_id": result.relay_id if result.ok else "",
+        "published_at": result.published_at if result.ok else "",
+        "idempotent": bool(result.idempotent),
+    })
+    return result
+
+def hydrate_website_relay_v2(guild_id: int) -> bool:
+    if not BNL_STATUS_URL or not BNL_API_KEY:
+        return False
+    req = urllib.request.Request(BNL_STATUS_URL, method="GET", headers={"x-api-key": BNL_API_KEY})
+    try:
+        with urllib.request.urlopen(req, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8") or "{}")
+    except Exception as exc:
+        logging.info("website_relay_hydration_skipped reason=%s", _safe_force_pull_error(exc))
+        return False
+    relay = parse_status_relay(data)
+    if not relay:
+        return False
+    changed = relay_hydrate_publication(
+        DB_FILE, guild_id, relay_id=relay["relayId"], message=relay["message"], directive=relay["currentDirective"],
+        source_class=relay["sourceClass"], trigger=relay["trigger"], published_timestamp=relay["publishedAt"]
+    )
+    if changed:
+        _remember_relay_message(guild_id, relay["message"])
+        _remember_relay_topic(guild_id, relay["message"])
+    return changed
+
 async def update_website_status_controlled_async(mode: str, message: str, status: str = "ONLINE", force: bool = False, current_directive: str = "", source: str = "relay", admin_note: str = "") -> bool:
     logging.info(f"website_status_push_offloaded source={source} mode={mode}")
     return await asyncio.to_thread(
@@ -2248,6 +2319,9 @@ async def update_website_status_controlled_async(mode: str, message: str, status
 
 
 def update_website_status_controlled(mode: str, message: str, status: str = "ONLINE", force: bool = False, current_directive: str = "", source: str = "relay", admin_note: str = "") -> bool:
+    if BNL_WEBSITE_CONTRACT_VERSION == "2":
+        logging.info("legacy_website_status_suppressed_under_v2 source=%s mode=%s", source, mode)
+        return False
     global _last_website_status_mode, _last_website_status_message, _last_website_directive, _last_website_status_at, _missing_status_key_warned
 
     now = datetime.now(PACIFIC_TZ)
@@ -3526,18 +3600,46 @@ async def _execute_website_relay_transaction(guild_id: int, *, force: bool = Fal
             outcome = "disabled" if reason == "website_relay_disabled" else ("provider_failed" if reason in {"provider_failure", "relay_generation_timeout"} else ("no_safe_source" if reason in {"no_new_public_signal", "bootstrap_no_publish", "fresh_context_expired"} else "rejected"))
             relay_complete_attempt(DB_FILE, attempt_id, source_class=source_class, outcome=outcome, reason=reason, aggregate_source_counts=counts, cursor=decision.sourceCursor, highest_eligible_conversation_id=highest)
             return decision
-        admin_note = build_admin_note(mode=decision.mode, message=decision.message, current_directive=decision.directive, source=admin_note_source) if force else ""
-        ok = await update_website_status_controlled_async(
-            mode=decision.mode, message=decision.message, status="ONLINE", force=force,
-            current_directive=decision.directive, source=source, admin_note=admin_note,
-        )
-        if not ok:
-            logging.warning("website_relay_delivery_failed_no_cursor_advance guild=%s sourceCursor=%s", guild_id, decision.sourceCursor)
-            relay_complete_attempt(DB_FILE, attempt_id, source_class=source_class, outcome="delivery_failed", reason="website_post_failed", aggregate_source_counts=counts, cursor=decision.sourceCursor, highest_eligible_conversation_id=highest)
-            return WebsiteRelayDecision(False, skipReason="website_post_failed", eventType=decision.eventType, sourceConversationIds=decision.sourceConversationIds, sourceCursor=decision.sourceCursor, message=decision.message, directive=decision.directive, mode=decision.mode, relayLane=decision.relayLane, metadata={**decision.metadata, "reason": "website_post_failed"})
-        relay_id = relay_record_publication(DB_FILE, guild_id, message=decision.message, directive=decision.directive, mode=decision.mode, relay_lane=decision.relayLane, event_type=decision.eventType, source_cursor=decision.sourceCursor)
-        relay_complete_attempt(DB_FILE, attempt_id, source_class=source_class, outcome="published", reason="", aggregate_source_counts=counts, cursor=decision.sourceCursor, highest_eligible_conversation_id=highest, accepted_relay_id=relay_id)
-        decision.metadata["accepted_relay_id"] = relay_id
+        if BNL_WEBSITE_CONTRACT_VERSION == "1":
+            admin_note = build_admin_note(mode=decision.mode, message=decision.message, current_directive=decision.directive, source=admin_note_source) if force else ""
+            ok = await update_website_status_controlled_async(
+                mode=decision.mode, message=decision.message, status="ONLINE", force=force,
+                current_directive=decision.directive, source=source, admin_note=admin_note,
+            )
+            if not ok:
+                logging.warning("website_relay_delivery_failed_no_cursor_advance guild=%s sourceCursor=%s", guild_id, decision.sourceCursor)
+                relay_complete_attempt(DB_FILE, attempt_id, source_class=source_class, outcome="delivery_failed", reason="website_post_failed", aggregate_source_counts=counts, cursor=decision.sourceCursor, highest_eligible_conversation_id=highest)
+                return WebsiteRelayDecision(False, skipReason="website_post_failed", eventType=decision.eventType, sourceConversationIds=decision.sourceConversationIds, sourceCursor=decision.sourceCursor, message=decision.message, directive=decision.directive, mode=decision.mode, relayLane=decision.relayLane, metadata={**decision.metadata, "reason": "website_post_failed"})
+            relay_id = relay_record_publication(DB_FILE, guild_id, message=decision.message, directive=decision.directive, mode=decision.mode, relay_lane=decision.relayLane, event_type=decision.eventType, source_cursor=decision.sourceCursor)
+            relay_complete_attempt(DB_FILE, attempt_id, source_class=source_class, outcome="published", reason="", aggregate_source_counts=counts, cursor=decision.sourceCursor, highest_eligible_conversation_id=highest, accepted_relay_id=relay_id)
+            decision.metadata["accepted_relay_id"] = relay_id
+        else:
+            prepared_relay_id = _new_stable_relay_id(attempt_id)
+            relay_prepare_attempt_relay(DB_FILE, attempt_id, prepared_relay_id)
+            try:
+                result = await asyncio.to_thread(
+                    publish_website_relay_v2,
+                    relay_id=prepared_relay_id,
+                    message=decision.message,
+                    current_directive=decision.directive,
+                    source_class=source_class,
+                    trigger=trigger,
+                )
+            except ContractV2Error as exc:
+                result = None
+                reason = str(exc) or "contract_validation_failed"
+            else:
+                reason = result.reason or "" if result else "contract_validation_failed"
+            if not result or not result.ok:
+                logging.warning("website_relay_delivery_failed_no_cursor_advance guild=%s sourceCursor=%s reason=%s", guild_id, decision.sourceCursor, reason)
+                relay_complete_attempt(DB_FILE, attempt_id, source_class=source_class, outcome="delivery_failed", reason=reason or "website_post_failed", aggregate_source_counts=counts, cursor=decision.sourceCursor, highest_eligible_conversation_id=highest, prepared_relay_id=prepared_relay_id)
+                return WebsiteRelayDecision(False, skipReason=reason or "website_post_failed", eventType=decision.eventType, sourceConversationIds=decision.sourceConversationIds, sourceCursor=decision.sourceCursor, message=decision.message, directive=decision.directive, mode=decision.mode, relayLane=decision.relayLane, metadata={**decision.metadata, "reason": reason or "website_post_failed", "prepared_relay_id": prepared_relay_id})
+            relay_id = relay_record_publication(DB_FILE, guild_id, message=decision.message, directive=decision.directive, mode=decision.mode, relay_lane=decision.relayLane, event_type=decision.eventType, source_cursor=decision.sourceCursor, published_timestamp=result.published_at, relay_id=result.relay_id)
+            relay_complete_attempt(DB_FILE, attempt_id, source_class=source_class, outcome="published", reason="idempotent_replay" if result.idempotent else "", aggregate_source_counts=counts, cursor=decision.sourceCursor, highest_eligible_conversation_id=highest, accepted_relay_id=relay_id, prepared_relay_id=prepared_relay_id, website_published_at=result.published_at, idempotent=result.idempotent)
+            decision.metadata["accepted_relay_id"] = relay_id
+            decision.metadata["prepared_relay_id"] = prepared_relay_id
+            decision.metadata["website_published_at"] = result.published_at
+            decision.metadata["website_idempotent"] = result.idempotent
         _remember_relay_message(guild_id, decision.message)
         _remember_relay_topic(guild_id, decision.message)
         _remember_relay_lane(guild_id, decision.relayLane)
@@ -13330,6 +13432,19 @@ async def _generate_website_relay_guarded(guild_id: int, *, allow_quiet_sources:
 
 
 @tasks.loop(minutes=1)
+async def website_presence_heartbeat_task():
+    flags = get_bnl_control_flags()
+    if not flags.get("heartbeatEnabled", True):
+        return
+    now_pt = datetime.now(PACIFIC_TZ)
+    if (now_pt.minute % max(1, BNL_WEBSITE_HEARTBEAT_INTERVAL_MINUTES)) != 0:
+        return
+    if BNL_WEBSITE_CONTRACT_VERSION == "2":
+        await asyncio.to_thread(publish_website_presence_v2, source="heartbeat", status="ONLINE", mode="OBSERVATION")
+    else:
+        await update_website_status_controlled_async(mode="OBSERVATION", message="BNL-01 remains online and observing.", status="ONLINE", source="heartbeat")
+
+@tasks.loop(minutes=1)
 async def website_relay_task():
     if not BNL_WEBSITE_RELAY_ENABLED:
         return
@@ -15221,6 +15336,15 @@ async def on_ready():
 
     if not barcode_radio_queue_task.is_running():
         barcode_radio_queue_task.start()
+
+    for g in client.guilds:
+        if BNL_WEBSITE_CONTRACT_VERSION == "2":
+            await asyncio.to_thread(hydrate_website_relay_v2, g.id)
+    if BNL_WEBSITE_CONTRACT_VERSION == "2":
+        await asyncio.to_thread(publish_website_presence_v2, source="startup", status="ONLINE", mode="OBSERVATION")
+
+    if not website_presence_heartbeat_task.is_running():
+        website_presence_heartbeat_task.start()
 
     if BNL_WEBSITE_RELAY_ENABLED and not website_relay_task.is_running():
         website_relay_task.start()
@@ -17963,7 +18087,12 @@ async def bnl_status(interaction: discord.Interaction):
         f"- next_ambient_message_at: `{next_ambient_message_at or 'none'}`",
         f"- last_ambient_mode: `{ambient_runtime.get('last_mode', 'unknown')}`",
         f"- last_ambient_skip_reason: `{ambient_runtime.get('last_skip_reason', 'unknown')}`",
+        f"- website_contract_version: `{BNL_WEBSITE_CONTRACT_VERSION}`",
         f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` (interval `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}m`)",
+        f"- website_heartbeat_interval: `{BNL_WEBSITE_HEARTBEAT_INTERVAL_MINUTES}m`",
+        f"- website_heartbeat_task_running: `{'yes' if website_presence_heartbeat_task.is_running() else 'no'}`",
+        f"- website_presence_last: `{_last_website_presence_result}`",
+        f"- website_relay_delivery_last: `{_last_website_relay_delivery_result}`",
         f"- website_relay_task_running: `{'yes' if website_relay_task.is_running() else 'no'}`",
         f"- website_bridge_configured: `{'yes' if website_bridge_configured else 'no'}`",
         f"- database_path: `{os.path.abspath(DB_FILE)}`",
@@ -18116,6 +18245,9 @@ async def bnl_status(interaction: discord.Interaction):
         f"- relay_last_attempt_source_class: `{relay_attempt.get('source_class') or 'none'}`",
         f"- relay_last_attempt_outcome: `{relay_attempt.get('outcome') or 'none'}`",
         f"- relay_last_attempt_reason: `{relay_attempt.get('reason') or 'none'}`",
+        f"- relay_last_prepared_relay_id: `{relay_attempt.get('prepared_relay_id') or 'none'}`",
+        f"- relay_last_accepted_relay_id: `{relay_attempt.get('accepted_relay_id') or 'none'}`",
+        f"- relay_last_idempotent: `{bool(relay_attempt.get('idempotent'))}`",
         f"- scoped_broadcast_memory_relay_context_active: `{'yes' if broadcast_count > 0 else 'no'}`",
     ])
     await send_safe_ephemeral_chunks(interaction, "\n".join(lines), limit=1700)
@@ -18170,13 +18302,17 @@ async def showtest(interaction: discord.Interaction, phase: app_commands.Choice[
     logging.info(f"/showtest website bridge target URL: {BNL_STATUS_URL}")
     logging.info(f"/showtest BNL_API_KEY present: {bool(BNL_API_KEY)}")
     logging.info(f"/showtest BNL_API_KEY length: {key_len}")
-    website_ok = website_ok if phase_key == "relay" else update_website_status_controlled(
-        mode=mode,
-        message=fit_complete_statement(website_msg, limit=360, min_chars=220, fallback=_pick_varied_fallback(phase_key)),
-        status="ONLINE",
-        force=True,
-        source="relay",
-    )
+    if phase_key != "relay" and BNL_WEBSITE_CONTRACT_VERSION == "2":
+        website_ok = True
+        logging.info("/showtest %s website write intentionally suppressed under contract v2", phase_key)
+    else:
+        website_ok = website_ok if phase_key == "relay" else update_website_status_controlled(
+            mode=mode,
+            message=fit_complete_statement(website_msg, limit=360, min_chars=220, fallback=_pick_varied_fallback(phase_key)),
+            status="ONLINE",
+            force=True,
+            source="relay",
+        )
 
     if phase_key != "relay":
         target_channel = interaction.channel if isinstance(interaction.channel, discord.TextChannel) else None
@@ -18201,7 +18337,7 @@ async def showtest(interaction: discord.Interaction, phase: app_commands.Choice[
         if phase_key == "relay":
             user_msg = f"✅ Website relay test fired for `{phase.value}` with mode `{mode}` and directive `{website_directive[:80]}`."
         else:
-            user_msg = f"✅ Show-day test fired for `{phase.value}` (mapped to `{phase_key}`)."
+            user_msg = f"✅ Show-day test fired for `{phase.value}` (mapped to `{phase_key}`); public website write intentionally suppressed under v2." if BNL_WEBSITE_CONTRACT_VERSION == "2" else f"✅ Show-day test fired for `{phase.value}` (mapped to `{phase_key}`)."
     else:
         user_msg = (
             f"⚠️ Show-day {'website relay' if phase_key == 'relay' else 'Discord test'} fired for `{phase.value}` "

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -13433,16 +13433,15 @@ async def _generate_website_relay_guarded(guild_id: int, *, allow_quiet_sources:
 
 @tasks.loop(minutes=1)
 async def website_presence_heartbeat_task():
+    if BNL_WEBSITE_CONTRACT_VERSION != "2":
+        return
     flags = get_bnl_control_flags()
     if not flags.get("heartbeatEnabled", True):
         return
     now_pt = datetime.now(PACIFIC_TZ)
     if (now_pt.minute % max(1, BNL_WEBSITE_HEARTBEAT_INTERVAL_MINUTES)) != 0:
         return
-    if BNL_WEBSITE_CONTRACT_VERSION == "2":
-        await asyncio.to_thread(publish_website_presence_v2, source="heartbeat", status="ONLINE", mode="OBSERVATION")
-    else:
-        await update_website_status_controlled_async(mode="OBSERVATION", message="BNL-01 remains online and observing.", status="ONLINE", source="heartbeat")
+    await asyncio.to_thread(publish_website_presence_v2, source="heartbeat", status="ONLINE", mode="OBSERVATION")
 
 @tasks.loop(minutes=1)
 async def website_relay_task():
@@ -15320,6 +15319,32 @@ def log_admin_controls_connection_check():
 
 # ==================== EVENT HANDLERS ====================
 
+def _resolve_startup_hydration_guild_id() -> int:
+    if BNL_PRIMARY_GUILD_ID:
+        return BNL_PRIMARY_GUILD_ID
+    try:
+        guild = next(iter_managed_guilds(), None)
+    except Exception:
+        guild = None
+    if guild is not None:
+        return int(getattr(guild, "id", 0) or 0)
+    if client.guilds:
+        return int(getattr(client.guilds[0], "id", 0) or 0)
+    return 0
+
+async def hydrate_startup_relay_v2_once() -> bool:
+    if BNL_WEBSITE_CONTRACT_VERSION != "2":
+        return False
+    hydration_guild_id = _resolve_startup_hydration_guild_id()
+    if not hydration_guild_id:
+        return False
+    return await asyncio.to_thread(hydrate_website_relay_v2, hydration_guild_id)
+
+async def publish_startup_presence_v2_if_enabled() -> bool:
+    if BNL_WEBSITE_CONTRACT_VERSION != "2":
+        return False
+    return await asyncio.to_thread(publish_website_presence_v2, source="startup", status="ONLINE", mode="OBSERVATION")
+
 @client.event
 async def on_ready():
     init_db()
@@ -15337,14 +15362,11 @@ async def on_ready():
     if not barcode_radio_queue_task.is_running():
         barcode_radio_queue_task.start()
 
-    for g in client.guilds:
-        if BNL_WEBSITE_CONTRACT_VERSION == "2":
-            await asyncio.to_thread(hydrate_website_relay_v2, g.id)
     if BNL_WEBSITE_CONTRACT_VERSION == "2":
-        await asyncio.to_thread(publish_website_presence_v2, source="startup", status="ONLINE", mode="OBSERVATION")
-
-    if not website_presence_heartbeat_task.is_running():
-        website_presence_heartbeat_task.start()
+        await hydrate_startup_relay_v2_once()
+        await publish_startup_presence_v2_if_enabled()
+        if not website_presence_heartbeat_task.is_running():
+            website_presence_heartbeat_task.start()
 
     if BNL_WEBSITE_RELAY_ENABLED and not website_relay_task.is_running():
         website_relay_task.start()

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -21,6 +21,8 @@ from bnl_website_contract_v2 import (
     canonical_payload_bytes,
     deliver_json as deliver_contract_v2_json,
     effective_contract_version,
+    map_source_class,
+    map_trigger,
     parse_status_relay,
     validate_relay_id,
 )
@@ -2256,16 +2258,17 @@ _last_website_presence_result = {"status": "idle", "reason": "", "source": "", "
 _last_website_relay_delivery_result = {"status": "idle", "reason": "", "prepared_relay_id": "", "accepted_relay_id": "", "published_at": "", "idempotent": False}
 
 def _new_stable_relay_id(*, guild_id: int, source_cursor: int, message: str, directive: str, source_class: str, trigger: str, source_conversation_fingerprint: str) -> str:
-    identity = "|".join([
-        str(int(guild_id or 0)),
-        str(int(source_cursor or 0)),
-        relay_normalize_text(message),
-        relay_normalize_text(directive),
-        source_class or "",
-        trigger or "",
-        source_conversation_fingerprint or "",
-    ])
-    return validate_relay_id("bnl-" + hashlib.sha256(identity.encode("utf-8")).hexdigest()[:32])
+    identity = {
+        "guildId": int(guild_id or 0),
+        "sourceCursor": int(source_cursor or 0),
+        "sourceFingerprint": source_conversation_fingerprint or "",
+        "message": (message or "").strip(),
+        "currentDirective": (directive or "").strip(),
+        "sourceClass": map_source_class(source_class),
+        "trigger": map_trigger(trigger),
+    }
+    canonical = json.dumps(identity, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return validate_relay_id("bnl-" + hashlib.sha256(canonical).hexdigest()[:32])
 
 def _relay_source_fingerprint(decision: WebsiteRelayDecision) -> str:
     ids = ",".join(str(int(x)) for x in sorted(decision.sourceConversationIds or []))
@@ -2349,6 +2352,40 @@ def hydrate_website_relay_v2(guild_id: int) -> bool:
     relay = parse_status_relay(data)
     if not relay:
         return False
+    pending = relay_get_pending_v2_publication(DB_FILE, guild_id)
+    if pending:
+        pending_matches = (
+            pending.get("relay_id") == relay["relayId"]
+            and pending.get("message") == relay["message"]
+            and pending.get("current_directive") == relay["currentDirective"]
+            and pending.get("source_class") == relay["sourceClass"]
+            and pending.get("trigger") == relay["trigger"]
+        )
+        if pending_matches:
+            try:
+                relay_record_publication(
+                    DB_FILE, guild_id, message=relay["message"], directive=relay["currentDirective"],
+                    mode=pending.get("mode") or "OBSERVATION", relay_lane=pending.get("relay_lane") or "current_signal",
+                    event_type=pending.get("event_type") or relay["sourceClass"], source_cursor=int(pending.get("source_cursor") or 0),
+                    published_timestamp=relay["publishedAt"], relay_id=relay["relayId"],
+                )
+            except ValueError as exc:
+                if str(exc) == "local_relay_id_conflict":
+                    logging.warning("website_relay_hydration_pending_conflict guild=%s relay_id=%s", guild_id, relay["relayId"])
+                    return False
+                raise
+            relay_clear_pending_v2_publication(DB_FILE, guild_id, relay["relayId"])
+            _last_website_relay_delivery_result.update({
+                "status": "hydrated_pending_confirmed",
+                "reason": "startup_hydration_confirmed_pending",
+                "prepared_relay_id": relay["relayId"],
+                "accepted_relay_id": relay["relayId"],
+                "published_at": relay["publishedAt"],
+                "idempotent": True,
+            })
+            _remember_relay_message(guild_id, relay["message"])
+            _remember_relay_topic(guild_id, relay["message"])
+            return True
     changed = relay_hydrate_publication(
         DB_FILE, guild_id, relay_id=relay["relayId"], message=relay["message"], directive=relay["currentDirective"],
         source_class=relay["sourceClass"], trigger=relay["trigger"], published_timestamp=relay["publishedAt"]

--- a/bnl_website_contract_v2.py
+++ b/bnl_website_contract_v2.py
@@ -182,7 +182,8 @@ def validate_relay_response(data: Any, submitted: Dict[str, Any]) -> DeliveryRes
     return DeliveryResult(True, "published", "", relay_id=relay["relayId"], published_at=published_at, idempotent=bool(data.get("idempotent")))
 
 
-def deliver_json(url: str, api_key: str, envelope: Dict[str, Any], *, opener: Callable[..., Any] = urllib.request.urlopen, retries: int = 1, timeout: int = 10) -> DeliveryResult:
+def deliver_json(url: str, api_key: str, envelope: Dict[str, Any], *, opener: Optional[Callable[..., Any]] = None, retries: int = 1, timeout: int = 10) -> DeliveryResult:
+    opener = opener or urllib.request.urlopen
     payload = canonical_payload_bytes(envelope)
     last_reason = "retryable_delivery_failure"
     for attempt in range(max(0, retries) + 1):
@@ -227,7 +228,7 @@ def deliver_json(url: str, api_key: str, envelope: Dict[str, Any], *, opener: Ca
 
 
 def parse_status_relay(data: Any) -> Optional[Dict[str, Any]]:
-    if not isinstance(data, dict) or data.get("contractVersion") != 2:
+    if not isinstance(data, dict) or data.get("contractVersion") != 2 or data.get("persisted") is not True:
         return None
     relay = data.get("relay")
     if not isinstance(relay, dict):

--- a/bnl_website_contract_v2.py
+++ b/bnl_website_contract_v2.py
@@ -6,9 +6,13 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional
 
+STATUSES = {"ONLINE", "OFFLINE"}
+MODES = {"STANDBY", "OBSERVATION", "ACTIVE_LIAISON", "SIGNAL_DEGRADATION", "RESTRICTED"}
 PRESENCE_SOURCES = {"heartbeat", "startup", "admin", "reset", "unknown"}
+MAX_MESSAGE_LENGTH = 600
+MAX_DIRECTIVE_LENGTH = 800
 WEBSITE_SOURCE_CLASSES = {
     "fresh_public_event",
     "recent_public_continuity",
@@ -26,7 +30,7 @@ SOURCE_CLASS_MAP = {
     "reflection": "grounded_reflection",
 }
 TRIGGER_MAP = {"scheduled": "scheduled", "forcePull": "force_pull", "manual": "manual"}
-RELAY_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$")
+RELAY_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{2,159}$")
 
 
 class ContractV2Error(ValueError):
@@ -51,8 +55,29 @@ def effective_contract_version(raw: Optional[str]) -> str:
     return version
 
 
+def _validated_text(value: str, max_length: int, reason: str) -> str:
+    if not isinstance(value, str):
+        raise ContractV2Error(reason)
+    clean = value.strip()
+    if not clean or len(clean) > max_length:
+        raise ContractV2Error(reason)
+    return clean
+
+
+def validate_status(status: str) -> str:
+    if status not in STATUSES:
+        raise ContractV2Error("invalid_status")
+    return status
+
+
+def validate_mode(mode: str) -> str:
+    if mode not in MODES:
+        raise ContractV2Error("invalid_mode")
+    return mode
+
+
 def validate_relay_id(relay_id: str) -> str:
-    rid = (relay_id or "").strip()
+    rid = _validated_text(relay_id, 160, "invalid_relay_id")
     if not RELAY_ID_RE.match(rid):
         raise ContractV2Error("invalid_relay_id")
     return rid
@@ -78,7 +103,7 @@ def build_presence_envelope(status: str = "ONLINE", mode: str = "OBSERVATION", s
     source = (source or "unknown").strip() or "unknown"
     if source not in PRESENCE_SOURCES:
         raise ContractV2Error("unknown_presence_source")
-    return {"contractVersion": 2, "kind": "presence", "presence": {"status": status, "mode": mode, "source": source}}
+    return {"contractVersion": 2, "kind": "presence", "presence": {"status": validate_status(status), "mode": validate_mode(mode), "source": source}}
 
 
 def build_relay_envelope(relay_id: str, message: str, current_directive: str, source_class: str, trigger: str) -> Dict[str, Any]:
@@ -89,8 +114,8 @@ def build_relay_envelope(relay_id: str, message: str, current_directive: str, so
         "kind": "relay",
         "relay": {
             "relayId": validate_relay_id(relay_id),
-            "message": message or "",
-            "currentDirective": current_directive or "",
+            "message": _validated_text(message, MAX_MESSAGE_LENGTH, "invalid_message"),
+            "currentDirective": _validated_text(current_directive, MAX_DIRECTIVE_LENGTH, "invalid_directive"),
             "sourceClass": website_source_class,
             "trigger": website_trigger,
         },
@@ -112,15 +137,42 @@ def _valid_published_at(value: Any) -> bool:
         return False
 
 
+def validate_presence_response(data: Any, submitted: Dict[str, Any]) -> DeliveryResult:
+    if not isinstance(data, dict):
+        return DeliveryResult(False, "delivery_failed", "malformed_json")
+    if data.get("ok") is not True:
+        return DeliveryResult(False, "delivery_failed", "contract_rejected")
+    if data.get("persisted") is not True:
+        return DeliveryResult(False, "delivery_failed", "not_persisted")
+    presence = data.get("presence")
+    expected = submitted.get("presence") if isinstance(submitted, dict) else None
+    if not isinstance(presence, dict) or not isinstance(expected, dict):
+        return DeliveryResult(False, "delivery_failed", "malformed_json")
+    if presence.get("contractVersion") != 2:
+        return DeliveryResult(False, "delivery_failed", "response_mismatch")
+    for key in ("status", "mode", "source"):
+        if presence.get(key) != expected.get(key):
+            return DeliveryResult(False, "delivery_failed", "response_mismatch")
+    if not _valid_published_at(presence.get("receivedAt")):
+        return DeliveryResult(False, "delivery_failed", "response_mismatch")
+    return DeliveryResult(True, "published")
+
+
 def validate_relay_response(data: Any, submitted: Dict[str, Any]) -> DeliveryResult:
     if not isinstance(data, dict):
         return DeliveryResult(False, "delivery_failed", "malformed_json")
     if data.get("ok") is not True:
         return DeliveryResult(False, "delivery_failed", "contract_rejected")
+    if data.get("persisted") is not True:
+        return DeliveryResult(False, "delivery_failed", "not_persisted")
+    if "idempotent" in data and not isinstance(data.get("idempotent"), bool):
+        return DeliveryResult(False, "delivery_failed", "response_mismatch")
     relay = data.get("relay")
     expected = submitted.get("relay") if isinstance(submitted, dict) else None
     if not isinstance(relay, dict) or not isinstance(expected, dict):
         return DeliveryResult(False, "delivery_failed", "malformed_json")
+    if relay.get("contractVersion") != 2:
+        return DeliveryResult(False, "delivery_failed", "response_mismatch")
     for key in ("relayId", "message", "currentDirective", "sourceClass", "trigger"):
         if relay.get(key) != expected.get(key):
             return DeliveryResult(False, "delivery_failed", "response_mismatch")
@@ -141,22 +193,33 @@ def deliver_json(url: str, api_key: str, envelope: Dict[str, Any], *, opener: Ca
                 body = response.read().decode("utf-8")
             if 200 <= code < 300:
                 try:
-                    return validate_relay_response(json.loads(body or "{}"), envelope) if envelope.get("kind") == "relay" else DeliveryResult(True, "published", http_status=code)
+                    data = json.loads(body or "{}")
+                    return validate_relay_response(data, envelope) if envelope.get("kind") == "relay" else validate_presence_response(data, envelope)
                 except json.JSONDecodeError:
                     return DeliveryResult(False, "delivery_failed", "malformed_json", http_status=code)
             if code == 400:
                 return DeliveryResult(False, "delivery_failed", "contract_rejected", http_status=code)
+            if code in {401, 403}:
+                return DeliveryResult(False, "delivery_failed", "authentication_failed", http_status=code)
             if code == 409:
                 return DeliveryResult(False, "delivery_failed", "relay_id_conflict", http_status=code)
-            if code < 500 or attempt >= retries:
-                return DeliveryResult(False, "delivery_failed", "retryable_delivery_failure", http_status=code)
+            if code == 429 or code >= 500:
+                if attempt >= retries:
+                    return DeliveryResult(False, "delivery_failed", "retryable_delivery_failure", http_status=code)
+                continue
+            return DeliveryResult(False, "delivery_failed", "http_rejected", http_status=code)
         except urllib.error.HTTPError as e:
             if e.code == 400:
                 return DeliveryResult(False, "delivery_failed", "contract_rejected", http_status=e.code)
+            if e.code in {401, 403}:
+                return DeliveryResult(False, "delivery_failed", "authentication_failed", http_status=e.code)
             if e.code == 409:
                 return DeliveryResult(False, "delivery_failed", "relay_id_conflict", http_status=e.code)
-            if e.code < 500 or attempt >= retries:
-                return DeliveryResult(False, "delivery_failed", "retryable_delivery_failure", http_status=e.code)
+            if e.code == 429 or e.code >= 500:
+                if attempt >= retries:
+                    return DeliveryResult(False, "delivery_failed", "retryable_delivery_failure", http_status=e.code)
+                continue
+            return DeliveryResult(False, "delivery_failed", "http_rejected", http_status=e.code)
         except (urllib.error.URLError, TimeoutError, OSError, ValueError):
             if attempt >= retries:
                 return DeliveryResult(False, "delivery_failed", last_reason)
@@ -169,11 +232,15 @@ def parse_status_relay(data: Any) -> Optional[Dict[str, Any]]:
     relay = data.get("relay")
     if not isinstance(relay, dict):
         return None
-    required = {"relayId", "message", "currentDirective", "sourceClass", "trigger", "publishedAt"}
+    required = {"contractVersion", "relayId", "message", "currentDirective", "sourceClass", "trigger", "publishedAt"}
     if set(relay.keys()) != required:
         return None
     try:
+        if relay.get("contractVersion") != 2:
+            return None
         validate_relay_id(relay["relayId"])
+        _validated_text(relay.get("message"), MAX_MESSAGE_LENGTH, "invalid_message")
+        _validated_text(relay.get("currentDirective"), MAX_DIRECTIVE_LENGTH, "invalid_directive")
         if relay["sourceClass"] not in WEBSITE_SOURCE_CLASSES or relay["trigger"] not in set(TRIGGER_MAP.values()):
             return None
         if not _valid_published_at(relay["publishedAt"]):

--- a/bnl_website_contract_v2.py
+++ b/bnl_website_contract_v2.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import re
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Callable, Dict, Optional, Tuple
+
+PRESENCE_SOURCES = {"heartbeat", "startup", "admin", "reset", "unknown"}
+WEBSITE_SOURCE_CLASSES = {
+    "fresh_public_event",
+    "recent_public_continuity",
+    "scoped_broadcast_memory",
+    "public_safe_memory",
+    "approved_canon",
+    "grounded_reflection",
+}
+SOURCE_CLASS_MAP = {
+    "fresh_discord": "fresh_public_event",
+    "conversation_continuity": "recent_public_continuity",
+    "broadcast_memory": "scoped_broadcast_memory",
+    "public_safe_memory": "public_safe_memory",
+    "canon": "approved_canon",
+    "reflection": "grounded_reflection",
+}
+TRIGGER_MAP = {"scheduled": "scheduled", "forcePull": "force_pull", "manual": "manual"}
+RELAY_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$")
+
+
+class ContractV2Error(ValueError):
+    pass
+
+
+@dataclass
+class DeliveryResult:
+    ok: bool
+    status: str
+    reason: str = ""
+    relay_id: str = ""
+    published_at: str = ""
+    idempotent: bool = False
+    http_status: int = 0
+
+
+def effective_contract_version(raw: Optional[str]) -> str:
+    version = (raw or "2").strip() or "2"
+    if version not in {"1", "2"}:
+        raise ContractV2Error("invalid_contract_version")
+    return version
+
+
+def validate_relay_id(relay_id: str) -> str:
+    rid = (relay_id or "").strip()
+    if not RELAY_ID_RE.match(rid):
+        raise ContractV2Error("invalid_relay_id")
+    return rid
+
+
+def map_source_class(source_class: str) -> str:
+    if source_class in WEBSITE_SOURCE_CLASSES:
+        return source_class
+    try:
+        return SOURCE_CLASS_MAP[source_class]
+    except KeyError:
+        raise ContractV2Error("unknown_source_class")
+
+
+def map_trigger(trigger: str) -> str:
+    try:
+        return TRIGGER_MAP[trigger]
+    except KeyError:
+        raise ContractV2Error("unknown_trigger")
+
+
+def build_presence_envelope(status: str = "ONLINE", mode: str = "OBSERVATION", source: str = "heartbeat") -> Dict[str, Any]:
+    source = (source or "unknown").strip() or "unknown"
+    if source not in PRESENCE_SOURCES:
+        raise ContractV2Error("unknown_presence_source")
+    return {"contractVersion": 2, "kind": "presence", "presence": {"status": status, "mode": mode, "source": source}}
+
+
+def build_relay_envelope(relay_id: str, message: str, current_directive: str, source_class: str, trigger: str) -> Dict[str, Any]:
+    website_source_class = map_source_class(source_class)
+    website_trigger = map_trigger(trigger)
+    return {
+        "contractVersion": 2,
+        "kind": "relay",
+        "relay": {
+            "relayId": validate_relay_id(relay_id),
+            "message": message or "",
+            "currentDirective": current_directive or "",
+            "sourceClass": website_source_class,
+            "trigger": website_trigger,
+        },
+    }
+
+
+def canonical_payload_bytes(envelope: Dict[str, Any]) -> bytes:
+    return json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _valid_published_at(value: Any) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    normalized = value.replace("Z", "+00:00")
+    try:
+        datetime.fromisoformat(normalized)
+        return True
+    except ValueError:
+        return False
+
+
+def validate_relay_response(data: Any, submitted: Dict[str, Any]) -> DeliveryResult:
+    if not isinstance(data, dict):
+        return DeliveryResult(False, "delivery_failed", "malformed_json")
+    if data.get("ok") is not True:
+        return DeliveryResult(False, "delivery_failed", "contract_rejected")
+    relay = data.get("relay")
+    expected = submitted.get("relay") if isinstance(submitted, dict) else None
+    if not isinstance(relay, dict) or not isinstance(expected, dict):
+        return DeliveryResult(False, "delivery_failed", "malformed_json")
+    for key in ("relayId", "message", "currentDirective", "sourceClass", "trigger"):
+        if relay.get(key) != expected.get(key):
+            return DeliveryResult(False, "delivery_failed", "response_mismatch")
+    published_at = relay.get("publishedAt")
+    if not _valid_published_at(published_at):
+        return DeliveryResult(False, "delivery_failed", "response_mismatch")
+    return DeliveryResult(True, "published", "", relay_id=relay["relayId"], published_at=published_at, idempotent=bool(data.get("idempotent")))
+
+
+def deliver_json(url: str, api_key: str, envelope: Dict[str, Any], *, opener: Callable[..., Any] = urllib.request.urlopen, retries: int = 1, timeout: int = 10) -> DeliveryResult:
+    payload = canonical_payload_bytes(envelope)
+    last_reason = "retryable_delivery_failure"
+    for attempt in range(max(0, retries) + 1):
+        req = urllib.request.Request(url, data=payload, method="POST", headers={"Content-Type": "application/json", "x-api-key": api_key})
+        try:
+            with opener(req, timeout=timeout) as response:
+                code = getattr(response, "status", None) or response.getcode()
+                body = response.read().decode("utf-8")
+            if 200 <= code < 300:
+                try:
+                    return validate_relay_response(json.loads(body or "{}"), envelope) if envelope.get("kind") == "relay" else DeliveryResult(True, "published", http_status=code)
+                except json.JSONDecodeError:
+                    return DeliveryResult(False, "delivery_failed", "malformed_json", http_status=code)
+            if code == 400:
+                return DeliveryResult(False, "delivery_failed", "contract_rejected", http_status=code)
+            if code == 409:
+                return DeliveryResult(False, "delivery_failed", "relay_id_conflict", http_status=code)
+            if code < 500 or attempt >= retries:
+                return DeliveryResult(False, "delivery_failed", "retryable_delivery_failure", http_status=code)
+        except urllib.error.HTTPError as e:
+            if e.code == 400:
+                return DeliveryResult(False, "delivery_failed", "contract_rejected", http_status=e.code)
+            if e.code == 409:
+                return DeliveryResult(False, "delivery_failed", "relay_id_conflict", http_status=e.code)
+            if e.code < 500 or attempt >= retries:
+                return DeliveryResult(False, "delivery_failed", "retryable_delivery_failure", http_status=e.code)
+        except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+            if attempt >= retries:
+                return DeliveryResult(False, "delivery_failed", last_reason)
+    return DeliveryResult(False, "delivery_failed", last_reason)
+
+
+def parse_status_relay(data: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(data, dict) or data.get("contractVersion") != 2:
+        return None
+    relay = data.get("relay")
+    if not isinstance(relay, dict):
+        return None
+    required = {"relayId", "message", "currentDirective", "sourceClass", "trigger", "publishedAt"}
+    if set(relay.keys()) != required:
+        return None
+    try:
+        validate_relay_id(relay["relayId"])
+        if relay["sourceClass"] not in WEBSITE_SOURCE_CLASSES or relay["trigger"] not in set(TRIGGER_MAP.values()):
+            return None
+        if not _valid_published_at(relay["publishedAt"]):
+            return None
+    except ContractV2Error:
+        return None
+    return relay

--- a/bnl_website_relay_state.py
+++ b/bnl_website_relay_state.py
@@ -279,11 +279,22 @@ def record_publication(db_path: str, guild_id: int, *, message: str, directive: 
     fam = semantic_family(message)
     relay_id = relay_id or hashlib.sha256(f"{guild_id}|{source_cursor}|{norm}|{ts}".encode()).hexdigest()[:24]
     with sqlite3.connect(db_path) as conn:
-        conn.execute("INSERT OR REPLACE INTO website_relay_state(guild_id,last_published_conversation_cursor,last_publication_timestamp) VALUES(?,?,?)", (guild_id, int(source_cursor or 0), ts))
-        conn.execute("""
-        INSERT INTO website_relay_history(relay_id,guild_id,public_message,public_directive,mode,relay_lane,event_type,highest_source_conversation_id,normalized_message,semantic_family,published_timestamp)
-        VALUES(?,?,?,?,?,?,?,?,?,?,?)
-        """, (relay_id, guild_id, message, directive, mode, relay_lane, event_type, int(source_cursor or 0), norm, fam, ts))
+        existing = conn.execute("SELECT public_message, public_directive FROM website_relay_history WHERE relay_id=?", (relay_id,)).fetchone()
+        if existing:
+            if existing[0] != message or existing[1] != directive:
+                raise ValueError("local_relay_id_conflict")
+            conn.execute("INSERT OR REPLACE INTO website_relay_state(guild_id,last_published_conversation_cursor,last_publication_timestamp) VALUES(?,?,?)", (guild_id, int(source_cursor or 0), ts))
+            conn.execute("""
+            UPDATE website_relay_history
+            SET guild_id=?, mode=?, relay_lane=?, event_type=?, highest_source_conversation_id=?, normalized_message=?, semantic_family=?, published_timestamp=?
+            WHERE relay_id=?
+            """, (guild_id, mode, relay_lane, event_type, int(source_cursor or 0), norm, fam, ts, relay_id))
+        else:
+            conn.execute("INSERT OR REPLACE INTO website_relay_state(guild_id,last_published_conversation_cursor,last_publication_timestamp) VALUES(?,?,?)", (guild_id, int(source_cursor or 0), ts))
+            conn.execute("""
+            INSERT INTO website_relay_history(relay_id,guild_id,public_message,public_directive,mode,relay_lane,event_type,highest_source_conversation_id,normalized_message,semantic_family,published_timestamp)
+            VALUES(?,?,?,?,?,?,?,?,?,?,?)
+            """, (relay_id, guild_id, message, directive, mode, relay_lane, event_type, int(source_cursor or 0), norm, fam, ts))
         old = conn.execute("SELECT relay_id FROM website_relay_history WHERE guild_id=? ORDER BY published_timestamp DESC LIMIT -1 OFFSET ?", (guild_id, MAX_HISTORY)).fetchall()
         if old:
             conn.executemany("DELETE FROM website_relay_history WHERE relay_id=?", [(r[0],) for r in old])

--- a/bnl_website_relay_state.py
+++ b/bnl_website_relay_state.py
@@ -111,6 +111,26 @@ def ensure_schema(db_path: str) -> None:
             if name not in cols:
                 conn.execute(ddl)
 
+        conn.execute("""
+        CREATE TABLE IF NOT EXISTS website_relay_pending_v2 (
+            guild_id INTEGER PRIMARY KEY,
+            relay_id TEXT NOT NULL,
+            message TEXT NOT NULL,
+            current_directive TEXT NOT NULL,
+            source_class TEXT NOT NULL,
+            trigger TEXT NOT NULL,
+            source_cursor INTEGER NOT NULL DEFAULT 0,
+            source_conversation_fingerprint TEXT NOT NULL,
+            canonical_json TEXT NOT NULL,
+            prepared_at TEXT NOT NULL,
+            mode TEXT NOT NULL DEFAULT 'OBSERVATION',
+            relay_lane TEXT NOT NULL DEFAULT 'current_signal',
+            event_type TEXT NOT NULL DEFAULT '',
+            aggregate_source_counts TEXT NOT NULL DEFAULT '{}',
+            highest_eligible_conversation_id INTEGER NOT NULL DEFAULT 0
+        )
+        """)
+
 
 def get_cursor(db_path: str, guild_id: int) -> int | None:
     ensure_schema(db_path)
@@ -201,6 +221,55 @@ def reject_reason_for_candidate(db_path: str, guild_id: int, message: str, direc
         if old and difflib.SequenceMatcher(None, norm, old).ratio() >= threshold:
             return "near_duplicate"
     return ""
+
+
+def get_pending_v2_publication(db_path: str, guild_id: int) -> dict[str, Any]:
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM website_relay_pending_v2 WHERE guild_id=?", (guild_id,)).fetchone()
+    return dict(row) if row else {}
+
+
+def save_pending_v2_publication(
+    db_path: str,
+    guild_id: int,
+    *,
+    relay_id: str,
+    message: str,
+    current_directive: str,
+    source_class: str,
+    trigger: str,
+    source_cursor: int,
+    source_conversation_fingerprint: str,
+    canonical_json: str,
+    mode: str = "OBSERVATION",
+    relay_lane: str = "current_signal",
+    event_type: str = "",
+    aggregate_source_counts: dict[str, int] | None = None,
+    highest_eligible_conversation_id: int = 0,
+) -> None:
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+        INSERT OR REPLACE INTO website_relay_pending_v2(
+            guild_id,relay_id,message,current_directive,source_class,trigger,source_cursor,source_conversation_fingerprint,
+            canonical_json,prepared_at,mode,relay_lane,event_type,aggregate_source_counts,highest_eligible_conversation_id
+        ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        """, (
+            guild_id, relay_id, message, current_directive, source_class, trigger, int(source_cursor or 0),
+            source_conversation_fingerprint or "", canonical_json, utc_now_iso(), mode or "OBSERVATION", relay_lane or "current_signal",
+            event_type or "", __import__('json').dumps(aggregate_source_counts or {}, sort_keys=True), int(highest_eligible_conversation_id or 0),
+        ))
+
+
+def clear_pending_v2_publication(db_path: str, guild_id: int, relay_id: str = "") -> None:
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        if relay_id:
+            conn.execute("DELETE FROM website_relay_pending_v2 WHERE guild_id=? AND relay_id=?", (guild_id, relay_id))
+        else:
+            conn.execute("DELETE FROM website_relay_pending_v2 WHERE guild_id=?", (guild_id,))
 
 
 def record_publication(db_path: str, guild_id: int, *, message: str, directive: str, mode: str, relay_lane: str, event_type: str, source_cursor: int, published_timestamp: str | None = None, relay_id: str | None = None) -> str:

--- a/bnl_website_relay_state.py
+++ b/bnl_website_relay_state.py
@@ -102,6 +102,14 @@ def ensure_schema(db_path: str) -> None:
         )
         """)
         conn.execute("CREATE INDEX IF NOT EXISTS idx_website_relay_attempts_guild_time ON website_relay_attempts(guild_id, started_at DESC)")
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(website_relay_attempts)").fetchall()}
+        for name, ddl in {
+            "prepared_relay_id": "ALTER TABLE website_relay_attempts ADD COLUMN prepared_relay_id TEXT",
+            "website_published_at": "ALTER TABLE website_relay_attempts ADD COLUMN website_published_at TEXT",
+            "idempotent": "ALTER TABLE website_relay_attempts ADD COLUMN idempotent INTEGER NOT NULL DEFAULT 0",
+        }.items():
+            if name not in cols:
+                conn.execute(ddl)
 
 
 def get_cursor(db_path: str, guild_id: int) -> int | None:
@@ -195,12 +203,12 @@ def reject_reason_for_candidate(db_path: str, guild_id: int, message: str, direc
     return ""
 
 
-def record_publication(db_path: str, guild_id: int, *, message: str, directive: str, mode: str, relay_lane: str, event_type: str, source_cursor: int, published_timestamp: str | None = None) -> str:
+def record_publication(db_path: str, guild_id: int, *, message: str, directive: str, mode: str, relay_lane: str, event_type: str, source_cursor: int, published_timestamp: str | None = None, relay_id: str | None = None) -> str:
     ensure_schema(db_path)
     ts = published_timestamp or utc_now_iso()
     norm = normalize_text(message)
     fam = semantic_family(message)
-    relay_id = hashlib.sha256(f"{guild_id}|{source_cursor}|{norm}|{ts}".encode()).hexdigest()[:24]
+    relay_id = relay_id or hashlib.sha256(f"{guild_id}|{source_cursor}|{norm}|{ts}".encode()).hexdigest()[:24]
     with sqlite3.connect(db_path) as conn:
         conn.execute("INSERT OR REPLACE INTO website_relay_state(guild_id,last_published_conversation_cursor,last_publication_timestamp) VALUES(?,?,?)", (guild_id, int(source_cursor or 0), ts))
         conn.execute("""
@@ -232,14 +240,36 @@ def begin_attempt(db_path: str, attempt_id: str, guild_id: int, trigger: str, so
         _prune_attempts(conn, guild_id)
 
 
-def complete_attempt(db_path: str, attempt_id: str, *, source_class: str, outcome: str, reason: str = "", aggregate_source_counts: dict[str, int] | None = None, cursor: int = 0, highest_eligible_conversation_id: int = 0, accepted_relay_id: str = "") -> None:
+def prepare_attempt_relay(db_path: str, attempt_id: str, prepared_relay_id: str) -> None:
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE website_relay_attempts SET prepared_relay_id=? WHERE attempt_id=?", (prepared_relay_id or "", attempt_id))
+
+def hydrate_publication(db_path: str, guild_id: int, *, relay_id: str, message: str, directive: str, source_class: str, trigger: str, published_timestamp: str) -> bool:
+    ensure_schema(db_path)
+    norm = normalize_text(message)
+    fam = semantic_family(message)
+    with sqlite3.connect(db_path) as conn:
+        existing = conn.execute("SELECT public_message, public_directive, published_timestamp FROM website_relay_history WHERE relay_id=?", (relay_id,)).fetchone()
+        if existing:
+            return False
+        conn.execute("""
+        INSERT INTO website_relay_history(relay_id,guild_id,public_message,public_directive,mode,relay_lane,event_type,highest_source_conversation_id,normalized_message,semantic_family,published_timestamp)
+        VALUES(?,?,?,?,?,?,?,?,?,?,?)
+        """, (relay_id, guild_id, message, directive, "OBSERVATION", "hydrated", source_class or trigger or "hydrated", 0, norm, fam, published_timestamp))
+        old = conn.execute("SELECT relay_id FROM website_relay_history WHERE guild_id=? ORDER BY published_timestamp DESC LIMIT -1 OFFSET ?", (guild_id, MAX_HISTORY)).fetchall()
+        if old:
+            conn.executemany("DELETE FROM website_relay_history WHERE relay_id=?", [(r[0],) for r in old])
+    return True
+
+def complete_attempt(db_path: str, attempt_id: str, *, source_class: str, outcome: str, reason: str = "", aggregate_source_counts: dict[str, int] | None = None, cursor: int = 0, highest_eligible_conversation_id: int = 0, accepted_relay_id: str = "", prepared_relay_id: str = "", website_published_at: str = "", idempotent: bool = False) -> None:
     ensure_schema(db_path)
     with sqlite3.connect(db_path) as conn:
         conn.execute("""
         UPDATE website_relay_attempts
-        SET source_class=?, completed_at=?, outcome=?, reason=?, aggregate_source_counts=?, cursor=?, highest_eligible_conversation_id=?, accepted_relay_id=?
+        SET source_class=?, completed_at=?, outcome=?, reason=?, aggregate_source_counts=?, cursor=?, highest_eligible_conversation_id=?, accepted_relay_id=?, prepared_relay_id=COALESCE(NULLIF(?, ''), prepared_relay_id), website_published_at=?, idempotent=?
         WHERE attempt_id=?
-        """, (source_class or "none", utc_now_iso(), outcome, reason or "", __import__('json').dumps(aggregate_source_counts or {}, sort_keys=True), int(cursor or 0), int(highest_eligible_conversation_id or 0), accepted_relay_id or "", attempt_id))
+        """, (source_class or "none", utc_now_iso(), outcome, reason or "", __import__('json').dumps(aggregate_source_counts or {}, sort_keys=True), int(cursor or 0), int(highest_eligible_conversation_id or 0), accepted_relay_id or "", prepared_relay_id or "", website_published_at or "", 1 if idempotent else 0, attempt_id))
 
 
 def get_attempt(db_path: str, attempt_id: str) -> dict[str, Any]:

--- a/tests/test_website_contract_v2.py
+++ b/tests/test_website_contract_v2.py
@@ -248,6 +248,76 @@ class ContractV2Tests(unittest.TestCase):
             self.assertEqual(state.recent_history(f.name, 42), [])
             self.assertIsNone(state.get_cursor(f.name, 42))
 
+
+    def test_lost_response_then_startup_hydration_confirms_pending_without_post(self):
+        decision = bnl01_bot.WebsiteRelayDecision(
+            True, eventType="canon", sourceConversationIds=[20], sourceCursor=20,
+            message="Hydration confirms the accepted relay.",
+            directive="Use the persisted website acceptance as local confirmation.",
+            mode="OBSERVATION", relayLane="network_posture",
+            metadata={"source_class": "canon", "aggregate_source_counts": {"canon": 1}},
+        )
+        sent = []
+        def lost_response(req, timeout=10):
+            sent.append(req.data)
+            raise urllib.error.URLError("lost")
+        with tempfile.NamedTemporaryFile() as f, mock.patch.object(bnl01_bot, "DB_FILE", f.name), mock.patch.object(bnl01_bot, "BNL_WEBSITE_CONTRACT_VERSION", "2"), mock.patch.object(bnl01_bot, "BNL_STATUS_URL", "https://site.test"), mock.patch.object(bnl01_bot, "BNL_API_KEY", "key"), mock.patch.object(bnl01_bot, "get_bnl_control_flags", return_value={"websiteRelayEnabled": True, "heartbeatEnabled": True}), mock.patch.object(bnl01_bot, "_generate_website_relay_guarded", return_value=decision), mock.patch("urllib.request.urlopen", side_effect=lost_response):
+            first = asyncio.run(bnl01_bot._execute_website_relay_transaction(42, source="relay"))
+            self.assertFalse(first.publish)
+            pending = state.get_pending_v2_publication(f.name, 42)
+            self.assertTrue(pending)
+
+            env = json.loads(pending["canonical_json"])
+            body = json.dumps({"status": "ONLINE", "mode": "OBSERVATION", "message": pending["message"], "currentDirective": pending["current_directive"], "source": "relay", "lastSeen": "2026-07-15T00:00:00Z", "persisted": True, "contractVersion": 2, "presence": {"contractVersion": 2, "status": "ONLINE", "mode": "OBSERVATION", "source": "startup", "receivedAt": "2026-07-15T00:00:00Z"}, "relay": dict(env["relay"], contractVersion=2, publishedAt="2026-07-15T00:00:00Z")}).encode()
+            methods = []
+            def get_only(req, timeout=10):
+                methods.append(req.get_method())
+                return Resp(200, body)
+            with mock.patch("urllib.request.urlopen", side_effect=get_only):
+                self.assertTrue(bnl01_bot.hydrate_website_relay_v2(42))
+            self.assertEqual(methods, ["GET"])
+            self.assertEqual(state.get_cursor(f.name, 42), 20)
+            hist = state.recent_history(f.name, 42)
+            self.assertEqual(len(hist), 1)
+            self.assertEqual(hist[0]["relay_id"], pending["relay_id"])
+            self.assertEqual(state.get_pending_v2_publication(f.name, 42), {})
+
+    def test_existing_hydrated_row_reconciles_pending_confirmation_once(self):
+        with tempfile.NamedTemporaryFile() as f, mock.patch.object(bnl01_bot, "DB_FILE", f.name), mock.patch.object(bnl01_bot, "BNL_STATUS_URL", "https://site.test"), mock.patch.object(bnl01_bot, "BNL_API_KEY", "key"):
+            relay_id = "bnl-reconcile-0001"
+            msg = "Already hydrated relay text."
+            directive = "Already hydrated directive text."
+            state.hydrate_publication(f.name, 42, relay_id=relay_id, message=msg, directive=directive, source_class="approved_canon", trigger="scheduled", published_timestamp="2026-07-15T00:00:00Z")
+            env = c.build_relay_envelope(relay_id, msg, directive, "approved_canon", "scheduled")
+            state.save_pending_v2_publication(f.name, 42, relay_id=relay_id, message=msg, current_directive=directive, source_class="approved_canon", trigger="scheduled", source_cursor=12, source_conversation_fingerprint="fp", canonical_json=c.canonical_payload_bytes(env).decode(), mode="OBSERVATION", relay_lane="network_posture", event_type="canon")
+            body = json.dumps({"persisted": True, "contractVersion": 2, "relay": dict(env["relay"], contractVersion=2, publishedAt="2026-07-15T00:00:01Z")}).encode()
+            with mock.patch("urllib.request.urlopen", return_value=Resp(200, body)):
+                self.assertTrue(bnl01_bot.hydrate_website_relay_v2(42))
+            self.assertEqual(state.get_cursor(f.name, 42), 12)
+            hist = state.recent_history(f.name, 42)
+            self.assertEqual(len(hist), 1)
+            self.assertEqual(hist[0]["relay_id"], relay_id)
+            self.assertEqual(state.get_pending_v2_publication(f.name, 42), {})
+
+    def test_same_relay_id_different_content_conflicts_and_retains_pending(self):
+        with tempfile.NamedTemporaryFile() as f, mock.patch.object(bnl01_bot, "DB_FILE", f.name), mock.patch.object(bnl01_bot, "BNL_STATUS_URL", "https://site.test"), mock.patch.object(bnl01_bot, "BNL_API_KEY", "key"):
+            relay_id = "bnl-conflict-0001"
+            state.record_publication(f.name, 42, message="Original relay text.", directive="Original directive text.", mode="OBSERVATION", relay_lane="network_posture", event_type="canon", source_cursor=3, relay_id=relay_id, published_timestamp="2026-07-15T00:00:00Z")
+            env = c.build_relay_envelope(relay_id, "Different relay text.", "Different directive text.", "approved_canon", "scheduled")
+            state.save_pending_v2_publication(f.name, 42, relay_id=relay_id, message="Different relay text.", current_directive="Different directive text.", source_class="approved_canon", trigger="scheduled", source_cursor=9, source_conversation_fingerprint="fp", canonical_json=c.canonical_payload_bytes(env).decode(), mode="OBSERVATION", relay_lane="network_posture", event_type="canon")
+            body = json.dumps({"persisted": True, "contractVersion": 2, "relay": dict(env["relay"], contractVersion=2, publishedAt="2026-07-15T00:00:01Z")}).encode()
+            with mock.patch("urllib.request.urlopen", return_value=Resp(200, body)):
+                self.assertFalse(bnl01_bot.hydrate_website_relay_v2(42))
+            self.assertEqual(state.get_cursor(f.name, 42), 3)
+            self.assertTrue(state.get_pending_v2_publication(f.name, 42))
+            hist = state.recent_history(f.name, 42)
+            self.assertEqual(hist[0]["public_message"], "Original relay text.")
+
+    def test_punctuation_and_capitalization_distinct_payloads_get_distinct_ids(self):
+        rid1 = bnl01_bot._new_stable_relay_id(guild_id=42, source_cursor=1, message="Relay text.", directive="Directive text.", source_class="canon", trigger="scheduled", source_conversation_fingerprint="fp")
+        rid2 = bnl01_bot._new_stable_relay_id(guild_id=42, source_cursor=1, message="relay text", directive="Directive text!", source_class="canon", trigger="scheduled", source_conversation_fingerprint="fp")
+        self.assertNotEqual(rid1, rid2)
+
     def test_v1_heartbeat_noops_without_http_stock_status(self):
         calls = []
         with mock.patch.object(bnl01_bot, "BNL_WEBSITE_CONTRACT_VERSION", "1"), mock.patch.object(bnl01_bot, "update_website_status_controlled_async", side_effect=lambda **kw: calls.append(kw)):

--- a/tests/test_website_contract_v2.py
+++ b/tests/test_website_contract_v2.py
@@ -1,0 +1,147 @@
+import json
+import os
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+import tempfile
+import unittest
+import urllib.error
+from io import BytesIO
+from unittest import mock
+
+import bnl01_bot
+import bnl_website_contract_v2 as c
+import bnl_website_relay_state as state
+
+
+class Resp:
+    def __init__(self, code, body):
+        self.status = code
+        self.body = body
+    def read(self):
+        return self.body
+    def getcode(self):
+        return self.status
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        return False
+
+
+def accepted_body(envelope, *, idempotent=False, override=None):
+    relay = dict(envelope["relay"])
+    relay["publishedAt"] = "2026-07-15T00:00:00Z"
+    if override:
+        relay.update(override)
+    return json.dumps({"ok": True, "relay": relay, "idempotent": idempotent}).encode()
+
+
+class ContractV2Tests(unittest.TestCase):
+    def test_presence_envelope_exact_and_extra_fields_absent(self):
+        env = c.build_presence_envelope(source="heartbeat")
+        self.assertEqual(env, {"contractVersion": 2, "kind": "presence", "presence": {"status": "ONLINE", "mode": "OBSERVATION", "source": "heartbeat"}})
+        self.assertFalse({"message", "currentDirective", "relayId", "sourceClass", "trigger", "adminNote"} & set(env["presence"]))
+
+    def test_relay_envelope_exact_and_extra_fields_absent(self):
+        env = c.build_relay_envelope("bnl-test-0001", "msg", "dir", "canon", "scheduled")
+        self.assertEqual(set(env), {"contractVersion", "kind", "relay"})
+        self.assertEqual(set(env["relay"]), {"relayId", "message", "currentDirective", "sourceClass", "trigger"})
+        self.assertEqual(env["relay"]["sourceClass"], "approved_canon")
+
+    def test_source_and_trigger_mapping_fail_closed(self):
+        self.assertEqual(c.map_source_class("fresh_discord"), "fresh_public_event")
+        self.assertEqual(c.map_source_class("conversation_continuity"), "recent_public_continuity")
+        self.assertEqual(c.map_source_class("broadcast_memory"), "scoped_broadcast_memory")
+        self.assertEqual(c.map_source_class("public_safe_memory"), "public_safe_memory")
+        self.assertEqual(c.map_source_class("canon"), "approved_canon")
+        self.assertEqual(c.map_source_class("reflection"), "grounded_reflection")
+        self.assertEqual(c.map_trigger("scheduled"), "scheduled")
+        self.assertEqual(c.map_trigger("forcePull"), "force_pull")
+        self.assertEqual(c.map_trigger("manual"), "manual")
+        with self.assertRaises(c.ContractV2Error):
+            c.map_source_class("mystery")
+        with self.assertRaises(c.ContractV2Error):
+            c.map_trigger("mystery")
+
+    def test_relay_id_validation(self):
+        self.assertEqual(c.validate_relay_id("bnl-abc_123:45"), "bnl-abc_123:45")
+        for bad in ("", "short", "bad space"):
+            with self.assertRaises(c.ContractV2Error):
+                c.validate_relay_id(bad)
+
+    def test_stable_payload_across_retry_and_idempotent_response(self):
+        env = c.build_relay_envelope("bnl-retry-0001", "msg", "dir", "canon", "scheduled")
+        seen = []
+        def opener(req, timeout=10):
+            seen.append(req.data)
+            if len(seen) == 1:
+                raise urllib.error.URLError("temporary")
+            return Resp(200, accepted_body(env, idempotent=True))
+        result = c.deliver_json("https://site.test", "key", env, opener=opener, retries=1)
+        self.assertTrue(result.ok)
+        self.assertTrue(result.idempotent)
+        self.assertEqual(result.relay_id, "bnl-retry-0001")
+        self.assertEqual(result.published_at, "2026-07-15T00:00:00Z")
+        self.assertEqual(seen[0], seen[1])
+
+    def test_delivery_failures(self):
+        env = c.build_relay_envelope("bnl-fail-0001", "msg", "dir", "canon", "scheduled")
+        cases = [
+            (Resp(400, b"{}"), "contract_rejected"),
+            (Resp(409, b"{}"), "relay_id_conflict"),
+            (Resp(500, b"{}"), "retryable_delivery_failure"),
+            (Resp(200, b"not-json"), "malformed_json"),
+            (Resp(200, accepted_body(env, override={"relayId": "bnl-other-0001"})), "response_mismatch"),
+            (Resp(200, accepted_body(env, override={"message": "changed"})), "response_mismatch"),
+        ]
+        for resp, reason in cases:
+            result = c.deliver_json("https://site.test", "k", env, opener=lambda req, timeout=10, r=resp: r, retries=0)
+            self.assertFalse(result.ok)
+            self.assertEqual(result.reason, reason)
+        result = c.deliver_json("https://site.test", "k", env, opener=lambda req, timeout=10: (_ for _ in ()).throw(urllib.error.URLError("down")), retries=0)
+        self.assertEqual(result.reason, "retryable_delivery_failure")
+
+    def test_record_publication_with_website_id_and_failed_attempt_does_not_advance(self):
+        with tempfile.NamedTemporaryFile() as f:
+            state.begin_attempt(f.name, "a1", 42, "scheduled", cursor=7)
+            state.prepare_attempt_relay(f.name, "a1", "bnl-prepared-0001")
+            state.complete_attempt(f.name, "a1", source_class="canon", outcome="delivery_failed", reason="contract_rejected", cursor=7, prepared_relay_id="bnl-prepared-0001")
+            self.assertIsNone(state.get_cursor(f.name, 42))
+            rid = state.record_publication(f.name, 42, message="msg", directive="dir", mode="OBSERVATION", relay_lane="current_signal", event_type="canon", source_cursor=7, relay_id="bnl-prepared-0001", published_timestamp="2026-07-15T00:00:00Z")
+            self.assertEqual(rid, "bnl-prepared-0001")
+            self.assertEqual(state.get_cursor(f.name, 42), 7)
+
+    def test_startup_hydration_get_no_post_and_no_duplicate(self):
+        env = c.build_relay_envelope("bnl-hydrate-0001", "msg", "dir", "canon", "scheduled")
+        body = json.dumps({"contractVersion": 2, "relay": dict(env["relay"], publishedAt="2026-07-15T00:00:00Z")}).encode()
+        posts = []
+        def opener(req, timeout=10):
+            if req.get_method() == "POST":
+                posts.append(req.data)
+            return Resp(200, body)
+        with tempfile.NamedTemporaryFile() as f, mock.patch.object(bnl01_bot, "DB_FILE", f.name), mock.patch.object(bnl01_bot, "BNL_STATUS_URL", "https://site.test"), mock.patch.object(bnl01_bot, "BNL_API_KEY", "key"), mock.patch("urllib.request.urlopen", side_effect=opener):
+            self.assertTrue(bnl01_bot.hydrate_website_relay_v2(42))
+            self.assertFalse(bnl01_bot.hydrate_website_relay_v2(42))
+            self.assertEqual(posts, [])
+            self.assertEqual(len(state.recent_history(f.name, 42)), 1)
+            self.assertIsNone(state.get_cursor(f.name, 42))
+
+    def test_version_one_legacy_payload_and_no_v2_fallback(self):
+        with mock.patch.object(bnl01_bot, "BNL_WEBSITE_CONTRACT_VERSION", "1"), mock.patch.object(bnl01_bot, "BNL_API_KEY", "key"), mock.patch.object(bnl01_bot, "BNL_STATUS_URL", "https://site.test"):
+            captured = {}
+            def opener(req, timeout=10):
+                captured.update(json.loads(req.data.decode()))
+                return Resp(200, b"{}")
+            with mock.patch("urllib.request.urlopen", side_effect=opener):
+                self.assertTrue(bnl01_bot.update_website_status_controlled("OBSERVATION", "A sufficiently specific public relay message for the legacy v1 payload.", force=True, current_directive="Review a sufficiently specific directive for the legacy v1 payload path and preserve exact flat transport fields during rollback testing.", source="relay"))
+            self.assertEqual(captured, {"status": "ONLINE", "mode": "OBSERVATION", "message": "A sufficiently specific public relay message for the legacy v1 payload.", "currentDirective": "Review a sufficiently specific directive for the legacy v1 payload path and preserve exact flat transport fields during rollback testing.", "source": "relay"})
+        with mock.patch.object(bnl01_bot, "BNL_WEBSITE_CONTRACT_VERSION", "2"):
+            self.assertFalse(bnl01_bot.update_website_status_controlled("OBSERVATION", "msg", source="relay"))
+
+    def test_flags_gate_only_expected_tasks_and_cadence_constant(self):
+        self.assertEqual(bnl01_bot.BNL_WEBSITE_RELAY_INTERVAL_MINUTES, 20)
+        self.assertEqual(bnl01_bot.BNL_WEBSITE_HEARTBEAT_INTERVAL_MINUTES, 5)
+        self.assertTrue(hasattr(bnl01_bot, "website_presence_heartbeat_task"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_website_contract_v2.py
+++ b/tests/test_website_contract_v2.py
@@ -169,6 +169,85 @@ class ContractV2Tests(unittest.TestCase):
             self.assertEqual(len(state.recent_history(f.name, 99)), 1)
             self.assertEqual(state.recent_history(f.name, 42), [])
 
+
+    def test_durable_pending_replay_across_transactions_and_restart(self):
+        decision_one = bnl01_bot.WebsiteRelayDecision(
+            True, eventType="canon", sourceConversationIds=[10, 11], sourceCursor=11,
+            message="First accepted relay speech stays durable.",
+            directive="Preserve this accepted directive across replay.",
+            mode="OBSERVATION", relayLane="network_posture",
+            metadata={"source_class": "canon", "aggregate_source_counts": {"canon": 1}},
+        )
+        sent = []
+        def lost_response(req, timeout=10):
+            sent.append(req.data)
+            raise urllib.error.URLError("lost after accept")
+        with tempfile.NamedTemporaryFile() as f, mock.patch.object(bnl01_bot, "DB_FILE", f.name), mock.patch.object(bnl01_bot, "BNL_WEBSITE_CONTRACT_VERSION", "2"), mock.patch.object(bnl01_bot, "BNL_STATUS_URL", "https://site.test"), mock.patch.object(bnl01_bot, "BNL_API_KEY", "key"), mock.patch.object(bnl01_bot, "get_bnl_control_flags", return_value={"websiteRelayEnabled": True, "heartbeatEnabled": True}), mock.patch.object(bnl01_bot, "_generate_website_relay_guarded", return_value=decision_one), mock.patch("urllib.request.urlopen", side_effect=lost_response):
+            first = asyncio.run(bnl01_bot._execute_website_relay_transaction(42, source="relay"))
+            self.assertFalse(first.publish)
+            self.assertEqual(first.skipReason, "website_post_failed")
+            self.assertEqual(first.metadata["reason"], "retryable_delivery_failure")
+            self.assertEqual(state.get_cursor(f.name, 42), None)
+            pending = state.get_pending_v2_publication(f.name, 42)
+            self.assertTrue(pending)
+            first_relay_id = pending["relay_id"]
+            first_bytes = pending["canonical_json"].encode()
+            self.assertEqual(sent[0], sent[1])
+            self.assertEqual(sent[0], first_bytes)
+
+            # Simulate a restart by clearing process-local transaction locks; pending state remains in SQLite.
+            bnl01_bot._website_relay_transaction_locks_by_guild.clear()
+            def should_not_generate(*args, **kwargs):
+                raise AssertionError("new candidate generated despite pending envelope")
+            def idempotent_response(req, timeout=10):
+                sent.append(req.data)
+                env = json.loads(req.data.decode())
+                return Resp(200, accepted_body(env, idempotent=True))
+            with mock.patch.object(bnl01_bot, "_generate_website_relay_guarded", side_effect=should_not_generate), mock.patch("urllib.request.urlopen", side_effect=idempotent_response):
+                second = asyncio.run(bnl01_bot._execute_website_relay_transaction(42, source="relay"))
+            self.assertTrue(second.publish)
+            self.assertTrue(second.metadata["pending_replay"])
+            self.assertEqual(second.metadata["accepted_relay_id"], first_relay_id)
+            self.assertEqual(sent[-1], first_bytes)
+            self.assertEqual(state.get_cursor(f.name, 42), 11)
+            hist = state.recent_history(f.name, 42)
+            self.assertEqual(len(hist), 1)
+            self.assertEqual(hist[0]["relay_id"], first_relay_id)
+            self.assertEqual(state.get_pending_v2_publication(f.name, 42), {})
+
+    def test_delivery_failures_are_hard_failures_for_manual_request(self):
+        async def failed_transaction(guild_id, **kwargs):
+            return bnl01_bot.WebsiteRelayDecision(False, skipReason="website_post_failed", metadata={"reason": "authentication_failed", "delivery_failure": True})
+        with mock.patch.object(bnl01_bot, "_execute_website_relay_transaction", side_effect=failed_transaction):
+            ok, _mode, msg, directive = asyncio.run(bnl01_bot.request_fresh_website_relay(42, force=True))
+        self.assertFalse(ok)
+        self.assertEqual((msg, directive), ("", ""))
+
+    def test_safe_no_publication_remains_non_failure_for_manual_request(self):
+        async def safe_empty(guild_id, **kwargs):
+            return bnl01_bot.WebsiteRelayDecision(False, skipReason="no_new_public_signal", metadata={"reason": "no_new_public_signal"})
+        with mock.patch.object(bnl01_bot, "_execute_website_relay_transaction", side_effect=safe_empty):
+            ok, _mode, msg, directive = asyncio.run(bnl01_bot.request_fresh_website_relay(42, force=True))
+        self.assertTrue(ok)
+        self.assertEqual((msg, directive), ("", ""))
+
+    def test_force_pull_delivery_failure_sets_failed_with_detail(self):
+        async def failed_transaction(guild_id, **kwargs):
+            return bnl01_bot.WebsiteRelayDecision(False, skipReason="website_post_failed", mode="OBSERVATION", metadata={"reason": "relay_id_conflict", "delivery_failure": True})
+        with mock.patch.object(bnl01_bot, "_execute_website_relay_transaction", side_effect=failed_transaction):
+            asyncio.run(bnl01_bot._run_force_pull_relay_update(42, request_id="force-fail"))
+        fp = bnl01_bot._get_force_pull_state(42)
+        self.assertEqual(fp["last_force_pull_status"], "failed")
+        self.assertEqual(fp["last_force_pull_error"], "relay_id_conflict")
+
+    def test_startup_hydration_rejects_persisted_false(self):
+        env = c.build_relay_envelope("bnl-hydrate-0003", "msg", "dir", "canon", "scheduled")
+        body = json.dumps({"status": "ONLINE", "mode": "OBSERVATION", "message": "msg", "currentDirective": "dir", "source": "relay", "lastSeen": "2026-07-15T00:00:00Z", "persisted": False, "contractVersion": 2, "presence": {"contractVersion": 2, "status": "ONLINE", "mode": "OBSERVATION", "source": "startup", "receivedAt": "2026-07-15T00:00:00Z"}, "relay": dict(env["relay"], contractVersion=2, publishedAt="2026-07-15T00:00:00Z")}).encode()
+        with tempfile.NamedTemporaryFile() as f, mock.patch.object(bnl01_bot, "DB_FILE", f.name), mock.patch.object(bnl01_bot, "BNL_STATUS_URL", "https://site.test"), mock.patch.object(bnl01_bot, "BNL_API_KEY", "key"), mock.patch("urllib.request.urlopen", return_value=Resp(200, body)):
+            self.assertFalse(bnl01_bot.hydrate_website_relay_v2(42))
+            self.assertEqual(state.recent_history(f.name, 42), [])
+            self.assertIsNone(state.get_cursor(f.name, 42))
+
     def test_v1_heartbeat_noops_without_http_stock_status(self):
         calls = []
         with mock.patch.object(bnl01_bot, "BNL_WEBSITE_CONTRACT_VERSION", "1"), mock.patch.object(bnl01_bot, "update_website_status_controlled_async", side_effect=lambda **kw: calls.append(kw)):

--- a/tests/test_website_contract_v2.py
+++ b/tests/test_website_contract_v2.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 os.environ.setdefault("GEMINI_API_KEY", "test-key")
@@ -5,7 +6,6 @@ os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
 import tempfile
 import unittest
 import urllib.error
-from io import BytesIO
 from unittest import mock
 
 import bnl01_bot
@@ -29,10 +29,11 @@ class Resp:
 
 def accepted_body(envelope, *, idempotent=False, override=None):
     relay = dict(envelope["relay"])
+    relay["contractVersion"] = 2
     relay["publishedAt"] = "2026-07-15T00:00:00Z"
     if override:
         relay.update(override)
-    return json.dumps({"ok": True, "relay": relay, "idempotent": idempotent}).encode()
+    return json.dumps({"ok": True, "relay": relay, "idempotent": idempotent, "persisted": True}).encode()
 
 
 class ContractV2Tests(unittest.TestCase):
@@ -64,7 +65,7 @@ class ContractV2Tests(unittest.TestCase):
 
     def test_relay_id_validation(self):
         self.assertEqual(c.validate_relay_id("bnl-abc_123:45"), "bnl-abc_123:45")
-        for bad in ("", "short", "bad space"):
+        for bad in ("", "ab", "bad space"):
             with self.assertRaises(c.ContractV2Error):
                 c.validate_relay_id(bad)
 
@@ -90,6 +91,9 @@ class ContractV2Tests(unittest.TestCase):
             (Resp(409, b"{}"), "relay_id_conflict"),
             (Resp(500, b"{}"), "retryable_delivery_failure"),
             (Resp(200, b"not-json"), "malformed_json"),
+            (Resp(401, b"{}"), "authentication_failed"),
+            (Resp(418, b"{}"), "http_rejected"),
+            (Resp(200, json.dumps({"ok": True, "relay": dict(env["relay"], contractVersion=2, publishedAt="2026-07-15T00:00:00Z"), "persisted": False}).encode()), "not_persisted"),
             (Resp(200, accepted_body(env, override={"relayId": "bnl-other-0001"})), "response_mismatch"),
             (Resp(200, accepted_body(env, override={"message": "changed"})), "response_mismatch"),
         ]
@@ -112,7 +116,7 @@ class ContractV2Tests(unittest.TestCase):
 
     def test_startup_hydration_get_no_post_and_no_duplicate(self):
         env = c.build_relay_envelope("bnl-hydrate-0001", "msg", "dir", "canon", "scheduled")
-        body = json.dumps({"contractVersion": 2, "relay": dict(env["relay"], publishedAt="2026-07-15T00:00:00Z")}).encode()
+        body = json.dumps({"status": "ONLINE", "mode": "OBSERVATION", "message": "msg", "currentDirective": "dir", "source": "relay", "lastSeen": "2026-07-15T00:00:00Z", "persisted": True, "contractVersion": 2, "presence": {"contractVersion": 2, "status": "ONLINE", "mode": "OBSERVATION", "source": "startup", "receivedAt": "2026-07-15T00:00:00Z"}, "relay": dict(env["relay"], contractVersion=2, publishedAt="2026-07-15T00:00:00Z")}).encode()
         posts = []
         def opener(req, timeout=10):
             if req.get_method() == "POST":
@@ -124,6 +128,58 @@ class ContractV2Tests(unittest.TestCase):
             self.assertEqual(posts, [])
             self.assertEqual(len(state.recent_history(f.name, 42)), 1)
             self.assertIsNone(state.get_cursor(f.name, 42))
+
+    def test_presence_response_validation(self):
+        env = c.build_presence_envelope(source="startup")
+        good = {"ok": True, "presence": {"contractVersion": 2, "status": "ONLINE", "mode": "OBSERVATION", "source": "startup", "receivedAt": "2026-07-15T00:00:00Z"}, "persisted": True}
+        self.assertTrue(c.validate_presence_response(good, env).ok)
+        for bad in (
+            b"not-json",
+            json.dumps({"ok": False, "presence": good["presence"], "persisted": True}).encode(),
+            json.dumps({"ok": True, "presence": dict(good["presence"], source="heartbeat"), "persisted": True}).encode(),
+            json.dumps({"ok": True, "presence": good["presence"], "persisted": False}).encode(),
+            json.dumps({"ok": True, "presence": dict(good["presence"], receivedAt="not-a-date"), "persisted": True}).encode(),
+        ):
+            result = c.deliver_json("https://site.test", "k", env, opener=lambda req, timeout=10, body=bad: Resp(200, body), retries=0)
+            self.assertFalse(result.ok)
+
+    def test_relay_persisted_false_does_not_advance_cursor_or_history(self):
+        with tempfile.NamedTemporaryFile() as f:
+            state.begin_attempt(f.name, "a2", 42, "scheduled", cursor=7)
+            env = c.build_relay_envelope("bnl-persist-0001", "Substantive public relay speech.", "A grounded line of inquiry or invitation.", "canon", "scheduled")
+            body = json.dumps({"ok": True, "relay": dict(env["relay"], contractVersion=2, publishedAt="2026-07-15T00:00:00Z"), "persisted": False}).encode()
+            result = c.deliver_json("https://site.test", "k", env, opener=lambda req, timeout=10: Resp(200, body), retries=0)
+            self.assertEqual(result.reason, "not_persisted")
+            self.assertIsNone(state.get_cursor(f.name, 42))
+            self.assertEqual(state.recent_history(f.name, 42), [])
+
+    def test_network_hydration_resolves_one_primary_guild(self):
+        env = c.build_relay_envelope("bnl-hydrate-0002", "msg", "dir", "canon", "scheduled")
+        body = json.dumps({"status": "ONLINE", "mode": "OBSERVATION", "message": "msg", "currentDirective": "dir", "source": "relay", "lastSeen": "2026-07-15T00:00:00Z", "persisted": True, "contractVersion": 2, "presence": {"contractVersion": 2, "status": "ONLINE", "mode": "OBSERVATION", "source": "startup", "receivedAt": "2026-07-15T00:00:00Z"}, "relay": dict(env["relay"], contractVersion=2, publishedAt="2026-07-15T00:00:00Z")}).encode()
+        gets = []
+        def opener(req, timeout=10):
+            gets.append(req.get_method())
+            return Resp(200, body)
+        with tempfile.NamedTemporaryFile() as f, mock.patch.object(bnl01_bot, "DB_FILE", f.name), mock.patch.object(bnl01_bot, "BNL_STATUS_URL", "https://site.test"), mock.patch.object(bnl01_bot, "BNL_API_KEY", "key"), mock.patch.object(bnl01_bot, "BNL_PRIMARY_GUILD_ID", 99), mock.patch("urllib.request.urlopen", side_effect=opener):
+            gid = bnl01_bot._resolve_startup_hydration_guild_id()
+            self.assertEqual(gid, 99)
+            self.assertTrue(bnl01_bot.hydrate_website_relay_v2(gid))
+            self.assertFalse(bnl01_bot.hydrate_website_relay_v2(gid))
+            self.assertEqual(gets, ["GET", "GET"])
+            self.assertEqual(len(state.recent_history(f.name, 99)), 1)
+            self.assertEqual(state.recent_history(f.name, 42), [])
+
+    def test_v1_heartbeat_noops_without_http_stock_status(self):
+        calls = []
+        with mock.patch.object(bnl01_bot, "BNL_WEBSITE_CONTRACT_VERSION", "1"), mock.patch.object(bnl01_bot, "update_website_status_controlled_async", side_effect=lambda **kw: calls.append(kw)):
+            asyncio.run(bnl01_bot.website_presence_heartbeat_task.coro())
+        self.assertEqual(calls, [])
+
+    def test_v1_startup_presence_noops_without_http_stock_status(self):
+        calls = []
+        with mock.patch.object(bnl01_bot, "BNL_WEBSITE_CONTRACT_VERSION", "1"), mock.patch.object(bnl01_bot, "publish_website_presence_v2", side_effect=lambda **kw: calls.append(kw)):
+            self.assertFalse(asyncio.run(bnl01_bot.publish_startup_presence_v2_if_enabled()))
+        self.assertEqual(calls, [])
 
     def test_version_one_legacy_payload_and_no_v2_fallback(self):
         with mock.patch.object(bnl01_bot, "BNL_WEBSITE_CONTRACT_VERSION", "1"), mock.patch.object(bnl01_bot, "BNL_API_KEY", "key"), mock.patch.object(bnl01_bot, "BNL_STATUS_URL", "https://site.test"):

--- a/tests/test_website_relay_event_driven.py
+++ b/tests/test_website_relay_event_driven.py
@@ -19,6 +19,8 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
         self.tmp.close()
         self.db = self.tmp.name
         self.old_db = bnl01_bot.DB_FILE
+        self.old_contract_version = bnl01_bot.BNL_WEBSITE_CONTRACT_VERSION
+        bnl01_bot.BNL_WEBSITE_CONTRACT_VERSION = "1"
         bnl01_bot.DB_FILE = self.db
         bnl01_bot._recent_relay_messages.clear()
         bnl01_bot._website_relay_transaction_locks_by_guild.clear()
@@ -41,6 +43,7 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
 
     def tearDown(self):
         bnl01_bot.DB_FILE = self.old_db
+        bnl01_bot.BNL_WEBSITE_CONTRACT_VERSION = self.old_contract_version
         try:
             os.unlink(self.db)
         except OSError:


### PR DESCRIPTION
### Motivation
- Move the bot’s website producer to the website’s verified v2 presence/relay contract so presence and public relay are distinct and idempotent. 
- Ensure producer-owned stable relay IDs, bounded idempotent retries, and truthful delivery outcomes while preserving the v1 producer as an operator rollback.
- Hydrate the last accepted v2 relay on startup without reposting it and add a dedicated heartbeat presence task independent of speech relays.

### Description
- Add `bnl_website_contract_v2.py` which implements strict v2 logic: exact presence/relay envelope builders, source/trigger mapping, relay-ID validation, canonical payload bytes, typed `DeliveryResult`, delivery `deliver_json`, and `parse_status_relay` for startup hydration. 
- Introduce `BNL_WEBSITE_CONTRACT_VERSION` (default `2`, accepts only `1` or `2`) and `BNL_WEBSITE_HEARTBEAT_INTERVAL_MINUTES` (default `5`) and route logic to preserve v1 only when explicitly selected. 
- Split transport paths by adding `publish_website_presence_v2`, `publish_website_relay_v2`, and `hydrate_website_relay_v2`, and suppress the legacy `update_website_status_controlled` path when contract version is `2`. 
- Prepare and persist a producer-owned stable relay ID before delivery (via `prepare_attempt_relay`), change the transaction so the same prepared ID/payload is retried, validate website responses (including idempotent replay), then record accepted relay id and `publishedAt` only after confirmation; the v1 flow is preserved behind the version flag. 
- Extend `bnl_website_relay_state.py` schema and API idempotently to add `prepared_relay_id`, `website_published_at`, and `idempotent`, plus `prepare_attempt_relay`, `hydrate_publication`, and allow `record_publication` to accept a producer-supplied `relay_id` and `published_timestamp`. 
- Add a dedicated heartbeat task `website_presence_heartbeat_task`, call startup hydration (no repost) and one startup presence send in `on_ready`, and suppress non-relay `/showtest` website writes under v2 while preserving Discord test behavior. 
- Extend diagnostics to report effective contract version, heartbeat task state, last presence/relay delivery results, prepared/accepted relay IDs, and idempotent outcomes. 
- Add focused tests in `tests/test_website_contract_v2.py` for envelope shapes, mappings, relay-ID validation, retry/idempotency behaviors, failure categories, startup hydration, v1 rollback semantics, and heartbeat/interval expectations; adjust existing event-driven tests to run under explicit v1 in their harness to preserve regression expectations. 
- Protected architecture unchanged: queue integration, personality, memory architecture, source-selection cascade, route/direct-session policies, and the 20-minute scheduled relay cadence were not altered. 

### Testing
- Compiled targets with `python -m py_compile bnl01_bot.py bnl_website_relay_state.py bnl_website_contract_v2.py tests/test_website_contract_v2.py` which succeeded. 
- Ran `python -m unittest tests.test_website_contract_v2 tests.test_website_relay_event_driven tests.test_async_relay_offload -v` and the suites passed. 
- Ran larger regression suites `python -m unittest tests.test_route_memory_governance tests.test_behavior_contract_regression tests.test_adaptive_memory_lifecycle tests.test_broadcast_memory_rd_sanitizer -v` and they passed. 
- Ran `git diff --check` and `py_compile` checks as part of validation and observed no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5814d945c8832194a388c5eddd3ba3)