### PR TITLE
Unified Memory Ledger v1 — Shadow Writes, Provenance, and Lifecycle Spine

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -21,6 +21,16 @@ from bnl_canon_source_contract import (
     render_prompt_canon_block,
     strip_queue_sections,
 )
+from bnl_memory_ledger import (
+    build_memory_ledger_evaluation,
+    ensure_memory_ledger_schema,
+    shadow_broadcast_memory_row,
+    shadow_conversation_row,
+    shadow_enabled as memory_ledger_shadow_enabled,
+    shadow_memory_tier_row,
+    shadow_relationship_journal_row,
+    shadow_user_fact_row,
+)
 from bnl_conversation_context_v2 import (
     CONVERSATION_CONTEXT_VERSION,
     ConversationContextRequest,
@@ -4348,10 +4358,27 @@ def init_db():
     evidence_conn = sqlite3.connect(DB_FILE)
     try:
         ensure_entity_evidence_schema(evidence_conn)
+        ensure_memory_ledger_schema(evidence_conn)
         evidence_conn.commit()
     finally:
         evidence_conn.close()
     logging.info("✅ Database initialized successfully.")
+
+
+def _shadow_memory_ledger_write(writer_name: str, callback):
+    if not memory_ledger_shadow_enabled():
+        return None
+    try:
+        conn = sqlite3.connect(DB_FILE)
+        try:
+            result = callback(conn)
+            conn.commit()
+            return result
+        finally:
+            conn.close()
+    except Exception as exc:
+        logging.debug("memory_ledger_shadow_write_failed writer=%s error=%s", writer_name, exc)
+        return None
 
 def _truncate_user_facts(user_id: int, guild_id: int, max_rows: int = MAX_FACTS_PER_USER):
     conn = sqlite3.connect(DB_FILE)
@@ -4418,8 +4445,13 @@ def upsert_user_fact(user_id: int, guild_id: int, fact_key: str, fact_value: str
             (user_id, guild_id, fact_key, fact_value, confidence, is_core, now),
         )
         changed = False
+    fact_row_id = int(existing[0] if existing else cursor.lastrowid or 0)
     conn.commit()
     conn.close()
+    _shadow_memory_ledger_write(
+        "user_memory_facts",
+        lambda ledger_conn: shadow_user_fact_row(ledger_conn, row_id=fact_row_id, user_id=user_id, guild_id=guild_id, fact_key=fact_key, fact_value=fact_value, confidence=confidence, updated_at=now),
+    )
     _truncate_user_facts(user_id, guild_id, MAX_FACTS_PER_USER)
 
     if changed:
@@ -4539,8 +4571,13 @@ def add_relationship_journal(user_id: int, guild_id: int, entry_type: str, summa
         """,
         (user_id, guild_id, entry_type, summary[:220], now),
     )
+    row_id = int(cursor.lastrowid or 0)
     conn.commit()
     conn.close()
+    _shadow_memory_ledger_write(
+        "relationship_journal",
+        lambda ledger_conn: shadow_relationship_journal_row(ledger_conn, row_id=row_id, user_id=user_id, guild_id=guild_id, entry_type=entry_type, summary=summary[:220], timestamp=now),
+    )
 
 def get_relationship_journal(user_id: int, guild_id: int, limit: int = 5):
     conn = sqlite3.connect(DB_FILE)
@@ -4788,6 +4825,7 @@ def _insert_memory_tier(cursor, user_id: int, guild_id: int, tier: str, summary:
     }
     ordered = [c for c in ("user_id","guild_id","tier","summary","salience","mentions","updated_at","source_role","source_channel_policy","source_channel_name","source_origin","source_trust","topic_key","subject_key","project_key","first_seen","last_seen","lifecycle_note") if c in data and (c in cols or c in {"user_id","guild_id","tier","summary","salience","mentions","updated_at"})]
     cursor.execute(f"INSERT INTO memory_tiers ({', '.join(ordered)}) VALUES ({', '.join(['?']*len(ordered))})", [data[c] for c in ordered])
+    return int(cursor.lastrowid or 0)
 
 
 def _add_memory_tier_entry(user_id: int, guild_id: int, tier: str, summary: str, salience: float, source_role: str = "legacy_unknown", source_channel_policy: str = "legacy_unknown", source_channel_name: str = "", source_origin: str = "legacy_unknown", source_trust: str = "legacy_unknown"):
@@ -4795,9 +4833,14 @@ def _add_memory_tier_entry(user_id: int, guild_id: int, tier: str, summary: str,
         return
     conn = sqlite3.connect(DB_FILE)
     cursor = conn.cursor()
-    _insert_memory_tier(cursor, user_id, guild_id, tier, summary, salience, source_role=source_role, source_channel_policy=source_channel_policy, source_channel_name=source_channel_name, source_origin=source_origin, source_trust=source_trust, topic_key=_memory_topic_key(summary), subject_key=_memory_subject_key(summary), project_key=_memory_project_key(summary), lifecycle_note="direct_entry")
+    row_id = _insert_memory_tier(cursor, user_id, guild_id, tier, summary, salience, source_role=source_role, source_channel_policy=source_channel_policy, source_channel_name=source_channel_name, source_origin=source_origin, source_trust=source_trust, topic_key=_memory_topic_key(summary), subject_key=_memory_subject_key(summary), project_key=_memory_project_key(summary), lifecycle_note="direct_entry")
     conn.commit()
     conn.close()
+    if row_id:
+        _shadow_memory_ledger_write(
+            "memory_tiers",
+            lambda ledger_conn: shadow_memory_tier_row(ledger_conn, row_id=row_id, user_id=user_id, guild_id=guild_id, tier=tier, summary=summary, salience=salience, channel_policy=source_channel_policy, topic_key=_memory_topic_key(summary), updated_at=datetime.now(PACIFIC_TZ).isoformat()),
+        )
 
 
 def _fetch_tier_rows(cursor, user_id: int, guild_id: int, tier: str) -> list[dict]:
@@ -9368,8 +9411,19 @@ def save_user_message(user_id: int, user_name: str, guild_id: int, content: str,
             "INSERT INTO conversations (user_id, user_name, guild_id, channel_name, channel_policy, channel_id, role, content) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             (user_id, user_name, guild_id, (channel_name or "").lower()[:80], (channel_policy or "unknown")[:40], int(channel_id or 0), "user", content),
         )
+    row_id = int(cursor.lastrowid or 0)
+    observed_at = cursor.execute("SELECT timestamp FROM conversations WHERE id=?", (row_id,)).fetchone()
+    observed_at = observed_at[0] if observed_at else ""
     conn.commit()
     conn.close()
+    _shadow_memory_ledger_write(
+        "conversations_user",
+        lambda ledger_conn: shadow_conversation_row(
+            ledger_conn, row_id=row_id, user_id=user_id, user_name=user_name, guild_id=guild_id, role="user",
+            content=content, channel_name=(channel_name or "").lower()[:80], channel_policy=(channel_policy or "unknown")[:40],
+            channel_id=int(channel_id or 0), message_id=int(message_id or 0) or None, route_mode=route_mode, observed_at=observed_at,
+        ),
+    )
     try:
         mark_subject_dirty_for_evidence(
             DB_FILE,
@@ -9424,8 +9478,19 @@ def save_model_message(user_id: int, guild_id: int, content: str, channel_name: 
         "INSERT INTO conversations (user_id, user_name, guild_id, channel_name, channel_policy, channel_id, role, content) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         (user_id, "BNL-01", guild_id, (channel_name or "").lower()[:80], (channel_policy or "unknown")[:40], int(channel_id or 0), "model", content),
     )
+    row_id = int(cursor.lastrowid or 0)
+    observed_at = cursor.execute("SELECT timestamp FROM conversations WHERE id=?", (row_id,)).fetchone()
+    observed_at = observed_at[0] if observed_at else ""
     conn.commit()
     conn.close()
+    _shadow_memory_ledger_write(
+        "conversations_model",
+        lambda ledger_conn: shadow_conversation_row(
+            ledger_conn, row_id=row_id, user_id=user_id, user_name="BNL-01", guild_id=guild_id, role="model",
+            content=content, channel_name=(channel_name or "").lower()[:80], channel_policy=(channel_policy or "unknown")[:40],
+            channel_id=int(channel_id or 0), message_id=None, route_mode=route_mode, observed_at=observed_at,
+        ),
+    )
     prune_conversation_history(user_id, guild_id, calculate_adaptive_memory_limits(user_id, guild_id, route_mode=route_mode, channel_policy=channel_policy, user_text=content).get("conversation_rows", MAX_CONVERSATION_ROWS_PER_USER))
     if decision.update_relationship:
         update_relationship_state(user_id, guild_id, content, delta_affinity=0.04)
@@ -10450,6 +10515,16 @@ def add_broadcast_memory_entry(guild_id: int, message: discord.Message, processe
     new_id = cursor.lastrowid
     conn.commit()
     conn.close()
+    _shadow_memory_ledger_write(
+        "broadcast_memory",
+        lambda ledger_conn: shadow_broadcast_memory_row(
+            ledger_conn, row_id=int(new_id or 0), guild_id=guild_id, cleaned_summary=processed.get("cleaned_summary", ""),
+            entry_type=processed.get("entry_type", "notable_moment"), public_safe=bool(processed.get("public_safe")),
+            status="active", usage_scope=processed.get("usage_scope", "internal"),
+            submitted_by_user_id=getattr(getattr(message, "author", None), "id", None), submitted_by_name=getattr(getattr(message, "author", None), "display_name", "system"),
+            created_at=now,
+        ),
+    )
     return int(new_id or 0)
 
 
@@ -18459,6 +18534,15 @@ async def bnl_memory_check(interaction: discord.Interaction):
     active_override = get_active_show_state_override(guild.id)
     latest_broadcast_context_episode_date = get_latest_broadcast_episode_date(guild.id, public_only=False)
     member_activity_events_count, recent_member_events_count_7d = get_member_activity_event_counts(guild.id)
+    try:
+        ledger_conn = sqlite3.connect(DB_FILE)
+        try:
+            ledger_diag = build_memory_ledger_evaluation(ledger_conn, guild_id=guild.id)
+        finally:
+            ledger_conn.close()
+    except Exception as exc:
+        logging.debug("memory_ledger_diagnostic_failed error=%s", exc)
+        ledger_diag = {"schemaVersion": "memory_ledger_v1", "insertedLedgerEntries": "error"}
     lines = [
         "**BNL Memory Diagnostic (safe)**",
         f"- guild: `{guild.name}` (`{guild.id}`)",
@@ -18520,6 +18604,16 @@ async def bnl_memory_check(interaction: discord.Interaction):
         "- ambient_legacy_memory_policy: `legacy down-ranked; source-safe preferred`",
         "- direct_legacy_memory_policy: `allowed cautiously; never overrides cleaner context`",
         "- memory_tier_future_writes_source_gated: `yes`",
+        f"- memory_ledger_shadow_enabled: `{'yes' if memory_ledger_shadow_enabled() else 'no'}`",
+        f"- memory_ledger_schema: `{ledger_diag.get('schemaVersion')}`",
+        f"- memory_ledger_entries: `{ledger_diag.get('insertedLedgerEntries', 0)}`",
+        f"- memory_ledger_counts_by_source: `{ledger_diag.get('countsBySourceLane', {})}`",
+        f"- memory_ledger_counts_by_type: `{ledger_diag.get('countsByEntryType', {})}`",
+        f"- memory_ledger_counts_by_visibility: `{ledger_diag.get('countsByVisibility', {})}`",
+        f"- memory_ledger_counts_by_lifecycle: `{ledger_diag.get('countsByLifecycle', {})}`",
+        f"- memory_ledger_unmapped_provenance: `{ledger_diag.get('missingUnmappedProvenance', 0)}`",
+        f"- memory_ledger_public_rejections: `{ledger_diag.get('publicUsabilityRejections', 0)}`",
+        f"- memory_ledger_multiple_active_values: `{ledger_diag.get('entriesWithMultipleActiveValues', 0)}`",
         f"- memory_tiers_source_policy: `{memory_tier_source_policy_state}`",
         "- sealed_test_passive_capture: `disabled`",
         f"- sealed_test_conversation_rows: `{'present' if sealed_test_rows_present else 'none'}`",

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -4388,14 +4388,27 @@ def _shadow_memory_ledger_write(writer_name: str, callback, *, guild_id: int = 0
         conn.commit()
         return result
     except Exception as exc:
-        logging.debug("memory_ledger_shadow_write_failed writer=%s error=%s", writer_name, exc)
+        logging.debug("memory_ledger_shadow_write_failed writer=%s error_type=%s", writer_name, type(exc).__name__)
+        if conn is not None:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            try:
+                conn.close()
+            except Exception:
+                pass
+            conn = None
+        receipt_conn = None
         try:
-            if conn is None:
-                conn = sqlite3.connect(DB_FILE)
-            record_shadow_receipt(conn, guild_id=int(guild_id or 0), writer=writer_name, source_table=source_table, source_row_id=source_row_id, source_revision=source_revision, source_event_key=source_event_key, outcome="error", reason_code="shadow_exception", entry_id="")
-            conn.commit()
+            receipt_conn = sqlite3.connect(DB_FILE)
+            record_shadow_receipt(receipt_conn, guild_id=int(guild_id or 0), writer=writer_name, source_table=source_table, source_row_id=source_row_id, source_revision=source_revision, source_event_key=source_event_key, outcome="error", reason_code="shadow_exception", entry_id="")
+            receipt_conn.commit()
         except Exception as receipt_exc:
-            logging.debug("memory_ledger_shadow_error_receipt_failed writer=%s error=%s", writer_name, receipt_exc)
+            logging.debug("memory_ledger_shadow_error_receipt_failed writer=%s error_type=%s", writer_name, type(receipt_exc).__name__)
+        finally:
+            if receipt_conn is not None:
+                receipt_conn.close()
         return None
     finally:
         if conn is not None:
@@ -4966,7 +4979,7 @@ def _consolidate_memory_tiers(user_id: int, guild_id: int, limits: dict | None =
                 ledger_conn, row_id=row_id, user_id=user_id, guild_id=guild_id, tier=event.get("tier") or "",
                 summary=event.get("summary") or "", salience=float(event.get("salience") or 0.5), topic_key=event.get("topic_key") or "",
                 updated_at=event.get("updated_at") or datetime.now(PACIFIC_TZ).isoformat(),
-                derived_from_entry_ids=tuple(f"mle_derived_source_row_{rid}" for rid in event.get("derived_from_rows") or ()),
+                derived_from_source_row_ids=tuple(int(rid or 0) for rid in event.get("derived_from_rows") or ()),
             ),
             guild_id=guild_id, source_table="memory_tiers", source_row_id=row_id, source_revision=f"rev:{row_id}:{str(event.get('updated_at') or '').lower()}",
         )
@@ -10560,19 +10573,22 @@ def add_broadcast_memory_entry(guild_id: int, message: discord.Message, processe
         ),
     )
     new_id = cursor.lastrowid
+    committed = cursor.execute("SELECT cleaned_summary, entry_type, public_safe, status, usage_scope, submitted_by_user_id, submitted_by_name, created_at, updated_at, supersedes_id FROM broadcast_memory WHERE id=?", (new_id,)).fetchone()
     conn.commit()
     conn.close()
-    _shadow_memory_ledger_write(
-        "broadcast_memory",
-        lambda ledger_conn: shadow_broadcast_memory_row(
-            ledger_conn, row_id=int(new_id or 0), guild_id=guild_id, cleaned_summary=processed.get("cleaned_summary", ""),
-            entry_type=processed.get("entry_type", "notable_moment"), public_safe=bool(processed.get("public_safe")),
-            status="active", usage_scope=processed.get("usage_scope", "internal"),
-            submitted_by_user_id=getattr(getattr(message, "author", None), "id", None), submitted_by_name=getattr(getattr(message, "author", None), "display_name", "system"),
-            created_at=now,
-        ),
-        guild_id=guild_id, source_table="broadcast_memory", source_row_id=int(new_id or 0), source_revision=f"rev:{int(new_id or 0)}:{now.lower()}",
-    )
+    if committed:
+        committed_updated_at = committed[8] or committed[7] or now
+        _shadow_memory_ledger_write(
+            "broadcast_memory",
+            lambda ledger_conn: shadow_broadcast_memory_row(
+                ledger_conn, row_id=int(new_id or 0), guild_id=guild_id, cleaned_summary=committed[0] or "",
+                entry_type=committed[1] or "notable_moment", public_safe=bool(committed[2]),
+                status=committed[3] or "active", usage_scope=committed[4] or "internal",
+                submitted_by_user_id=committed[5], submitted_by_name=committed[6] or "system",
+                created_at=committed[7] or committed_updated_at, updated_at=committed_updated_at, supersedes_id=committed[9],
+            ),
+            guild_id=guild_id, source_table="broadcast_memory", source_row_id=int(new_id or 0), source_revision=f"rev:{int(new_id or 0)}:{committed_updated_at.lower()}",
+        )
     return int(new_id or 0)
 
 
@@ -11081,7 +11097,7 @@ def _set_broadcast_memory_status(memory_id: int, status: str, actor_id: int, act
     row = cursor.execute("SELECT guild_id, superseded_by_id FROM broadcast_memory WHERE id=?", (memory_id,)).fetchone()
     conn.commit()
     conn.close()
-    if changed and row:
+    if changed and row and not (str(status or "").lower() == "superseded" and not row[1]):
         _shadow_memory_ledger_write(
             "broadcast_memory_status",
             lambda ledger_conn: shadow_broadcast_status_event(ledger_conn, row_id=memory_id, guild_id=int(row[0] or 0), status=status, updated_at=now_iso, actor_id=actor_id, actor_name=actor_name, superseded_by_id=row[1]),

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -10573,6 +10573,8 @@ def add_broadcast_memory_entry(guild_id: int, message: discord.Message, processe
         ),
     )
     new_id = cursor.lastrowid
+    if processed.get("supersedes_id"):
+        cursor.execute("UPDATE broadcast_memory SET supersedes_id=?, corrected_by_user_id=?, corrected_by_name=?, correction_reason=?, updated_at=? WHERE id=?", (int(processed.get("supersedes_id") or 0), getattr(getattr(message, "author", None), "id", None), getattr(getattr(message, "author", None), "display_name", "system"), "replacement", now, new_id))
     committed = cursor.execute("SELECT cleaned_summary, entry_type, public_safe, status, usage_scope, submitted_by_user_id, submitted_by_name, created_at, updated_at, supersedes_id FROM broadcast_memory WHERE id=?", (new_id,)).fetchone()
     conn.commit()
     conn.close()
@@ -17178,7 +17180,6 @@ async def on_message(message: discord.Message):
                 cleared = clear_active_show_state_overrides(message.guild.id)
                 await message.reply(f"Logged. Normal schedule restored; resolved overrides: {cleared}.")
                 return
-            _set_broadcast_memory_status(target_id, "superseded", message.author.id, message.author.display_name, "explicit correction/replace request")
             if processed.get("entry_type") == "reject":
                 processed = {
                     "entry_type": target_type,
@@ -17191,23 +17192,18 @@ async def on_message(message: discord.Message):
                 }
             processed["episode_date"] = _extract_exact_episode_date(correction_text) or target_date
             processed["entry_type"] = processed.get("entry_type") or target_type
+            processed["supersedes_id"] = target_id
             new_id = add_broadcast_memory_entry(message.guild.id, faux_message, processed)
+            updated_at = datetime.now(PACIFIC_TZ).isoformat()
             conn = sqlite3.connect(DB_FILE)
             cursor = conn.cursor()
-            cursor.execute("UPDATE broadcast_memory SET supersedes_id=?, corrected_by_user_id=?, corrected_by_name=?, correction_reason=? WHERE id=?", (target_id, message.author.id, message.author.display_name, "replacement", new_id))
-            cursor.execute("UPDATE broadcast_memory SET superseded_by_id=?, updated_at=? WHERE id=?", (new_id, datetime.now(PACIFIC_TZ).isoformat(), target_id))
-            updated_at = datetime.now(PACIFIC_TZ).isoformat()
+            cursor.execute("UPDATE broadcast_memory SET status='superseded', superseded_by_id=?, updated_at=?, corrected_by_user_id=?, corrected_by_name=?, correction_reason=? WHERE id=?", (new_id, updated_at, message.author.id, message.author.display_name, "explicit correction/replace request", target_id))
             conn.commit()
             conn.close()
             _shadow_memory_ledger_write(
-                "broadcast_memory_replacement",
-                lambda ledger_conn: shadow_broadcast_memory_row(
-                    ledger_conn, row_id=int(new_id or 0), guild_id=message.guild.id, cleaned_summary=processed.get("cleaned_summary", ""),
-                    entry_type=processed.get("entry_type", target_type), public_safe=bool(processed.get("public_safe")), status="active",
-                    usage_scope=processed.get("usage_scope", "internal"), submitted_by_user_id=message.author.id, submitted_by_name=message.author.display_name,
-                    created_at=updated_at, updated_at=updated_at, supersedes_id=target_id,
-                ),
-                guild_id=message.guild.id, source_table="broadcast_memory", source_row_id=int(new_id or 0), source_revision=f"rev:{int(new_id or 0)}:{updated_at.lower()}",
+                "broadcast_memory_status",
+                lambda ledger_conn: shadow_broadcast_status_event(ledger_conn, row_id=target_id, guild_id=message.guild.id, status="superseded", updated_at=updated_at, actor_id=message.author.id, actor_name=message.author.display_name, superseded_by_id=new_id),
+                guild_id=message.guild.id, source_table="broadcast_memory", source_row_id=target_id, source_revision=f"event:status:superseded:{updated_at.lower()}", source_event_key="status:superseded",
             )
             await message.reply(f"Corrected broadcast memory: resolved/superseded id {target_id} and added replacement id {new_id} for {processed.get('episode_date')}.")
             return

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -22,10 +22,13 @@ from bnl_canon_source_contract import (
     strip_queue_sections,
 )
 from bnl_memory_ledger import (
+    LedgerWriteResult,
     build_memory_ledger_evaluation,
     ensure_memory_ledger_schema,
     shadow_broadcast_memory_row,
     shadow_conversation_row,
+    record_shadow_receipt,
+    shadow_broadcast_status_event,
     shadow_enabled as memory_ledger_shadow_enabled,
     shadow_memory_tier_row,
     shadow_relationship_journal_row,
@@ -4365,20 +4368,38 @@ def init_db():
     logging.info("✅ Database initialized successfully.")
 
 
-def _shadow_memory_ledger_write(writer_name: str, callback):
+def _shadow_memory_ledger_write(writer_name: str, callback, *, guild_id: int = 0, source_table: str = "unknown", source_row_id: int | str = "", source_revision: str = "", source_event_key: str = ""):
     if not memory_ledger_shadow_enabled():
         return None
+    conn = None
     try:
         conn = sqlite3.connect(DB_FILE)
+        result = callback(conn)
+        if not isinstance(result, LedgerWriteResult):
+            result = LedgerWriteResult(entry_id=str(result or ""), outcome="inserted" if result else "skipped", reason_code="legacy_adapter_result", source_table=source_table, source_row_id=str(source_row_id), source_revision=source_revision, source_event_key=source_event_key, guild_id=int(guild_id or 0))
         try:
-            result = callback(conn)
-            conn.commit()
-            return result
-        finally:
-            conn.close()
+            record_shadow_receipt(
+                conn, guild_id=result.guild_id or int(guild_id or 0), writer=writer_name, source_table=result.source_table or source_table,
+                source_row_id=result.source_row_id or source_row_id, source_revision=result.source_revision or source_revision,
+                source_event_key=result.source_event_key or source_event_key, outcome=result.outcome, reason_code=result.reason_code, entry_id=result.entry_id,
+            )
+        except Exception as receipt_exc:
+            logging.debug("memory_ledger_shadow_receipt_failed writer=%s error=%s", writer_name, receipt_exc)
+        conn.commit()
+        return result
     except Exception as exc:
         logging.debug("memory_ledger_shadow_write_failed writer=%s error=%s", writer_name, exc)
+        try:
+            if conn is None:
+                conn = sqlite3.connect(DB_FILE)
+            record_shadow_receipt(conn, guild_id=int(guild_id or 0), writer=writer_name, source_table=source_table, source_row_id=source_row_id, source_revision=source_revision, source_event_key=source_event_key, outcome="error", reason_code="shadow_exception", entry_id="")
+            conn.commit()
+        except Exception as receipt_exc:
+            logging.debug("memory_ledger_shadow_error_receipt_failed writer=%s error=%s", writer_name, receipt_exc)
         return None
+    finally:
+        if conn is not None:
+            conn.close()
 
 def _truncate_user_facts(user_id: int, guild_id: int, max_rows: int = MAX_FACTS_PER_USER):
     conn = sqlite3.connect(DB_FILE)
@@ -4451,6 +4472,7 @@ def upsert_user_fact(user_id: int, guild_id: int, fact_key: str, fact_value: str
     _shadow_memory_ledger_write(
         "user_memory_facts",
         lambda ledger_conn: shadow_user_fact_row(ledger_conn, row_id=fact_row_id, user_id=user_id, guild_id=guild_id, fact_key=fact_key, fact_value=fact_value, confidence=confidence, updated_at=now),
+        guild_id=guild_id, source_table="user_memory_facts", source_row_id=fact_row_id, source_revision=f"rev:{fact_row_id}:{now.lower()}",
     )
     _truncate_user_facts(user_id, guild_id, MAX_FACTS_PER_USER)
 
@@ -4577,6 +4599,7 @@ def add_relationship_journal(user_id: int, guild_id: int, entry_type: str, summa
     _shadow_memory_ledger_write(
         "relationship_journal",
         lambda ledger_conn: shadow_relationship_journal_row(ledger_conn, row_id=row_id, user_id=user_id, guild_id=guild_id, entry_type=entry_type, summary=summary[:220], timestamp=now),
+        guild_id=guild_id, source_table="relationship_journal", source_row_id=row_id, source_revision=str(row_id),
     )
 
 def get_relationship_journal(user_id: int, guild_id: int, limit: int = 5):
@@ -4840,6 +4863,7 @@ def _add_memory_tier_entry(user_id: int, guild_id: int, tier: str, summary: str,
         _shadow_memory_ledger_write(
             "memory_tiers",
             lambda ledger_conn: shadow_memory_tier_row(ledger_conn, row_id=row_id, user_id=user_id, guild_id=guild_id, tier=tier, summary=summary, salience=salience, channel_policy=source_channel_policy, topic_key=_memory_topic_key(summary), updated_at=datetime.now(PACIFIC_TZ).isoformat()),
+            guild_id=guild_id, source_table="memory_tiers", source_row_id=row_id, source_revision=f"rev:{row_id}",
         )
 
 
@@ -4865,14 +4889,17 @@ def _merge_or_insert_cluster(cursor, user_id: int, guild_id: int, tier: str, row
     if compatible:
         target = compatible[0]
         cursor.execute("UPDATE memory_tiers SET summary=?, salience=MAX(salience, ?), mentions=mentions + ?, updated_at=?, last_seen=?, lifecycle_note=? WHERE id=?", (summary, sal, mentions, now, now, lifecycle_note, target["id"]))
+        return {"row_id": target["id"], "summary": summary, "salience": sal, "tier": tier, "topic_key": topic_key, "updated_at": now, "derived_from_rows": tuple(int(r.get("id") or 0) for r in rows if r.get("id"))}
     else:
         first = rows[0]
-        _insert_memory_tier(cursor, user_id, guild_id, tier, summary, sal, mentions=mentions, source_role="consolidation", source_channel_policy=first.get("source_channel_policy") or "consolidated", source_channel_name="", source_origin=lifecycle_note, source_trust=source_trust, topic_key=topic_key, subject_key=first.get("subject_key") or "", project_key=first.get("project_key") or "", lifecycle_note=lifecycle_note)
+        row_id = _insert_memory_tier(cursor, user_id, guild_id, tier, summary, sal, mentions=mentions, source_role="consolidation", source_channel_policy=first.get("source_channel_policy") or "consolidated", source_channel_name="", source_origin=lifecycle_note, source_trust=source_trust, topic_key=topic_key, subject_key=first.get("subject_key") or "", project_key=first.get("project_key") or "", lifecycle_note=lifecycle_note)
+        return {"row_id": row_id, "summary": summary, "salience": sal, "tier": tier, "topic_key": topic_key, "updated_at": now, "derived_from_rows": tuple(int(r.get("id") or 0) for r in rows if r.get("id"))}
 
 
 def _consolidate_memory_tiers(user_id: int, guild_id: int, limits: dict | None = None) -> dict:
     limits = limits or calculate_adaptive_memory_limits(user_id, guild_id)
     result = {"short_to_medium": 0, "medium_to_long": 0, "aged_out": 0, "merged_topics": [], "limits": limits}
+    shadow_tier_events = []
     conn = sqlite3.connect(DB_FILE)
     cursor = conn.cursor()
     cols = _memory_tiers_columns(cursor)
@@ -4887,7 +4914,9 @@ def _consolidate_memory_tiers(user_id: int, guild_id: int, limits: dict | None =
             buckets[(topic, group)].append(r)
         for (topic, _group), rows in buckets.items():
             trust = _consolidated_trust_for(rows)
-            _merge_or_insert_cluster(cursor, user_id, guild_id, "medium", rows, topic, trust, "consolidated_short_to_medium")
+            shadow_event = _merge_or_insert_cluster(cursor, user_id, guild_id, "medium", rows, topic, trust, "consolidated_short_to_medium")
+            if shadow_event:
+                shadow_tier_events.append(shadow_event)
             result["short_to_medium"] += len(rows); result["merged_topics"].append(topic)
         cursor.executemany("DELETE FROM memory_tiers WHERE id=?", [(r["id"],) for r in overflow])
 
@@ -4907,7 +4936,9 @@ def _consolidate_memory_tiers(user_id: int, guild_id: int, limits: dict | None =
             confirmed = any(any(k in (r.get("summary") or "").lower() for k in ("remember", "confirmed", "owner-confirmed", "this matters", "keep this")) for r in rows)
             safe = _memory_visibility_group(rows[0].get("source_trust", ""), rows[0].get("source_channel_policy", "")) != "sealed_test"
             if safe and (repeated or high_salience or confirmed):
-                _merge_or_insert_cluster(cursor, user_id, guild_id, "long", rows, topic, _consolidated_trust_for(rows), "crystallized_medium_to_long")
+                shadow_event = _merge_or_insert_cluster(cursor, user_id, guild_id, "long", rows, topic, _consolidated_trust_for(rows), "crystallized_medium_to_long")
+                if shadow_event:
+                    shadow_tier_events.append(shadow_event)
                 result["medium_to_long"] += len(rows); result["merged_topics"].append(topic)
                 promoted_ids.update(r["id"] for r in rows)
             elif not safe or max(float(r.get("salience") or 0.0) for r in rows) < 0.55:
@@ -4925,6 +4956,20 @@ def _consolidate_memory_tiers(user_id: int, guild_id: int, limits: dict | None =
     result["aged_out"] += max(0, len(_fetch_tier_rows(cursor, user_id, guild_id, "long")) - limits["long"])
     conn.commit()
     conn.close()
+    for event in shadow_tier_events:
+        row_id = int(event.get("row_id") or 0)
+        if not row_id:
+            continue
+        _shadow_memory_ledger_write(
+            "memory_tiers_consolidation",
+            lambda ledger_conn, event=event, row_id=row_id: shadow_memory_tier_row(
+                ledger_conn, row_id=row_id, user_id=user_id, guild_id=guild_id, tier=event.get("tier") or "",
+                summary=event.get("summary") or "", salience=float(event.get("salience") or 0.5), topic_key=event.get("topic_key") or "",
+                updated_at=event.get("updated_at") or datetime.now(PACIFIC_TZ).isoformat(),
+                derived_from_entry_ids=tuple(f"mle_derived_source_row_{rid}" for rid in event.get("derived_from_rows") or ()),
+            ),
+            guild_id=guild_id, source_table="memory_tiers", source_row_id=row_id, source_revision=f"rev:{row_id}:{str(event.get('updated_at') or '').lower()}",
+        )
     LAST_MEMORY_LIFECYCLE_RESULT[(user_id, guild_id)] = result
     return result
 
@@ -9423,6 +9468,7 @@ def save_user_message(user_id: int, user_name: str, guild_id: int, content: str,
             content=content, channel_name=(channel_name or "").lower()[:80], channel_policy=(channel_policy or "unknown")[:40],
             channel_id=int(channel_id or 0), message_id=int(message_id or 0) or None, route_mode=route_mode, observed_at=observed_at,
         ),
+        guild_id=guild_id, source_table="conversations", source_row_id=row_id, source_revision=str(row_id),
     )
     try:
         mark_subject_dirty_for_evidence(
@@ -9486,10 +9532,11 @@ def save_model_message(user_id: int, guild_id: int, content: str, channel_name: 
     _shadow_memory_ledger_write(
         "conversations_model",
         lambda ledger_conn: shadow_conversation_row(
-            ledger_conn, row_id=row_id, user_id=user_id, user_name="BNL-01", guild_id=guild_id, role="model",
+            ledger_conn, row_id=row_id, user_id=user_id, user_name="", guild_id=guild_id, role="model",
             content=content, channel_name=(channel_name or "").lower()[:80], channel_policy=(channel_policy or "unknown")[:40],
             channel_id=int(channel_id or 0), message_id=None, route_mode=route_mode, observed_at=observed_at,
         ),
+        guild_id=guild_id, source_table="conversations", source_row_id=row_id, source_revision=str(row_id),
     )
     prune_conversation_history(user_id, guild_id, calculate_adaptive_memory_limits(user_id, guild_id, route_mode=route_mode, channel_policy=channel_policy, user_text=content).get("conversation_rows", MAX_CONVERSATION_ROWS_PER_USER))
     if decision.update_relationship:
@@ -10524,6 +10571,7 @@ def add_broadcast_memory_entry(guild_id: int, message: discord.Message, processe
             submitted_by_user_id=getattr(getattr(message, "author", None), "id", None), submitted_by_name=getattr(getattr(message, "author", None), "display_name", "system"),
             created_at=now,
         ),
+        guild_id=guild_id, source_table="broadcast_memory", source_row_id=int(new_id or 0), source_revision=f"rev:{int(new_id or 0)}:{now.lower()}",
     )
     return int(new_id or 0)
 
@@ -11029,9 +11077,16 @@ def _set_broadcast_memory_status(memory_id: int, status: str, actor_id: int, act
         """,
         (status, now_iso, actor_id, actor_name, reason[:200], memory_id),
     )
-    conn.commit()
     changed = cursor.rowcount
+    row = cursor.execute("SELECT guild_id, superseded_by_id FROM broadcast_memory WHERE id=?", (memory_id,)).fetchone()
+    conn.commit()
     conn.close()
+    if changed and row:
+        _shadow_memory_ledger_write(
+            "broadcast_memory_status",
+            lambda ledger_conn: shadow_broadcast_status_event(ledger_conn, row_id=memory_id, guild_id=int(row[0] or 0), status=status, updated_at=now_iso, actor_id=actor_id, actor_name=actor_name, superseded_by_id=row[1]),
+            guild_id=int(row[0] or 0), source_table="broadcast_memory", source_row_id=memory_id, source_revision=f"event:status:{status}:{now_iso.lower()}", source_event_key=f"status:{status}",
+        )
     return int(changed or 0)
 
 async def process_broadcast_memory_note(message) -> dict:
@@ -17125,8 +17180,19 @@ async def on_message(message: discord.Message):
             cursor = conn.cursor()
             cursor.execute("UPDATE broadcast_memory SET supersedes_id=?, corrected_by_user_id=?, corrected_by_name=?, correction_reason=? WHERE id=?", (target_id, message.author.id, message.author.display_name, "replacement", new_id))
             cursor.execute("UPDATE broadcast_memory SET superseded_by_id=?, updated_at=? WHERE id=?", (new_id, datetime.now(PACIFIC_TZ).isoformat(), target_id))
+            updated_at = datetime.now(PACIFIC_TZ).isoformat()
             conn.commit()
             conn.close()
+            _shadow_memory_ledger_write(
+                "broadcast_memory_replacement",
+                lambda ledger_conn: shadow_broadcast_memory_row(
+                    ledger_conn, row_id=int(new_id or 0), guild_id=message.guild.id, cleaned_summary=processed.get("cleaned_summary", ""),
+                    entry_type=processed.get("entry_type", target_type), public_safe=bool(processed.get("public_safe")), status="active",
+                    usage_scope=processed.get("usage_scope", "internal"), submitted_by_user_id=message.author.id, submitted_by_name=message.author.display_name,
+                    created_at=updated_at, updated_at=updated_at, supersedes_id=target_id,
+                ),
+                guild_id=message.guild.id, source_table="broadcast_memory", source_row_id=int(new_id or 0), source_revision=f"rev:{int(new_id or 0)}:{updated_at.lower()}",
+            )
             await message.reply(f"Corrected broadcast memory: resolved/superseded id {target_id} and added replacement id {new_id} for {processed.get('episode_date')}.")
             return
         processed_entries = await process_broadcast_memory_notes(message)

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -45,16 +45,6 @@ REJECTED_LIFECYCLE = "rejected"
 _NUMBER_REMEMBER_RE = re.compile(r"\bremember\b[^\n]{0,80}?\bnumber\b\D+(\d{1,12})(?!\d)", re.I)
 _REPLACE_NUMBER_RE = re.compile(r"\b(?:replace|supersede)\s+(\d{1,12})\s+\bwith\b\s+(\d{1,12})(?!\d)", re.I)
 _CORRECTION_NUMBER_RE = re.compile(r"\b(?:correction|actually|correcting|i meant)\b[^\n]{0,80}?\b(?:number\s+)?(?:is|was)?\s*(\d{1,12})\s*,?\s+not\s+(\d{1,12})(?!\d)", re.I)
-_QUEUE_OPERATIONAL_RE = re.compile(
-    r"\b(?:website|site|current|live)\s+queue\s+(?:is|was|currently|status|open|closed|active|available|full)\b|\bqueue\s+(?:status|open|closed)\b"
-    r"|\bqueue\s+(?:is\s+)?currently\s+(?:open|closed|active|available|full)\b"
-    r"|\bpayment\s+(?:cleared|pending|paid|failed|confirmed)\b"
-    r"|\bnow\s*playing\b|\bup\s*next\b|\bcurrent\s+session\b|\bavailability\b"
-    r"|\bpriority\s+(?:signal|slot|enabled|upgrade)\b|\bwheel\s+(?:spin|owed|enabled)\b"
-    r"|\bqueue[-_ ]derived\s+artist\b|\bqueueOpen\b|\bcurrentTrack\b|\bupNext\b|\bqueuedTracks\b",
-    re.I,
-)
-
 @dataclass(frozen=True)
 class LedgerWriteResult:
     entry_id: str = ""
@@ -271,9 +261,6 @@ def _public_ok(subject_key: str, predicate: str, value: str, source_class: Sourc
     return is_public_usable(claim)
 
 
-def is_queue_operational_state(text: str) -> bool:
-    return bool(_QUEUE_OPERATIONAL_RE.search(text or ""))
-
 
 def _unique_active_value_target(conn: sqlite3.Connection, *, guild_id: int, subject_key: str, predicate_key: str, old_value: str) -> str:
     ensure_memory_ledger_schema(conn)
@@ -304,17 +291,15 @@ def _conversation_fact(text: str, conn: sqlite3.Connection, guild_id: int, subje
         new, old = correction.group(1), correction.group(2)
         target = _unique_active_value_target(conn, guild_id=guild_id, subject_key=subject_key, predicate_key="remembered_number", old_value=old)
         if target:
-            return "remembered_number", new, (("correction_of", target),), ACTIVE_LIFECYCLE, "explicit_correction_linked"
+            return "remembered_number", new, (("supersedes", target), ("correction_of", target)), ACTIVE_LIFECYCLE, "explicit_correction_linked"
         return "remembered_number", new, (), REVIEW_ONLY_LIFECYCLE, "unresolved_correction_target"
     if "?" in (text or ""):
-        return "question", "", (), ACTIVE_LIFECYCLE, "ok"
+        return "conversation", (text or "")[:500], (), ACTIVE_LIFECYCLE, "ok"
     return "conversation", (text or "")[:500], (), ACTIVE_LIFECYCLE, "ok"
 
 
 def shadow_conversation_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, user_name: str, guild_id: int, role: str, content: str, channel_name: str = "", channel_policy: str = "unknown", channel_id: int = 0, message_id: int | None = None, route_mode: str = "unknown", observed_at: str = "") -> LedgerWriteResult:
     role_norm = (role or "").lower()
-    if role_norm == "user" and is_queue_operational_state(content):
-        return skipped_result(guild_id=guild_id, source_table="conversations", source_row_id=row_id, reason_code="queue_operational_state_excluded", source_revision=str(row_id))
     visibility = _visibility(channel_policy)
     if role_norm != "user":
         subject_key = BNL_SUBJECT_KEY
@@ -336,9 +321,23 @@ def shadow_user_fact_row(conn: sqlite3.Connection, *, row_id: int, user_id: int,
     return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="user_memory_facts", source_row_id=row_id, source_revision=rev, source_role="legacy_source_blind", entry_type="claim", subject_key=subject_key_for_user(user_id), predicate_key=fact_key or "legacy_fact", value=(fact_value or "")[:500], source_class=SourceClass.LEGACY_SOURCE_BLIND, visibility=Visibility.PRIVATE, confidence=Confidence.LOW, public_usable=False, observed_at=updated_at or _now(), source_sequence=int(row_id or 0), lifecycle_status=REVIEW_ONLY_LIFECYCLE, participants=(LedgerParticipant(subject_key_for_user(user_id), "", "subject", 0),)))
 
 
-def shadow_memory_tier_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, guild_id: int, tier: str, summary: str, salience: float = 0.5, channel_policy: str = "legacy_unknown", topic_key: str = "", updated_at: str = "", derived_from_entry_ids: tuple[str, ...] = ()) -> LedgerWriteResult:
+def _entry_ids_for_source_rows(conn: sqlite3.Connection, *, guild_id: int, source_table: str, source_row_ids: tuple[int, ...]) -> tuple[str, ...]:
+    ensure_memory_ledger_schema(conn)
+    ids: list[str] = []
+    for source_row_id in source_row_ids:
+        rows = conn.execute(
+            "SELECT entry_id FROM memory_ledger_entries WHERE guild_id=? AND source_table=? AND source_row_id=? ORDER BY created_at DESC",
+            (guild_id, source_table, str(source_row_id)),
+        ).fetchall()
+        if len(rows) == 1:
+            ids.append(rows[0][0])
+    return tuple(sorted(set(ids)))
+
+
+def shadow_memory_tier_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, guild_id: int, tier: str, summary: str, salience: float = 0.5, channel_policy: str = "legacy_unknown", topic_key: str = "", updated_at: str = "", derived_from_entry_ids: tuple[str, ...] = (), derived_from_source_row_ids: tuple[int, ...] = ()) -> LedgerWriteResult:
     rev = source_revision_for(row_id, updated_at)
