### PR TITLE
Automate daily and weekly BNL Journal publishing

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -74,7 +74,22 @@ from bnl_journal import (
     generate_and_store_draft as generate_and_store_journal_draft,
     preview as preview_journal_draft,
     regenerate_draft as regenerate_journal_draft,
+    rehydrate_published_entries as rehydrate_published_journal_entries,
     reject_draft as reject_journal_draft,
+)
+from bnl_journal_source_store import (
+    purge_guild_discord_sources as purge_guild_journal_sources,
+    purge_user_discord_sources as purge_user_journal_sources,
+    record_source_event as record_journal_source_event,
+    sanitize_summary as sanitize_journal_source_summary,
+    timestamp_to_epoch_ms as journal_timestamp_to_epoch_ms,
+)
+from bnl_journal_automation import (
+    automation_status as journal_automation_status,
+    result_dict as journal_automation_result_dict,
+    run_daily as run_daily_journal_automation,
+    run_scheduled as run_scheduled_journal_automation,
+    run_weekly as run_weekly_journal_automation,
 )
 from bnl_website_contract_v2 import (
     ContractV2Error,
@@ -309,6 +324,7 @@ BNL_OWNER_USER_ID = int(os.getenv("BNL_OWNER_USER_ID", "0") or 0)
 BNL_MOD_ROLE_ID = int(os.getenv("BNL_MOD_ROLE_ID", "0") or 0)
 BNL_TESTING_CHANNEL_ID = int(os.getenv("BNL_TESTING_CHANNEL_ID", "0") or 0)
 BNL_BROADCAST_MEMORY_CHANNEL_ID = int(os.getenv("BNL_BROADCAST_MEMORY_CHANNEL_ID", "1509384896554995752") or 0)
+BNL_JOURNAL_AUTOMATION_ENABLED = os.getenv("BNL_JOURNAL_AUTOMATION_ENABLED", "true").strip().lower() in {"1", "true", "yes", "on"}
 BNL_COMMUNITY_SCOUTING_ENABLED = community_scouting_enabled()
 BNL_COMMUNITY_SCOUTING_MIN_SIGNALS = community_min_signals()
 
@@ -1088,6 +1104,7 @@ _classification_last_missing_info_count = 0
 BNL_CONTROL_FLAGS_TTL_SECONDS = 300
 _bnl_control_flags_cache = None
 _bnl_control_flags_cached_at = None
+_bnl_control_flags_has_remote_snapshot = False
 _bnl_control_flags_404_warned = False
 _bnl_control_flags_last_source_url = None
 BNL_READ_MODEL_TTL_SECONDS = 20
@@ -1130,13 +1147,19 @@ def get_bnl_control_flags(force_refresh: bool = False) -> dict:
       websiteRelayEnabled: True
       heartbeatEnabled: True
       showdayDiscordPostsEnabled: False
+      journalAutoPublishEnabled: True
+      journalDailyEnabled: True
+      journalWeeklyEnabled: True
     """
-    global _bnl_control_flags_cache, _bnl_control_flags_cached_at, _bnl_control_flags_404_warned, _bnl_control_flags_last_source_url
+    global _bnl_control_flags_cache, _bnl_control_flags_cached_at, _bnl_control_flags_has_remote_snapshot, _bnl_control_flags_404_warned, _bnl_control_flags_last_source_url
     now = datetime.now(PACIFIC_TZ)
     defaults = {
         "websiteRelayEnabled": True,
         "heartbeatEnabled": True,
         "showdayDiscordPostsEnabled": False,
+        "journalAutoPublishEnabled": True,
+        "journalDailyEnabled": True,
+        "journalWeeklyEnabled": True,
     }
 
     if not force_refresh and _bnl_control_flags_cache and _bnl_control_flags_cached_at:
@@ -1169,13 +1192,28 @@ def get_bnl_control_flags(force_refresh: bool = False) -> dict:
                     continue
                 body = response.read().decode("utf-8", errors="replace")
                 data = json.loads(body) if body else {}
+                journal_keys = {
+                    "journalAutoPublishEnabled",
+                    "journalDailyEnabled",
+                    "journalWeeklyEnabled",
+                }
+                if not isinstance(data, dict) or not journal_keys.issubset(data):
+                    logging.warning(
+                        "⚠️ Control flags response from %s omitted required Journal flags; ignoring it.",
+                        url,
+                    )
+                    continue
                 flags = {
                     "websiteRelayEnabled": _coerce_flag(data.get("websiteRelayEnabled"), defaults["websiteRelayEnabled"]),
                     "heartbeatEnabled": _coerce_flag(data.get("heartbeatEnabled"), defaults["heartbeatEnabled"]),
                     "showdayDiscordPostsEnabled": _coerce_flag(data.get("showdayDiscordPostsEnabled"), defaults["showdayDiscordPostsEnabled"]),
+                    "journalAutoPublishEnabled": _coerce_flag(data.get("journalAutoPublishEnabled"), defaults["journalAutoPublishEnabled"]),
+                    "journalDailyEnabled": _coerce_flag(data.get("journalDailyEnabled"), defaults["journalDailyEnabled"]),
+                    "journalWeeklyEnabled": _coerce_flag(data.get("journalWeeklyEnabled"), defaults["journalWeeklyEnabled"]),
                 }
                 _bnl_control_flags_cache = flags
                 _bnl_control_flags_cached_at = now
+                _bnl_control_flags_has_remote_snapshot = True
                 _bnl_control_flags_last_source_url = url
                 logging.info(f"🌐 Control flags fetched from {url} (HTTP {code}).")
                 return flags
@@ -1193,10 +1231,19 @@ def get_bnl_control_flags(force_refresh: bool = False) -> dict:
         except Exception as e:
             logging.warning(f"⚠️ Control flags fetch failed for {url}: {e}")
 
+    if _bnl_control_flags_has_remote_snapshot and _bnl_control_flags_cache:
+        logging.warning(
+            "⚠️ All control flag fetches failed; retaining the last confirmed remote flags."
+        )
+        return dict(_bnl_control_flags_cache)
+
+    # Preserve the historical local-startup behavior when no control plane has
+    # ever answered. These defaults are not marked as a confirmed remote
+    # snapshot and therefore cannot overwrite a later confirmed pause state.
     _bnl_control_flags_cache = defaults
     _bnl_control_flags_cached_at = now
     _bnl_control_flags_last_source_url = None
-    return defaults
+    return dict(defaults)
 
 
 def fetch_bnl_read_model(force: bool = False) -> dict:
@@ -2692,6 +2739,8 @@ _force_pull_state_by_guild: dict[int, dict] = {}
 _force_pull_tasks_by_guild: dict[int, asyncio.Task] = {}
 _force_pull_request_id_by_guild: dict[int, str] = {}
 _force_pull_recent_requests_by_peer: dict[str, deque] = defaultdict(lambda: deque(maxlen=8))
+_journal_automation_locks_by_guild: dict[int, asyncio.Lock] = {}
+_journal_automation_runtime_by_guild: dict[int, dict] = {}
 FORCE_PULL_THROTTLE_SECONDS = 10
 FORCE_PULL_THROTTLE_MAX_REQUESTS = 4
 
@@ -5853,7 +5902,10 @@ def _format_rd_entity_context_response(subject: str, context: dict) -> str:
 
 
 def _parse_journal_command(text: str) -> tuple[bool, dict, str]:
-    m = re.match(r"(?is)^\s*!bnl\s+journal\s+(create|preview|regenerate|reject|approve|retry)\b(.*)$", text or "")
+    m = re.match(
+        r"(?is)^\s*!bnl\s+journal\s+(create|preview|regenerate|reject|approve|retry|status|run-daily|run-weekly|rehydrate)\b(.*)$",
+        text or "",
+    )
     if not m:
         return False, {}, ""
     action = m.group(1).lower()
@@ -5897,6 +5949,321 @@ def _generate_journal_json_sync(_packet: dict, prompt: str) -> str:
     return text or ""
 
 
+def _journal_control_url() -> str:
+    explicit = os.getenv("BNL_JOURNAL_CONTROL_URL", "").strip()
+    if explicit:
+        return explicit.rstrip("/")
+    base = _journal_website_base_url()
+    return f"{base}/api/bnl/journal/control" if base else ""
+
+
+def _journal_control_request_sync(method: str, payload: dict | None = None) -> tuple[dict | None, str]:
+    """Read or update the website control plane without making it a runtime dependency."""
+    url = _journal_control_url()
+    if not url or not BNL_API_KEY:
+        return None, "control_plane_configuration_missing"
+    body = None
+    headers = {"Accept": "application/json", "x-api-key": BNL_API_KEY}
+    if payload is not None:
+        body = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(url, data=body, method=method.upper(), headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            status = int(getattr(response, "status", None) or response.getcode())
+            raw = response.read().decode("utf-8", errors="replace")
+            data = json.loads(raw) if raw else {}
+            if not 200 <= status < 300 or not isinstance(data, dict):
+                return None, f"control_plane_http_{status}"
+            return data, ""
+    except urllib.error.HTTPError as exc:
+        return None, f"control_plane_http_{int(exc.code or 0)}"
+    except Exception as exc:
+        return None, f"control_plane_{type(exc).__name__.lower()}"
+
+
+def _journal_control_flags(control: dict | None, fallback: dict) -> dict:
+    flags = dict(fallback or {})
+    if isinstance(control, dict):
+        config = control.get("config") if isinstance(control.get("config"), dict) else {}
+        for key in ("journalAutoPublishEnabled", "journalDailyEnabled", "journalWeeklyEnabled"):
+            value = control.get(key, config.get(key))
+            if isinstance(value, bool):
+                flags[key] = value
+    return flags
+
+
+def _journal_control_claim_sync(control: dict | None) -> tuple[dict | None, str]:
+    requests = control.get("runRequests") if isinstance(control, dict) else None
+    if not isinstance(requests, list):
+        return None, ""
+    candidates = [item for item in requests if isinstance(item, dict) and item.get("status") == "queued"]
+    # A request left running by a process crash is safe to reclaim only with
+    # this VPS worker's stable token. The site rejects a different worker.
+    candidates.extend(
+        item for item in requests
+        if isinstance(item, dict) and item.get("status") == "running" and item not in candidates
+    )
+    worker_identity = (
+        os.getenv("BNL_JOURNAL_WORKER_ID", "").strip()
+        or os.getenv("HOSTNAME", "").strip()
+        or "bnl01-primary"
+    )
+    for candidate in candidates:
+        request_id = str(candidate.get("requestId") or "")[:120]
+        cadence = str(candidate.get("cadence") or "").lower()
+        if not request_id or cadence not in {"daily", "weekly"}:
+            continue
+        claim_token = "worker-" + hashlib.sha256(
+            f"{worker_identity}|{request_id}".encode("utf-8")
+        ).hexdigest()[:32]
+        data, reason = _journal_control_request_sync("POST", {
+            "action": "claimRunRequest",
+            "requestId": request_id,
+            "claimedAt": _utc_now_iso(),
+            "claimToken": claim_token,
+        })
+        if data and isinstance(data.get("request"), dict):
+            return data["request"], ""
+        if reason in {"control_plane_http_404", "control_plane_http_409"}:
+            continue
+        return None, reason or "claim_response_invalid"
+    return None, ""
+
+
+def _journal_site_run_state(status: str) -> str:
+    normalized = str(status or "").strip().lower()
+    if normalized in {
+        "running", "published", "held", "delivery_failed", "busy", "backoff",
+        "failed", "complete", "already_processed", "disabled",
+    }:
+        return normalized
+    if normalized in {"paused"}:
+        return "disabled"
+    if normalized in {"quiet", "deferred", "not_due"}:
+        return "skipped"
+    return "failed"
+
+
+def _journal_site_run_record(result: dict, *, guild_id: int, request_id: str = "") -> dict:
+    cadence = str(result.get("cadence") or "all")[:16]
+    start = str(result.get("source_window_start") or "")
+    end = str(result.get("source_window_end") or "")
+    entry_id = str(result.get("entry_id") or "")[:160]
+    stable_key = f"{guild_id}|{cadence}|{start}|{end}|{entry_id}|{request_id}"
+    run_id = request_id or ("jsite_" + hashlib.sha256(stable_key.encode("utf-8")).hexdigest()[:20])
+    counts = result.get("aggregate_counts") if isinstance(result.get("aggregate_counts"), dict) else {}
+    source_count = int(counts.get("eligibleRelays") or 0) + int(counts.get("eligibleConversations") or 0)
+    run = {
+        "runId": run_id[:160],
+        "cadence": cadence if cadence in {"daily", "weekly"} else "daily",
+        "state": _journal_site_run_state(str(result.get("status") or "failed")),
+        "occurredAt": _utc_now_iso(),
+        "detail": str(result.get("reason") or "")[:240],
+    }
+    if request_id:
+        run["requestId"] = request_id[:120]
+    if entry_id:
+        run["entryId"] = entry_id
+    if source_count:
+        run["sourceCount"] = source_count
+    return run
+
+
+def _journal_report_run_sync(result: dict, *, guild_id: int, request_id: str = "") -> tuple[dict | None, str]:
+    run = _journal_site_run_record(result, guild_id=guild_id, request_id=request_id)
+    return _journal_control_request_sync("POST", {"action": "reportRun", "run": run})
+
+
+def _journal_heartbeat_sync(runtime: dict, flags: dict) -> tuple[dict | None, str]:
+    last_site_run = runtime.get("lastSiteRun") if isinstance(runtime.get("lastSiteRun"), dict) else None
+    if not BNL_JOURNAL_AUTOMATION_ENABLED or not flags.get("journalAutoPublishEnabled", True):
+        automation_status = "paused"
+    elif runtime.get("lastError"):
+        automation_status = "degraded"
+    else:
+        automation_status = "online"
+    telemetry = {
+        "observedAt": _utc_now_iso(),
+        "automationStatus": automation_status,
+        "detail": str(runtime.get("lastError") or runtime.get("lastDetail") or "scheduler_ready")[:240],
+    }
+    if runtime.get("nextDailyAt"):
+        telemetry["nextDailyAt"] = str(runtime["nextDailyAt"])
+    if runtime.get("nextWeeklyAt"):
+        telemetry["nextWeeklyAt"] = str(runtime["nextWeeklyAt"])
+    if last_site_run:
+        telemetry["lastRun"] = last_site_run
+    return _journal_control_request_sync("POST", {"action": "heartbeat", "telemetry": telemetry})
+
+
+def _journal_automation_lock(guild_id: int) -> asyncio.Lock:
+    lock = _journal_automation_locks_by_guild.get(int(guild_id))
+    if lock is None:
+        lock = asyncio.Lock()
+        _journal_automation_locks_by_guild[int(guild_id)] = lock
+    return lock
+
+
+def _journal_control_result(cadence: str, status: str, reason: str) -> dict:
+    return {
+        "ok": False,
+        "cadence": cadence,
+        "status": status,
+        "reason": reason,
+        "entry_id": "",
+        "revision": 0,
+        "source_window_start": "",
+        "source_window_end": "",
+        "aggregate_counts": {},
+    }
+
+
+async def run_journal_automation_once(
+    guild_id: int,
+    *,
+    cadence: str = "scheduled",
+    force: bool = False,
+    flags: dict | None = None,
+) -> list[dict]:
+    """Serialize generation/delivery per guild and enforce every automation control flag."""
+    guild_id = resolve_network_guild_id(int(guild_id))
+    cadence = str(cadence or "scheduled").lower()
+    lock = _journal_automation_lock(guild_id)
+    if lock.locked():
+        return [_journal_control_result(cadence, "busy", "journal_automation_already_running")]
+    async with lock:
+        runtime = _journal_automation_runtime_by_guild.setdefault(guild_id, {})
+        runtime.update({"lastStartedAt": _utc_now_iso(), "lastError": "", "lastCadence": cadence})
+        if not BNL_JOURNAL_AUTOMATION_ENABLED:
+            results = [_journal_control_result(cadence, "paused", "local_automation_disabled")]
+        else:
+            effective_flags = flags
+            if effective_flags is None:
+                effective_flags = await asyncio.to_thread(get_bnl_control_flags, force_refresh=force)
+            if not effective_flags.get("journalAutoPublishEnabled", True):
+                results = [_journal_control_result(cadence, "paused", "auto_publish_paused")]
+            elif cadence == "daily" and not effective_flags.get("journalDailyEnabled", True):
+                results = [_journal_control_result("daily", "paused", "daily_automation_paused")]
+            elif cadence == "weekly" and not effective_flags.get("journalWeeklyEnabled", True):
+                results = [_journal_control_result("weekly", "paused", "weekly_automation_paused")]
+            elif cadence == "daily":
+                result = await asyncio.to_thread(
+                    run_daily_journal_automation,
+                    DB_FILE,
+                    guild_id,
+                    _generate_journal_json_sync,
+                    _journal_website_base_url(),
+                    BNL_API_KEY,
+                    force=force,
+                )
+                results = [journal_automation_result_dict(result)]
+            elif cadence == "weekly":
+                result = await asyncio.to_thread(
+                    run_weekly_journal_automation,
+                    DB_FILE,
+                    guild_id,
+                    _generate_journal_json_sync,
+                    _journal_website_base_url(),
+                    BNL_API_KEY,
+                    force=force,
+                )
+                results = [journal_automation_result_dict(result)]
+            else:
+                scheduled = await asyncio.to_thread(
+                    run_scheduled_journal_automation,
+                    DB_FILE,
+                    guild_id,
+                    _generate_journal_json_sync,
+                    _journal_website_base_url(),
+                    BNL_API_KEY,
+                    effective_flags,
+                )
+                results = [journal_automation_result_dict(item) for item in scheduled]
+        runtime.update({
+            "lastCompletedAt": _utc_now_iso(),
+            "lastResults": results,
+            "lastDetail": "; ".join(str(item.get("reason") or item.get("status") or "") for item in results)[:240],
+        })
+        logging.info(
+            "journal_automation_cycle guild=%s cadence=%s results=%s",
+            guild_id,
+            cadence,
+            ",".join(f"{item.get('cadence')}:{item.get('status')}" for item in results),
+        )
+        return results
+
+
+async def run_journal_automation_control_cycle(guild_id: int) -> list[dict]:
+    """Poll admin controls, claim at most one Run Now request, then run/report safely."""
+    guild_id = resolve_network_guild_id(int(guild_id))
+    base_flags = await asyncio.to_thread(get_bnl_control_flags)
+    control, control_error = await asyncio.to_thread(_journal_control_request_sync, "GET")
+    if control is not None and (
+        not isinstance(control.get("config"), dict)
+        or not isinstance(control.get("runRequests"), list)
+    ):
+        control = None
+        control_error = control_error or "control_plane_response_invalid"
+    flags = _journal_control_flags(control, base_flags)
+    if control is None:
+        reason = "control_plane_unavailable:%s" % (control_error or "control_get_failed")
+        results = [_journal_control_result("scheduled", "held", reason)]
+        runtime = _journal_automation_runtime_by_guild.setdefault(guild_id, {})
+        runtime.update({
+            "lastCompletedAt": _utc_now_iso(),
+            "lastResults": results,
+            "lastDetail": reason[:240],
+            "lastError": reason[:240],
+        })
+        logging.warning(
+            "journal_automation_cycle_held guild=%s reason=%s",
+            guild_id,
+            reason,
+        )
+        await asyncio.to_thread(_journal_heartbeat_sync, runtime, flags)
+        return results
+    claimed = None
+    if control is not None:
+        claimed, claim_error = await asyncio.to_thread(_journal_control_claim_sync, control)
+        control_error = claim_error or control_error
+    request_id = str((claimed or {}).get("requestId") or "")[:120]
+    cadence = str((claimed or {}).get("cadence") or "scheduled").lower()
+    if claimed:
+        await asyncio.to_thread(_journal_control_request_sync, "POST", {
+            "action": "reportRun",
+            "run": {
+                "runId": request_id,
+                "cadence": cadence,
+                "state": "running",
+                "occurredAt": _utc_now_iso(),
+                "requestId": request_id,
+                "detail": "claimed_by_bot_scheduler",
+            },
+        })
+    results = await run_journal_automation_once(
+        guild_id,
+        cadence=cadence if cadence in {"daily", "weekly"} else "scheduled",
+        force=bool(claimed),
+        flags=flags,
+    )
+    local_status = await asyncio.to_thread(journal_automation_status, DB_FILE, guild_id)
+    for result in results:
+        if claimed or result.get("status") not in {"not_due", "paused"}:
+            await asyncio.to_thread(_journal_report_run_sync, result, guild_id=guild_id, request_id=request_id)
+    runtime = _journal_automation_runtime_by_guild.setdefault(guild_id, {})
+    runtime["nextDailyAt"] = local_status.get("nextDailyAt") or ""
+    runtime["nextWeeklyAt"] = local_status.get("nextWeeklyAt") or ""
+    reported = [item for item in results if claimed or item.get("status") not in {"not_due", "paused"}]
+    if reported:
+        runtime["lastSiteRun"] = _journal_site_run_record(
+            reported[-1], guild_id=guild_id, request_id=request_id
+        )
+    runtime["lastError"] = control_error
+    await asyncio.to_thread(_journal_heartbeat_sync, runtime, flags)
+    return results
+
+
 async def maybe_handle_journal_command(message: discord.Message, clean_content: str) -> bool:
     matched, options, _ = _parse_journal_command(clean_content)
     if not matched:
@@ -5916,6 +6283,57 @@ async def maybe_handle_journal_command(message: discord.Message, clean_content: 
     action = options.get("action")
     guild_id = message.guild.id
     try:
+        if action == "status":
+            flags = await asyncio.to_thread(get_bnl_control_flags, force_refresh=True)
+            control, control_error = await asyncio.to_thread(_journal_control_request_sync, "GET")
+            flags = _journal_control_flags(control, flags)
+            status = await asyncio.to_thread(journal_automation_status, DB_FILE, guild_id)
+            last_state = status.get("lastState") if isinstance(status.get("lastState"), dict) else {}
+            await message.reply(
+                "Journal automation: "
+                f"local=`{'on' if BNL_JOURNAL_AUTOMATION_ENABLED else 'off'}` "
+                f"auto=`{'on' if flags.get('journalAutoPublishEnabled', True) else 'off'}` "
+                f"daily=`{'on' if flags.get('journalDailyEnabled', True) else 'off'}` "
+                f"weekly=`{'on' if flags.get('journalWeeklyEnabled', True) else 'off'}` "
+                f"last=`{last_state.get('last_status') or 'none'}` "
+                f"reason=`{last_state.get('last_reason') or control_error or 'none'}`"
+            )
+            return True
+        if action in {"run-daily", "run-weekly"}:
+            cadence = "daily" if action == "run-daily" else "weekly"
+            flags = await asyncio.to_thread(get_bnl_control_flags, force_refresh=True)
+            control, _ = await asyncio.to_thread(_journal_control_request_sync, "GET")
+            flags = _journal_control_flags(control, flags)
+            results = await run_journal_automation_once(guild_id, cadence=cadence, force=True, flags=flags)
+            for item in results:
+                await asyncio.to_thread(_journal_report_run_sync, item, guild_id=guild_id)
+            _journal_automation_runtime_by_guild.setdefault(guild_id, {})["lastSiteRun"] = (
+                _journal_site_run_record(results[-1], guild_id=guild_id)
+            )
+            item = results[-1]
+            counts = item.get("aggregate_counts") if isinstance(item.get("aggregate_counts"), dict) else {}
+            source_count = int(counts.get("eligibleRelays") or 0) + int(counts.get("eligibleConversations") or 0)
+            await message.reply(
+                f"Journal {cadence} run: state=`{item.get('status')}` reason=`{item.get('reason') or 'none'}` "
+                f"entry=`{item.get('entry_id') or 'none'}` sources=`{source_count}`"
+            )
+            return True
+        if action == "rehydrate":
+            result = await asyncio.to_thread(
+                rehydrate_published_journal_entries,
+                DB_FILE,
+                guild_id,
+                _journal_website_base_url(),
+                BNL_API_KEY,
+            )
+            await message.reply(
+                "Journal website restore: "
+                f"attempted=`{int(result.get('attempted') or 0)}` "
+                f"restored=`{int(result.get('restored') or 0)}` "
+                f"failed=`{int(result.get('failed') or 0)}` "
+                f"reason=`{result.get('reason') or 'none'}`"
+            )
+            return True
         if action == "create":
             hours = _parse_journal_hours(options.get("hours") or options.get("window"))
             result = await asyncio.to_thread(generate_and_store_journal_draft, DB_FILE, guild_id, hours, _generate_journal_json_sync)
@@ -7638,7 +8056,29 @@ def insert_backfilled_conversation_row(*, guild_id: int, channel_id: int, channe
                 """,
                 (user_id, user_name, guild_id, (channel_name or "").lower()[:80], (channel_policy or "unknown")[:40], int(channel_id or 0), content, timestamp),
             )
