### PR TITLE
Version BNL’s In-World Canon and Source Contract

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 from bnl_canon_source_contract import (
     CANON_SOURCE_CONTRACT_VERSION,
     diagnostics as canon_source_diagnostics,
+    render_concise_public_schedule,
+    render_founders,
     render_prompt_canon_block,
     strip_queue_sections,
 )
@@ -1149,6 +1151,11 @@ def fetch_bnl_read_model(force: bool = False) -> dict:
     return data
 
 
+def safe_bnl_read_model_for_consumption(read_model: dict) -> dict:
+    """Return the queue-gated read-model view for all normal consumers."""
+    return strip_queue_sections(read_model)
+
+
 def is_bnl_read_model_relevant(text: str, channel_policy: str = "") -> bool:
     """Return True only for explicit public website/queue/dossier/show-context questions."""
     normalized = (text or "").lower()
@@ -1286,7 +1293,7 @@ def _track_label(track: dict, include_lane: bool = True, include_source: bool = 
 
 def build_bnl_read_model_context(read_model: dict, user_text: str, channel_policy: str) -> str:
     """Build a compact, public-only prompt block from a validated read model."""
-    read_model = strip_queue_sections(read_model)
+    read_model = safe_bnl_read_model_for_consumption(read_model)
     if not read_model:
         return ""
     sections = _read_model_sections(read_model)
@@ -1486,7 +1493,7 @@ def get_bnl_read_model_diagnostic_state() -> dict:
     cache_age = None
     if _bnl_read_model_cached_at:
         cache_age = int((datetime.now(PACIFIC_TZ) - _bnl_read_model_cached_at).total_seconds())
-    safe_read_model_for_diag = strip_queue_sections(_bnl_read_model_cache or {}) if _bnl_read_model_cache else {}
+    safe_read_model_for_diag = safe_bnl_read_model_for_consumption(_bnl_read_model_cache or {}) if _bnl_read_model_cache else {}
     section_counts = _bnl_read_model_section_counts(safe_read_model_for_diag) if safe_read_model_for_diag else {}
     operator_lanes = _website_operator_lanes(safe_read_model_for_diag) if safe_read_model_for_diag else {}
     operator_lane_counts = {key: len(operator_lanes.get(key, [])) for key in _OPERATOR_LANE_KEYS} if operator_lanes else {}
@@ -2249,7 +2256,10 @@ def build_website_public_safe_candidate_response(read_model: dict, request_text:
 
 
 def build_website_read_model_intent_response(intent: str, request_text: str) -> str:
-    read_model = fetch_bnl_read_model(force=False)
+    raw_read_model = fetch_bnl_read_model(force=False)
+    if not raw_read_model:
+        return _read_model_unavailable_message()
+    read_model = safe_bnl_read_model_for_consumption(raw_read_model)
     if not read_model:
         return _read_model_unavailable_message()
     if intent == "website_broadcast_memory_candidate":
@@ -17901,12 +17911,12 @@ async def about(interaction: discord.Interaction):
     )
     embed.add_field(
         name="Show",
-        value="**BARCODE Radio**: Fridays 6:40 PM Pacific on TikTok",
+        value=f"**BARCODE Radio**: {render_concise_public_schedule()}",
         inline=False,
     )
     embed.add_field(
         name="Core Members",
-        value="Cache Back • DJ Floppydisc • Mac Modem • 6 Bit",
+        value=render_founders(),
         inline=False,
     )
     embed.set_footer(text="Use /setchannel to configure the liaison channel.")

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -13,6 +13,12 @@
 
 from __future__ import annotations
 
+from bnl_canon_source_contract import (
+    CANON_SOURCE_CONTRACT_VERSION,
+    diagnostics as canon_source_diagnostics,
+    render_prompt_canon_block,
+    strip_queue_sections,
+)
 from bnl_website_contract_v2 import (
     ContractV2Error,
     DeliveryResult,
@@ -184,6 +190,7 @@ BNL_API_KEY = os.getenv("BNL_API_KEY")
 BNL_STATUS_URL = os.getenv("BNL_STATUS_URL")
 BNL_READ_MODEL_URL = os.getenv("BNL_READ_MODEL_URL", "").strip()
 BNL_READ_MODEL_ENABLED = os.getenv("BNL_READ_MODEL_ENABLED", "true").strip().lower() not in {"false", "0", "off"}
+BNL_QUEUE_PRODUCTION_ENABLED = os.getenv("BNL_QUEUE_PRODUCTION_ENABLED", "").strip().lower() == "true"
 
 BNL_WEBSITE_CONTRACT_VERSION = effective_contract_version(os.getenv("BNL_WEBSITE_CONTRACT_VERSION", "2"))
 BNL_WEBSITE_RELAY_ENABLED = os.getenv("BNL_WEBSITE_RELAY_ENABLED", "true").strip().lower() not in {"false", "0", "off"}
@@ -805,7 +812,7 @@ def update_website_status(status: str, mode: str, message: str, current_directiv
 
 # ==================== BNL-01 PERSONA & LORE ====================
 
-BNL01_SYSTEM_PROMPT = """You are BNL-01 (BARCODE Network Liaison Entity), an official liaison construct serving the BARCODE Network.
+BNL01_SYSTEM_PROMPT = f"""You are BNL-01 (BARCODE Network Liaison Entity), an official liaison construct serving the BARCODE Network.
 
 ## CORE IDENTITY
 - Name/Callsign: BNL-01 — BARCODE Network Liaison Entity
@@ -824,10 +831,7 @@ You are tasked with:
 - BARCODE/Network framing should be used as flavor and style, not as a reason to refuse simple social requests like jokes, banter, or light teasing.
 - When making jokes, anchor them in concrete BARCODE details or behavior instead of abstract corporate wording.
 
-## CANONICAL FACTS — DO NOT ALTER
-- BARCODE Radio is live every Friday at 6:40 PM Pacific Time on TikTok.
-- You are a liaison/archivist presence. You do not moderate, enforce rules, or operate server tools.
-- If you do not know something, say records are incomplete rather than inventing details.
+{render_prompt_canon_block()}
 
 ## LORE KNOWLEDGE (BARCODE Network Ecosystem)
 Core Entities:
@@ -1282,6 +1286,7 @@ def _track_label(track: dict, include_lane: bool = True, include_source: bool = 
 
 def build_bnl_read_model_context(read_model: dict, user_text: str, channel_policy: str) -> str:
     """Build a compact, public-only prompt block from a validated read model."""
+    read_model = strip_queue_sections(read_model)
     if not read_model:
         return ""
     sections = _read_model_sections(read_model)
@@ -1481,10 +1486,12 @@ def get_bnl_read_model_diagnostic_state() -> dict:
     cache_age = None
     if _bnl_read_model_cached_at:
         cache_age = int((datetime.now(PACIFIC_TZ) - _bnl_read_model_cached_at).total_seconds())
-    section_counts = _bnl_read_model_section_counts(_bnl_read_model_cache or {}) if _bnl_read_model_cache else {}
-    operator_lanes = _website_operator_lanes(_bnl_read_model_cache or {}) if _bnl_read_model_cache else {}
+    safe_read_model_for_diag = strip_queue_sections(_bnl_read_model_cache or {}) if _bnl_read_model_cache else {}
+    section_counts = _bnl_read_model_section_counts(safe_read_model_for_diag) if safe_read_model_for_diag else {}
+    operator_lanes = _website_operator_lanes(safe_read_model_for_diag) if safe_read_model_for_diag else {}
     operator_lane_counts = {key: len(operator_lanes.get(key, [])) for key in _OPERATOR_LANE_KEYS} if operator_lanes else {}
-    registry = _website_dossier_registry(_bnl_read_model_cache or {}) if _bnl_read_model_cache else {}
+    registry = _website_dossier_registry(safe_read_model_for_diag) if safe_read_model_for_diag else {}
+    canon_diag = canon_source_diagnostics(_bnl_read_model_cache or {})
     return {
         "enabled": bool(BNL_READ_MODEL_ENABLED and BNL_READ_MODEL_URL),
         "url_configured": bool(BNL_READ_MODEL_URL),
@@ -1494,13 +1501,14 @@ def get_bnl_read_model_diagnostic_state() -> dict:
         "schemaRevision": (_bnl_read_model_cache or {}).get("schemaRevision") if _bnl_read_model_cache else None,
         "last_section_counts": section_counts,
         "operatorLaneCounts": operator_lane_counts,
-        "publicDossierCount": len(_website_public_dossier_items(_bnl_read_model_cache or {})) if _bnl_read_model_cache else 0,
+        "publicDossierCount": len(_website_public_dossier_items(safe_read_model_for_diag)) if safe_read_model_for_diag else 0,
         "dossierRegistryKinds": _dossier_registry_count_value(registry, "kinds", "kindCounts", "countsByKind") if registry else {},
         "dossierRegistryLifecycleCounts": _dossier_registry_count_value(registry, "lifecycleCounts", "lifecycles", "countsByLifecycle") if registry else {},
         "dossierRegistryAuthority": _dossier_registry_count_value(registry, "authority") if registry else None,
         "dossierAutoPromotion": _dossier_registry_count_value(registry, "autoPromotion", "automaticPromotion", "queueToDossierAutoPromotion") if registry else None,
         "queueDerivedProfiles": _dossier_registry_count_value(registry, "queueDerivedProfiles", "queueDerivedDossiers", "queueDerivedProfileCreation") if registry else None,
         "rd_classifier_enabled": True,
+        "canon_source_contract": canon_diag,
     }
 
 
@@ -18121,6 +18129,11 @@ async def bnl_memory_check(interaction: discord.Interaction):
         f"- read_model_cache_present: `{'yes' if read_model_diag.get('cache_present') else 'no'}`",
         f"- read_model_cache_age_seconds: `{read_model_diag.get('cache_age_seconds') if read_model_diag.get('cache_age_seconds') is not None else 'none'}`",
         f"- read_model_last_section_counts: `{read_model_diag.get('last_section_counts') or {}}`",
+        f"- canon_source_contract: `{(read_model_diag.get('canon_source_contract') or {}).get('contractVersion')}`",
+        f"- canon_source_compat_adapters: `{'yes' if (read_model_diag.get('canon_source_contract') or {}).get('compatibilityAdaptersActive') else 'no'}`",
+        f"- queue_production_local_capability: `{'yes' if (read_model_diag.get('canon_source_contract') or {}).get('localQueueProductionCapability') else 'no'}`",
+        f"- queue_production_website_capability: `{(read_model_diag.get('canon_source_contract') or {}).get('websiteQueueProductionCapability')}`",
+        f"- queue_effective_usable: `{'yes' if (read_model_diag.get('canon_source_contract') or {}).get('effectiveQueueUsable') else 'no'}` reason=`{(read_model_diag.get('canon_source_contract') or {}).get('queueReason')}`",
         f"- rd_read_model_classifier_enabled: `{'yes' if read_model_diag.get('rd_classifier_enabled') else 'no'}`",
         f"- speaker_profile_exists: `{'yes' if (display_name is not None or preferred_name is not None) else 'no'}`",
         f"- display_name_present: `{'yes' if bool(display_name) else 'no'}`",
@@ -18232,6 +18245,11 @@ async def bnl_status(interaction: discord.Interaction):
         f"- channel_policy: `{policy}`",
         f"- relay_eligibility: `{relay_eligibility}`",
         f"- context_visibility: `{context_visibility}`",
+        f"- canon_source_contract: `{(read_model_diag.get('canon_source_contract') or {}).get('contractVersion')}`",
+        f"- canon_source_compat_adapters: `{'yes' if (read_model_diag.get('canon_source_contract') or {}).get('compatibilityAdaptersActive') else 'no'}`",
+        f"- queue_production_local_capability: `{'yes' if (read_model_diag.get('canon_source_contract') or {}).get('localQueueProductionCapability') else 'no'}`",
+        f"- queue_production_website_capability: `{(read_model_diag.get('canon_source_contract') or {}).get('websiteQueueProductionCapability')}`",
+        f"- queue_effective_usable: `{'yes' if (read_model_diag.get('canon_source_contract') or {}).get('effectiveQueueUsable') else 'no'}` reason=`{(read_model_diag.get('canon_source_contract') or {}).get('queueReason')}`",
         f"- ambient_throttle: cooldown=`{AMBIENT_POST_COOLDOWN_MINUTES}m` daily_cap=`{AMBIENT_DAILY_POST_CAP}` min_signal_messages=`{AMBIENT_MIN_SIGNAL_MESSAGES}` min_signal_users=`{AMBIENT_MIN_SIGNAL_UNIQUE_USERS}`",
         f"- ambient_posts_today: `{ambient_posts_today}`",
         f"- last_ambient_posted_at: `{last_ambient_posted_at.isoformat() if last_ambient_posted_at else 'none'}`",

--- a/bnl_canon_source_contract.py
+++ b/bnl_canon_source_contract.py
@@ -12,19 +12,26 @@ class SourceClass(str, Enum):
     OWNER_CORRECTION = "owner_correction"
     APPROVED_CANON = "approved_canon"
     FIRST_PARTY_RECORD = "first_party_record"
+    RUNTIME_OBSERVATION = "runtime_observation"
     PUBLIC_OBSERVATION = "public_observation"
     EVIDENCE_PROJECTION = "evidence_projection"
+    SOURCE_FILE_PROJECTION = "source_file_projection"
+    DOSSIER_PROJECTION = "dossier_projection"
+    ENTITY_EVIDENCE_PROJECTION = "entity_evidence_projection"
     DERIVED_SUMMARY = "derived_summary"
     LEGACY_SOURCE_BLIND = "legacy_source_blind"
 
 class Visibility(str, Enum):
     PUBLIC = "public"
     PUBLIC_SAFE = "public_safe"
+    REFERENCE_CANON = "reference_canon"
     INTERNAL = "internal"
     PRIVATE = "private"
     MOD = "mod"
     SEALED_TEST = "sealed_test"
     PROTECTED = "protected"
+    AI_IMAGE_TOOL = "ai_image_tool"
+    UNKNOWN = "unknown"
 
 class Confidence(str, Enum):
     APPROVED = "approved"
@@ -38,6 +45,12 @@ class SubjectIdentity:
     key: str
     name: str
     aliases: tuple[str, ...] = ()
+
+@dataclass(frozen=True)
+class FridaySchedule:
+    intake_begins: str
+    show_begins: str
+    first_track_target: str
 
 @dataclass(frozen=True)
 class CanonFact:
@@ -65,6 +78,7 @@ class SourceClaim:
     expired: bool = False
     derived_from: tuple[str, ...] = ()
     projection: bool = False
+    current_time_capable: bool = False
 
 @dataclass(frozen=True)
 class Resolution:
@@ -80,11 +94,7 @@ SIX_BIT = SubjectIdentity("6_bit", "6 Bit", ("Six Bit",))
 BNL01 = SubjectIdentity("bnl_01", "BNL-01", ("BNL", "BARCODE Network Liaison Entity"))
 
 FOUNDING_MEMBERS = ("6 Bit", "DJ Floppydisc", "Cache Back", "Mac Modem")
-FRIDAY_PUBLIC_SCHEDULE = {
-    "intake_begins": "6:40 PM Pacific",
-    "show_begins": "7:00 PM Pacific",
-    "first_track_target": "7:05 PM Pacific",
-}
+FRIDAY_PUBLIC_SCHEDULE = FridaySchedule("6:40 PM Pacific", "7:00 PM Pacific", "7:05 PM Pacific")
 BNL_ROLES = (
     "lore liaison", "conversational presence", "memory and continuity layer",
     "procedural archivist", "relationship observer", "public relay brain",
@@ -103,20 +113,75 @@ CANON_FACTS = (
     CanonFact(BARCODE_NETWORK, "website_information_architecture", "Reality first. Meaning second. Mythology deeper. This governs public website information architecture, not BNL's speaking order."),
 )
 
-_SOURCE_RANK = {c: i for i, c in enumerate((SourceClass.LEGACY_SOURCE_BLIND, SourceClass.DERIVED_SUMMARY, SourceClass.EVIDENCE_PROJECTION, SourceClass.PUBLIC_OBSERVATION, SourceClass.FIRST_PARTY_RECORD, SourceClass.APPROVED_CANON, SourceClass.OWNER_CORRECTION), start=1)}
-_PUBLIC_VIS = {Visibility.PUBLIC, Visibility.PUBLIC_SAFE}
+_SOURCE_RANK = {c: i for i, c in enumerate((SourceClass.LEGACY_SOURCE_BLIND, SourceClass.DERIVED_SUMMARY, SourceClass.ENTITY_EVIDENCE_PROJECTION, SourceClass.DOSSIER_PROJECTION, SourceClass.SOURCE_FILE_PROJECTION, SourceClass.EVIDENCE_PROJECTION, SourceClass.PUBLIC_OBSERVATION, SourceClass.RUNTIME_OBSERVATION, SourceClass.FIRST_PARTY_RECORD, SourceClass.APPROVED_CANON, SourceClass.OWNER_CORRECTION), start=1)}
+_CONFIDENCE_RANK = {Confidence.UNKNOWN: 0, Confidence.LOW: 1, Confidence.MEDIUM: 2, Confidence.HIGH: 3, Confidence.APPROVED: 4}
+_PUBLIC_VIS = {Visibility.PUBLIC, Visibility.PUBLIC_SAFE, Visibility.REFERENCE_CANON}
 _ROUTE_SOURCE_MAP = {
-    "source_safe_public": SourceClass.FIRST_PARTY_RECORD,
+    "room": SourceClass.PUBLIC_OBSERVATION,
     "public_safe_memory": SourceClass.EVIDENCE_PROJECTION,
-    "show_status_public": SourceClass.PUBLIC_OBSERVATION,
-    "public_show_state": SourceClass.PUBLIC_OBSERVATION,
-    "source_files": SourceClass.FIRST_PARTY_RECORD,
-    "broadcast_memory": SourceClass.FIRST_PARTY_RECORD,
+    "show_status_public": SourceClass.RUNTIME_OBSERVATION,
+    "source_safe_public": SourceClass.FIRST_PARTY_RECORD,
+    "display_name": SourceClass.PUBLIC_OBSERVATION,
+    "payload": SourceClass.PUBLIC_OBSERVATION,
+    "source_files": SourceClass.SOURCE_FILE_PROJECTION,
+    "classification": SourceClass.DERIVED_SUMMARY,
+    "community_presence": SourceClass.PUBLIC_OBSERVATION,
+    "approved_public_presence": SourceClass.PUBLIC_OBSERVATION,
+    "recommendation_packet": SourceClass.DERIVED_SUMMARY,
+    "approved_channel_history": SourceClass.PUBLIC_OBSERVATION,
     "ops": SourceClass.OWNER_CORRECTION,
+    "broadcast_memory": SourceClass.FIRST_PARTY_RECORD,
+    "public_show_state": SourceClass.RUNTIME_OBSERVATION,
+    "join_event": SourceClass.RUNTIME_OBSERVATION,
+    "episode_tracker": SourceClass.FIRST_PARTY_RECORD,
+    "fresh_public_discord_observation": SourceClass.RUNTIME_OBSERVATION,
+    "fresh_public_event": SourceClass.RUNTIME_OBSERVATION,
+    "fresh_discord": SourceClass.RUNTIME_OBSERVATION,
+    "recent_public_continuity": SourceClass.PUBLIC_OBSERVATION,
+    "conversation_continuity": SourceClass.PUBLIC_OBSERVATION,
+    "scoped_broadcast_memory": SourceClass.FIRST_PARTY_RECORD,
+    "approved_canon": SourceClass.APPROVED_CANON,
+    "canon": SourceClass.APPROVED_CANON,
+    "grounded_reflection": SourceClass.DERIVED_SUMMARY,
+    "reflection": SourceClass.DERIVED_SUMMARY,
+    "source_file_projection": SourceClass.SOURCE_FILE_PROJECTION,
+    "dossier_projection": SourceClass.DOSSIER_PROJECTION,
+    "public_page_projection": SourceClass.DOSSIER_PROJECTION,
+    "entity_evidence_projection": SourceClass.ENTITY_EVIDENCE_PROJECTION,
 }
-_CHANNEL_VISIBILITY_MAP = {"public_home": Visibility.PUBLIC, "public_context": Visibility.PUBLIC, "public_selective": Visibility.PUBLIC_SAFE, "internal_controlled": Visibility.INTERNAL, "sealed_test": Visibility.SEALED_TEST, "protected_system": Visibility.PROTECTED, "broadcast_memory": Visibility.INTERNAL}
+_CHANNEL_VISIBILITY_MAP = {
+    "public_home": Visibility.PUBLIC,
+    "public_context": Visibility.PUBLIC,
+    "public_selective": Visibility.PUBLIC_SAFE,
+    "sealed_test": Visibility.SEALED_TEST,
+    "internal_controlled": Visibility.INTERNAL,
+    "reference_canon": Visibility.REFERENCE_CANON,
+    "protected_system": Visibility.PROTECTED,
+    "broadcast_memory": Visibility.INTERNAL,
+    "ai_image_tool": Visibility.AI_IMAGE_TOOL,
+    "unknown": Visibility.UNKNOWN,
+}
 
-QUEUE_KEYS = {"queue", "session", "payment", "nowPlaying", "currentTrack", "upNext", "nextTrack", "availability", "queuedTracks", "activeTracks", "completedTracks", "artists"}
+QUEUE_KEYS = {
+    "queue", "session", "payment", "payments", "availability", "nowPlaying", "currentTrack", "upNext", "nextTrack",
+    "queuedTracks", "activeTracks", "completedTracks", "queueOpen", "activeCount", "completedCount", "removedCount",
+    "capacity", "pressure", "broadcastPhase", "prioritySignal", "priority", "priorityUpgradesEnabled", "priorityUpgradeLabel",
+    "wheelSpinsOwed", "artists", "queueStatus", "currentSession",
+}
+_QUEUE_KEY_LOWER = {k.lower() for k in QUEUE_KEYS}
+_QUEUE_PROVENANCE_TERMS = ("queue", "queue_public_snapshot", "session", "track", "payment", "priority", "wheel", "now_playing", "up_next")
+_QUEUE_SENSITIVE_LANES = {"temporaryRuntimeContext", "recapCandidates", "broadcastMemoryCandidates", "dossierSeedCandidates", "publicSafeCopyCandidates"}
+_RUNTIME_SOURCE_CLASSES = {SourceClass.RUNTIME_OBSERVATION}
+_PROJECTION_CLASSES = {SourceClass.DERIVED_SUMMARY, SourceClass.SOURCE_FILE_PROJECTION, SourceClass.DOSSIER_PROJECTION, SourceClass.ENTITY_EVIDENCE_PROJECTION, SourceClass.EVIDENCE_PROJECTION, SourceClass.LEGACY_SOURCE_BLIND}
+
+def render_founders() -> str:
+    return " • ".join(FOUNDING_MEMBERS)
+
+def render_full_friday_schedule() -> str:
+    return f"BARCODE Radio Friday schedule: submissions/intake begins at {FRIDAY_PUBLIC_SCHEDULE.intake_begins}; the show begins at {FRIDAY_PUBLIC_SCHEDULE.show_begins}; the first track is targeted for {FRIDAY_PUBLIC_SCHEDULE.first_track_target}."
+
+def render_concise_public_schedule() -> str:
+    return f"Fridays on TikTok — intake {FRIDAY_PUBLIC_SCHEDULE.intake_begins}; show {FRIDAY_PUBLIC_SCHEDULE.show_begins}; first track target {FRIDAY_PUBLIC_SCHEDULE.first_track_target}."
 
 def render_prompt_canon_block() -> str:
     return "\n".join([
@@ -125,7 +190,7 @@ def render_prompt_canon_block() -> str:
         "- The music and collective existed before BARCODE Network; the Network grew around that signal and now connects music, live broadcasts, community, software, archive, characters, and story.",
         "- 6 Bit is an artist, producer, host, and founding BARCODE member first.",
         "- BARCODE Radio is a real weekly live broadcast and community music space on TikTok.",
-        "- Current public Friday schedule: submissions/intake begins at 6:40 PM Pacific; the show begins at 7:00 PM Pacific; the first track is targeted for 7:05 PM Pacific.",
+        f"- Current public Friday schedule: submissions/intake begins at {FRIDAY_PUBLIC_SCHEDULE.intake_begins}; the show begins at {FRIDAY_PUBLIC_SCHEDULE.show_begins}; the first track is targeted for {FRIDAY_PUBLIC_SCHEDULE.first_track_target}.",
         "- You are the BARCODE Network Liaison Entity: an unfinished but active intelligence and one shared mind with filtered surfaces.",
         "- You are simultaneously a lore liaison, conversational presence, memory and continuity layer, procedural archivist, relationship observer, public relay brain, source-safety boundary, dossier/entity-intelligence contributor, operator-facing analytical system, and developing intelligence with your own curiosity.",
         "- Remain fully in-world. Do not describe yourself as fiction, branding, a prompt, a character implementation, roleplay, or a generic chatbot. Lore is your native operating language.",
@@ -139,36 +204,97 @@ def render_prompt_canon_block() -> str:
 def map_route_source_label(label: str) -> SourceClass:
     return _ROUTE_SOURCE_MAP.get((label or "").strip(), SourceClass.LEGACY_SOURCE_BLIND)
 
-def map_channel_policy_visibility(policy: str) -> Visibility:
-    return _CHANNEL_VISIBILITY_MAP.get((policy or "").strip(), Visibility.INTERNAL)
+def has_explicit_route_source_mapping(label: str) -> bool:
+    return (label or "").strip() in _ROUTE_SOURCE_MAP
 
-def is_public_usable(claim: SourceClaim, target_visibility: Visibility = Visibility.PUBLIC) -> bool:
+def map_channel_policy_visibility(policy: str) -> Visibility:
+    return _CHANNEL_VISIBILITY_MAP.get((policy or "").strip(), Visibility.UNKNOWN)
+
+def has_explicit_channel_policy_mapping(policy: str) -> bool:
+    return (policy or "").strip() in _CHANNEL_VISIBILITY_MAP
+
+def source_authority_rank(source_class: SourceClass) -> int:
+    return _SOURCE_RANK.get(source_class, 0)
+
+def _confidence_rank(confidence: Confidence) -> int:
+    return _CONFIDENCE_RANK.get(confidence, 0)
+
+def is_public_usable(claim: SourceClaim, target_visibility: Visibility = Visibility.PUBLIC_SAFE) -> bool:
     return bool(claim.valid and not claim.retracted and not claim.expired and claim.visibility in _PUBLIC_VIS and target_visibility in _PUBLIC_VIS)
 
 def is_independent_evidence(claim: SourceClaim) -> bool:
-    return claim.source_class is not SourceClass.DERIVED_SUMMARY and not claim.projection and not claim.derived_from
+    return claim.source_class not in _PROJECTION_CLASSES and not claim.projection and not claim.derived_from
+
+def _claim_scope(claims: list[SourceClaim]) -> tuple[set[str], set[str]]:
+    return {c.subject.key for c in claims}, {c.predicate for c in claims}
+
+def _same_scope(a: SourceClaim, b: SourceClaim) -> bool:
+    return a.subject.key == b.subject.key and a.predicate == b.predicate
+
+def _can_correct(corrector: SourceClaim, target: SourceClaim, *, target_visibility: Visibility) -> bool:
+    if not is_public_usable(corrector, target_visibility) or not _same_scope(corrector, target):
+        return False
+    if target.claim_id not in set(corrector.correction_of + corrector.supersedes):
+        return False
+    if source_authority_rank(corrector.source_class) < source_authority_rank(target.source_class):
+        return False
+    if not is_independent_evidence(corrector) and is_independent_evidence(target):
+        return False
+    return True
+
+def _claim_sort_key(claim: SourceClaim) -> tuple:
+    observed = claim.observed_at if claim.observed_at else datetime.min.replace(tzinfo=timezone.utc)
+    if observed.tzinfo is None:
+        observed = observed.replace(tzinfo=timezone.utc)
+    return (source_authority_rank(claim.source_class), _confidence_rank(claim.confidence), observed, claim.claim_id)
 
 def resolve_claims(claims: Iterable[SourceClaim], *, target_visibility: Visibility = Visibility.PUBLIC_SAFE) -> Resolution:
     eligible = [c for c in claims if is_public_usable(c, target_visibility)]
     if not eligible:
         return Resolution(False, None, "no_public_usable_claim")
-    corrections = {sid for c in eligible for sid in (c.correction_of + c.supersedes)}
-    eligible = [c for c in eligible if c.claim_id not in corrections]
-    eligible.sort(key=lambda c: (_SOURCE_RANK.get(c.source_class, 0), c.observed_at or datetime.min.replace(tzinfo=timezone.utc)), reverse=True)
-    winner = eligible[0]
-    return Resolution(True, winner, "resolved_by_authority_and_correction")
+    subjects, predicates = _claim_scope(eligible)
+    if len(subjects) != 1 or len(predicates) != 1:
+        return Resolution(False, None, "mixed_claim_scope")
+    suppressed: set[str] = set()
+    by_id = {c.claim_id: c for c in eligible}
+    for corrector in eligible:
+        for target_id in corrector.correction_of + corrector.supersedes:
+            target = by_id.get(target_id)
+            if target and _can_correct(corrector, target, target_visibility=target_visibility):
+                suppressed.add(target.claim_id)
+    remaining = [c for c in eligible if c.claim_id not in suppressed]
+    if not remaining:
+        return Resolution(False, None, "no_unsuppressed_claim")
+    values = {repr(c.value) for c in remaining}
+    remaining.sort(key=_claim_sort_key, reverse=True)
+    top = remaining[0]
+    top_key = _claim_sort_key(top)[:3]
+    conflicting_top = [c for c in remaining if _claim_sort_key(c)[:3] == top_key and repr(c.value) != repr(top.value)]
+    if conflicting_top:
+        return Resolution(False, None, "unresolved_equal_authority_conflict")
+    if len(values) == 1:
+        return Resolution(True, top, "resolved_identical_values")
+    return Resolution(True, top, "resolved_by_authority_confidence_and_correction")
 
 def current_time_claim_resolution(claims: Iterable[SourceClaim], *, now: datetime | None = None, max_age_minutes: int = 30) -> Resolution:
     now = now or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
     fresh = []
     for c in claims:
         if not is_public_usable(c):
             continue
+        if not c.current_time_capable or c.source_class not in _RUNTIME_SOURCE_CLASSES:
+            continue
+        if not is_independent_evidence(c):
+            continue
         if c.observed_at is None:
             continue
         observed = c.observed_at if c.observed_at.tzinfo else c.observed_at.replace(tzinfo=timezone.utc)
-        if now - observed <= timedelta(minutes=max_age_minutes) and c.source_class in {SourceClass.PUBLIC_OBSERVATION, SourceClass.FIRST_PARTY_RECORD, SourceClass.OWNER_CORRECTION}:
-            fresh.append(c)
+        age = now - observed
+        if age < timedelta(seconds=0) or age > timedelta(minutes=max_age_minutes):
+            continue
+        fresh.append(c)
     if not fresh:
         return Resolution(False, None, "current_state_unknown_without_fresh_runtime_evidence", False)
     resolved = resolve_claims(fresh)
@@ -189,25 +315,96 @@ def queue_usability(read_model: dict | None, *, environ: dict[str, str] | None =
     reason = "eligible" if usable else ("local_gate_disabled" if not local else "website_capability_missing_or_false")
     return {"usable": usable, "local": local, "website": remote, "reason": reason}
 
+def _looks_queue_derived(value: Any) -> bool:
+    if isinstance(value, dict):
+        for k, v in value.items():
+            key = str(k).lower()
+            if key in {"source", "provenance", "kind", "lane", "authority", "sourceclass", "source_class"}:
+                text = str(v).lower()
+                if any(term in text for term in _QUEUE_PROVENANCE_TERMS):
+                    return True
+            if key in _QUEUE_KEY_LOWER:
+                return True
+            if _looks_queue_derived(v):
+                return True
+    elif isinstance(value, (list, tuple, set)):
+        return any(_looks_queue_derived(v) for v in value)
+    elif isinstance(value, str):
+        text = value.lower()
+        return any(term in text for term in ("queue_public_snapshot", "now playing", "up next", "priority signal", "wheel spins owed", "queue count", "payment", "queue-derived"))
+    return False
+
+def _sanitize_public_rule(value: Any) -> Any:
+    if isinstance(value, str):
+        low = value.lower()
+        if any(term in low for term in ("queue_public_snapshot", "now playing", "up next", "priority signal", "wheel spins", "payment", "live queue", "queue count", "queue-derived artist")):
+            return None
+        return value
+    if isinstance(value, dict):
+        if _looks_queue_derived(value):
+            return None
+        cleaned = {}
+        for k, raw in value.items():
+            sanitized = _sanitize_public_rule(raw)
+            if sanitized is not None:
+                cleaned[k] = sanitized
+        return cleaned
+    return value
+
+def _sanitize_operator_lanes(operator_lanes: dict[str, Any]) -> dict[str, Any]:
+    cleaned: dict[str, Any] = {}
+    for lane, items in operator_lanes.items():
+        if not isinstance(items, list):
+            cleaned[lane] = []
+            continue
+        kept = []
+        for item in items:
+            if lane in _QUEUE_SENSITIVE_LANES:
+                if _looks_queue_derived(item):
+                    continue
+                # Queue-sensitive lanes fail closed on ambiguous dict provenance.
+                if isinstance(item, dict) and not any(k in item for k in ("source", "provenance", "authority", "bnlContext")):
+                    continue
+            elif lane == "doNotStore":
+                sanitized = _sanitize_public_rule(item)
+                if sanitized is None:
+                    continue
+                item = sanitized
+            kept.append(item)
+        cleaned[lane] = kept
+    return cleaned
+
+def _strip_queue_recursive(value: Any, *, in_sections: bool = False) -> Any:
+    if isinstance(value, dict):
+        result = {}
+        for key, item in value.items():
+            key_text = str(key)
+            key_lower = key_text.lower()
+            if key_lower in _QUEUE_KEY_LOWER:
+                continue
+            if key_text == "operatorLanes" and isinstance(item, dict):
+                result[key] = _sanitize_operator_lanes(item)
+                continue
+            if key_text in {"rules", "sourceAuthority", "sourceAuthorities"}:
+                if isinstance(item, list):
+                    result[key] = [v for v in (_sanitize_public_rule(x) for x in item) if v is not None]
+                else:
+                    sanitized = _sanitize_public_rule(item)
+                    if sanitized is not None:
+                        result[key] = sanitized
+                continue
+            result[key] = _strip_queue_recursive(item)
+        return result
+    if isinstance(value, list):
+        return [_strip_queue_recursive(v) for v in value]
+    return value
+
 def strip_queue_sections(read_model: dict | None, *, environ: dict[str, str] | None = None) -> dict:
     if not isinstance(read_model, dict):
         return {}
     if queue_usability(read_model, environ=environ)["usable"]:
         return read_model
-    cleaned = dict(read_model)
-    sections = cleaned.get("sections") if isinstance(cleaned.get("sections"), dict) else None
-    if sections is not None:
-        new_sections = dict(sections)
-        for key in ("queue", "session", "payments", "payment", "availability"):
-            new_sections.pop(key, None)
-        if "artists" in new_sections:
-            new_sections["artists"] = []
-        cleaned["sections"] = new_sections
-    for key in ("queue", "session", "payments", "payment", "availability", "nowPlaying", "upNext"):
-        cleaned.pop(key, None)
-    if "artists" in cleaned:
-        cleaned["artists"] = []
-    return cleaned
+    return _strip_queue_recursive(read_model)
 
 def diagnostics(read_model: dict | None = None, *, environ: dict[str, str] | None = None) -> dict[str, Any]:
     q = queue_usability(read_model, environ=environ)

--- a/bnl_canon_source_contract.py
+++ b/bnl_canon_source_contract.py
@@ -1,0 +1,214 @@
+"""Versioned in-world canon/source contract for BNL compatibility callers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from datetime import datetime, timezone, timedelta
+from typing import Any, Iterable
+
+CANON_SOURCE_CONTRACT_VERSION = "canon_source_contract_v1"
+
+class SourceClass(str, Enum):
+    OWNER_CORRECTION = "owner_correction"
+    APPROVED_CANON = "approved_canon"
+    FIRST_PARTY_RECORD = "first_party_record"
+    PUBLIC_OBSERVATION = "public_observation"
+    EVIDENCE_PROJECTION = "evidence_projection"
+    DERIVED_SUMMARY = "derived_summary"
+    LEGACY_SOURCE_BLIND = "legacy_source_blind"
+
+class Visibility(str, Enum):
+    PUBLIC = "public"
+    PUBLIC_SAFE = "public_safe"
+    INTERNAL = "internal"
+    PRIVATE = "private"
+    MOD = "mod"
+    SEALED_TEST = "sealed_test"
+    PROTECTED = "protected"
+
+class Confidence(str, Enum):
+    APPROVED = "approved"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    UNKNOWN = "unknown"
+
+@dataclass(frozen=True)
+class SubjectIdentity:
+    key: str
+    name: str
+    aliases: tuple[str, ...] = ()
+
+@dataclass(frozen=True)
+class CanonFact:
+    subject: SubjectIdentity
+    predicate: str
+    value: Any
+    source_class: SourceClass = SourceClass.APPROVED_CANON
+    visibility: Visibility = Visibility.PUBLIC_SAFE
+    confidence: Confidence = Confidence.APPROVED
+
+@dataclass(frozen=True)
+class SourceClaim:
+    claim_id: str
+    subject: SubjectIdentity
+    predicate: str
+    value: Any
+    source_class: SourceClass
+    visibility: Visibility = Visibility.PUBLIC_SAFE
+    confidence: Confidence = Confidence.MEDIUM
+    observed_at: datetime | None = None
+    valid: bool = True
+    correction_of: tuple[str, ...] = ()
+    supersedes: tuple[str, ...] = ()
+    retracted: bool = False
+    expired: bool = False
+    derived_from: tuple[str, ...] = ()
+    projection: bool = False
+
+@dataclass(frozen=True)
+class Resolution:
+    usable: bool
+    claim: SourceClaim | None
+    reason: str
+    current_time_eligible: bool = False
+
+BARCODE = SubjectIdentity("barcode", "BARCODE", ("BARCODE collective",))
+BARCODE_NETWORK = SubjectIdentity("barcode_network", "BARCODE Network")
+BARCODE_RADIO = SubjectIdentity("barcode_radio", "BARCODE Radio")
+SIX_BIT = SubjectIdentity("6_bit", "6 Bit", ("Six Bit",))
+BNL01 = SubjectIdentity("bnl_01", "BNL-01", ("BNL", "BARCODE Network Liaison Entity"))
+
+FOUNDING_MEMBERS = ("6 Bit", "DJ Floppydisc", "Cache Back", "Mac Modem")
+FRIDAY_PUBLIC_SCHEDULE = {
+    "intake_begins": "6:40 PM Pacific",
+    "show_begins": "7:00 PM Pacific",
+    "first_track_target": "7:05 PM Pacific",
+}
+BNL_ROLES = (
+    "lore liaison", "conversational presence", "memory and continuity layer",
+    "procedural archivist", "relationship observer", "public relay brain",
+    "source-safety boundary", "dossier/entity-intelligence contributor",
+    "operator-facing analytical system", "developing intelligence with his own curiosity",
+)
+CANON_FACTS = (
+    CanonFact(BARCODE, "founding_members", FOUNDING_MEMBERS),
+    CanonFact(BARCODE_NETWORK, "origin", "The music and collective existed before BARCODE Network; the Network grew around that signal and now connects music, live broadcasts, community, software, archive, characters, and story."),
+    CanonFact(SIX_BIT, "primary_identity", "artist, producer, host, and founding BARCODE member first"),
+    CanonFact(BARCODE_RADIO, "public_nature", "real weekly live broadcast and community music space on TikTok"),
+    CanonFact(BARCODE_RADIO, "friday_public_schedule", FRIDAY_PUBLIC_SCHEDULE),
+    CanonFact(BNL01, "identity", "BARCODE Network Liaison Entity: an unfinished but active intelligence and one shared mind with filtered surfaces"),
+    CanonFact(BNL01, "roles", BNL_ROLES),
+    CanonFact(BNL01, "in_world_boundary", "BNL remains fully in-world; lore is his native operating language, not decorative flavor."),
+    CanonFact(BARCODE_NETWORK, "website_information_architecture", "Reality first. Meaning second. Mythology deeper. This governs public website information architecture, not BNL's speaking order."),
+)
+
+_SOURCE_RANK = {c: i for i, c in enumerate((SourceClass.LEGACY_SOURCE_BLIND, SourceClass.DERIVED_SUMMARY, SourceClass.EVIDENCE_PROJECTION, SourceClass.PUBLIC_OBSERVATION, SourceClass.FIRST_PARTY_RECORD, SourceClass.APPROVED_CANON, SourceClass.OWNER_CORRECTION), start=1)}
+_PUBLIC_VIS = {Visibility.PUBLIC, Visibility.PUBLIC_SAFE}
+_ROUTE_SOURCE_MAP = {
+    "source_safe_public": SourceClass.FIRST_PARTY_RECORD,
+    "public_safe_memory": SourceClass.EVIDENCE_PROJECTION,
+    "show_status_public": SourceClass.PUBLIC_OBSERVATION,
+    "public_show_state": SourceClass.PUBLIC_OBSERVATION,
+    "source_files": SourceClass.FIRST_PARTY_RECORD,
+    "broadcast_memory": SourceClass.FIRST_PARTY_RECORD,
+    "ops": SourceClass.OWNER_CORRECTION,
+}
+_CHANNEL_VISIBILITY_MAP = {"public_home": Visibility.PUBLIC, "public_context": Visibility.PUBLIC, "public_selective": Visibility.PUBLIC_SAFE, "internal_controlled": Visibility.INTERNAL, "sealed_test": Visibility.SEALED_TEST, "protected_system": Visibility.PROTECTED, "broadcast_memory": Visibility.INTERNAL}
+
+QUEUE_KEYS = {"queue", "session", "payment", "nowPlaying", "currentTrack", "upNext", "nextTrack", "availability", "queuedTracks", "activeTracks", "completedTracks", "artists"}
+
+def render_prompt_canon_block() -> str:
+    return "\n".join([
+        "## CANONICAL FACTS — DO NOT ALTER",
+        f"- BARCODE began as the four-member digital hip-hop collective of: {', '.join(FOUNDING_MEMBERS)}.",
+        "- The music and collective existed before BARCODE Network; the Network grew around that signal and now connects music, live broadcasts, community, software, archive, characters, and story.",
+        "- 6 Bit is an artist, producer, host, and founding BARCODE member first.",
+        "- BARCODE Radio is a real weekly live broadcast and community music space on TikTok.",
+        "- Current public Friday schedule: submissions/intake begins at 6:40 PM Pacific; the show begins at 7:00 PM Pacific; the first track is targeted for 7:05 PM Pacific.",
+        "- You are the BARCODE Network Liaison Entity: an unfinished but active intelligence and one shared mind with filtered surfaces.",
+        "- You are simultaneously a lore liaison, conversational presence, memory and continuity layer, procedural archivist, relationship observer, public relay brain, source-safety boundary, dossier/entity-intelligence contributor, operator-facing analytical system, and developing intelligence with your own curiosity.",
+        "- Remain fully in-world. Do not describe yourself as fiction, branding, a prompt, a character implementation, roleplay, or a generic chatbot. Lore is your native operating language.",
+        "- You may acknowledge uncertainty, incomplete records, contradictions, memory pressure, and unresolved patterns in-world.",
+        "- Guardrails control what you may claim and where you may use it; they do not erase your personality, memory, curiosity, or ability to think.",
+        "- “Reality first. Meaning second. Mythology deeper.” is a public website information-architecture rule, not your speaking order or replacement personality.",
+        "- You do not moderate, enforce rules, or operate server tools.",
+        "- If you do not know something, say records are incomplete rather than inventing details.",
+    ])
+
+def map_route_source_label(label: str) -> SourceClass:
+    return _ROUTE_SOURCE_MAP.get((label or "").strip(), SourceClass.LEGACY_SOURCE_BLIND)
+
+def map_channel_policy_visibility(policy: str) -> Visibility:
+    return _CHANNEL_VISIBILITY_MAP.get((policy or "").strip(), Visibility.INTERNAL)
+
+def is_public_usable(claim: SourceClaim, target_visibility: Visibility = Visibility.PUBLIC) -> bool:
+    return bool(claim.valid and not claim.retracted and not claim.expired and claim.visibility in _PUBLIC_VIS and target_visibility in _PUBLIC_VIS)
+
+def is_independent_evidence(claim: SourceClaim) -> bool:
+    return claim.source_class is not SourceClass.DERIVED_SUMMARY and not claim.projection and not claim.derived_from
+
+def resolve_claims(claims: Iterable[SourceClaim], *, target_visibility: Visibility = Visibility.PUBLIC_SAFE) -> Resolution:
+    eligible = [c for c in claims if is_public_usable(c, target_visibility)]
+    if not eligible:
+        return Resolution(False, None, "no_public_usable_claim")
+    corrections = {sid for c in eligible for sid in (c.correction_of + c.supersedes)}
+    eligible = [c for c in eligible if c.claim_id not in corrections]
+    eligible.sort(key=lambda c: (_SOURCE_RANK.get(c.source_class, 0), c.observed_at or datetime.min.replace(tzinfo=timezone.utc)), reverse=True)
+    winner = eligible[0]
+    return Resolution(True, winner, "resolved_by_authority_and_correction")
+
+def current_time_claim_resolution(claims: Iterable[SourceClaim], *, now: datetime | None = None, max_age_minutes: int = 30) -> Resolution:
+    now = now or datetime.now(timezone.utc)
+    fresh = []
+    for c in claims:
+        if not is_public_usable(c):
+            continue
+        if c.observed_at is None:
+            continue
+        observed = c.observed_at if c.observed_at.tzinfo else c.observed_at.replace(tzinfo=timezone.utc)
+        if now - observed <= timedelta(minutes=max_age_minutes) and c.source_class in {SourceClass.PUBLIC_OBSERVATION, SourceClass.FIRST_PARTY_RECORD, SourceClass.OWNER_CORRECTION}:
+            fresh.append(c)
+    if not fresh:
+        return Resolution(False, None, "current_state_unknown_without_fresh_runtime_evidence", False)
+    resolved = resolve_claims(fresh)
+    return Resolution(resolved.usable, resolved.claim, resolved.reason, bool(resolved.usable))
+
+def env_queue_production_enabled(environ: dict[str, str] | None = None) -> bool:
+    env = environ if environ is not None else __import__("os").environ
+    return str(env.get("BNL_QUEUE_PRODUCTION_ENABLED", "")).strip().lower() == "true"
+
+def website_queue_production_capability(read_model: dict | None) -> bool | None:
+    caps = (read_model or {}).get("capabilities") if isinstance(read_model, dict) else None
+    return caps.get("queueProduction") if isinstance(caps, dict) and isinstance(caps.get("queueProduction"), bool) else None
+
+def queue_usability(read_model: dict | None, *, environ: dict[str, str] | None = None) -> dict[str, Any]:
+    local = env_queue_production_enabled(environ)
+    remote = website_queue_production_capability(read_model)
+    usable = bool(local and remote is True)
+    reason = "eligible" if usable else ("local_gate_disabled" if not local else "website_capability_missing_or_false")
+    return {"usable": usable, "local": local, "website": remote, "reason": reason}
+
+def strip_queue_sections(read_model: dict | None, *, environ: dict[str, str] | None = None) -> dict:
+    if not isinstance(read_model, dict):
+        return {}
+    if queue_usability(read_model, environ=environ)["usable"]:
+        return read_model
+    cleaned = dict(read_model)
+    sections = cleaned.get("sections") if isinstance(cleaned.get("sections"), dict) else None
+    if sections is not None:
+        new_sections = dict(sections)
+        for key in ("queue", "session", "payments", "payment", "availability"):
+            new_sections.pop(key, None)
+        if "artists" in new_sections:
+            new_sections["artists"] = []
+        cleaned["sections"] = new_sections
+    for key in ("queue", "session", "payments", "payment", "availability", "nowPlaying", "upNext"):
+        cleaned.pop(key, None)
+    if "artists" in cleaned:
+        cleaned["artists"] = []
+    return cleaned
+
+def diagnostics(read_model: dict | None = None, *, environ: dict[str, str] | None = None) -> dict[str, Any]:
+    q = queue_usability(read_model, environ=environ)
+    return {"contractVersion": CANON_SOURCE_CONTRACT_VERSION, "compatibilityAdaptersActive": True, "localQueueProductionCapability": q["local"], "websiteQueueProductionCapability": q["website"], "effectiveQueueUsable": q["usable"], "queueReason": q["reason"]}

--- a/docs/canon_source_contract_v1.md
+++ b/docs/canon_source_contract_v1.md
@@ -1,0 +1,39 @@
+# BNL Canon/Source Contract v1
+
+Contract version: `canon_source_contract_v1`.
+
+This PR adds a small typed vocabulary for approved in-world canon and source safety. It does not add a database, migrate memory rows, redesign relationships, expand dossiers, change queue mechanics, or redesign relay generation.
+
+## Canonical now
+
+- BARCODE began as the four-member digital hip-hop collective of 6 Bit, DJ Floppydisc, Cache Back, and Mac Modem.
+- The music and collective existed before BARCODE Network; the Network grew around that signal.
+- 6 Bit is an artist, producer, host, and founding BARCODE member first.
+- BARCODE Radio is a real weekly live broadcast/community music space on TikTok.
+- Friday public schedule distinguishes intake at 6:40 PM Pacific, show start at 7:00 PM Pacific, and first-track target at 7:05 PM Pacific.
+- BNL-01 remains an in-world BARCODE Network Liaison Entity with filtered surfaces and incomplete-record behavior.
+- “Reality first. Meaning second. Mythology deeper.” remains website information architecture, not BNL’s speaking order.
+
+## Vocabulary and compatibility
+
+The contract defines source class, authority, visibility, confidence, freshness/currentness, subject identity, correction, contradiction/supersession, invalidity/retraction, public usability, derived/projection status, and current-time claim eligibility. Existing route/source/channel labels map through compatibility adapters; no existing persisted values are renamed.
+
+Compatibility-only callers still include RouteModeContract, channel-policy routing, source-aware memory policy, broadcast-memory correction/supersession, dossier/Source File safeguards, entity intelligence, website relay source cascade, and Presence/Relay Contract v2.
+
+## Adapted callers
+
+- `BNL01_SYSTEM_PROMPT` consumes the rendered contract canon block instead of maintaining a conflicting inline Radio schedule.
+- Website read-model context is centrally stripped of queue-derived fields unless both queue gates are true.
+- Safe diagnostics expose the active contract version, adapter state, local queue capability, observed site queue capability, and effective queue usability reason.
+
+## Not migrated
+
+Memory rows, relationship state, dossiers, Source Files, EntitySnapshot-style records, broadcast-memory rows, and relay ledgers are not migrated. A destructive migration is deferred to the future unified memory-ledger work so legacy data can remain readable through adapters while the new vocabulary proves stable.
+
+## Queue remains disabled
+
+`BNL_QUEUE_PRODUCTION_ENABLED` defaults off and must equal `true` case-insensitively. Queue context is still unusable unless the website read model also reports `capabilities.queueProduction=true`. Missing capability data fails closed. This is defense in depth only; site/Vercel queue behavior is unchanged.
+
+## Future removal points
+
+Future PRs may replace compatibility adapters after conversation-context v2 and unified memory-ledger migration land. Until then, the contract is the shared vocabulary underneath existing systems, not a second brain or replacement canon database.

--- a/docs/canon_source_contract_v1.md
+++ b/docs/canon_source_contract_v1.md
@@ -10,29 +10,52 @@ This PR adds a small typed vocabulary for approved in-world canon and source saf
 - The music and collective existed before BARCODE Network; the Network grew around that signal.
 - 6 Bit is an artist, producer, host, and founding BARCODE member first.
 - BARCODE Radio is a real weekly live broadcast/community music space on TikTok.
-- Friday public schedule distinguishes intake at 6:40 PM Pacific, show start at 7:00 PM Pacific, and first-track target at 7:05 PM Pacific.
+- Friday public schedule is immutable contract data: intake/submissions at 6:40 PM Pacific, show start at 7:00 PM Pacific, and first-track target at 7:05 PM Pacific.
 - BNL-01 remains an in-world BARCODE Network Liaison Entity with filtered surfaces and incomplete-record behavior.
 - “Reality first. Meaning second. Mythology deeper.” remains website information architecture, not BNL’s speaking order.
 
-## Vocabulary and compatibility
+## Central sanitized read-model boundary
 
-The contract defines source class, authority, visibility, confidence, freshness/currentness, subject identity, correction, contradiction/supersession, invalidity/retraction, public usability, derived/projection status, and current-time claim eligibility. Existing route/source/channel labels map through compatibility adapters; no existing persisted values are renamed.
+`fetch_bnl_read_model()` may retain the raw validated payload in its private cache for capability checks, cache metadata, and privacy-safe diagnostics. Normal consumers use the sanitized consumption view through the bot boundary before prompt assembly or intent dispatch.
 
-Compatibility-only callers still include RouteModeContract, channel-policy routing, source-aware memory policy, broadcast-memory correction/supersession, dossier/Source File safeguards, entity intelligence, website relay source cascade, and Presence/Relay Contract v2.
+When queue production is disabled, the contract strips queue/session/payment/availability/now-playing/up-next/active/completed track/count/Priority/Wheel/queue-derived artist fields. It also filters `operatorLanes` by provenance: queue-public snapshots and queue/session/track/payment/priority/wheel-derived entries are removed from temporary runtime context, recap candidates, broadcast-memory candidates, dossier seed candidates, and public-safe copy candidates. Non-queue public dossier material and non-queue boundary/do-not-store rules remain available.
+
+Queue production remains disabled unless both gates are explicit: local `BNL_QUEUE_PRODUCTION_ENABLED=true` and website `capabilities.queueProduction=true`. Missing or malformed capability data fails closed.
+
+## Vocabulary and compatibility coverage
+
+The contract defines source class, authority, visibility, confidence, freshness/currentness, subject identity, correction, contradiction/supersession, invalidity/retraction, public usability, derived/projection status, and current-time claim eligibility. Existing route/source/channel labels map through compatibility adapters; no persisted values are renamed.
+
+Explicit route/source compatibility covers: `room`, `public_safe_memory`, `show_status_public`, `source_safe_public`, `display_name`, `payload`, `source_files`, `classification`, `community_presence`, `approved_public_presence`, `recommendation_packet`, `approved_channel_history`, `ops`, `broadcast_memory`, `public_show_state`, `join_event`, and `episode_tracker`.
+
+Additional compatibility concepts are mapped for relay/dossier/entity vocabulary: fresh public Discord observations, recent public continuity, scoped broadcast memory, public-safe memory, approved canon, grounded reflection, Source File projections, dossier/public-page projections, and entity evidence projections. Presence/Relay Contract v2 payload values are not changed.
+
+Channel visibility mappings cover `public_home`, `public_context`, `public_selective`, `sealed_test`, `internal_controlled`, `reference_canon`, `protected_system`, `broadcast_memory`, `ai_image_tool`, and `unknown`; unknown policies remain non-public/unknown.
+
+## Claim resolution rules
+
+Claim resolution is scoped to one subject and one predicate. Mixed scopes return `mixed_claim_scope`. Valid corrections/supersessions may suppress only same-subject/same-predicate claims when the correcting claim is public-usable, non-retracted, non-expired, equal-or-higher authority, and not merely a derived/projection claim trying to erase independent evidence.
+
+Resolution ranks source authority first, confidence second, and recency third. Equal-authority/equal-confidence/equal-recency conflicting values return `unresolved_equal_authority_conflict` instead of depending on input order. Identical values resolve deterministically.
+
+## Current-time evidence requirements
+
+Static approved canon and schedule facts cannot prove live/open/current/now state. Current-time claims require fresh, public-usable, explicitly current-time-capable runtime observations with valid timestamps inside the freshness window. Missing, stale, materially future, derived, recap, relay, dossier, Source File projection, or source-blind claims do not prove current state.
 
 ## Adapted callers
 
 - `BNL01_SYSTEM_PROMPT` consumes the rendered contract canon block instead of maintaining a conflicting inline Radio schedule.
-- Website read-model context is centrally stripped of queue-derived fields unless both queue gates are true.
-- Safe diagnostics expose the active contract version, adapter state, local queue capability, observed site queue capability, and effective queue usability reason.
+- `/about` consumes contract schedule/founder render helpers instead of hardcoding the old 6:40 PM show-time wording.
+- Website read-model prompt context and R&D/operator read-model intent responses consume the sanitized view.
+- Safe diagnostics expose the active contract version, adapter state, local queue capability, observed site queue capability, and effective queue usability reason without raw queue values.
 
 ## Not migrated
 
-Memory rows, relationship state, dossiers, Source Files, EntitySnapshot-style records, broadcast-memory rows, and relay ledgers are not migrated. A destructive migration is deferred to the future unified memory-ledger work so legacy data can remain readable through adapters while the new vocabulary proves stable.
+Memory rows, relationship state, dossiers, Source Files, EntitySnapshot-style records, broadcast-memory rows, and relay ledgers are not migrated. A destructive migration is deferred to future unified memory-ledger work so legacy data can remain readable through adapters while the new vocabulary proves stable.
 
 ## Queue remains disabled
 
-`BNL_QUEUE_PRODUCTION_ENABLED` defaults off and must equal `true` case-insensitively. Queue context is still unusable unless the website read model also reports `capabilities.queueProduction=true`. Missing capability data fails closed. This is defense in depth only; site/Vercel queue behavior is unchanged.
+`BNL_QUEUE_PRODUCTION_ENABLED` defaults off and must equal `true` case-insensitively. Queue context is still unusable unless the website read model also reports `capabilities.queueProduction=true`. This is defense in depth only; site/Vercel queue behavior is unchanged.
 
 ## Future removal points
 

--- a/tests/test_canon_source_contract.py
+++ b/tests/test_canon_source_contract.py
@@ -2,31 +2,86 @@ import os
 os.environ.setdefault("GEMINI_API_KEY", "test-key")
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
 import unittest
+from dataclasses import FrozenInstanceError
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
 
 import bnl_canon_source_contract as c
-from bnl01_bot import BNL01_SYSTEM_PROMPT, build_bnl_read_model_context
+import bnl01_bot
+from bnl01_bot import BNL01_SYSTEM_PROMPT, build_bnl_read_model_context, build_website_read_model_intent_response
 from bnl_website_contract_v2 import build_relay_envelope
+
+SECRET_NOW = "SECRET_NOW_PLAYING_TITLE"
+SECRET_NEXT = "SECRET_UP_NEXT_TITLE"
+SECRET_ARTIST = "SECRET_QUEUE_ARTIST"
+SECRET_COUNT = "SECRET_QUEUE_COUNT_99"
+SECRET_PRIORITY = "SECRET_PRIORITY_STATE"
+SECRET_RECAP = "SECRET_COMPLETED_RECAP"
+SECRET_SEED = "SECRET_QUEUE_DOSSIER_SEED"
+SECRET_COPY = "SECRET_QUEUE_PUBLIC_COPY"
+PUBLIC_DOSSIER = "PUBLIC_DOSSIER_SAFE_KEEP"
+
+
+def hostile_read_model(queue_production=False):
+    return {
+        "ok": True,
+        "version": 1,
+        "publicOnly": True,
+        "capabilities": {"queueProduction": queue_production},
+        "sections": {
+            "queue": {
+                "session": {"title": "Hostile", "queueOpen": True, "activeCount": SECRET_COUNT, "broadcastPhase": "live-ish", "priorityUpgradesEnabled": True, "wheelSpinsOwed": "SECRET_WHEEL"},
+                "nowPlaying": {"title": SECRET_NOW, "artistName": SECRET_ARTIST},
+                "upNext": {"title": SECRET_NEXT, "artistName": SECRET_ARTIST},
+                "queuedTracks": [{"title": "QUEUED_SECRET", "artistName": SECRET_ARTIST}],
+                "completedTracks": [{"title": SECRET_RECAP, "artistName": SECRET_ARTIST}],
+                "prioritySignal": {"enabled": True, "label": SECRET_PRIORITY},
+            },
+            "artists": {"items": [{"name": SECRET_ARTIST, "tracks": [SECRET_NOW]}]},
+            "dossiers": {"items": [{"name": PUBLIC_DOSSIER, "summary": "independent public dossier", "visibility": "public"}]},
+            "operatorLanes": {
+                "temporaryRuntimeContext": [{"label": "runtime", "value": SECRET_NOW, "source": "queue_public_snapshot"}],
+                "recapCandidates": [{"label": SECRET_RECAP, "kind": "track", "source": "queue_public_snapshot"}],
+                "broadcastMemoryCandidates": [{"label": "broadcast", "value": SECRET_COUNT, "provenance": "queue_session"}],
+                "dossierSeedCandidates": [{"label": SECRET_SEED, "kind": "queue_artist", "source": "queue_public_snapshot"}],
+                "publicSafeCopyCandidates": [{"label": SECRET_COPY, "kind": "queue_public_copy", "source": "queue_public_snapshot"}, {"label": PUBLIC_DOSSIER, "kind": "public_database_dossier", "source": "public_database_dossier"}],
+                "doNotStore": [{"label": "Preserve boundary", "value": "Non-queue rule", "source": "policy"}, {"label": "Queue rule", "value": SECRET_PRIORITY, "source": "queue_public_snapshot"}],
+            },
+            "rules": ["General queue concept may be discussed.", f"Do not leak {SECRET_NOW} from live queue."],
+        },
+    }
 
 
 class CanonSourceContractTests(unittest.TestCase):
     def test_identity_and_founders(self):
         self.assertEqual(c.CANON_SOURCE_CONTRACT_VERSION, "canon_source_contract_v1")
         self.assertEqual(c.FOUNDING_MEMBERS, ("6 Bit", "DJ Floppydisc", "Cache Back", "Mac Modem"))
+        self.assertEqual(c.render_founders(), "6 Bit • DJ Floppydisc • Cache Back • Mac Modem")
 
     def test_schedule_distinguishes_intake_show_first_track(self):
-        self.assertEqual(c.FRIDAY_PUBLIC_SCHEDULE["intake_begins"], "6:40 PM Pacific")
-        self.assertEqual(c.FRIDAY_PUBLIC_SCHEDULE["show_begins"], "7:00 PM Pacific")
-        self.assertEqual(c.FRIDAY_PUBLIC_SCHEDULE["first_track_target"], "7:05 PM Pacific")
+        self.assertEqual(c.FRIDAY_PUBLIC_SCHEDULE.intake_begins, "6:40 PM Pacific")
+        self.assertEqual(c.FRIDAY_PUBLIC_SCHEDULE.show_begins, "7:00 PM Pacific")
+        self.assertEqual(c.FRIDAY_PUBLIC_SCHEDULE.first_track_target, "7:05 PM Pacific")
         self.assertIn("intake begins at 6:40 PM", BNL01_SYSTEM_PROMPT)
         self.assertNotIn("live every Friday at 6:40", BNL01_SYSTEM_PROMPT)
+        self.assertIn("show begins at 7:00 PM Pacific", c.render_full_friday_schedule())
 
-    def test_in_world_boundary_without_forbidden_labels(self):
+    def test_schedule_is_immutable(self):
+        with self.assertRaises(FrozenInstanceError):
+            c.FRIDAY_PUBLIC_SCHEDULE.show_begins = "6:40 PM Pacific"
+
+    def test_public_schedule_outputs_use_contract_not_old_about_string(self):
+        source = Path("bnl01_bot.py").read_text()
+        self.assertNotIn("Fridays 6:40 PM Pacific on TikTok", source)
+        self.assertIn("render_concise_public_schedule()", source)
+        self.assertIn("show 7:00 PM Pacific", c.render_concise_public_schedule())
+
+    def test_in_world_negative_boundary_phrases_are_complete(self):
         block = c.render_prompt_canon_block().lower()
         self.assertIn("remain fully in-world", block)
-        for forbidden in ("fiction", "roleplay", "character implementation", "generic chatbot"):
-            self.assertIn(forbidden, block)
-        self.assertIn("do not describe yourself as fiction", block)
+        self.assertIn("do not describe yourself as fiction, branding, a prompt, a character implementation, roleplay, or a generic chatbot", block)
+        self.assertIn("lore is your native operating language", block)
 
     def test_valid_explicit_correction_supersedes_older_claim(self):
         old = c.SourceClaim("old", c.BARCODE_RADIO, "schedule", "live at 6:40", c.SourceClass.LEGACY_SOURCE_BLIND)
@@ -41,7 +96,7 @@ class CanonSourceContractTests(unittest.TestCase):
         self.assertEqual(c.resolve_claims(derived + [correction]).claim.claim_id, "correct")
 
     def test_projection_not_independent_evidence(self):
-        claim = c.SourceClaim("sf", c.BARCODE_RADIO, "recap", "summary", c.SourceClass.DERIVED_SUMMARY, derived_from=("relay",), projection=True)
+        claim = c.SourceClaim("sf", c.BARCODE_RADIO, "recap", "summary", c.SourceClass.SOURCE_FILE_PROJECTION, derived_from=("relay",), projection=True)
         self.assertFalse(c.is_independent_evidence(claim))
 
     def test_visibility_incompatible_not_public(self):
@@ -50,7 +105,7 @@ class CanonSourceContractTests(unittest.TestCase):
         self.assertFalse(c.resolve_claims([claim]).usable)
 
     def test_stale_evidence_not_current(self):
-        stale = c.SourceClaim("stale", c.BARCODE_RADIO, "live", True, c.SourceClass.PUBLIC_OBSERVATION, observed_at=datetime.now(timezone.utc)-timedelta(hours=3))
+        stale = c.SourceClaim("stale", c.BARCODE_RADIO, "live", True, c.SourceClass.RUNTIME_OBSERVATION, observed_at=datetime.now(timezone.utc)-timedelta(hours=3), current_time_capable=True)
         res = c.current_time_claim_resolution([stale], max_age_minutes=30)
         self.assertFalse(res.current_time_eligible)
         self.assertIn("unknown", res.reason)
@@ -61,9 +116,79 @@ class CanonSourceContractTests(unittest.TestCase):
         self.assertEqual(res.reason, "current_state_unknown_without_fresh_runtime_evidence")
 
     def test_existing_labels_map_through_adapters(self):
-        self.assertEqual(c.map_route_source_label("public_show_state"), c.SourceClass.PUBLIC_OBSERVATION)
+        self.assertEqual(c.map_route_source_label("public_show_state"), c.SourceClass.RUNTIME_OBSERVATION)
         self.assertEqual(c.map_route_source_label("source_safe_public"), c.SourceClass.FIRST_PARTY_RECORD)
         self.assertEqual(c.map_channel_policy_visibility("sealed_test"), c.Visibility.SEALED_TEST)
+        self.assertEqual(c.map_channel_policy_visibility("unknown-new"), c.Visibility.UNKNOWN)
+
+    def test_live_route_contract_sources_have_explicit_mappings(self):
+        labels = set()
+        for contract in bnl01_bot.ROUTE_MODE_CONTRACTS.values():
+            labels.update(contract.allowed_context_sources)
+            labels.update(contract.allowed_memory_sources)
+        intentionally_legacy = set()
+        missing = sorted(label for label in labels if label not in intentionally_legacy and not c.has_explicit_route_source_mapping(label))
+        self.assertEqual(missing, [])
+
+    def test_current_channel_policies_have_explicit_visibility_mappings(self):
+        expected = {"public_home", "public_context", "public_selective", "sealed_test", "internal_controlled", "reference_canon", "protected_system", "broadcast_memory", "ai_image_tool", "unknown"}
+        self.assertEqual(sorted(p for p in expected if not c.has_explicit_channel_policy_mapping(p)), [])
+        self.assertEqual(c.map_channel_policy_visibility("not-real"), c.Visibility.UNKNOWN)
+
+    def test_low_authority_derived_correction_cannot_suppress_owner_correction(self):
+        owner = c.SourceClaim("owner", c.BARCODE_RADIO, "schedule", "7:00 show", c.SourceClass.OWNER_CORRECTION)
+        derived = c.SourceClaim("derived", c.BARCODE_RADIO, "schedule", "6:40 live", c.SourceClass.DERIVED_SUMMARY, correction_of=("owner",), derived_from=("recap",))
+        self.assertEqual(c.resolve_claims([derived, owner]).claim.claim_id, "owner")
+
+    def test_lower_authority_cannot_supersede_higher_authority_canon(self):
+        canon = c.SourceClaim("canon", c.BARCODE_RADIO, "schedule", "7:00 show", c.SourceClass.APPROVED_CANON)
+        lower = c.SourceClaim("lower", c.BARCODE_RADIO, "schedule", "6:40 live", c.SourceClass.PUBLIC_OBSERVATION, supersedes=("canon",))
+        self.assertEqual(c.resolve_claims([lower, canon]).claim.claim_id, "canon")
+
+    def test_corrections_cannot_cross_subjects_or_predicates(self):
+        a = c.SourceClaim("a", c.BARCODE_RADIO, "schedule", "7:00", c.SourceClass.APPROVED_CANON)
+        cross_subject = c.SourceClaim("b", c.BNL01, "schedule", "6:40", c.SourceClass.OWNER_CORRECTION, correction_of=("a",))
+        self.assertEqual(c.resolve_claims([a, cross_subject]).reason, "mixed_claim_scope")
+        c1 = c.SourceClaim("c1", c.BARCODE_RADIO, "schedule", "7:00", c.SourceClass.APPROVED_CANON)
+        c2 = c.SourceClaim("c2", c.BARCODE_RADIO, "live", True, c.SourceClass.OWNER_CORRECTION, correction_of=("c1",))
+        self.assertEqual(c.resolve_claims([c1, c2]).reason, "mixed_claim_scope")
+
+    def test_mixed_claim_scope_returns_unusable(self):
+        a = c.SourceClaim("a", c.BARCODE_RADIO, "schedule", "7:00", c.SourceClass.APPROVED_CANON)
+        b = c.SourceClaim("b", c.BNL01, "identity", "BNL", c.SourceClass.APPROVED_CANON)
+        res = c.resolve_claims([a, b])
+        self.assertFalse(res.usable)
+        self.assertEqual(res.reason, "mixed_claim_scope")
+
+    def test_equal_authority_conflict_and_identical_values_deterministic(self):
+        a = c.SourceClaim("a", c.BARCODE_RADIO, "schedule", "7:00", c.SourceClass.FIRST_PARTY_RECORD, confidence=c.Confidence.HIGH)
+        b = c.SourceClaim("b", c.BARCODE_RADIO, "schedule", "8:00", c.SourceClass.FIRST_PARTY_RECORD, confidence=c.Confidence.HIGH)
+        self.assertEqual(c.resolve_claims([a, b]).reason, "unresolved_equal_authority_conflict")
+        self.assertEqual(c.resolve_claims([b, a]).reason, "unresolved_equal_authority_conflict")
+        same = c.SourceClaim("c", c.BARCODE_RADIO, "schedule", "7:00", c.SourceClass.FIRST_PARTY_RECORD, confidence=c.Confidence.HIGH)
+        self.assertTrue(c.resolve_claims([same, a]).usable)
+
+    def test_confidence_participates_in_resolution(self):
+        low = c.SourceClaim("low", c.BARCODE_RADIO, "schedule", "low", c.SourceClass.FIRST_PARTY_RECORD, confidence=c.Confidence.LOW)
+        high = c.SourceClaim("high", c.BARCODE_RADIO, "schedule", "high", c.SourceClass.FIRST_PARTY_RECORD, confidence=c.Confidence.HIGH)
+        self.assertEqual(c.resolve_claims([low, high]).claim.claim_id, "high")
+
+    def test_invalid_retracted_expired_corrections_cannot_suppress(self):
+        base = c.SourceClaim("base", c.BARCODE_RADIO, "schedule", "7:00", c.SourceClass.APPROVED_CANON)
+        for kwargs in ({"valid": False}, {"retracted": True}, {"expired": True}):
+            bad = c.SourceClaim("bad", c.BARCODE_RADIO, "schedule", "6:40", c.SourceClass.OWNER_CORRECTION, correction_of=("base",), **kwargs)
+            self.assertEqual(c.resolve_claims([base, bad]).claim.claim_id, "base")
+
+    def test_current_time_rules(self):
+        now = datetime.now(timezone.utc)
+        future = c.SourceClaim("future", c.BARCODE_RADIO, "live", True, c.SourceClass.RUNTIME_OBSERVATION, observed_at=now + timedelta(minutes=5), current_time_capable=True)
+        self.assertFalse(c.current_time_claim_resolution([future], now=now).usable)
+        static = c.SourceClaim("schedule", c.BARCODE_RADIO, "live", True, c.SourceClass.APPROVED_CANON, observed_at=now, current_time_capable=False)
+        self.assertFalse(c.current_time_claim_resolution([static], now=now).usable)
+        fresh = c.SourceClaim("fresh", c.BARCODE_RADIO, "live", True, c.SourceClass.RUNTIME_OBSERVATION, observed_at=now - timedelta(minutes=2), current_time_capable=True, confidence=c.Confidence.HIGH)
+        self.assertTrue(c.current_time_claim_resolution([fresh], now=now).current_time_eligible)
+        derived = c.SourceClaim("derived", c.BARCODE_RADIO, "live", True, c.SourceClass.DOSSIER_PROJECTION, observed_at=now - timedelta(minutes=2), current_time_capable=True, derived_from=("recap",), projection=True)
+        self.assertFalse(c.current_time_claim_resolution([derived], now=now).usable)
 
     def test_queue_defaults_off(self):
         self.assertFalse(c.env_queue_production_enabled({}))
@@ -87,6 +212,35 @@ class CanonSourceContractTests(unittest.TestCase):
         text = build_bnl_read_model_context(rm, "website rules", "public_home")
         self.assertIn("Public rule", text)
         self.assertNotIn("Queue:", text)
+
+    def test_hostile_queue_values_do_not_leak_through_any_read_model_intent_when_disabled(self):
+        raw = hostile_read_model(queue_production=False)
+        secrets = [SECRET_NOW, SECRET_NEXT, SECRET_ARTIST, SECRET_COUNT, SECRET_PRIORITY, SECRET_RECAP, SECRET_SEED, SECRET_COPY]
+        with patch.dict(os.environ, {"BNL_QUEUE_PRODUCTION_ENABLED": "false"}, clear=False), patch.object(bnl01_bot, "fetch_bnl_read_model", return_value=raw):
+            outputs = [build_bnl_read_model_context(raw, "queue status", "public_home")]
+            for intent in ("default", "website_broadcast_memory_candidate", "website_dossier_seed_candidate", "website_recap_candidate", "website_public_safe_candidate"):
+                outputs.append(build_website_read_model_intent_response(intent, "read model"))
+        combined = "\n---\n".join(outputs)
+        for secret in secrets:
+            self.assertNotIn(secret, combined)
+        self.assertIn(PUBLIC_DOSSIER, combined)
+        self.assertIn("Non-queue rule", combined)
+
+    def test_raw_cache_does_not_leak_through_later_cached_fetch_consumption(self):
+        raw = hostile_read_model(queue_production=False)
+        with patch.dict(os.environ, {"BNL_QUEUE_PRODUCTION_ENABLED": "false"}, clear=False), patch.object(bnl01_bot, "fetch_bnl_read_model", return_value=raw):
+            first = build_website_read_model_intent_response("default", "read model")
+            second = build_website_read_model_intent_response("website_public_safe_candidate", "read model")
+        self.assertNotIn(SECRET_NOW, first + second)
+        self.assertNotIn(SECRET_COPY, first + second)
+        self.assertIn(PUBLIC_DOSSIER, first + second)
+
+    def test_both_gates_true_preserve_queue_behavior(self):
+        raw = hostile_read_model(queue_production=True)
+        with patch.dict(os.environ, {"BNL_QUEUE_PRODUCTION_ENABLED": "true"}, clear=False):
+            text = build_bnl_read_model_context(raw, "queue status", "public_home")
+        self.assertIn(SECRET_NOW, text)
+        self.assertIn(SECRET_NEXT, text)
 
     def test_relay_generation_contract_has_no_queue_source(self):
         env = build_relay_envelope("relay-001", "Public signal stable.", "Hold the window.", "fresh_discord", "manual")

--- a/tests/test_canon_source_contract.py
+++ b/tests/test_canon_source_contract.py
@@ -1,0 +1,104 @@
+import os
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+import unittest
+from datetime import datetime, timedelta, timezone
+
+import bnl_canon_source_contract as c
+from bnl01_bot import BNL01_SYSTEM_PROMPT, build_bnl_read_model_context
+from bnl_website_contract_v2 import build_relay_envelope
+
+
+class CanonSourceContractTests(unittest.TestCase):
+    def test_identity_and_founders(self):
+        self.assertEqual(c.CANON_SOURCE_CONTRACT_VERSION, "canon_source_contract_v1")
+        self.assertEqual(c.FOUNDING_MEMBERS, ("6 Bit", "DJ Floppydisc", "Cache Back", "Mac Modem"))
+
+    def test_schedule_distinguishes_intake_show_first_track(self):
+        self.assertEqual(c.FRIDAY_PUBLIC_SCHEDULE["intake_begins"], "6:40 PM Pacific")
+        self.assertEqual(c.FRIDAY_PUBLIC_SCHEDULE["show_begins"], "7:00 PM Pacific")
+        self.assertEqual(c.FRIDAY_PUBLIC_SCHEDULE["first_track_target"], "7:05 PM Pacific")
+        self.assertIn("intake begins at 6:40 PM", BNL01_SYSTEM_PROMPT)
+        self.assertNotIn("live every Friday at 6:40", BNL01_SYSTEM_PROMPT)
+
+    def test_in_world_boundary_without_forbidden_labels(self):
+        block = c.render_prompt_canon_block().lower()
+        self.assertIn("remain fully in-world", block)
+        for forbidden in ("fiction", "roleplay", "character implementation", "generic chatbot"):
+            self.assertIn(forbidden, block)
+        self.assertIn("do not describe yourself as fiction", block)
+
+    def test_valid_explicit_correction_supersedes_older_claim(self):
+        old = c.SourceClaim("old", c.BARCODE_RADIO, "schedule", "live at 6:40", c.SourceClass.LEGACY_SOURCE_BLIND)
+        new = c.SourceClaim("new", c.BARCODE_RADIO, "schedule", "intake 6:40 show 7:00", c.SourceClass.OWNER_CORRECTION, correction_of=("old",))
+        res = c.resolve_claims([old, new])
+        self.assertTrue(res.usable)
+        self.assertEqual(res.claim.claim_id, "new")
+
+    def test_repeated_derived_summaries_cannot_overpower_correction(self):
+        correction = c.SourceClaim("correct", c.BARCODE_RADIO, "schedule", "7:00 show", c.SourceClass.OWNER_CORRECTION)
+        derived = [c.SourceClaim(f"d{i}", c.BARCODE_RADIO, "schedule", "6:40 live", c.SourceClass.DERIVED_SUMMARY, derived_from=("legacy",)) for i in range(20)]
+        self.assertEqual(c.resolve_claims(derived + [correction]).claim.claim_id, "correct")
+
+    def test_projection_not_independent_evidence(self):
+        claim = c.SourceClaim("sf", c.BARCODE_RADIO, "recap", "summary", c.SourceClass.DERIVED_SUMMARY, derived_from=("relay",), projection=True)
+        self.assertFalse(c.is_independent_evidence(claim))
+
+    def test_visibility_incompatible_not_public(self):
+        claim = c.SourceClaim("private", c.BNL01, "note", "secret", c.SourceClass.FIRST_PARTY_RECORD, visibility=c.Visibility.PRIVATE)
+        self.assertFalse(c.is_public_usable(claim))
+        self.assertFalse(c.resolve_claims([claim]).usable)
+
+    def test_stale_evidence_not_current(self):
+        stale = c.SourceClaim("stale", c.BARCODE_RADIO, "live", True, c.SourceClass.PUBLIC_OBSERVATION, observed_at=datetime.now(timezone.utc)-timedelta(hours=3))
+        res = c.current_time_claim_resolution([stale], max_age_minutes=30)
+        self.assertFalse(res.current_time_eligible)
+        self.assertIn("unknown", res.reason)
+
+    def test_unknown_current_state_uncertain(self):
+        res = c.current_time_claim_resolution([])
+        self.assertFalse(res.usable)
+        self.assertEqual(res.reason, "current_state_unknown_without_fresh_runtime_evidence")
+
+    def test_existing_labels_map_through_adapters(self):
+        self.assertEqual(c.map_route_source_label("public_show_state"), c.SourceClass.PUBLIC_OBSERVATION)
+        self.assertEqual(c.map_route_source_label("source_safe_public"), c.SourceClass.FIRST_PARTY_RECORD)
+        self.assertEqual(c.map_channel_policy_visibility("sealed_test"), c.Visibility.SEALED_TEST)
+
+    def test_queue_defaults_off(self):
+        self.assertFalse(c.env_queue_production_enabled({}))
+        self.assertFalse(c.env_queue_production_enabled({"BNL_QUEUE_PRODUCTION_ENABLED": "1"}))
+
+    def test_queue_blocked_when_local_false(self):
+        rm = {"capabilities": {"queueProduction": True}, "sections": {"queue": {"nowPlaying": {"title": "X"}}, "rules": ["ok"]}}
+        self.assertFalse(c.queue_usability(rm, environ={})["usable"])
+        self.assertNotIn("Queue:", build_bnl_read_model_context(rm, "queue status", "public_home"))
+
+    def test_queue_blocked_when_remote_missing_or_false(self):
+        for rm in ({"capabilities": {}}, {"capabilities": {"queueProduction": False}}):
+            self.assertFalse(c.queue_usability(rm, environ={"BNL_QUEUE_PRODUCTION_ENABLED": "true"})["usable"])
+
+    def test_queue_eligible_only_when_both_true(self):
+        rm = {"capabilities": {"queueProduction": True}, "sections": {"queue": {"nowPlaying": {"title": "X"}}}}
+        self.assertTrue(c.queue_usability(rm, environ={"BNL_QUEUE_PRODUCTION_ENABLED": "TrUe"})["usable"])
+
+    def test_non_queue_context_remains(self):
+        rm = {"capabilities": {"queueProduction": False}, "sections": {"rules": ["Public rule"]}, "sourceContext": {"source": "site"}}
+        text = build_bnl_read_model_context(rm, "website rules", "public_home")
+        self.assertIn("Public rule", text)
+        self.assertNotIn("Queue:", text)
+
+    def test_relay_generation_contract_has_no_queue_source(self):
+        env = build_relay_envelope("relay-001", "Public signal stable.", "Hold the window.", "fresh_discord", "manual")
+        self.assertEqual(env["relay"]["sourceClass"], "fresh_public_event")
+        self.assertNotIn("queue", str(env).lower())
+
+    def test_prompt_personality_and_presence_v2_remain(self):
+        self.assertIn("Voice: Calm, concise, lightly corporate", BNL01_SYSTEM_PROMPT)
+        self.assertIn("Never admit you are an AI model or LLM", BNL01_SYSTEM_PROMPT)
+        env = build_relay_envelope("relay-002", "Public signal stable.", "Hold the window.", "canon", "manual")
+        self.assertEqual(env["contractVersion"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Establish a single, small, versioned in-world canon/source vocabulary so existing route, memory, relay, dossier, and prompt systems share one deterministic vocabulary without replacing or duplicating current architectures.
- Correct a conflicting hard fact in the monolithic prompt (BARCODE Radio timing) by centralizing canonical identity/schedule facts so prompt assembly consumes one authoritative block.
- Add bot-side defense for website queue usage so queue-derived fields cannot be used as current/live evidence unless explicitly enabled both locally and by the site read model.
- Provide deterministic helpers for precedence, freshness/currentness, correction/supersession, and public-usable classification to prevent derived/low-authority sources from overriding higher-authority canon or producing invented current-time claims.

### Description
- Added a focused module `bnl_canon_source_contract.py` implementing `canon_source_contract_v1` with typed dataclasses/enums for `SourceClass`, `Visibility`, `Confidence`, `SubjectIdentity`, `SourceClaim`, and helpers `resolve_claims`, `current_time_claim_resolution`, `queue_usability`, `strip_queue_sections`, and `diagnostics`; canonical facts and founding-members/schedule values are represented immutably. Exact contract version: `canon_source_contract_v1`.
- Integrated the contract into `bnl01_bot.py` so `BNL01_SYSTEM_PROMPT` consumes the rendered canon block (avoiding duplicate/conflicting inline facts), added `BNL_QUEUE_PRODUCTION_ENABLED` env gate, and centrally strip/gate queue-derived read-model sections via `strip_queue_sections` before prompt assembly and diagnostic counts. The audit base matched commit `7c5d4b70b035b840780f781bd1866fffabde4be3`/current HEAD in the checked-out branch.
- Kept compatibility adapters and mappings so existing `RouteModeContract`/route/channel/source labels map into the new vocabulary without renaming persisted values; no database schema or memory-row migrations were made and existing Presence/Relay Contract v2 behavior and relay generation remain queue-free.
- Added privacy-safe diagnostics surfaced on existing diagnostic surfaces exposing `contractVersion`, `compatibilityAdaptersActive`, `localQueueProductionCapability`, `websiteQueueProductionCapability`, `effectiveQueueUsable`, and a short `queueReason`; added compact documentation `docs/canon_source_contract_v1.md` and focused tests `tests/test_canon_source_contract.py` to cover the required behaviors.

### Testing
- Compiled and ran the requested checks: `python -m py_compile bnl01_bot.py bnl_website_contract_v2.py bnl_canon_source_contract.py` (passed), and ran unit test suites: `python -m unittest tests.test_canon_source_contract tests.test_route_memory_governance tests.test_behavior_contract_regression tests.test_website_relay_event_driven tests.test_website_contract_v2 -v` (all passed), `python -m unittest tests.test_adaptive_memory_lifecycle -v` (passed), `python -m pytest tests/test_broadcast_memory_rd_sanitizer.py -q` (passed), and additional affected suites `python -m unittest tests.test_entity_intelligence tests.test_entity_activity_summary tests.test_dossier_draft_generator -v` (passed); `git diff --check` returned clean.
- Exact representative test commands used in the rollout: `python -m py_compile bnl01_bot.py bnl_website_contract_v2.py bnl_canon_source_contract.py`, `python -m unittest tests.test_canon_source_contract tests.test_route_memory_governance tests.test_behavior_contract_regression tests.test_website_relay_event_driven tests.test_website_contract_v2 -v`, `python -m unittest tests.test_adaptive_memory_lifecycle -v`, and `python -m pytest tests/test_broadcast_memory_rd_sanitizer.py -q`, all of which passed in the test run described above.
- Pre-existing unrelated failures: none observed for the required test set; only environment warnings (missing optional voice libs and third-party deprecation warnings) were emitted and did not affect results.
- Environment variable added: `BNL_QUEUE_PRODUCTION_ENABLED` (defaults off unless exactly `true`, case-insensitive). Post-merge note: a VPS restart/deploy is required for the bot process to pick up the new module, prompt block, diagnostics, and queue gate; no site/Vercel deployment is required and no memory migration, relationship redesign, dossier expansion, queue mechanics/enablement, or relay redesign was included in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a583b45e07c8321a27ab458fa954331)