### PR TITLE
Memory Governance Explicit-Recall Integration and Remember-Directive Parsing

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -11906,6 +11906,14 @@ def extract_user_facts(text: str):
         if subject and raw_value:
             facts.append((f"favorite_{subject[:30]}", raw_value[:120], 0.88))
 
+    remembered_number = re.search(
+        r"\b(?:please\s+)?remember\s+(?:(?:that\s+)?(?:(?:this|the)\s+)?number\s*(?::|-|is)?|this\s*:)\s*(\d{1,12})(?!\d)\b",
+        content,
+        flags=re.IGNORECASE,
+    )
+    if remembered_number:
+        facts.append(("remembered_number", remembered_number.group(1), 0.9))
+
     directive_note = None
     directive_patterns = (
         r"\b(?:please\s+)?remember\s+(?:this\s*:|that\s+)([^.!?\n]{3,140})",
@@ -11922,7 +11930,7 @@ def extract_user_facts(text: str):
             if m:
                 directive_note = m.group(1).strip(" .,!?;:")
                 break
-    if directive_note:
+    if directive_note and not remembered_number:
         note_lower = directive_note.strip().lower()
         structured_values = {str(value).strip().lower() for (_key, value, _confidence) in facts}
         structured_duplicate = note_lower in structured_values or any(value and value in note_lower for value in structured_values)
@@ -12051,13 +12059,13 @@ def apply_explicit_recall_governance(
     if not legacy_recall_response:
         return legacy_recall_response
     policy = (channel_policy or "unknown").strip().lower() or "unknown"
-    if route_mode in SOURCE_INTERNAL_MODES or policy in {"unknown", "sealed_test", "protected_system", "broadcast_memory", "reference_canon", "ai_image_tool", "internal_controlled"}:
+    if route_mode in SOURCE_INTERNAL_MODES or policy not in PUBLIC_CHAT_POLICIES:
         return legacy_recall_response
     if not memory_governance_shadow_enabled():
         return legacy_recall_response
     try:
         limits = calculate_adaptive_memory_limits(user_id, guild_id, route_mode=route_mode, channel_policy=policy, user_text=user_text, is_owner_or_mod=is_owner_or_mod)
-        visibility = limits.get("visibility", "public_safe")
+        visibility = "public_safe"
         gov_req = GovernanceRequest(
             guild_id=guild_id,
             subject_user_id=user_id,
@@ -12078,7 +12086,14 @@ def apply_explicit_recall_governance(
         unsafe_governed = bool(gov_result.diagnostics.processing_errors or gov_result.diagnostics.invalid_invariants)
         if memory_governance_live_enabled() and not unsafe_governed:
             return _format_explicit_recall_governed_response(gov_result)
-    except Exception:
+    except Exception as exc:
+        logging.warning(
+            "memory_governance_explicit_recall_exception event=%s route_mode=%s channel_policy=%s exception_type=%s",
+            "explicit_recall_governance_exception",
+            str(route_mode or "unknown")[:80],
+            policy[:80],
+            type(exc).__name__[:80],
+        )
         return legacy_recall_response
     return legacy_recall_response
 

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -11906,15 +11906,28 @@ def extract_user_facts(text: str):
         if subject and raw_value:
             facts.append((f"favorite_{subject[:30]}", raw_value[:120], 0.88))
 
-    remember_note = re.search(
-        r"\bremember (?:that )?([^.!?\n]{3,140})",
-        content,
-        flags=re.IGNORECASE
+    directive_note = None
+    directive_patterns = (
+        r"\b(?:please\s+)?remember\s+(?:this\s*:|that\s+)([^.!?\n]{3,140})",
+        r"\b(?:please\s+)?remember\s+((?:my|i\s+prefer|i\s+like|i\s+want|i\s+need|i\s+am|i'm|[0-9])[^.!?\n]{2,140})",
     )
-    if remember_note:
-        note = remember_note.group(1).strip(" .,!?:;")
-        if note:
-            facts.append(("user_note", note[:140], 0.64))
+    interrogative_remember = (
+        re.search(r"\?\s*$", content)
+        or re.search(r"\b(?:what|do|did|can|why|how|when|where|who)\b[^.!?\n]{0,80}\bremember\b", lower, flags=re.IGNORECASE)
+        or re.search(r"\bremember\b[^.!?\n]{0,80}\?", lower, flags=re.IGNORECASE)
+    )
+    if not interrogative_remember:
+        for pattern in directive_patterns:
+            m = re.search(pattern, content, flags=re.IGNORECASE)
+            if m:
+                directive_note = m.group(1).strip(" .,!?;:")
+                break
+    if directive_note:
+        note_lower = directive_note.strip().lower()
+        structured_values = {str(value).strip().lower() for (_key, value, _confidence) in facts}
+        structured_duplicate = note_lower in structured_values or any(value and value in note_lower for value in structured_values)
+        if not structured_duplicate:
+            facts.append(("user_note", directive_note[:140], 0.64))
 
     return facts
 
@@ -12006,6 +12019,68 @@ def try_memory_recall_response(user_id: int, guild_id: int, user_text: str) -> s
         return f"I do not have your favorite {dynamic_favorite_ask.group(1).strip()} recorded yet."
 
     return ""
+
+def _format_explicit_recall_governed_response(gov_result) -> str:
+    if not gov_result.selected:
+        return "I do not have eligible durable memories available for this recall."
+    lines = []
+    for candidate in gov_result.selected[:5]:
+        text = re.sub(r"\s+", " ", str(candidate.text or "")).strip()
+        if text:
+            lines.append(f"- {text[:240]}")
+    if not lines:
+        return "I do not have eligible durable memories available for this recall."
+    return "Here is what I can safely recall:\n" + "\n".join(lines)
+
+def apply_explicit_recall_governance(
+    user_id: int,
+    guild_id: int,
+    user_text: str,
+    legacy_recall_response: str,
+    route_mode: str,
+    channel_policy: str,
+    channel_id: int = 0,
+    channel_name: str = "",
+    is_owner_or_mod: bool = False,
+) -> str:
+    """Shadow/live governance wrapper for legacy explicit durable-memory recall.
+
+    The caller must invoke this only after try_memory_recall_response() returns a
+    non-empty legacy response, and only for that immediate explicit-recall path.
+    """
+    if not legacy_recall_response:
+        return legacy_recall_response
+    policy = (channel_policy or "unknown").strip().lower() or "unknown"
+    if route_mode in SOURCE_INTERNAL_MODES or policy in {"unknown", "sealed_test", "protected_system", "broadcast_memory", "reference_canon", "ai_image_tool", "internal_controlled"}:
+        return legacy_recall_response
+    if not memory_governance_shadow_enabled():
+        return legacy_recall_response
+    try:
+        limits = calculate_adaptive_memory_limits(user_id, guild_id, route_mode=route_mode, channel_policy=policy, user_text=user_text, is_owner_or_mod=is_owner_or_mod)
+        visibility = limits.get("visibility", "public_safe")
+        gov_req = GovernanceRequest(
+            guild_id=guild_id,
+            subject_user_id=user_id,
+            route_mode=route_mode,
+            conversation_surface="discord_explicit_recall",
+            channel_id=int(channel_id or 0),
+            channel_name=str(channel_name or "")[:120],
+            channel_policy=policy,
+            visibility_allowance=visibility,
+            user_text=user_text or "",
+            budget_chars=int(limits.get("prompt_budget") or 1200),
+            allowed_source_classes=("owner_correction", "approved_canon", "first_party_record", "runtime_observation", "public_observation", "evidence_projection", "derived_summary"),
+            now=datetime.now(PACIFIC_TZ).isoformat(),
+        )
+        with sqlite3.connect(DB_FILE) as gov_conn:
+            gov_result = build_governed_context(gov_conn, gov_req, legacy_context=legacy_recall_response, include_review_moments=True)
+            persist_shadow_diagnostics(gov_conn, gov_req, gov_result, legacy_recall_response)
+        unsafe_governed = bool(gov_result.diagnostics.processing_errors or gov_result.diagnostics.invalid_invariants)
+        if memory_governance_live_enabled() and not unsafe_governed:
+            return _format_explicit_recall_governed_response(gov_result)
+    except Exception:
+        return legacy_recall_response
+    return legacy_recall_response
 
 def _memory_row_relevance(row, topic_key: str, user_text: str) -> float:
     summary = (row[1] or "") if len(row) > 1 else ""
@@ -15215,6 +15290,8 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             memory_recall = resolve_recent_media_followup(unique_user_ids[0], channel.guild.id, channel_id, channel_policy, combined_text)
             if not memory_recall:
                 memory_recall = try_memory_recall_response(unique_user_ids[0], channel.guild.id, combined_text)
+                if memory_recall:
+                    memory_recall = apply_explicit_recall_governance(unique_user_ids[0], channel.guild.id, combined_text, memory_recall, ROUTE_MODE_NORMAL_CHAT, channel_policy, channel_id=channel_id, channel_name=getattr(channel, "name", ""), is_owner_or_mod=is_privileged_member(member, channel.guild))
             if memory_recall:
                 await send_channel_then_save_model(channel, memory_recall, user_id=unique_user_ids[0], guild_id=channel.guild.id, channel_name=getattr(channel, "name", ""), channel_policy=channel_policy, channel_id=channel_id, route_mode=ROUTE_MODE_NORMAL_CHAT, allowed_mentions=safe_mentions)
                 _channel_last_reply_at[channel_id] = datetime.now(PACIFIC_TZ)
@@ -17681,6 +17758,8 @@ async def on_message(message: discord.Message):
             memory_recall = resolve_recent_media_followup(message.author.id, message.guild.id, message.channel.id, channel_policy, direct_content)
             if not memory_recall:
                 memory_recall = try_memory_recall_response(message.author.id, message.guild.id, direct_content)
+                if memory_recall:
+                    memory_recall = apply_explicit_recall_governance(message.author.id, message.guild.id, direct_content, memory_recall, route_mode, channel_policy, channel_id=getattr(message.channel, "id", 0), channel_name=getattr(message.channel, "name", ""), is_owner_or_mod=is_privileged_member(message.author, message.guild))
             if memory_recall:
                 await send_reply_then_save_model(message, memory_recall, user_id=message.author.id, guild_id=message.guild.id, channel_name=getattr(message.channel, "name", ""), channel_policy=channel_policy, channel_id=getattr(message.channel, "id", 0), route_mode=route_mode)
                 return
@@ -17945,6 +18024,8 @@ async def on_message(message: discord.Message):
         memory_recall = resolve_recent_media_followup(message.author.id, message.guild.id, message.channel.id, channel_policy, direct_content)
         if not memory_recall:
             memory_recall = try_memory_recall_response(message.author.id, message.guild.id, direct_content)
+            if memory_recall:
+                memory_recall = apply_explicit_recall_governance(message.author.id, message.guild.id, direct_content, memory_recall, route_mode, channel_policy, channel_id=getattr(message.channel, "id", 0), channel_name=getattr(message.channel, "name", ""), is_owner_or_mod=is_privileged_member(message.author, message.guild))
         if memory_recall:
             await send_reply_then_save_model(message, memory_recall, user_id=message.author.id, guild_id=message.guild.id, channel_name=getattr(message.channel, "name", ""), channel_policy=channel_policy, channel_id=getattr(message.channel, "id", 0), route_mode=route_mode)
             return
@@ -18155,6 +18236,8 @@ async def on_message(message: discord.Message):
         memory_recall = resolve_recent_media_followup(message.author.id, message.guild.id, message.channel.id, channel_policy, direct_content)
         if not memory_recall:
             memory_recall = try_memory_recall_response(message.author.id, message.guild.id, direct_content)
+            if memory_recall:
+                memory_recall = apply_explicit_recall_governance(message.author.id, message.guild.id, direct_content, memory_recall, route_mode, channel_policy, channel_id=getattr(message.channel, "id", 0), channel_name=getattr(message.channel, "name", ""), is_owner_or_mod=is_privileged_member(message.author, message.guild))
         if memory_recall:
             await send_reply_then_save_model(message, memory_recall, user_id=message.author.id, guild_id=message.guild.id, channel_name=getattr(message.channel, "name", ""), channel_policy=channel_policy, channel_id=getattr(message.channel, "id", 0), route_mode=route_mode, reply_text=memory_recall if len(memory_recall) <= 2000 else memory_recall[:1900] + "...")
             return

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -11906,25 +11906,26 @@ def extract_user_facts(text: str):
         if subject and raw_value:
             facts.append((f"favorite_{subject[:30]}", raw_value[:120], 0.88))
 
-    remembered_number = re.search(
-        r"\b(?:please\s+)?remember\s+(?:(?:that\s+)?(?:(?:this|the)\s+)?number\s*(?::|-|is)?|this\s*:)\s*(\d{1,12})(?!\d)\b",
-        content,
-        flags=re.IGNORECASE,
-    )
-    if remembered_number:
-        facts.append(("remembered_number", remembered_number.group(1), 0.9))
-
-    directive_note = None
-    directive_patterns = (
-        r"\b(?:please\s+)?remember\s+(?:this\s*:|that\s+)([^.!?\n]{3,140})",
-        r"\b(?:please\s+)?remember\s+((?:my|i\s+prefer|i\s+like|i\s+want|i\s+need|i\s+am|i'm|[0-9])[^.!?\n]{2,140})",
-    )
     interrogative_remember = (
         re.search(r"\?\s*$", content)
         or re.search(r"\b(?:what|do|did|can|why|how|when|where|who)\b[^.!?\n]{0,80}\bremember\b", lower, flags=re.IGNORECASE)
         or re.search(r"\bremember\b[^.!?\n]{0,80}\?", lower, flags=re.IGNORECASE)
     )
+
+    remembered_number = None
+    directive_note = None
+    directive_patterns = (
+        r"\b(?:please\s+)?remember\s+(?:this\s*:|that\s+)([^.!?\n]{3,140})",
+        r"\b(?:please\s+)?remember\s+((?:my|i\s+prefer|i\s+like|i\s+want|i\s+need|i\s+am|i'm|[0-9])[^.!?\n]{2,140})",
+    )
     if not interrogative_remember:
+        remembered_number = re.search(
+            r"\b(?:please\s+)?remember\s+(?:(?:that\s+)?(?:(?:this|the)\s+)?number\s*(?::|-|is)?|this\s*:)\s*(\d{1,12})(?!\d)\b",
+            content,
+            flags=re.IGNORECASE,
+        )
+        if remembered_number:
+            facts.append(("remembered_number", remembered_number.group(1), 0.9))
         for pattern in directive_patterns:
             m = re.search(pattern, content, flags=re.IGNORECASE)
             if m:

--- a/tests/test_explicit_recall_governance.py
+++ b/tests/test_explicit_recall_governance.py
@@ -133,11 +133,15 @@ class RememberDirectiveExtractionTests(unittest.TestCase):
     def facts(self, text):
         return bnl01_bot.extract_user_facts(text)
 
-    def test_negative_interrogatives_create_no_user_note_and_greetings_unchanged(self):
+    def test_negative_interrogatives_create_no_remember_derived_facts_and_greetings_unchanged(self):
         negatives = [
+            "do you remember the number 8?",
+            "can you remember this number: 731946?",
+            "what number did I tell you to remember, 8?",
+            "why don’t you remember number 8?",
+            "do you remember X?",
             "what do you remember about me?",
             "what do you remember?",
-            "do you remember X?",
             "what number did I tell you to remember?",
             "what numbers did I ask you to remember?",
             "do you remember the number?",
@@ -145,8 +149,10 @@ class RememberDirectiveExtractionTests(unittest.TestCase):
             "what number did I ask you to remember?",
             "why don’t you remember X?",
         ]
+        remember_derived_keys = {"remembered_number", "user_note"}
         for text in negatives:
-            self.assertFalse(any(k == "user_note" for k, _v, _c in self.facts(text)), text)
+            facts = self.facts(text)
+            self.assertFalse(any(k in remember_derived_keys for k, _v, _c in facts), text)
         self.assertEqual(self.facts("hello BNL"), [])
 
     def test_exact_remember_number_production_phrases_create_only_remembered_number(self):

--- a/tests/test_explicit_recall_governance.py
+++ b/tests/test_explicit_recall_governance.py
@@ -1,0 +1,146 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+from unittest import mock
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+from bnl_memory_governance import ensure_governance_schema
+from bnl_memory_ledger import subject_key_for_user
+
+
+class ExplicitRecallGovernanceTests(unittest.TestCase):
+    def setUp(self):
+        self.old_db = bnl01_bot.DB_FILE
+        self.tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.tmp.close()
+        bnl01_bot.DB_FILE = self.tmp.name
+        self.env = mock.patch.dict(os.environ, {}, clear=False)
+        self.env.start()
+        os.environ.pop("BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED", None)
+        os.environ.pop("BNL_MEMORY_GOVERNANCE_LIVE_ENABLED", None)
+        bnl01_bot.init_db()
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            ensure_governance_schema(conn)
+
+    def tearDown(self):
+        self.env.stop()
+        bnl01_bot.DB_FILE = self.old_db
+        try:
+            os.unlink(self.tmp.name)
+        except OSError:
+            pass
+
+    def rows(self, sql, params=()):
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            return conn.execute(sql, params).fetchall()
+
+    def insert_ledger(self, value="favorite color is green", *, public=1, vis="public_safe", life="active", user=42, guild=1):
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            ensure_governance_schema(conn)
+            subj = subject_key_for_user(user)
+            conn.execute(
+                "INSERT INTO memory_ledger_entries (entry_id,schema_version,guild_id,subject_key,subject_display_name,entry_type,predicate_key,normalized_value,source_class,source_table,source_row_id,source_revision,source_role,visibility,confidence,public_usable,derived,projection,salience,observed_at,lifecycle_status,created_at,updated_at,route_mode,channel_policy) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                ("e1", "memory_ledger_v1", guild, subj, "", "preference", "favorite_color", value, "first_party_record", "test", "e1", "", "test", vis, "high", public, 0, 0, 0.9, "2026-07-01T00:00:00+00:00", life, "2026-07-01T00:00:00+00:00", "2026-07-01T00:00:00+00:00", bnl01_bot.ROUTE_MODE_NORMAL_CHAT, "public_home"),
+            )
+            conn.commit()
+
+    def govern(self, legacy="Archive recall:\n- favorite color: old"):
+        return bnl01_bot.apply_explicit_recall_governance(
+            42, 1, "BNL, what do you remember about me?", legacy,
+            bnl01_bot.ROUTE_MODE_NORMAL_CHAT, "public_home", channel_id=99, channel_name="general",
+        )
+
+    def test_public_direct_shadow_live_off_one_row_and_legacy_byte_exact(self):
+        os.environ["BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED"] = "1"
+        legacy = "Archive recall:\n- favorite color: old"
+        out = self.govern(legacy)
+        self.assertEqual(out, legacy)
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_governance_shadow_runs")[0][0], 1)
+        self.assertEqual(self.rows("SELECT errors_json FROM memory_governance_shadow_runs")[0][0], "[]")
+
+    def test_public_batched_shadow_live_off_one_row(self):
+        os.environ["BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED"] = "1"
+        out = bnl01_bot.apply_explicit_recall_governance(42, 1, "what do you remember about me?", "legacy", bnl01_bot.ROUTE_MODE_NORMAL_CHAT, "public_home")
+        self.assertEqual(out, "legacy")
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_governance_shadow_runs")[0][0], 1)
+
+    def test_sealed_and_protected_are_excluded(self):
+        os.environ["BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED"] = "1"
+        for policy in ("sealed_test", "protected_system"):
+            self.assertEqual(bnl01_bot.apply_explicit_recall_governance(42, 1, "what do you remember about me?", "legacy", bnl01_bot.ROUTE_MODE_NORMAL_CHAT, policy), "legacy")
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_governance_shadow_runs")[0][0], 0)
+
+    def test_live_on_safe_selection_user_facing_and_safe_empty_hides_legacy(self):
+        os.environ["BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED"] = "1"
+        os.environ["BNL_MEMORY_GOVERNANCE_LIVE_ENABLED"] = "1"
+        self.insert_ledger()
+        out = self.govern("legacy says old private thing")
+        self.assertIn("Here is what I can safely recall:", out)
+        self.assertIn("favorite color is green", out)
+        self.assertNotIn("legacy", out)
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            conn.execute("DELETE FROM memory_ledger_entries")
+            conn.commit()
+        empty = self.govern("legacy ineligible secret")
+        self.assertEqual(empty, "I do not have eligible durable memories available for this recall.")
+        self.assertNotIn("secret", empty)
+
+    def test_error_result_falls_back_legacy_and_no_duplicate_rows(self):
+        os.environ["BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED"] = "1"
+        os.environ["BNL_MEMORY_GOVERNANCE_LIVE_ENABLED"] = "1"
+        with mock.patch("bnl01_bot.build_governed_context", side_effect=RuntimeError("boom")):
+            self.assertEqual(self.govern("legacy"), "legacy")
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_governance_shadow_runs")[0][0], 0)
+        os.environ.pop("BNL_MEMORY_GOVERNANCE_LIVE_ENABLED", None)
+        self.govern("legacy")
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_governance_shadow_runs")[0][0], 1)
+
+    def test_every_try_memory_recall_call_site_has_nearby_governance(self):
+        from pathlib import Path
+        text = Path("bnl01_bot.py").read_text()
+        offsets = [i for i in range(len(text)) if text.startswith("try_memory_recall_response", i) and text[max(0, i-4):i].strip().endswith("=")]
+        self.assertGreaterEqual(len(offsets), 4)
+        for i in offsets:
+            window = text[i:i + 500]
+            self.assertIn("apply_explicit_recall_governance", window)
+
+
+class RememberDirectiveExtractionTests(unittest.TestCase):
+    def facts(self, text):
+        return bnl01_bot.extract_user_facts(text)
+
+    def test_negative_interrogatives_create_no_user_note_and_greetings_unchanged(self):
+        negatives = [
+            "what do you remember about me?",
+            "what do you remember?",
+            "do you remember X?",
+            "what number did I ask you to remember?",
+            "can you remember what I said?",
+            "why don’t you remember X?",
+        ]
+        for text in negatives:
+            self.assertFalse(any(k == "user_note" for k, _v, _c in self.facts(text)), text)
+        self.assertEqual(self.facts("hello BNL"), [])
+
+    def test_positive_directives_create_notes_without_structured_duplicates(self):
+        cases = {
+            "remember this: 731946": "731946",
+            "remember that my door code changed": "my door code changed",
+            "remember my backup contact is Leo": "my backup contact is Leo",
+        }
+        for text, expected in cases.items():
+            self.assertIn(("user_note", expected, 0.64), self.facts(text))
+        preference_facts = self.facts("please remember I prefer short answers")
+        self.assertIn(("preferences", "short answers", 0.72), preference_facts)
+        self.assertFalse(any(k == "user_note" and "short answers" in v for k, v, _c in preference_facts))
+        facts = self.facts("remember that my favorite movie is Hackers")
+        self.assertIn(("favorite_movie", "Hackers", 0.92), facts)
+        self.assertFalse(any(k == "user_note" and v == "my favorite movie is Hackers" for k, v, _c in facts))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_explicit_recall_governance.py
+++ b/tests/test_explicit_recall_governance.py
@@ -38,13 +38,13 @@ class ExplicitRecallGovernanceTests(unittest.TestCase):
         with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
             return conn.execute(sql, params).fetchall()
 
-    def insert_ledger(self, value="favorite color is green", *, public=1, vis="public_safe", life="active", user=42, guild=1):
+    def insert_ledger(self, value="favorite color is green", *, public=1, vis="public_safe", life="active", user=42, guild=1, eid="e1", pred="favorite_color"):
         with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
             ensure_governance_schema(conn)
             subj = subject_key_for_user(user)
             conn.execute(
                 "INSERT INTO memory_ledger_entries (entry_id,schema_version,guild_id,subject_key,subject_display_name,entry_type,predicate_key,normalized_value,source_class,source_table,source_row_id,source_revision,source_role,visibility,confidence,public_usable,derived,projection,salience,observed_at,lifecycle_status,created_at,updated_at,route_mode,channel_policy) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-                ("e1", "memory_ledger_v1", guild, subj, "", "preference", "favorite_color", value, "first_party_record", "test", "e1", "", "test", vis, "high", public, 0, 0, 0.9, "2026-07-01T00:00:00+00:00", life, "2026-07-01T00:00:00+00:00", "2026-07-01T00:00:00+00:00", bnl01_bot.ROUTE_MODE_NORMAL_CHAT, "public_home"),
+                (eid, "memory_ledger_v1", guild, subj, "", "preference", pred, value, "first_party_record", "test", eid, "", "test", vis, "high", public, 0, 0, 0.9, "2026-07-01T00:00:00+00:00", life, "2026-07-01T00:00:00+00:00", "2026-07-01T00:00:00+00:00", bnl01_bot.ROUTE_MODE_NORMAL_CHAT, "public_home"),
             )
             conn.commit()
 
@@ -68,9 +68,9 @@ class ExplicitRecallGovernanceTests(unittest.TestCase):
         self.assertEqual(out, "legacy")
         self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_governance_shadow_runs")[0][0], 1)
 
-    def test_sealed_and_protected_are_excluded(self):
+    def test_unknown_sealed_and_protected_are_excluded(self):
         os.environ["BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED"] = "1"
-        for policy in ("sealed_test", "protected_system"):
+        for policy in ("unknown", "sealed_test", "protected_system", "internal_controlled"):
             self.assertEqual(bnl01_bot.apply_explicit_recall_governance(42, 1, "what do you remember about me?", "legacy", bnl01_bot.ROUTE_MODE_NORMAL_CHAT, policy), "legacy")
         self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_governance_shadow_runs")[0][0], 0)
 
@@ -89,11 +89,31 @@ class ExplicitRecallGovernanceTests(unittest.TestCase):
         self.assertEqual(empty, "I do not have eligible durable memories available for this recall.")
         self.assertNotIn("secret", empty)
 
+    def test_public_owner_mod_live_recall_remains_public_safe_only(self):
+        os.environ["BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED"] = "1"
+        os.environ["BNL_MEMORY_GOVERNANCE_LIVE_ENABLED"] = "1"
+        self.insert_ledger("public-safe favorite color is green", eid="pub")
+        self.insert_ledger("operator-only secret color is ultraviolet", eid="priv", vis="private", public=0)
+        out = bnl01_bot.apply_explicit_recall_governance(
+            42, 1, "BNL, what do you remember about me?", "legacy",
+            bnl01_bot.ROUTE_MODE_NORMAL_CHAT, "public_home", is_owner_or_mod=True,
+        )
+        self.assertIn("public-safe favorite color is green", out)
+        self.assertNotIn("operator-only secret", out)
+
     def test_error_result_falls_back_legacy_and_no_duplicate_rows(self):
         os.environ["BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED"] = "1"
         os.environ["BNL_MEMORY_GOVERNANCE_LIVE_ENABLED"] = "1"
-        with mock.patch("bnl01_bot.build_governed_context", side_effect=RuntimeError("boom")):
-            self.assertEqual(self.govern("legacy"), "legacy")
+        with self.assertLogs(level="WARNING") as logs:
+            with mock.patch("bnl01_bot.build_governed_context", side_effect=RuntimeError("boom")):
+                self.assertEqual(self.govern("legacy"), "legacy")
+        joined = "\n".join(logs.output)
+        self.assertIn("explicit_recall_governance_exception", joined)
+        self.assertIn("route_mode=normal_chat", joined)
+        self.assertIn("channel_policy=public_home", joined)
+        self.assertIn("exception_type=RuntimeError", joined)
+        self.assertNotIn("boom", joined)
+        self.assertNotIn("what do you remember", joined)
         self.assertEqual(self.rows("SELECT COUNT(*) FROM memory_governance_shadow_runs")[0][0], 0)
         os.environ.pop("BNL_MEMORY_GOVERNANCE_LIVE_ENABLED", None)
         self.govern("legacy")
@@ -118,17 +138,32 @@ class RememberDirectiveExtractionTests(unittest.TestCase):
             "what do you remember about me?",
             "what do you remember?",
             "do you remember X?",
-            "what number did I ask you to remember?",
+            "what number did I tell you to remember?",
+            "what numbers did I ask you to remember?",
+            "do you remember the number?",
             "can you remember what I said?",
+            "what number did I ask you to remember?",
             "why don’t you remember X?",
         ]
         for text in negatives:
             self.assertFalse(any(k == "user_note" for k, _v, _c in self.facts(text)), text)
         self.assertEqual(self.facts("hello BNL"), [])
 
+    def test_exact_remember_number_production_phrases_create_only_remembered_number(self):
+        cases = {
+            "remember this number: 731946": "731946",
+            "Remember this number - 8": "8",
+            "please remember the number 284517": "284517",
+            "remember this: 731946": "731946",
+            "remember that the number is 8": "8",
+        }
+        for text, expected in cases.items():
+            facts = self.facts(text)
+            self.assertEqual([f for f in facts if f[0] == "remembered_number"], [("remembered_number", expected, 0.9)], text)
+            self.assertFalse(any(k == "user_note" for k, _v, _c in facts), text)
+
     def test_positive_directives_create_notes_without_structured_duplicates(self):
         cases = {
-            "remember this: 731946": "731946",
             "remember that my door code changed": "my door code changed",
             "remember my backup contact is Leo": "my backup contact is Leo",
         }


### PR DESCRIPTION
### Motivation

- Ensure explicit durable-memory recall requests are evaluated by the memory-governance pipeline (shadow + optional live) so governance diagnostics are recorded and live-governed results can safely replace legacy recall when enabled. 
- Prevent overbroad "remember" extraction from converting interrogative recall questions into `user_note` facts and avoid duplication when structured patterns (favorites/preferences) already match.
- Make the change narrowly scoped to explicit-recall handling and remember-directive parsing without altering other memory, conversation, ledger, website, or relationship subsystems.

### Description

- Add a reusable wrapper `apply_explicit_recall_governance(...)` that builds a `GovernanceRequest` (using `conversation_surface="discord_explicit_recall"`), calls `build_governed_context()`, and records `persist_shadow_diagnostics()` while honoring the `memory_governance_shadow_enabled()` and `memory_governance_live_enabled()` gates, returning the legacy response when live is off or on errors. 
- Add `_format_explicit_recall_governed_response()` to render governed `MemoryCandidate` selections as concise, user-facing recall text that omits internal metadata. 
- Integrate the wrapper at each `try_memory_recall_response()` call site (batched active-channel path and the three direct-message paths) while preserving `resolve_recent_media_followup()` precedence so governance only runs when the legacy function actually recognized an explicit recall. 
- Tighten `extract_user_facts()`: replace the single broad `remember ...` pattern with conservative directive detection that rejects interrogative forms and only records `user_note` for explicit directives while avoiding duplicates when a structured fact was extracted. 
- Add behavioral tests in `tests/test_explicit_recall_governance.py` covering shadow-row creation for public recall with shadow-on/live-off, batched/direct paths, sealed/protected exclusions, live-on safe selection and empty results, fallback on errors, no duplicate shadow rows, call-site coverage, and positive/negative remember-directive parsing.
- Files changed: `bnl01_bot.py` (modifications and additions) and new test file `tests/test_explicit_recall_governance.py`.

### Testing

- Ran `python -m py_compile bnl01_bot.py` to validate syntax successfully. 
- Ran `pytest tests/test_explicit_recall_governance.py` and the new explicit-recall and remember-directive tests passed. 
- Ran targeted governance and ledger test groups (including `tests/test_memory_governance_v1.py`, `tests/test_memory_ledger_bot_paths.py`, `tests/test_moment_engine_bot_paths.py`, `tests/test_conversation_context_v2.py`, and `tests/test_route_memory_governance.py`) and observed no regressions in those suites. 
- Ran the full test suite which reveals existing unrelated baseline failures in `tests/test_subject_memory_resolver.py` and `tests/test_website_relay_event_driven.py` (these failures predate and are outside the explicit-recall scope); the explicit-recall and remember-directive changes themselves are covered and passing locally with the added tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a592fb3f2008321ba648b450e0980e3)