+        row_id = int(cur.lastrowid or 0)
         conn.commit()
+        if (channel_policy or "").strip().lower() in PUBLIC_CHAT_POLICIES:
+            try:
+                occurred_at_ms = journal_timestamp_to_epoch_ms(timestamp)
+                if occurred_at_ms is not None:
+                    record_journal_source_event(
+                        DB_FILE,
+                        guild_id=guild_id,
+                        source_kind="discord_message",
+                        source_key=str(int(message_id or 0)) if int(message_id or 0) else f"legacy_row:{row_id}",
+                        occurred_at_ms=occurred_at_ms,
+                        raw_text=content,
+                        sanitized_summary=sanitize_journal_source_summary(content, [user_name]),
+                        channel_id=int(channel_id or 0) or None,
+                        channel_policy=(channel_policy or "unknown")[:40],
+                        subject_ref=f"discord_user:{user_id}",
+                        private_display_name=user_name,
+                        public_usable=True,
+                        metadata={"messageId": int(message_id or 0) or None, "conversationRowId": row_id, "source": "discord_backfill"},
+                    )
+            except Exception as exc:
+                logging.warning("journal_source_capture_failed source=discord_backfill row_id=%s error_type=%s", row_id, type(exc).__name__)
         return True
     finally:
         conn.close()
@@ -9656,6 +10096,31 @@ def save_user_message(user_id: int, user_name: str, guild_id: int, content: str,
     observed_at = observed_at[0] if observed_at else ""
     conn.commit()
     conn.close()
+    if (channel_policy or "").strip().lower() in PUBLIC_CHAT_POLICIES:
+        try:
+            occurred_at_ms = journal_timestamp_to_epoch_ms(observed_at)
+            if occurred_at_ms is not None:
+                record_journal_source_event(
+                    DB_FILE,
+                    guild_id=guild_id,
+                    source_kind="discord_message",
+                    source_key=str(int(message_id or 0)) if int(message_id or 0) else f"legacy_row:{row_id}",
+                    occurred_at_ms=occurred_at_ms,
+                    raw_text=content,
+                    sanitized_summary=sanitize_journal_source_summary(content, [user_name]),
+                    channel_id=int(channel_id or 0) or None,
+                    channel_policy=(channel_policy or "unknown")[:40],
+                    subject_ref=f"discord_user:{user_id}",
+                    private_display_name=user_name,
+                    public_usable=True,
+                    metadata={
+                        "messageId": int(message_id or 0) or None,
+                        "conversationRowId": row_id,
+                        "routeMode": route_mode,
+                    },
+                )
+        except Exception as exc:
+            logging.warning("journal_source_capture_failed source=discord_message row_id=%s error_type=%s", row_id, type(exc).__name__)
     _shadow_memory_ledger_write(
         "conversations_user",
         lambda ledger_conn: shadow_conversation_row(
@@ -11768,6 +12233,12 @@ def clear_guild_history(guild_id: int):
     rows_deleted = cursor.rowcount
     conn.commit()
     conn.close()
+    purged_sources = purge_guild_journal_sources(DB_FILE, guild_id)
+    logging.info(
+        "journal_source_archive_purged scope=guild guild_id=%s rows=%s",
+        guild_id,
+        purged_sources,
+    )
     return rows_deleted
 
 def clear_user_history(user_id: int, guild_id: int):
@@ -11777,6 +12248,13 @@ def clear_user_history(user_id: int, guild_id: int):
     rows_deleted = cursor.rowcount
     conn.commit()
     conn.close()
+    purged_sources = purge_user_journal_sources(DB_FILE, guild_id, user_id)
+    logging.info(
+        "journal_source_archive_purged scope=user guild_id=%s user_id=%s rows=%s",
+        guild_id,
+        user_id,
+        purged_sources,
+    )
     return rows_deleted
 
 def get_recent_guild_user_messages(guild_id: int, limit: int = AMBIENT_CONTEXT_MESSAGES):
@@ -13988,6 +14466,21 @@ async def source_file_refresh_worker_task():
         )
     except Exception as exc:
         logging.warning("source_refresh_worker_cycle processed=0 skipped=0 failed=1 error=%s", exc)
+
+    for guild in iter_managed_guilds():
+        guild_id = int(getattr(guild, "id", 0) or 0)
+        if not guild_id:
+            continue
+        try:
+            await run_journal_automation_control_cycle(guild_id)
+        except Exception as exc:
+            runtime = _journal_automation_runtime_by_guild.setdefault(guild_id, {})
+            runtime.update({"lastCompletedAt": _utc_now_iso(), "lastError": type(exc).__name__})
+            logging.exception(
+                "journal_automation_cycle_failed guild=%s error_type=%s",
+                guild_id,
+                type(exc).__name__,
+            )
 
 # ==================== AMBIENT MESSAGE TASK ====================
 
@@ -16240,12 +16733,16 @@ def log_admin_controls_connection_check():
             f"✅ Admin controls connected via {_bnl_control_flags_last_source_url} "
             f"(websiteRelayEnabled={flags.get('websiteRelayEnabled')}, "
             f"heartbeatEnabled={flags.get('heartbeatEnabled')}, "
-            f"showdayDiscordPostsEnabled={flags.get('showdayDiscordPostsEnabled')})."
+            f"showdayDiscordPostsEnabled={flags.get('showdayDiscordPostsEnabled')}, "
+            f"journalAutoPublishEnabled={flags.get('journalAutoPublishEnabled')}, "
+            f"journalDailyEnabled={flags.get('journalDailyEnabled')}, "
+            f"journalWeeklyEnabled={flags.get('journalWeeklyEnabled')})."
         )
     else:
         logging.warning(
             "⚠️ Admin controls unreachable; using local defaults "
-            "(websiteRelayEnabled=True, heartbeatEnabled=True, showdayDiscordPostsEnabled=False)."
+            "(websiteRelayEnabled=True, heartbeatEnabled=True, showdayDiscordPostsEnabled=False, "
+            "journalAutoPublishEnabled=True, journalDailyEnabled=True, journalWeeklyEnabled=True)."
         )
 
 

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -15,6 +15,13 @@ STATES = {"draft", "rejected", "approved_pending_delivery", "published", "delive
 WORD_MIN, WORD_MAX = 250, 500
 JOURNAL_ROUTE = "bnl_journal_generation"
 JOURNAL_GENERATION_ATTEMPTS = 4
+MAX_RELAY_SOURCES_PER_WINDOW = 500
+MAX_CONVERSATION_SOURCES_PER_WINDOW = 2_000
+MAX_PROMPT_SOURCES = 180
+JOURNAL_TOPIC_STOPWORDS = {
+    "about", "after", "again", "being", "could", "from", "have", "into", "just", "more", "other", "their",
+    "there", "these", "they", "this", "through", "under", "where", "which", "while", "with", "would", "someone",
+}
 
 _REPAIR_GUIDANCE = {
     "discord_phrase_copy": (
@@ -105,6 +112,202 @@ def table_exists(conn: sqlite3.Connection, name: str) -> bool:
     return bool(conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)).fetchone())
 
 
+def journal_topic_counts(sources: list[dict[str, Any]], limit: int = 30) -> dict[str, int]:
+    """Build the deterministic, non-identifying topic rollup used by observations."""
+    counts: dict[str, int] = {}
+    for source in sources:
+        words = set(re.findall(r"[a-z0-9]+", str(source.get("summary") or "").lower()))
+        for word in words:
+            if len(word) >= 5 and word not in JOURNAL_TOPIC_STOPWORDS:
+                counts[word] = counts.get(word, 0) + 1
+    return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0]))[:limit])
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    try:
+        parsed = json.loads(value or "{}") if isinstance(value, str) else value
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return dict(parsed) if isinstance(parsed, dict) else {}
+
+
+def _json_list(value: Any) -> list[Any]:
+    try:
+        parsed = json.loads(value or "[]") if isinstance(value, str) else value
+    except (TypeError, json.JSONDecodeError):
+        return []
+    return list(parsed) if isinstance(parsed, list) else []
+
+
+def _contains_exact_json_scalar(value: Any, target: str) -> bool:
+    if isinstance(value, dict):
+        return any(_contains_exact_json_scalar(item, target) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_exact_json_scalar(item, target) for item in value)
+    return isinstance(value, str) and value == target
+
+
+def purge_user_journal_derivatives_on_connection(
+    conn: sqlite3.Connection,
+    guild_id: int,
+    user_id: int,
+) -> dict[str, int]:
+    """Scrub one member from hidden Journal derivatives in the caller transaction.
+
+    Published public prose is immutable. Its private source linkage is scrubbed.
+    Unpublished revisions grounded in the deleted member are removed so they can
+    never be approved or delivered later. Daily observations are recalculated
+    from their remaining representative sources before weekly synthesis can use
+    them again.
+    """
+    guild = int(guild_id)
+    user = int(user_id)
+    if guild <= 0 or user <= 0:
+        raise ValueError("invalid_journal_privacy_scope")
+    subject_ref = f"discord_user:{user}"
+    now = utc_now_iso()
+    counts: dict[str, int] = {}
+
+    if table_exists(conn, "bnl_journal_observations"):
+        rows = conn.execute(
+            """SELECT observation_id,aggregate_counts_json,topic_counts_json,
+                      subject_counts_json,representative_sources_json
+               FROM bnl_journal_observations WHERE guild_id=?""",
+            (guild,),
+        ).fetchall()
+        for observation_id, aggregate_raw, _topics_raw, subjects_raw, representatives_raw in rows:
+            subjects = _json_object(subjects_raw)
+            representatives = [item for item in _json_list(representatives_raw) if isinstance(item, dict)]
+            removed = [item for item in representatives if str(item.get("subjectRef") or "") == subject_ref]
+            if subject_ref not in subjects and not removed:
+                continue
+            subjects.pop(subject_ref, None)
+            remaining = [item for item in representatives if str(item.get("subjectRef") or "") != subject_ref]
+            aggregate = _json_object(aggregate_raw)
+            removed_conversations = len([item for item in removed if item.get("sourceKind") == "conversation"])
+            for key in ("eligibleConversations", "promptConversations", "archivedSourceEvents"):
+                if key in aggregate:
+                    aggregate[key] = max(0, int(aggregate.get(key) or 0) - removed_conversations)
+            if "participants" in aggregate:
+                aggregate["participants"] = len(subjects)
+            conn.execute(
+                """UPDATE bnl_journal_observations
+                   SET aggregate_counts_json=?,topic_counts_json=?,subject_counts_json=?,
+                       representative_sources_json=?,updated_at=?
+                   WHERE guild_id=? AND observation_id=?""",
+                (
+                    _json(aggregate),
+                    _json(journal_topic_counts(remaining)),
+                    _json(subjects),
+                    _json(remaining),
+                    now,
+                    guild,
+                    observation_id,
+                ),
+            )
+            counts["bnl_journal_observations_scrubbed"] = counts.get("bnl_journal_observations_scrubbed", 0) + 1
+
+    unpublished: list[tuple[str, int]] = []
+    if table_exists(conn, "bnl_journal_private_metadata"):
+        has_entries = table_exists(conn, "bnl_journal_entries")
+        if has_entries:
+            rows = conn.execute(
+                """SELECT m.entry_id,m.revision,m.metadata_json,
+                          COALESCE(e.lifecycle_state,m.lifecycle_state)
+                   FROM bnl_journal_private_metadata m
+                   LEFT JOIN bnl_journal_entries e
+                     ON e.entry_id=m.entry_id AND e.revision=m.revision
+                   WHERE m.guild_id=?""",
+                (guild,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT entry_id,revision,metadata_json,lifecycle_state FROM bnl_journal_private_metadata WHERE guild_id=?",
+                (guild,),
+            ).fetchall()
+        for entry_id, revision, metadata_raw, lifecycle_state in rows:
+            metadata = _json_object(metadata_raw)
+            supporting = [item for item in metadata.get("supportingConversationRefs", []) if isinstance(item, dict)]
+            target_supporting = [item for item in supporting if str(item.get("subjectRef") or "") == subject_ref]
+            subject_refs = [str(item) for item in metadata.get("subjectRefs", [])]
+            affected = (
+                subject_ref in subject_refs
+                or bool(target_supporting)
+                or _contains_exact_json_scalar(metadata, subject_ref)
+            )
+            if not affected:
+                continue
+            key = (str(entry_id), int(revision))
+            if str(lifecycle_state or "") != "published":
+                unpublished.append(key)
+                continue
+
+            target_ref_ids = {str(item.get("refId")) for item in target_supporting if item.get("refId")}
+            metadata["supportingConversationRefs"] = [
+                item for item in supporting if str(item.get("subjectRef") or "") != subject_ref
+            ]
+            metadata["subjectRefs"] = [item for item in subject_refs if item != subject_ref]
+            metadata["sourceSummaries"] = [
+                item for item in metadata.get("sourceSummaries", [])
+                if isinstance(item, dict) and str(item.get("refId") or "") not in target_ref_ids
+            ]
+            source_ref_ids = metadata.get("sourceRefIds")
+            if isinstance(source_ref_ids, dict):
+                metadata["sourceRefIds"] = {
+                    str(heading): [str(ref) for ref in refs if str(ref) not in target_ref_ids]
+                    for heading, refs in source_ref_ids.items()
+                    if isinstance(refs, list)
+                }
+            # These model-derived fields cannot be reliably separated by source.
+            # Clear them on an affected published entry rather than allowing a
+            # deleted member's private evidence to guide future synthesis.
+            for key_name in ("topicTags", "continuityNotes", "unresolvedQuestions", "recurringTopicCounts"):
+                metadata[key_name] = {} if key_name == "recurringTopicCounts" else []
+            metadata["privacyScrubbed"] = True
+            conn.execute(
+                """UPDATE bnl_journal_private_metadata SET metadata_json=?,updated_at=?
+                   WHERE guild_id=? AND entry_id=? AND revision=?""",
+                (_json(metadata), now, guild, entry_id, int(revision)),
+            )
+            counts["bnl_journal_published_metadata_scrubbed"] = counts.get("bnl_journal_published_metadata_scrubbed", 0) + 1
+
+    if unpublished:
+        for entry_id, revision in sorted(set(unpublished)):
+            counts["bnl_journal_unpublished_metadata_deleted"] = counts.get("bnl_journal_unpublished_metadata_deleted", 0) + conn.execute(
+                "DELETE FROM bnl_journal_private_metadata WHERE guild_id=? AND entry_id=? AND revision=?",
+                (guild, entry_id, revision),
+            ).rowcount
+            if table_exists(conn, "bnl_journal_entries"):
+                counts["bnl_journal_unpublished_entries_deleted"] = counts.get("bnl_journal_unpublished_entries_deleted", 0) + conn.execute(
+                    "DELETE FROM bnl_journal_entries WHERE guild_id=? AND entry_id=? AND revision=? AND lifecycle_state<>'published'",
+                    (guild, entry_id, revision),
+                ).rowcount
+            if table_exists(conn, "bnl_journal_observations"):
+                conn.execute(
+                    """UPDATE bnl_journal_observations
+                       SET lifecycle_state='observed',journal_entry_id=NULL,journal_revision=0,updated_at=?
+                       WHERE guild_id=? AND journal_entry_id=? AND journal_revision=?""",
+                    (now, guild, entry_id, revision),
+                )
+            if table_exists(conn, "bnl_journal_automation_runs"):
+                counts["bnl_journal_automation_runs_invalidated"] = counts.get("bnl_journal_automation_runs_invalidated", 0) + conn.execute(
+                    """UPDATE bnl_journal_automation_runs
+                       SET lifecycle_state='held',reason='privacy_source_deleted',journal_entry_id=NULL,
+                           journal_revision=0,lease_expires_at=NULL,updated_at=?
+                       WHERE guild_id=? AND journal_entry_id=? AND journal_revision=?
+                         AND lifecycle_state<>'published'""",
+                    (now, guild, entry_id, revision),
+                ).rowcount
+            if table_exists(conn, "bnl_journal_automation_state"):
+                conn.execute(
+                    """UPDATE bnl_journal_automation_state
+                       SET last_status='held',last_reason='privacy_source_deleted',last_entry_id='',last_revision=0,updated_at=?
+                       WHERE guild_id=? AND last_entry_id=? AND last_revision=?""",
+                    (now, guild, entry_id, revision),
+                )
+    return {key: int(value or 0) for key, value in counts.items() if int(value or 0)}
+
+
 def _cols(conn: sqlite3.Connection, table: str) -> set[str]:
     return {r[1] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()}
 
@@ -124,12 +327,12 @@ def _anon_ref(prefix: str, idx: int) -> str:
     return f"{prefix}:{idx}"
 
 
-def accepted_relays(conn: sqlite3.Connection, guild_id: int, start: str, end: str, limit: int = 20) -> list[dict[str, Any]]:
+def accepted_relays(conn: sqlite3.Connection, guild_id: int, start: str, end: str, limit: int = MAX_RELAY_SOURCES_PER_WINDOW) -> list[dict[str, Any]]:
     if not table_exists(conn, "website_relay_history"):
         return []
     rows = conn.execute("""SELECT relay_id, public_message, public_directive, event_type, published_timestamp
-        FROM website_relay_history WHERE guild_id=? AND published_timestamp>=? AND published_timestamp<=?
-        ORDER BY published_timestamp DESC LIMIT ?""", (guild_id, start, end, limit)).fetchall()
+        FROM website_relay_history WHERE guild_id=? AND published_timestamp>=? AND published_timestamp<?
+        ORDER BY published_timestamp ASC, relay_id ASC LIMIT ?""", (guild_id, start, end, limit)).fetchall()
     out = []
     for idx, row in enumerate(rows, 1):
         summary = sanitize_source_summary(f"{row[1]} {row[2]}")
@@ -138,7 +341,7 @@ def accepted_relays(conn: sqlite3.Connection, guild_id: int, start: str, end: st
     return out
 
 
-def public_conversations(conn: sqlite3.Connection, guild_id: int, start: str, end: str, limit: int = 40) -> list[dict[str, Any]]:
+def public_conversations(conn: sqlite3.Connection, guild_id: int, start: str, end: str, limit: int = MAX_CONVERSATION_SOURCES_PER_WINDOW) -> list[dict[str, Any]]:
     if not table_exists(conn, "conversations"):
         return []
     cols = _cols(conn, "conversations")
@@ -147,8 +350,8 @@ def public_conversations(conn: sqlite3.Connection, guild_id: int, start: str, en
     role_clause = " AND role='user'" if "role" in cols else ""
     rows = conn.execute(f"""SELECT id, user_id, user_name, channel_policy, channel_name, content, timestamp
         FROM conversations WHERE guild_id=? AND channel_policy IN ({','.join('?' for _ in sorted(PUBLIC_POLICIES))})
-        AND timestamp>=? AND timestamp<=? {public_usable_clause} {visibility_clause} {role_clause}
-        ORDER BY timestamp DESC LIMIT ?""", (guild_id, *sorted(PUBLIC_POLICIES), start, end, limit)).fetchall()
+        AND timestamp>=? AND timestamp<? {public_usable_clause} {visibility_clause} {role_clause}
+        ORDER BY timestamp ASC, id ASC LIMIT ?""", (guild_id, *sorted(PUBLIC_POLICIES), start, end, limit)).fetchall()
     raw_names = [str(r[2] or "").strip() for r in rows if str(r[2] or "").strip()]
     out = []
     for idx, row in enumerate(rows, 1):
