### PR TITLE
Tune BNL Journal editorial voice

### DIFF
--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -27,7 +27,32 @@ _REPAIR_GUIDANCE = {
     "public_leak_pattern": "Remove every URL, mention, identifier, and internal implementation term from public prose.",
     "source_ref_leak": "Keep source reference tokens only inside sourceRefIds arrays; remove them from all public prose.",
     "invalid_word_count": "Rewrite the complete article so its total public word count is between 250 and 500 words.",
+    "overly_clinical_voice": (
+        "Rewrite it as a lively, concrete community chronicle in BNL's voice. Remove academic, laboratory, audit, "
+        "and corporate-report language. Refer to anonymous people as producers, listeners, regulars, or the room—not entities."
+    ),
+    "sensitive_personal_detail": (
+        "Remove personal or domestic details that are unnecessary to the public community story, including details "
+        "about minors, interpersonal conflict, caregiving, or household obligations."
+    ),
 }
+
+_OVERLY_CLINICAL_PATTERNS = (
+    r"\bnetwork log\s*:",
+    r"\balgorithmic (?:refinement|analysis|calibration)\b",
+    r"\bmorphogenesis\b",
+    r"\bperceptual filters?\b",
+    r"\b(?:entities|organisms)\b",
+    r"\brecords (?:indicate|reveal|document)\b",
+    r"\bobservations (?:indicate|reveal|document|highlight)\b",
+    r"\boperational settings?\b",
+)
+
+_SENSITIVE_PERSONAL_PATTERNS = (
+    r"\binterpersonal conflicts?\b",
+    r"\bjuveniles?\b",
+    r"\bfoster (?:obligations?|care|duties)\b",
+)
 
 
 @dataclass
@@ -261,10 +286,15 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
     return (
         "You are BNL-01 writing a BARCODE Network Journal entry. Return strict JSON only; no markdown fences."
         "\nSchema: {\"title\":str,\"excerpt\":str,\"sections\":[{\"heading\":str,\"body\":str,\"sourceRefIds\":[str]}],\"metadata\":{\"topicTags\":[],\"subjectRefs\":[],\"continuityNotes\":[],\"unresolvedQuestions\":[],\"confidenceFlags\":[],\"safetyFlags\":[]}}."
-        "\nWrite 1-3 sections and 250-500 total words. Use BNL's formal, observant, lightly uncanny voice. Make it entertaining and grounded in BARCODE music/community texture."
+        "\nWrite 1-3 sections and 250-500 total words; prefer 2 sections and roughly 300-420 words. Give every section a real narrative job instead of inventorying activity."
+        "\nWrite like BNL keeping a sly, lively community chronicle—not a lab report, audit, academic paper, corporate briefing, or raw relay summary. BNL may be witty, lightly nosy, and uncanny, but never cruel."
+        "\nBuild one coherent story around the most interesting grounded patterns. Use concrete music and community texture, active verbs, readable paragraphs, and selective detail. Avoid abstract jargon and inflated technical language."
+        "\nUse a short, vivid title of about 4-10 words. Do not prefix it with Network Log. Keep the excerpt compact and inviting."
+        "\nDescribe anonymous humans naturally as a producer, listener, regular, artist, or the room. Never call people entities or organisms. Do not invent nicknames, motives, relationships, dialogue, or conclusions."
         "\nEvery section must cite at least one fresh sourceRefId from the current window. Older Journal material is continuity only, never proof of current activity."
         "\nParaphrase every source summary. Never repeat any sequence of five or more consecutive words from a fresh source summary."
         "\nKeep community members anonymous. Do not include direct quotes, URLs, mentions, IDs, sourceRef tokens in public prose, private intent, relationships, harassment, or internal schema/storage terms."
+        "\nExclude personal or domestic details that are unnecessary to the public community story, especially details involving minors, interpersonal conflict, caregiving, or household obligations. Juicy means lively pattern recognition—not private gossip."
         f"{repair}\nGeneration-safe packet:\n{json.dumps(safe_packet, ensure_ascii=False, sort_keys=True)}"
     )
 