-    lineage = tuple(("derived_from", eid) for eid in sorted(set(derived_from_entry_ids)) if eid)
+    real_source_ids = _entry_ids_for_source_rows(conn, guild_id=guild_id, source_table="memory_tiers", source_row_ids=derived_from_source_row_ids)
+    lineage = tuple(("derived_from", eid) for eid in sorted(set(tuple(derived_from_entry_ids) + real_source_ids)) if eid)
     return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="memory_tiers", source_row_id=row_id, source_revision=rev, source_role="derived_projection", entry_type="derived_summary", subject_key=subject_key_for_user(user_id), predicate_key=topic_key or f"memory_tier:{tier}", value=(summary or "")[:500], source_class=SourceClass.DERIVED_SUMMARY, visibility=Visibility.PRIVATE, confidence=Confidence.LOW, public_usable=False, derived=True, projection=True, salience=salience, observed_at=updated_at or _now(), source_sequence=int(row_id or 0), lifecycle_status=REVIEW_ONLY_LIFECYCLE, participants=(LedgerParticipant(subject_key_for_user(user_id), "", "subject", 0),), lineage=lineage))
 
 
@@ -346,14 +345,24 @@ def shadow_relationship_journal_row(conn: sqlite3.Connection, *, row_id: int, us
     return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="relationship_journal", source_row_id=row_id, source_revision=str(row_id), source_role="internal", entry_type="relationship_event", subject_key=subject_key_for_user(user_id), predicate_key=entry_type or "relationship_event", value=(summary or "")[:500], source_class=SourceClass.DERIVED_SUMMARY, visibility=Visibility.INTERNAL, confidence=Confidence.LOW, public_usable=False, derived=True, projection=True, salience=0.3, observed_at=timestamp or _now(), source_sequence=int(row_id or 0), lifecycle_status=REVIEW_ONLY_LIFECYCLE, participants=(LedgerParticipant(subject_key_for_user(user_id), "", "subject", 0),)))
 
 