@@ -159,6 +362,7 @@ def public_conversations(conn: sqlite3.Connection, guild_id: int, start: str, en
                 "sourceKind": "conversation",
                 "messageId": int(row[0]),
                 "subjectRef": f"discord_user:{row[1]}",
+                "participantAlias": "participant-" + _hash("journal-participant", guild_id, row[1])[:8],
                 "displayName": str(row[2] or "").strip(),
                 "channelPolicy": row[3],
                 "summary": summary,
@@ -168,8 +372,40 @@ def public_conversations(conn: sqlite3.Connection, guild_id: int, start: str, en
 
 
 def _source_for_prompt(source: dict[str, Any]) -> dict[str, Any]:
-    allowed = {"refId", "sourceKind", "summary", "observedAt", "eventType", "channelPolicy"}
+    allowed = {"refId", "sourceKind", "summary", "observedAt", "eventType", "channelPolicy", "participantAlias"}
     return {k: v for k, v in source.items() if k in allowed and v not in (None, "")}
+
+
+def _evenly_sample(items: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    """Keep chronological coverage without silently taking only the newest rows."""
+    if limit <= 0 or len(items) <= limit:
+        return list(items)
+    if limit == 1:
+        return [items[-1]]
+    indexes = {round(i * (len(items) - 1) / (limit - 1)) for i in range(limit)}
+    return [items[i] for i in sorted(indexes)]
+
+
+def _count_legacy_sources(conn: sqlite3.Connection, guild_id: int, start: str, end: str) -> tuple[int, int]:
+    relay_count = 0
+    conversation_count = 0
+    if table_exists(conn, "website_relay_history"):
+        relay_count = int(conn.execute(
+            "SELECT COUNT(*) FROM website_relay_history WHERE guild_id=? AND published_timestamp>=? AND published_timestamp<?",
+            (guild_id, start, end),
+        ).fetchone()[0])
+    if table_exists(conn, "conversations"):
+        cols = _cols(conn, "conversations")
+        public_usable_clause = " AND public_usable=1" if "public_usable" in cols else ""
+        visibility_clause = " AND visibility IN ('public','public_safe')" if "visibility" in cols else ""
+        role_clause = " AND role='user'" if "role" in cols else ""
+        conversation_count = int(conn.execute(
+            f"""SELECT COUNT(*) FROM conversations WHERE guild_id=?
+            AND channel_policy IN ({','.join('?' for _ in sorted(PUBLIC_POLICIES))})
+            AND timestamp>=? AND timestamp<? {public_usable_clause} {visibility_clause} {role_clause}""",
+            (guild_id, *sorted(PUBLIC_POLICIES), start, end),
+        ).fetchone()[0])
+    return relay_count, conversation_count
 
 
 def _subject_refs(packet: dict[str, Any]) -> set[str]:
@@ -220,30 +456,177 @@ def retrieve_history(db_path: str, guild_id: int, current_packet: dict[str, Any]
     }
 
 
-def build_source_packet(db_path: str, guild_id: int, hours: int = 72, now: Optional[str] = None) -> dict[str, Any]:
-    bounded_hours = max(1, min(int(hours or 72), 168))
-    end = now or utc_now_iso()
-    start = (datetime.fromisoformat(end.replace("Z", "+00:00")) - timedelta(hours=bounded_hours)).isoformat().replace("+00:00", "Z")
-    with sqlite3.connect(db_path) as conn:
-        relays = accepted_relays(conn, guild_id, start, end)
-        conversations = public_conversations(conn, guild_id, start, end)
-    private_sources = relays + conversations
+def _sample_source_kinds(relays: list[dict[str, Any]], conversations: list[dict[str, Any]], limit: int = MAX_PROMPT_SOURCES) -> list[dict[str, Any]]:
+    total = len(relays) + len(conversations)
+    if total <= limit:
+        chosen = list(relays) + list(conversations)
+    elif not relays:
+        chosen = _evenly_sample(conversations, limit)
+    elif not conversations:
+        chosen = _evenly_sample(relays, limit)
+    else:
+        relay_quota = min(len(relays), max(1, limit // 2))
+        conversation_quota = min(len(conversations), max(1, limit - relay_quota))
+        spare = limit - relay_quota - conversation_quota
+        if spare > 0:
+            add_relays = min(spare, len(relays) - relay_quota)
+            relay_quota += add_relays
+            conversation_quota += min(spare - add_relays, len(conversations) - conversation_quota)
+        chosen = _evenly_sample(relays, relay_quota) + _evenly_sample(conversations, conversation_quota)
+    return sorted(chosen, key=lambda src: (str(src.get("observedAt") or ""), str(src.get("sourceKind") or ""), str(src.get("refId") or "")))
+
+
+def build_packet_from_sources(
+    db_path: str,
+    guild_id: int,
+    start: str,
+    end: str,
+    relays: list[dict[str, Any]],
+    conversations: list[dict[str, Any]],
+    *,
+    entry_kind: str = "daily",
+    aggregate_counts: Optional[dict[str, Any]] = None,
+    observation_context: Optional[list[dict[str, Any]]] = None,
+    coverage_complete: bool = True,
+) -> dict[str, Any]:
+    private_sources = _sample_source_kinds(relays, conversations)
     safe_sources = [_source_for_prompt(src) for src in private_sources]
+    counts = dict(aggregate_counts or {})
+    counts.setdefault("eligibleRelays", len(relays))
+    counts.setdefault("eligibleConversations", len(conversations))
+    counts.setdefault("participants", len({x.get("subjectRef") for x in conversations if x.get("subjectRef")}))
+    counts.setdefault("channels", len({x.get("channelPolicy") for x in conversations if x.get("channelPolicy")}))
+    counts["promptRelays"] = len([s for s in private_sources if s.get("sourceKind") == "relay"])
+    counts["promptConversations"] = len([s for s in private_sources if s.get("sourceKind") == "conversation"])
     packet = {
+        "entryKind": entry_kind if entry_kind in {"daily", "weekly", "manual"} else "manual",
         "sourceWindowStart": start,
         "sourceWindowEnd": end,
         "safeSources": safe_sources,
         "privateSources": private_sources,
-        "candidateTopicTags": sorted({w for src in safe_sources for w in _norm(src.get("summary", "")).split() if len(w) > 4})[:20],
+        "candidateTopicTags": sorted({w for src in safe_sources for w in _norm(src.get("summary", "")).split() if len(w) > 4})[:30],
+        "aggregateCounts": counts,
+        "coverageComplete": bool(coverage_complete),
+        "observationContext": list(observation_context or []),
     }
     packet["history"] = retrieve_history(db_path, guild_id, packet)
-    packet["aggregateCounts"] = {
-        "eligibleRelays": len(relays),
-        "eligibleConversations": len(conversations),
-        "participants": len({x.get("subjectRef") for x in conversations}),
-        "channels": len({x.get("channelPolicy") for x in conversations}),
-    }
     return packet
+
+
+def build_source_packet_between(
+    db_path: str,
+    guild_id: int,
+    start: str,
+    end: str,
+    *,
+    entry_kind: str = "daily",
+    observation_context: Optional[list[dict[str, Any]]] = None,
+) -> dict[str, Any]:
+    try:
+        from bnl_journal_source_store import backfill_legacy_sources, query_source_events, timestamp_to_epoch_ms
+
+        backfill_legacy_sources(db_path, guild_id)
+        start_ms = timestamp_to_epoch_ms(start)
+        end_ms = timestamp_to_epoch_ms(end)
+        if start_ms is None or end_ms is None:
+            raise ValueError("invalid_source_window")
+        archived = query_source_events(db_path, guild_id, start_ms, end_ms)
+        relays: list[dict[str, Any]] = []
+        conversations: list[dict[str, Any]] = []
+        for event in archived.events:
+            if not event.get("public_usable") or not str(event.get("sanitized_summary") or "").strip():
+                continue
+            observed_at = datetime.fromtimestamp(int(event["occurred_at_ms"]) / 1000.0, tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+            metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+            base = {
+                "refId": f"fresh:{int(event['event_seq'])}",
+                "summary": str(event.get("sanitized_summary") or "")[:1000],
+                "observedAt": observed_at,
+            }
+            if event.get("source_kind") == "discord_message":
+                subject_ref = str(event.get("subject_ref") or "")
+                source_key = str(event.get("source_key") or "")
+                message_id = metadata.get("messageId") or metadata.get("legacyMessageId")
+                if message_id in (None, "") and source_key.isdigit():
+                    message_id = int(source_key)
+                conversations.append({
+                    **base,
+                    "sourceKind": "conversation",
+                    "messageId": message_id or source_key,
+                    "subjectRef": subject_ref,
+                    "participantAlias": "participant-" + _hash("journal-participant", guild_id, subject_ref)[:8] if subject_ref else "",
+                    "displayName": str(event.get("private_display_name") or ""),
+                    "channelPolicy": str(event.get("channel_policy") or ""),
+                })
+            elif event.get("source_kind") == "website_relay":
+                relays.append({
+                    **base,
+                    "sourceKind": "relay",
+                    "relayId": str(event.get("source_key") or ""),
+                    "eventType": str(metadata.get("event_type") or metadata.get("eventType") or ""),
+                })
+        packet = build_packet_from_sources(
+            db_path,
+            guild_id,
+            start,
+            end,
+            relays,
+            conversations,
+            entry_kind=entry_kind,
+            aggregate_counts={
+                "eligibleRelays": len(relays),
+                "eligibleConversations": len(conversations),
+                "participants": len({x.get("subjectRef") for x in conversations if x.get("subjectRef")}),
+                "channels": int(archived.counts.get("uniqueChannels") or 0),
+                "archivedSourceEvents": int(archived.counts.get("total") or 0),
+            },
+            observation_context=observation_context,
+            # The archive activation watermark prevents the automatic
+            # publisher from claiming a full day that began before durable
+            # capture was enabled. Manual previews remain available during
+            # the first partial day.
+            coverage_complete=(
+                bool(archived.counts.get("coverageComplete"))
+                if entry_kind in {"daily", "weekly"}
+                else True
+            ),
+        )
+        packet["sourceArchiveAvailable"] = True
+        return packet
+    except (ImportError, sqlite3.Error, ValueError):
+        # Safe compatibility path for a partially deployed schema. Automation
+        # exposes this in private metadata so operators can see the downgrade.
+        pass
+    with sqlite3.connect(db_path) as conn:
+        relay_count, conversation_count = _count_legacy_sources(conn, guild_id, start, end)
+        relays = accepted_relays(conn, guild_id, start, end)
+        conversations = public_conversations(conn, guild_id, start, end)
+    packet = build_packet_from_sources(
+        db_path,
+        guild_id,
+        start,
+        end,
+        relays,
+        conversations,
+        entry_kind=entry_kind,
+        aggregate_counts={
+            "eligibleRelays": relay_count,
+            "eligibleConversations": conversation_count,
+            "participants": len({x.get("subjectRef") for x in conversations if x.get("subjectRef")}),
+            "channels": len({x.get("channelPolicy") for x in conversations if x.get("channelPolicy")}),
+        },
+        observation_context=observation_context,
+        coverage_complete=relay_count <= MAX_RELAY_SOURCES_PER_WINDOW and conversation_count <= MAX_CONVERSATION_SOURCES_PER_WINDOW,
+    )
+    packet["sourceArchiveAvailable"] = False
+    return packet
+
+
+def build_source_packet(db_path: str, guild_id: int, hours: int = 72, now: Optional[str] = None, *, entry_kind: str = "manual") -> dict[str, Any]:
+    bounded_hours = max(1, min(int(hours or 72), 168))
+    end = now or utc_now_iso()
+    start = (datetime.fromisoformat(end.replace("Z", "+00:00")) - timedelta(hours=bounded_hours)).isoformat().replace("+00:00", "Z")
+    return build_source_packet_between(db_path, guild_id, start, end, entry_kind=entry_kind)
 
 
 def _bounded_history_for_prompt(history: dict[str, Any]) -> dict[str, Any]:
@@ -261,13 +644,21 @@ def _bounded_history_for_prompt(history: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", previous_output: str = "") -> str:
+    entry_kind = str(packet.get("entryKind") or "manual")
     safe_packet = {
+        "entryKind": entry_kind,
         "sourceWindowStart": packet.get("sourceWindowStart"),
         "sourceWindowEnd": packet.get("sourceWindowEnd"),
-        "freshSources": packet.get("safeSources", [])[:60],
+        "freshSources": packet.get("safeSources", [])[:MAX_PROMPT_SOURCES],
         "history": _bounded_history_for_prompt(packet.get("history", {})),
         "aggregateCounts": packet.get("aggregateCounts", {}),
+        "dailyObservations": packet.get("observationContext", [])[:7],
     }
+    cadence_rule = (
+        "\nThis is a weekly synthesis. Connect patterns across the supplied daily observations and current source evidence; do not merely list seven daily recaps."
+        if entry_kind == "weekly"
+        else "\nThis is a daily chronicle covering one complete source window. Distill the day instead of listing every relay."
+    )
     repair = ""
     if repair_reason:
         guidance = _REPAIR_GUIDANCE.get(
@@ -291,11 +682,12 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
         "\nBuild one coherent story around the most interesting grounded patterns. Use concrete music and community texture, active verbs, readable paragraphs, and selective detail. Avoid abstract jargon and inflated technical language."
         "\nUse a short, vivid title of about 4-10 words. Do not prefix it with Network Log. Keep the excerpt compact and inviting."
         "\nDescribe anonymous humans naturally as a producer, listener, regular, artist, or the room. Never call people entities or organisms. Do not invent nicknames, motives, relationships, dialogue, or conclusions."
+        "\nStable participant aliases in the packet are private pattern-analysis aids. Never reproduce an alias in public prose."
         "\nEvery section must cite at least one fresh sourceRefId from the current window. Older Journal material is continuity only, never proof of current activity."
         "\nParaphrase every source summary. Never repeat any sequence of five or more consecutive words from a fresh source summary."
         "\nKeep community members anonymous. Do not include direct quotes, URLs, mentions, IDs, sourceRef tokens in public prose, private intent, relationships, harassment, or internal schema/storage terms."
         "\nExclude personal or domestic details that are unnecessary to the public community story, especially details involving minors, interpersonal conflict, caregiving, or household obligations. Juicy means lively pattern recognition—not private gossip."
-        f"{repair}\nGeneration-safe packet:\n{json.dumps(safe_packet, ensure_ascii=False, sort_keys=True)}"
+        f"{cadence_rule}{repair}\nGeneration-safe packet:\n{json.dumps(safe_packet, ensure_ascii=False, sort_keys=True)}"
     )
 
 
@@ -360,13 +752,13 @@ def validate_article(article: dict[str, Any], packet: dict[str, Any], prior_titl
         return "no_new_source"
     refmap = article.get("sourceRefIds") or {}
     public_text = _public_text(article)
-    if re.search(r"\bfresh:\d+\b", public_text):
+    if any(str(ref) in public_text for ref in valid_refs) or re.search(r"\b(?:fresh|week):[a-z0-9:._-]+\b", public_text, re.I):
         return "source_ref_leak"
     for section in sections:
         refs = refmap.get(section.get("heading")) or section.get("sourceRefIds")
         if not refs or any(str(r) not in valid_refs for r in refs):
             return "invalid_section_source_refs"
-    if re.search(r"<@!?\d+>|@\w+|https?://|\b\d{12,}\b|relationship_journal|memory_tiers|source[- ]?file|dossier|private_metadata|sourceRefIds?", public_text, re.I):
+    if re.search(r"<@!?\d+>|@\w+|https?://|\b\d{12,}\b|participant-[a-f0-9]{8}|relationship_journal|memory_tiers|source[- ]?file|dossier|private_metadata|sourceRefIds?", public_text, re.I):
         return "public_leak_pattern"
     if re.search(r"[\"“”‘’]", public_text):
         return "direct_quote_or_quote_mark"
@@ -428,8 +820,10 @@ def _draft_records(guild_id: int, packet: dict[str, Any], article: dict[str, Any
     meta = dict(article.get("metadata") or {})
     meta.pop("subjectRefs", None)
     meta.update({
+        "entryKind": packet.get("entryKind", "manual"),
         "sourceWindowStart": packet["sourceWindowStart"],
         "sourceWindowEnd": packet["sourceWindowEnd"],
+        "coverageComplete": bool(packet.get("coverageComplete", True)),
         "supportingRelayIds": [s.get("relayId") for s in cited_sources if s.get("sourceKind") == "relay"],
         "supportingConversationRefs": [{k: v for k, v in s.items() if k in {"refId", "messageId", "subjectRef", "channelPolicy", "observedAt"}} for s in cited_sources if s.get("sourceKind") == "conversation"],
         "subjectRefs": sorted({str(s.get("subjectRef")) for s in cited_sources if s.get("subjectRef")}),
@@ -462,10 +856,18 @@ def store_validated_draft(db_path: str, guild_id: int, packet: dict[str, Any], a
     return result
 
 
-def generate_and_store_draft(db_path: str, guild_id: int, hours: int, generator: Callable[[dict[str, Any], str], str]) -> JournalResult:
-    packet = build_source_packet(db_path, guild_id, hours)
+def generate_and_store_packet_draft(
+    db_path: str,
+    guild_id: int,
+    packet: dict[str, Any],
+    generator: Callable[[dict[str, Any], str], str],
+    *,
+    entry_id: str = "",
+) -> JournalResult:
+    if not packet.get("coverageComplete", True):
+        return JournalResult(False, "no_draft", "incomplete_source_window", entry_id=entry_id)
     if not packet.get("safeSources"):
-        return JournalResult(False, "no_draft", "insufficient_grounded_material")
+        return JournalResult(False, "no_draft", "insufficient_grounded_material", entry_id=entry_id)
     prompt = build_generation_prompt(packet)
     last_reason = ""
     previous_output = ""
@@ -481,7 +883,7 @@ def generate_and_store_draft(db_path: str, guild_id: int, hours: int, generator:
             )
         except Exception as exc:
             reason = "quota_unavailable" if "quota" in str(exc).lower() else "provider_failure"
-            return JournalResult(False, "no_draft", reason)
+            return JournalResult(False, "no_draft", reason, entry_id=entry_id)
         previous_output = raw
         try:
             article = parse_generated_json(raw)
@@ -491,9 +893,23 @@ def generate_and_store_draft(db_path: str, guild_id: int, hours: int, generator:
         with sqlite3.connect(db_path) as conn:
             validation = validate_article(article, packet, _prior_titles(conn, guild_id))
         if not validation:
-            return store_validated_draft(db_path, guild_id, packet, article)
+            return store_validated_draft(db_path, guild_id, packet, article, entry_id=entry_id)
         last_reason = validation
-    return JournalResult(False, "no_draft", last_reason or "generation_failed")
+    return JournalResult(False, "no_draft", last_reason or "generation_failed", entry_id=entry_id)
+
+
+def generate_and_store_draft(
+    db_path: str,
+    guild_id: int,
+    hours: int,
+    generator: Callable[[dict[str, Any], str], str],
+    *,
+    entry_id: str = "",
+    entry_kind: str = "manual",
+    now: Optional[str] = None,
+) -> JournalResult:
+    packet = build_source_packet(db_path, guild_id, hours, now, entry_kind=entry_kind)
+    return generate_and_store_packet_draft(db_path, guild_id, packet, generator, entry_id=entry_id)
 
 
 def approve_draft(db_path: str, guild_id: int, entry_id: str, content_hash: str, revision: Optional[int] = None) -> JournalResult:
@@ -594,14 +1010,8 @@ def regenerate_draft(db_path: str, guild_id: int, entry_id: str, hours: int, gen
     return result
 
 
-def deliver_approved(db_path: str, guild_id: int, entry_id: str, base_url: str, api_key: str, opener=None, timeout: int = 10, revision: Optional[int] = None) -> JournalResult:
-    ensure_schema(db_path)
+def _post_canonical_payload(canonical: bytes, base_url: str, api_key: str, opener, timeout: int) -> tuple[str, str, int, bool, str]:
     opener = opener or urllib.request.urlopen
-    with sqlite3.connect(db_path) as conn:
-        row = conn.execute("SELECT revision,canonical_payload_bytes,content_hash FROM bnl_journal_entries WHERE guild_id=? AND entry_id=? AND lifecycle_state IN ('approved_pending_delivery','delivery_failed') " + ("AND revision=?" if revision is not None else "ORDER BY revision DESC LIMIT 1"), (guild_id, entry_id, revision) if revision is not None else (guild_id, entry_id)).fetchone()
-    if not row:
-        return JournalResult(False, "not_deliverable", "not_approved", entry_id)
-    rev, canonical, content_hash = int(row[0]), row[1], row[2]
     req = urllib.request.Request(base_url.rstrip("/") + "/api/bnl/journal", data=canonical, method="POST", headers={"Content-Type": "application/json", "x-api-key": api_key})
     status = "delivery_failed"; reason = "retryable_delivery_failure"; http = 0; idem = False; published = ""
     try:
@@ -625,9 +1035,26 @@ def deliver_approved(db_path: str, guild_id: int, entry_id: str, base_url: str, 
         else:
             reason = "http_rejected"
     except urllib.error.HTTPError as exc:
-        http = exc.code; reason = "endpoint_not_found" if exc.code == 404 else ("journal_id_conflict" if exc.code == 409 else "http_rejected")
+        http = exc.code
+        reason = (
+            "endpoint_not_found" if exc.code == 404
+            else "authentication_failed" if exc.code in (401, 403)
+            else "journal_id_conflict" if exc.code == 409
+            else "http_rejected"
+        )
     except Exception:
         reason = "retryable_delivery_failure"
+    return status, reason, int(http or 0), idem, published
+
+
+def deliver_approved(db_path: str, guild_id: int, entry_id: str, base_url: str, api_key: str, opener=None, timeout: int = 10, revision: Optional[int] = None) -> JournalResult:
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute("SELECT revision,canonical_payload_bytes,content_hash FROM bnl_journal_entries WHERE guild_id=? AND entry_id=? AND lifecycle_state IN ('approved_pending_delivery','delivery_failed') " + ("AND revision=?" if revision is not None else "ORDER BY revision DESC LIMIT 1"), (guild_id, entry_id, revision) if revision is not None else (guild_id, entry_id)).fetchone()
+    if not row:
+        return JournalResult(False, "not_deliverable", "not_approved", entry_id)
+    rev, canonical, content_hash = int(row[0]), row[1], row[2]
+    status, reason, http, idem, published = _post_canonical_payload(canonical, base_url, api_key, opener, timeout)
     now = utc_now_iso()
     with sqlite3.connect(db_path) as conn:
         with conn:
@@ -636,6 +1063,50 @@ def deliver_approved(db_path: str, guild_id: int, entry_id: str, base_url: str, 
             if cur1.rowcount != 1 or cur2.rowcount != 1:
                 raise sqlite3.IntegrityError("journal_delivery_sync_failed")
     return JournalResult(status == "published", status, reason, entry_id, rev, content_hash, http, idem)
+
+
+def rehydrate_published_entries(
+    db_path: str,
+    guild_id: int,
+    base_url: str,
+    api_key: str,
+    *,
+    opener=None,
+    timeout: int = 10,
+) -> dict[str, Any]:
+    """Re-send exact published payloads after a disposable site cache loss.
+
+    This never regenerates prose or changes revision history. The website's
+    immutable/idempotent Journal endpoint either restores the exact record or
+    acknowledges that it is already present.
+    """
+    ensure_schema(db_path)
+    if not base_url or not api_key:
+        return {"ok": False, "reason": "website_configuration_missing", "attempted": 0, "restored": 0, "failed": 0}
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            """SELECT entry_id,revision,canonical_payload_bytes,content_hash
+               FROM bnl_journal_entries
+               WHERE guild_id=? AND lifecycle_state='published'
+               ORDER BY COALESCE(published_at,created_at) ASC,entry_id ASC,revision ASC""",
+            (guild_id,),
+        ).fetchall()
+    restored = 0
+    failed: list[dict[str, Any]] = []
+    for entry_id, revision, canonical, _content_hash in rows:
+        status, reason, http, _idem, _published = _post_canonical_payload(canonical, base_url, api_key, opener, timeout)
+        if status == "published":
+            restored += 1
+        else:
+            failed.append({"entryId": str(entry_id), "revision": int(revision), "reason": reason, "httpStatus": http})
+    return {
+        "ok": not failed,
+        "reason": "" if not failed else "one_or_more_entries_failed",
+        "attempted": len(rows),
+        "restored": restored,
+        "failed": len(failed),
+        "failures": failed[:20],
+    }
 
 
 def preview(db_path: str, guild_id: int, entry_id: Optional[str] = None, revision: Optional[int] = None) -> Optional[dict[str, Any]]:

--- a/bnl_journal_automation.py
+++ b/bnl_journal_automation.py
@@ -1,0 +1,627 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import asdict, dataclass
+from datetime import date, datetime, time as datetime_time, timedelta, timezone
+from typing import Any, Callable, Optional
+
+import pytz
+
+from bnl_journal import (
+    JournalResult,
+    approve_draft,
+    build_packet_from_sources,
+    build_source_packet_between,
+    deliver_approved,
+    generate_and_store_packet_draft,
+    journal_topic_counts,
+    utc_now_iso,
+)
+
+PACIFIC = pytz.timezone("US/Pacific")
+DAILY_READY_HOUR = 4
+DAILY_READY_MINUTE = 15
+WEEKLY_READY_WEEKDAY = 0  # Monday, covering the prior Monday-Sunday week.
+WEEKLY_READY_HOUR = 5
+MIN_DAILY_SOURCE_COUNT = 5
+MIN_WEEKLY_ACTIVE_DAYS = 1
+LEASE_MINUTES = 30
+RETRY_MINUTES = 60
+TERMINAL_RUN_STATES = {"published", "quiet", "incomplete"}
+
+
+@dataclass
+class AutomationResult:
+    ok: bool
+    cadence: str
+    status: str
+    reason: str = ""
+    entry_id: str = ""
+    revision: int = 0
+    source_window_start: str = ""
+    source_window_end: str = ""
+    aggregate_counts: Optional[dict[str, Any]] = None
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _parse_utc(value: str) -> datetime:
+    parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _utc_iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _pacific_midnight(day: date) -> datetime:
+    return PACIFIC.localize(datetime.combine(day, datetime_time.min))
+
+
+def _daily_period_for_day(day: date) -> tuple[str, str, str]:
+    start_local = _pacific_midnight(day)
+    end_local = _pacific_midnight(day + timedelta(days=1))
+    return _utc_iso(start_local), _utc_iso(end_local), day.isoformat()
+
+
+def daily_period(now_utc: Optional[datetime] = None) -> tuple[str, str, str]:
+    now = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
+    return _daily_period_for_day(now.date() - timedelta(days=1))
+
+
+def _weekly_period_for_monday(monday: date) -> tuple[str, str, str]:
+    start_local = _pacific_midnight(monday)
+    end_local = _pacific_midnight(monday + timedelta(days=7))
+    return _utc_iso(start_local), _utc_iso(end_local), monday.isoformat()
+
+
+def weekly_period(now_utc: Optional[datetime] = None) -> tuple[str, str, str]:
+    now = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
+    monday = now.date() - timedelta(days=now.weekday())
+    return _weekly_period_for_monday(monday - timedelta(days=7))
+
+
+def daily_due(now_utc: Optional[datetime] = None) -> bool:
+    local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
+    return (local.hour, local.minute) >= (DAILY_READY_HOUR, DAILY_READY_MINUTE)
+
+
+def weekly_due(now_utc: Optional[datetime] = None) -> bool:
+    local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
+    return local.weekday() == WEEKLY_READY_WEEKDAY and local.hour >= WEEKLY_READY_HOUR
+
+
+def next_schedule_times(now_utc: Optional[datetime] = None) -> tuple[str, str]:
+    local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
+    daily_day = local.date()
+    daily_local = PACIFIC.localize(
+        datetime.combine(daily_day, datetime_time(DAILY_READY_HOUR, DAILY_READY_MINUTE))
+    )
+    if daily_local <= local:
+        daily_local = PACIFIC.localize(
+            datetime.combine(daily_day + timedelta(days=1), datetime_time(DAILY_READY_HOUR, DAILY_READY_MINUTE))
+        )
+    days_until_monday = (WEEKLY_READY_WEEKDAY - local.weekday()) % 7
+    weekly_day = local.date() + timedelta(days=days_until_monday)
+    weekly_local = PACIFIC.localize(
+        datetime.combine(weekly_day, datetime_time(WEEKLY_READY_HOUR, 0))
+    )
+    if weekly_local <= local:
+        weekly_local = PACIFIC.localize(
+            datetime.combine(weekly_day + timedelta(days=7), datetime_time(WEEKLY_READY_HOUR, 0))
+        )
+    return _utc_iso(daily_local), _utc_iso(weekly_local)
+
+
+def ensure_schema(db_path: str) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""CREATE TABLE IF NOT EXISTS bnl_journal_observations (
+            observation_id TEXT PRIMARY KEY,
+            guild_id INTEGER NOT NULL,
+            observation_date TEXT NOT NULL,
+            source_window_start TEXT NOT NULL,
+            source_window_end TEXT NOT NULL,
+            aggregate_counts_json TEXT NOT NULL,
+            topic_counts_json TEXT NOT NULL,
+            subject_counts_json TEXT NOT NULL,
+            representative_sources_json TEXT NOT NULL,
+            lifecycle_state TEXT NOT NULL,
+            journal_entry_id TEXT,
+            journal_revision INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            UNIQUE(guild_id, observation_date))""")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_bnl_journal_observation_window ON bnl_journal_observations(guild_id,source_window_start,source_window_end)")
+        conn.execute("""CREATE TABLE IF NOT EXISTS bnl_journal_automation_runs (
+            run_id TEXT PRIMARY KEY,
+            guild_id INTEGER NOT NULL,
+            cadence TEXT NOT NULL,
+            source_window_start TEXT NOT NULL,
+            source_window_end TEXT NOT NULL,
+            lifecycle_state TEXT NOT NULL,
+            reason TEXT,
+            journal_entry_id TEXT,
+            journal_revision INTEGER NOT NULL DEFAULT 0,
+            aggregate_counts_json TEXT NOT NULL DEFAULT '{}',
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            lease_expires_at TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            UNIQUE(guild_id,cadence,source_window_start,source_window_end))""")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_bnl_journal_runs_latest ON bnl_journal_automation_runs(guild_id,updated_at DESC)")
+        conn.execute("""CREATE TABLE IF NOT EXISTS bnl_journal_automation_state (
+            guild_id INTEGER PRIMARY KEY,
+            last_checked_at TEXT,
+            last_status TEXT,
+            last_reason TEXT,
+            last_cadence TEXT,
+            last_entry_id TEXT,
+            last_revision INTEGER NOT NULL DEFAULT 0,
+            last_source_window_start TEXT,
+            last_source_window_end TEXT,
+            next_retry_at TEXT,
+            updated_at TEXT NOT NULL)""")
+
+
+def _run_id(guild_id: int, cadence: str, start: str, end: str) -> str:
+    return "jrun_" + hashlib.sha256(f"{guild_id}|{cadence}|{start}|{end}".encode("utf-8")).hexdigest()[:20]
+
+
+def _entry_id(guild_id: int, cadence: str, label: str) -> str:
+    suffix = hashlib.sha256(str(guild_id).encode("utf-8")).hexdigest()[:8]
+    return f"journal_{cadence}_{label}_{suffix}"
+
+
+def _update_state(conn: sqlite3.Connection, guild_id: int, result: AutomationResult, *, next_retry_at: str = "") -> None:
+    now = utc_now_iso()
+    conn.execute("""INSERT INTO bnl_journal_automation_state(
+        guild_id,last_checked_at,last_status,last_reason,last_cadence,last_entry_id,last_revision,
+        last_source_window_start,last_source_window_end,next_retry_at,updated_at
+    ) VALUES(?,?,?,?,?,?,?,?,?,?,?)
+    ON CONFLICT(guild_id) DO UPDATE SET
+        last_checked_at=excluded.last_checked_at,last_status=excluded.last_status,last_reason=excluded.last_reason,
+        last_cadence=excluded.last_cadence,last_entry_id=excluded.last_entry_id,last_revision=excluded.last_revision,
+        last_source_window_start=excluded.last_source_window_start,last_source_window_end=excluded.last_source_window_end,
+        next_retry_at=excluded.next_retry_at,updated_at=excluded.updated_at""", (
+        guild_id, now, result.status, result.reason, result.cadence, result.entry_id, int(result.revision or 0),
+        result.source_window_start, result.source_window_end, next_retry_at or None, now,
+    ))
+
+
+def _claim_run(db_path: str, guild_id: int, cadence: str, start: str, end: str, *, force: bool = False) -> tuple[str, str, dict[str, Any]]:
+    ensure_schema(db_path)
+    run_id = _run_id(guild_id, cadence, start, end)
+    now = datetime.now(timezone.utc)
+    lease = _utc_iso(now + timedelta(minutes=LEASE_MINUTES))
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute("SELECT * FROM bnl_journal_automation_runs WHERE run_id=?", (run_id,)).fetchone()
+        if row:
+            current = dict(row)
+            if current["lifecycle_state"] in TERMINAL_RUN_STATES:
+                conn.commit()
+                return "complete", run_id, current
+            if current["lifecycle_state"] in {"held", "delivery_failed", "deferred"} and not force:
+                updated_at = str(current.get("updated_at") or "")
+                if updated_at:
+                    retry_at = _parse_utc(updated_at) + timedelta(minutes=RETRY_MINUTES)
+                    if retry_at > now:
+                        current["retry_at"] = _utc_iso(retry_at)
+                        conn.commit()
+                        return "backoff", run_id, current
+            lease_expires = current.get("lease_expires_at") or ""
+            # A manual Run Now may bypass retry backoff, but it must never
+            # steal a live lease from the scheduler or another operator.
+            if current["lifecycle_state"] == "running" and lease_expires and _parse_utc(lease_expires) > now:
+                conn.commit()
+                return "busy", run_id, current
+            conn.execute("""UPDATE bnl_journal_automation_runs
+                SET lifecycle_state='running',reason='',attempt_count=attempt_count+1,lease_expires_at=?,updated_at=?
+                WHERE run_id=?""", (lease, utc_now_iso(), run_id))
+        else:
+            now_iso = utc_now_iso()
+            conn.execute("""INSERT INTO bnl_journal_automation_runs(
+                run_id,guild_id,cadence,source_window_start,source_window_end,lifecycle_state,reason,
+                aggregate_counts_json,attempt_count,lease_expires_at,created_at,updated_at
+            ) VALUES(?,?,?,?,?,'running','', '{}',1,?,?,?)""", (
+                run_id, guild_id, cadence, start, end, lease, now_iso, now_iso,
+            ))
+        conn.commit()
+    return "claimed", run_id, {}
+
+
+def _finish_run(db_path: str, run_id: str, result: AutomationResult) -> AutomationResult:
+    retry_at = ""
+    if result.status in {"held", "delivery_failed", "deferred"}:
+        retry_at = _utc_iso(datetime.now(timezone.utc) + timedelta(minutes=RETRY_MINUTES))
+    with sqlite3.connect(db_path) as conn:
+        with conn:
+            conn.execute("""UPDATE bnl_journal_automation_runs SET lifecycle_state=?,reason=?,journal_entry_id=?,
+                journal_revision=?,aggregate_counts_json=?,lease_expires_at=NULL,updated_at=? WHERE run_id=?""", (
+                result.status, result.reason, result.entry_id or None, int(result.revision or 0),
+                _json(result.aggregate_counts or {}), utc_now_iso(), run_id,
+            ))
+            _update_state(conn, int(conn.execute("SELECT guild_id FROM bnl_journal_automation_runs WHERE run_id=?", (run_id,)).fetchone()[0]), result, next_retry_at=retry_at)
+    return result
+
+
+def _result_from_existing(cadence: str, row: dict[str, Any], *, claim: str = "complete") -> AutomationResult:
+    counts = json.loads(row.get("aggregate_counts_json") or "{}")
+    status = str(row.get("lifecycle_state") or "unknown")
+    reason = str(row.get("reason") or "already_processed")
+    if claim == "busy":
+        status = "busy"
+        reason = "automation_run_in_progress"
+    elif claim == "backoff":
+        status = "backoff"
+        reason = "retry_after_" + str(row.get("retry_at") or "later")
+    return AutomationResult(
+        status == "published",
+        cadence,
+        status,
+        reason,
+        str(row.get("journal_entry_id") or ""),
+        int(row.get("journal_revision") or 0),
+        str(row.get("source_window_start") or ""),
+        str(row.get("source_window_end") or ""),
+        counts,
+    )
+
+
+def _topic_counts(sources: list[dict[str, Any]], limit: int = 30) -> dict[str, int]:
+    return journal_topic_counts(sources, limit=limit)
+
+
+def _store_observation(db_path: str, guild_id: int, label: str, packet: dict[str, Any], state: str = "observed") -> str:
+    observation_id = "jobs_" + hashlib.sha256(f"{guild_id}|{label}".encode("utf-8")).hexdigest()[:20]
+    subject_counts: dict[str, int] = {}
+    for source in packet.get("privateSources", []):
+        subject = str(source.get("subjectRef") or "")
+        if subject:
+            subject_counts[subject] = subject_counts.get(subject, 0) + 1
+    representative = [
+        {key: source.get(key) for key in (
+            "refId", "sourceKind", "relayId", "messageId", "subjectRef", "participantAlias", "channelPolicy", "summary", "observedAt", "eventType"
+        ) if source.get(key) not in (None, "")}
+        for source in packet.get("privateSources", [])
+    ]
+    now = utc_now_iso()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""INSERT INTO bnl_journal_observations(
+            observation_id,guild_id,observation_date,source_window_start,source_window_end,
+            aggregate_counts_json,topic_counts_json,subject_counts_json,representative_sources_json,
+            lifecycle_state,journal_entry_id,journal_revision,created_at,updated_at
+        ) VALUES(?,?,?,?,?,?,?,?,?,?,NULL,0,?,?)
+        ON CONFLICT(guild_id,observation_date) DO UPDATE SET
+            aggregate_counts_json=excluded.aggregate_counts_json,topic_counts_json=excluded.topic_counts_json,
+            subject_counts_json=excluded.subject_counts_json,representative_sources_json=excluded.representative_sources_json,
+            lifecycle_state=CASE WHEN bnl_journal_observations.lifecycle_state='published' THEN 'published' ELSE excluded.lifecycle_state END,
+            updated_at=excluded.updated_at""", (
+            observation_id, guild_id, label, packet["sourceWindowStart"], packet["sourceWindowEnd"],
+            _json(packet.get("aggregateCounts") or {}), _json(_topic_counts(packet.get("privateSources", []))),
+            _json(subject_counts), _json(representative), state, now, now,
+        ))
+    return observation_id
+
+
+def _mark_observation(db_path: str, guild_id: int, label: str, result: AutomationResult) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""UPDATE bnl_journal_observations SET lifecycle_state=?,journal_entry_id=?,journal_revision=?,updated_at=?
+            WHERE guild_id=? AND observation_date=?""", (
+            result.status, result.entry_id or None, int(result.revision or 0), utc_now_iso(), guild_id, label,
+        ))
+
+
+def _has_meaningful_daily_activity(packet: dict[str, Any]) -> bool:
+    counts = packet.get("aggregateCounts") or {}
+    total = int(counts.get("eligibleRelays") or 0) + int(counts.get("eligibleConversations") or 0)
+    if total < MIN_DAILY_SOURCE_COUNT:
+        return False
+    if int(counts.get("eligibleConversations") or 0) > 0:
+        return True
+    quiet_markers = {"quiet", "quiet_source", "non_event_stock", "heartbeat", "hydrated"}
+    return any(str(source.get("eventType") or "").lower() not in quiet_markers for source in packet.get("privateSources", []))
+
+
+def _publish_packet(
+    db_path: str,
+    guild_id: int,
+    cadence: str,
+    label: str,
+    packet: dict[str, Any],
+    generator: Callable[[dict[str, Any], str], str],
+    base_url: str,
+    api_key: str,
+    *,
+    opener=None,
+) -> AutomationResult:
+    entry_id = _entry_id(guild_id, cadence, label)
+    if not base_url or not api_key:
+        return AutomationResult(False, cadence, "held", "website_configuration_missing", entry_id, 0, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
+    with sqlite3.connect(db_path) as conn:
+        existing = conn.execute("""SELECT revision,lifecycle_state,content_hash FROM bnl_journal_entries
+            WHERE guild_id=? AND entry_id=? ORDER BY revision DESC LIMIT 1""", (guild_id, entry_id)).fetchone()
+    if existing and existing[1] in {"approved_pending_delivery", "delivery_failed"}:
+        delivered = deliver_approved(db_path, guild_id, entry_id, base_url, api_key, opener=opener)
+        return AutomationResult(delivered.ok, cadence, delivered.status, delivered.reason, entry_id, delivered.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
+    if existing and existing[1] == "published":
+        return AutomationResult(True, cadence, "published", "already_published", entry_id, int(existing[0]), packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
+    if existing and existing[1] == "draft":
+        approved = approve_draft(db_path, guild_id, entry_id, existing[2], revision=int(existing[0]))
+        if not approved.ok:
+            return AutomationResult(False, cadence, "held", approved.reason, entry_id, int(existing[0]), packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
+        delivered = deliver_approved(db_path, guild_id, entry_id, base_url, api_key, opener=opener, revision=int(existing[0]))
+        return AutomationResult(delivered.ok, cadence, delivered.status, delivered.reason, entry_id, delivered.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
+    generated = generate_and_store_packet_draft(db_path, guild_id, packet, generator, entry_id=entry_id)
+    if not generated.ok:
+        return AutomationResult(False, cadence, "held", generated.reason, entry_id, generated.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
+    approved = approve_draft(db_path, guild_id, entry_id, generated.content_hash, revision=generated.revision)
+    if not approved.ok:
+        return AutomationResult(False, cadence, "held", approved.reason, entry_id, generated.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
+    delivered = deliver_approved(db_path, guild_id, entry_id, base_url, api_key, opener=opener, revision=generated.revision)
+    return AutomationResult(delivered.ok, cadence, delivered.status, delivered.reason, entry_id, delivered.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
+
+
+def run_daily(
+    db_path: str,
+    guild_id: int,
+    generator: Callable[[dict[str, Any], str], str],
+    base_url: str,
+    api_key: str,
+    *,
+    now_utc: Optional[datetime] = None,
+    target_day: Optional[date] = None,
+    force: bool = False,
+    opener=None,
+) -> AutomationResult:
+    ensure_schema(db_path)
+    start, end, label = _daily_period_for_day(target_day) if target_day else daily_period(now_utc)
+    if not force and target_day is None and not daily_due(now_utc):
+        return AutomationResult(False, "daily", "not_due", "before_daily_publish_time", source_window_start=start, source_window_end=end)
+    claim, run_id, row = _claim_run(db_path, guild_id, "daily", start, end, force=force)
+    if claim != "claimed":
+        return _result_from_existing("daily", row, claim=claim)
+    packet = build_source_packet_between(db_path, guild_id, start, end, entry_kind="daily")
+    _store_observation(db_path, guild_id, label, packet)
+    if not packet.get("sourceArchiveAvailable", False):
+        result = AutomationResult(False, "daily", "held", "source_archive_unavailable", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
+    elif not packet.get("coverageComplete", True):
+        # Time cannot make a pre-archive window complete. Record it explicitly
+        # and move on instead of blocking every later catch-up day forever.
+        result = AutomationResult(False, "daily", "incomplete", "window_began_before_archive_activation", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
+    elif not _has_meaningful_daily_activity(packet):
+        result = AutomationResult(True, "daily", "quiet", "insufficient_meaningful_activity", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
+    else:
+        result = _publish_packet(db_path, guild_id, "daily", label, packet, generator, base_url, api_key, opener=opener)
+    _mark_observation(db_path, guild_id, label, result)
+    return _finish_run(db_path, run_id, result)
+
+
+def _weekly_packet(db_path: str, guild_id: int, start: str, end: str) -> tuple[Optional[dict[str, Any]], int, int]:
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        observations = conn.execute("""SELECT * FROM bnl_journal_observations
+            WHERE guild_id=? AND source_window_start>=? AND source_window_end<=?
+            ORDER BY source_window_start ASC""", (guild_id, start, end)).fetchall()
+        daily_entries = {
+            row[0]: {"title": row[1], "excerpt": row[2]}
+            for row in conn.execute("""SELECT entry_id,title,excerpt FROM bnl_journal_entries
+                WHERE guild_id=? AND lifecycle_state='published' AND source_window_start>=? AND source_window_end<=?""", (guild_id, start, end)).fetchall()
+        }
+    complete = [row for row in observations if row["lifecycle_state"] in {"published", "quiet"}]
+    active = [row for row in complete if row["lifecycle_state"] == "published"]
+    # A weekly synthesis is only grounded once all seven daily windows have
+    # reached a durable terminal state. Held/incomplete days are excluded.
+    if len(complete) < 7 or len(active) < MIN_WEEKLY_ACTIVE_DAYS:
+        return None, len(complete), len(active)
+    relays: list[dict[str, Any]] = []
+    conversations: list[dict[str, Any]] = []
+    observation_context: list[dict[str, Any]] = []
+    totals = {"eligibleRelays": 0, "eligibleConversations": 0, "participants": 0, "channels": 0}
+    seen_subjects: set[str] = set()
+    for row in complete:
+        counts = json.loads(row["aggregate_counts_json"] or "{}")
+        topics = json.loads(row["topic_counts_json"] or "{}")
+        subjects = json.loads(row["subject_counts_json"] or "{}")
+        for key in ("eligibleRelays", "eligibleConversations"):
+            totals[key] += int(counts.get(key) or 0)
+        seen_subjects.update(subjects)
+        entry = daily_entries.get(row["journal_entry_id"] or "", {})
+        observation_context.append({
+            "date": row["observation_date"], "state": row["lifecycle_state"], "counts": counts,
+            "topicCounts": topics, "dailyEntryId": row["journal_entry_id"] or "",
+            "dailyTitle": entry.get("title", ""), "dailyExcerpt": entry.get("excerpt", ""),
+        })
+        for idx, source in enumerate(json.loads(row["representative_sources_json"] or "[]"), 1):
+            item = dict(source)
+            item["refId"] = f"week:{row['observation_date'].replace('-', '')}:{idx}"
+            if item.get("sourceKind") == "conversation":
+                conversations.append(item)
+            else:
+                relays.append(item)
+    totals["participants"] = len(seen_subjects)
+    totals["daysObserved"] = len(complete)
+    totals["activeDays"] = len(active)
+    packet = build_packet_from_sources(
+        db_path, guild_id, start, end, relays, conversations,
+        entry_kind="weekly", aggregate_counts=totals, observation_context=observation_context,
+    )
+    return packet, len(complete), len(active)
+
+
+def run_weekly(
+    db_path: str,
+    guild_id: int,
+    generator: Callable[[dict[str, Any], str], str],
+    base_url: str,
+    api_key: str,
+    *,
+    now_utc: Optional[datetime] = None,
+    target_monday: Optional[date] = None,
+    force: bool = False,
+    opener=None,
+) -> AutomationResult:
+    ensure_schema(db_path)
+    start, end, label = _weekly_period_for_monday(target_monday) if target_monday else weekly_period(now_utc)
+    if not force and target_monday is None and not weekly_due(now_utc):
+        return AutomationResult(False, "weekly", "not_due", "before_weekly_publish_time", source_window_start=start, source_window_end=end)
+    claim, run_id, row = _claim_run(db_path, guild_id, "weekly", start, end, force=force)
+    if claim != "claimed":
+        return _result_from_existing("weekly", row, claim=claim)
+    packet, complete_days, active_days = _weekly_packet(db_path, guild_id, start, end)
+    if packet is None and complete_days == 7 and active_days == 0:
+        result = AutomationResult(True, "weekly", "quiet", "no_meaningful_weekly_activity", source_window_start=start, source_window_end=end, aggregate_counts={"completeDays": complete_days, "activeDays": active_days})
+    elif packet is None:
+        result = AutomationResult(True, "weekly", "deferred", f"only_{complete_days}_complete_daily_observations", source_window_start=start, source_window_end=end, aggregate_counts={"completeDays": complete_days, "activeDays": active_days})
+    else:
+        result = _publish_packet(db_path, guild_id, "weekly", label, packet, generator, base_url, api_key, opener=opener)
+    return _finish_run(db_path, run_id, result)
+
+
+def _archive_activation_day(db_path: str, guild_id: int) -> Optional[date]:
+    try:
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT activated_at_ms FROM bnl_journal_source_archive_state WHERE guild_id=?",
+                (guild_id,),
+            ).fetchone()
+    except sqlite3.Error:
+        return None
+    if not row:
+        return None
+    activated = datetime.fromtimestamp(int(row[0]) / 1000.0, tz=timezone.utc).astimezone(PACIFIC)
+    # Activation normally occurs mid-day. Only the following local day is a
+    # guaranteed complete 24-hour window.
+    return activated.date() + timedelta(days=1)
+
+
+def _latest_daily_day(now_utc: Optional[datetime]) -> date:
+    local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
+    latest = local.date() - timedelta(days=1)
+    if (local.hour, local.minute) < (DAILY_READY_HOUR, DAILY_READY_MINUTE):
+        latest -= timedelta(days=1)
+    return latest
+
+
+def _pending_daily_day(db_path: str, guild_id: int, now_utc: Optional[datetime]) -> Optional[date]:
+    first = _archive_activation_day(db_path, guild_id)
+    latest = _latest_daily_day(now_utc)
+    if first is None or first > latest:
+        return None
+    with sqlite3.connect(db_path) as conn:
+        rows = {
+            (str(row[0]), str(row[1]), str(row[2])): str(row[3])
+            for row in conn.execute(
+                "SELECT cadence,source_window_start,source_window_end,lifecycle_state FROM bnl_journal_automation_runs WHERE guild_id=? AND cadence='daily'",
+                (guild_id,),
+            ).fetchall()
+        }
+    current = first
+    while current <= latest:
+        start, end, _ = _daily_period_for_day(current)
+        if rows.get(("daily", start, end)) not in TERMINAL_RUN_STATES:
+            return current
+        current += timedelta(days=1)
+    return None
+
+
+def _latest_week_monday(now_utc: Optional[datetime]) -> date:
+    local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
+    current_monday = local.date() - timedelta(days=local.weekday())
+    if local.weekday() == WEEKLY_READY_WEEKDAY and local.hour < WEEKLY_READY_HOUR:
+        current_monday -= timedelta(days=7)
+    return current_monday - timedelta(days=7)
+
+
+def _pending_week_monday(db_path: str, guild_id: int, now_utc: Optional[datetime]) -> Optional[date]:
+    first_day = _archive_activation_day(db_path, guild_id)
+    if first_day is None:
+        return None
+    first_monday = first_day + timedelta(days=(7 - first_day.weekday()) % 7)
+    latest = _latest_week_monday(now_utc)
+    if first_monday > latest:
+        return None
+    with sqlite3.connect(db_path) as conn:
+        rows = {
+            (str(row[0]), str(row[1])): str(row[2])
+            for row in conn.execute(
+                "SELECT source_window_start,source_window_end,lifecycle_state FROM bnl_journal_automation_runs WHERE guild_id=? AND cadence='weekly'",
+                (guild_id,),
+            ).fetchall()
+        }
+    current = first_monday
+    while current <= latest:
+        start, end, _ = _weekly_period_for_monday(current)
+        if rows.get((start, end)) not in TERMINAL_RUN_STATES:
+            return current
+        current += timedelta(days=7)
+    return None
+
+
+def run_scheduled(
+    db_path: str,
+    guild_id: int,
+    generator: Callable[[dict[str, Any], str], str],
+    base_url: str,
+    api_key: str,
+    flags: Optional[dict[str, Any]] = None,
+    *,
+    now_utc: Optional[datetime] = None,
+    opener=None,
+) -> list[AutomationResult]:
+    controls = flags or {}
+    if not bool(controls.get("journalAutoPublishEnabled", True)):
+        return [AutomationResult(False, "all", "paused", "auto_publish_paused")]
+    try:
+        from bnl_journal_source_store import backfill_legacy_sources
+
+        backfill_legacy_sources(db_path, guild_id)
+    except (ImportError, sqlite3.Error, ValueError):
+        return [AutomationResult(False, "all", "held", "source_archive_unavailable")]
+    results: list[AutomationResult] = []
+    if bool(controls.get("journalDailyEnabled", True)):
+        target_day = _pending_daily_day(db_path, guild_id, now_utc)
+        if target_day is not None:
+            results.append(run_daily(db_path, guild_id, generator, base_url, api_key, now_utc=now_utc, target_day=target_day, opener=opener))
+    if bool(controls.get("journalWeeklyEnabled", True)):
+        target_monday = _pending_week_monday(db_path, guild_id, now_utc)
+        if target_monday is not None:
+            results.append(run_weekly(db_path, guild_id, generator, base_url, api_key, now_utc=now_utc, target_monday=target_monday, opener=opener))
+    return results or [AutomationResult(False, "all", "not_due", "no_schedule_due")]
+
+
+def automation_status(db_path: str, guild_id: int) -> dict[str, Any]:
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        state = conn.execute("SELECT * FROM bnl_journal_automation_state WHERE guild_id=?", (guild_id,)).fetchone()
+        runs = conn.execute("""SELECT cadence,lifecycle_state,reason,journal_entry_id,journal_revision,
+            source_window_start,source_window_end,aggregate_counts_json,updated_at
+            FROM bnl_journal_automation_runs WHERE guild_id=? ORDER BY updated_at DESC LIMIT 10""", (guild_id,)).fetchall()
+    now = datetime.now(timezone.utc)
+    daily_start, daily_end, _ = daily_period(now)
+    weekly_start, weekly_end, _ = weekly_period(now)
+    next_daily_at, next_weekly_at = next_schedule_times(now)
+    return {
+        "contractVersion": 1,
+        "guildId": guild_id,
+        "schedulerState": "ready",
+        "dailyWindow": {"start": daily_start, "end": daily_end},
+        "weeklyWindow": {"start": weekly_start, "end": weekly_end},
+        "nextDailyAt": next_daily_at,
+        "nextWeeklyAt": next_weekly_at,
+        "lastState": dict(state) if state else None,
+        "recentRuns": [dict(row, aggregate_counts_json=None, aggregateCounts=json.loads(row["aggregate_counts_json"] or "{}")) for row in runs],
+    }
+
+
+def result_dict(result: AutomationResult) -> dict[str, Any]:
+    return asdict(result)

--- a/bnl_journal_source_store.py
+++ b/bnl_journal_source_store.py
@@ -1,0 +1,650 @@
+"""Append-only source archive for BNL Journal generation.
+
+This module intentionally has no dependency on the live Journal producer, bot
+message flow, or website relay state.  It provides a durable landing table that
+those systems can dual-write to in later integration changes.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+
+PUBLIC_POLICIES = ("public_context", "public_home", "public_selective")
+SOURCE_TABLE = "bnl_journal_source_events"
+STATE_TABLE = "bnl_journal_source_archive_state"
+DELETE_TRIGGER = "trg_bnl_journal_sources_no_delete"
+
+
+@dataclass(frozen=True)
+class SourceRecordResult:
+    ok: bool
+    status: str
+    event_seq: int = 0
+    content_hash: str = ""
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class SourceQueryResult:
+    events: Tuple[Dict[str, Any], ...]
+    counts: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class LegacyBackfillResult:
+    inserted: int = 0
+    idempotent: int = 0
+    conflicts: int = 0
+    skipped: int = 0
+    relay_rows_scanned: int = 0
+    conversation_rows_scanned: int = 0
+    invalid_timestamps: int = 0
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _content_hash(raw_text: str) -> str:
+    return hashlib.sha256((raw_text or "").encode("utf-8")).hexdigest()
+
+
+def _canonical_json(value: Optional[Mapping[str, Any]]) -> str:
+    return json.dumps(dict(value or {}), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def timestamp_to_epoch_ms(value: Any) -> Optional[int]:
+    """Normalize legacy SQLite/ISO timestamps to UTC epoch milliseconds."""
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+        if number < 0:
+            return None
+        return int(number if number >= 1_000_000_000_000 else number * 1000)
+    raw = str(value).strip()
+    if not raw:
+        return None
+    if re.fullmatch(r"\d+(?:\.\d+)?", raw):
+        return timestamp_to_epoch_ms(float(raw))
+    try:
+        parsed = datetime.fromisoformat(raw[:-1] + "+00:00" if raw.endswith("Z") else raw)
+    except ValueError:
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+            try:
+                parsed = datetime.strptime(raw, fmt)
+                break
+            except ValueError:
+                parsed = None
+        if parsed is None:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return int(parsed.astimezone(timezone.utc).timestamp() * 1000)
+
+
+def sanitize_summary(text: str, private_names: Optional[Sequence[str]] = None, limit: int = 1000) -> str:
+    """Build prompt-safe source text while leaving the immutable raw text private."""
+    clean = re.sub(r"https?://\S+", "", text or "")
+    clean = re.sub(r"<@!?\d+>|@\w+", "someone", clean)
+    clean = re.sub(r"\b\d{12,}\b", "", clean)
+    for name in sorted({str(item).strip() for item in (private_names or ()) if str(item).strip()}, key=len, reverse=True):
+        clean = re.sub(r"\b" + re.escape(name) + r"\b", "someone", clean, flags=re.IGNORECASE)
+    clean = re.sub(r"[\"“”‘’]", "", clean)
+    clean = re.sub(r"\s+", " ", clean).strip()
+    return clean[: max(1, int(limit))]
+
+
+def ensure_schema(db_path: str) -> None:
+    with sqlite3.connect(db_path, timeout=30) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bnl_journal_source_archive_state (
+                guild_id INTEGER PRIMARY KEY,
+                activated_at_ms INTEGER NOT NULL CHECK(activated_at_ms >= 0),
+                created_at_ms INTEGER NOT NULL CHECK(created_at_ms >= 0),
+                legacy_backfill_completed_at_ms INTEGER,
+                legacy_conversation_cursor INTEGER NOT NULL DEFAULT 0,
+                legacy_relay_cursor_rowid INTEGER NOT NULL DEFAULT 0,
+                legacy_relay_cursor_timestamp TEXT NOT NULL DEFAULT '',
+                legacy_relay_cursor_id TEXT NOT NULL DEFAULT ''
+            )
+            """
+        )
+        state_columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(bnl_journal_source_archive_state)")}
+        if "legacy_backfill_completed_at_ms" not in state_columns:
+            conn.execute("ALTER TABLE bnl_journal_source_archive_state ADD COLUMN legacy_backfill_completed_at_ms INTEGER")
+        if "legacy_conversation_cursor" not in state_columns:
+            conn.execute("ALTER TABLE bnl_journal_source_archive_state ADD COLUMN legacy_conversation_cursor INTEGER NOT NULL DEFAULT 0")
+        if "legacy_relay_cursor_rowid" not in state_columns:
+            conn.execute("ALTER TABLE bnl_journal_source_archive_state ADD COLUMN legacy_relay_cursor_rowid INTEGER NOT NULL DEFAULT 0")
+        if "legacy_relay_cursor_timestamp" not in state_columns:
+            conn.execute("ALTER TABLE bnl_journal_source_archive_state ADD COLUMN legacy_relay_cursor_timestamp TEXT NOT NULL DEFAULT ''")
+        if "legacy_relay_cursor_id" not in state_columns:
+            conn.execute("ALTER TABLE bnl_journal_source_archive_state ADD COLUMN legacy_relay_cursor_id TEXT NOT NULL DEFAULT ''")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bnl_journal_source_events (
+                event_seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                guild_id INTEGER NOT NULL,
+                source_kind TEXT NOT NULL,
+                source_key TEXT NOT NULL,
+                occurred_at_ms INTEGER NOT NULL CHECK(occurred_at_ms >= 0),
+                ingested_at_ms INTEGER NOT NULL CHECK(ingested_at_ms >= 0),
+                channel_id INTEGER,
+                channel_policy TEXT NOT NULL DEFAULT '',
+                subject_ref TEXT NOT NULL DEFAULT '',
+                private_display_name TEXT NOT NULL DEFAULT '',
+                raw_text TEXT NOT NULL,
+                sanitized_summary TEXT NOT NULL,
+                content_hash TEXT NOT NULL,
+                public_usable INTEGER NOT NULL CHECK(public_usable IN (0, 1)),
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                UNIQUE(guild_id, source_kind, source_key)
+            )
+            """
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_bnl_journal_sources_window "
+            "ON bnl_journal_source_events(guild_id, occurred_at_ms, source_kind, source_key)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_bnl_journal_sources_public_window "
+            "ON bnl_journal_source_events(guild_id, public_usable, occurred_at_ms)"
+        )
+        conn.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS trg_bnl_journal_sources_no_duplicate_insert
+            BEFORE INSERT ON bnl_journal_source_events
+            WHEN EXISTS (
+                SELECT 1 FROM bnl_journal_source_events
+                WHERE event_seq=NEW.event_seq
+                   OR (
+                        guild_id=NEW.guild_id
+                        AND source_kind=NEW.source_kind
+                        AND source_key=NEW.source_key
+                   )
+            )
+            BEGIN
+                SELECT RAISE(ABORT, 'bnl_journal_source_events_duplicate_identity');
+            END
+            """
+        )
+        conn.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS trg_bnl_journal_sources_no_update
+            BEFORE UPDATE ON bnl_journal_source_events
+            BEGIN
+                SELECT RAISE(ABORT, 'bnl_journal_source_events_immutable');
+            END
+            """
+        )
+        _create_delete_trigger(conn)
+
+
+def _create_delete_trigger(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_bnl_journal_sources_no_delete
+        BEFORE DELETE ON bnl_journal_source_events
+        BEGIN
+            SELECT RAISE(ABORT, 'bnl_journal_source_events_immutable');
+        END
+        """
+    )
+
+
+def _validate_identity(guild_id: int, source_kind: str, source_key: str, occurred_at_ms: int) -> Tuple[int, str, str, int]:
+    guild = int(guild_id)
+    kind = str(source_kind or "").strip().lower()
+    key = str(source_key or "").strip()
+    occurred = int(occurred_at_ms)
+    if guild <= 0:
+        raise ValueError("invalid_guild_id")
+    if not re.fullmatch(r"[a-z0-9_:-]{1,64}", kind):
+        raise ValueError("invalid_source_kind")
+    if not key or len(key) > 240:
+        raise ValueError("invalid_source_key")
+    if occurred < 0:
+        raise ValueError("invalid_occurred_at_ms")
+    return guild, kind, key, occurred
+
+
+def _record_on_connection(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    source_kind: str,
+    source_key: str,
+    occurred_at_ms: int,
+    raw_text: str,
+    sanitized_summary: Optional[str] = None,
+    channel_id: Optional[int] = None,
+    channel_policy: str = "",
+    subject_ref: str = "",
+    private_display_name: str = "",
+    public_usable: bool = True,
+    metadata: Optional[Mapping[str, Any]] = None,
+    ingested_at_ms: Optional[int] = None,
+) -> SourceRecordResult:
+    guild, kind, key, occurred = _validate_identity(guild_id, source_kind, source_key, occurred_at_ms)
+    raw = str(raw_text or "")
+    summary = str(sanitized_summary if sanitized_summary is not None else sanitize_summary(raw))
+    digest = _content_hash(raw)
+    metadata_json = _canonical_json(metadata)
+    immutable_values = (
+        occurred,
+        int(channel_id) if channel_id not in (None, "") else None,
+        str(channel_policy or "")[:80],
+        str(subject_ref or "")[:160],
+        str(private_display_name or "")[:160],
+        raw,
+        summary,
+        digest,
+        1 if public_usable else 0,
+        metadata_json,
+    )
+    existing = conn.execute(
+        """
+        SELECT event_seq, occurred_at_ms, channel_id, channel_policy, subject_ref,
+               private_display_name, raw_text, sanitized_summary, content_hash,
+               public_usable, metadata_json
+        FROM bnl_journal_source_events
+        WHERE guild_id=? AND source_kind=? AND source_key=?
+        """,
+        (guild, kind, key),
+    ).fetchone()
+    if existing:
+        if tuple(existing[1:]) == immutable_values:
+            return SourceRecordResult(True, "idempotent", int(existing[0]), digest)
+        return SourceRecordResult(False, "conflict", int(existing[0]), str(existing[8]), "immutable_source_conflict")
+    cursor = conn.execute(
+        """
+        INSERT INTO bnl_journal_source_events(
+            guild_id, source_kind, source_key, occurred_at_ms, ingested_at_ms,
+            channel_id, channel_policy, subject_ref, private_display_name,
+            raw_text, sanitized_summary, content_hash, public_usable, metadata_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            guild,
+            kind,
+            key,
+            occurred,
+            int(ingested_at_ms) if ingested_at_ms is not None else _now_ms(),
+            *immutable_values[1:],
+        ),
+    )
+    return SourceRecordResult(True, "inserted", int(cursor.lastrowid or 0), digest)
+
+
+def record_source_event(
+    db_path: str,
+    *,
+    guild_id: int,
+    source_kind: str,
+    source_key: str,
+    occurred_at_ms: int,
+    raw_text: str,
+    sanitized_summary: Optional[str] = None,
+    channel_id: Optional[int] = None,
+    channel_policy: str = "",
+    subject_ref: str = "",
+    private_display_name: str = "",
+    public_usable: bool = True,
+    metadata: Optional[Mapping[str, Any]] = None,
+    ingested_at_ms: Optional[int] = None,
+) -> SourceRecordResult:
+    """Insert one immutable event, returning idempotent for an exact replay."""
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path, timeout=30) as conn:
+        # Serialize the identity check and insert.  Without this write lock, two
+        # processes can both observe a missing identity and one can leak a
+        # UNIQUE/locking error instead of returning an idempotent result.
+        conn.execute("BEGIN IMMEDIATE")
+        now_ms = _now_ms()
+        conn.execute(
+            "INSERT OR IGNORE INTO bnl_journal_source_archive_state(guild_id,activated_at_ms,created_at_ms) VALUES(?,?,?)",
+            (int(guild_id), now_ms, now_ms),
+        )
+        return _record_on_connection(
+            conn,
+            guild_id=guild_id,
+            source_kind=source_kind,
+            source_key=source_key,
+            occurred_at_ms=occurred_at_ms,
+            raw_text=raw_text,
+            sanitized_summary=sanitized_summary,
+            channel_id=channel_id,
+            channel_policy=channel_policy,
+            subject_ref=subject_ref,
+            private_display_name=private_display_name,
+            public_usable=public_usable,
+            metadata=metadata,
+            ingested_at_ms=ingested_at_ms,
+        )
+
+
+def query_source_events(db_path: str, guild_id: int, start_ms: int, end_ms: int) -> SourceQueryResult:
+    """Return every event in the exact half-open interval ``[start_ms, end_ms)``."""
+    start = int(start_ms)
+    end = int(end_ms)
+    if start < 0 or end < start:
+        raise ValueError("invalid_source_window")
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        state = conn.execute(
+            "SELECT activated_at_ms FROM bnl_journal_source_archive_state WHERE guild_id=?",
+            (int(guild_id),),
+        ).fetchone()
+        rows = conn.execute(
+            """
+            SELECT * FROM bnl_journal_source_events
+            WHERE guild_id=? AND occurred_at_ms>=? AND occurred_at_ms<?
+            ORDER BY occurred_at_ms ASC, source_kind ASC, source_key ASC, event_seq ASC
+            """,
+            (int(guild_id), start, end),
+        ).fetchall()
+    events: List[Dict[str, Any]] = []
+    by_kind: Dict[str, int] = {}
+    by_policy: Dict[str, int] = {}
+    subjects = set()
+    channels = set()
+    public_count = 0
+    for row in rows:
+        item = dict(row)
+        item["public_usable"] = bool(item["public_usable"])
+        try:
+            item["metadata"] = json.loads(item.pop("metadata_json") or "{}")
+        except (TypeError, json.JSONDecodeError):
+            item["metadata"] = {}
+        events.append(item)
+        kind = str(item.get("source_kind") or "")
+        policy = str(item.get("channel_policy") or "")
+        by_kind[kind] = by_kind.get(kind, 0) + 1
+        by_policy[policy] = by_policy.get(policy, 0) + 1
+        if item.get("subject_ref"):
+            subjects.add(item["subject_ref"])
+        if item.get("channel_id") not in (None, 0):
+            channels.add(int(item["channel_id"]))
+        public_count += 1 if item["public_usable"] else 0
+    counts = {
+        "total": len(events),
+        "publicUsable": public_count,
+        "notPublicUsable": len(events) - public_count,
+        "bySourceKind": dict(sorted(by_kind.items())),
+        "byChannelPolicy": dict(sorted(by_policy.items())),
+        "uniqueSubjects": len(subjects),
+        "uniqueChannels": len(channels),
+        "archiveActivatedAtMs": int(state[0]) if state else None,
+        "coverageComplete": bool(state and start >= int(state[0])),
+    }
+    return SourceQueryResult(tuple(events), counts)
+
+
+def _purge_discord_source_events_on_connection(
+    conn: sqlite3.Connection,
+    guild_id: int,
+    user_id: Optional[int] = None,
+) -> int:
+    """Purge a Discord archive scope inside the caller's active transaction.
+
+    This is the controlled exception to the archive's normal immutability rule.
+    Callers must own the surrounding transaction so the trigger change, delete,
+    and any related governance deletion commit or roll back together.
+    """
+    guild = int(guild_id)
+    if guild <= 0:
+        raise ValueError("invalid_guild_id")
+    subject_ref = ""
+    if user_id is not None:
+        user = int(user_id)
+        if user <= 0:
+            raise ValueError("invalid_user_id")
+        subject_ref = "discord_user:%s" % user
+
+    table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (SOURCE_TABLE,),
+    ).fetchone()
+    if not table_exists:
+        return 0
+
+    conn.execute("DROP TRIGGER IF EXISTS %s" % DELETE_TRIGGER)
+    try:
+        if subject_ref:
+            cursor = conn.execute(
+                "DELETE FROM bnl_journal_source_events "
+                "WHERE guild_id=? AND source_kind='discord_message' AND subject_ref=?",
+                (guild, subject_ref),
+            )
+        else:
+            cursor = conn.execute(
+                "DELETE FROM bnl_journal_source_events "
+                "WHERE guild_id=? AND source_kind='discord_message'",
+                (guild,),
+            )
+        return int(cursor.rowcount or 0)
+    finally:
+        _create_delete_trigger(conn)
+
+
+def purge_user_discord_sources_on_connection(conn: sqlite3.Connection, guild_id: int, user_id: int) -> int:
+    """Purge one user's raw Discord Journal sources in a caller transaction."""
+    return _purge_discord_source_events_on_connection(conn, guild_id, user_id)
+
+
+def _purge_discord_source_events(db_path: str, guild_id: int, user_id: Optional[int] = None) -> int:
+    """Delete an explicitly scoped Discord archive while keeping normal rows immutable.
+
+    The exclusive transaction makes the temporary trigger removal invisible to
+    concurrent writers. If any statement fails, SQLite rolls the schema change
+    and deletion back together, so the immutability guard remains installed.
+    """
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path, timeout=30) as conn:
+        conn.execute("BEGIN EXCLUSIVE")
+        try:
+            removed = _purge_discord_source_events_on_connection(conn, guild_id, user_id)
+            conn.commit()
+            return removed
+        except Exception:
+            conn.rollback()
+            raise
+
+
+def purge_guild_discord_sources(db_path: str, guild_id: int) -> int:
+    """Purge durable Discord source rows for one guild, preserving relay history."""
+    return _purge_discord_source_events(db_path, guild_id)
+
+
+def purge_user_discord_sources(db_path: str, guild_id: int, user_id: int) -> int:
+    """Purge durable Discord source rows authored by one user in one guild."""
+    return _purge_discord_source_events(db_path, guild_id, user_id)
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return bool(conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)).fetchone())
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set:
+    return {str(row[1]) for row in conn.execute("PRAGMA table_info(%s)" % table).fetchall()}
+
+
+def _result_tally(result: SourceRecordResult, totals: Dict[str, int]) -> None:
+    if result.status == "inserted":
+        totals["inserted"] += 1
+    elif result.status == "idempotent":
+        totals["idempotent"] += 1
+    elif result.status == "conflict":
+        totals["conflicts"] += 1
+    else:
+        totals["skipped"] += 1
+
+
+def backfill_legacy_sources(db_path: str, guild_id: int) -> LegacyBackfillResult:
+    """Idempotently import all currently retained eligible legacy source rows."""
+    ensure_schema(db_path)
+    totals = {
+        "inserted": 0,
+        "idempotent": 0,
+        "conflicts": 0,
+        "skipped": 0,
+        "relay_rows_scanned": 0,
+        "conversation_rows_scanned": 0,
+        "invalid_timestamps": 0,
+    }
+    with sqlite3.connect(db_path, timeout=30) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        now_ms = _now_ms()
+        conn.execute(
+            "INSERT OR IGNORE INTO bnl_journal_source_archive_state(guild_id,activated_at_ms,created_at_ms) VALUES(?,?,?)",
+            (int(guild_id), now_ms, now_ms),
+        )
+        state = conn.execute(
+            "SELECT legacy_conversation_cursor,legacy_relay_cursor_rowid,legacy_relay_cursor_timestamp,legacy_relay_cursor_id "
+            "FROM bnl_journal_source_archive_state WHERE guild_id=?",
+            (int(guild_id),),
+        ).fetchone()
+        conversation_cursor = int(state[0] or 0)
+        relay_cursor_rowid = int(state[1] or 0)
+        relay_cursor_timestamp = str(state[2] or "")
+        relay_cursor_id = str(state[3] or "")
+        if _table_exists(conn, "website_relay_history"):
+            relay_cols = _columns(conn, "website_relay_history")
+            required = {"relay_id", "guild_id", "public_message", "public_directive", "published_timestamp"}
+            if required.issubset(relay_cols):
+                optional = [name for name in ("event_type", "mode", "relay_lane") if name in relay_cols]
+                select_names = ["legacy_rowid", "relay_id", "public_message", "public_directive", "published_timestamp"] + optional
+                select_sql = ["rowid"] + select_names[1:]
+                rows = conn.execute(
+                    "SELECT %s FROM website_relay_history WHERE guild_id=? AND rowid>? "
+                    "ORDER BY rowid ASC" % ",".join(select_sql),
+                    (int(guild_id), relay_cursor_rowid),
+                ).fetchall()
+                totals["relay_rows_scanned"] += len(rows)
+                for row in rows:
+                    values = dict(zip(select_names, row))
+                    occurred = timestamp_to_epoch_ms(values.get("published_timestamp"))
+                    relay_id = str(values.get("relay_id") or "").strip()
+                    if occurred is None or not relay_id:
+                        totals["invalid_timestamps"] += 1 if occurred is None else 0
+                        totals["skipped"] += 1
+                        continue
+                    message = str(values.get("public_message") or "").strip()
+                    directive = str(values.get("public_directive") or "").strip()
+                    raw = message + (("\n" + directive) if directive else "")
+                    metadata = {"legacyTable": "website_relay_history"}
+                    for name in optional:
+                        if values.get(name) not in (None, ""):
+                            metadata[name] = values[name]
+                    result = _record_on_connection(
+                        conn,
+                        guild_id=guild_id,
+                        source_kind="website_relay",
+                        source_key=relay_id,
+                        occurred_at_ms=occurred,
+                        raw_text=raw,
+                        sanitized_summary=sanitize_summary(raw),
+                        channel_policy="public_relay",
+                        subject_ref="bnl_01",
+                        private_display_name="BNL-01",
+                        public_usable=True,
+                        metadata=metadata,
+                    )
+                    _result_tally(result, totals)
+                if rows:
+                    last_values = dict(zip(select_names, rows[-1]))
+                    relay_cursor_rowid = int(last_values.get("legacy_rowid") or relay_cursor_rowid)
+                    relay_cursor_timestamp = str(last_values.get("published_timestamp") or relay_cursor_timestamp)
+                    relay_cursor_id = str(last_values.get("relay_id") or relay_cursor_id)
+
+        if _table_exists(conn, "conversations"):
+            cols = _columns(conn, "conversations")
+            required = {"id", "user_id", "user_name", "guild_id", "channel_policy", "content", "timestamp"}
+            if required.issubset(cols):
+                expressions = [
+                    "id",
+                    "user_id",
+                    "user_name",
+                    "channel_policy",
+                    "content",
+                    "timestamp",
+                    "message_id" if "message_id" in cols else "NULL AS message_id",
+                    "channel_id" if "channel_id" in cols else "NULL AS channel_id",
+                    "channel_name" if "channel_name" in cols else "'' AS channel_name",
+                ]
+                predicates = [
+                    "guild_id=?",
+                    "id>?",
+                    "channel_policy IN (?,?,?)",
+                ]
+                args: List[Any] = [int(guild_id), conversation_cursor, *PUBLIC_POLICIES]
+                if "role" in cols:
+                    predicates.append("role='user'")
+                if "public_usable" in cols:
+                    predicates.append("public_usable=1")
+                if "visibility" in cols:
+                    predicates.append("visibility IN ('public','public_safe')")
+                rows = conn.execute(
+                    "SELECT %s FROM conversations WHERE %s ORDER BY timestamp ASC, id ASC"
+                    % (",".join(expressions), " AND ".join(predicates)),
+                    tuple(args),
+                ).fetchall()
+                totals["conversation_rows_scanned"] += len(rows)
+                names = [str(row[2] or "").strip() for row in rows if str(row[2] or "").strip()]
+                for row in rows:
+                    row_id, user_id, user_name, policy, content, timestamp, message_id, channel_id, channel_name = row
+                    occurred = timestamp_to_epoch_ms(timestamp)
+                    if occurred is None:
+                        totals["invalid_timestamps"] += 1
+                        totals["skipped"] += 1
+                        continue
+                    try:
+                        message_id_text = str(message_id or "").strip()
+                        real_message_id = int(message_id_text) if re.fullmatch(r"\d+", message_id_text) else 0
+                        if real_message_id <= 0:
+                            real_message_id = 0
+                    except (TypeError, ValueError, OverflowError):
+                        real_message_id = 0
+                    source_key = str(real_message_id) if real_message_id else "legacy_row:%s" % int(row_id)
+                    raw = str(content or "")
+                    result = _record_on_connection(
+                        conn,
+                        guild_id=guild_id,
+                        source_kind="discord_message",
+                        source_key=source_key,
+                        occurred_at_ms=occurred,
+                        raw_text=raw,
+                        sanitized_summary=sanitize_summary(raw, names),
+                        channel_id=int(channel_id) if channel_id not in (None, "") else None,
+                        channel_policy=str(policy or ""),
+                        subject_ref="discord_user:%s" % int(user_id or 0),
+                        private_display_name=str(user_name or ""),
+                        public_usable=True,
+                        metadata={
+                            "legacyTable": "conversations",
+                            "legacyRowId": int(row_id),
+                            "legacyMessageId": real_message_id or None,
+                            "channelName": str(channel_name or ""),
+                        },
+                    )
+                    _result_tally(result, totals)
+                if rows:
+                    conversation_cursor = max(int(row[0]) for row in rows)
+        conn.execute(
+            """UPDATE bnl_journal_source_archive_state SET
+                legacy_backfill_completed_at_ms=?,legacy_conversation_cursor=?,
+                legacy_relay_cursor_rowid=?,legacy_relay_cursor_timestamp=?,legacy_relay_cursor_id=?
+                WHERE guild_id=?""",
+            (_now_ms(), conversation_cursor, relay_cursor_rowid, relay_cursor_timestamp, relay_cursor_id, int(guild_id)),
+        )
+    return LegacyBackfillResult(**totals)

--- a/bnl_memory_governance.py
+++ b/bnl_memory_governance.py
@@ -19,6 +19,8 @@ import sqlite3
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from bnl_dossier_source_packets import subject_key as normalized_subject_key
+from bnl_journal import purge_user_journal_derivatives_on_connection
+from bnl_journal_source_store import purge_user_discord_sources_on_connection
 from bnl_memory_ledger import ensure_memory_ledger_schema, subject_key_for_user
 from bnl_relationship_engine import complete_delete_relationship_v2, ensure_relationship_v2_schema, propagate_ledger_lifecycle
 
@@ -669,6 +671,15 @@ def complete_delete_member_data(conn: sqlite3.Connection, *, guild_id: int, user
         # Delete shadow runs and prior receipts for this member only in this guild.
         counts["memory_governance_shadow_runs"] = conn.execute("DELETE FROM memory_governance_shadow_runs WHERE guild_id=? AND subject_hash=?", (guild_id, subject_hash)).rowcount if _table_exists(conn, "memory_governance_shadow_runs") else 0
         counts["prior_governance_receipts"] = conn.execute("DELETE FROM memory_governance_receipts WHERE guild_id=? AND subject_hash=?", (guild_id, subject_hash)).rowcount
+        # The Journal source archive is normally immutable. Complete deletion is
+        # the governed, transaction-scoped exception for this member's raw Discord
+        # inputs; website relays and other members/guilds remain untouched.
+        counts["bnl_journal_source_events"] = purge_user_discord_sources_on_connection(
+            conn, guild_id=guild_id, user_id=user_id
+        )
+        counts.update(purge_user_journal_derivatives_on_connection(
+            conn, guild_id=guild_id, user_id=user_id
+        ))
         if inject_failure: raise RuntimeError("injected_complete_delete_failure")
         safe_counts = {k: int(v or 0) for k, v in counts.items() if int(v or 0)}
         conn.execute("INSERT INTO memory_governance_receipts VALUES (?,?,?,?,?,?,?)", (rid, guild_id, subject_hash, "complete_delete", "", now, json.dumps(safe_counts, sort_keys=True)))

--- a/bnl_website_relay_state.py
+++ b/bnl_website_relay_state.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from bnl_journal_source_store import record_source_event, timestamp_to_epoch_ms
+
 MAX_HISTORY = 25
 MAX_ATTEMPTS_PER_GUILD = 100
 STOCK_FAMILIES = {
@@ -194,11 +196,15 @@ def stock_directive_reason(directive: str) -> str:
 
 def recent_history(db_path: str, guild_id: int, limit: int = MAX_HISTORY) -> list[dict[str, Any]]:
     ensure_schema(db_path)
+    # The relay table is now a durable journal source archive.  Keep the
+    # operational duplicate-detection view bounded without deleting older
+    # rows that daily and weekly journals still need.
+    bounded_limit = max(0, min(int(limit), MAX_HISTORY))
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(
             "SELECT * FROM website_relay_history WHERE guild_id=? ORDER BY published_timestamp DESC LIMIT ?",
-            (guild_id, limit),
+            (guild_id, bounded_limit),
         ).fetchall()
     return [dict(r) for r in rows]
 
@@ -295,9 +301,26 @@ def record_publication(db_path: str, guild_id: int, *, message: str, directive: 
             INSERT INTO website_relay_history(relay_id,guild_id,public_message,public_directive,mode,relay_lane,event_type,highest_source_conversation_id,normalized_message,semantic_family,published_timestamp)
             VALUES(?,?,?,?,?,?,?,?,?,?,?)
             """, (relay_id, guild_id, message, directive, mode, relay_lane, event_type, int(source_cursor or 0), norm, fam, ts))
-        old = conn.execute("SELECT relay_id FROM website_relay_history WHERE guild_id=? ORDER BY published_timestamp DESC LIMIT -1 OFFSET ?", (guild_id, MAX_HISTORY)).fetchall()
-        if old:
-            conn.executemany("DELETE FROM website_relay_history WHERE relay_id=?", [(r[0],) for r in old])
+    occurred_at_ms = timestamp_to_epoch_ms(ts)
+    if occurred_at_ms is not None:
+        try:
+            record_source_event(
+                db_path,
+                guild_id=guild_id,
+                source_kind="website_relay",
+                source_key=relay_id,
+                occurred_at_ms=occurred_at_ms,
+                raw_text=message + (("\n" + directive) if directive else ""),
+                channel_policy="public_relay",
+                subject_ref="bnl_01",
+                private_display_name="BNL-01",
+                public_usable=True,
+                metadata={"event_type": event_type, "mode": mode, "relay_lane": relay_lane, "source_cursor": int(source_cursor or 0)},
+            )
+        except Exception:
+            # Relay delivery must remain available if the local archive is
+            # temporarily unhealthy; the retained relay row can be backfilled.
+            pass
     return relay_id
 
 
@@ -337,9 +360,24 @@ def hydrate_publication(db_path: str, guild_id: int, *, relay_id: str, message: 
         INSERT INTO website_relay_history(relay_id,guild_id,public_message,public_directive,mode,relay_lane,event_type,highest_source_conversation_id,normalized_message,semantic_family,published_timestamp)
         VALUES(?,?,?,?,?,?,?,?,?,?,?)
         """, (relay_id, guild_id, message, directive, "OBSERVATION", "hydrated", source_class or trigger or "hydrated", 0, norm, fam, published_timestamp))
-        old = conn.execute("SELECT relay_id FROM website_relay_history WHERE guild_id=? ORDER BY published_timestamp DESC LIMIT -1 OFFSET ?", (guild_id, MAX_HISTORY)).fetchall()
-        if old:
-            conn.executemany("DELETE FROM website_relay_history WHERE relay_id=?", [(r[0],) for r in old])
+    occurred_at_ms = timestamp_to_epoch_ms(published_timestamp)
+    if occurred_at_ms is not None:
+        try:
+            record_source_event(
+                db_path,
+                guild_id=guild_id,
+                source_kind="website_relay",
+                source_key=relay_id,
+                occurred_at_ms=occurred_at_ms,
+                raw_text=message + (("\n" + directive) if directive else ""),
+                channel_policy="public_relay",
+                subject_ref="bnl_01",
+                private_display_name="BNL-01",
+                public_usable=True,
+                metadata={"event_type": source_class or trigger or "hydrated", "mode": "OBSERVATION", "relay_lane": "hydrated"},
+            )
+        except Exception:
+            pass
     return True
 
 def complete_attempt(db_path: str, attempt_id: str, *, source_class: str, outcome: str, reason: str = "", aggregate_source_counts: dict[str, int] | None = None, cursor: int = 0, highest_eligible_conversation_id: int = 0, accepted_relay_id: str = "", prepared_relay_id: str = "", website_published_at: str = "", idempotent: bool = False) -> None:

--- a/tests/test_bnl_journal.py
+++ b/tests/test_bnl_journal.py
@@ -35,6 +35,8 @@ class Resp:
 
 class JournalTests(unittest.TestCase):
     def setUp(self):
+        self.clock = patch.object(j, "utc_now_iso", return_value="2026-07-18T01:00:00Z")
+        self.clock.start()
         self.tmp = tempfile.NamedTemporaryFile(delete=False); self.db = self.tmp.name; self.tmp.close(); j.ensure_schema(self.db)
         with sqlite3.connect(self.db) as c:
             c.execute("CREATE TABLE website_relay_history(relay_id TEXT PRIMARY KEY,guild_id INTEGER,public_message TEXT,public_directive TEXT,mode TEXT,relay_lane TEXT,event_type TEXT,highest_source_conversation_id INTEGER,normalized_message TEXT,semantic_family TEXT,published_timestamp TEXT)")
@@ -51,6 +53,9 @@ class JournalTests(unittest.TestCase):
             c.execute("CREATE TABLE relationship_journal(id INTEGER,user_id INTEGER,guild_id INTEGER,entry_type TEXT,summary TEXT,timestamp TEXT)")
             c.execute("INSERT INTO relationship_journal VALUES (1,7,1,'state','private relationship dirt','2026-07-18T00:00:00Z')")
 
+    def tearDown(self):
+        self.clock.stop()
+
     def packet(self):
         return j.build_source_packet(self.db, 1, 24, '2026-07-18T01:00:00Z')
 
@@ -58,7 +63,7 @@ class JournalTests(unittest.TestCase):
         packet = self.packet()
         self.assertEqual(len([s for s in packet['privateSources'] if s['sourceKind'] == 'conversation']), 2)
         prompt = j.build_generation_prompt(packet)
-        self.assertIn('fresh:101', prompt)
+        self.assertIn('"sourceKind": "conversation"', prompt)
         self.assertNotIn('KnownUser', prompt)
         self.assertNotIn('discord_user:7', prompt)
         self.assertNotIn('relationship_journal', json.dumps(packet))
@@ -239,6 +244,22 @@ class JournalTests(unittest.TestCase):
         def missing(req, timeout=10): raise urllib.error.HTTPError(req.full_url, 404, 'not found', {}, io.BytesIO())
         d2 = j.deliver_approved(self.db, 1, res2.entry_id, 'https://site.example', 'k', missing)
         self.assertFalse(d2.ok); self.assertEqual(d2.reason, 'endpoint_not_found')
+
+    def test_rehydrate_replays_exact_published_payload_without_regeneration(self):
+        res = j.generate_and_store_draft(self.db, 1, 24, lambda p, pr: article_json(p, 'Restore Me')); self.assertTrue(res.ok)
+        self.assertTrue(j.approve_draft(self.db, 1, res.entry_id, res.content_hash).ok)
+        payloads = []
+        def opener(req, timeout=10):
+            payloads.append(req.data)
+            submitted = json.loads(req.data.decode())['entry']
+            return Resp(json.dumps({"ok": True, "persisted": True, "idempotent": False, "entry": {"entryId": submitted['entryId'], "revision": submitted['revision'], "contentHash": submitted['contentHash'], "publishedAt": "2026-07-18T01:00:00Z"}}).encode())
+        self.assertTrue(j.deliver_approved(self.db, 1, res.entry_id, 'https://site.example', 'k', opener).ok)
+        restored = j.rehydrate_published_entries(self.db, 1, 'https://site.example', 'k', opener=opener)
+        self.assertTrue(restored['ok'], restored)
+        self.assertEqual(1, restored['restored'])
+        self.assertEqual(payloads[0], payloads[1])
+        with sqlite3.connect(self.db) as c:
+            self.assertEqual('published', c.execute("SELECT lifecycle_state FROM bnl_journal_entries WHERE entry_id=?", (res.entry_id,)).fetchone()[0])
 
 
 class BotJournalCommandTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_bnl_journal_automation.py
+++ b/tests/test_bnl_journal_automation.py
@@ -1,0 +1,305 @@
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+
+import bnl_journal as journal
+import bnl_journal_automation as automation
+import bnl_journal_source_store as source_store
+
+
+def article_json(packet):
+    ref = packet["safeSources"][0]["refId"]
+    label = packet["sourceWindowEnd"][:10]
+    cadence = "Weekly Signal Weather" if packet.get("entryKind") == "weekly" else "Signal Weather"
+    body = " ".join(
+        [
+            "BNL watches the public music room fold a fresh rhythm into community mischief while producers and listeners keep the signal moving."
+            for _ in range(18)
+        ]
+    )
+    return json.dumps(
+        {
+            "title": f"{cadence} Ending {label}",
+            "excerpt": "A grounded community chronicle connects the room's music activity without exposing the people behind it.",
+            "sections": [
+                {
+                    "heading": "What the Room Carried",
+                    "body": body,
+                    "sourceRefIds": [ref],
+                }
+            ],
+            "metadata": {
+                "topicTags": ["music", "community"],
+                "subjectRefs": [],
+                "continuityNotes": ["music activity continued"],
+                "unresolvedQuestions": [],
+                "confidenceFlags": ["grounded"],
+                "safetyFlags": ["anonymous"],
+            },
+        }
+    )
+
+
+class Response:
+    status = 200
+
+    def __init__(self, request):
+        submitted = json.loads(request.data.decode("utf-8"))["entry"]
+        self.body = json.dumps(
+            {
+                "ok": True,
+                "persisted": True,
+                "idempotent": False,
+                "entry": {
+                    "entryId": submitted["entryId"],
+                    "revision": submitted["revision"],
+                    "contentHash": submitted["contentHash"],
+                    "publishedAt": "2026-07-20T12:00:00Z",
+                },
+            }
+        ).encode("utf-8")
+
+    def read(self):
+        return self.body
+
+    def getcode(self):
+        return self.status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class JournalAutomationTests(unittest.TestCase):
+    def setUp(self):
+        self.archive_clock = patch.object(source_store, "_now_ms", return_value=0)
+        self.archive_clock.start()
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.db = tmp.name
+        tmp.close()
+        journal.ensure_schema(self.db)
+        automation.ensure_schema(self.db)
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "CREATE TABLE website_relay_history(relay_id TEXT PRIMARY KEY,guild_id INTEGER,public_message TEXT,public_directive TEXT,mode TEXT,relay_lane TEXT,event_type TEXT,highest_source_conversation_id INTEGER,normalized_message TEXT,semantic_family TEXT,published_timestamp TEXT)"
+            )
+            conn.execute(
+                "CREATE TABLE conversations(id INTEGER PRIMARY KEY,user_id INTEGER,user_name TEXT,guild_id INTEGER,channel_name TEXT,channel_policy TEXT,role TEXT,content TEXT,timestamp TEXT,public_usable INTEGER,visibility TEXT)"
+            )
+
+    def tearDown(self):
+        self.archive_clock.stop()
+
+    def add_day(self, day, guild_id=1):
+        with sqlite3.connect(self.db) as conn:
+            for index in range(6):
+                stamp = f"{day}T12:{index:02d}:00Z"
+                conn.execute(
+                    "INSERT INTO website_relay_history VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        f"relay-{day}-{index}",
+                        guild_id,
+                        f"A public producer shared track activity number {index}.",
+                        "Keep listening to the community music room.",
+                        "OBSERVATION",
+                        "current_signal",
+                        "fresh_public_discord_activity",
+                        index,
+                        "track activity",
+                        "public_discord_activity",
+                        stamp,
+                    ),
+                )
+                conn.execute(
+                    "INSERT INTO conversations VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        int(day.replace("-", "")) * 10 + index,
+                        100 + index,
+                        f"Member{index}",
+                        guild_id,
+                        "general",
+                        "public_home",
+                        "user",
+                        f"Member{index} discusses a new mix, bass movement, and community listening plan number {index}.",
+                        stamp,
+                        1,
+                        "public_safe",
+                    ),
+                )
+
+    @staticmethod
+    def opener(request, timeout=10):
+        return Response(request)
+
+    def set_archive_activation(self, value):
+        activated_ms = int(datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp() * 1000)
+        source_store.ensure_schema(self.db)
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                """INSERT INTO bnl_journal_source_archive_state(guild_id,activated_at_ms,created_at_ms)
+                   VALUES(1,?,?) ON CONFLICT(guild_id) DO UPDATE SET activated_at_ms=excluded.activated_at_ms""",
+                (activated_ms, activated_ms),
+            )
+
+    def test_daily_auto_publishes_once_and_persists_observation(self):
+        self.add_day("2026-07-19")
+        now = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+        first = automation.run_daily(
+            self.db,
+            1,
+            lambda packet, prompt: article_json(packet),
+            "https://site.example",
+            "key",
+            now_utc=now,
+            opener=self.opener,
+        )
+        second = automation.run_daily(
+            self.db,
+            1,
+            lambda *_args: self.fail("duplicate run generated again"),
+            "https://site.example",
+            "key",
+            now_utc=now,
+            opener=self.opener,
+        )
+        self.assertTrue(first.ok, first)
+        self.assertEqual("published", first.status)
+        self.assertEqual(first.entry_id, second.entry_id)
+        self.assertEqual("published", second.status)
+        self.assertEqual(6, first.aggregate_counts["eligibleRelays"])
+        self.assertEqual(6, first.aggregate_counts["eligibleConversations"])
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(1, conn.execute("SELECT COUNT(*) FROM bnl_journal_observations").fetchone()[0])
+            self.assertEqual("published", conn.execute("SELECT lifecycle_state FROM bnl_journal_observations").fetchone()[0])
+            self.assertEqual(1, conn.execute("SELECT COUNT(*) FROM bnl_journal_entries WHERE lifecycle_state='published'").fetchone()[0])
+
+    def test_daily_uses_complete_half_open_window_and_far_more_than_25(self):
+        with sqlite3.connect(self.db) as conn:
+            for index in range(90):
+                observed = datetime(2026, 7, 19, 7, 0, tzinfo=timezone.utc) + timedelta(minutes=index * 10)
+                stamp = observed.isoformat().replace("+00:00", "Z")
+                conn.execute(
+                    "INSERT INTO website_relay_history VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        f"r{index}",
+                        1,
+                        f"Track activity {index}",
+                        "Listen for changes",
+                        "OBS",
+                        "lane",
+                        "fresh_public_discord_activity",
+                        index,
+                        f"track {index}",
+                        "public",
+                        stamp,
+                    ),
+                )
+            conn.execute(
+                "INSERT INTO website_relay_history VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+                ("boundary", 1, "Next day", "Later", "OBS", "lane", "fresh_public_discord_activity", 100, "next", "public", "2026-07-20T07:00:00Z"),
+            )
+        packet = journal.build_source_packet_between(
+            self.db,
+            1,
+            "2026-07-19T07:00:00Z",
+            "2026-07-20T07:00:00Z",
+            entry_kind="daily",
+        )
+        self.assertEqual(90, packet["aggregateCounts"]["eligibleRelays"])
+        self.assertEqual(90, len(packet["safeSources"]))
+        self.assertFalse(any(source.get("relayId") == "boundary" for source in packet["privateSources"]))
+
+    def test_scheduler_catches_up_oldest_missing_complete_day(self):
+        for day in ("2026-07-17", "2026-07-18", "2026-07-19"):
+            self.add_day(day)
+        source_store.backfill_legacy_sources(self.db, 1)
+        self.set_archive_activation("2026-07-16T19:00:00Z")
+        now = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+
+        first = automation.run_scheduled(
+            self.db, 1, lambda packet, prompt: article_json(packet),
+            "https://site.example", "key", now_utc=now, opener=self.opener,
+        )
+        second = automation.run_scheduled(
+            self.db, 1, lambda packet, prompt: article_json(packet),
+            "https://site.example", "key", now_utc=now, opener=self.opener,
+        )
+
+        self.assertEqual("2026-07-17T07:00:00Z", first[0].source_window_start)
+        self.assertEqual("published", first[0].status)
+        self.assertEqual("2026-07-18T07:00:00Z", second[0].source_window_start)
+        self.assertEqual("published", second[0].status)
+
+    def test_weekly_uses_durable_daily_observations(self):
+        for day, now_day in (
+            ("2026-07-13", 14),
+            ("2026-07-14", 15),
+            ("2026-07-15", 16),
+            ("2026-07-16", 17),
+            ("2026-07-17", 18),
+            ("2026-07-18", 19),
+            ("2026-07-19", 20),
+        ):
+            self.add_day(day)
+            result = automation.run_daily(
+                self.db,
+                1,
+                lambda packet, prompt: article_json(packet),
+                "https://site.example",
+                "key",
+                now_utc=datetime(2026, 7, now_day, 12, 0, tzinfo=timezone.utc),
+                opener=self.opener,
+            )
+            self.assertEqual("published", result.status, result)
+        self.set_archive_activation("2026-07-12T19:00:00Z")
+        scheduled = automation.run_scheduled(
+            self.db, 1, lambda packet, prompt: article_json(packet),
+            "https://site.example", "key",
+            now_utc=datetime(2026, 7, 21, 13, 0, tzinfo=timezone.utc),
+            opener=self.opener,
+        )
+        weekly = next(item for item in scheduled if item.cadence == "weekly")
+        self.assertTrue(weekly.ok, weekly)
+        self.assertEqual("published", weekly.status)
+        self.assertIn("journal_weekly_", weekly.entry_id)
+        self.assertEqual(7, weekly.aggregate_counts["activeDays"])
+        self.assertEqual(7, weekly.aggregate_counts["daysObserved"])
+
+    def test_all_quiet_week_is_terminal_and_does_not_block_catchup(self):
+        for offset in range(7):
+            day = datetime(2026, 7, 13, tzinfo=timezone.utc).date() + timedelta(days=offset)
+            start, end, label = automation._daily_period_for_day(day)
+            packet = journal.build_packet_from_sources(
+                self.db, 1, start, end, [], [], entry_kind="daily",
+                aggregate_counts={"eligibleRelays": 0, "eligibleConversations": 0},
+            )
+            automation._store_observation(self.db, 1, label, packet)
+            automation._mark_observation(
+                self.db, 1, label,
+                automation.AutomationResult(True, "daily", "quiet", source_window_start=start, source_window_end=end),
+            )
+        now = datetime(2026, 7, 20, 13, 0, tzinfo=timezone.utc)
+        first = automation.run_weekly(
+            self.db, 1, lambda *_args: self.fail("quiet week must not generate"),
+            "https://site.example", "key", now_utc=now, force=True, opener=self.opener,
+        )
+        second = automation.run_weekly(
+            self.db, 1, lambda *_args: self.fail("completed quiet week must not rerun"),
+            "https://site.example", "key", now_utc=now, opener=self.opener,
+        )
+        self.assertEqual("quiet", first.status)
+        self.assertEqual("no_meaningful_weekly_activity", first.reason)
+        self.assertEqual("quiet", second.status)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bnl_journal_runtime_controls.py
+++ b/tests/test_bnl_journal_runtime_controls.py
@@ -1,0 +1,249 @@
+import asyncio
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from unittest import mock
+
+import bnl_journal_source_store as source_store
+
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+
+try:
+    import bnl01_bot
+except ModuleNotFoundError as exc:  # Local minimal test images may omit the Discord runtime dependency.
+    if exc.name != "discord":
+        raise
+    bnl01_bot = None
+
+
+class Response:
+    status = 200
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+    def getcode(self):
+        return self.status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+@unittest.skipIf(bnl01_bot is None, "discord.py is not installed in this local test image")
+class JournalRuntimeControlTests(unittest.TestCase):
+    def setUp(self):
+        bnl01_bot._journal_automation_locks_by_guild.clear()
+        bnl01_bot._journal_automation_runtime_by_guild.clear()
+
+    def test_new_operator_commands_parse(self):
+        for command, action in (
+            ("!bnl journal status", "status"),
+            ("!bnl journal run-daily", "run-daily"),
+            ("!bnl journal run-weekly", "run-weekly"),
+            ("!bnl journal rehydrate", "rehydrate"),
+        ):
+            matched, options, error = bnl01_bot._parse_journal_command(command)
+            self.assertTrue(matched)
+            self.assertEqual(action, options["action"])
+            self.assertEqual("", error)
+
+    def test_control_get_uses_api_key_and_expected_endpoint(self):
+        captured = []
+
+        def opener(request, timeout=10):
+            captured.append((request, timeout))
+            return Response({"contractVersion": 1, "runRequests": []})
+
+        with mock.patch.object(bnl01_bot, "BNL_STATUS_URL", "https://site.example/api/bnl/status"), \
+             mock.patch.object(bnl01_bot, "BNL_API_KEY", "secret"), \
+             mock.patch("urllib.request.urlopen", side_effect=opener):
+            payload, reason = bnl01_bot._journal_control_request_sync("GET")
+
+        self.assertEqual("", reason)
+        self.assertEqual(1, payload["contractVersion"])
+        request, timeout = captured[0]
+        self.assertEqual("https://site.example/api/bnl/journal/control", request.full_url)
+        self.assertEqual("secret", request.get_header("X-api-key"))
+        self.assertEqual(10, timeout)
+
+    def test_claim_and_run_reports_match_site_contract(self):
+        posts = []
+
+        def post(method, payload=None):
+            posts.append((method, payload))
+            if payload["action"] == "claimRunRequest":
+                return {
+                    "ok": True,
+                    "request": {
+                        "requestId": "request-1",
+                        "cadence": "daily",
+                        "status": "running",
+                    },
+                }, ""
+            return {"ok": True}, ""
+
+        control = {
+            "runRequests": [
+                {"requestId": "request-1", "cadence": "daily", "status": "queued"}
+            ]
+        }
+        with mock.patch.object(bnl01_bot, "_journal_control_request_sync", side_effect=post):
+            claimed, reason = bnl01_bot._journal_control_claim_sync(control)
+            self.assertEqual("", reason)
+            self.assertEqual("request-1", claimed["requestId"])
+            bnl01_bot._journal_report_run_sync(
+                {
+                    "cadence": "daily",
+                    "status": "quiet",
+                    "reason": "insufficient_meaningful_activity",
+                    "entry_id": "",
+                    "source_window_start": "2026-07-17T07:00:00Z",
+                    "source_window_end": "2026-07-18T07:00:00Z",
+                    "aggregate_counts": {"eligibleRelays": 75, "eligibleConversations": 8},
+                },
+                guild_id=1,
+                request_id="request-1",
+            )
+
+        claim = posts[0][1]
+        report = posts[1][1]["run"]
+        self.assertEqual("claimRunRequest", claim["action"])
+        self.assertEqual("request-1", claim["requestId"])
+        self.assertRegex(claim["claimToken"], r"^worker-[a-f0-9]{32}$")
+        self.assertEqual("reportRun", posts[1][1]["action"])
+        self.assertEqual("request-1", report["runId"])
+        self.assertEqual("request-1", report["requestId"])
+        self.assertEqual("skipped", report["state"])
+        self.assertEqual(83, report["sourceCount"])
+
+    def test_daily_pause_flag_blocks_generator_runner(self):
+        flags = {
+            "journalAutoPublishEnabled": True,
+            "journalDailyEnabled": False,
+            "journalWeeklyEnabled": True,
+        }
+        with mock.patch.object(bnl01_bot, "BNL_JOURNAL_AUTOMATION_ENABLED", True), \
+             mock.patch.object(bnl01_bot, "BNL_PRIMARY_GUILD_ID", 0), \
+             mock.patch.object(bnl01_bot, "run_daily_journal_automation") as daily:
+            results = asyncio.run(
+                bnl01_bot.run_journal_automation_once(
+                    1, cadence="daily", force=True, flags=flags
+                )
+            )
+        daily.assert_not_called()
+        self.assertEqual("paused", results[0]["status"])
+        self.assertEqual("daily_automation_paused", results[0]["reason"])
+
+    def test_control_flag_fetch_failure_retains_confirmed_pause(self):
+        paused = {
+            "websiteRelayEnabled": True,
+            "heartbeatEnabled": True,
+            "showdayDiscordPostsEnabled": False,
+            "journalAutoPublishEnabled": False,
+            "journalDailyEnabled": False,
+            "journalWeeklyEnabled": True,
+        }
+        with mock.patch.object(bnl01_bot, "_bnl_control_flags_cache", dict(paused)), \
+             mock.patch.object(bnl01_bot, "_bnl_control_flags_cached_at", None), \
+             mock.patch.object(bnl01_bot, "_bnl_control_flags_has_remote_snapshot", True), \
+             mock.patch.object(bnl01_bot, "_build_bnl_control_flag_urls", return_value=["https://site.example/api/bnl/control-flags"]), \
+             mock.patch("urllib.request.urlopen", side_effect=OSError("temporary network failure")):
+            flags = bnl01_bot.get_bnl_control_flags(force_refresh=True)
+
+        self.assertFalse(flags["journalAutoPublishEnabled"])
+        self.assertFalse(flags["journalDailyEnabled"])
+
+    def test_control_flag_initial_local_failure_still_uses_startup_defaults(self):
+        with mock.patch.object(bnl01_bot, "_bnl_control_flags_cache", None), \
+             mock.patch.object(bnl01_bot, "_bnl_control_flags_cached_at", None), \
+             mock.patch.object(bnl01_bot, "_bnl_control_flags_has_remote_snapshot", False), \
+             mock.patch.object(bnl01_bot, "_build_bnl_control_flag_urls", return_value=[]):
+            flags = bnl01_bot.get_bnl_control_flags(force_refresh=True)
+
+        self.assertTrue(flags["journalAutoPublishEnabled"])
+        self.assertTrue(flags["journalDailyEnabled"])
+        self.assertTrue(flags["journalWeeklyEnabled"])
+
+    def test_control_get_failure_holds_without_running_scheduler(self):
+        runner = mock.AsyncMock()
+        with mock.patch.object(bnl01_bot, "resolve_network_guild_id", return_value=1), \
+             mock.patch.object(bnl01_bot, "get_bnl_control_flags", return_value={
+                 "journalAutoPublishEnabled": True,
+                 "journalDailyEnabled": True,
+                 "journalWeeklyEnabled": True,
+             }), \
+             mock.patch.object(bnl01_bot, "_journal_control_request_sync", return_value=(None, "control_plane_timeout")), \
+             mock.patch.object(bnl01_bot, "_journal_heartbeat_sync", return_value=(None, "")), \
+             mock.patch.object(bnl01_bot, "run_journal_automation_once", new=runner):
+            results = asyncio.run(bnl01_bot.run_journal_automation_control_cycle(1))
+
+        runner.assert_not_awaited()
+        self.assertEqual("held", results[0]["status"])
+        self.assertEqual(
+            "control_plane_unavailable:control_plane_timeout",
+            results[0]["reason"],
+        )
+        self.assertEqual(results[0]["reason"], bnl01_bot._journal_automation_runtime_by_guild[1]["lastError"])
+
+    def test_clear_history_also_purges_durable_journal_discord_sources(self):
+        temp = tempfile.NamedTemporaryFile(delete=False)
+        db_path = temp.name
+        temp.close()
+        try:
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    "CREATE TABLE conversations(id INTEGER PRIMARY KEY AUTOINCREMENT,user_id INTEGER,guild_id INTEGER)"
+                )
+                conn.executemany(
+                    "INSERT INTO conversations(user_id,guild_id) VALUES(?,?)",
+                    [(7, 1), (8, 1), (7, 2)],
+                )
+            for key, guild_id, source_kind, subject_ref in (
+                ("u7-g1", 1, "discord_message", "discord_user:7"),
+                ("u8-g1", 1, "discord_message", "discord_user:8"),
+                ("u7-g2", 2, "discord_message", "discord_user:7"),
+                ("relay-g1", 1, "website_relay", "bnl_01"),
+            ):
+                source_store.record_source_event(
+                    db_path,
+                    guild_id=guild_id,
+                    source_kind=source_kind,
+                    source_key=key,
+                    occurred_at_ms=1_000,
+                    raw_text="durable source text",
+                    sanitized_summary="durable source text",
+                    subject_ref=subject_ref,
+                    channel_policy="public_home" if source_kind == "discord_message" else "public_relay",
+                )
+
+            with mock.patch.object(bnl01_bot, "DB_FILE", db_path):
+                self.assertEqual(1, bnl01_bot.clear_user_history(7, 1))
+                self.assertEqual(
+                    {"u8-g1", "relay-g1"},
+                    {event["source_key"] for event in source_store.query_source_events(db_path, 1, 0, 2_000).events},
+                )
+                self.assertEqual(1, bnl01_bot.clear_guild_history(1))
+
+            self.assertEqual(
+                {"relay-g1"},
+                {event["source_key"] for event in source_store.query_source_events(db_path, 1, 0, 2_000).events},
+            )
+            self.assertEqual(
+                {"u7-g2"},
+                {event["source_key"] for event in source_store.query_source_events(db_path, 2, 0, 2_000).events},
+            )
+        finally:
+            os.unlink(db_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bnl_journal_source_store.py
+++ b/tests/test_bnl_journal_source_store.py
@@ -1,0 +1,259 @@
+import sqlite3
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import bnl_journal_source_store as store
+
+
+class JournalSourceStoreTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.db = str(Path(self.temp.name) / "journal.db")
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def _record(self, key, occurred=1_000, **overrides):
+        values = {
+            "guild_id": 1,
+            "source_kind": "discord_message",
+            "source_key": str(key),
+            "occurred_at_ms": occurred,
+            "raw_text": "A public source message",
+            "sanitized_summary": "A public source message",
+            "channel_id": 10,
+            "channel_policy": "public_home",
+            "subject_ref": "discord_user:7",
+            "private_display_name": "KnownUser",
+            "public_usable": True,
+            "metadata": {"messageId": str(key)},
+            "ingested_at_ms": 2_000,
+        }
+        values.update(overrides)
+        return store.record_source_event(self.db, **values)
+
+    def test_exact_replay_is_idempotent_and_rows_are_immutable(self):
+        first = self._record("123")
+        replay = self._record("123", ingested_at_ms=9_999)
+        conflict = self._record("123", raw_text="Changed source text", sanitized_summary="Changed source text")
+
+        self.assertTrue(first.ok)
+        self.assertEqual("inserted", first.status)
+        self.assertTrue(replay.ok)
+        self.assertEqual("idempotent", replay.status)
+        self.assertEqual(first.event_seq, replay.event_seq)
+        self.assertFalse(conflict.ok)
+        self.assertEqual("conflict", conflict.status)
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(1, conn.execute("SELECT COUNT(*) FROM bnl_journal_source_events").fetchone()[0])
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute("UPDATE bnl_journal_source_events SET raw_text='mutated'")
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute("DELETE FROM bnl_journal_source_events")
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO bnl_journal_source_events(
+                        event_seq,guild_id,source_kind,source_key,occurred_at_ms,ingested_at_ms,
+                        channel_id,channel_policy,subject_ref,private_display_name,raw_text,
+                        sanitized_summary,content_hash,public_usable,metadata_json
+                    )
+                    SELECT event_seq,guild_id,source_kind,source_key,occurred_at_ms+1,ingested_at_ms,
+                           channel_id,channel_policy,subject_ref,private_display_name,'replaced',
+                           sanitized_summary,content_hash,public_usable,metadata_json
+                    FROM bnl_journal_source_events WHERE source_key='123'
+                    """
+                )
+
+    def test_concurrent_exact_replays_return_inserted_then_idempotent(self):
+        store.ensure_schema(self.db)
+
+        def record_once(_index):
+            return self._record("same-concurrent-key")
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(record_once, range(24)))
+
+        self.assertEqual(1, sum(result.status == "inserted" for result in results))
+        self.assertEqual(23, sum(result.status == "idempotent" for result in results))
+        self.assertTrue(all(result.ok for result in results))
+        self.assertEqual(1, len({result.event_seq for result in results}))
+
+    def test_query_is_exact_unbounded_deterministic_and_fully_counted(self):
+        self._record("before", occurred=999)
+        self._record("end", occurred=2_000)
+        for index in reversed(range(85)):
+            self._record(
+                "%03d" % index,
+                occurred=1_500 + (index % 3),
+                source_kind="website_relay" if index % 2 else "discord_message",
+                channel_id=10 if index % 4 else 11,
+                channel_policy="public_home" if index % 3 else "public_context",
+                subject_ref="discord_user:%d" % (index % 5),
+                public_usable=index % 7 != 0,
+            )
+
+        result = store.query_source_events(self.db, 1, 1_000, 2_000)
+
+        self.assertEqual(85, len(result.events))
+        ordering = [(e["occurred_at_ms"], e["source_kind"], e["source_key"], e["event_seq"]) for e in result.events]
+        self.assertEqual(sorted(ordering), ordering)
+        self.assertEqual(85, result.counts["total"])
+        self.assertEqual(43, result.counts["bySourceKind"]["discord_message"])
+        self.assertEqual(42, result.counts["bySourceKind"]["website_relay"])
+        self.assertEqual(72, result.counts["publicUsable"])
+        self.assertEqual(13, result.counts["notPublicUsable"])
+        self.assertEqual(56, result.counts["byChannelPolicy"]["public_home"])
+        self.assertEqual(29, result.counts["byChannelPolicy"]["public_context"])
+        self.assertEqual(5, result.counts["uniqueSubjects"])
+        self.assertEqual(2, result.counts["uniqueChannels"])
+        self.assertFalse(result.counts["coverageComplete"])
+        activated_at = result.counts["archiveActivatedAtMs"]
+        self.assertIsInstance(activated_at, int)
+        covered = store.query_source_events(self.db, 1, activated_at, activated_at + 1)
+        self.assertTrue(covered.counts["coverageComplete"])
+        self.assertNotIn("before", {e["source_key"] for e in result.events})
+        self.assertNotIn("end", {e["source_key"] for e in result.events})
+
+    def test_legacy_backfill_uses_real_message_ids_filters_and_is_idempotent(self):
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "CREATE TABLE website_relay_history("
+                "relay_id TEXT PRIMARY KEY,guild_id INTEGER,public_message TEXT,public_directive TEXT,"
+                "mode TEXT,relay_lane TEXT,event_type TEXT,published_timestamp TEXT)"
+            )
+            conn.executemany(
+                "INSERT INTO website_relay_history VALUES (?,?,?,?,?,?,?,?)",
+                [
+                    ("relay-b", 1, "Second relay", "Follow the hook", "OBS", "signal", "accepted", "2026-07-18T01:00:00Z"),
+                    ("relay-a", 1, "First relay", "Watch the room", "OBS", "signal", "accepted", "2026-07-18 00:00:00"),
+                    ("other-guild", 2, "Ignore", "Ignore", "OBS", "signal", "accepted", "2026-07-18T00:00:00Z"),
+                ],
+            )
+            conn.execute(
+                "CREATE TABLE conversations("
+                "id INTEGER PRIMARY KEY,user_id INTEGER,user_name TEXT,guild_id INTEGER,channel_name TEXT,"
+                "channel_policy TEXT,channel_id INTEGER,message_id INTEGER,role TEXT,content TEXT,timestamp TEXT,"
+                "public_usable INTEGER,visibility TEXT)"
+            )
+            conn.executemany(
+                "INSERT INTO conversations VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                [
+                    (1, 7, "KnownUser", 1, "general-chat", "public_home", 10, 777001, "user", "KnownUser shared a https://example.com hook", "2026-07-18T02:00:00+00:00", 1, "public_safe"),
+                    (2, 8, "OtherUser", 1, "wips", "public_context", 11, None, "user", "OtherUser answered KnownUser", "2026-07-18 02:01:00", 1, "public"),
+                    (3, 9, "PrivateUser", 1, "staff", "internal_controlled", 12, 777003, "user", "private", "2026-07-18T02:02:00Z", 1, "public_safe"),
+                    (4, 10, "Bot", 1, "general-chat", "public_home", 10, 777004, "model", "model output", "2026-07-18T02:03:00Z", 1, "public_safe"),
+                    (5, 11, "Unsafe", 1, "general-chat", "public_home", 10, 777005, "user", "unsafe", "2026-07-18T02:04:00Z", 0, "public_safe"),
+                    (6, 12, "Hidden", 1, "general-chat", "public_home", 10, 777006, "user", "hidden", "2026-07-18T02:05:00Z", 1, "internal"),
+                    (7, 13, "Broken", 1, "general-chat", "public_home", 10, 777007, "user", "bad time", "not-a-time", 1, "public_safe"),
+                    (8, 14, "MalformedId", 1, "general-chat", "public_home", 10, "not-a-message-id", "user", "valid public content", "2026-07-18T02:06:00Z", 1, "public_safe"),
+                ],
+            )
+
+        first = store.backfill_legacy_sources(self.db, 1)
+        second = store.backfill_legacy_sources(self.db, 1)
+        result = store.query_source_events(self.db, 1, 0, 9_999_999_999_999)
+
+        self.assertEqual(5, first.inserted)
+        self.assertEqual(0, first.idempotent)
+        self.assertEqual(2, first.relay_rows_scanned)
+        self.assertEqual(4, first.conversation_rows_scanned)
+        self.assertEqual(1, first.invalid_timestamps)
+        self.assertEqual(1, first.skipped)
+        self.assertEqual(0, second.inserted)
+        self.assertEqual(0, second.idempotent)
+        self.assertEqual(0, second.relay_rows_scanned)
+        self.assertEqual(0, second.conversation_rows_scanned)
+        self.assertEqual(5, result.counts["total"])
+        discord = {e["source_key"]: e for e in result.events if e["source_kind"] == "discord_message"}
+        self.assertIn("777001", discord)
+        self.assertIn("legacy_row:2", discord)
+        self.assertIn("legacy_row:8", discord)
+        self.assertEqual("KnownUser shared a https://example.com hook", discord["777001"]["raw_text"])
+        self.assertNotIn("KnownUser", discord["777001"]["sanitized_summary"])
+        self.assertNotIn("example.com", discord["777001"]["sanitized_summary"])
+        self.assertEqual(777001, discord["777001"]["metadata"]["legacyMessageId"])
+
+    def test_legacy_relay_backfill_recovers_late_insert_with_older_timestamp(self):
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "CREATE TABLE website_relay_history("
+                "relay_id TEXT PRIMARY KEY,guild_id INTEGER,public_message TEXT,public_directive TEXT,"
+                "mode TEXT,relay_lane TEXT,event_type TEXT,published_timestamp TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO website_relay_history VALUES (?,?,?,?,?,?,?,?)",
+                ("newer", 1, "Newer relay", "", "OBS", "signal", "accepted", "2026-07-18T02:00:00Z"),
+            )
+
+        first = store.backfill_legacy_sources(self.db, 1)
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "INSERT INTO website_relay_history VALUES (?,?,?,?,?,?,?,?)",
+                ("late-old", 1, "Late hydrated relay", "", "OBS", "hydrated", "accepted", "2026-07-18T01:00:00Z"),
+            )
+        second = store.backfill_legacy_sources(self.db, 1)
+        result = store.query_source_events(self.db, 1, 0, 9_999_999_999_999)
+
+        self.assertEqual(1, first.inserted)
+        self.assertEqual(1, second.relay_rows_scanned)
+        self.assertEqual(1, second.inserted)
+        self.assertEqual({"newer", "late-old"}, {event["source_key"] for event in result.events})
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(
+                2,
+                conn.execute(
+                    "SELECT legacy_relay_cursor_rowid FROM bnl_journal_source_archive_state WHERE guild_id=1"
+                ).fetchone()[0],
+            )
+
+    def test_explicit_user_and_guild_purges_preserve_normal_immutability(self):
+        self._record("user-7", subject_ref="discord_user:7")
+        self._record("user-8", subject_ref="discord_user:8")
+        self._record("other-guild", guild_id=2, subject_ref="discord_user:7")
+        self._record(
+            "relay-1",
+            source_kind="website_relay",
+            subject_ref="bnl_01",
+            channel_policy="public_relay",
+        )
+        with sqlite3.connect(self.db) as conn:
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute("DELETE FROM bnl_journal_source_events WHERE source_key='user-7'")
+
+        self.assertEqual(1, store.purge_user_discord_sources(self.db, 1, 7))
+        guild_one = store.query_source_events(self.db, 1, 0, 9_999_999_999_999)
+        self.assertEqual({"user-8", "relay-1"}, {event["source_key"] for event in guild_one.events})
+
+        self.assertEqual(1, store.purge_guild_discord_sources(self.db, 1))
+        guild_one = store.query_source_events(self.db, 1, 0, 9_999_999_999_999)
+        guild_two = store.query_source_events(self.db, 2, 0, 9_999_999_999_999)
+        self.assertEqual({"relay-1"}, {event["source_key"] for event in guild_one.events})
+        self.assertEqual({"other-guild"}, {event["source_key"] for event in guild_two.events})
+        with sqlite3.connect(self.db) as conn:
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute("DELETE FROM bnl_journal_source_events WHERE source_key='relay-1'")
+
+    def test_legacy_backfill_supports_current_minimal_conversation_schema(self):
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "CREATE TABLE conversations("
+                "id INTEGER PRIMARY KEY,user_id INTEGER,user_name TEXT,guild_id INTEGER,channel_name TEXT,"
+                "channel_policy TEXT,role TEXT,content TEXT,timestamp TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO conversations VALUES (1,7,'User',1,'general-chat','public_home','user','hello','2026-07-18 00:00:00')"
+            )
+
+        backfill = store.backfill_legacy_sources(self.db, 1)
+        result = store.query_source_events(self.db, 1, 0, 9_999_999_999_999)
+
+        self.assertEqual(1, backfill.inserted)
+        self.assertEqual("legacy_row:1", result.events[0]["source_key"])
+        self.assertIsNone(result.events[0]["channel_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_governance_v1.py
+++ b/tests/test_memory_governance_v1.py
@@ -153,6 +153,17 @@ def test_view_authorization_redaction_and_correct_rejects_unauthorized():
 def test_complete_delete_real_schemas_shared_moment_repeat_receipt_and_rollback():
     c = make_conn(); insert(c, eid='mine', value='delete me', pred='preference'); insert(c, user=11, eid='other', value='keep other', pred='preference')
     c.execute("CREATE TABLE conversations (id INTEGER PRIMARY KEY, guild_id INTEGER, user_id INTEGER, content TEXT)"); c.execute("INSERT INTO conversations VALUES (1,1,10,'secret')")
+    c.execute("CREATE TABLE bnl_journal_source_events (event_seq INTEGER PRIMARY KEY, guild_id INTEGER NOT NULL, source_kind TEXT NOT NULL, subject_ref TEXT NOT NULL)")
+    c.execute("CREATE TRIGGER trg_bnl_journal_sources_no_delete BEFORE DELETE ON bnl_journal_source_events BEGIN SELECT RAISE(ABORT, 'bnl_journal_source_events_immutable'); END")
+    c.executemany(
+        "INSERT INTO bnl_journal_source_events VALUES (?,?,?,?)",
+        [
+            (1, 1, 'discord_message', 'discord_user:10'),
+            (2, 1, 'discord_message', 'discord_user:11'),
+            (3, 2, 'discord_message', 'discord_user:10'),
+            (4, 1, 'website_relay', 'discord_user:10'),
+        ],
+    )
     c.execute("CREATE TABLE response_style_log (id INTEGER, guild_id INTEGER, user_id INTEGER, style_key TEXT)"); c.execute("INSERT INTO response_style_log VALUES (1,1,10,'x')")
     c.execute("CREATE TABLE memory_moment_windows (moment_id TEXT, guild_id INTEGER, lifecycle_status TEXT, summary TEXT, updated_at TEXT)")
     c.execute("CREATE TABLE memory_moment_members (moment_id TEXT, ledger_entry_id TEXT)")
@@ -167,18 +178,128 @@ def test_complete_delete_real_schemas_shared_moment_repeat_receipt_and_rollback(
     except RuntimeError:
         pass
     assert c.execute("SELECT COUNT(*) FROM conversations WHERE user_id=10").fetchone()[0] == 1
+    assert c.execute("SELECT COUNT(*) FROM bnl_journal_source_events WHERE event_seq=1").fetchone()[0] == 1
     res = complete_delete_member_data(c, guild_id=1, user_id=10, confirmation='DELETE MY BNL DATA 1')
     assert res['ok']
+    assert res['row_counts']['bnl_journal_source_events'] == 1
     assert c.execute("SELECT COUNT(*) FROM conversations WHERE user_id=10").fetchone()[0] == 0
+    assert {row[0] for row in c.execute("SELECT event_seq FROM bnl_journal_source_events")} == {2, 3, 4}
     assert c.execute("SELECT COUNT(*) FROM memory_moment_participants WHERE participant_key=?", (subject_key_for_user(10),)).fetchone()[0] == 0
     assert c.execute("SELECT COUNT(*) FROM memory_moment_participants WHERE participant_key=?", (subject_key_for_user(11),)).fetchone()[0] == 1
     assert c.execute("SELECT summary,lifecycle_status FROM memory_moment_windows WHERE moment_id='m1'").fetchone() == ('', 'needs_review')
     receipt_row = c.execute("SELECT subject_hash,row_counts_json FROM memory_governance_receipts WHERE action='complete_delete'").fetchone()
     assert str(10) not in receipt_row[0] and 'secret' not in receipt_row[1]
-    import json; json.loads(receipt_row[1])
+    import json; assert json.loads(receipt_row[1])['bnl_journal_source_events'] == 1
+    try:
+        c.execute("DELETE FROM bnl_journal_source_events WHERE event_seq=2")
+        assert False, 'archive delete guard was not restored'
+    except sqlite3.IntegrityError:
+        c.rollback()
     c.execute("INSERT INTO conversations VALUES (2,1,10,'new secret')"); c.commit()
     assert complete_delete_member_data(c, guild_id=1, user_id=10, confirmation='DELETE MY BNL DATA 1')['ok']
     assert c.execute("SELECT COUNT(*) FROM conversations WHERE user_id=10").fetchone()[0] == 0
+
+
+def test_complete_delete_lays_journal_privacy_groundwork_without_touching_published_prose():
+    import json
+
+    c = make_conn()
+    c.executescript("""
+        CREATE TABLE bnl_journal_source_events (
+            event_seq INTEGER PRIMARY KEY, guild_id INTEGER NOT NULL,
+            source_kind TEXT NOT NULL, subject_ref TEXT NOT NULL
+        );
+        CREATE TRIGGER trg_bnl_journal_sources_no_delete
+        BEFORE DELETE ON bnl_journal_source_events
+        BEGIN SELECT RAISE(ABORT, 'bnl_journal_source_events_immutable'); END;
+        CREATE TABLE bnl_journal_entries (
+            entry_id TEXT, revision INTEGER, guild_id INTEGER, lifecycle_state TEXT,
+            PRIMARY KEY(entry_id, revision)
+        );
+        CREATE TABLE bnl_journal_private_metadata (
+            entry_id TEXT, revision INTEGER, guild_id INTEGER, metadata_json TEXT,
+            lifecycle_state TEXT, updated_at TEXT, PRIMARY KEY(entry_id, revision)
+        );
+        CREATE TABLE bnl_journal_observations (
+            observation_id TEXT PRIMARY KEY, guild_id INTEGER,
+            aggregate_counts_json TEXT, topic_counts_json TEXT, subject_counts_json TEXT,
+            representative_sources_json TEXT, lifecycle_state TEXT,
+            journal_entry_id TEXT, journal_revision INTEGER, updated_at TEXT
+        );
+    """)
+    target = 'discord_user:10'
+    # The prefix-overlapping ID proves deletion uses exact identity matching.
+    other = 'discord_user:100'
+    c.executemany(
+        "INSERT INTO bnl_journal_source_events VALUES (?,?,?,?)",
+        [(1, 1, 'discord_message', target), (2, 1, 'discord_message', other)],
+    )
+    c.executemany(
+        "INSERT INTO bnl_journal_entries VALUES (?,?,?,?)",
+        [('published-entry', 1, 1, 'published'), ('target-draft', 1, 1, 'draft'), ('other-draft', 1, 1, 'draft')],
+    )
+
+    def metadata(subject, ref_id, summary):
+        return json.dumps({
+            'subjectRefs': [subject],
+            'supportingConversationRefs': [{'refId': ref_id, 'subjectRef': subject}],
+            'sourceSummaries': [{'refId': ref_id, 'summary': summary}],
+            'sourceRefIds': {'A': [ref_id]},
+            'topicTags': [summary],
+            'continuityNotes': [summary],
+        })
+
+    c.executemany(
+        "INSERT INTO bnl_journal_private_metadata VALUES (?,?,?,?,?,?)",
+        [
+            ('published-entry', 1, 1, metadata(target, 'fresh:1', 'secretword'), 'published', ''),
+            ('target-draft', 1, 1, metadata(target, 'fresh:1', 'secretword'), 'draft', ''),
+            ('other-draft', 1, 1, metadata(other, 'fresh:2', 'synthwave'), 'draft', ''),
+        ],
+    )
+    representatives = [
+        {'refId': 'fresh:1', 'sourceKind': 'conversation', 'subjectRef': target, 'summary': 'secretword'},
+        {'refId': 'fresh:2', 'sourceKind': 'conversation', 'subjectRef': other, 'summary': 'synthwave'},
+    ]
+    c.execute(
+        "INSERT INTO bnl_journal_observations VALUES (?,?,?,?,?,?,?,?,?,?)",
+        (
+            'obs-1', 1,
+            json.dumps({'eligibleConversations': 2, 'participants': 2, 'archivedSourceEvents': 2}),
+            json.dumps({'secretword': 1, 'synthwave': 1}),
+            json.dumps({target: 1, other: 1}), json.dumps(representatives),
+            'observed', 'target-draft', 1, '',
+        ),
+    )
+    c.commit()
+
+    try:
+        complete_delete_member_data(
+            c, guild_id=1, user_id=10,
+            confirmation='DELETE MY BNL DATA 1', inject_failure=True,
+        )
+    except RuntimeError:
+        pass
+    assert c.execute("SELECT COUNT(*) FROM bnl_journal_entries WHERE entry_id='target-draft'").fetchone()[0] == 1
+    assert target in c.execute("SELECT representative_sources_json FROM bnl_journal_observations").fetchone()[0]
+
+    result = complete_delete_member_data(c, guild_id=1, user_id=10, confirmation='DELETE MY BNL DATA 1')
+    assert result['ok']
+    assert c.execute("SELECT COUNT(*) FROM bnl_journal_entries WHERE entry_id='published-entry'").fetchone()[0] == 1
+    assert c.execute("SELECT COUNT(*) FROM bnl_journal_entries WHERE entry_id='target-draft'").fetchone()[0] == 0
+    assert c.execute("SELECT COUNT(*) FROM bnl_journal_entries WHERE entry_id='other-draft'").fetchone()[0] == 1
+    published_meta = c.execute("SELECT metadata_json FROM bnl_journal_private_metadata WHERE entry_id='published-entry'").fetchone()[0]
+    assert target not in published_meta and 'secretword' not in published_meta
+    observation = c.execute(
+        "SELECT aggregate_counts_json,topic_counts_json,subject_counts_json,representative_sources_json,journal_entry_id "
+        "FROM bnl_journal_observations WHERE observation_id='obs-1'"
+    ).fetchone()
+    assert json.loads(observation[0])['eligibleConversations'] == 1
+    assert json.loads(observation[1]) == {'synthwave': 1}
+    assert json.loads(observation[2]) == {other: 1}
+    assert all(item.get('subjectRef') != target for item in json.loads(observation[3]))
+    assert any(item.get('subjectRef') == other for item in json.loads(observation[3]))
+    assert observation[4] is None
 
 
 def test_clearhistory_wording_and_queue_subsystem_untouched_static():


### PR DESCRIPTION
## Summary

- add a durable, append-only Journal source archive in the bot database so source history no longer depends on Redis or the 25-item relay display window
- automatically publish complete Pacific-time daily summaries and weekly syntheses, with coverage gates, quiet-period handling, retries, idempotency, and continuity observations
- connect the bot to the website Journal control plane for pause flags, Run Now requests, leases, telemetry, and exact restoration of previously published entries
- preserve privacy deletion behavior for archived Discord sources while retaining non-personal relay history

## Operational behavior

- daily entries use one complete prior calendar day and become eligible after 4:15 AM Pacific
- weekly entries use the complete prior Monday-Sunday period and become eligible Monday after 5:00 AM Pacific
- incomplete pre-deployment windows are held rather than presented as complete summaries
- the existing 25-relay view remains bounded, while the underlying Journal archive is retained for long-term continuity
- `!bnl journal rehydrate` restores canonical locally published entries to the website after Redis loss without regenerating or revising them

## Validation

- focused Journal archive, automation, runtime-control, generation, and relay suites pass
- Python compilation passes, including Python 3.9-compatible syntax checks
- full bot suite: 933/935 tests pass; the same two `subject_memory_resolver` failures reproduce unchanged on the base commit

## Deployment dependency

Deploy the coordinated website Observation Center/control-plane PR first: https://github.com/6-Bit-01/barcode-network-site/pull/266. Then deploy this bot PR.