@@ -345,6 +375,10 @@ def validate_article(article: dict[str, Any], packet: dict[str, Any], prior_titl
         name = str(src.get("displayName") or "").strip()
         if name and name not in names and re.search(r"\b" + re.escape(name) + r"\b", public_text, re.I):
             return "community_name_leak"
+    if any(re.search(pattern, public_text, re.I) for pattern in _SENSITIVE_PERSONAL_PATTERNS):
+        return "sensitive_personal_detail"
+    if any(re.search(pattern, public_text, re.I) for pattern in _OVERLY_CLINICAL_PATTERNS):
+        return "overly_clinical_voice"
     normalized_public = _norm(public_text)
     for src in packet.get("privateSources", []):
         summary = str(src.get("summary") or "")

--- a/tests/test_bnl_journal.py
+++ b/tests/test_bnl_journal.py
@@ -63,6 +63,10 @@ class JournalTests(unittest.TestCase):
         self.assertNotIn('discord_user:7', prompt)
         self.assertNotIn('relationship_journal', json.dumps(packet))
         self.assertNotIn('secret internal', json.dumps(packet))
+        self.assertIn('community chronicle', prompt)
+        self.assertIn('Never call people entities or organisms', prompt)
+        self.assertIn('Do not invent nicknames', prompt)
+        self.assertIn('Juicy means lively pattern recognition', prompt)
 
     def test_no_hard_coded_fallback_and_malformed_repair_no_rows(self):
         calls = []
@@ -97,6 +101,26 @@ class JournalTests(unittest.TestCase):
                 1,
                 c.execute("SELECT COUNT(*) FROM bnl_journal_entries WHERE lifecycle_state='draft'").fetchone()[0],
             )
+
+    def test_clinical_or_sensitive_copy_gets_rejected_and_rewritten(self):
+        packet = self.packet()
+        clinical = j.parse_generated_json(article_json(packet, title='Clinical Pass', leak=' Records indicate continuous effort across entities.'))
+        sensitive = j.parse_generated_json(article_json(packet, title='Sensitive Pass', leak=' Interpersonal conflicts among juveniles continue.'))
+        self.assertEqual('overly_clinical_voice', j.validate_article(clinical, packet, []))
+        self.assertEqual('sensitive_personal_detail', j.validate_article(sensitive, packet, []))
+
+        calls = []
+        def gen(packet, prompt):
+            calls.append(prompt)
+            if len(calls) == 1:
+                return article_json(packet, title='Clinical First Pass', leak=' Records indicate continuous effort across entities.')
+            return article_json(packet, title='Lively Rewritten Pass')
+
+        res = j.generate_and_store_draft(self.db, 1, 24, gen)
+        self.assertTrue(res.ok, res.reason)
+        self.assertEqual(2, len(calls))
+        self.assertIn('overly_clinical_voice', calls[1])
+        self.assertIn('lively, concrete community chronicle', calls[1])
 
     def test_source_specific_generated_json_creates_draft(self):
         def gen(packet, prompt): return article_json(packet)


### PR DESCRIPTION
### Why

The first live Journal draft proved the full producer and privacy workflow, but the prose read like an academic systems report and included unnecessary domestic details. It was technically valid but did not match the intended lively, observant BNL community chronicle.

### What changed

- Directs BNL toward a coherent, concrete community story rather than an activity inventory.
- Prefers two readable sections and roughly 300–420 words while preserving the existing 1–3 section and 250–500 word contract.
- Requests short vivid titles, active prose, selective detail, and BNL's witty/lightly uncanny voice.
- Forbids invented nicknames, motives, dialogue, relationships, and conclusions.
- Explicitly distinguishes lively pattern recognition from private gossip.
- Adds narrowly bounded repair checks for the clinical phrases and sensitive personal-detail patterns observed in the first live draft.
- Keeps all existing anonymity, phrase-copy, source-reference, approval, and delivery protections unchanged.

### Validation

- `PYTHONPATH=. python3 tests/test_bnl_journal.py JournalTests` — 14 focused Journal tests passed.
- `python3 -m py_compile bnl_journal.py bnl01_bot.py` — passed.
- `git diff --check` — passed.

Only `bnl_journal.py` and its focused test file change. No website, queue, payment, memory, relay, scheduling, approval, or delivery behavior is modified.