+def _unique_entry_for_source(conn: sqlite3.Connection, *, guild_id: int, source_table: str, source_row_id: int | str, preferred_lifecycle: str | None = None) -> str:
+    ensure_memory_ledger_schema(conn)
+    sql = "SELECT entry_id FROM memory_ledger_entries WHERE guild_id=? AND source_table=? AND source_row_id=?"
+    params: list[Any] = [guild_id, source_table, str(source_row_id)]
+    if preferred_lifecycle:
+        sql += " AND lifecycle_status=?"
+        params.append(preferred_lifecycle)
+    rows = conn.execute(sql + " ORDER BY created_at DESC", params).fetchall()
+    return rows[0][0] if len(rows) == 1 else ""
+
+
 def shadow_broadcast_memory_row(conn: sqlite3.Connection, *, row_id: int, guild_id: int, cleaned_summary: str, entry_type: str, public_safe: bool, status: str, usage_scope: str, submitted_by_user_id: int | None = None, submitted_by_name: str = "", created_at: str = "", updated_at: str = "", supersedes_id: int | None = None) -> LedgerWriteResult:
     if not cleaned_summary:
         return skipped_result(guild_id=guild_id, source_table="broadcast_memory", source_row_id=row_id, reason_code="empty_cleaned_summary", source_revision=source_revision_for(row_id, updated_at or created_at))
     lifecycle = ACTIVE_LIFECYCLE if str(status or "active").lower() == "active" else (RESOLVED_LIFECYCLE if str(status or "").lower() == "resolved" else REVIEW_ONLY_LIFECYCLE)
-    public_ok = bool(public_safe and lifecycle == ACTIVE_LIFECYCLE and any(scope in {"public", "public_context", "recap", "show", "website", "broadcast", "ambient", "direct", "relay"} for scope in re.split(r"[,\s]+", usage_scope or "")))
-    target = ""
-    if supersedes_id:
-        target = stable_entry_id(guild_id=guild_id, source_table="broadcast_memory", source_row_id=supersedes_id, source_revision=str(supersedes_id), entry_type="show_event" if "show" in (entry_type or "") else "event", subject_key="barcode_radio", predicate_key=entry_type or "broadcast_memory")
+    scopes = {scope.strip().lower() for scope in re.split(r"[,\s]+", usage_scope or "") if scope.strip()}
+    public_ok = bool(public_safe and lifecycle == ACTIVE_LIFECYCLE and bool(scopes & {"ambient", "direct", "show_status", "relay"}))
+    target = _unique_entry_for_source(conn, guild_id=guild_id, source_table="broadcast_memory", source_row_id=supersedes_id, preferred_lifecycle=ACTIVE_LIFECYCLE) if supersedes_id else ""
     lineage = (("supersedes", target), ("correction_of", target)) if target else ()
     rev = source_revision_for(row_id, updated_at or created_at)
     return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="broadcast_memory", source_row_id=row_id, source_revision=rev, source_role="broadcast_memory", entry_type="show_event" if "show" in (entry_type or "") else "event", subject_key="barcode_radio", subject_display_name="BARCODE Radio", predicate_key=entry_type or "broadcast_memory", value=cleaned_summary[:500], source_class=SourceClass.FIRST_PARTY_RECORD, visibility=Visibility.PUBLIC_SAFE if public_ok else Visibility.INTERNAL, confidence=Confidence.HIGH if public_ok else Confidence.MEDIUM, public_usable=public_ok, salience=0.5, observed_at=created_at or updated_at or _now(), source_sequence=int(row_id or 0), freshness=usage_scope or "", lifecycle_status=lifecycle, participants=tuple([LedgerParticipant(f"discord_user:{submitted_by_user_id}", submitted_by_name or "", "submitter", 0)] if submitted_by_user_id else ()), lineage=lineage))
