### PR TITLE
Moment Engine v1 — Time-Bounded Conversational Memory in Shadow Mode

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -4391,7 +4391,14 @@ def _shadow_memory_ledger_write(writer_name: str, callback, *, guild_id: int = 0
         except Exception as receipt_exc:
             logging.debug("memory_ledger_shadow_receipt_failed writer=%s error=%s", writer_name, receipt_exc)
         conn.commit()
-        if result and result.entry_id and (result.source_table or source_table) == "conversations":
+        if (
+            result
+            and result.entry_id
+            and result.outcome in {"inserted", "deduplicated"}
+            and (result.source_table or source_table) == "conversations"
+            and moment_engine_shadow_enabled()
+            and memory_ledger_shadow_enabled()
+        ):
             try:
                 moment_conn = sqlite3.connect(DB_FILE)
                 try:

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -34,6 +34,7 @@ from bnl_memory_ledger import (
     shadow_relationship_journal_row,
     shadow_user_fact_row,
 )
+from bnl_moment_engine import observe_ledger_entry as observe_moment_ledger_entry
 from bnl_conversation_context_v2 import (
     CONVERSATION_CONTEXT_VERSION,
     ConversationContextRequest,
@@ -4386,6 +4387,16 @@ def _shadow_memory_ledger_write(writer_name: str, callback, *, guild_id: int = 0
         except Exception as receipt_exc:
             logging.debug("memory_ledger_shadow_receipt_failed writer=%s error=%s", writer_name, receipt_exc)
         conn.commit()
+        if result and result.entry_id and (result.source_table or source_table) == "conversations":
+            try:
+                moment_conn = sqlite3.connect(DB_FILE)
+                try:
+                    observe_moment_ledger_entry(moment_conn, result.entry_id)
+                    moment_conn.commit()
+                finally:
+                    moment_conn.close()
+            except Exception as moment_exc:
+                logging.debug("moment_engine_shadow_failed writer=%s error_type=%s", writer_name, type(moment_exc).__name__)
         return result
     except Exception as exc:
         logging.debug("memory_ledger_shadow_write_failed writer=%s error_type=%s", writer_name, type(exc).__name__)

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -34,7 +34,11 @@ from bnl_memory_ledger import (
     shadow_relationship_journal_row,
     shadow_user_fact_row,
 )
-from bnl_moment_engine import observe_ledger_entry as observe_moment_ledger_entry
+from bnl_moment_engine import (
+    observe_ledger_entry as observe_moment_ledger_entry,
+    shadow_enabled as moment_engine_shadow_enabled,
+    sweep_expired_windows as sweep_expired_moment_windows,
+)
 from bnl_conversation_context_v2 import (
     CONVERSATION_CONTEXT_VERSION,
     ConversationContextRequest,
@@ -13823,6 +13827,26 @@ def iter_managed_guilds():
         return [guild]
     return list(client.guilds)
 
+
+@tasks.loop(minutes=1)
+async def moment_engine_sweep_task():
+    if not moment_engine_shadow_enabled() or not memory_ledger_shadow_enabled():
+        return
+    try:
+        def _sweep():
+            conn = sqlite3.connect(DB_FILE)
+            try:
+                results = sweep_expired_moment_windows(conn)
+                conn.commit()
+                return results
+            finally:
+                conn.close()
+        results = await asyncio.to_thread(_sweep)
+        if results:
+            logging.info("moment_engine_sweep finalized_or_rejected=%s", len(results))
+    except Exception as exc:
+        logging.debug("moment_engine_sweep_failed error_type=%s", type(exc).__name__)
+
 @tasks.loop(minutes=1)
 async def barcode_radio_queue_task():
     now = datetime.now(PACIFIC_TZ)
@@ -15927,6 +15951,9 @@ async def on_ready():
 
     if not barcode_radio_queue_task.is_running():
         barcode_radio_queue_task.start()
+
+    if not moment_engine_sweep_task.is_running():
+        moment_engine_sweep_task.start()
 
     if BNL_WEBSITE_CONTRACT_VERSION == "2":
         await hydrate_startup_relay_v2_once()

--- a/bnl_moment_engine.py
+++ b/bnl_moment_engine.py
@@ -434,8 +434,13 @@ def finalize_moment(conn: sqlite3.Connection, moment_id: str) -> MomentObservati
     if not win:
         return MomentObservationResult(reason_code="missing_window", moment_id=moment_id)
     existing = _existing_moment_entry_id(conn, moment_id, int(win[0] or 0))
-    if win[10] == "finalized" and existing:
+    lifecycle = win[10] or ""
+    if lifecycle == "finalized":
         return MomentObservationResult("deduplicated", "already_finalized", moment_id, existing)
+    if lifecycle in {"needs_review", "rejected", "superseded", "retracted", "expired"}:
+        return MomentObservationResult("deduplicated", f"terminal_{lifecycle}", moment_id, existing)
+    if lifecycle != "open":
+        return MomentObservationResult("skipped", f"not_open_{lifecycle or 'unknown'}", moment_id, existing)
     rows = _entries(conn, moment_id)
     qtype, reason, humans, _models = _qualify(rows)
     if not qtype:

--- a/bnl_moment_engine.py
+++ b/bnl_moment_engine.py
@@ -6,14 +6,22 @@ conversation entries only. This module is deliberately not used by prompt assemb
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone, timedelta
-import hashlib, json, os, re, sqlite3
+from datetime import datetime, timedelta, timezone
+import hashlib
+import json
+import os
+import re
+import sqlite3
 from typing import Any
 
 from bnl_canon_source_contract import Confidence, SourceClass, Visibility
 from bnl_memory_ledger import (
-    BNL_SUBJECT_KEY, LedgerEntry, LedgerParticipant, LedgerWriteResult,
-    ensure_memory_ledger_schema, insert_ledger_entry, shadow_enabled as ledger_shadow_enabled,
+    BNL_SUBJECT_KEY,
+    LedgerEntry,
+    LedgerParticipant,
+    ensure_memory_ledger_schema,
+    insert_ledger_entry,
+    shadow_enabled as ledger_shadow_enabled,
 )
 
 MOMENT_ENGINE_SHADOW_ENV = "BNL_MOMENT_ENGINE_SHADOW_ENABLED"
@@ -21,10 +29,11 @@ MOMENT_SCHEMA_VERSION = "memory_moment_v1"
 MAX_WINDOW_SECONDS = 5 * 60
 INACTIVITY_SECONDS = 2 * 60
 
-STOP = set("a an and are as at be but by for from how i in is it me my of on or our that the this to was we what when where who why with you your did do does about into can could would should just yep yes no ok okay hey hi hello thanks thank lol lmao".split())
-STRONG_MARKERS = ("remember", "recall", "what numbers", "correction", "actually", "replace", "commit", "promise", "boundary", "milestone", "follow up", "follow-up", "celebrate")
+STOP = set("a an and are as at be but by for from how i in is it me my of on or our that the this to was we what when where who why with you your did do does about into can could would should just yep yes no ok okay hey hi hello thanks thank lol lmao got noted also ask asked".split())
 LOW_SIGNAL = set("hi hey hello thanks thank you ok okay yep yes no lol lmao cool nice got it noted".split())
+STRONG_MARKERS = ("remember", "recall", "what numbers", "correction", "actually", "replace", "commit", "promise", "boundary", "milestone", "follow up", "follow-up", "celebrate")
 VIS_RANK = {"public": 0, "public_safe": 0, "reference_canon": 0, "internal": 2, "private": 3, "mod": 3, "sealed_test": 4, "protected": 4, "ai_image_tool": 4, "unknown": 5}
+
 
 @dataclass(frozen=True)
 class MomentObservationResult:
@@ -34,36 +43,138 @@ class MomentObservationResult:
     ledger_entry_id: str = ""
 
 
+@dataclass(frozen=True)
+class SourceEntry:
+    entry_id: str
+    guild_id: int
+    source_table: str
+    source_role: str
+    entry_type: str
+    predicate_key: str
+    normalized_value: str
+    route_mode: str
+    channel_id: int
+    channel_name: str
+    channel_policy: str
+    visibility: str
+    public_usable: bool
+    observed_at: str
+    source_sequence: int
+    lifecycle_status: str
+    subject_key: str
+    subject_display_name: str
+
+    @property
+    def is_human(self) -> bool:
+        return self.source_role == "user"
+
+    @property
+    def is_model(self) -> bool:
+        return self.source_role != "user"
+
+
 def shadow_enabled(environ: dict[str, str] | None = None) -> bool:
     return str((environ or os.environ).get(MOMENT_ENGINE_SHADOW_ENV, "")).strip().lower() in {"1", "true", "yes", "on", "enabled"}
 
 
-def _now() -> str: return datetime.now(timezone.utc).isoformat()
-def _parse_ts(v: str) -> datetime:
-    try: return datetime.fromisoformat((v or "").replace("Z", "+00:00"))
-    except Exception: return datetime.now(timezone.utc)
-def _canon(v: Any) -> str: return re.sub(r"\s+", " ", str(v or "").strip().lower())
-def _tokens(text: str) -> tuple[str, ...]: return tuple(t for t in re.findall(r"[a-z0-9]{2,}", _canon(text)) if t not in STOP)[:12]
-def _topic_key(text: str, predicate: str = "") -> str:
-    nums = re.findall(r"\b\d{2,12}\b", text or "")
-    toks = list(_tokens(text)) + nums
-    if predicate == "remembered_number": toks.append("remembered_number")
-    if not toks: return "low_signal"
-    return "topic_" + hashlib.sha256(" ".join(sorted(set(toks))[:10]).encode()).hexdigest()[:16]
-def stable_moment_id(guild_id:int, channel_id:int, topic_key:str, started_at:str) -> str:
-    return "mom_" + hashlib.sha256(f"{MOMENT_SCHEMA_VERSION}\x1f{guild_id}\x1f{channel_id}\x1f{topic_key}\x1f{started_at}".encode()).hexdigest()[:32]
-def stable_moment_entry_id(moment_id: str) -> str: return "moment_entry_" + hashlib.sha256(moment_id.encode()).hexdigest()[:32]
-def _meaningful(text: str, role: str, predicate: str) -> bool:
-    c = _canon(text)
-    if role != "user": return False
-    if predicate == "remembered_number" or any(m in c for m in STRONG_MARKERS): return True
-    toks = [t for t in _tokens(c) if t not in LOW_SIGNAL]
-    if not toks: return False
-    if re.fullmatch(r"[!?.\s]+", c or ""): return False
-    return len(toks) >= 2 or len(c) >= 24
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _parse_ts(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat((value or "").replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    except Exception:
+        return datetime.now(timezone.utc)
+
+
+def _canon(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip().lower())
+
+
+def _tokens(text: str) -> tuple[str, ...]:
+    return tuple(t for t in re.findall(r"[a-z0-9]{2,}", _canon(text)) if t not in STOP)[:24]
+
+
+def _topic_family(text: str, predicate_key: str) -> str:
+    canon = _canon(text)
+    toks = set(_tokens(canon))
+    if predicate_key == "remembered_number" or (("number" in toks or "numbers" in toks) and ({"remember", "recall"} & toks or "what numbers" in canon)):
+        return "remembered_number"
+    families = (
+        ("music_production", {"synth", "drum", "drums", "bass", "riff", "vocal", "mix", "patch", "bridge", "production"}),
+        ("cooking", {"pizza", "oven", "dough", "sauce", "bake", "baking", "cheese"}),
+        ("outdoors", {"hiking", "hike", "trail", "rain", "weather", "mountain", "boots", "conditions"}),
+    )
+    for name, markers in families:
+        if toks & markers:
+            return name
+    if toks:
+        return "topic:" + ":".join(sorted(toks)[:3])
+    return "low_signal"
+
+
+def _topic_signature(text: str, predicate_key: str) -> tuple[str, ...]:
+    family = _topic_family(text, predicate_key)
+    if family == "remembered_number":
+        return ("remembered_number",)
+    return tuple(sorted(set(_tokens(text))))[:16]
+
+
+def _topic_key(family: str, signature: tuple[str, ...]) -> str:
+    base = family + "|" + " ".join(signature)
+    return "topic_" + hashlib.sha256(base.encode("utf-8")).hexdigest()[:16]
+
+
+def stable_moment_id(guild_id: int, channel_id: int, topic_key: str, started_at: str) -> str:
+    return "mom_" + hashlib.sha256(f"{MOMENT_SCHEMA_VERSION}\x1f{guild_id}\x1f{channel_id}\x1f{topic_key}\x1f{started_at}".encode("utf-8")).hexdigest()[:32]
+
+
+def _meaningful(text: str, role: str, predicate_key: str) -> bool:
+    canon = _canon(text)
+    if role != "user":
+        return False
+    if predicate_key == "remembered_number" or any(marker in canon for marker in STRONG_MARKERS):
+        return True
+    if re.fullmatch(r"[!?.\s]+", canon or ""):
+        return False
+    toks = [t for t in _tokens(canon) if t not in LOW_SIGNAL]
+    return len(toks) >= 2 or len(canon) >= 24
+
+
+def _strong_marker(text: str, predicate_key: str) -> bool:
+    canon = _canon(text)
+    return predicate_key == "remembered_number" or any(marker in canon for marker in STRONG_MARKERS)
+
+
+def _coherent(family: str, signature: tuple[str, ...], window_family: str, window_signature: tuple[str, ...]) -> bool:
+    if not signature or family == "low_signal":
+        return False
+    if family == window_family and family != "topic":
+        return True
+    overlap = set(signature) & set(window_signature)
+    if len(overlap) >= 2:
+        return True
+    denom = max(1, min(len(set(signature)), len(set(window_signature))))
+    return (len(overlap) / denom) >= 0.5 and len(overlap) >= 1
+
+
+def _json_sig(sig: tuple[str, ...]) -> str:
+    return json.dumps(list(sig), sort_keys=True)
+
+
+def _load_sig(raw: str) -> tuple[str, ...]:
+    try:
+        value = json.loads(raw or "[]")
+        return tuple(str(v) for v in value if str(v))
+    except Exception:
+        return ()
+
 
 def ensure_moment_schema(conn: sqlite3.Connection) -> None:
-    ensure_memory_ledger_schema(conn); cur=conn.cursor()
+    ensure_memory_ledger_schema(conn)
+    cur = conn.cursor()
     cur.execute("""CREATE TABLE IF NOT EXISTS memory_moment_windows (
       moment_id TEXT PRIMARY KEY, guild_id INTEGER NOT NULL, channel_id INTEGER NOT NULL, channel_name TEXT,
       channel_policy TEXT, route_mode TEXT, topic_key TEXT NOT NULL, window_started_at TEXT NOT NULL,
@@ -71,6 +182,15 @@ def ensure_moment_schema(conn: sqlite3.Connection) -> None:
       lifecycle_status TEXT NOT NULL, visibility TEXT, public_usable INTEGER DEFAULT 0, salience REAL DEFAULT 0,
       human_entry_count INTEGER DEFAULT 0, model_entry_count INTEGER DEFAULT 0, participant_count INTEGER DEFAULT 0,
       summary TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)""")
+    for sql in (
+        "ALTER TABLE memory_moment_windows ADD COLUMN topic_family TEXT DEFAULT ''",
+        "ALTER TABLE memory_moment_windows ADD COLUMN topic_signature TEXT DEFAULT '[]'",
+        "ALTER TABLE memory_moment_windows ADD COLUMN canonical_ledger_entry_id TEXT DEFAULT ''",
+    ):
+        try:
+            cur.execute(sql)
+        except sqlite3.OperationalError:
+            pass
     cur.execute("""CREATE TABLE IF NOT EXISTS memory_moment_members (
       moment_id TEXT NOT NULL, ledger_entry_id TEXT NOT NULL, source_sequence INTEGER DEFAULT 0, observed_at TEXT,
       membership_role TEXT, created_at TEXT NOT NULL, PRIMARY KEY(moment_id, ledger_entry_id))""")
@@ -82,159 +202,379 @@ def ensure_moment_schema(conn: sqlite3.Connection) -> None:
       id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER DEFAULT 0, moment_id TEXT DEFAULT '', event_type TEXT NOT NULL,
       reason_code TEXT DEFAULT '', ledger_entry_id TEXT DEFAULT '', created_at TEXT NOT NULL)""")
     for sql in [
-      "CREATE INDEX IF NOT EXISTS idx_mmw_scope ON memory_moment_windows(guild_id, channel_id, lifecycle_status, last_activity_at)",
-      "CREATE INDEX IF NOT EXISTS idx_mmm_entry ON memory_moment_members(ledger_entry_id)",
-      "CREATE INDEX IF NOT EXISTS idx_mmp_participant ON memory_moment_participants(participant_key, moment_id)",
-      "CREATE INDEX IF NOT EXISTS idx_mmd_guild ON memory_moment_diagnostics(guild_id, event_type, reason_code)"]:
+        "CREATE INDEX IF NOT EXISTS idx_mmw_scope ON memory_moment_windows(guild_id, channel_id, lifecycle_status, last_activity_at)",
+        "CREATE INDEX IF NOT EXISTS idx_mmw_canonical ON memory_moment_windows(guild_id, canonical_ledger_entry_id)",
+        "CREATE INDEX IF NOT EXISTS idx_mmm_entry ON memory_moment_members(ledger_entry_id)",
+        "CREATE INDEX IF NOT EXISTS idx_mmp_participant ON memory_moment_participants(participant_key, moment_id)",
+        "CREATE INDEX IF NOT EXISTS idx_mmd_guild ON memory_moment_diagnostics(guild_id, event_type, reason_code)",
+    ]:
         cur.execute(sql)
 
-def _diag(conn, guild_id, event, reason="", moment_id="", entry_id=""):
-    conn.execute("INSERT INTO memory_moment_diagnostics(guild_id,moment_id,event_type,reason_code,ledger_entry_id,created_at) VALUES(?,?,?,?,?,?)", (guild_id, moment_id, event, reason, entry_id, _now()))
 
-def _fetch_entry(conn, entry_id):
-    return conn.execute("SELECT entry_id,guild_id,source_table,source_role,entry_type,predicate_key,normalized_value,route_mode,channel_id,channel_name,channel_policy,visibility,public_usable,salience,observed_at,source_sequence,lifecycle_status,subject_key,subject_display_name FROM memory_ledger_entries WHERE entry_id=?", (entry_id,)).fetchone()
+def _diag(conn: sqlite3.Connection, guild_id: int, event: str, reason: str = "", moment_id: str = "", entry_id: str = "") -> None:
+    conn.execute(
+        "INSERT INTO memory_moment_diagnostics(guild_id,moment_id,event_type,reason_code,ledger_entry_id,created_at) VALUES(?,?,?,?,?,?)",
+        (int(guild_id or 0), moment_id or "", event[:80], reason[:120], entry_id or "", _now()),
+    )
+
+
+def _fetch_entry(conn: sqlite3.Connection, entry_id: str) -> SourceEntry | None:
+    row = conn.execute(
+        """
+        SELECT entry_id,guild_id,source_table,source_role,entry_type,predicate_key,normalized_value,route_mode,
+               channel_id,channel_name,channel_policy,visibility,public_usable,observed_at,source_sequence,
+               lifecycle_status,subject_key,subject_display_name
+        FROM memory_ledger_entries WHERE entry_id=?
+        """,
+        (entry_id,),
+    ).fetchone()
+    if not row:
+        return None
+    return SourceEntry(
+        entry_id=row[0], guild_id=int(row[1] or 0), source_table=row[2] or "", source_role=row[3] or "",
+        entry_type=row[4] or "", predicate_key=row[5] or "", normalized_value=row[6] or "", route_mode=row[7] or "unknown",
+        channel_id=int(row[8] or 0), channel_name=row[9] or "", channel_policy=row[10] or "unknown", visibility=row[11] or "unknown",
+        public_usable=bool(row[12]), observed_at=row[13] or _now(), source_sequence=int(row[14] or 0), lifecycle_status=row[15] or "",
+        subject_key=row[16] or "", subject_display_name=row[17] or "",
+    )
+
+
+def _entries(conn: sqlite3.Connection, moment_id: str) -> list[SourceEntry]:
+    rows = conn.execute(
+        """
+        SELECT e.entry_id,e.guild_id,e.source_table,e.source_role,e.entry_type,e.predicate_key,e.normalized_value,e.route_mode,
+               e.channel_id,e.channel_name,e.channel_policy,e.visibility,e.public_usable,e.observed_at,e.source_sequence,
+               e.lifecycle_status,e.subject_key,e.subject_display_name
+        FROM memory_moment_members m JOIN memory_ledger_entries e ON e.entry_id=m.ledger_entry_id
+        WHERE m.moment_id=? ORDER BY e.observed_at, e.source_sequence, e.entry_id
+        """,
+        (moment_id,),
+    ).fetchall()
+    return [SourceEntry(r[0], int(r[1] or 0), r[2] or "", r[3] or "", r[4] or "", r[5] or "", r[6] or "", r[7] or "unknown", int(r[8] or 0), r[9] or "", r[10] or "unknown", r[11] or "unknown", bool(r[12]), r[13] or _now(), int(r[14] or 0), r[15] or "", r[16] or "", r[17] or "") for r in rows]
+
+
+def _mark_targets_for_correction(conn: sqlite3.Connection, source: SourceEntry) -> int:
+    targets = [r[0] for r in conn.execute(
+        "SELECT target_entry_id FROM memory_ledger_lineage WHERE guild_id=? AND entry_id=? AND lineage_type IN ('correction_of','supersedes','retracts')",
+        (source.guild_id, source.entry_id),
+    ).fetchall()]
+    count = 0
+    for target in targets:
+        count += handle_source_correction(conn, target, guild_id=source.guild_id)
+    return count
+
 
 def observe_ledger_entry(conn: sqlite3.Connection, ledger_entry_id: str) -> MomentObservationResult:
-    ensure_moment_schema(conn)
-    if not shadow_enabled(): return MomentObservationResult(reason_code="moment_gate_disabled")
+    if not shadow_enabled():
+        return MomentObservationResult(reason_code="moment_gate_disabled", ledger_entry_id=ledger_entry_id)
     if not ledger_shadow_enabled():
-        _diag(conn, 0, "moment_processing_skipped", "ledger_shadow_unavailable", entry_id=ledger_entry_id); return MomentObservationResult(reason_code="ledger_shadow_unavailable")
+        ensure_moment_schema(conn)
+        _diag(conn, 0, "moment_processing_skipped", "ledger_shadow_unavailable", entry_id=ledger_entry_id)
+        return MomentObservationResult(reason_code="ledger_shadow_unavailable", ledger_entry_id=ledger_entry_id)
+    ensure_moment_schema(conn)
     try:
-        row=_fetch_entry(conn, ledger_entry_id)
-        if not row: return MomentObservationResult(reason_code="missing_ledger_entry", ledger_entry_id=ledger_entry_id)
-        (eid,guild,table,role,etype,pred,val,route,chan,cname,policy,vis,pub,sal,obs,seq,life,subj,disp)=row
-        if table!="conversations" or life not in ("active","review_only") or etype not in ("observation","derived_summary"):
-            return MomentObservationResult(reason_code="ineligible_source", ledger_entry_id=eid)
-        _diag(conn,guild,"eligible_ledger_entry_observed","ok",entry_id=eid)
-        topic=_topic_key(val or "", pred or "")
-        ts=_parse_ts(obs); open_rows=conn.execute("SELECT moment_id,topic_key,window_started_at,last_activity_at,channel_policy,visibility FROM memory_moment_windows WHERE guild_id=? AND channel_id=? AND lifecycle_status='open' ORDER BY last_activity_at DESC",(guild,chan)).fetchall()
-        chosen=None
-        for m in open_rows:
-            if (ts-_parse_ts(m[3])).total_seconds()>INACTIVITY_SECONDS or (ts-_parse_ts(m[2])).total_seconds()>MAX_WINDOW_SECONDS or m[4] != policy or m[5] != vis:
-                finalize_moment(conn,m[0]); continue
-            shift = "different" in _canon(val) or "unrelated" in _canon(val)
-            if not shift and not chosen: chosen=m[0]
-            else: finalize_moment(conn,m[0]); _diag(conn,guild,"window_split","topic_or_visibility_shift",m[0],eid)
-        if not chosen:
-            started=obs or _now(); chosen=stable_moment_id(guild,chan,topic,started)
-            conn.execute("INSERT OR IGNORE INTO memory_moment_windows(moment_id,guild_id,channel_id,channel_name,channel_policy,route_mode,topic_key,window_started_at,last_activity_at,lifecycle_status,visibility,public_usable,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",(chosen,guild,chan,cname,policy,route,topic,started,started,"open",vis,int(bool(pub)),_now(),_now()))
-            _diag(conn,guild,"window_opened","ok",chosen,eid)
-        role_name = "human_author" if role=="user" else "bnl_participant"
-        before=conn.execute("SELECT COUNT(*) FROM memory_moment_members WHERE moment_id=? AND ledger_entry_id=?",(chosen,eid)).fetchone()[0]
-        conn.execute("INSERT OR IGNORE INTO memory_moment_members VALUES(?,?,?,?,?,?)",(chosen,eid,int(seq or 0),obs,role_name,_now()))
-        if before: _diag(conn,guild,"exact_source_duplicate_ignored","duplicate",chosen,eid)
-        pkey = subj if role=="user" else BNL_SUBJECT_KEY; pname = disp if role=="user" else "BNL-01"
-        existing=conn.execute("SELECT authored_entry_count, participation_order FROM memory_moment_participants WHERE moment_id=? AND participant_key=? AND participant_role=?",(chosen,pkey,role_name)).fetchone()
-        order=existing[1] if existing else conn.execute("SELECT COUNT(*) FROM memory_moment_participants WHERE moment_id=?",(chosen,)).fetchone()[0]
+        conn.execute("SAVEPOINT moment_observe")
+        existing = conn.execute("SELECT moment_id FROM memory_moment_members WHERE ledger_entry_id=? ORDER BY created_at LIMIT 1", (ledger_entry_id,)).fetchone()
         if existing:
-            conn.execute("UPDATE memory_moment_participants SET last_seen_at=?, authored_entry_count=authored_entry_count+?, updated_at=? WHERE moment_id=? AND participant_key=? AND participant_role=?",(obs,1 if role=="user" and not before else 0,_now(),chosen,pkey,role_name))
-        else:
-            conn.execute("INSERT INTO memory_moment_participants VALUES(?,?,?,?,?,?,?,?,?,?)",(chosen,pkey,(pname or "")[:120],role_name,obs,obs,1 if role=="user" else 0,order,_now(),_now()))
-        _recount(conn, chosen); _diag(conn,guild,"window_extended","ok",chosen,eid)
-        return MomentObservationResult("observed","ok",chosen,eid)
+            conn.execute("RELEASE moment_observe")
+            return MomentObservationResult("deduplicated", "exact_source_duplicate", existing[0], ledger_entry_id)
+        source = _fetch_entry(conn, ledger_entry_id)
+        if not source:
+            conn.execute("RELEASE moment_observe")
+            return MomentObservationResult(reason_code="missing_ledger_entry", ledger_entry_id=ledger_entry_id)
+        if source.source_table != "conversations" or source.lifecycle_status not in {"active", "review_only"} or source.entry_type not in {"observation", "derived_summary"}:
+            conn.execute("RELEASE moment_observe")
+            return MomentObservationResult(reason_code="ineligible_source", ledger_entry_id=source.entry_id)
+        _diag(conn, source.guild_id, "eligible_ledger_entry_observed", "ok", entry_id=source.entry_id)
+        _mark_targets_for_correction(conn, source)
+        family = _topic_family(source.normalized_value, source.predicate_key)
+        signature = _topic_signature(source.normalized_value, source.predicate_key)
+        meaningful = _meaningful(source.normalized_value, source.source_role, source.predicate_key)
+        ts = _parse_ts(source.observed_at)
+        chosen = ""
+        open_rows = conn.execute(
+            """
+            SELECT moment_id,window_started_at,last_activity_at,channel_policy,visibility,topic_family,topic_signature
+            FROM memory_moment_windows
+            WHERE guild_id=? AND channel_id=? AND lifecycle_status='open'
+            ORDER BY last_activity_at DESC, moment_id
+            """,
+            (source.guild_id, source.channel_id),
+        ).fetchall()
+        for row in open_rows:
+            mid, started, last, policy, visibility, win_family, win_sig_raw = row
+            expired = (ts - _parse_ts(last)).total_seconds() > INACTIVITY_SECONDS or (ts - _parse_ts(started)).total_seconds() > MAX_WINDOW_SECONDS
+            incompatible = policy != source.channel_policy or visibility != source.visibility
+            if expired or incompatible:
+                finalize_moment(conn, mid)
+                continue
+            if source.is_model or not meaningful:
+                if not chosen:
+                    chosen = mid
+                continue
+            if _coherent(family, signature, win_family or "", _load_sig(win_sig_raw)):
+                chosen = mid
+                break
+            finalize_moment(conn, mid)
+            _diag(conn, source.guild_id, "window_split", "topic_coherence_mismatch", mid, source.entry_id)
+        if not chosen:
+            topic_key = _topic_key(family, signature)
+            started = source.observed_at or _now()
+            chosen = stable_moment_id(source.guild_id, source.channel_id, topic_key, started)
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO memory_moment_windows(
+                    moment_id,guild_id,channel_id,channel_name,channel_policy,route_mode,topic_key,topic_family,topic_signature,
+                    window_started_at,last_activity_at,lifecycle_status,visibility,public_usable,created_at,updated_at
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (chosen, source.guild_id, source.channel_id, source.channel_name, source.channel_policy, source.route_mode, topic_key, family, _json_sig(signature), started, started, "open", source.visibility, int(source.public_usable), _now(), _now()),
+            )
+            _diag(conn, source.guild_id, "window_opened", "ok", chosen, source.entry_id)
+        _insert_membership(conn, chosen, source, meaningful, family, signature)
+        conn.execute("RELEASE moment_observe")
+        return MomentObservationResult("observed", "ok", chosen, source.entry_id)
     except Exception:
-        try: _diag(conn,0,"moment_processing_error","exception",entry_id=ledger_entry_id)
-        except Exception: pass
-        return MomentObservationResult("error","exception",ledger_entry_id=ledger_entry_id)
+        try:
+            conn.execute("ROLLBACK TO moment_observe")
+            conn.execute("RELEASE moment_observe")
+        except Exception:
+            pass
+        try:
+            _diag(conn, 0, "moment_processing_error", "exception", entry_id=ledger_entry_id)
+        except Exception:
+            pass
+        return MomentObservationResult("error", "exception", ledger_entry_id=ledger_entry_id)
 
-def _entries(conn, moment_id):
-    return conn.execute("""SELECT e.* FROM memory_moment_members m JOIN memory_ledger_entries e ON e.entry_id=m.ledger_entry_id WHERE m.moment_id=? ORDER BY e.observed_at, e.source_sequence, e.entry_id""",(moment_id,)).fetchall()
 
-def _recount(conn, moment_id):
-    rows=_entries(conn,moment_id); humans=[r for r in rows if r[13]=="user" and _meaningful(r[7] or "", "user", r[6] or "")]; models=[r for r in rows if r[13]!="user"]
-    parts=conn.execute("SELECT COUNT(DISTINCT participant_key) FROM memory_moment_participants WHERE moment_id=? AND participant_role='human_author'",(moment_id,)).fetchone()[0]
-    vis=max([r[19] for r in rows] or ["unknown"], key=lambda v: VIS_RANK.get(v,5)); pub=all(bool(r[22]) for r in rows) if rows else False
-    conn.execute("UPDATE memory_moment_windows SET human_entry_count=?, model_entry_count=?, participant_count=?, visibility=?, public_usable=?, last_activity_at=COALESCE((SELECT MAX(observed_at) FROM memory_moment_members WHERE moment_id=?), last_activity_at), updated_at=? WHERE moment_id=?",(len(humans),len(models),parts,vis,int(pub),moment_id,_now(),moment_id))
+def _insert_membership(conn: sqlite3.Connection, moment_id: str, source: SourceEntry, meaningful: bool, family: str, signature: tuple[str, ...]) -> None:
+    role_name = "human_author" if source.is_human else "bnl_participant"
+    before = conn.execute("SELECT COUNT(*) FROM memory_moment_members WHERE moment_id=? AND ledger_entry_id=?", (moment_id, source.entry_id)).fetchone()[0]
+    conn.execute("INSERT OR IGNORE INTO memory_moment_members VALUES(?,?,?,?,?,?)", (moment_id, source.entry_id, source.source_sequence, source.observed_at, role_name, _now()))
+    if before:
+        _diag(conn, source.guild_id, "exact_source_duplicate_ignored", "duplicate", moment_id, source.entry_id)
+        return
+    pkey = source.subject_key if source.is_human else BNL_SUBJECT_KEY
+    pname = source.subject_display_name if source.is_human else "BNL-01"
+    existing = conn.execute("SELECT participation_order FROM memory_moment_participants WHERE moment_id=? AND participant_key=? AND participant_role=?", (moment_id, pkey, role_name)).fetchone()
+    if existing:
+        conn.execute(
+            "UPDATE memory_moment_participants SET last_seen_at=?, authored_entry_count=authored_entry_count+?, updated_at=? WHERE moment_id=? AND participant_key=? AND participant_role=?",
+            (source.observed_at, 1 if source.is_human else 0, _now(), moment_id, pkey, role_name),
+        )
+    else:
+        order = conn.execute("SELECT COUNT(*) FROM memory_moment_participants WHERE moment_id=?", (moment_id,)).fetchone()[0]
+        conn.execute("INSERT INTO memory_moment_participants VALUES(?,?,?,?,?,?,?,?,?,?)", (moment_id, pkey, (pname or "")[:120], role_name, source.observed_at, source.observed_at, 1 if source.is_human else 0, order, _now(), _now()))
+    if source.is_human and meaningful:
+        old = _load_sig(conn.execute("SELECT topic_signature FROM memory_moment_windows WHERE moment_id=?", (moment_id,)).fetchone()[0])
+        merged = tuple(sorted(set(old) | set(signature)))[:24]
+        conn.execute("UPDATE memory_moment_windows SET topic_family=?, topic_signature=? WHERE moment_id=?", (family, _json_sig(merged), moment_id))
+    _recount(conn, moment_id)
+    _diag(conn, source.guild_id, "window_extended", "ok", moment_id, source.entry_id)
 
-def _qualify(rows):
-    humans=[r for r in rows if r[13]=="user" and _meaningful(r[7] or "", "user", r[6] or "")]; models=[r for r in rows if r[13]!="user"]
-    human_parts={r[3] for r in humans}; text=" ".join((r[7] or "") for r in humans).lower(); strong=any(m in text for m in STRONG_MARKERS) or any(r[6]=="remembered_number" for r in humans)
-    if len(human_parts)>=2 and len(humans)>=3: return "shared_activity", "two_humans_three_meaningful_entries"
-    if len(human_parts)==1 and models and (len(humans)>=3 or strong): return "conversational", "one_human_bnl_meaningful_continuity_or_marker"
-    if len(human_parts)==1 and strong and len(humans)>=1: return "conversational", "explicit_marker_continuity"
-    return "", "low_signal_or_bnl_only"
 
-def _summary(rows, qtype, reason):
-    vals=[]
-    for r in rows:
-        if r[13]=="user" and (r[6]=="remembered_number" or any(m in (r[7] or "").lower() for m in STRONG_MARKERS)):
-            vals.append(f"{r[6]}={str(r[7])[:80]}")
-    detail=("; ".join(dict.fromkeys(vals)) or "bounded conversation activity")[:240]
+def _recount(conn: sqlite3.Connection, moment_id: str) -> None:
+    rows = _entries(conn, moment_id)
+    humans = [r for r in rows if _meaningful(r.normalized_value, r.source_role, r.predicate_key)]
+    models = [r for r in rows if r.is_model]
+    parts = len({r.subject_key for r in humans})
+    visibility = max([r.visibility for r in rows] or ["unknown"], key=lambda v: VIS_RANK.get(v, 5))
+    public_usable = bool(rows) and all(r.public_usable for r in rows) and VIS_RANK.get(visibility, 5) <= VIS_RANK.get("public_safe", 0)
+    conn.execute(
+        """
+        UPDATE memory_moment_windows
+        SET human_entry_count=?, model_entry_count=?, participant_count=?, visibility=?, public_usable=?,
+            last_activity_at=COALESCE((SELECT MAX(observed_at) FROM memory_moment_members WHERE moment_id=?), last_activity_at), updated_at=?
+        WHERE moment_id=?
+        """,
+        (len(humans), len(models), parts, visibility, int(public_usable), moment_id, _now(), moment_id),
+    )
+
+
+def _qualify(rows: list[SourceEntry]) -> tuple[str, str, list[SourceEntry], list[SourceEntry]]:
+    humans = [r for r in rows if _meaningful(r.normalized_value, r.source_role, r.predicate_key)]
+    models = [r for r in rows if r.is_model]
+    human_parts = {r.subject_key for r in humans}
+    strong = any(_strong_marker(r.normalized_value, r.predicate_key) for r in humans)
+    if len(human_parts) >= 2 and len(humans) >= 3:
+        return "shared_activity", "two_humans_three_meaningful_entries", humans, models
+    if len(human_parts) == 1 and models and ((len(humans) >= 2 and strong) or len(humans) >= 3):
+        return "conversational", "one_human_bnl_continuity", humans, models
+    return "", "low_signal_or_insufficient_continuity", humans, models
+
+
+def _summary(rows: list[SourceEntry], qtype: str, reason: str) -> str:
+    vals: list[str] = []
+    for row in rows:
+        if row.is_human and (row.predicate_key == "remembered_number" or _strong_marker(row.normalized_value, row.predicate_key)):
+            vals.append(f"{row.predicate_key}={row.normalized_value[:80]}")
+    detail = ("; ".join(dict.fromkeys(vals)) or "bounded coherent conversation activity")[:240]
     return f"Derived moment ({qtype}): {detail}; reason={reason}."
 
+
+def _existing_moment_entry_id(conn: sqlite3.Connection, moment_id: str, guild_id: int | None = None) -> str:
+    row = conn.execute("SELECT canonical_ledger_entry_id FROM memory_moment_windows WHERE moment_id=?", (moment_id,)).fetchone()
+    if row and row[0] and conn.execute("SELECT 1 FROM memory_ledger_entries WHERE entry_id=?", (row[0],)).fetchone():
+        return row[0]
+    params: list[Any] = [str(moment_id)]
+    where = "source_table='memory_moment_windows' AND source_row_id=? AND entry_type='shared_moment'"
+    if guild_id is not None:
+        where += " AND guild_id=?"
+        params.append(guild_id)
+    row = conn.execute(f"SELECT entry_id FROM memory_ledger_entries WHERE {where} ORDER BY created_at LIMIT 1", params).fetchone()
+    return row[0] if row else ""
+
+
 def finalize_moment(conn: sqlite3.Connection, moment_id: str) -> MomentObservationResult:
-    ensure_moment_schema(conn); win=conn.execute("SELECT guild_id,channel_id,channel_name,channel_policy,route_mode,topic_key,window_started_at,last_activity_at,visibility,public_usable,lifecycle_status FROM memory_moment_windows WHERE moment_id=?",(moment_id,)).fetchone()
-    if not win: return MomentObservationResult(reason_code="missing_window", moment_id=moment_id)
-    if win[10]=="finalized": return MomentObservationResult("deduplicated","already_finalized",moment_id,stable_moment_entry_id(moment_id))
-    rows=_entries(conn,moment_id); qtype, reason=_qualify(rows)
+    ensure_moment_schema(conn)
+    win = conn.execute(
+        "SELECT guild_id,channel_id,channel_name,channel_policy,route_mode,topic_key,window_started_at,last_activity_at,visibility,public_usable,lifecycle_status,canonical_ledger_entry_id FROM memory_moment_windows WHERE moment_id=?",
+        (moment_id,),
+    ).fetchone()
+    if not win:
+        return MomentObservationResult(reason_code="missing_window", moment_id=moment_id)
+    existing = _existing_moment_entry_id(conn, moment_id, int(win[0] or 0))
+    if win[10] == "finalized" and existing:
+        return MomentObservationResult("deduplicated", "already_finalized", moment_id, existing)
+    rows = _entries(conn, moment_id)
+    qtype, reason, humans, _models = _qualify(rows)
     if not qtype:
-        conn.execute("UPDATE memory_moment_windows SET lifecycle_status='rejected', qualification_reason=?, finalized_at=?, updated_at=? WHERE moment_id=?",(reason,_now(),_now(),moment_id)); _diag(conn,win[0],"window_rejected",reason,moment_id); return MomentObservationResult("rejected",reason,moment_id)
-    source_ids=[r[0] for r in rows]
-    if any(not conn.execute("SELECT 1 FROM memory_ledger_entries WHERE entry_id=?",(x,)).fetchone() for x in source_ids):
-        _diag(conn,win[0],"lineage_validation_failure","dangling_source",moment_id); return MomentObservationResult("error","dangling_source",moment_id)
-    sal=min(1.0,0.2+0.12*len([r for r in rows if r[13]=="user"])+0.08*len({r[3] for r in rows if r[13]=="user"}))
-    summary=_summary(rows,qtype,reason); participants=[]
-    for p in conn.execute("SELECT participant_key,safe_display_name,participant_role,participation_order FROM memory_moment_participants WHERE moment_id=? ORDER BY participation_order,participant_key",(moment_id,)).fetchall(): participants.append(LedgerParticipant(p[0],p[1] or "",p[2],p[3]))
-    value=json.dumps({"schema":MOMENT_SCHEMA_VERSION,"moment_id":moment_id,"summary":summary,"window_started_at":win[6],"last_activity_at":win[7],"topic_key":win[5],"qualification_type":qtype,"qualification_reason":reason,"salience":sal,"participants":[p.participant_key for p in participants],"public_usable":bool(win[9]),"lifecycle_status":"finalized"},sort_keys=True)
-    entry=LedgerEntry(guild_id=win[0],source_table="memory_moment_windows",source_row_id=moment_id,source_revision="1",source_role="derived_assessment",entry_type="shared_moment",subject_key=f"moment:{moment_id}",predicate_key="shared_moment",value=value,source_class=SourceClass.DERIVED_SUMMARY,route_mode=win[4] or "unknown",channel_id=win[1],channel_name=win[2] or "",channel_policy=win[3] or "",visibility=Visibility(win[8] or "unknown"),confidence=Confidence.LOW,public_usable=bool(win[9]),derived=True,projection=True,salience=sal,observed_at=win[7],source_sequence=0,valid_from=win[6],valid_until=win[7],freshness="shadow_moment_v1",lifecycle_status="active",participants=tuple(participants),lineage=tuple(("derived_from",x) for x in source_ids))
-    res=insert_ledger_entry(conn,entry)
-    moment_entry=res.entry_id
-    for sid in source_ids: conn.execute("INSERT OR IGNORE INTO memory_ledger_lineage VALUES(?,?,?,?,?)",(sid,win[0],"part_of_moment",moment_entry,_now()))
-    conn.execute("UPDATE memory_moment_windows SET lifecycle_status='finalized', finalized_at=?, qualification_type=?, qualification_reason=?, salience=?, summary=?, updated_at=? WHERE moment_id=?",(_now(),qtype,reason,sal,summary,_now(),moment_id)); _diag(conn,win[0],"window_finalized",reason,moment_id,moment_entry)
-    return MomentObservationResult(res.outcome,res.reason_code,moment_id,moment_entry)
+        conn.execute("UPDATE memory_moment_windows SET lifecycle_status='rejected', qualification_reason=?, finalized_at=?, updated_at=? WHERE moment_id=?", (reason, _now(), _now(), moment_id))
+        _diag(conn, int(win[0] or 0), "window_rejected", reason, moment_id)
+        return MomentObservationResult("rejected", reason, moment_id)
+    source_ids = [r.entry_id for r in rows]
+    if any(not conn.execute("SELECT 1 FROM memory_ledger_entries WHERE entry_id=?", (entry_id,)).fetchone() for entry_id in source_ids):
+        _diag(conn, int(win[0] or 0), "lineage_validation_failure", "dangling_source", moment_id)
+        return MomentObservationResult("error", "dangling_source", moment_id)
+    participant_count = len({r.subject_key for r in humans})
+    salience = min(1.0, 0.15 + 0.10 * len(humans) + 0.10 * participant_count + (0.08 if qtype == "conversational" else 0.12))
+    summary = _summary(rows, qtype, reason)
+    participants = [LedgerParticipant(p[0], p[1] or "", p[2], int(p[3] or 0)) for p in conn.execute("SELECT participant_key,safe_display_name,participant_role,participation_order FROM memory_moment_participants WHERE moment_id=? ORDER BY participation_order,participant_key", (moment_id,)).fetchall()]
+    visibility = win[8] or "unknown"
+    public_usable = bool(win[9]) and VIS_RANK.get(visibility, 5) <= VIS_RANK.get("public_safe", 0)
+    value = json.dumps({
+        "schema": MOMENT_SCHEMA_VERSION, "moment_id": moment_id, "summary": summary, "window_started_at": win[6], "last_activity_at": win[7],
+        "topic_key": win[5], "qualification_type": qtype, "qualification_reason": reason, "salience": salience,
+        "participants": [p.participant_key for p in participants], "public_usable": public_usable, "lifecycle_status": "finalized", "source_revision": "1",
+    }, sort_keys=True)
+    entry = LedgerEntry(
+        guild_id=int(win[0] or 0), source_table="memory_moment_windows", source_row_id=moment_id, source_revision="1",
+        source_role="derived_assessment", entry_type="shared_moment", subject_key=f"moment:{moment_id}", predicate_key="shared_moment",
+        value=value, source_class=SourceClass.DERIVED_SUMMARY, route_mode=win[4] or "unknown", channel_id=int(win[1] or 0),
+        channel_name=win[2] or "", channel_policy=win[3] or "", visibility=Visibility(visibility), confidence=Confidence.LOW,
+        public_usable=public_usable, derived=True, projection=True, salience=salience, observed_at=win[7], source_sequence=0,
+        valid_from=win[6], valid_until=win[7], freshness="shadow_moment_v1", lifecycle_status="review_only",
+        participants=tuple(participants), lineage=tuple(("derived_from", source_id) for source_id in source_ids),
+    )
+    result = insert_ledger_entry(conn, entry)
+    moment_entry_id = result.entry_id or _existing_moment_entry_id(conn, moment_id, int(win[0] or 0))
+    for source_id in source_ids:
+        conn.execute("INSERT OR IGNORE INTO memory_ledger_lineage VALUES(?,?,?,?,?)", (source_id, int(win[0] or 0), "part_of_moment", moment_entry_id, _now()))
+    conn.execute(
+        """
+        UPDATE memory_moment_windows SET lifecycle_status='finalized', finalized_at=?, qualification_type=?, qualification_reason=?,
+            salience=?, summary=?, canonical_ledger_entry_id=?, updated_at=? WHERE moment_id=?
+        """,
+        (_now(), qtype, reason, salience, summary, moment_entry_id, _now(), moment_id),
+    )
+    _diag(conn, int(win[0] or 0), "window_finalized", reason, moment_id, moment_entry_id)
+    return MomentObservationResult(result.outcome, result.reason_code, moment_id, moment_entry_id)
 
-def sweep_expired_windows(conn: sqlite3.Connection, *, guild_id:int|None=None, now:str|None=None):
-    ensure_moment_schema(conn); base=_parse_ts(now or _now()); params=[]; where="lifecycle_status='open'"
-    if guild_id is not None: where+=" AND guild_id=?"; params.append(guild_id)
-    out=[]
-    for mid,last in conn.execute(f"SELECT moment_id,last_activity_at FROM memory_moment_windows WHERE {where}",params).fetchall():
-        if (base-_parse_ts(last)).total_seconds()>=INACTIVITY_SECONDS: out.append(finalize_moment(conn,mid))
-    return out
 
-def handle_source_correction(conn: sqlite3.Connection, source_entry_id: str) -> int:
-    ensure_moment_schema(conn); rows=conn.execute("SELECT DISTINCT moment_id FROM memory_moment_members WHERE ledger_entry_id=?",(source_entry_id,)).fetchall()
-    for (mid,) in rows: conn.execute("UPDATE memory_moment_windows SET lifecycle_status='needs_review', updated_at=? WHERE moment_id=?",(_now(),mid)); _diag(conn,0,"moment_awaiting_review","source_corrected",mid,source_entry_id)
+def sweep_expired_windows(conn: sqlite3.Connection, *, guild_id: int | None = None, now: str | None = None) -> list[MomentObservationResult]:
+    if not shadow_enabled() or not ledger_shadow_enabled():
+        return []
+    ensure_moment_schema(conn)
+    base = _parse_ts(now or _now())
+    params: list[Any] = []
+    where = "lifecycle_status='open'"
+    if guild_id is not None:
+        where += " AND guild_id=?"
+        params.append(guild_id)
+    results: list[MomentObservationResult] = []
+    for moment_id, last_activity_at in conn.execute(f"SELECT moment_id,last_activity_at FROM memory_moment_windows WHERE {where}", params).fetchall():
+        if (base - _parse_ts(last_activity_at)).total_seconds() >= INACTIVITY_SECONDS:
+            results.append(finalize_moment(conn, moment_id))
+    return results
+
+
+def handle_source_correction(conn: sqlite3.Connection, source_entry_id: str, *, guild_id: int | None = None) -> int:
+    ensure_moment_schema(conn)
+    params: list[Any] = [source_entry_id]
+    sql = "SELECT DISTINCT w.moment_id,w.guild_id FROM memory_moment_members m JOIN memory_moment_windows w ON w.moment_id=m.moment_id WHERE m.ledger_entry_id=?"
+    if guild_id is not None:
+        sql += " AND w.guild_id=?"
+        params.append(guild_id)
+    rows = conn.execute(sql, params).fetchall()
+    for moment_id, gid in rows:
+        conn.execute("UPDATE memory_moment_windows SET lifecycle_status='needs_review', updated_at=? WHERE moment_id=? AND lifecycle_status IN ('open','finalized')", (_now(), moment_id))
+        _diag(conn, int(gid or 0), "moment_awaiting_review", "source_corrected", moment_id, source_entry_id)
     return len(rows)
 
-def render_shadow_moment_context(conn: sqlite3.Connection, *, guild_id:int, channel_id:int, participant_key:str="", visibility:str="public_safe", topic_text:str="", token_budget:int=120, freshness_days:int=3650) -> str:
-    ensure_moment_schema(conn); cutoff=(datetime.now(timezone.utc)-timedelta(days=freshness_days)).isoformat(); toks=set(_tokens(topic_text)); lines=[]; used=0
-    for r in conn.execute("SELECT moment_id,summary,topic_key,visibility,last_activity_at,salience FROM memory_moment_windows WHERE guild_id=? AND channel_id=? AND lifecycle_status='finalized' AND last_activity_at>=? ORDER BY salience DESC,last_activity_at DESC",(guild_id,channel_id,cutoff)).fetchall():
-        if VIS_RANK.get(r[3],5)>VIS_RANK.get(visibility,0): continue
-        if participant_key and not conn.execute("SELECT 1 FROM memory_moment_participants WHERE moment_id=? AND participant_key=?",(r[0],participant_key)).fetchone(): continue
-        if toks and not (toks & set(_tokens((r[1] or '')+' '+(r[2] or ''))) or ({"number","numbers"} & toks and "remembered_number" in (r[1] or ""))): continue
-        line=f"[Derived moment context] {r[1]}"
-        n=len(line.split())
-        if used+n>token_budget:
+
+def render_shadow_moment_context(conn: sqlite3.Connection, *, guild_id: int, channel_id: int, participant_key: str = "", visibility: str = "public_safe", topic_text: str = "", token_budget: int = 120, freshness_days: int = 3650) -> str:
+    ensure_moment_schema(conn)
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=freshness_days)).isoformat()
+    family = _topic_family(topic_text, "conversation")
+    signature = _topic_signature(topic_text, "conversation")
+    lines: list[str] = []
+    used = 0
+    for row in conn.execute(
+        """
+        SELECT moment_id,summary,topic_family,topic_signature,visibility,last_activity_at,salience
+        FROM memory_moment_windows
+        WHERE guild_id=? AND channel_id=? AND lifecycle_status='finalized' AND last_activity_at>=?
+        ORDER BY salience DESC,last_activity_at DESC
+        """,
+        (guild_id, channel_id, cutoff),
+    ).fetchall():
+        if VIS_RANK.get(row[4], 5) > VIS_RANK.get(visibility, 0):
+            continue
+        if participant_key and not conn.execute("SELECT 1 FROM memory_moment_participants WHERE moment_id=? AND participant_key=?", (row[0], participant_key)).fetchone():
+            continue
+        if signature and not _coherent(family, signature, row[2] or "", _load_sig(row[3])):
+            continue
+        line = f"[Derived moment context] {row[1]}"
+        words = line.split()
+        if used + len(words) > token_budget:
             if not lines:
-                line=" ".join(line.split()[:max(1, token_budget)])
-                lines.append(line)
+                lines.append(" ".join(words[:max(1, token_budget)]))
             break
-        lines.append(line); used+=n
+        lines.append(line)
+        used += len(words)
     return "\n".join(lines)
 
-def build_moment_evaluation_report(conn: sqlite3.Connection, *, guild_id:int|None=None) -> dict[str,Any]:
-    ensure_moment_schema(conn); where=""; params=[]
-    if guild_id is not None: where=" WHERE guild_id=?"; params=[guild_id]
-    def one(sql,p=None):
-        bind = params if p is None and "?" in sql else ([] if p is None else p)
-        return conn.execute(sql, bind).fetchone()[0]
-    report={"eligible_entries_observed":one(f"SELECT COUNT(*) FROM memory_moment_diagnostics{where + (' AND' if where else ' WHERE')} event_type='eligible_ledger_entry_observed'"),"open_windows":one(f"SELECT COUNT(*) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} lifecycle_status='open'"),"finalized_moments":one(f"SELECT COUNT(*) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} lifecycle_status='finalized'"),"processing_errors":one(f"SELECT COUNT(*) FROM memory_moment_diagnostics{where + (' AND' if where else ' WHERE')} event_type='moment_processing_error'")}
-    report["rejected_windows_by_reason"]=dict(conn.execute(f"SELECT qualification_reason,COUNT(*) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} lifecycle_status='rejected' GROUP BY qualification_reason",params).fetchall())
-    report["moments_by_qualification_type"]=dict(conn.execute(f"SELECT qualification_type,COUNT(*) FROM memory_moment_windows{where} GROUP BY qualification_type",params).fetchall())
-    report["moments_by_visibility"]=dict(conn.execute(f"SELECT visibility,COUNT(*) FROM memory_moment_windows{where} GROUP BY visibility",params).fetchall())
-    report["moments_by_lifecycle"]=dict(conn.execute(f"SELECT lifecycle_status,COUNT(*) FROM memory_moment_windows{where} GROUP BY lifecycle_status",params).fetchall())
-    prefix="m.guild_id=? AND " if guild_id is not None else ""
-    p=[guild_id] if guild_id is not None else []
-    report.update({
-      "one_human_conversational_moments":one(f"SELECT COUNT(*) FROM memory_moment_windows m WHERE {prefix}qualification_type='conversational'",p),
-      "multi_human_shared_moments":one(f"SELECT COUNT(*) FROM memory_moment_windows m WHERE {prefix}qualification_type='shared_activity'",p),
-      "average_participant_count":one(f"SELECT COALESCE(AVG(participant_count),0) FROM memory_moment_windows m WHERE {prefix}lifecycle_status='finalized'",p),
-      "duplicate_memberships":one("SELECT COUNT(*) FROM (SELECT moment_id,ledger_entry_id,COUNT(*) c FROM memory_moment_members GROUP BY moment_id,ledger_entry_id HAVING c>1)"),
-      "bnl_only_violations":one(f"SELECT COUNT(*) FROM memory_moment_windows m WHERE {prefix}lifecycle_status='finalized' AND human_entry_count=0",p),
-      "cross_guild_violations":one("SELECT COUNT(*) FROM memory_moment_members mm JOIN memory_moment_windows mw ON mw.moment_id=mm.moment_id JOIN memory_ledger_entries e ON e.entry_id=mm.ledger_entry_id WHERE e.guild_id<>mw.guild_id"),
-      "cross_channel_violations":one("SELECT COUNT(*) FROM memory_moment_members mm JOIN memory_moment_windows mw ON mw.moment_id=mm.moment_id JOIN memory_ledger_entries e ON e.entry_id=mm.ledger_entry_id WHERE e.channel_id<>mw.channel_id"),
-      "incompatible_visibility_violations":one("SELECT COUNT(*) FROM memory_moment_members mm JOIN memory_moment_windows mw ON mw.moment_id=mm.moment_id JOIN memory_ledger_entries e ON e.entry_id=mm.ledger_entry_id WHERE e.visibility<>mw.visibility"),
-      "dangling_lineage_targets":one("SELECT COUNT(*) FROM memory_ledger_lineage l LEFT JOIN memory_ledger_entries e ON e.guild_id=l.guild_id AND e.entry_id=l.target_entry_id WHERE e.entry_id IS NULL"),
-      "affected_moments_awaiting_correction_review":one(f"SELECT COUNT(*) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} lifecycle_status='needs_review'"),
-      "finalization_latency":one(f"SELECT COALESCE(AVG(strftime('%s',finalized_at)-strftime('%s',last_activity_at)),0) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} finalized_at IS NOT NULL")})
+
+def build_moment_evaluation_report(conn: sqlite3.Connection, *, guild_id: int | None = None) -> dict[str, Any]:
+    ensure_moment_schema(conn)
+    where = ""
+    params: list[Any] = []
+    if guild_id is not None:
+        where = " WHERE guild_id=?"
+        params = [guild_id]
+    def one(sql: str, bind: list[Any] | None = None) -> Any:
+        return conn.execute(sql, [] if bind is None else bind).fetchone()[0]
+    scoped = "guild_id=? AND " if guild_id is not None else ""
+    p = [guild_id] if guild_id is not None else []
+    report = {
+        "eligible_entries_observed": one(f"SELECT COUNT(*) FROM memory_moment_diagnostics{where + (' AND' if where else ' WHERE')} event_type='eligible_ledger_entry_observed'", params),
+        "open_windows": one(f"SELECT COUNT(*) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} lifecycle_status='open'", params),
+        "finalized_moments": one(f"SELECT COUNT(*) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} lifecycle_status='finalized'", params),
+        "processing_errors": one(f"SELECT COUNT(*) FROM memory_moment_diagnostics{where + (' AND' if where else ' WHERE')} event_type='moment_processing_error'", params),
+        "rejected_windows_by_reason": dict(conn.execute(f"SELECT qualification_reason,COUNT(*) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} lifecycle_status='rejected' GROUP BY qualification_reason", params).fetchall()),
+        "moments_by_qualification_type": dict(conn.execute(f"SELECT qualification_type,COUNT(*) FROM memory_moment_windows{where} GROUP BY qualification_type", params).fetchall()),
+        "moments_by_visibility": dict(conn.execute(f"SELECT visibility,COUNT(*) FROM memory_moment_windows{where} GROUP BY visibility", params).fetchall()),
+        "moments_by_lifecycle": dict(conn.execute(f"SELECT lifecycle_status,COUNT(*) FROM memory_moment_windows{where} GROUP BY lifecycle_status", params).fetchall()),
+        "one_human_conversational_moments": one(f"SELECT COUNT(*) FROM memory_moment_windows WHERE {scoped}qualification_type='conversational'", p),
+        "multi_human_shared_moments": one(f"SELECT COUNT(*) FROM memory_moment_windows WHERE {scoped}qualification_type='shared_activity'", p),
+        "average_participant_count": one(f"SELECT COALESCE(AVG(participant_count),0) FROM memory_moment_windows WHERE {scoped}lifecycle_status='finalized'", p),
+        "duplicate_memberships": one(f"SELECT COUNT(*) FROM (SELECT m.moment_id,m.ledger_entry_id,COUNT(*) c FROM memory_moment_members m JOIN memory_moment_windows w ON w.moment_id=m.moment_id WHERE {scoped}1=1 GROUP BY m.moment_id,m.ledger_entry_id HAVING c>1)", p),
+        "bnl_only_violations": one(f"SELECT COUNT(*) FROM memory_moment_windows WHERE {scoped}lifecycle_status='finalized' AND human_entry_count=0", p),
+        "cross_guild_violations": one(f"SELECT COUNT(*) FROM memory_moment_members mm JOIN memory_moment_windows mw ON mw.moment_id=mm.moment_id JOIN memory_ledger_entries e ON e.entry_id=mm.ledger_entry_id WHERE {('mw.guild_id=? AND ' if guild_id is not None else '')}e.guild_id<>mw.guild_id", p),
+        "cross_channel_violations": one(f"SELECT COUNT(*) FROM memory_moment_members mm JOIN memory_moment_windows mw ON mw.moment_id=mm.moment_id JOIN memory_ledger_entries e ON e.entry_id=mm.ledger_entry_id WHERE {('mw.guild_id=? AND ' if guild_id is not None else '')}e.channel_id<>mw.channel_id", p),
+        "incompatible_visibility_violations": one(f"SELECT COUNT(*) FROM memory_moment_members mm JOIN memory_moment_windows mw ON mw.moment_id=mm.moment_id JOIN memory_ledger_entries e ON e.entry_id=mm.ledger_entry_id WHERE {('mw.guild_id=? AND ' if guild_id is not None else '')}e.visibility<>mw.visibility", p),
+        "dangling_lineage_targets": one(f"SELECT COUNT(*) FROM memory_ledger_lineage l LEFT JOIN memory_ledger_entries e ON e.guild_id=l.guild_id AND e.entry_id=l.target_entry_id WHERE {('l.guild_id=? AND ' if guild_id is not None else '')}e.entry_id IS NULL", p),
+        "affected_moments_awaiting_correction_review": one(f"SELECT COUNT(*) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} lifecycle_status='needs_review'", params),
+        "finalization_latency": one(f"SELECT COALESCE(AVG(strftime('%s',finalized_at)-strftime('%s',last_activity_at)),0) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} finalized_at IS NOT NULL", params),
+    }
     return report

--- a/bnl_moment_engine.py
+++ b/bnl_moment_engine.py
@@ -1,0 +1,240 @@
+"""Moment Engine v1 shadow infrastructure.
+
+Builds bounded, auditable conversational moments from Unified Memory Ledger
+conversation entries only. This module is deliberately not used by prompt assembly.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone, timedelta
+import hashlib, json, os, re, sqlite3
+from typing import Any
+
+from bnl_canon_source_contract import Confidence, SourceClass, Visibility
+from bnl_memory_ledger import (
+    BNL_SUBJECT_KEY, LedgerEntry, LedgerParticipant, LedgerWriteResult,
+    ensure_memory_ledger_schema, insert_ledger_entry, shadow_enabled as ledger_shadow_enabled,
+)
+
+MOMENT_ENGINE_SHADOW_ENV = "BNL_MOMENT_ENGINE_SHADOW_ENABLED"
+MOMENT_SCHEMA_VERSION = "memory_moment_v1"
+MAX_WINDOW_SECONDS = 5 * 60
+INACTIVITY_SECONDS = 2 * 60
+
+STOP = set("a an and are as at be but by for from how i in is it me my of on or our that the this to was we what when where who why with you your did do does about into can could would should just yep yes no ok okay hey hi hello thanks thank lol lmao".split())
+STRONG_MARKERS = ("remember", "recall", "what numbers", "correction", "actually", "replace", "commit", "promise", "boundary", "milestone", "follow up", "follow-up", "celebrate")
+LOW_SIGNAL = set("hi hey hello thanks thank you ok okay yep yes no lol lmao cool nice got it noted".split())
+VIS_RANK = {"public": 0, "public_safe": 0, "reference_canon": 0, "internal": 2, "private": 3, "mod": 3, "sealed_test": 4, "protected": 4, "ai_image_tool": 4, "unknown": 5}
+
+@dataclass(frozen=True)
+class MomentObservationResult:
+    outcome: str = "skipped"
+    reason_code: str = "not_attempted"
+    moment_id: str = ""
+    ledger_entry_id: str = ""
+
+
+def shadow_enabled(environ: dict[str, str] | None = None) -> bool:
+    return str((environ or os.environ).get(MOMENT_ENGINE_SHADOW_ENV, "")).strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def _now() -> str: return datetime.now(timezone.utc).isoformat()
+def _parse_ts(v: str) -> datetime:
+    try: return datetime.fromisoformat((v or "").replace("Z", "+00:00"))
+    except Exception: return datetime.now(timezone.utc)
+def _canon(v: Any) -> str: return re.sub(r"\s+", " ", str(v or "").strip().lower())
+def _tokens(text: str) -> tuple[str, ...]: return tuple(t for t in re.findall(r"[a-z0-9]{2,}", _canon(text)) if t not in STOP)[:12]
+def _topic_key(text: str, predicate: str = "") -> str:
+    nums = re.findall(r"\b\d{2,12}\b", text or "")
+    toks = list(_tokens(text)) + nums
+    if predicate == "remembered_number": toks.append("remembered_number")
+    if not toks: return "low_signal"
+    return "topic_" + hashlib.sha256(" ".join(sorted(set(toks))[:10]).encode()).hexdigest()[:16]
+def stable_moment_id(guild_id:int, channel_id:int, topic_key:str, started_at:str) -> str:
+    return "mom_" + hashlib.sha256(f"{MOMENT_SCHEMA_VERSION}\x1f{guild_id}\x1f{channel_id}\x1f{topic_key}\x1f{started_at}".encode()).hexdigest()[:32]
+def stable_moment_entry_id(moment_id: str) -> str: return "moment_entry_" + hashlib.sha256(moment_id.encode()).hexdigest()[:32]
+def _meaningful(text: str, role: str, predicate: str) -> bool:
+    c = _canon(text)
+    if role != "user": return False
+    if predicate == "remembered_number" or any(m in c for m in STRONG_MARKERS): return True
+    toks = [t for t in _tokens(c) if t not in LOW_SIGNAL]
+    if not toks: return False
+    if re.fullmatch(r"[!?.\s]+", c or ""): return False
+    return len(toks) >= 2 or len(c) >= 24
+
+def ensure_moment_schema(conn: sqlite3.Connection) -> None:
+    ensure_memory_ledger_schema(conn); cur=conn.cursor()
+    cur.execute("""CREATE TABLE IF NOT EXISTS memory_moment_windows (
+      moment_id TEXT PRIMARY KEY, guild_id INTEGER NOT NULL, channel_id INTEGER NOT NULL, channel_name TEXT,
+      channel_policy TEXT, route_mode TEXT, topic_key TEXT NOT NULL, window_started_at TEXT NOT NULL,
+      last_activity_at TEXT NOT NULL, finalized_at TEXT, qualification_type TEXT, qualification_reason TEXT,
+      lifecycle_status TEXT NOT NULL, visibility TEXT, public_usable INTEGER DEFAULT 0, salience REAL DEFAULT 0,
+      human_entry_count INTEGER DEFAULT 0, model_entry_count INTEGER DEFAULT 0, participant_count INTEGER DEFAULT 0,
+      summary TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)""")
+    cur.execute("""CREATE TABLE IF NOT EXISTS memory_moment_members (
+      moment_id TEXT NOT NULL, ledger_entry_id TEXT NOT NULL, source_sequence INTEGER DEFAULT 0, observed_at TEXT,
+      membership_role TEXT, created_at TEXT NOT NULL, PRIMARY KEY(moment_id, ledger_entry_id))""")
+    cur.execute("""CREATE TABLE IF NOT EXISTS memory_moment_participants (
+      moment_id TEXT NOT NULL, participant_key TEXT NOT NULL, safe_display_name TEXT, participant_role TEXT,
+      first_seen_at TEXT, last_seen_at TEXT, authored_entry_count INTEGER DEFAULT 0, participation_order INTEGER DEFAULT 0,
+      created_at TEXT NOT NULL, updated_at TEXT NOT NULL, PRIMARY KEY(moment_id, participant_key, participant_role))""")
+    cur.execute("""CREATE TABLE IF NOT EXISTS memory_moment_diagnostics (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER DEFAULT 0, moment_id TEXT DEFAULT '', event_type TEXT NOT NULL,
+      reason_code TEXT DEFAULT '', ledger_entry_id TEXT DEFAULT '', created_at TEXT NOT NULL)""")
+    for sql in [
+      "CREATE INDEX IF NOT EXISTS idx_mmw_scope ON memory_moment_windows(guild_id, channel_id, lifecycle_status, last_activity_at)",
+      "CREATE INDEX IF NOT EXISTS idx_mmm_entry ON memory_moment_members(ledger_entry_id)",
+      "CREATE INDEX IF NOT EXISTS idx_mmp_participant ON memory_moment_participants(participant_key, moment_id)",
+      "CREATE INDEX IF NOT EXISTS idx_mmd_guild ON memory_moment_diagnostics(guild_id, event_type, reason_code)"]:
+        cur.execute(sql)
+
+def _diag(conn, guild_id, event, reason="", moment_id="", entry_id=""):
+    conn.execute("INSERT INTO memory_moment_diagnostics(guild_id,moment_id,event_type,reason_code,ledger_entry_id,created_at) VALUES(?,?,?,?,?,?)", (guild_id, moment_id, event, reason, entry_id, _now()))
+
+def _fetch_entry(conn, entry_id):
+    return conn.execute("SELECT entry_id,guild_id,source_table,source_role,entry_type,predicate_key,normalized_value,route_mode,channel_id,channel_name,channel_policy,visibility,public_usable,salience,observed_at,source_sequence,lifecycle_status,subject_key,subject_display_name FROM memory_ledger_entries WHERE entry_id=?", (entry_id,)).fetchone()
+
+def observe_ledger_entry(conn: sqlite3.Connection, ledger_entry_id: str) -> MomentObservationResult:
+    ensure_moment_schema(conn)
+    if not shadow_enabled(): return MomentObservationResult(reason_code="moment_gate_disabled")
+    if not ledger_shadow_enabled():
+        _diag(conn, 0, "moment_processing_skipped", "ledger_shadow_unavailable", entry_id=ledger_entry_id); return MomentObservationResult(reason_code="ledger_shadow_unavailable")
+    try:
+        row=_fetch_entry(conn, ledger_entry_id)
+        if not row: return MomentObservationResult(reason_code="missing_ledger_entry", ledger_entry_id=ledger_entry_id)
+        (eid,guild,table,role,etype,pred,val,route,chan,cname,policy,vis,pub,sal,obs,seq,life,subj,disp)=row
+        if table!="conversations" or life not in ("active","review_only") or etype not in ("observation","derived_summary"):
+            return MomentObservationResult(reason_code="ineligible_source", ledger_entry_id=eid)
+        _diag(conn,guild,"eligible_ledger_entry_observed","ok",entry_id=eid)
+        topic=_topic_key(val or "", pred or "")
+        ts=_parse_ts(obs); open_rows=conn.execute("SELECT moment_id,topic_key,window_started_at,last_activity_at,channel_policy,visibility FROM memory_moment_windows WHERE guild_id=? AND channel_id=? AND lifecycle_status='open' ORDER BY last_activity_at DESC",(guild,chan)).fetchall()
+        chosen=None
+        for m in open_rows:
+            if (ts-_parse_ts(m[3])).total_seconds()>INACTIVITY_SECONDS or (ts-_parse_ts(m[2])).total_seconds()>MAX_WINDOW_SECONDS or m[4] != policy or m[5] != vis:
+                finalize_moment(conn,m[0]); continue
+            shift = "different" in _canon(val) or "unrelated" in _canon(val)
+            if not shift and not chosen: chosen=m[0]
+            else: finalize_moment(conn,m[0]); _diag(conn,guild,"window_split","topic_or_visibility_shift",m[0],eid)
+        if not chosen:
+            started=obs or _now(); chosen=stable_moment_id(guild,chan,topic,started)
+            conn.execute("INSERT OR IGNORE INTO memory_moment_windows(moment_id,guild_id,channel_id,channel_name,channel_policy,route_mode,topic_key,window_started_at,last_activity_at,lifecycle_status,visibility,public_usable,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",(chosen,guild,chan,cname,policy,route,topic,started,started,"open",vis,int(bool(pub)),_now(),_now()))
+            _diag(conn,guild,"window_opened","ok",chosen,eid)
+        role_name = "human_author" if role=="user" else "bnl_participant"
+        before=conn.execute("SELECT COUNT(*) FROM memory_moment_members WHERE moment_id=? AND ledger_entry_id=?",(chosen,eid)).fetchone()[0]
+        conn.execute("INSERT OR IGNORE INTO memory_moment_members VALUES(?,?,?,?,?,?)",(chosen,eid,int(seq or 0),obs,role_name,_now()))
+        if before: _diag(conn,guild,"exact_source_duplicate_ignored","duplicate",chosen,eid)
+        pkey = subj if role=="user" else BNL_SUBJECT_KEY; pname = disp if role=="user" else "BNL-01"
+        existing=conn.execute("SELECT authored_entry_count, participation_order FROM memory_moment_participants WHERE moment_id=? AND participant_key=? AND participant_role=?",(chosen,pkey,role_name)).fetchone()
+        order=existing[1] if existing else conn.execute("SELECT COUNT(*) FROM memory_moment_participants WHERE moment_id=?",(chosen,)).fetchone()[0]
+        if existing:
+            conn.execute("UPDATE memory_moment_participants SET last_seen_at=?, authored_entry_count=authored_entry_count+?, updated_at=? WHERE moment_id=? AND participant_key=? AND participant_role=?",(obs,1 if role=="user" and not before else 0,_now(),chosen,pkey,role_name))
+        else:
+            conn.execute("INSERT INTO memory_moment_participants VALUES(?,?,?,?,?,?,?,?,?,?)",(chosen,pkey,(pname or "")[:120],role_name,obs,obs,1 if role=="user" else 0,order,_now(),_now()))
+        _recount(conn, chosen); _diag(conn,guild,"window_extended","ok",chosen,eid)
+        return MomentObservationResult("observed","ok",chosen,eid)
+    except Exception:
+        try: _diag(conn,0,"moment_processing_error","exception",entry_id=ledger_entry_id)
+        except Exception: pass
+        return MomentObservationResult("error","exception",ledger_entry_id=ledger_entry_id)
+
+def _entries(conn, moment_id):
+    return conn.execute("""SELECT e.* FROM memory_moment_members m JOIN memory_ledger_entries e ON e.entry_id=m.ledger_entry_id WHERE m.moment_id=? ORDER BY e.observed_at, e.source_sequence, e.entry_id""",(moment_id,)).fetchall()
+
+def _recount(conn, moment_id):
+    rows=_entries(conn,moment_id); humans=[r for r in rows if r[13]=="user" and _meaningful(r[7] or "", "user", r[6] or "")]; models=[r for r in rows if r[13]!="user"]
+    parts=conn.execute("SELECT COUNT(DISTINCT participant_key) FROM memory_moment_participants WHERE moment_id=? AND participant_role='human_author'",(moment_id,)).fetchone()[0]
+    vis=max([r[19] for r in rows] or ["unknown"], key=lambda v: VIS_RANK.get(v,5)); pub=all(bool(r[22]) for r in rows) if rows else False
+    conn.execute("UPDATE memory_moment_windows SET human_entry_count=?, model_entry_count=?, participant_count=?, visibility=?, public_usable=?, last_activity_at=COALESCE((SELECT MAX(observed_at) FROM memory_moment_members WHERE moment_id=?), last_activity_at), updated_at=? WHERE moment_id=?",(len(humans),len(models),parts,vis,int(pub),moment_id,_now(),moment_id))
+
+def _qualify(rows):
+    humans=[r for r in rows if r[13]=="user" and _meaningful(r[7] or "", "user", r[6] or "")]; models=[r for r in rows if r[13]!="user"]
+    human_parts={r[3] for r in humans}; text=" ".join((r[7] or "") for r in humans).lower(); strong=any(m in text for m in STRONG_MARKERS) or any(r[6]=="remembered_number" for r in humans)
+    if len(human_parts)>=2 and len(humans)>=3: return "shared_activity", "two_humans_three_meaningful_entries"
+    if len(human_parts)==1 and models and (len(humans)>=3 or strong): return "conversational", "one_human_bnl_meaningful_continuity_or_marker"
+    if len(human_parts)==1 and strong and len(humans)>=1: return "conversational", "explicit_marker_continuity"
+    return "", "low_signal_or_bnl_only"
+
+def _summary(rows, qtype, reason):
+    vals=[]
+    for r in rows:
+        if r[13]=="user" and (r[6]=="remembered_number" or any(m in (r[7] or "").lower() for m in STRONG_MARKERS)):
+            vals.append(f"{r[6]}={str(r[7])[:80]}")
+    detail=("; ".join(dict.fromkeys(vals)) or "bounded conversation activity")[:240]
+    return f"Derived moment ({qtype}): {detail}; reason={reason}."
+
+def finalize_moment(conn: sqlite3.Connection, moment_id: str) -> MomentObservationResult:
+    ensure_moment_schema(conn); win=conn.execute("SELECT guild_id,channel_id,channel_name,channel_policy,route_mode,topic_key,window_started_at,last_activity_at,visibility,public_usable,lifecycle_status FROM memory_moment_windows WHERE moment_id=?",(moment_id,)).fetchone()
+    if not win: return MomentObservationResult(reason_code="missing_window", moment_id=moment_id)
+    if win[10]=="finalized": return MomentObservationResult("deduplicated","already_finalized",moment_id,stable_moment_entry_id(moment_id))
+    rows=_entries(conn,moment_id); qtype, reason=_qualify(rows)
+    if not qtype:
+        conn.execute("UPDATE memory_moment_windows SET lifecycle_status='rejected', qualification_reason=?, finalized_at=?, updated_at=? WHERE moment_id=?",(reason,_now(),_now(),moment_id)); _diag(conn,win[0],"window_rejected",reason,moment_id); return MomentObservationResult("rejected",reason,moment_id)
+    source_ids=[r[0] for r in rows]
+    if any(not conn.execute("SELECT 1 FROM memory_ledger_entries WHERE entry_id=?",(x,)).fetchone() for x in source_ids):
+        _diag(conn,win[0],"lineage_validation_failure","dangling_source",moment_id); return MomentObservationResult("error","dangling_source",moment_id)
+    sal=min(1.0,0.2+0.12*len([r for r in rows if r[13]=="user"])+0.08*len({r[3] for r in rows if r[13]=="user"}))
+    summary=_summary(rows,qtype,reason); participants=[]
+    for p in conn.execute("SELECT participant_key,safe_display_name,participant_role,participation_order FROM memory_moment_participants WHERE moment_id=? ORDER BY participation_order,participant_key",(moment_id,)).fetchall(): participants.append(LedgerParticipant(p[0],p[1] or "",p[2],p[3]))
+    value=json.dumps({"schema":MOMENT_SCHEMA_VERSION,"moment_id":moment_id,"summary":summary,"window_started_at":win[6],"last_activity_at":win[7],"topic_key":win[5],"qualification_type":qtype,"qualification_reason":reason,"salience":sal,"participants":[p.participant_key for p in participants],"public_usable":bool(win[9]),"lifecycle_status":"finalized"},sort_keys=True)
+    entry=LedgerEntry(guild_id=win[0],source_table="memory_moment_windows",source_row_id=moment_id,source_revision="1",source_role="derived_assessment",entry_type="shared_moment",subject_key=f"moment:{moment_id}",predicate_key="shared_moment",value=value,source_class=SourceClass.DERIVED_SUMMARY,route_mode=win[4] or "unknown",channel_id=win[1],channel_name=win[2] or "",channel_policy=win[3] or "",visibility=Visibility(win[8] or "unknown"),confidence=Confidence.LOW,public_usable=bool(win[9]),derived=True,projection=True,salience=sal,observed_at=win[7],source_sequence=0,valid_from=win[6],valid_until=win[7],freshness="shadow_moment_v1",lifecycle_status="active",participants=tuple(participants),lineage=tuple(("derived_from",x) for x in source_ids))
+    res=insert_ledger_entry(conn,entry)
+    moment_entry=res.entry_id
+    for sid in source_ids: conn.execute("INSERT OR IGNORE INTO memory_ledger_lineage VALUES(?,?,?,?,?)",(sid,win[0],"part_of_moment",moment_entry,_now()))
+    conn.execute("UPDATE memory_moment_windows SET lifecycle_status='finalized', finalized_at=?, qualification_type=?, qualification_reason=?, salience=?, summary=?, updated_at=? WHERE moment_id=?",(_now(),qtype,reason,sal,summary,_now(),moment_id)); _diag(conn,win[0],"window_finalized",reason,moment_id,moment_entry)
+    return MomentObservationResult(res.outcome,res.reason_code,moment_id,moment_entry)
+
+def sweep_expired_windows(conn: sqlite3.Connection, *, guild_id:int|None=None, now:str|None=None):
+    ensure_moment_schema(conn); base=_parse_ts(now or _now()); params=[]; where="lifecycle_status='open'"
+    if guild_id is not None: where+=" AND guild_id=?"; params.append(guild_id)
+    out=[]
+    for mid,last in conn.execute(f"SELECT moment_id,last_activity_at FROM memory_moment_windows WHERE {where}",params).fetchall():
+        if (base-_parse_ts(last)).total_seconds()>=INACTIVITY_SECONDS: out.append(finalize_moment(conn,mid))
+    return out
+
+def handle_source_correction(conn: sqlite3.Connection, source_entry_id: str) -> int:
+    ensure_moment_schema(conn); rows=conn.execute("SELECT DISTINCT moment_id FROM memory_moment_members WHERE ledger_entry_id=?",(source_entry_id,)).fetchall()
+    for (mid,) in rows: conn.execute("UPDATE memory_moment_windows SET lifecycle_status='needs_review', updated_at=? WHERE moment_id=?",(_now(),mid)); _diag(conn,0,"moment_awaiting_review","source_corrected",mid,source_entry_id)
+    return len(rows)
+
+def render_shadow_moment_context(conn: sqlite3.Connection, *, guild_id:int, channel_id:int, participant_key:str="", visibility:str="public_safe", topic_text:str="", token_budget:int=120, freshness_days:int=3650) -> str:
+    ensure_moment_schema(conn); cutoff=(datetime.now(timezone.utc)-timedelta(days=freshness_days)).isoformat(); toks=set(_tokens(topic_text)); lines=[]; used=0
+    for r in conn.execute("SELECT moment_id,summary,topic_key,visibility,last_activity_at,salience FROM memory_moment_windows WHERE guild_id=? AND channel_id=? AND lifecycle_status='finalized' AND last_activity_at>=? ORDER BY salience DESC,last_activity_at DESC",(guild_id,channel_id,cutoff)).fetchall():
+        if VIS_RANK.get(r[3],5)>VIS_RANK.get(visibility,0): continue
+        if participant_key and not conn.execute("SELECT 1 FROM memory_moment_participants WHERE moment_id=? AND participant_key=?",(r[0],participant_key)).fetchone(): continue
+        if toks and not (toks & set(_tokens((r[1] or '')+' '+(r[2] or ''))) or ({"number","numbers"} & toks and "remembered_number" in (r[1] or ""))): continue
+        line=f"[Derived moment context] {r[1]}"
+        n=len(line.split())
+        if used+n>token_budget:
+            if not lines:
+                line=" ".join(line.split()[:max(1, token_budget)])
+                lines.append(line)
+            break
+        lines.append(line); used+=n
+    return "\n".join(lines)
+
+def build_moment_evaluation_report(conn: sqlite3.Connection, *, guild_id:int|None=None) -> dict[str,Any]:
+    ensure_moment_schema(conn); where=""; params=[]
+    if guild_id is not None: where=" WHERE guild_id=?"; params=[guild_id]
+    def one(sql,p=None):
+        bind = params if p is None and "?" in sql else ([] if p is None else p)
+        return conn.execute(sql, bind).fetchone()[0]
+    report={"eligible_entries_observed":one(f"SELECT COUNT(*) FROM memory_moment_diagnostics{where + (' AND' if where else ' WHERE')} event_type='eligible_ledger_entry_observed'"),"open_windows":one(f"SELECT COUNT(*) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} lifecycle_status='open'"),"finalized_moments":one(f"SELECT COUNT(*) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} lifecycle_status='finalized'"),"processing_errors":one(f"SELECT COUNT(*) FROM memory_moment_diagnostics{where + (' AND' if where else ' WHERE')} event_type='moment_processing_error'")}
+    report["rejected_windows_by_reason"]=dict(conn.execute(f"SELECT qualification_reason,COUNT(*) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} lifecycle_status='rejected' GROUP BY qualification_reason",params).fetchall())
+    report["moments_by_qualification_type"]=dict(conn.execute(f"SELECT qualification_type,COUNT(*) FROM memory_moment_windows{where} GROUP BY qualification_type",params).fetchall())
+    report["moments_by_visibility"]=dict(conn.execute(f"SELECT visibility,COUNT(*) FROM memory_moment_windows{where} GROUP BY visibility",params).fetchall())
+    report["moments_by_lifecycle"]=dict(conn.execute(f"SELECT lifecycle_status,COUNT(*) FROM memory_moment_windows{where} GROUP BY lifecycle_status",params).fetchall())
+    prefix="m.guild_id=? AND " if guild_id is not None else ""
+    p=[guild_id] if guild_id is not None else []
+    report.update({
+      "one_human_conversational_moments":one(f"SELECT COUNT(*) FROM memory_moment_windows m WHERE {prefix}qualification_type='conversational'",p),
+      "multi_human_shared_moments":one(f"SELECT COUNT(*) FROM memory_moment_windows m WHERE {prefix}qualification_type='shared_activity'",p),
+      "average_participant_count":one(f"SELECT COALESCE(AVG(participant_count),0) FROM memory_moment_windows m WHERE {prefix}lifecycle_status='finalized'",p),
+      "duplicate_memberships":one("SELECT COUNT(*) FROM (SELECT moment_id,ledger_entry_id,COUNT(*) c FROM memory_moment_members GROUP BY moment_id,ledger_entry_id HAVING c>1)"),
+      "bnl_only_violations":one(f"SELECT COUNT(*) FROM memory_moment_windows m WHERE {prefix}lifecycle_status='finalized' AND human_entry_count=0",p),
+      "cross_guild_violations":one("SELECT COUNT(*) FROM memory_moment_members mm JOIN memory_moment_windows mw ON mw.moment_id=mm.moment_id JOIN memory_ledger_entries e ON e.entry_id=mm.ledger_entry_id WHERE e.guild_id<>mw.guild_id"),
+      "cross_channel_violations":one("SELECT COUNT(*) FROM memory_moment_members mm JOIN memory_moment_windows mw ON mw.moment_id=mm.moment_id JOIN memory_ledger_entries e ON e.entry_id=mm.ledger_entry_id WHERE e.channel_id<>mw.channel_id"),
+      "incompatible_visibility_violations":one("SELECT COUNT(*) FROM memory_moment_members mm JOIN memory_moment_windows mw ON mw.moment_id=mm.moment_id JOIN memory_ledger_entries e ON e.entry_id=mm.ledger_entry_id WHERE e.visibility<>mw.visibility"),
+      "dangling_lineage_targets":one("SELECT COUNT(*) FROM memory_ledger_lineage l LEFT JOIN memory_ledger_entries e ON e.guild_id=l.guild_id AND e.entry_id=l.target_entry_id WHERE e.entry_id IS NULL"),
+      "affected_moments_awaiting_correction_review":one(f"SELECT COUNT(*) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} lifecycle_status='needs_review'"),
+      "finalization_latency":one(f"SELECT COALESCE(AVG(strftime('%s',finalized_at)-strftime('%s',last_activity_at)),0) FROM memory_moment_windows{where + (' AND' if where else ' WHERE')} finalized_at IS NOT NULL")})
+    return report

--- a/tests/test_moment_engine_bot_paths.py
+++ b/tests/test_moment_engine_bot_paths.py
@@ -36,4 +36,11 @@ class MomentEngineBotPathTests(unittest.TestCase):
             rendered=bnl01_bot.build_conversation_context_v2_for_prompt(guild_id=1,current_user_id=1,channel_id=10,channel_name="c10",channel_policy="sealed_test",route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,current_texts=["synth question"],current_participants={1})
         self.assertEqual(rendered,"")
 
+    def test_disabled_gate_does_not_call_moment_observer(self):
+        os.environ.pop("BNL_MOMENT_ENGINE_SHADOW_ENABLED",None)
+        with mock.patch("bnl01_bot.observe_moment_ledger_entry", side_effect=AssertionError("observer should not be called")):
+            bnl01_bot.save_user_message(3,"C",1,"remember this number: 10",channel_policy="sealed_test",channel_id=10)
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_ledger_entries WHERE source_table='conversations'")[0][0],1)
+        self.assertEqual(self.rows("SELECT name FROM sqlite_master WHERE type='table' AND name='memory_moment_windows'"),[])
+
 if __name__ == "__main__": unittest.main()

--- a/tests/test_moment_engine_bot_paths.py
+++ b/tests/test_moment_engine_bot_paths.py
@@ -1,7 +1,8 @@
 import os, sqlite3, tempfile, unittest
+from unittest import mock
 os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
-import bnl01_bot, bnl_moment_engine as moments
+import bnl01_bot
 
 class MomentEngineBotPathTests(unittest.TestCase):
     def setUp(self):
@@ -13,9 +14,10 @@ class MomentEngineBotPathTests(unittest.TestCase):
         bnl01_bot.DB_FILE=self.old
     def rows(self,sql):
         c=sqlite3.connect(self.tmp.name); r=c.execute(sql).fetchall(); c.close(); return r
-    def test_disabled_gate_creates_no_moment_windows(self):
+    def test_disabled_gate_creates_no_moment_schema_or_windows(self):
         bnl01_bot.save_user_message(1,"A",1,"remember this number: 8",channel_policy="sealed_test",channel_id=10)
-        self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_moment_windows")[0][0],0)
+        tables=self.rows("SELECT name FROM sqlite_master WHERE type='table' AND name='memory_moment_windows'")
+        self.assertEqual(tables,[])
     def test_enabled_gate_observes_after_ledger_write_and_failure_is_isolated(self):
         os.environ["BNL_MOMENT_ENGINE_SHADOW_ENABLED"]="1"
         bnl01_bot.save_user_message(1,"A",1,"remember this number: 731946",channel_policy="sealed_test",channel_id=10)
@@ -27,5 +29,11 @@ class MomentEngineBotPathTests(unittest.TestCase):
         os.environ.pop("BNL_MEMORY_LEDGER_SHADOW_ENABLED",None); os.environ["BNL_MOMENT_ENGINE_SHADOW_ENABLED"]="1"
         bnl01_bot.save_user_message(2,"B",1,"remember this number: 9",channel_policy="sealed_test",channel_id=10)
         self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_ledger_entries")[0][0],0)
+    def test_prompt_context_does_not_read_moments(self):
+        os.environ["BNL_MOMENT_ENGINE_SHADOW_ENABLED"]="1"
+        with mock.patch("bnl01_bot.observe_moment_ledger_entry", side_effect=AssertionError("production prompt read moment observer")):
+            os.environ["BNL_CONVERSATION_CONTEXT_V2_ENABLED"]="1"
+            rendered=bnl01_bot.build_conversation_context_v2_for_prompt(guild_id=1,current_user_id=1,channel_id=10,channel_name="c10",channel_policy="sealed_test",route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,current_texts=["synth question"],current_participants={1})
+        self.assertEqual(rendered,"")
 
 if __name__ == "__main__": unittest.main()

--- a/tests/test_moment_engine_bot_paths.py
+++ b/tests/test_moment_engine_bot_paths.py
@@ -1,0 +1,31 @@
+import os, sqlite3, tempfile, unittest
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+import bnl01_bot, bnl_moment_engine as moments
+
+class MomentEngineBotPathTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp=tempfile.NamedTemporaryFile(delete=False); self.tmp.close()
+        self.old=bnl01_bot.DB_FILE; bnl01_bot.DB_FILE=self.tmp.name
+        os.environ["BNL_MEMORY_LEDGER_SHADOW_ENABLED"]="1"; os.environ.pop("BNL_MOMENT_ENGINE_SHADOW_ENABLED",None)
+        bnl01_bot.init_db()
+    def tearDown(self):
+        bnl01_bot.DB_FILE=self.old
+    def rows(self,sql):
+        c=sqlite3.connect(self.tmp.name); r=c.execute(sql).fetchall(); c.close(); return r
+    def test_disabled_gate_creates_no_moment_windows(self):
+        bnl01_bot.save_user_message(1,"A",1,"remember this number: 8",channel_policy="sealed_test",channel_id=10)
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_moment_windows")[0][0],0)
+    def test_enabled_gate_observes_after_ledger_write_and_failure_is_isolated(self):
+        os.environ["BNL_MOMENT_ENGINE_SHADOW_ENABLED"]="1"
+        bnl01_bot.save_user_message(1,"A",1,"remember this number: 731946",channel_policy="sealed_test",channel_id=10)
+        bnl01_bot.save_model_message(1,1,"ok",channel_policy="sealed_test",channel_id=10)
+        bnl01_bot.save_user_message(1,"A",1,"what numbers did I ask you to remember?",channel_policy="sealed_test",channel_id=10)
+        self.assertGreaterEqual(self.rows("SELECT COUNT(*) FROM memory_ledger_entries WHERE source_table='conversations'")[0][0],3)
+        self.assertGreaterEqual(self.rows("SELECT COUNT(*) FROM memory_moment_windows")[0][0],1)
+    def test_moment_gate_without_ledger_gate_skips_safely(self):
+        os.environ.pop("BNL_MEMORY_LEDGER_SHADOW_ENABLED",None); os.environ["BNL_MOMENT_ENGINE_SHADOW_ENABLED"]="1"
+        bnl01_bot.save_user_message(2,"B",1,"remember this number: 9",channel_policy="sealed_test",channel_id=10)
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_ledger_entries")[0][0],0)
+
+if __name__ == "__main__": unittest.main()

--- a/tests/test_moment_engine_v1.py
+++ b/tests/test_moment_engine_v1.py
@@ -1,0 +1,77 @@
+import os, sqlite3, unittest
+from datetime import datetime, timezone, timedelta
+
+import bnl_memory_ledger as ledger
+import bnl_moment_engine as moments
+
+class MomentEngineV1Tests(unittest.TestCase):
+    def setUp(self):
+        os.environ["BNL_MEMORY_LEDGER_SHADOW_ENABLED"]="1"
+        os.environ["BNL_MOMENT_ENGINE_SHADOW_ENABLED"]="1"
+        self.conn=sqlite3.connect(":memory:")
+        ledger.ensure_memory_ledger_schema(self.conn); moments.ensure_moment_schema(self.conn)
+    def tearDown(self): self.conn.close()
+    def add(self,row,user,role,text,guild=1,chan=10,policy="sealed_test",mins=0,name=None):
+        ts=(datetime(2026,1,1,tzinfo=timezone.utc)+timedelta(minutes=mins)).isoformat()
+        r=ledger.shadow_conversation_row(self.conn,row_id=row,user_id=user,user_name=name or f"U{user}",guild_id=guild,role=role,content=text,channel_policy=policy,channel_id=chan,channel_name=f"c{chan}",route_mode="normal_chat",observed_at=ts)
+        moments.observe_ledger_entry(self.conn,r.entry_id)
+        return r
+    def finalize_all(self): return moments.sweep_expired_windows(self.conn, now=datetime(2026,1,1,0,10,tzinfo=timezone.utc).isoformat())
+    def test_two_humans_create_shared_activity_and_lineage_resolves(self):
+        self.add(1,1,"user","red synth riff sounds huge")
+        self.add(2,2,"user","red synth riff needs a drum answer")
+        self.add(3,1,"user","yes the red synth and drums lock together")
+        self.finalize_all()
+        self.assertEqual(self.conn.execute("SELECT qualification_type FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()[0],"shared_activity")
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_ledger_entries WHERE entry_type='shared_moment'").fetchone()[0],1)
+        self.assertEqual(moments.build_moment_evaluation_report(self.conn,guild_id=1)["dangling_lineage_targets"],0)
+    def test_one_human_and_bnl_conversational_moment(self):
+        self.add(1,1,"user","remember this number: 731946")
+        self.add(2,1,"model","I can track that as context")
+        self.add(3,1,"user","also remember this number: 284517")
+        self.add(4,1,"model","Noted")
+        self.add(5,1,"user","what numbers did I ask you to remember?")
+        self.finalize_all()
+        row=self.conn.execute("SELECT qualification_type,summary FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()
+        self.assertEqual(row[0],"conversational"); self.assertIn("731946",row[1]); self.assertIn("284517",row[1])
+    def test_correction_marks_affected_moment_needs_review(self):
+        r1=self.add(1,1,"user","remember this number: 8")
+        self.add(2,1,"model","ok")
+        self.add(3,1,"user","actually remember this number: 9 too")
+        self.finalize_all(); self.assertEqual(moments.handle_source_correction(self.conn,r1.entry_id),1)
+        self.assertEqual(self.conn.execute("SELECT lifecycle_status FROM memory_moment_windows").fetchone()[0],"needs_review")
+    def test_bnl_only_and_low_signal_rejected(self):
+        self.add(1,1,"model","hello") ; self.add(2,1,"model","ok") ; self.finalize_all()
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()[0],0)
+        self.add(3,2,"user","hi",mins=3); self.add(4,2,"user","ok",mins=3); self.finalize_all()
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()[0],0)
+    def test_punctuation_alone_does_not_qualify_but_burst_salience(self):
+        self.add(1,1,"user","!!!!!"); self.add(2,2,"user","????"); self.add(3,1,"user","!!!!!"); self.finalize_all()
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()[0],0)
+        self.add(10,1,"user","crystal bass patch opened in the bridge",mins=3)
+        self.add(11,2,"user","crystal bass patch should answer the vocal",mins=3)
+        self.add(12,3,"user","crystal bass patch made the room react",mins=3)
+        self.finalize_all(); self.assertGreater(self.conn.execute("SELECT salience FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()[0],0.4)
+    def test_topic_shift_channels_guilds_visibility_and_duplicates(self):
+        r=self.add(1,1,"user","blue drums pattern is steady")
+        moments.observe_ledger_entry(self.conn,r.entry_id)
+        self.add(2,2,"user","blue drums pattern gets louder")
+        self.add(3,1,"user","totally different pizza oven topic")
+        self.add(4,3,"user","blue drums separate channel",chan=20)
+        self.add(5,4,"user","blue drums separate guild",guild=2)
+        self.add(6,5,"user","blue drums public visibility",policy="public_home")
+        self.finalize_all()
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_moment_members WHERE ledger_entry_id=?",(r.entry_id,)).fetchone()[0],1)
+        report=moments.build_moment_evaluation_report(self.conn)
+        self.assertEqual(report["cross_guild_violations"],0); self.assertEqual(report["cross_channel_violations"],0); self.assertEqual(report["incompatible_visibility_violations"],0)
+    def test_restart_recovery_renderer_and_eval_detects_violations(self):
+        self.add(1,1,"user","remember this number: 12345")
+        mid=self.conn.execute("SELECT moment_id FROM memory_moment_windows WHERE lifecycle_status='open'").fetchone()[0]
+        moments.sweep_expired_windows(self.conn, now=datetime(2026,1,1,0,3,tzinfo=timezone.utc).isoformat())
+        moments.finalize_moment(self.conn,mid)
+        rendered=moments.render_shadow_moment_context(self.conn,guild_id=1,channel_id=10,participant_key="discord_user:1",visibility="sealed_test",topic_text="number",token_budget=20)
+        self.assertIn("Derived moment context",rendered)
+        self.conn.execute("INSERT INTO memory_ledger_lineage VALUES('x',1,'derived_from','missing','now')")
+        self.assertGreater(moments.build_moment_evaluation_report(self.conn)["dangling_lineage_targets"],0)
+
+if __name__ == "__main__": unittest.main()

--- a/tests/test_moment_engine_v1.py
+++ b/tests/test_moment_engine_v1.py
@@ -118,4 +118,25 @@ class MomentEngineV1Tests(unittest.TestCase):
         self.assertGreater(moments.build_moment_evaluation_report(self.conn,guild_id=2)["dangling_lineage_targets"],0)
         self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_ledger_lineage l LEFT JOIN memory_ledger_entries e ON e.guild_id=l.guild_id AND e.entry_id=l.target_entry_id WHERE e.entry_id IS NULL AND l.guild_id=1").fetchone()[0],0)
 
+    def test_terminal_lifecycle_preserved_after_correction_and_rejected_refinalize(self):
+        self.add(101,1,"user","remember this number: 8",mins=20)
+        self.add(102,1,"model","ok",mins=20)
+        self.add(103,1,"user","remember this number: 9",mins=20)
+        self.sweep(24)
+        mid, entry_id = self.conn.execute("SELECT moment_id,canonical_ledger_entry_id FROM memory_moment_windows WHERE lifecycle_status='finalized' ORDER BY window_started_at DESC").fetchone()
+        self.assertTrue(entry_id.startswith("mle_"))
+        self.add(104,1,"user","Correction: the number is 10, not 8",mins=25)
+        self.assertEqual(self.conn.execute("SELECT lifecycle_status FROM memory_moment_windows WHERE moment_id=?",(mid,)).fetchone()[0],"needs_review")
+        result=moments.finalize_moment(self.conn, mid)
+        self.assertEqual(result.reason_code,"terminal_needs_review")
+        self.assertEqual(self.conn.execute("SELECT lifecycle_status FROM memory_moment_windows WHERE moment_id=?",(mid,)).fetchone()[0],"needs_review")
+        rendered=moments.render_shadow_moment_context(self.conn,guild_id=1,channel_id=10,participant_key="discord_user:1",visibility="sealed_test",topic_text="number",token_budget=50)
+        self.assertNotIn("Derived moment context", rendered)
+        self.add(201,7,"user","hello",mins=30)
+        self.sweep(35)
+        rejected_mid=self.conn.execute("SELECT moment_id FROM memory_moment_windows WHERE lifecycle_status='rejected' ORDER BY window_started_at DESC").fetchone()[0]
+        rejected_result=moments.finalize_moment(self.conn,rejected_mid)
+        self.assertEqual(rejected_result.reason_code,"terminal_rejected")
+        self.assertEqual(self.conn.execute("SELECT lifecycle_status FROM memory_moment_windows WHERE moment_id=?",(rejected_mid,)).fetchone()[0],"rejected")
+
 if __name__ == "__main__": unittest.main()

--- a/tests/test_moment_engine_v1.py
+++ b/tests/test_moment_engine_v1.py
@@ -1,5 +1,6 @@
 import os, sqlite3, unittest
 from datetime import datetime, timezone, timedelta
+from unittest import mock
 
 import bnl_memory_ledger as ledger
 import bnl_moment_engine as moments
@@ -11,67 +12,110 @@ class MomentEngineV1Tests(unittest.TestCase):
         self.conn=sqlite3.connect(":memory:")
         ledger.ensure_memory_ledger_schema(self.conn); moments.ensure_moment_schema(self.conn)
     def tearDown(self): self.conn.close()
-    def add(self,row,user,role,text,guild=1,chan=10,policy="sealed_test",mins=0,name=None):
+    def add(self,row,user,role,text,guild=1,chan=10,policy="sealed_test",mins=0,name=None, observe=True):
         ts=(datetime(2026,1,1,tzinfo=timezone.utc)+timedelta(minutes=mins)).isoformat()
         r=ledger.shadow_conversation_row(self.conn,row_id=row,user_id=user,user_name=name or f"U{user}",guild_id=guild,role=role,content=text,channel_policy=policy,channel_id=chan,channel_name=f"c{chan}",route_mode="normal_chat",observed_at=ts)
-        moments.observe_ledger_entry(self.conn,r.entry_id)
+        if observe: moments.observe_ledger_entry(self.conn,r.entry_id)
         return r
-    def finalize_all(self): return moments.sweep_expired_windows(self.conn, now=datetime(2026,1,1,0,10,tzinfo=timezone.utc).isoformat())
-    def test_two_humans_create_shared_activity_and_lineage_resolves(self):
+    def sweep(self, mins=10): return moments.sweep_expired_windows(self.conn, now=(datetime(2026,1,1,tzinfo=timezone.utc)+timedelta(minutes=mins)).isoformat())
+
+    def test_gates_disabled_and_ledger_unavailable(self):
+        os.environ.pop("BNL_MOMENT_ENGINE_SHADOW_ENABLED",None)
+        r=self.add(1,1,"user","remember this number: 12345", observe=False)
+        self.assertEqual(moments.observe_ledger_entry(self.conn,r.entry_id).reason_code,"moment_gate_disabled")
+        os.environ["BNL_MOMENT_ENGINE_SHADOW_ENABLED"]="1"; os.environ.pop("BNL_MEMORY_LEDGER_SHADOW_ENABLED",None)
+        self.assertEqual(moments.observe_ledger_entry(self.conn,r.entry_id).reason_code,"ledger_shadow_unavailable")
+
+    def test_unrelated_topics_split_without_magic_words(self):
+        self.add(1,1,"user","synth production needs a brighter bass patch")
+        self.add(2,2,"user","the drum mix should answer that synth line")
+        self.add(3,1,"user","that bass patch works with the bridge")
+        self.add(4,3,"user","pizza ovens need hotter stones for crust")
+        self.add(5,4,"user","hiking conditions look rainy on the trail")
+        self.sweep()
+        rows=self.conn.execute("SELECT qualification_type,lifecycle_status FROM memory_moment_windows ORDER BY window_started_at").fetchall()
+        self.assertEqual(rows[0],("shared_activity","finalized"))
+        self.assertGreaterEqual(len(rows),3)
+
+    def test_remembered_numbers_one_episode_but_isolated_remember_rejected(self):
+        self.add(1,1,"user","remember this number: 12345")
+        self.sweep()
+        self.assertEqual(self.conn.execute("SELECT lifecycle_status FROM memory_moment_windows").fetchone()[0],"rejected")
+        self.add(10,1,"user","remember this number: 731946",mins=3)
+        self.add(11,1,"model","I can keep that in the thread",mins=3)
+        self.add(12,1,"user","remember this number: 284517",mins=3)
+        self.add(13,1,"user","what numbers did I ask you to remember?",mins=3)
+        self.sweep(7)
+        row=self.conn.execute("SELECT qualification_type,summary FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()
+        self.assertEqual(row[0],"conversational"); self.assertIn("731946",row[1]); self.assertIn("284517",row[1])
+
+    def test_multi_human_shared_activity_qualifies_and_lineage_resolves(self):
         self.add(1,1,"user","red synth riff sounds huge")
         self.add(2,2,"user","red synth riff needs a drum answer")
         self.add(3,1,"user","yes the red synth and drums lock together")
-        self.finalize_all()
-        self.assertEqual(self.conn.execute("SELECT qualification_type FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()[0],"shared_activity")
-        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_ledger_entries WHERE entry_type='shared_moment'").fetchone()[0],1)
+        self.sweep()
+        mid, entry_id = self.conn.execute("SELECT moment_id,canonical_ledger_entry_id FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()
+        self.assertTrue(entry_id.startswith("mle_"))
+        self.assertEqual(moments.finalize_moment(self.conn, mid).ledger_entry_id, entry_id)
+        self.assertEqual(self.conn.execute("SELECT lifecycle_status FROM memory_ledger_entries WHERE entry_id=?",(entry_id,)).fetchone()[0],"review_only")
         self.assertEqual(moments.build_moment_evaluation_report(self.conn,guild_id=1)["dangling_lineage_targets"],0)
-    def test_one_human_and_bnl_conversational_moment(self):
-        self.add(1,1,"user","remember this number: 731946")
-        self.add(2,1,"model","I can track that as context")
-        self.add(3,1,"user","also remember this number: 284517")
-        self.add(4,1,"model","Noted")
-        self.add(5,1,"user","what numbers did I ask you to remember?")
-        self.finalize_all()
-        row=self.conn.execute("SELECT qualification_type,summary FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()
-        self.assertEqual(row[0],"conversational"); self.assertIn("731946",row[1]); self.assertIn("284517",row[1])
-    def test_correction_marks_affected_moment_needs_review(self):
+
+    def test_duplicates_before_and_after_finalization_are_global_noops(self):
+        r=self.add(1,1,"user","synth patch keeps the lead stable")
+        self.assertEqual(moments.observe_ledger_entry(self.conn,r.entry_id).outcome,"deduplicated")
+        self.add(2,2,"user","synth patch needs drums under it")
+        self.add(3,1,"user","synth patch and drums are locked")
+        self.sweep()
+        self.assertEqual(moments.observe_ledger_entry(self.conn,r.entry_id).outcome,"deduplicated")
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_moment_members WHERE ledger_entry_id=?",(r.entry_id,)).fetchone()[0],1)
+
+    def test_correction_marks_review_but_additive_values_do_not(self):
         r1=self.add(1,1,"user","remember this number: 8")
         self.add(2,1,"model","ok")
-        self.add(3,1,"user","actually remember this number: 9 too")
-        self.finalize_all(); self.assertEqual(moments.handle_source_correction(self.conn,r1.entry_id),1)
-        self.assertEqual(self.conn.execute("SELECT lifecycle_status FROM memory_moment_windows").fetchone()[0],"needs_review")
-    def test_bnl_only_and_low_signal_rejected(self):
-        self.add(1,1,"model","hello") ; self.add(2,1,"model","ok") ; self.finalize_all()
+        self.add(3,1,"user","remember this number: 9")
+        self.sweep(); mid=self.conn.execute("SELECT moment_id FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()[0]
+        self.assertEqual(self.conn.execute("SELECT lifecycle_status FROM memory_moment_windows WHERE moment_id=?",(mid,)).fetchone()[0],"finalized")
+        corr=self.add(4,1,"user","Correction: the number is 10, not 8",mins=3)
+        self.assertEqual(self.conn.execute("SELECT lifecycle_status FROM memory_moment_windows WHERE moment_id=?",(mid,)).fetchone()[0],"needs_review")
+        self.assertGreater(self.conn.execute("SELECT COUNT(*) FROM memory_ledger_lineage WHERE entry_id=? AND lineage_type='correction_of'",(corr.entry_id,)).fetchone()[0],0)
+
+    def test_public_usable_visibility_and_isolation(self):
+        self.add(1,1,"user","synth production public safe phrase",policy="public_home")
+        self.add(2,2,"user","synth production public safe answer",policy="public_home")
+        self.add(3,1,"user","synth production public safe close",policy="public_home")
+        self.add(4,3,"user","synth production sealed phrase",policy="sealed_test")
+        self.sweep()
+        pubs=dict(self.conn.execute("SELECT channel_policy,public_usable FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchall())
+        self.assertEqual(pubs.get("public_home"),1)
+        self.assertNotIn("sealed_test", pubs)  # isolated singleton does not finalize as public moment
+        report=moments.build_moment_evaluation_report(self.conn,guild_id=1)
+        self.assertEqual(report["cross_channel_violations"],0); self.assertEqual(report["incompatible_visibility_violations"],0)
+
+    def test_punctuation_low_signal_no_salience_and_failure_rolls_back(self):
+        self.add(1,1,"user","!!!!!"); self.add(2,2,"user","????"); self.add(3,1,"user","ok")
+        self.sweep()
         self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()[0],0)
-        self.add(3,2,"user","hi",mins=3); self.add(4,2,"user","ok",mins=3); self.finalize_all()
-        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()[0],0)
-    def test_punctuation_alone_does_not_qualify_but_burst_salience(self):
-        self.add(1,1,"user","!!!!!"); self.add(2,2,"user","????"); self.add(3,1,"user","!!!!!"); self.finalize_all()
-        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()[0],0)
-        self.add(10,1,"user","crystal bass patch opened in the bridge",mins=3)
-        self.add(11,2,"user","crystal bass patch should answer the vocal",mins=3)
-        self.add(12,3,"user","crystal bass patch made the room react",mins=3)
-        self.finalize_all(); self.assertGreater(self.conn.execute("SELECT salience FROM memory_moment_windows WHERE lifecycle_status='finalized'").fetchone()[0],0.4)
-    def test_topic_shift_channels_guilds_visibility_and_duplicates(self):
-        r=self.add(1,1,"user","blue drums pattern is steady")
-        moments.observe_ledger_entry(self.conn,r.entry_id)
-        self.add(2,2,"user","blue drums pattern gets louder")
-        self.add(3,1,"user","totally different pizza oven topic")
-        self.add(4,3,"user","blue drums separate channel",chan=20)
-        self.add(5,4,"user","blue drums separate guild",guild=2)
-        self.add(6,5,"user","blue drums public visibility",policy="public_home")
-        self.finalize_all()
-        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_moment_members WHERE ledger_entry_id=?",(r.entry_id,)).fetchone()[0],1)
-        report=moments.build_moment_evaluation_report(self.conn)
-        self.assertEqual(report["cross_guild_violations"],0); self.assertEqual(report["cross_channel_violations"],0); self.assertEqual(report["incompatible_visibility_violations"],0)
-    def test_restart_recovery_renderer_and_eval_detects_violations(self):
-        self.add(1,1,"user","remember this number: 12345")
-        mid=self.conn.execute("SELECT moment_id FROM memory_moment_windows WHERE lifecycle_status='open'").fetchone()[0]
-        moments.sweep_expired_windows(self.conn, now=datetime(2026,1,1,0,3,tzinfo=timezone.utc).isoformat())
-        moments.finalize_moment(self.conn,mid)
-        rendered=moments.render_shadow_moment_context(self.conn,guild_id=1,channel_id=10,participant_key="discord_user:1",visibility="sealed_test",topic_text="number",token_budget=20)
-        self.assertIn("Derived moment context",rendered)
-        self.conn.execute("INSERT INTO memory_ledger_lineage VALUES('x',1,'derived_from','missing','now')")
-        self.assertGreater(moments.build_moment_evaluation_report(self.conn)["dangling_lineage_targets"],0)
+        r=self.add(10,1,"user","synth patch opens", observe=False)
+        with mock.patch("bnl_moment_engine._insert_membership", side_effect=RuntimeError("boom")):
+            self.assertEqual(moments.observe_ledger_entry(self.conn,r.entry_id).outcome,"error")
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_moment_members WHERE ledger_entry_id=?",(r.entry_id,)).fetchone()[0],0)
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_moment_diagnostics WHERE event_type='moment_processing_error'").fetchone()[0],1)
+
+    def test_restart_renderer_eval_guild_scope_and_lineage(self):
+        self.add(1,1,"user","synth patch opens the room")
+        self.add(2,2,"user","synth patch needs a drum reply")
+        self.add(3,1,"user","synth patch and drums resolve")
+        # restart recovery: new connection would see the persisted open window; same conn simulates persisted state
+        self.sweep(3)
+        text=moments.render_shadow_moment_context(self.conn,guild_id=1,channel_id=10,participant_key="discord_user:1",visibility="sealed_test",topic_text="synth drums",token_budget=30)
+        self.assertIn("Derived moment context", text)
+        self.add(10,9,"user","pizza oven crust stays crisp",guild=2)
+        self.add(11,8,"user","pizza oven heat is steady",guild=2)
+        self.add(12,9,"user","pizza oven stone works",guild=2)
+        self.sweep()
+        self.conn.execute("INSERT INTO memory_ledger_lineage VALUES('x',2,'derived_from','missing','now')")
+        self.assertEqual(moments.build_moment_evaluation_report(self.conn,guild_id=1)["dangling_lineage_targets"],0)
+        self.assertGreater(moments.build_moment_evaluation_report(self.conn,guild_id=2)["dangling_lineage_targets"],0)
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM memory_ledger_lineage l LEFT JOIN memory_ledger_entries e ON e.guild_id=l.guild_id AND e.entry_id=l.target_entry_id WHERE e.entry_id IS NULL AND l.guild_id=1").fetchone()[0],0)
 
 if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
### Motivation

- Add a bounded, auditable Moment Engine v1 that detects short-lived conversational moments from the existing Unified Memory Ledger without changing production prompt assembly or live responses. 
- Keep the engine shadow-only and dependent on the Unified Memory Ledger so legacy memory remains authoritative and moments can be evaluated before any cutover. 
- Provide deterministic, idempotent storage and canonical ledger representation for finalized moments while preserving provenance, visibility, and correction lineage. 

### Description

- New module `bnl_moment_engine.py` implements shadow-mode moment windows, membership/participant tables, safe diagnostics, deterministic topic/topic-keying, bounded windowing (5 min max, ~2 min inactivity), qualification rules for `shared_activity` and `conversational`, deterministic summarization, and finalization that writes one canonical `entry_type='shared_moment'` ledger row with `derived_from` and `part_of_moment` lineage. 
- Minimal integration in `bnl01_bot.py` calls the moment observer only after a successful conversation shadow ledger write and receipt commit, and failures are isolated so they never affect Discord delivery, conversation storage, ledger writes, or prompt assembly. 
- Feature gate `BNL_MOMENT_ENGINE_SHADOW_ENABLED` is added and disabled by default, and moment processing also requires `BNL_MEMORY_LEDGER_SHADOW_ENABLED`; if ledger shadowing is unavailable the engine skips safely and records a diagnostic reason. 
- Files changed: `bnl_moment_engine.py`, small safe integration in `bnl01_bot.py`, and new tests `tests/test_moment_engine_v1.py` and `tests/test_moment_engine_bot_paths.py`; Base SHA: `e3fe0e30fc271953ad2615e240102d6c275e2d22`, Head SHA: `578c44560ff7216970ffb53b48552764ae7c1e57`. 

### Testing

- Static compile: `python -m py_compile bnl01_bot.py bnl_memory_ledger.py bnl_moment_engine.py` completed successfully. 
- Focused tests: `python -m pytest tests/test_moment_engine_v1.py tests/test_moment_engine_bot_paths.py tests/test_memory_ledger_v1.py tests/test_memory_ledger_bot_paths.py -q` passed (focused suite covering moment logic and bot-paths). 
- Wider integration: `python -m pytest tests/test_conversation_context_v2.py tests/test_route_memory_governance.py tests/test_canon_source_contract.py -q` passed; full-suite `python -m pytest -q` on the branch produced `854 passed, 31 failed` and the required base commit produced `844 passed, 31 failed`, and the 31 failures are pre-existing base-suite failures unrelated to the moment engine. 
- Additional verification: `git diff --check` passed and finalization logic validates every included source ledger entry before writing the canonical moment entry so every stored lineage target resolves to a real `memory_ledger_entries` row.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a588141a1b8832198f08188a07ccd64)