@@ -403,11 +412,17 @@ def build_memory_ledger_evaluation(conn: sqlite3.Connection, *, guild_id: int | 
     report["publicUsabilityRejections"] = int(cur.fetchone()[0] or 0)
     cur.execute(f"SELECT COUNT(*) FROM memory_ledger_entries{where + (' AND' if where else ' WHERE')} entry_id NOT IN (SELECT target_entry_id FROM memory_ledger_lineage WHERE {'guild_id=? AND ' if guild_id is not None else ''} lineage_type IN ('supersedes','retracts')) AND lifecycle_status='active' GROUP BY subject_key, predicate_key HAVING COUNT(*) > 1", params + ([guild_id] if guild_id is not None else []))
     report["entriesWithMultipleActiveValues"] = len(cur.fetchall())
-    cur.execute(f"SELECT lineage_type, COUNT(*) FROM memory_ledger_lineage{where} GROUP BY lineage_type", params)
-    lineage_counts = dict(cur.fetchall())
-    report["explicitCorrectionCounts"] = int(lineage_counts.get("correction_of", 0) + lineage_counts.get("supersedes", 0))
+    cur.execute(f"SELECT COUNT(DISTINCT entry_id) FROM memory_ledger_lineage{where + (' AND' if where else ' WHERE')} lineage_type IN ('correction_of','supersedes')", params)
+    report["explicitCorrectionCounts"] = int(cur.fetchone()[0] or 0)
     cur.execute(f"SELECT COUNT(*) FROM memory_ledger_entries{where + (' AND' if where else ' WHERE')} lifecycle_status='review_only' AND predicate_key='remembered_number'", params)
     report["unresolvedCorrectionAttempts"] = int(cur.fetchone()[0] or 0)
-    report["legacyToLedgerParityMismatches"] = 0
-    report["implicitSupersessionsBlocked"] = int(report.get("entriesWithMultipleActiveValues", 0))
+    cur.execute(f"SELECT COUNT(*) FROM memory_ledger_shadow_receipts{where + (' AND' if where else ' WHERE')} outcome IN ('inserted','deduplicated') AND (entry_id='' OR entry_id NOT IN (SELECT entry_id FROM memory_ledger_entries WHERE {'guild_id=? AND ' if guild_id is not None else ''} 1=1))", params + ([guild_id] if guild_id is not None else []))
+    missing_receipt_entries = int(cur.fetchone()[0] or 0)
+    cur.execute(f"SELECT COUNT(*) FROM memory_ledger_entries e{where.replace('WHERE', 'WHERE e.') if where else ''} AND NOT EXISTS (SELECT 1 FROM memory_ledger_shadow_receipts r WHERE r.guild_id=e.guild_id AND r.entry_id=e.entry_id AND r.outcome IN ('inserted','deduplicated'))" if where else "SELECT COUNT(*) FROM memory_ledger_entries e WHERE NOT EXISTS (SELECT 1 FROM memory_ledger_shadow_receipts r WHERE r.guild_id=e.guild_id AND r.entry_id=e.entry_id AND r.outcome IN ('inserted','deduplicated'))", params)
+    entries_without_receipts = int(cur.fetchone()[0] or 0)
+    cur.execute(f"SELECT COUNT(*) FROM memory_ledger_lineage l{where.replace('WHERE', 'WHERE l.') if where else ''} AND NOT EXISTS (SELECT 1 FROM memory_ledger_entries e WHERE e.guild_id=l.guild_id AND e.entry_id=l.target_entry_id)" if where else "SELECT COUNT(*) FROM memory_ledger_lineage l WHERE NOT EXISTS (SELECT 1 FROM memory_ledger_entries e WHERE e.guild_id=l.guild_id AND e.entry_id=l.target_entry_id)", params)
+    dangling_lineage = int(cur.fetchone()[0] or 0)
+    report["danglingLineageTargets"] = dangling_lineage
+    report["legacyToLedgerParityMismatches"] = missing_receipt_entries + entries_without_receipts + dangling_lineage + int(report.get("shadowWriteErrors", 0)) + int(report.get("unresolvedCorrectionAttempts", 0))
+    report["implicitSupersessionsBlocked"] = 0
     return report

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -9,11 +9,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 import hashlib
-import json
 import os
 import re
 import sqlite3
-from typing import Any, Iterable
+from typing import Any
 
 from bnl_canon_source_contract import (
     Confidence,
@@ -30,20 +29,52 @@ from bnl_canon_source_contract import (
 
 MEMORY_LEDGER_SCHEMA_VERSION = "memory_ledger_v1"
 MEMORY_LEDGER_SHADOW_ENV = "BNL_MEMORY_LEDGER_SHADOW_ENABLED"
+BNL_SUBJECT_KEY = "bnl_01"
 
 ENTRY_TYPES = frozenset({
     "observation", "claim", "event", "preference", "boundary", "goal", "open_loop", "commitment",
     "shared_moment", "relationship_event", "canon_reference", "show_event", "unresolved_question", "derived_summary",
 })
 LINEAGE_TYPES = frozenset({"derived_from", "correction_of", "supersedes", "retracts", "duplicate_of", "part_of_moment"})
+OUTCOMES = frozenset({"inserted", "deduplicated", "skipped", "error"})
 ACTIVE_LIFECYCLE = "active"
 REVIEW_ONLY_LIFECYCLE = "review_only"
+RESOLVED_LIFECYCLE = "resolved"
 REJECTED_LIFECYCLE = "rejected"
 
-_QUEUE_STATE_RE = re.compile(r"\b(?:website|site|payment|session|availability|now[- ]?playing|up[- ]?next|priority|wheel|queue_open|current queue|queue status)\b", re.I)
-_NUMBER_REMEMBER_RE = re.compile(r"\bremember\b.*?\bnumber\b\D+(\d{2,})", re.I)
-_REPLACE_RE = re.compile(r"\b(?:replace|supersede)\s+(.{1,80}?)\s+\bwith\b\s+(.{1,80})", re.I)
-_NOT_RE = re.compile(r"\b(.{1,80}?)\s*,?\s+not\s+(.{1,80})", re.I)
+_NUMBER_REMEMBER_RE = re.compile(r"\bremember\b[^\n]{0,80}?\bnumber\b\D+(\d{1,12})(?!\d)", re.I)
+_REPLACE_NUMBER_RE = re.compile(r"\b(?:replace|supersede)\s+(\d{1,12})\s+\bwith\b\s+(\d{1,12})(?!\d)", re.I)
+_CORRECTION_NUMBER_RE = re.compile(r"\b(?:correction|actually|correcting|i meant)\b[^\n]{0,80}?\b(?:number\s+)?(?:is|was)?\s*(\d{1,12})\s*,?\s+not\s+(\d{1,12})(?!\d)", re.I)
+_QUEUE_OPERATIONAL_RE = re.compile(
+    r"\b(?:website|site|current|live)\s+queue\s+(?:is|was|currently|status|open|closed|active|available|full)\b|\bqueue\s+(?:status|open|closed)\b"
+    r"|\bqueue\s+(?:is\s+)?currently\s+(?:open|closed|active|available|full)\b"
+    r"|\bpayment\s+(?:cleared|pending|paid|failed|confirmed)\b"
+    r"|\bnow\s*playing\b|\bup\s*next\b|\bcurrent\s+session\b|\bavailability\b"
+    r"|\bpriority\s+(?:signal|slot|enabled|upgrade)\b|\bwheel\s+(?:spin|owed|enabled)\b"
+    r"|\bqueue[-_ ]derived\s+artist\b|\bqueueOpen\b|\bcurrentTrack\b|\bupNext\b|\bqueuedTracks\b",
+    re.I,
+)
+
+@dataclass(frozen=True)
+class LedgerWriteResult:
+    entry_id: str = ""
+    outcome: str = "skipped"
+    reason_code: str = "not_attempted"
+    source_table: str = ""
+    source_row_id: str = ""
+    source_revision: str = ""
+    source_event_key: str = ""
+    guild_id: int = 0
+
+    def __post_init__(self):
+        if self.outcome not in OUTCOMES:
+            object.__setattr__(self, "outcome", "error")
+
+    def __str__(self) -> str:
+        return self.entry_id
+
+    def __bool__(self) -> bool:
+        return self.outcome in {"inserted", "deduplicated"} and bool(self.entry_id)
 
 
 def shadow_enabled(environ: dict[str, str] | None = None) -> bool:
@@ -65,8 +96,16 @@ def subject_key_for_user(user_id: int | str | None) -> str:
     return f"discord_user:{int(user_id or 0)}"
 
 
-def stable_entry_id(*, guild_id: int | str | None, source_table: str, source_row_id: int | str, entry_type: str, subject_key: str, predicate_key: str) -> str:
-    parts = [MEMORY_LEDGER_SCHEMA_VERSION, str(guild_id or 0), _canon(source_table), str(source_row_id), _canon(entry_type), _canon(subject_key), _canon(predicate_key)]
+def source_revision_for(row_id: int | str, updated_at: str | None = None, event: str | None = None) -> str:
+    if event:
+        return f"event:{_canon(event)}"
+    if updated_at:
+        return f"rev:{row_id}:{_canon(updated_at)}"
+    return str(row_id or "0")
+
+
+def stable_entry_id(*, guild_id: int | str | None, source_table: str, source_row_id: int | str, entry_type: str, subject_key: str, predicate_key: str, source_revision: str = "") -> str:
+    parts = [MEMORY_LEDGER_SCHEMA_VERSION, str(guild_id or 0), _canon(source_table), str(source_row_id), _canon(source_revision or source_row_id), _canon(entry_type), _canon(subject_key), _canon(predicate_key)]
     return "mle_" + hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()[:40]
 
 
@@ -95,6 +134,8 @@ class LedgerEntry:
     channel_name: str = ""
     channel_policy: str = "unknown"
     source_message_id: int | None = None
+    source_revision: str = ""
+    source_event_key: str = ""
     visibility: Visibility = Visibility.UNKNOWN
     confidence: Confidence = Confidence.UNKNOWN
     public_usable: bool = False
@@ -112,7 +153,7 @@ class LedgerEntry:
 
     @property
     def entry_id(self) -> str:
-        return stable_entry_id(guild_id=self.guild_id, source_table=self.source_table, source_row_id=self.source_row_id, entry_type=self.entry_type, subject_key=self.subject_key, predicate_key=self.predicate_key)
+        return stable_entry_id(guild_id=self.guild_id, source_table=self.source_table, source_row_id=self.source_row_id, entry_type=self.entry_type, subject_key=self.subject_key, predicate_key=self.predicate_key, source_revision=self.source_revision)
 
 
 def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
@@ -122,22 +163,34 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
             entry_id TEXT PRIMARY KEY, schema_version TEXT NOT NULL, guild_id INTEGER NOT NULL,
             subject_key TEXT NOT NULL, subject_display_name TEXT, entry_type TEXT NOT NULL,
             predicate_key TEXT NOT NULL, normalized_value TEXT, source_class TEXT NOT NULL,
-            source_table TEXT NOT NULL, source_row_id TEXT NOT NULL, source_role TEXT NOT NULL,
-            route_mode TEXT, channel_id INTEGER, channel_name TEXT, channel_policy TEXT,
+            source_table TEXT NOT NULL, source_row_id TEXT NOT NULL, source_revision TEXT DEFAULT '', source_event_key TEXT DEFAULT '',
+            source_role TEXT NOT NULL, route_mode TEXT, channel_id INTEGER, channel_name TEXT, channel_policy TEXT,
             source_message_id INTEGER, visibility TEXT NOT NULL, confidence TEXT NOT NULL,
             public_usable INTEGER DEFAULT 0, derived INTEGER DEFAULT 0, projection INTEGER DEFAULT 0,
             salience REAL DEFAULT 0.0, observed_at TEXT, source_sequence INTEGER,
             valid_from TEXT, valid_until TEXT, freshness TEXT, lifecycle_status TEXT NOT NULL,
             created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
-            UNIQUE(schema_version, guild_id, source_table, source_row_id, entry_type, subject_key, predicate_key)
+            UNIQUE(schema_version, guild_id, source_table, source_row_id, source_revision, entry_type, subject_key, predicate_key)
         )
     """)
+    for sql in (
+        "ALTER TABLE memory_ledger_entries ADD COLUMN source_revision TEXT DEFAULT ''",
+        "ALTER TABLE memory_ledger_entries ADD COLUMN source_event_key TEXT DEFAULT ''",
+    ):
+        try:
+            cur.execute(sql)
+        except sqlite3.OperationalError:
+            pass
     cur.execute("""
         CREATE TABLE IF NOT EXISTS memory_ledger_lineage (
-            entry_id TEXT NOT NULL, lineage_type TEXT NOT NULL, target_entry_id TEXT NOT NULL,
+            entry_id TEXT NOT NULL, guild_id INTEGER NOT NULL DEFAULT 0, lineage_type TEXT NOT NULL, target_entry_id TEXT NOT NULL,
             created_at TEXT NOT NULL, PRIMARY KEY(entry_id, lineage_type, target_entry_id)
         )
     """)
+    try:
+        cur.execute("ALTER TABLE memory_ledger_lineage ADD COLUMN guild_id INTEGER NOT NULL DEFAULT 0")
+    except sqlite3.OperationalError:
+        pass
     cur.execute("""
         CREATE TABLE IF NOT EXISTS memory_ledger_participants (
             entry_id TEXT NOT NULL, guild_id INTEGER NOT NULL, participant_key TEXT NOT NULL,
@@ -145,41 +198,64 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
             PRIMARY KEY(entry_id, participant_key, participant_role)
         )
     """)
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS memory_ledger_shadow_receipts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER NOT NULL, writer TEXT NOT NULL,
+            source_table TEXT NOT NULL, source_row_id TEXT NOT NULL, source_revision TEXT DEFAULT '', source_event_key TEXT DEFAULT '',
+            attempted_at TEXT NOT NULL, outcome TEXT NOT NULL, reason_code TEXT NOT NULL, entry_id TEXT DEFAULT ''
+        )
+    """)
     for sql in [
         "CREATE INDEX IF NOT EXISTS idx_mle_guild ON memory_ledger_entries(guild_id)",
         "CREATE INDEX IF NOT EXISTS idx_mle_subject ON memory_ledger_entries(guild_id, subject_key)",
-        "CREATE INDEX IF NOT EXISTS idx_mle_type ON memory_ledger_entries(entry_type)",
-        "CREATE INDEX IF NOT EXISTS idx_mle_source ON memory_ledger_entries(source_table, source_row_id)",
-        "CREATE INDEX IF NOT EXISTS idx_mle_lifecycle ON memory_ledger_entries(lifecycle_status)",
-        "CREATE INDEX IF NOT EXISTS idx_mle_visibility ON memory_ledger_entries(visibility)",
+        "CREATE INDEX IF NOT EXISTS idx_mle_type ON memory_ledger_entries(guild_id, entry_type)",
+        "CREATE INDEX IF NOT EXISTS idx_mle_source ON memory_ledger_entries(guild_id, source_table, source_row_id, source_revision)",
+        "CREATE INDEX IF NOT EXISTS idx_mle_lifecycle ON memory_ledger_entries(guild_id, lifecycle_status)",
+        "CREATE INDEX IF NOT EXISTS idx_mle_visibility ON memory_ledger_entries(guild_id, visibility)",
         "CREATE INDEX IF NOT EXISTS idx_mle_predicate ON memory_ledger_entries(guild_id, predicate_key)",
-        "CREATE INDEX IF NOT EXISTS idx_mle_observed ON memory_ledger_entries(observed_at)",
+        "CREATE INDEX IF NOT EXISTS idx_mle_observed ON memory_ledger_entries(guild_id, observed_at)",
+        "CREATE INDEX IF NOT EXISTS idx_mll_guild ON memory_ledger_lineage(guild_id, lineage_type, target_entry_id)",
         "CREATE INDEX IF NOT EXISTS idx_mlp_participant ON memory_ledger_participants(guild_id, participant_key, order_index)",
+        "CREATE INDEX IF NOT EXISTS idx_mlr_guild ON memory_ledger_shadow_receipts(guild_id, writer, outcome, reason_code)",
     ]:
         cur.execute(sql)
 
 
-def insert_ledger_entry(conn: sqlite3.Connection, entry: LedgerEntry) -> str:
+def record_shadow_receipt(conn: sqlite3.Connection, *, guild_id: int, writer: str, source_table: str, source_row_id: int | str, source_revision: str = "", source_event_key: str = "", outcome: str, reason_code: str, entry_id: str = "") -> None:
+    ensure_memory_ledger_schema(conn)
+    conn.execute(
+        "INSERT INTO memory_ledger_shadow_receipts (guild_id, writer, source_table, source_row_id, source_revision, source_event_key, attempted_at, outcome, reason_code, entry_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (int(guild_id or 0), (writer or "unknown")[:80], (source_table or "unknown")[:80], str(source_row_id or ""), (source_revision or "")[:160], (source_event_key or "")[:160], _now(), outcome if outcome in OUTCOMES else "error", (reason_code or "unknown")[:120], entry_id or ""),
+    )
+
+
+def skipped_result(*, guild_id: int, source_table: str, source_row_id: int | str, reason_code: str, source_revision: str = "", source_event_key: str = "") -> LedgerWriteResult:
+    return LedgerWriteResult(outcome="skipped", reason_code=reason_code, source_table=source_table, source_row_id=str(source_row_id), source_revision=source_revision, source_event_key=source_event_key, guild_id=int(guild_id or 0))
+
+
+def insert_ledger_entry(conn: sqlite3.Connection, entry: LedgerEntry) -> LedgerWriteResult:
     if entry.entry_type not in ENTRY_TYPES:
-        raise ValueError(f"unsupported ledger entry type: {entry.entry_type}")
+        return LedgerWriteResult(outcome="error", reason_code="unsupported_entry_type", source_table=entry.source_table, source_row_id=str(entry.source_row_id), source_revision=entry.source_revision, source_event_key=entry.source_event_key, guild_id=entry.guild_id)
     ensure_memory_ledger_schema(conn)
     now = _now()
     cur = conn.cursor()
     cur.execute("""
         INSERT OR IGNORE INTO memory_ledger_entries (
             entry_id, schema_version, guild_id, subject_key, subject_display_name, entry_type, predicate_key,
-            normalized_value, source_class, source_table, source_row_id, source_role, route_mode, channel_id,
+            normalized_value, source_class, source_table, source_row_id, source_revision, source_event_key, source_role, route_mode, channel_id,
             channel_name, channel_policy, source_message_id, visibility, confidence, public_usable, derived,
             projection, salience, observed_at, source_sequence, valid_from, valid_until, freshness,
             lifecycle_status, created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    """, (entry.entry_id, MEMORY_LEDGER_SCHEMA_VERSION, entry.guild_id, entry.subject_key, entry.subject_display_name, entry.entry_type, entry.predicate_key, entry.value[:1000], entry.source_class.value, entry.source_table, str(entry.source_row_id), entry.source_role, entry.route_mode, int(entry.channel_id or 0), entry.channel_name[:120], entry.channel_policy[:80], entry.source_message_id, entry.visibility.value, entry.confidence.value, 1 if entry.public_usable else 0, 1 if entry.derived else 0, 1 if entry.projection else 0, float(entry.salience or 0.0), entry.observed_at, entry.source_sequence, entry.valid_from, entry.valid_until, entry.freshness, entry.lifecycle_status, now, now))
-    for idx, p in enumerate(sorted(entry.participants, key=lambda x: (x.order_index, x.participant_key))):
-        cur.execute("INSERT OR IGNORE INTO memory_ledger_participants VALUES (?, ?, ?, ?, ?, ?, ?)", (entry.entry_id, entry.guild_id, p.participant_key, p.display_name[:120], p.role[:40], idx, now))
-    for lineage_type, target in entry.lineage:
-        if lineage_type in LINEAGE_TYPES and target:
-            cur.execute("INSERT OR IGNORE INTO memory_ledger_lineage VALUES (?, ?, ?, ?)", (entry.entry_id, lineage_type, target, now))
-    return entry.entry_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """, (entry.entry_id, MEMORY_LEDGER_SCHEMA_VERSION, entry.guild_id, entry.subject_key, entry.subject_display_name, entry.entry_type, entry.predicate_key, entry.value[:1000], entry.source_class.value, entry.source_table, str(entry.source_row_id), entry.source_revision, entry.source_event_key, entry.source_role, entry.route_mode, int(entry.channel_id or 0), entry.channel_name[:120], entry.channel_policy[:80], entry.source_message_id, entry.visibility.value, entry.confidence.value, 1 if entry.public_usable else 0, 1 if entry.derived else 0, 1 if entry.projection else 0, float(entry.salience or 0.0), entry.observed_at, entry.source_sequence, entry.valid_from, entry.valid_until, entry.freshness, entry.lifecycle_status, now, now))
+    outcome = "inserted" if cur.rowcount else "deduplicated"
+    if outcome == "inserted":
+        for idx, p in enumerate(sorted(entry.participants, key=lambda x: (x.order_index, x.participant_key))):
+            cur.execute("INSERT OR IGNORE INTO memory_ledger_participants VALUES (?, ?, ?, ?, ?, ?, ?)", (entry.entry_id, entry.guild_id, p.participant_key, p.display_name[:120], p.role[:40], idx, now))
+        for lineage_type, target in entry.lineage:
+            if lineage_type in LINEAGE_TYPES and target:
+                cur.execute("INSERT OR IGNORE INTO memory_ledger_lineage VALUES (?, ?, ?, ?, ?)", (entry.entry_id, entry.guild_id, lineage_type, target, now))
+    return LedgerWriteResult(entry.entry_id, outcome, "ok" if outcome == "inserted" else "exact_source_duplicate", entry.source_table, str(entry.source_row_id), entry.source_revision, entry.source_event_key, entry.guild_id)
 
 
 def _visibility(policy: str) -> Visibility:
@@ -195,53 +271,109 @@ def _public_ok(subject_key: str, predicate: str, value: str, source_class: Sourc
     return is_public_usable(claim)
 
 
-def infer_conversation_predicate(text: str) -> tuple[str, str, tuple[tuple[str, str], ...], str]:
-    low = (text or "").lower()
-    number = _NUMBER_REMEMBER_RE.search(text or "")
-    if number:
-        return "remembered_number", number.group(1), (), ACTIVE_LIFECYCLE
-    if _REPLACE_RE.search(text or ""):
-        return "explicit_replacement", (text or "")[:240], (), REVIEW_ONLY_LIFECYCLE
-    if _NOT_RE.search(text or "") and any(k in low for k in ("correction", "actually", "was", "number")):
-        return "explicit_correction", (text or "")[:240], (), REVIEW_ONLY_LIFECYCLE
+def is_queue_operational_state(text: str) -> bool:
+    return bool(_QUEUE_OPERATIONAL_RE.search(text or ""))
+
+
+def _unique_active_value_target(conn: sqlite3.Connection, *, guild_id: int, subject_key: str, predicate_key: str, old_value: str) -> str:
+    ensure_memory_ledger_schema(conn)
+    rows = conn.execute(
+        """
+        SELECT entry_id FROM memory_ledger_entries
+        WHERE guild_id=? AND subject_key=? AND predicate_key=? AND normalized_value=? AND lifecycle_status='active'
+          AND entry_id NOT IN (SELECT target_entry_id FROM memory_ledger_lineage WHERE guild_id=? AND lineage_type IN ('supersedes','retracts'))
+        """,
+        (guild_id, subject_key, predicate_key, old_value, guild_id),
+    ).fetchall()
+    return rows[0][0] if len(rows) == 1 else ""
+
+
+def _conversation_fact(text: str, conn: sqlite3.Connection, guild_id: int, subject_key: str) -> tuple[str, str, tuple[tuple[str, str], ...], str, str]:
+    remember = _NUMBER_REMEMBER_RE.search(text or "")
+    if remember:
+        return "remembered_number", remember.group(1), (), ACTIVE_LIFECYCLE, "ok"
+    replacement = _REPLACE_NUMBER_RE.search(text or "")
+    if replacement:
+        old, new = replacement.group(1), replacement.group(2)
+        target = _unique_active_value_target(conn, guild_id=guild_id, subject_key=subject_key, predicate_key="remembered_number", old_value=old)
+        if target:
+            return "remembered_number", new, (("supersedes", target), ("correction_of", target)), ACTIVE_LIFECYCLE, "explicit_correction_linked"
+        return "remembered_number", new, (), REVIEW_ONLY_LIFECYCLE, "unresolved_correction_target"
+    correction = _CORRECTION_NUMBER_RE.search(text or "")
+    if correction:
+        new, old = correction.group(1), correction.group(2)
+        target = _unique_active_value_target(conn, guild_id=guild_id, subject_key=subject_key, predicate_key="remembered_number", old_value=old)
+        if target:
+            return "remembered_number", new, (("correction_of", target),), ACTIVE_LIFECYCLE, "explicit_correction_linked"
+        return "remembered_number", new, (), REVIEW_ONLY_LIFECYCLE, "unresolved_correction_target"
     if "?" in (text or ""):
-        return "question", "", (), ACTIVE_LIFECYCLE
-    return "conversation", (text or "")[:500], (), ACTIVE_LIFECYCLE
+        return "question", "", (), ACTIVE_LIFECYCLE, "ok"
+    return "conversation", (text or "")[:500], (), ACTIVE_LIFECYCLE, "ok"
 
 
-def shadow_conversation_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, user_name: str, guild_id: int, role: str, content: str, channel_name: str = "", channel_policy: str = "unknown", channel_id: int = 0, message_id: int | None = None, route_mode: str = "unknown", observed_at: str = "") -> str | None:
+def shadow_conversation_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, user_name: str, guild_id: int, role: str, content: str, channel_name: str = "", channel_policy: str = "unknown", channel_id: int = 0, message_id: int | None = None, route_mode: str = "unknown", observed_at: str = "") -> LedgerWriteResult:
     role_norm = (role or "").lower()
+    if role_norm == "user" and is_queue_operational_state(content):
+        return skipped_result(guild_id=guild_id, source_table="conversations", source_row_id=row_id, reason_code="queue_operational_state_excluded", source_revision=str(row_id))
     visibility = _visibility(channel_policy)
-    source_class = _source_class("conversation_continuity" if role_norm == "user" else "grounded_reflection", SourceClass.PUBLIC_OBSERVATION if role_norm == "user" else SourceClass.DERIVED_SUMMARY)
-    predicate, value, lineage, lifecycle = infer_conversation_predicate(content)
     if role_norm != "user":
-        predicate = "model_output"
-        value = (content or "")[:500]
-        lifecycle = ACTIVE_LIFECYCLE
-    derived = role_norm != "user"
-    public_ok = (not derived) and _public_ok(subject_key_for_user(user_id), predicate, value, source_class, visibility, Confidence.MEDIUM)
-    entry = LedgerEntry(guild_id=guild_id, source_table="conversations", source_row_id=row_id, source_role=role_norm or "unknown", entry_type="observation" if role_norm == "user" else "derived_summary", subject_key=subject_key_for_user(user_id), subject_display_name=user_name or ("BNL-01" if role_norm != "user" else ""), predicate_key=predicate, value=value, source_class=source_class, route_mode=route_mode, channel_id=channel_id, channel_name=channel_name, channel_policy=channel_policy, source_message_id=message_id, visibility=visibility, confidence=Confidence.MEDIUM if role_norm == "user" else Confidence.LOW, public_usable=public_ok, derived=derived, projection=derived, salience=0.2, observed_at=observed_at or _now(), source_sequence=row_id, lifecycle_status=lifecycle, participants=(LedgerParticipant(subject_key_for_user(user_id), user_name or "", "author", 0),), lineage=lineage)
-    return insert_ledger_entry(conn, entry)
+        subject_key = BNL_SUBJECT_KEY
+        participants = (LedgerParticipant(BNL_SUBJECT_KEY, "BNL-01", "author", 0), LedgerParticipant(subject_key_for_user(user_id), user_name or "", "conversation_target", 1))
+        entry = LedgerEntry(guild_id=guild_id, source_table="conversations", source_row_id=row_id, source_revision=str(row_id), source_role="model", entry_type="derived_summary", subject_key=BNL_SUBJECT_KEY, subject_display_name="BNL-01", predicate_key="model_output", value=(content or "")[:500], source_class=SourceClass.DERIVED_SUMMARY, route_mode=route_mode, channel_id=channel_id, channel_name=channel_name, channel_policy=channel_policy, source_message_id=message_id, visibility=visibility, confidence=Confidence.LOW, public_usable=False, derived=True, projection=True, salience=0.1, observed_at=observed_at or _now(), source_sequence=row_id, participants=participants)
+        return insert_ledger_entry(conn, entry)
+    subject_key = subject_key_for_user(user_id)
+    predicate, value, lineage, lifecycle, reason = _conversation_fact(content, conn, guild_id, subject_key)
+    source_class = _source_class("conversation_continuity", SourceClass.PUBLIC_OBSERVATION)
+    public_ok = _public_ok(subject_key, predicate, value, source_class, visibility, Confidence.MEDIUM) if lifecycle == ACTIVE_LIFECYCLE else False
+    result = insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="conversations", source_row_id=row_id, source_revision=str(row_id), source_role="user", entry_type="observation", subject_key=subject_key, subject_display_name=user_name or "", predicate_key=predicate, value=value, source_class=source_class, route_mode=route_mode, channel_id=channel_id, channel_name=channel_name, channel_policy=channel_policy, source_message_id=message_id, visibility=visibility, confidence=Confidence.MEDIUM, public_usable=public_ok, salience=0.2, observed_at=observed_at or _now(), source_sequence=row_id, lifecycle_status=lifecycle, participants=(LedgerParticipant(subject_key, user_name or "", "author", 0),), lineage=lineage))
+    if reason != "ok" and result.outcome == "inserted":
+        return LedgerWriteResult(result.entry_id, result.outcome, reason, result.source_table, result.source_row_id, result.source_revision, result.source_event_key, result.guild_id)
+    return result
 
 
-def shadow_user_fact_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, guild_id: int, fact_key: str, fact_value: str, confidence: float = 0.7, updated_at: str = "") -> str:
-    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="user_memory_facts", source_row_id=row_id, source_role="legacy_source_blind", entry_type="claim", subject_key=subject_key_for_user(user_id), predicate_key=fact_key or "legacy_fact", value=(fact_value or "")[:500], source_class=SourceClass.LEGACY_SOURCE_BLIND, visibility=Visibility.PRIVATE, confidence=Confidence.LOW, public_usable=False, observed_at=updated_at or _now(), source_sequence=row_id, lifecycle_status=REVIEW_ONLY_LIFECYCLE, participants=(LedgerParticipant(subject_key_for_user(user_id), "", "subject", 0),)))
+def shadow_user_fact_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, guild_id: int, fact_key: str, fact_value: str, confidence: float = 0.7, updated_at: str = "") -> LedgerWriteResult:
+    rev = source_revision_for(row_id, updated_at)
+    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="user_memory_facts", source_row_id=row_id, source_revision=rev, source_role="legacy_source_blind", entry_type="claim", subject_key=subject_key_for_user(user_id), predicate_key=fact_key or "legacy_fact", value=(fact_value or "")[:500], source_class=SourceClass.LEGACY_SOURCE_BLIND, visibility=Visibility.PRIVATE, confidence=Confidence.LOW, public_usable=False, observed_at=updated_at or _now(), source_sequence=int(row_id or 0), lifecycle_status=REVIEW_ONLY_LIFECYCLE, participants=(LedgerParticipant(subject_key_for_user(user_id), "", "subject", 0),)))
 
 
-def shadow_memory_tier_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, guild_id: int, tier: str, summary: str, salience: float = 0.5, channel_policy: str = "legacy_unknown", topic_key: str = "", updated_at: str = "") -> str:
-    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="memory_tiers", source_row_id=row_id, source_role="derived_projection", entry_type="derived_summary", subject_key=subject_key_for_user(user_id), predicate_key=topic_key or f"memory_tier:{tier}", value=(summary or "")[:500], source_class=SourceClass.DERIVED_SUMMARY, visibility=Visibility.PRIVATE, confidence=Confidence.LOW, public_usable=False, derived=True, projection=True, salience=salience, observed_at=updated_at or _now(), source_sequence=row_id, lifecycle_status=REVIEW_ONLY_LIFECYCLE, participants=(LedgerParticipant(subject_key_for_user(user_id), "", "subject", 0),)))
+def shadow_memory_tier_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, guild_id: int, tier: str, summary: str, salience: float = 0.5, channel_policy: str = "legacy_unknown", topic_key: str = "", updated_at: str = "", derived_from_entry_ids: tuple[str, ...] = ()) -> LedgerWriteResult:
+    rev = source_revision_for(row_id, updated_at)
+    lineage = tuple(("derived_from", eid) for eid in sorted(set(derived_from_entry_ids)) if eid)
+    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="memory_tiers", source_row_id=row_id, source_revision=rev, source_role="derived_projection", entry_type="derived_summary", subject_key=subject_key_for_user(user_id), predicate_key=topic_key or f"memory_tier:{tier}", value=(summary or "")[:500], source_class=SourceClass.DERIVED_SUMMARY, visibility=Visibility.PRIVATE, confidence=Confidence.LOW, public_usable=False, derived=True, projection=True, salience=salience, observed_at=updated_at or _now(), source_sequence=int(row_id or 0), lifecycle_status=REVIEW_ONLY_LIFECYCLE, participants=(LedgerParticipant(subject_key_for_user(user_id), "", "subject", 0),), lineage=lineage))
 
 
-def shadow_relationship_journal_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, guild_id: int, entry_type: str, summary: str, timestamp: str = "") -> str:
-    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="relationship_journal", source_row_id=row_id, source_role="internal", entry_type="relationship_event", subject_key=subject_key_for_user(user_id), predicate_key=entry_type or "relationship_event", value=(summary or "")[:500], source_class=SourceClass.DERIVED_SUMMARY, visibility=Visibility.INTERNAL, confidence=Confidence.LOW, public_usable=False, derived=True, projection=True, salience=0.3, observed_at=timestamp or _now(), source_sequence=row_id, lifecycle_status=REVIEW_ONLY_LIFECYCLE, participants=(LedgerParticipant(subject_key_for_user(user_id), "", "subject", 0),)))
+def shadow_relationship_journal_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, guild_id: int, entry_type: str, summary: str, timestamp: str = "") -> LedgerWriteResult:
+    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="relationship_journal", source_row_id=row_id, source_revision=str(row_id), source_role="internal", entry_type="relationship_event", subject_key=subject_key_for_user(user_id), predicate_key=entry_type or "relationship_event", value=(summary or "")[:500], source_class=SourceClass.DERIVED_SUMMARY, visibility=Visibility.INTERNAL, confidence=Confidence.LOW, public_usable=False, derived=True, projection=True, salience=0.3, observed_at=timestamp or _now(), source_sequence=int(row_id or 0), lifecycle_status=REVIEW_ONLY_LIFECYCLE, participants=(LedgerParticipant(subject_key_for_user(user_id), "", "subject", 0),)))
 
 
-def shadow_broadcast_memory_row(conn: sqlite3.Connection, *, row_id: int, guild_id: int, cleaned_summary: str, entry_type: str, public_safe: bool, status: str, usage_scope: str, submitted_by_user_id: int | None = None, submitted_by_name: str = "", created_at: str = "") -> str | None:
+def shadow_broadcast_memory_row(conn: sqlite3.Connection, *, row_id: int, guild_id: int, cleaned_summary: str, entry_type: str, public_safe: bool, status: str, usage_scope: str, submitted_by_user_id: int | None = None, submitted_by_name: str = "", created_at: str = "", updated_at: str = "", supersedes_id: int | None = None) -> LedgerWriteResult:
     if not cleaned_summary:
-        return None
-    lifecycle = ACTIVE_LIFECYCLE if str(status or "active").lower() == "active" else REVIEW_ONLY_LIFECYCLE
-    public_ok = bool(public_safe and lifecycle == ACTIVE_LIFECYCLE and usage_scope in {"public", "public_context", "recap", "show", "website", "broadcast"})
-    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="broadcast_memory", source_row_id=row_id, source_role="broadcast_memory", entry_type="show_event" if "show" in (entry_type or "") else "event", subject_key="barcode_radio", subject_display_name="BARCODE Radio", predicate_key=entry_type or "broadcast_memory", value=cleaned_summary[:500], source_class=SourceClass.FIRST_PARTY_RECORD, visibility=Visibility.PUBLIC_SAFE if public_ok else Visibility.INTERNAL, confidence=Confidence.HIGH if public_ok else Confidence.MEDIUM, public_usable=public_ok, salience=0.5, observed_at=created_at or _now(), source_sequence=row_id, valid_until="", freshness=usage_scope or "", lifecycle_status=lifecycle, participants=tuple([LedgerParticipant(f"discord_user:{submitted_by_user_id}", submitted_by_name or "", "submitter", 0)] if submitted_by_user_id else ())))
+        return skipped_result(guild_id=guild_id, source_table="broadcast_memory", source_row_id=row_id, reason_code="empty_cleaned_summary", source_revision=source_revision_for(row_id, updated_at or created_at))
+    lifecycle = ACTIVE_LIFECYCLE if str(status or "active").lower() == "active" else (RESOLVED_LIFECYCLE if str(status or "").lower() == "resolved" else REVIEW_ONLY_LIFECYCLE)
+    public_ok = bool(public_safe and lifecycle == ACTIVE_LIFECYCLE and any(scope in {"public", "public_context", "recap", "show", "website", "broadcast", "ambient", "direct", "relay"} for scope in re.split(r"[,\s]+", usage_scope or "")))
+    target = ""
+    if supersedes_id:
+        target = stable_entry_id(guild_id=guild_id, source_table="broadcast_memory", source_row_id=supersedes_id, source_revision=str(supersedes_id), entry_type="show_event" if "show" in (entry_type or "") else "event", subject_key="barcode_radio", predicate_key=entry_type or "broadcast_memory")
+    lineage = (("supersedes", target), ("correction_of", target)) if target else ()
+    rev = source_revision_for(row_id, updated_at or created_at)
+    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="broadcast_memory", source_row_id=row_id, source_revision=rev, source_role="broadcast_memory", entry_type="show_event" if "show" in (entry_type or "") else "event", subject_key="barcode_radio", subject_display_name="BARCODE Radio", predicate_key=entry_type or "broadcast_memory", value=cleaned_summary[:500], source_class=SourceClass.FIRST_PARTY_RECORD, visibility=Visibility.PUBLIC_SAFE if public_ok else Visibility.INTERNAL, confidence=Confidence.HIGH if public_ok else Confidence.MEDIUM, public_usable=public_ok, salience=0.5, observed_at=created_at or updated_at or _now(), source_sequence=int(row_id or 0), freshness=usage_scope or "", lifecycle_status=lifecycle, participants=tuple([LedgerParticipant(f"discord_user:{submitted_by_user_id}", submitted_by_name or "", "submitter", 0)] if submitted_by_user_id else ()), lineage=lineage))
+
+
+def shadow_broadcast_status_event(conn: sqlite3.Connection, *, row_id: int, guild_id: int, status: str, updated_at: str, actor_id: int | None = None, actor_name: str = "", superseded_by_id: int | None = None) -> LedgerWriteResult:
+    rev = source_revision_for(row_id, updated_at, event=f"status:{status}:{updated_at}")
+    target = stable_entry_id(guild_id=guild_id, source_table="broadcast_memory", source_row_id=row_id, source_revision=str(row_id), entry_type="event", subject_key="barcode_radio", predicate_key="broadcast_status")
+    lineage = ()
+    lifecycle = RESOLVED_LIFECYCLE if status == "resolved" else REVIEW_ONLY_LIFECYCLE
+    predicate = f"broadcast_status:{status or 'unknown'}"
+    if status == "superseded" and superseded_by_id:
+        lifecycle = REVIEW_ONLY_LIFECYCLE
+    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="broadcast_memory", source_row_id=row_id, source_revision=rev, source_event_key=f"status:{status}", source_role="broadcast_memory_status", entry_type="event", subject_key="barcode_radio", subject_display_name="BARCODE Radio", predicate_key=predicate, value=status or "unknown", source_class=SourceClass.FIRST_PARTY_RECORD, visibility=Visibility.INTERNAL, confidence=Confidence.HIGH, public_usable=False, observed_at=updated_at or _now(), source_sequence=int(row_id or 0), lifecycle_status=lifecycle, participants=tuple([LedgerParticipant(f"discord_user:{actor_id}", actor_name or "", "correction_actor", 0)] if actor_id else ()), lineage=lineage))
+
+
+def shadow_canon_reference(conn: sqlite3.Connection, *, guild_id: int, canon_id: str, subject_key: str, subject_display_name: str, predicate_key: str, value: str, observed_at: str = "") -> LedgerWriteResult:
+    if not canon_id or not subject_key or not predicate_key:
+        return skipped_result(guild_id=guild_id, source_table="approved_canon", source_row_id=canon_id or "", reason_code="missing_canon_source_identity")
+    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="approved_canon", source_row_id=canon_id, source_revision=str(canon_id), source_role="approved_canon", entry_type="canon_reference", subject_key=subject_key, subject_display_name=subject_display_name, predicate_key=predicate_key, value=(value or "")[:500], source_class=SourceClass.APPROVED_CANON, visibility=Visibility.REFERENCE_CANON, confidence=Confidence.APPROVED, public_usable=True, observed_at=observed_at or _now(), lifecycle_status=ACTIVE_LIFECYCLE))
 
 
 def build_memory_ledger_evaluation(conn: sqlite3.Connection, *, guild_id: int | None = None) -> dict[str, Any]:
@@ -252,21 +384,30 @@ def build_memory_ledger_evaluation(conn: sqlite3.Connection, *, guild_id: int | 
         where = " WHERE guild_id=?"
         params.append(guild_id)
     cur = conn.cursor()
-    report: dict[str, Any] = {"schemaVersion": MEMORY_LEDGER_SCHEMA_VERSION, "eligibleLegacyWrites": 0, "insertedLedgerEntries": 0, "exactSourceDeduplications": 0, "skippedWrites": {}, "shadowWriteErrors": 0, "countsBySourceLane": {}, "countsByEntryType": {}, "countsByVisibility": {}, "countsByLifecycle": {}, "missingUnmappedProvenance": 0, "publicUsabilityRejections": 0, "legacyToLedgerParityMismatches": 0, "entriesWithMultipleActiveValues": 0, "explicitCorrectionCounts": 0, "inferredCorrectionCounts": 0, "attemptedImplicitSupersessionsBlocked": 0}
+    report: dict[str, Any] = {"schemaVersion": MEMORY_LEDGER_SCHEMA_VERSION}
+    cur.execute(f"SELECT COUNT(*) FROM memory_ledger_shadow_receipts{where}", params)
+    report["eligibleLegacyWrites"] = int(cur.fetchone()[0] or 0)
+    for outcome, key in (("inserted", "insertedLedgerEntries"), ("deduplicated", "exactSourceDeduplications"), ("error", "shadowWriteErrors")):
+        cur.execute(f"SELECT COUNT(*) FROM memory_ledger_shadow_receipts{where + (' AND' if where else ' WHERE')} outcome=?", params + [outcome])
+        report[key] = int(cur.fetchone()[0] or 0)
+    cur.execute(f"SELECT reason_code, COUNT(*) FROM memory_ledger_shadow_receipts{where + (' AND' if where else ' WHERE')} outcome='skipped' GROUP BY reason_code", params)
+    report["skippedWrites"] = dict(cur.fetchall())
     cur.execute(f"SELECT source_table, COUNT(*) FROM memory_ledger_entries{where} GROUP BY source_table", params)
     report["countsBySourceLane"] = dict(cur.fetchall())
     for key, col in (("countsByEntryType", "entry_type"), ("countsByVisibility", "visibility"), ("countsByLifecycle", "lifecycle_status")):
         cur.execute(f"SELECT {col}, COUNT(*) FROM memory_ledger_entries{where} GROUP BY {col}", params)
         report[key] = dict(cur.fetchall())
-    cur.execute(f"SELECT COUNT(*) FROM memory_ledger_entries{where}", params)
-    report["insertedLedgerEntries"] = int(cur.fetchone()[0] or 0)
-    cur.execute(f"SELECT COUNT(*) FROM memory_ledger_entries{where + (' AND' if where else ' WHERE')} public_usable=0", params)
-    report["publicUsabilityRejections"] = int(cur.fetchone()[0] or 0)
     cur.execute(f"SELECT COUNT(*) FROM memory_ledger_entries{where + (' AND' if where else ' WHERE')} (source_class='legacy_source_blind' OR visibility='unknown')", params)
     report["missingUnmappedProvenance"] = int(cur.fetchone()[0] or 0)
-    cur.execute(f"SELECT COUNT(*) FROM (SELECT subject_key, predicate_key FROM memory_ledger_entries{where + (' AND' if where else ' WHERE')} lifecycle_status='active' GROUP BY subject_key, predicate_key HAVING COUNT(*) > 1)", params)
-    report["entriesWithMultipleActiveValues"] = int(cur.fetchone()[0] or 0)
-    cur.execute("SELECT lineage_type, COUNT(*) FROM memory_ledger_lineage GROUP BY lineage_type")
+    cur.execute(f"SELECT COUNT(*) FROM memory_ledger_entries{where + (' AND' if where else ' WHERE')} public_usable=0", params)
+    report["publicUsabilityRejections"] = int(cur.fetchone()[0] or 0)
+    cur.execute(f"SELECT COUNT(*) FROM memory_ledger_entries{where + (' AND' if where else ' WHERE')} entry_id NOT IN (SELECT target_entry_id FROM memory_ledger_lineage WHERE {'guild_id=? AND ' if guild_id is not None else ''} lineage_type IN ('supersedes','retracts')) AND lifecycle_status='active' GROUP BY subject_key, predicate_key HAVING COUNT(*) > 1", params + ([guild_id] if guild_id is not None else []))
+    report["entriesWithMultipleActiveValues"] = len(cur.fetchall())
+    cur.execute(f"SELECT lineage_type, COUNT(*) FROM memory_ledger_lineage{where} GROUP BY lineage_type", params)
     lineage_counts = dict(cur.fetchall())
     report["explicitCorrectionCounts"] = int(lineage_counts.get("correction_of", 0) + lineage_counts.get("supersedes", 0))
+    cur.execute(f"SELECT COUNT(*) FROM memory_ledger_entries{where + (' AND' if where else ' WHERE')} lifecycle_status='review_only' AND predicate_key='remembered_number'", params)
+    report["unresolvedCorrectionAttempts"] = int(cur.fetchone()[0] or 0)
+    report["legacyToLedgerParityMismatches"] = 0
+    report["implicitSupersessionsBlocked"] = int(report.get("entriesWithMultipleActiveValues", 0))
     return report

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -1,0 +1,272 @@
+"""Unified Memory Ledger v1 shadow schema and write adapters.
+
+The ledger is append-oriented shadow infrastructure only. Legacy memory remains the
+production source of truth; this module never participates in prompt assembly or
+retrieval.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+import re
+import sqlite3
+from typing import Any, Iterable
+
+from bnl_canon_source_contract import (
+    Confidence,
+    SourceClass,
+    SourceClaim,
+    SubjectIdentity,
+    Visibility,
+    has_explicit_channel_policy_mapping,
+    has_explicit_route_source_mapping,
+    is_public_usable,
+    map_channel_policy_visibility,
+    map_route_source_label,
+)
+
+MEMORY_LEDGER_SCHEMA_VERSION = "memory_ledger_v1"
+MEMORY_LEDGER_SHADOW_ENV = "BNL_MEMORY_LEDGER_SHADOW_ENABLED"
+
+ENTRY_TYPES = frozenset({
+    "observation", "claim", "event", "preference", "boundary", "goal", "open_loop", "commitment",
+    "shared_moment", "relationship_event", "canon_reference", "show_event", "unresolved_question", "derived_summary",
+})
+LINEAGE_TYPES = frozenset({"derived_from", "correction_of", "supersedes", "retracts", "duplicate_of", "part_of_moment"})
+ACTIVE_LIFECYCLE = "active"
+REVIEW_ONLY_LIFECYCLE = "review_only"
+REJECTED_LIFECYCLE = "rejected"
+
+_QUEUE_STATE_RE = re.compile(r"\b(?:website|site|payment|session|availability|now[- ]?playing|up[- ]?next|priority|wheel|queue_open|current queue|queue status)\b", re.I)
+_NUMBER_REMEMBER_RE = re.compile(r"\bremember\b.*?\bnumber\b\D+(\d{2,})", re.I)
+_REPLACE_RE = re.compile(r"\b(?:replace|supersede)\s+(.{1,80}?)\s+\bwith\b\s+(.{1,80})", re.I)
+_NOT_RE = re.compile(r"\b(.{1,80}?)\s*,?\s+not\s+(.{1,80})", re.I)
+
+
+def shadow_enabled(environ: dict[str, str] | None = None) -> bool:
+    value = (environ or os.environ).get(MEMORY_LEDGER_SHADOW_ENV, "")
+    return str(value).strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _canon(value: Any) -> str:
+    if value is None:
+        return ""
+    return re.sub(r"\s+", " ", str(value).strip().lower())
+
+
+def subject_key_for_user(user_id: int | str | None) -> str:
+    return f"discord_user:{int(user_id or 0)}"
+
+
+def stable_entry_id(*, guild_id: int | str | None, source_table: str, source_row_id: int | str, entry_type: str, subject_key: str, predicate_key: str) -> str:
+    parts = [MEMORY_LEDGER_SCHEMA_VERSION, str(guild_id or 0), _canon(source_table), str(source_row_id), _canon(entry_type), _canon(subject_key), _canon(predicate_key)]
+    return "mle_" + hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()[:40]
+
+
+@dataclass(frozen=True)
+class LedgerParticipant:
+    participant_key: str
+    display_name: str = ""
+    role: str = "participant"
+    order_index: int = 0
+
+
+@dataclass(frozen=True)
+class LedgerEntry:
+    guild_id: int
+    source_table: str
+    source_row_id: int | str
+    source_role: str
+    entry_type: str
+    subject_key: str
+    subject_display_name: str = ""
+    predicate_key: str = "conversation"
+    value: str = ""
+    source_class: SourceClass = SourceClass.LEGACY_SOURCE_BLIND
+    route_mode: str = "unknown"
+    channel_id: int = 0
+    channel_name: str = ""
+    channel_policy: str = "unknown"
+    source_message_id: int | None = None
+    visibility: Visibility = Visibility.UNKNOWN
+    confidence: Confidence = Confidence.UNKNOWN
+    public_usable: bool = False
+    derived: bool = False
+    projection: bool = False
+    salience: float = 0.0
+    observed_at: str = ""
+    source_sequence: int | None = None
+    valid_from: str = ""
+    valid_until: str = ""
+    freshness: str = ""
+    lifecycle_status: str = ACTIVE_LIFECYCLE
+    participants: tuple[LedgerParticipant, ...] = field(default_factory=tuple)
+    lineage: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+
+    @property
+    def entry_id(self) -> str:
+        return stable_entry_id(guild_id=self.guild_id, source_table=self.source_table, source_row_id=self.source_row_id, entry_type=self.entry_type, subject_key=self.subject_key, predicate_key=self.predicate_key)
+
+
+def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
+    cur = conn.cursor()
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS memory_ledger_entries (
+            entry_id TEXT PRIMARY KEY, schema_version TEXT NOT NULL, guild_id INTEGER NOT NULL,
+            subject_key TEXT NOT NULL, subject_display_name TEXT, entry_type TEXT NOT NULL,
+            predicate_key TEXT NOT NULL, normalized_value TEXT, source_class TEXT NOT NULL,
+            source_table TEXT NOT NULL, source_row_id TEXT NOT NULL, source_role TEXT NOT NULL,
+            route_mode TEXT, channel_id INTEGER, channel_name TEXT, channel_policy TEXT,
+            source_message_id INTEGER, visibility TEXT NOT NULL, confidence TEXT NOT NULL,
+            public_usable INTEGER DEFAULT 0, derived INTEGER DEFAULT 0, projection INTEGER DEFAULT 0,
+            salience REAL DEFAULT 0.0, observed_at TEXT, source_sequence INTEGER,
+            valid_from TEXT, valid_until TEXT, freshness TEXT, lifecycle_status TEXT NOT NULL,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+            UNIQUE(schema_version, guild_id, source_table, source_row_id, entry_type, subject_key, predicate_key)
+        )
+    """)
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS memory_ledger_lineage (
+            entry_id TEXT NOT NULL, lineage_type TEXT NOT NULL, target_entry_id TEXT NOT NULL,
+            created_at TEXT NOT NULL, PRIMARY KEY(entry_id, lineage_type, target_entry_id)
+        )
+    """)
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS memory_ledger_participants (
+            entry_id TEXT NOT NULL, guild_id INTEGER NOT NULL, participant_key TEXT NOT NULL,
+            display_name TEXT, participant_role TEXT, order_index INTEGER DEFAULT 0, created_at TEXT NOT NULL,
+            PRIMARY KEY(entry_id, participant_key, participant_role)
+        )
+    """)
+    for sql in [
+        "CREATE INDEX IF NOT EXISTS idx_mle_guild ON memory_ledger_entries(guild_id)",
+        "CREATE INDEX IF NOT EXISTS idx_mle_subject ON memory_ledger_entries(guild_id, subject_key)",
+        "CREATE INDEX IF NOT EXISTS idx_mle_type ON memory_ledger_entries(entry_type)",
+        "CREATE INDEX IF NOT EXISTS idx_mle_source ON memory_ledger_entries(source_table, source_row_id)",
+        "CREATE INDEX IF NOT EXISTS idx_mle_lifecycle ON memory_ledger_entries(lifecycle_status)",
+        "CREATE INDEX IF NOT EXISTS idx_mle_visibility ON memory_ledger_entries(visibility)",
+        "CREATE INDEX IF NOT EXISTS idx_mle_predicate ON memory_ledger_entries(guild_id, predicate_key)",
+        "CREATE INDEX IF NOT EXISTS idx_mle_observed ON memory_ledger_entries(observed_at)",
+        "CREATE INDEX IF NOT EXISTS idx_mlp_participant ON memory_ledger_participants(guild_id, participant_key, order_index)",
+    ]:
+        cur.execute(sql)
+
+
+def insert_ledger_entry(conn: sqlite3.Connection, entry: LedgerEntry) -> str:
+    if entry.entry_type not in ENTRY_TYPES:
+        raise ValueError(f"unsupported ledger entry type: {entry.entry_type}")
+    ensure_memory_ledger_schema(conn)
+    now = _now()
+    cur = conn.cursor()
+    cur.execute("""
+        INSERT OR IGNORE INTO memory_ledger_entries (
+            entry_id, schema_version, guild_id, subject_key, subject_display_name, entry_type, predicate_key,
+            normalized_value, source_class, source_table, source_row_id, source_role, route_mode, channel_id,
+            channel_name, channel_policy, source_message_id, visibility, confidence, public_usable, derived,
+            projection, salience, observed_at, source_sequence, valid_from, valid_until, freshness,
+            lifecycle_status, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """, (entry.entry_id, MEMORY_LEDGER_SCHEMA_VERSION, entry.guild_id, entry.subject_key, entry.subject_display_name, entry.entry_type, entry.predicate_key, entry.value[:1000], entry.source_class.value, entry.source_table, str(entry.source_row_id), entry.source_role, entry.route_mode, int(entry.channel_id or 0), entry.channel_name[:120], entry.channel_policy[:80], entry.source_message_id, entry.visibility.value, entry.confidence.value, 1 if entry.public_usable else 0, 1 if entry.derived else 0, 1 if entry.projection else 0, float(entry.salience or 0.0), entry.observed_at, entry.source_sequence, entry.valid_from, entry.valid_until, entry.freshness, entry.lifecycle_status, now, now))
+    for idx, p in enumerate(sorted(entry.participants, key=lambda x: (x.order_index, x.participant_key))):
+        cur.execute("INSERT OR IGNORE INTO memory_ledger_participants VALUES (?, ?, ?, ?, ?, ?, ?)", (entry.entry_id, entry.guild_id, p.participant_key, p.display_name[:120], p.role[:40], idx, now))
+    for lineage_type, target in entry.lineage:
+        if lineage_type in LINEAGE_TYPES and target:
+            cur.execute("INSERT OR IGNORE INTO memory_ledger_lineage VALUES (?, ?, ?, ?)", (entry.entry_id, lineage_type, target, now))
+    return entry.entry_id
+
+
+def _visibility(policy: str) -> Visibility:
+    return map_channel_policy_visibility(policy) if has_explicit_channel_policy_mapping(policy) else Visibility.UNKNOWN
+
+
+def _source_class(route: str, fallback: SourceClass) -> SourceClass:
+    return map_route_source_label(route) if has_explicit_route_source_mapping(route) else fallback
+
+
+def _public_ok(subject_key: str, predicate: str, value: str, source_class: SourceClass, visibility: Visibility, confidence: Confidence, *, valid: bool = True, projection: bool = False) -> bool:
+    claim = SourceClaim(stable_entry_id(guild_id=0, source_table="eval", source_row_id=0, entry_type="claim", subject_key=subject_key, predicate_key=predicate), SubjectIdentity(subject_key, subject_key), predicate, value, source_class, visibility, confidence, valid=valid, projection=projection)
+    return is_public_usable(claim)
+
+
+def infer_conversation_predicate(text: str) -> tuple[str, str, tuple[tuple[str, str], ...], str]:
+    low = (text or "").lower()
+    number = _NUMBER_REMEMBER_RE.search(text or "")
+    if number:
+        return "remembered_number", number.group(1), (), ACTIVE_LIFECYCLE
+    if _REPLACE_RE.search(text or ""):
+        return "explicit_replacement", (text or "")[:240], (), REVIEW_ONLY_LIFECYCLE
+    if _NOT_RE.search(text or "") and any(k in low for k in ("correction", "actually", "was", "number")):
+        return "explicit_correction", (text or "")[:240], (), REVIEW_ONLY_LIFECYCLE
+    if "?" in (text or ""):
+        return "question", "", (), ACTIVE_LIFECYCLE
+    return "conversation", (text or "")[:500], (), ACTIVE_LIFECYCLE
+
+
+def shadow_conversation_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, user_name: str, guild_id: int, role: str, content: str, channel_name: str = "", channel_policy: str = "unknown", channel_id: int = 0, message_id: int | None = None, route_mode: str = "unknown", observed_at: str = "") -> str | None:
+    role_norm = (role or "").lower()
+    visibility = _visibility(channel_policy)
+    source_class = _source_class("conversation_continuity" if role_norm == "user" else "grounded_reflection", SourceClass.PUBLIC_OBSERVATION if role_norm == "user" else SourceClass.DERIVED_SUMMARY)
+    predicate, value, lineage, lifecycle = infer_conversation_predicate(content)
+    if role_norm != "user":
+        predicate = "model_output"
+        value = (content or "")[:500]
+        lifecycle = ACTIVE_LIFECYCLE
+    derived = role_norm != "user"
+    public_ok = (not derived) and _public_ok(subject_key_for_user(user_id), predicate, value, source_class, visibility, Confidence.MEDIUM)
+    entry = LedgerEntry(guild_id=guild_id, source_table="conversations", source_row_id=row_id, source_role=role_norm or "unknown", entry_type="observation" if role_norm == "user" else "derived_summary", subject_key=subject_key_for_user(user_id), subject_display_name=user_name or ("BNL-01" if role_norm != "user" else ""), predicate_key=predicate, value=value, source_class=source_class, route_mode=route_mode, channel_id=channel_id, channel_name=channel_name, channel_policy=channel_policy, source_message_id=message_id, visibility=visibility, confidence=Confidence.MEDIUM if role_norm == "user" else Confidence.LOW, public_usable=public_ok, derived=derived, projection=derived, salience=0.2, observed_at=observed_at or _now(), source_sequence=row_id, lifecycle_status=lifecycle, participants=(LedgerParticipant(subject_key_for_user(user_id), user_name or "", "author", 0),), lineage=lineage)
+    return insert_ledger_entry(conn, entry)
+
+
+def shadow_user_fact_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, guild_id: int, fact_key: str, fact_value: str, confidence: float = 0.7, updated_at: str = "") -> str:
+    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="user_memory_facts", source_row_id=row_id, source_role="legacy_source_blind", entry_type="claim", subject_key=subject_key_for_user(user_id), predicate_key=fact_key or "legacy_fact", value=(fact_value or "")[:500], source_class=SourceClass.LEGACY_SOURCE_BLIND, visibility=Visibility.PRIVATE, confidence=Confidence.LOW, public_usable=False, observed_at=updated_at or _now(), source_sequence=row_id, lifecycle_status=REVIEW_ONLY_LIFECYCLE, participants=(LedgerParticipant(subject_key_for_user(user_id), "", "subject", 0),)))
+
+
+def shadow_memory_tier_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, guild_id: int, tier: str, summary: str, salience: float = 0.5, channel_policy: str = "legacy_unknown", topic_key: str = "", updated_at: str = "") -> str:
+    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="memory_tiers", source_row_id=row_id, source_role="derived_projection", entry_type="derived_summary", subject_key=subject_key_for_user(user_id), predicate_key=topic_key or f"memory_tier:{tier}", value=(summary or "")[:500], source_class=SourceClass.DERIVED_SUMMARY, visibility=Visibility.PRIVATE, confidence=Confidence.LOW, public_usable=False, derived=True, projection=True, salience=salience, observed_at=updated_at or _now(), source_sequence=row_id, lifecycle_status=REVIEW_ONLY_LIFECYCLE, participants=(LedgerParticipant(subject_key_for_user(user_id), "", "subject", 0),)))
+
+
+def shadow_relationship_journal_row(conn: sqlite3.Connection, *, row_id: int, user_id: int, guild_id: int, entry_type: str, summary: str, timestamp: str = "") -> str:
+    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="relationship_journal", source_row_id=row_id, source_role="internal", entry_type="relationship_event", subject_key=subject_key_for_user(user_id), predicate_key=entry_type or "relationship_event", value=(summary or "")[:500], source_class=SourceClass.DERIVED_SUMMARY, visibility=Visibility.INTERNAL, confidence=Confidence.LOW, public_usable=False, derived=True, projection=True, salience=0.3, observed_at=timestamp or _now(), source_sequence=row_id, lifecycle_status=REVIEW_ONLY_LIFECYCLE, participants=(LedgerParticipant(subject_key_for_user(user_id), "", "subject", 0),)))
+
+
+def shadow_broadcast_memory_row(conn: sqlite3.Connection, *, row_id: int, guild_id: int, cleaned_summary: str, entry_type: str, public_safe: bool, status: str, usage_scope: str, submitted_by_user_id: int | None = None, submitted_by_name: str = "", created_at: str = "") -> str | None:
+    if not cleaned_summary:
+        return None
+    lifecycle = ACTIVE_LIFECYCLE if str(status or "active").lower() == "active" else REVIEW_ONLY_LIFECYCLE
+    public_ok = bool(public_safe and lifecycle == ACTIVE_LIFECYCLE and usage_scope in {"public", "public_context", "recap", "show", "website", "broadcast"})
+    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="broadcast_memory", source_row_id=row_id, source_role="broadcast_memory", entry_type="show_event" if "show" in (entry_type or "") else "event", subject_key="barcode_radio", subject_display_name="BARCODE Radio", predicate_key=entry_type or "broadcast_memory", value=cleaned_summary[:500], source_class=SourceClass.FIRST_PARTY_RECORD, visibility=Visibility.PUBLIC_SAFE if public_ok else Visibility.INTERNAL, confidence=Confidence.HIGH if public_ok else Confidence.MEDIUM, public_usable=public_ok, salience=0.5, observed_at=created_at or _now(), source_sequence=row_id, valid_until="", freshness=usage_scope or "", lifecycle_status=lifecycle, participants=tuple([LedgerParticipant(f"discord_user:{submitted_by_user_id}", submitted_by_name or "", "submitter", 0)] if submitted_by_user_id else ())))
+
+
+def build_memory_ledger_evaluation(conn: sqlite3.Connection, *, guild_id: int | None = None) -> dict[str, Any]:
+    ensure_memory_ledger_schema(conn)
+    params: list[Any] = []
+    where = ""
+    if guild_id is not None:
+        where = " WHERE guild_id=?"
+        params.append(guild_id)
+    cur = conn.cursor()
+    report: dict[str, Any] = {"schemaVersion": MEMORY_LEDGER_SCHEMA_VERSION, "eligibleLegacyWrites": 0, "insertedLedgerEntries": 0, "exactSourceDeduplications": 0, "skippedWrites": {}, "shadowWriteErrors": 0, "countsBySourceLane": {}, "countsByEntryType": {}, "countsByVisibility": {}, "countsByLifecycle": {}, "missingUnmappedProvenance": 0, "publicUsabilityRejections": 0, "legacyToLedgerParityMismatches": 0, "entriesWithMultipleActiveValues": 0, "explicitCorrectionCounts": 0, "inferredCorrectionCounts": 0, "attemptedImplicitSupersessionsBlocked": 0}
+    cur.execute(f"SELECT source_table, COUNT(*) FROM memory_ledger_entries{where} GROUP BY source_table", params)
+    report["countsBySourceLane"] = dict(cur.fetchall())
+    for key, col in (("countsByEntryType", "entry_type"), ("countsByVisibility", "visibility"), ("countsByLifecycle", "lifecycle_status")):
+        cur.execute(f"SELECT {col}, COUNT(*) FROM memory_ledger_entries{where} GROUP BY {col}", params)
+        report[key] = dict(cur.fetchall())
+    cur.execute(f"SELECT COUNT(*) FROM memory_ledger_entries{where}", params)
+    report["insertedLedgerEntries"] = int(cur.fetchone()[0] or 0)
+    cur.execute(f"SELECT COUNT(*) FROM memory_ledger_entries{where + (' AND' if where else ' WHERE')} public_usable=0", params)
+    report["publicUsabilityRejections"] = int(cur.fetchone()[0] or 0)
+    cur.execute(f"SELECT COUNT(*) FROM memory_ledger_entries{where + (' AND' if where else ' WHERE')} (source_class='legacy_source_blind' OR visibility='unknown')", params)
+    report["missingUnmappedProvenance"] = int(cur.fetchone()[0] or 0)
+    cur.execute(f"SELECT COUNT(*) FROM (SELECT subject_key, predicate_key FROM memory_ledger_entries{where + (' AND' if where else ' WHERE')} lifecycle_status='active' GROUP BY subject_key, predicate_key HAVING COUNT(*) > 1)", params)
+    report["entriesWithMultipleActiveValues"] = int(cur.fetchone()[0] or 0)
+    cur.execute("SELECT lineage_type, COUNT(*) FROM memory_ledger_lineage GROUP BY lineage_type")
+    lineage_counts = dict(cur.fetchall())
+    report["explicitCorrectionCounts"] = int(lineage_counts.get("correction_of", 0) + lineage_counts.get("supersedes", 0))
+    return report

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -368,15 +368,32 @@ def shadow_broadcast_memory_row(conn: sqlite3.Connection, *, row_id: int, guild_
     return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="broadcast_memory", source_row_id=row_id, source_revision=rev, source_role="broadcast_memory", entry_type="show_event" if "show" in (entry_type or "") else "event", subject_key="barcode_radio", subject_display_name="BARCODE Radio", predicate_key=entry_type or "broadcast_memory", value=cleaned_summary[:500], source_class=SourceClass.FIRST_PARTY_RECORD, visibility=Visibility.PUBLIC_SAFE if public_ok else Visibility.INTERNAL, confidence=Confidence.HIGH if public_ok else Confidence.MEDIUM, public_usable=public_ok, salience=0.5, observed_at=created_at or updated_at or _now(), source_sequence=int(row_id or 0), freshness=usage_scope or "", lifecycle_status=lifecycle, participants=tuple([LedgerParticipant(f"discord_user:{submitted_by_user_id}", submitted_by_name or "", "submitter", 0)] if submitted_by_user_id else ()), lineage=lineage))
 
 
+def _unique_broadcast_primary_entry(conn: sqlite3.Connection, *, guild_id: int, source_row_id: int | str) -> str:
+    ensure_memory_ledger_schema(conn)
+    rows = conn.execute(
+        "SELECT entry_id FROM memory_ledger_entries WHERE guild_id=? AND source_table='broadcast_memory' AND source_row_id=? AND source_role='broadcast_memory' ORDER BY created_at DESC",
+        (guild_id, str(source_row_id)),
+    ).fetchall()
+    return rows[0][0] if len(rows) == 1 else ""
+
+
 def shadow_broadcast_status_event(conn: sqlite3.Connection, *, row_id: int, guild_id: int, status: str, updated_at: str, actor_id: int | None = None, actor_name: str = "", superseded_by_id: int | None = None) -> LedgerWriteResult:
     rev = source_revision_for(row_id, updated_at, event=f"status:{status}:{updated_at}")
-    target = stable_entry_id(guild_id=guild_id, source_table="broadcast_memory", source_row_id=row_id, source_revision=str(row_id), entry_type="event", subject_key="barcode_radio", predicate_key="broadcast_status")
     lineage = ()
+    reason_override = "ok"
+    if status == "superseded" and superseded_by_id:
+        old_entry = _unique_broadcast_primary_entry(conn, guild_id=guild_id, source_row_id=row_id)
+        replacement_entry = _unique_broadcast_primary_entry(conn, guild_id=guild_id, source_row_id=superseded_by_id)
+        if old_entry and replacement_entry:
+            lineage = (("derived_from", old_entry), ("derived_from", replacement_entry))
+        else:
+            reason_override = "unresolved_broadcast_status_lineage"
     lifecycle = RESOLVED_LIFECYCLE if status == "resolved" else REVIEW_ONLY_LIFECYCLE
     predicate = f"broadcast_status:{status or 'unknown'}"
-    if status == "superseded" and superseded_by_id:
-        lifecycle = REVIEW_ONLY_LIFECYCLE
-    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="broadcast_memory", source_row_id=row_id, source_revision=rev, source_event_key=f"status:{status}", source_role="broadcast_memory_status", entry_type="event", subject_key="barcode_radio", subject_display_name="BARCODE Radio", predicate_key=predicate, value=status or "unknown", source_class=SourceClass.FIRST_PARTY_RECORD, visibility=Visibility.INTERNAL, confidence=Confidence.HIGH, public_usable=False, observed_at=updated_at or _now(), source_sequence=int(row_id or 0), lifecycle_status=lifecycle, participants=tuple([LedgerParticipant(f"discord_user:{actor_id}", actor_name or "", "correction_actor", 0)] if actor_id else ()), lineage=lineage))
+    result = insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="broadcast_memory", source_row_id=row_id, source_revision=rev, source_event_key=f"status:{status}", source_role="broadcast_memory_status", entry_type="event", subject_key="barcode_radio", subject_display_name="BARCODE Radio", predicate_key=predicate, value=status or "unknown", source_class=SourceClass.FIRST_PARTY_RECORD, visibility=Visibility.INTERNAL, confidence=Confidence.HIGH, public_usable=False, observed_at=updated_at or _now(), source_sequence=int(row_id or 0), lifecycle_status=lifecycle, participants=tuple([LedgerParticipant(f"discord_user:{actor_id}", actor_name or "", "correction_actor", 0)] if actor_id else ()), lineage=lineage))
+    if reason_override != "ok" and result.outcome == "inserted":
+        return LedgerWriteResult(result.entry_id, result.outcome, reason_override, result.source_table, result.source_row_id, result.source_revision, result.source_event_key, result.guild_id)
+    return result
 
 
 def shadow_canon_reference(conn: sqlite3.Connection, *, guild_id: int, canon_id: str, subject_key: str, subject_display_name: str, predicate_key: str, value: str, observed_at: str = "") -> LedgerWriteResult:
@@ -424,5 +441,4 @@ def build_memory_ledger_evaluation(conn: sqlite3.Connection, *, guild_id: int | 
     dangling_lineage = int(cur.fetchone()[0] or 0)
     report["danglingLineageTargets"] = dangling_lineage
     report["legacyToLedgerParityMismatches"] = missing_receipt_entries + entries_without_receipts + dangling_lineage + int(report.get("shadowWriteErrors", 0)) + int(report.get("unresolvedCorrectionAttempts", 0))
-    report["implicitSupersessionsBlocked"] = 0
     return report

--- a/tests/test_memory_ledger_bot_paths.py
+++ b/tests/test_memory_ledger_bot_paths.py
@@ -138,6 +138,113 @@ class MemoryLedgerBotPathTests(unittest.TestCase):
         dump = str(self.rows("SELECT * FROM memory_ledger_shadow_receipts"))
         self.assertNotIn("RAW SECRET", dump)
 
+    def test_broadcast_replacement_has_one_revision_and_real_lineage(self):
+        self.enable()
+        original_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW original"),
+            {
+                "cleaned_summary": "Original safe summary.",
+                "entry_type": "show_note",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        replacement_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW replacement"),
+            {
+                "cleaned_summary": "Replacement safe summary.",
+                "entry_type": "show_note",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+                "supersedes_id": original_id,
+            },
+        )
+        updated_at = "2026-07-16T00:00:00-07:00"
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            conn.execute(
+                "UPDATE broadcast_memory SET status='superseded', superseded_by_id=?, updated_at=? WHERE id=?",
+                (replacement_id, updated_at, original_id),
+            )
+            conn.commit()
+        bnl01_bot._shadow_memory_ledger_write(
+            "broadcast_memory_status",
+            lambda ledger_conn: ledger.shadow_broadcast_status_event(
+                ledger_conn,
+                row_id=original_id,
+                guild_id=1,
+                status="superseded",
+                updated_at=updated_at,
+                actor_id=42,
+                actor_name="Crow",
+                superseded_by_id=replacement_id,
+            ),
+            guild_id=1,
+            source_table="broadcast_memory",
+            source_row_id=original_id,
+            source_revision=f"event:status:superseded:{updated_at.lower()}",
+            source_event_key="status:superseded",
+        )
+        primary_rows = self.rows(
+            """
+            SELECT source_row_id, entry_id, normalized_value
+            FROM memory_ledger_entries
+            WHERE source_table='broadcast_memory' AND source_role='broadcast_memory'
+            ORDER BY CAST(source_row_id AS INTEGER)
+            """
+        )
+        self.assertEqual(len(primary_rows), 2)
+        original_entry = primary_rows[0][1]
+        replacement_entry = primary_rows[1][1]
+        self.assertEqual(primary_rows[0][0], str(original_id))
+        self.assertEqual(primary_rows[1][0], str(replacement_id))
+        self.assertEqual(primary_rows[1][2], "Replacement safe summary.")
+        self.assertEqual(
+            self.rows(
+                "SELECT COUNT(*) FROM memory_ledger_entries WHERE source_table='broadcast_memory' AND source_role='broadcast_memory' AND source_row_id=?",
+                (str(replacement_id),),
+            )[0][0],
+            1,
+        )
+        self.assertEqual(
+            self.rows(
+                "SELECT COUNT(*) FROM memory_ledger_entries WHERE source_table='broadcast_memory' AND source_role='broadcast_memory_status' AND source_row_id=?",
+                (str(original_id),),
+            )[0][0],
+            1,
+        )
+        self.assertEqual(
+            set(self.rows("SELECT lineage_type, target_entry_id FROM memory_ledger_lineage WHERE entry_id=?", (replacement_entry,))),
+            {("correction_of", original_entry), ("supersedes", original_entry)},
+        )
+        self.assertEqual(
+            self.rows(
+                """
+                SELECT COUNT(*)
+                FROM memory_ledger_lineage l
+                LEFT JOIN memory_ledger_entries e
+                  ON e.guild_id=l.guild_id AND e.entry_id=l.target_entry_id
+                WHERE e.entry_id IS NULL
+                """
+            )[0][0],
+            0,
+        )
+        effective_active = self.rows(
+            """
+            SELECT entry_id
+            FROM memory_ledger_entries
+            WHERE source_table='broadcast_memory'
+              AND source_role='broadcast_memory'
+              AND lifecycle_status='active'
+              AND entry_id NOT IN (
+                SELECT target_entry_id FROM memory_ledger_lineage
+                WHERE lineage_type IN ('supersedes', 'retracts')
+              )
+            """
+        )
+        self.assertEqual(effective_active, [(replacement_entry,)])
+
     def test_report_is_guild_scoped_and_counts_real_outcomes(self):
         self.enable()
         bnl01_bot.save_user_message(42, "Crow", 1, "remember this number: 8", channel_policy="sealed_test")

--- a/tests/test_memory_ledger_bot_paths.py
+++ b/tests/test_memory_ledger_bot_paths.py
@@ -1,0 +1,133 @@
+import asyncio
+import os
+import sqlite3
+import tempfile
+import unittest
+from unittest import mock
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+import bnl_memory_ledger as ledger
+
+
+class _Author:
+    id = 42
+    display_name = "Crow"
+
+class _Message:
+    def __init__(self, content="note"):
+        self.content = content
+        self.author = _Author()
+        self.replies = []
+    async def reply(self, text):
+        self.replies.append(text)
+
+class _FailMessage(_Message):
+    async def reply(self, text):
+        raise RuntimeError("send failed")
+
+class MemoryLedgerBotPathTests(unittest.TestCase):
+    def setUp(self):
+        self.old_db = bnl01_bot.DB_FILE
+        self.tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.tmp.close()
+        bnl01_bot.DB_FILE = self.tmp.name
+        self.env = mock.patch.dict(os.environ, {}, clear=False)
+        self.env.start()
+        os.environ.pop("BNL_MEMORY_LEDGER_SHADOW_ENABLED", None)
+        bnl01_bot.init_db()
+
+    def tearDown(self):
+        self.env.stop()
+        bnl01_bot.DB_FILE = self.old_db
+        try:
+            os.unlink(self.tmp.name)
+        except OSError:
+            pass
+
+    def rows(self, sql, params=()):
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            return conn.execute(sql, params).fetchall()
+
+    def enable(self):
+        os.environ["BNL_MEMORY_LEDGER_SHADOW_ENABLED"] = "1"
+
+    def test_disabled_gate_save_user_message_creates_no_ledger(self):
+        bnl01_bot.save_user_message(42, "Crow", 1, "remember this number: 8", channel_policy="sealed_test")
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM conversations")[0][0], 1)
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_ledger_entries")[0][0], 0)
+
+    def test_enabled_gate_save_user_message_inserts_and_dedup_receipts(self):
+        self.enable()
+        bnl01_bot.save_user_message(42, "Crow", 1, "remember this number: 8", channel_policy="sealed_test")
+        self.assertEqual(self.rows("SELECT normalized_value FROM memory_ledger_entries")[0][0], "8")
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            result = ledger.shadow_conversation_row(conn, row_id=1, user_id=42, user_name="Crow", guild_id=1, role="user", content="remember this number: 8", channel_policy="sealed_test")
+            ledger.record_shadow_receipt(conn, guild_id=1, writer="test", source_table=result.source_table, source_row_id=result.source_row_id, source_revision=result.source_revision, outcome=result.outcome, reason_code=result.reason_code, entry_id=result.entry_id)
+            conn.commit()
+        outcomes = dict(self.rows("SELECT outcome, COUNT(*) FROM memory_ledger_shadow_receipts GROUP BY outcome"))
+        self.assertEqual(outcomes.get("inserted"), 1)
+        self.assertEqual(outcomes.get("deduplicated"), 1)
+
+    def test_shadow_failure_keeps_legacy_conversation_and_records_error(self):
+        self.enable()
+        with mock.patch("bnl01_bot.shadow_conversation_row", side_effect=RuntimeError("boom")):
+            bnl01_bot.save_user_message(42, "Crow", 1, "hello", channel_policy="public_home")
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM conversations")[0][0], 1)
+        self.assertEqual(self.rows("SELECT outcome, reason_code FROM memory_ledger_shadow_receipts")[0], ("error", "shadow_exception"))
+
+    def test_model_send_after_delivery_subject_and_participants(self):
+        self.enable()
+        asyncio.run(bnl01_bot.send_reply_then_save_model(_Message(), "I remember 8.", user_id=42, guild_id=1, channel_policy="sealed_test"))
+        entry = self.rows("SELECT subject_key, source_role, derived, projection, public_usable FROM memory_ledger_entries")[0]
+        self.assertEqual(entry, ("bnl_01", "model", 1, 1, 0))
+        parts = self.rows("SELECT participant_key, participant_role FROM memory_ledger_participants ORDER BY order_index")
+        self.assertEqual(parts[0], ("bnl_01", "author"))
+        self.assertEqual(parts[1], ("discord_user:42", "conversation_target"))
+
+    def test_failed_send_creates_no_model_conversation_or_ledger(self):
+        self.enable()
+        with self.assertRaises(RuntimeError):
+            asyncio.run(bnl01_bot.send_reply_then_save_model(_FailMessage(), "No row", user_id=42, guild_id=1, channel_policy="sealed_test"))
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM conversations WHERE role='model'")[0][0], 0)
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_ledger_entries")[0][0], 0)
+
+    def test_mutable_fact_update_creates_second_revision_but_same_revision_is_idempotent(self):
+        self.enable()
+        bnl01_bot.upsert_user_fact(42, 1, "favorite_number", "8", 0.8)
+        bnl01_bot.upsert_user_fact(42, 1, "favorite_number", "9", 0.8)
+        values = self.rows("SELECT normalized_value FROM memory_ledger_entries WHERE source_table='user_memory_facts' ORDER BY source_revision")
+        self.assertEqual([v[0] for v in values], ["8", "9"])
+
+    def test_queue_operational_state_excluded_but_discussion_allowed(self):
+        self.enable()
+        bnl01_bot.save_user_message(42, "Crow", 1, "We joked that the queue is haunted.", channel_policy="public_home")
+        bnl01_bot.save_user_message(42, "Crow", 1, "The website queue is open.", channel_policy="public_home")
+        rows = self.rows("SELECT predicate_key, normalized_value FROM memory_ledger_entries WHERE source_table='conversations' ORDER BY source_row_id")
+        self.assertEqual(rows, [("conversation", "We joked that the queue is haunted.")])
+        self.assertEqual(self.rows("SELECT outcome, reason_code FROM memory_ledger_shadow_receipts WHERE outcome='skipped'")[0], ("skipped", "queue_operational_state_excluded"))
+
+    def test_broadcast_insert_cleaned_summary_and_raw_absent_from_receipts(self):
+        self.enable()
+        msg = _Message("RAW SECRET note")
+        new_id = bnl01_bot.add_broadcast_memory_entry(1, msg, {"cleaned_summary": "Clean show summary.", "entry_type": "show_note", "public_safe": True, "usage_scope": "public"})
+        self.assertGreater(new_id, 0)
+        self.assertEqual(self.rows("SELECT normalized_value FROM memory_ledger_entries WHERE source_table='broadcast_memory'")[0][0], "Clean show summary.")
+        dump = str(self.rows("SELECT * FROM memory_ledger_shadow_receipts"))
+        self.assertNotIn("RAW SECRET", dump)
+
+    def test_report_is_guild_scoped_and_counts_real_outcomes(self):
+        self.enable()
+        bnl01_bot.save_user_message(42, "Crow", 1, "remember this number: 8", channel_policy="sealed_test")
+        bnl01_bot.save_user_message(43, "Other", 2, "remember this number: 9", channel_policy="sealed_test")
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            r1 = ledger.build_memory_ledger_evaluation(conn, guild_id=1)
+            r2 = ledger.build_memory_ledger_evaluation(conn, guild_id=2)
+        self.assertEqual(r1["eligibleLegacyWrites"], 1)
+        self.assertEqual(r2["eligibleLegacyWrites"], 1)
+        self.assertEqual(r1["insertedLedgerEntries"], 1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_ledger_bot_paths.py
+++ b/tests/test_memory_ledger_bot_paths.py
@@ -101,13 +101,33 @@ class MemoryLedgerBotPathTests(unittest.TestCase):
         values = self.rows("SELECT normalized_value FROM memory_ledger_entries WHERE source_table='user_memory_facts' ORDER BY source_revision")
         self.assertEqual([v[0] for v in values], ["8", "9"])
 
-    def test_queue_operational_state_excluded_but_discussion_allowed(self):
+    def test_discord_queue_and_payment_discussion_is_not_content_excluded(self):
         self.enable()
-        bnl01_bot.save_user_message(42, "Crow", 1, "We joked that the queue is haunted.", channel_policy="public_home")
-        bnl01_bot.save_user_message(42, "Crow", 1, "The website queue is open.", channel_policy="public_home")
-        rows = self.rows("SELECT predicate_key, normalized_value FROM memory_ledger_entries WHERE source_table='conversations' ORDER BY source_row_id")
-        self.assertEqual(rows, [("conversation", "We joked that the queue is haunted.")])
-        self.assertEqual(self.rows("SELECT outcome, reason_code FROM memory_ledger_shadow_receipts WHERE outcome='skipped'")[0], ("skipped", "queue_operational_state_excluded"))
+        samples = [
+            "is the queue open?",
+            "payment is pending",
+            "what's your availability?",
+            "the current session was fun",
+            "we were talking about the queue",
+            "the DJ queue is full tonight",
+        ]
+        for idx, text in enumerate(samples, start=1):
+            bnl01_bot.save_user_message(42, "Crow", 1, text, channel_policy="public_home", message_id=idx)
+        rows = self.rows("SELECT normalized_value FROM memory_ledger_entries WHERE source_table='conversations' ORDER BY source_row_id")
+        self.assertEqual([r[0] for r in rows], samples)
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_ledger_shadow_receipts WHERE reason_code='queue_operational_state_excluded'")[0][0], 0)
+
+    def test_partial_shadow_failure_rolls_back_and_records_safe_error(self):
+        self.enable()
+        def partial_then_fail(conn):
+            ledger.shadow_conversation_row(conn, row_id=1, user_id=42, user_name="Crow", guild_id=1, role="user", content="remember this number: 8", channel_policy="sealed_test")
+            raise RuntimeError("boom with PRIVATE CONTENT")
+        bnl01_bot.save_user_message(42, "Crow", 1, "legacy survives", channel_policy="sealed_test")
+        bnl01_bot._shadow_memory_ledger_write("partial_failure_test", partial_then_fail, guild_id=1, source_table="conversations", source_row_id=999, source_revision="999")
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM conversations")[0][0], 1)
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_ledger_entries WHERE normalized_value='8'")[0][0], 0)
+        self.assertEqual(self.rows("SELECT outcome, reason_code FROM memory_ledger_shadow_receipts WHERE writer='partial_failure_test'")[0], ("error", "shadow_exception"))
+        self.assertNotIn("PRIVATE CONTENT", str(self.rows("SELECT * FROM memory_ledger_shadow_receipts")))
 
     def test_broadcast_insert_cleaned_summary_and_raw_absent_from_receipts(self):
         self.enable()

--- a/tests/test_memory_ledger_v1.py
+++ b/tests/test_memory_ledger_v1.py
@@ -29,8 +29,9 @@ class MemoryLedgerV1Tests(unittest.TestCase):
         duplicate = ledger.shadow_conversation_row(self.conn, row_id=500, **kwargs)
         second = ledger.shadow_conversation_row(self.conn, row_id=501, **kwargs)
         self.conn.commit()
-        self.assertEqual(first, duplicate)
-        self.assertNotEqual(first, second)
+        self.assertEqual(first.entry_id, duplicate.entry_id)
+        self.assertEqual(duplicate.outcome, "deduplicated")
+        self.assertNotEqual(first.entry_id, second.entry_id)
         self.assertEqual(self.count_entries(), 2)
 
     def test_number_sequence_is_additive_not_supersession(self):
@@ -60,6 +61,24 @@ class MemoryLedgerV1Tests(unittest.TestCase):
         ledger.shadow_conversation_row(self.conn, row_id=10, user_id=7, user_name="Crow", guild_id=1, role="user", content="We joked that the queue is haunted.", channel_policy="public_home")
         row = self.conn.execute("SELECT source_table, predicate_key FROM memory_ledger_entries").fetchone()
         self.assertEqual(row, ("conversations", "conversation"))
+
+
+    def test_single_and_twelve_digit_numbers_are_supported(self):
+        r1 = ledger.shadow_conversation_row(self.conn, row_id=20, user_id=7, user_name="Crow", guild_id=1, role="user", content="Remember this number: 8", channel_policy="sealed_test")
+        r2 = ledger.shadow_conversation_row(self.conn, row_id=21, user_id=7, user_name="Crow", guild_id=1, role="user", content="remember this number: 123456789012", channel_policy="sealed_test")
+        self.assertEqual((r1.outcome, r2.outcome), ("inserted", "inserted"))
+        values = [r[0] for r in self.conn.execute("SELECT normalized_value FROM memory_ledger_entries ORDER BY source_sequence").fetchall()]
+        self.assertEqual(values, ["8", "123456789012"])
+
+    def test_explicit_unique_correction_links_and_ambiguous_does_not(self):
+        ledger.shadow_conversation_row(self.conn, row_id=30, user_id=7, user_name="Crow", guild_id=1, role="user", content="remember this number: 731946", channel_policy="sealed_test")
+        linked = ledger.shadow_conversation_row(self.conn, row_id=31, user_id=7, user_name="Crow", guild_id=1, role="user", content="Correction: the number is 284517, not 731946", channel_policy="sealed_test")
+        self.assertEqual(linked.reason_code, "explicit_correction_linked")
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_ledger_lineage WHERE lineage_type='correction_of'").fetchone()[0], 1)
+        ledger.shadow_conversation_row(self.conn, row_id=32, user_id=7, user_name="Crow", guild_id=1, role="user", content="remember this number: 111", channel_policy="sealed_test")
+        ledger.shadow_conversation_row(self.conn, row_id=33, user_id=7, user_name="Crow", guild_id=1, role="user", content="remember this number: 111", channel_policy="sealed_test")
+        unresolved = ledger.shadow_conversation_row(self.conn, row_id=34, user_id=7, user_name="Crow", guild_id=1, role="user", content="replace 111 with 222", channel_policy="sealed_test")
+        self.assertEqual(unresolved.reason_code, "unresolved_correction_target")
 
     def test_shadow_gate_default_disabled(self):
         with mock.patch.dict(os.environ, {}, clear=True):

--- a/tests/test_memory_ledger_v1.py
+++ b/tests/test_memory_ledger_v1.py
@@ -53,7 +53,7 @@ class MemoryLedgerV1Tests(unittest.TestCase):
         self.assertEqual([r[0] for r in rows], ["discord_user:1", "discord_user:2"])
 
     def test_broadcast_uses_cleaned_summary_not_raw_note(self):
-        ledger.shadow_broadcast_memory_row(self.conn, row_id=9, guild_id=1, cleaned_summary="Safe show summary", entry_type="show_note", public_safe=True, status="active", usage_scope="public")
+        ledger.shadow_broadcast_memory_row(self.conn, row_id=9, guild_id=1, cleaned_summary="Safe show summary", entry_type="show_note", public_safe=True, status="active", usage_scope="ambient,direct")
         row = self.conn.execute("SELECT normalized_value, public_usable, visibility FROM memory_ledger_entries").fetchone()
         self.assertEqual(row, ("Safe show summary", 1, "public_safe"))
 
@@ -79,6 +79,41 @@ class MemoryLedgerV1Tests(unittest.TestCase):
         ledger.shadow_conversation_row(self.conn, row_id=33, user_id=7, user_name="Crow", guild_id=1, role="user", content="remember this number: 111", channel_policy="sealed_test")
         unresolved = ledger.shadow_conversation_row(self.conn, row_id=34, user_id=7, user_name="Crow", guild_id=1, role="user", content="replace 111 with 222", channel_policy="sealed_test")
         self.assertEqual(unresolved.reason_code, "unresolved_correction_target")
+
+
+    def test_explicit_correction_retires_old_value_from_effective_active_count(self):
+        ledger.shadow_conversation_row(self.conn, row_id=40, user_id=7, user_name="Crow", guild_id=1, role="user", content="remember this number: 8", channel_policy="sealed_test")
+        linked = ledger.shadow_conversation_row(self.conn, row_id=41, user_id=7, user_name="Crow", guild_id=1, role="user", content="replace 8 with 9", channel_policy="sealed_test")
+        self.assertEqual(linked.reason_code, "explicit_correction_linked")
+        edges = set(self.conn.execute("SELECT lineage_type FROM memory_ledger_lineage WHERE entry_id=?", (linked.entry_id,)).fetchall())
+        self.assertEqual(edges, {("correction_of",), ("supersedes",)})
+        report = ledger.build_memory_ledger_evaluation(self.conn, guild_id=1)
+        self.assertEqual(report["entriesWithMultipleActiveValues"], 0)
+        self.assertEqual(report["explicitCorrectionCounts"], 1)
+
+    def test_all_lineage_targets_resolve_to_entries(self):
+        ledger.shadow_conversation_row(self.conn, row_id=50, user_id=7, user_name="Crow", guild_id=1, role="user", content="remember this number: 8", channel_policy="sealed_test")
+        ledger.shadow_conversation_row(self.conn, row_id=51, user_id=7, user_name="Crow", guild_id=1, role="user", content="Correction: the number is 9, not 8", channel_policy="sealed_test")
+        missing = self.conn.execute("""
+            SELECT COUNT(*) FROM memory_ledger_lineage l
+            LEFT JOIN memory_ledger_entries e ON e.guild_id=l.guild_id AND e.entry_id=l.target_entry_id
+            WHERE e.entry_id IS NULL
+        """).fetchone()[0]
+        self.assertEqual(missing, 0)
+
+    def test_broadcast_usage_scopes_public_usability(self):
+        cases = [("ambient,direct", 1, "public_safe"), ("show_status", 1, "public_safe"), ("relay", 1, "public_safe"), ("internal", 0, "internal"), ("ambient", 0, "internal")]
+        for idx, (scope, expected_public, expected_visibility) in enumerate(cases, start=60):
+            ledger.shadow_broadcast_memory_row(self.conn, row_id=idx, guild_id=1, cleaned_summary=f"Summary {idx}", entry_type="show_note", public_safe=(idx != 64), status="active", usage_scope=scope)
+            row = self.conn.execute("SELECT public_usable, visibility FROM memory_ledger_entries WHERE source_row_id=?", (str(idx),)).fetchone()
+            self.assertEqual(row, (expected_public, expected_visibility))
+
+    def test_evaluation_detects_missing_success_receipt_entry_and_dangling_lineage(self):
+        ledger.record_shadow_receipt(self.conn, guild_id=1, writer="test", source_table="conversations", source_row_id=999, outcome="inserted", reason_code="ok", entry_id="missing")
+        self.conn.execute("INSERT INTO memory_ledger_lineage(entry_id, guild_id, lineage_type, target_entry_id, created_at) VALUES ('source', 1, 'supersedes', 'missing-target', 'now')")
+        report = ledger.build_memory_ledger_evaluation(self.conn, guild_id=1)
+        self.assertGreaterEqual(report["legacyToLedgerParityMismatches"], 2)
+        self.assertEqual(report["danglingLineageTargets"], 1)
 
     def test_shadow_gate_default_disabled(self):
         with mock.patch.dict(os.environ, {}, clear=True):

--- a/tests/test_memory_ledger_v1.py
+++ b/tests/test_memory_ledger_v1.py
@@ -1,0 +1,70 @@
+import os
+import sqlite3
+import unittest
+from unittest import mock
+
+import bnl_memory_ledger as ledger
+
+
+class MemoryLedgerV1Tests(unittest.TestCase):
+    def setUp(self):
+        self.conn = sqlite3.connect(":memory:")
+        ledger.ensure_memory_ledger_schema(self.conn)
+
+    def tearDown(self):
+        self.conn.close()
+
+    def count_entries(self):
+        return self.conn.execute("SELECT COUNT(*) FROM memory_ledger_entries").fetchone()[0]
+
+    def test_schema_idempotent_and_stable_id(self):
+        ledger.ensure_memory_ledger_schema(self.conn)
+        one = ledger.stable_entry_id(guild_id=1, source_table="conversations", source_row_id=500, entry_type="observation", subject_key="discord_user:7", predicate_key="remembered_number")
+        two = ledger.stable_entry_id(guild_id=1, source_table="conversations", source_row_id=500, entry_type="observation", subject_key="discord_user:7", predicate_key="remembered_number")
+        self.assertEqual(one, two)
+
+    def test_exact_source_dedup_but_separate_rows_survive(self):
+        kwargs = dict(user_id=7, user_name="Crow", guild_id=1, role="user", content="remember this number: 8", channel_policy="sealed_test")
+        first = ledger.shadow_conversation_row(self.conn, row_id=500, **kwargs)
+        duplicate = ledger.shadow_conversation_row(self.conn, row_id=500, **kwargs)
+        second = ledger.shadow_conversation_row(self.conn, row_id=501, **kwargs)
+        self.conn.commit()
+        self.assertEqual(first, duplicate)
+        self.assertNotEqual(first, second)
+        self.assertEqual(self.count_entries(), 2)
+
+    def test_number_sequence_is_additive_not_supersession(self):
+        ledger.shadow_conversation_row(self.conn, row_id=1, user_id=7, user_name="Crow", guild_id=1, role="user", content="remember this number: 731946", channel_policy="sealed_test", observed_at="2026-01-01T00:00:01+00:00")
+        ledger.shadow_conversation_row(self.conn, row_id=2, user_id=7, user_name="Crow", guild_id=1, role="user", content="remember this number: 284517", channel_policy="sealed_test", observed_at="2026-01-01T00:00:02+00:00")
+        rows = self.conn.execute("SELECT normalized_value, lifecycle_status FROM memory_ledger_entries ORDER BY source_sequence").fetchall()
+        self.assertEqual(rows, [("731946", "active"), ("284517", "active")])
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_ledger_lineage WHERE lineage_type IN ('supersedes','correction_of')").fetchone()[0], 0)
+
+    def test_model_row_is_derived_and_cannot_establish_user_fact(self):
+        ledger.shadow_conversation_row(self.conn, row_id=3, user_id=7, user_name="BNL-01", guild_id=1, role="model", content="I remember 284517.", channel_policy="sealed_test")
+        row = self.conn.execute("SELECT entry_type, source_role, derived, projection, predicate_key, public_usable FROM memory_ledger_entries").fetchone()
+        self.assertEqual(row, ("derived_summary", "model", 1, 1, "model_output", 0))
+
+    def test_participants_are_queryable_and_ordered(self):
+        entry = ledger.LedgerEntry(guild_id=1, source_table="manual", source_row_id=1, source_role="operator", entry_type="shared_moment", subject_key="moment:1", predicate_key="manual_shared_moment", participants=(ledger.LedgerParticipant("discord_user:2", "B", "participant", 1), ledger.LedgerParticipant("discord_user:1", "A", "participant", 0)))
+        ledger.insert_ledger_entry(self.conn, entry)
+        rows = self.conn.execute("SELECT participant_key FROM memory_ledger_participants WHERE entry_id=? ORDER BY order_index", (entry.entry_id,)).fetchall()
+        self.assertEqual([r[0] for r in rows], ["discord_user:1", "discord_user:2"])
+
+    def test_broadcast_uses_cleaned_summary_not_raw_note(self):
+        ledger.shadow_broadcast_memory_row(self.conn, row_id=9, guild_id=1, cleaned_summary="Safe show summary", entry_type="show_note", public_safe=True, status="active", usage_scope="public")
+        row = self.conn.execute("SELECT normalized_value, public_usable, visibility FROM memory_ledger_entries").fetchone()
+        self.assertEqual(row, ("Safe show summary", 1, "public_safe"))
+
+    def test_queue_discussion_is_conversation_not_website_state(self):
+        ledger.shadow_conversation_row(self.conn, row_id=10, user_id=7, user_name="Crow", guild_id=1, role="user", content="We joked that the queue is haunted.", channel_policy="public_home")
+        row = self.conn.execute("SELECT source_table, predicate_key FROM memory_ledger_entries").fetchone()
+        self.assertEqual(row, ("conversations", "conversation"))
+
+    def test_shadow_gate_default_disabled(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(ledger.shadow_enabled())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Introduce a versioned, append-only Unified Memory Ledger (schema `memory_ledger_v1`) as BNL’s canonical intelligence spine in shadow mode while preserving all existing behavior. 
- Capture provenance-rich, non-destructive memory rows (observations, claims, events, broadcast entries, memory-tiers, relationships, etc.) so later Moment Engine work has deterministic timestamps, participant lists, and lineage primitives. 
- Ensure ledger writes are additive, idempotent per exact legacy source row, and never replace or alter legacy production memory, retrieval or responses.

### Description

- Adds a dedicated module `bnl_memory_ledger.py` implementing the `memory_ledger_v1` contract, supported entry types and lineage (`derived_from`, `correction_of`, `supersedes`, `retracts`, `duplicate_of`, `part_of_moment`), deterministic ordered `memory_ledger_participants`, and stable entry ID generation. 
- Creates an idempotent SQLite schema (`memory_ledger_entries`, `memory_ledger_lineage`, `memory_ledger_participants`) with the requested indexes and a uniqueness constraint to provide exact-source deduplication. 
- Wires non-fatal shadow-write adapters into legacy write paths (conversation rows, model rows, `user_memory_facts`, `memory_tiers`, `relationship_journal`, approved `broadcast_memory`) that run only after the legacy write commits and preserve existing function return behavior. 
- Adds the feature gate `BNL_MEMORY_LEDGER_SHADOW_ENABLED` (shadow disabled by default) and a compact read-only evaluation reporter integrated into the existing memory diagnostic snapshot; broadcast rows use only `cleaned_summary` and model rows are marked derived/projection and cannot create authoritative user facts.

### Testing

- Verified compilation with `python -m py_compile bnl01_bot.py bnl_memory_ledger.py` (passed) and `git diff --check` (no issues). 
- Added focused ledger unit tests in `tests/test_memory_ledger_v1.py` and ran `python -m pytest tests/test_memory_ledger_v1.py -q` (8 passed). 
- Ran an expanded focused test set `python -m pytest tests/test_memory_ledger_v1.py tests/test_canon_source_contract.py tests/test_conversation_context_v2.py tests/test_route_memory_governance.py tests/test_broadcast_memory_rd_sanitizer.py tests/test_adaptive_memory_lifecycle.py -q` (174 passed, 5 warnings). 
- Full-suite `python -m pytest -q` on the branch produced `31 failed, 827 passed, 26 warnings, 88 subtests passed`, and an identical full-suite run at the required base commit `4d3b8fccdb0148f0e18e410fcb15403d9a14e998` produced the same failing-family footprint (`31 failed`) indicating the failing tests are pre-existing and not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a586e15708c8321b60d740564d95504)