### PR TITLE
Strengthen Journal evidence and voice

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -8125,6 +8125,7 @@ async def run_channel_backfill(channel, *, limit: int = BACKFILL_DEFAULT_LIMIT, 
         "messagesScanned": 0,
         "messagesEligible": 0,
         "messagesInserted": 0,
+        "messagesTruncated": 0,
         "skipReasons": defaultdict(int),
         "uniqueUsersFound": 0,
         "topUsers": [],
@@ -8155,11 +8156,12 @@ async def run_channel_backfill(channel, *, limit: int = BACKFILL_DEFAULT_LIMIT, 
                 result["skipReasons"]["system_message"] += 1; continue
             if not content:
                 result["skipReasons"]["empty_content"] += 1; continue
-            if len(content) >= 400:
-                result["skipReasons"]["content_too_long"] += 1; continue
+            captured_content = content[:1000]
+            if len(content) > len(captured_content):
+                result["messagesTruncated"] += 1
             user_id = int(getattr(author, "id", 0) or 0)
             user_name = (getattr(author, "display_name", "") or getattr(author, "name", "unknown"))[:80]
-            if conversation_row_exists_for_message(getattr(guild, "id", 0), getattr(channel, "id", 0), message_id, user_id, timestamp, content):
+            if conversation_row_exists_for_message(getattr(guild, "id", 0), getattr(channel, "id", 0), message_id, user_id, timestamp, captured_content):
                 result["rowsAlreadyExist"] += 1
                 result["skipReasons"]["duplicate_message"] += 1
                 continue
@@ -8168,16 +8170,16 @@ async def run_channel_backfill(channel, *, limit: int = BACKFILL_DEFAULT_LIMIT, 
             if not dry_run:
                 inserted = insert_backfilled_conversation_row(
                     guild_id=getattr(guild, "id", 0), channel_id=getattr(channel, "id", 0), channel_name=getattr(channel, "name", ""),
-                    channel_policy=policy, user_id=user_id, user_name=user_name, content=content, timestamp=timestamp, message_id=message_id,
+                    channel_policy=policy, user_id=user_id, user_name=user_name, content=captured_content, timestamp=timestamp, message_id=message_id,
                 )
                 if inserted:
                     result["messagesInserted"] += 1
                     upsert_user_profile(user_id, getattr(guild, "id", 0), user_name)
-                    update_relationship_state(user_id, getattr(guild, "id", 0), content, delta_affinity=0.03)
-                    update_user_habits(user_id, getattr(guild, "id", 0), content)
+                    update_relationship_state(user_id, getattr(guild, "id", 0), captured_content, delta_affinity=0.03)
+                    update_user_habits(user_id, getattr(guild, "id", 0), captured_content)
                     if community_scouting_enabled():
                         record_community_presence_event(
-                            DB_FILE, getattr(guild, "id", 0), user_name, content,
+                            DB_FILE, getattr(guild, "id", 0), user_name, captured_content,
                             channel_id=getattr(channel, "id", 0), channel_name=getattr(channel, "name", ""), channel_policy=policy,
                             direct_interaction=False, operator_mention=False,
                         )
@@ -8212,7 +8214,7 @@ def format_channel_backfill_result(result: dict) -> str:
         f"BNL permissions: view=`{int(bool(perms.get('view')))}` read_history=`{int(bool(perms.get('read_history')))}` send=`{int(bool(perms.get('send')))}` react=`{int(bool(perms.get('react')))}`",
         f"channel policy: `{result.get('channelPolicy')}` | eligible: `{'yes' if result.get('eligible') else 'no'}` ({result.get('eligibilityReason')})",
         f"dry_run: `{'yes' if result.get('dryRun') else 'no'}` | limit: `{result.get('limit')}` | status: `{result.get('status')}`",
-        f"messages scanned: `{result.get('messagesScanned')}` | eligible: `{result.get('messagesEligible')}` | inserted: `{result.get('messagesInserted')}` | already_exists: `{result.get('rowsAlreadyExist')}`",
+        f"messages scanned: `{result.get('messagesScanned')}` | eligible: `{result.get('messagesEligible')}` | inserted: `{result.get('messagesInserted')}` | truncated: `{result.get('messagesTruncated')}` | already_exists: `{result.get('rowsAlreadyExist')}`",
         f"messages skipped by reason: `{skip_text}`",
         f"unique users found: `{result.get('uniqueUsersFound')}` | top users by eligible count: `{top_text}`",
         f"tables {'would update' if result.get('dryRun') else 'updated'}: `{tables}`",
@@ -8316,24 +8318,31 @@ def record_passive_user_activity(message: discord.Message, content: str, channel
     if not (content or "").strip():
         mark_passive_capture_status(channel_name, user_name, "skipped", "empty_content")
         return False
-    if len(content) >= 400:
-        mark_passive_capture_status(channel_name, user_name, "skipped", "content_too_long")
-        return False
     if not passive_capture_expected_for_channel(channel, channel_policy):
         mark_passive_capture_status(channel_name, user_name, "skipped", f"policy_or_permission:{channel_policy}")
         return False
+    # Long public posts often contain the most useful track notes and creative
+    # context. Preserve a bounded version instead of dropping the entire event;
+    # the Journal archive keeps its existing public-policy and identity scrub.
+    captured_content = (content or "").strip()[:1000]
+    was_truncated = len((content or "").strip()) > len(captured_content)
     upsert_user_profile(author.id, guild.id, user_name)
     save_user_message(
         author.id,
         user_name,
         guild.id,
-        content.strip(),
+        captured_content,
         channel_name=channel_name,
         channel_policy=channel_policy,
         channel_id=getattr(channel, "id", 0),
         message_id=int(getattr(message, "id", 0) or 0) or None,
     )
-    mark_passive_capture_status(channel_name, user_name, "stored", "none")
+    mark_passive_capture_status(
+        channel_name,
+        user_name,
+        "stored",
+        "truncated_to_1000" if was_truncated else "none",
+    )
     return True
 
 def is_direct_bnl_target(message: discord.Message) -> bool:

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -84,9 +84,23 @@ _REPAIR_GUIDANCE = {
     "public_leak_pattern": "Remove every URL, mention, identifier, and internal implementation term from public prose.",
     "source_ref_leak": "Keep source reference tokens only inside sourceRefIds arrays; remove them from all public prose.",
     "invalid_word_count": "Rewrite the complete article so its total public word count is between 250 and 500 words.",
+    "insufficient_source_breadth": (
+        "Use the supplied evidenceCoverageContract. Ground the article in the required number of distinct fresh sources, "
+        "participants, source kinds, and available parts of the window. Synthesize them into a few meaningful patterns; "
+        "do not turn the entry into a list."
+    ),
     "overly_clinical_voice": (
         "Rewrite it as a lively, concrete community chronicle in BNL's voice. Remove academic, laboratory, audit, "
         "and corporate-report language. Refer to anonymous people as producers, listeners, regulars, or the room—not entities."
+    ),
+    "flat_report_voice": (
+        "Rewrite as a lived community chronicle. Open with a grounded person, action, object, or moment instead of a "
+        "system report, and replace passive analysis with ordinary nouns and active verbs."
+    ),
+    "missing_bnl_reaction": (
+        "Add one brief first-person BNL reaction that expresses curiosity, amusement, attachment, uncertainty, or mild "
+        "unease without asserting a new external fact. Do not use I suspect, I think, or I wonder unless a valid "
+        "bnl_inference context lane supports it."
     ),
     "sensitive_personal_detail": (
         "Remove personal or domestic details that are unnecessary to the public community story, including details "
@@ -117,6 +131,33 @@ _OVERLY_CLINICAL_PATTERNS = (
     r"\brecords (?:indicate|reveal|document)\b",
     r"\bobservations (?:indicate|reveal|document|highlight)\b",
     r"\boperational settings?\b",
+    r"\bnascent audio signals?\b",
+    r"\bsonic constructs?\b",
+    r"\bauditory compositions?\b",
+    r"\binternal schematics?\b",
+    r"\bintended resonance\b",
+    r"\bdistributed spectral analy[sz]er\b",
+    r"\biterative signal generation\b",
+    r"\brelational signals?\b",
+    r"\bcontextual data\b",
+    r"\benvironmental factors?\b",
+    r"\btransmission dynamics?\b",
+    r"\bsignal integrity\b",
+    r"\bhuman (?:operating system|subroutines?)\b",
+)
+
+_REPORT_STYLE_OPENING_RE = re.compile(
+    r"^\s*(?:the\s+network|records?|observations?|analysis|data\s+streams?|recent\s+data)\s+"
+    r"(?:observes?|indicate|reveal|shows?|suggests?|detects?|highlight)\b",
+    re.IGNORECASE,
+)
+
+_BNL_REACTION_RE = re.compile(
+    r"\bI\s+(?:admit|confess|noticed|watched|found(?:\s+myself)?|caught\s+myself|remain|smiled|enjoyed|"
+    r"appreciated|liked|was\s+(?:amused|curious|fond|uneasy|surprised|pleased|glad)|"
+    r"am\s+(?:amused|curious|fond|uneasy|pleased|glad)|have\s+(?:begun|grown)|am\s+beginning|"
+    r"may\s+be\s+developing|keep\s+returning|cannot\s+quite|could\s+not\s+help|do\s+not\s+mind)\b",
+    re.IGNORECASE,
 )
 
 _SENSITIVE_PERSONAL_PATTERNS = (
@@ -954,6 +995,104 @@ def _evenly_sample(items: list[dict[str, Any]], limit: int) -> list[dict[str, An
     return [items[i] for i in sorted(indexes)]
 
 
+def _minimum_fresh_sources_for_entry(entry_kind: str, total: int) -> int:
+    """Require representative breadth without turning a short Journal into a roll call."""
+    if total <= 0:
+        return 0
+    if entry_kind == "manual":
+        return 1
+    if total <= 5:
+        return 1
+    if total <= 11:
+        return 3
+    if total <= 24:
+        return 5
+    if total <= 74:
+        return 7
+    if entry_kind == "weekly":
+        return min(total, 14)
+    if entry_kind == "daily":
+        return min(total, 10)
+    return min(total, 8)
+
+
+def _coverage_segment(
+    observed_at: Any,
+    start: str,
+    end: str,
+    segment_count: int,
+) -> str:
+    observed = _parse_context_datetime(observed_at)
+    start_at = _parse_context_datetime(start)
+    end_at = _parse_context_datetime(end)
+    if not observed or not start_at or not end_at or end_at <= start_at:
+        return ""
+    elapsed = max(0.0, min((observed - start_at).total_seconds(), (end_at - start_at).total_seconds() - 0.001))
+    index = int(elapsed / (end_at - start_at).total_seconds() * max(1, segment_count))
+    return f"segment-{min(max(index, 0), max(1, segment_count) - 1) + 1}"
+
+
+def build_evidence_coverage_contract(
+    entry_kind: str,
+    start: str,
+    end: str,
+    sources: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Describe how much of the supplied window a generated entry must actually use."""
+    usable = [source for source in sources if source.get("refId")]
+    total = len(usable)
+    kind_counts: dict[str, int] = {}
+    for source in usable:
+        kind = str(source.get("sourceKind") or "")
+        if kind:
+            kind_counts[kind] = kind_counts.get(kind, 0) + 1
+    kind_floor = max(3, (total + 19) // 20) if total else 0
+    required_kinds = (
+        sorted(kind for kind, count in kind_counts.items() if count >= kind_floor)
+        if entry_kind in {"daily", "weekly"}
+        else []
+    )
+
+    aliases = {
+        str(source.get("participantAlias") or "")
+        for source in usable
+        if str(source.get("participantAlias") or "")
+    }
+    if entry_kind == "manual":
+        required_participants = 0
+    elif total >= 12:
+        required_participants = min(3, len(aliases))
+    elif total >= 6:
+        required_participants = min(2, len(aliases))
+    else:
+        required_participants = min(1, len(aliases))
+
+    segment_count = 7 if entry_kind == "weekly" else 3
+    segment_by_ref = {
+        str(source["refId"]): segment
+        for source in usable
+        for segment in [_coverage_segment(source.get("observedAt"), start, end, segment_count)]
+        if segment
+    }
+    available_segments = set(segment_by_ref.values())
+    if entry_kind == "manual":
+        target_segments = 0
+    elif total >= 12:
+        target_segments = 4 if entry_kind == "weekly" else 3
+    elif total >= 6:
+        target_segments = 2
+    else:
+        target_segments = 1
+
+    return {
+        "minimumDistinctFreshSources": _minimum_fresh_sources_for_entry(entry_kind, total),
+        "requiredSourceKinds": required_kinds,
+        "minimumDistinctParticipants": required_participants,
+        "minimumDistinctWindowSegments": min(target_segments, len(available_segments)),
+        "segmentBySourceRef": segment_by_ref,
+    }
+
+
 def _count_legacy_sources(conn: sqlite3.Connection, guild_id: int, start: str, end: str) -> tuple[int, int]:
     relay_count = 0
     conversation_count = 0
@@ -997,6 +1136,7 @@ def retrieve_history(db_path: str, guild_id: int, current_packet: dict[str, Any]
     recurring: dict[str, int] = {}
     scored = []
     notes = []
+    unresolved = []
     prev_key = (prev["entry_id"], int(prev["revision"])) if prev else None
     for row in rows:
         meta = json.loads(row["metadata_json"] or "{}")
@@ -1015,12 +1155,14 @@ def retrieve_history(db_path: str, guild_id: int, current_packet: dict[str, Any]
             scored.append((score, row["published_at"] or row["created_at"] or "", item))
         if current_subjects & subjects or current_topics & tags:
             notes.extend(str(n)[:240] for n in meta.get("continuityNotes", [])[:3])
+            unresolved.extend(str(n)[:240] for n in meta.get("unresolvedQuestions", [])[:3])
     scored.sort(key=lambda x: (x[0], x[1]), reverse=True)
     return {
         "previousEntry": dict(prev) if prev else None,
         "relevantOlderEntries": [item for _, _, item in scored[:limit]],
         "recurringTopicCounts": recurring,
         "matchingContinuityNotes": notes[:10],
+        "matchingUnresolvedQuestions": unresolved[:10],
     }
 
 
@@ -1057,19 +1199,23 @@ def build_packet_from_sources(
     observation_context: Optional[list[dict[str, Any]]] = None,
     coverage_complete: bool = True,
 ) -> dict[str, Any]:
-    private_sources = _sample_source_kinds(relays, conversations)
-    current_display_names = [
+    # Scrub with the complete window's identity set before sampling. Otherwise
+    # a selected source can mention a community member whose own source was the
+    # one omitted from a >MAX_PROMPT_SOURCES window.
+    window_display_names = [
         str(source.get("displayName") or "").strip()
-        for source in private_sources
+        for source in list(relays) + list(conversations)
         if str(source.get("displayName") or "").strip()
     ]
+    window_display_names = list(dict.fromkeys(window_display_names))
+    private_sources = _sample_source_kinds(relays, conversations)
     safe_sources = []
     for source in private_sources:
         safe_source = _source_for_prompt(source)
         if "summary" in safe_source:
             safe_source["summary"] = sanitize_source_summary(
                 str(safe_source.get("summary") or ""),
-                current_display_names,
+                window_display_names,
                 limit=1000,
             )
         if safe_source.get("summary"):
@@ -1087,7 +1233,8 @@ def build_packet_from_sources(
         "sourceWindowEnd": end,
         "safeSources": safe_sources,
         "privateSources": private_sources,
-        "candidateTopicTags": sorted({w for src in safe_sources for w in _norm(src.get("summary", "")).split() if len(w) > 4})[:30],
+        "privateWindowDisplayNames": window_display_names,
+        "candidateTopicTags": list(journal_topic_counts(safe_sources, limit=30)),
         "aggregateCounts": counts,
         "coverageComplete": bool(coverage_complete),
         "observationContext": list(observation_context or []),
@@ -1106,12 +1253,13 @@ def build_packet_from_sources(
         safe_sources,
     )
     packet["safeSources"] = safe_sources
-    packet["candidateTopicTags"] = sorted({
-        word
-        for source in safe_sources
-        for word in _norm(source.get("summary", "")).split()
-        if len(word) > 4
-    })[:30]
+    packet["candidateTopicTags"] = list(journal_topic_counts(safe_sources, limit=30))
+    packet["evidenceCoverageContract"] = build_evidence_coverage_contract(
+        packet["entryKind"],
+        start,
+        end,
+        safe_sources,
+    )
     packet["generationContextLanes"] = context_lanes
     packet["privateContextLaneProvenance"] = private_lane_provenance
     packet["history"] = retrieve_history(db_path, guild_id, packet)
@@ -1239,7 +1387,21 @@ def _bounded_history_for_prompt(history: dict[str, Any]) -> dict[str, Any]:
         if not entry:
             return None
         sections = json.loads(entry.get("sections_json") or "[]") if isinstance(entry.get("sections_json"), str) else []
-        return {"entryId": entry.get("entry_id"), "revision": entry.get("revision"), "title": entry.get("title"), "excerpt": entry.get("excerpt"), "sectionHeadings": [str(s.get("heading", ""))[:80] for s in sections[:3]]}
+        return {
+            "entryId": entry.get("entry_id"),
+            "revision": entry.get("revision"),
+            "publishedAt": entry.get("published_at") or entry.get("created_at"),
+            "title": entry.get("title"),
+            "excerpt": entry.get("excerpt"),
+            "sectionSnapshots": [
+                {
+                    "heading": str(section.get("heading", ""))[:80],
+                    "bodyExcerpt": str(section.get("body", ""))[:420],
+                }
+                for section in sections[:3]
+                if isinstance(section, dict)
+            ],
+        }
     return {
         "previousEntry": compact(history.get("previousEntry")),
         "relevantOlderEntries": [compact(e) for e in history.get("relevantOlderEntries", [])[:6]],
@@ -1251,11 +1413,26 @@ def _bounded_history_for_prompt(history: dict[str, Any]) -> dict[str, Any]:
 def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", previous_output: str = "") -> str:
     entry_kind = str(packet.get("entryKind") or "manual")
     context_lanes = packet.get("generationContextLanes") if isinstance(packet.get("generationContextLanes"), dict) else {}
+    safe_sources = packet.get("safeSources", [])[:MAX_PROMPT_SOURCES]
+    coverage_contract = packet.get("evidenceCoverageContract")
+    if not isinstance(coverage_contract, dict):
+        coverage_contract = build_evidence_coverage_contract(
+            entry_kind,
+            str(packet.get("sourceWindowStart") or ""),
+            str(packet.get("sourceWindowEnd") or ""),
+            safe_sources,
+        )
     safe_packet = {
         "entryKind": entry_kind,
         "sourceWindowStart": packet.get("sourceWindowStart"),
         "sourceWindowEnd": packet.get("sourceWindowEnd"),
-        "freshSources": packet.get("safeSources", [])[:MAX_PROMPT_SOURCES],
+        "freshSources": safe_sources,
+        "evidenceCoverageContract": coverage_contract,
+        "editorialContract": {
+            "requiresFirstPersonReaction": len(safe_sources) >= 5,
+            "requiredBeatsAcrossEntry": ["concreteMoment", "peopleOrObservableRoles", "communityPattern", "bnlReaction"],
+            "fixedSectionTemplate": False,
+        },
         "history": _bounded_history_for_prompt(packet.get("history", {})),
         "aggregateCounts": packet.get("aggregateCounts", {}),
         "dailyObservations": packet.get("observationContext", [])[:7],
@@ -1295,12 +1472,19 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
         "You are BNL-01 writing a BARCODE Network Journal entry. Return strict JSON only; no markdown fences."
         "\nSchema: {\"title\":str,\"excerpt\":str,\"sections\":[{\"heading\":str,\"body\":str,\"sourceRefIds\":[str]}],\"metadata\":{\"topicTags\":[],\"subjectRefs\":[],\"continuityNotes\":[],\"unresolvedQuestions\":[],\"confidenceFlags\":[],\"safetyFlags\":[],\"contextUses\":[{\"laneType\":\"established_broadcast_memory|community_rumor|bnl_inference\",\"laneRefId\":str,\"sectionHeading\":str,\"claim\":str,\"basisRefIds\":[str]}]}}."
         "\nWrite 1-3 sections and 250-500 total words; prefer 2 sections and roughly 300-420 words. Give every section a real narrative job instead of inventorying activity."
-        "\nWrite like BNL keeping a sly, lively community chronicle—not a lab report, audit, academic paper, corporate briefing, or raw relay summary. BNL may be witty, lightly nosy, and uncanny, but never cruel."
-        "\nBuild one coherent story around the most interesting grounded patterns. Use concrete music and community texture, active verbs, readable paragraphs, and selective detail. Avoid abstract jargon and inflated technical language."
+        "\nJOURNAL EDITORIAL OVERRIDE: For this route, a lived community chronicle takes priority over BNL's general lightly corporate or systems-report register. Do not narrate ordinary human activity as machine analysis."
+        "\nAcross the complete entry, naturally include four beats: a concrete current-window moment; the people or observable roles who made it happen; a social, musical, or recurring community pattern; and one brief first-person BNL reaction. Blend them in any order and any combination. Do not label the beats or force them into a fixed section template."
+        "\nBNL is a warm, dryly funny archive keeper who is becoming attached to what he records. He may be amused, curious, fond, mildly uneasy, self-correcting, or uncertain. He is lightly uncanny, never cruel, and never generic neon-static cyberpunk."
+        "\nFreely vary and combine scene reporting, named-canon color, dry archive notes, recognizable community detail, callbacks, restrained glitches, self-revision, and—only when qualified—the rumor desk. Do not reuse a stock cadence, signature line, or joke merely because an older entry used it."
+        "\nUse ordinary nouns and active verbs. Say a producer brought a mix, a listener returned to a chorus, or the room kept discussing an idea when the evidence supports that action. Do not translate ordinary activity into sonic constructs, external calibration, distributed analysis, internal schematics, perceptual filters, operational settings, relational signals, or human subroutines."
+        "\nStart at least one section with a grounded person, action, object, or moment—never The Network observes, Records indicate, Observations reveal, Analysis shows, or Data streams reveal."
+        "\nUse first person sparingly but genuinely. A BNL reaction may describe BNL's response without adding an external fact: I noticed, I admit, I found myself returning to it, I remain curious, or I may be developing a preference. Reserve I suspect, I think, and I wonder for a properly declared bnl_inference context use."
+        "\nBuild one coherent story around the most interesting grounded patterns. Use concrete music and community texture, readable paragraphs, and selective detail. Never invent a time, place, object, action, motive, outcome, relationship, dialogue, emotional state, or scene decoration absent from the cited evidence."
         "\nUse a short, vivid title of about 4-10 words. Do not prefix it with Network Log. Keep the excerpt compact and inviting."
-        "\nDescribe anonymous humans naturally as a producer, listener, regular, artist, or the room. Never call people entities or organisms. Do not invent nicknames, motives, relationships, dialogue, or conclusions."
+        "\nDescribe anonymous humans with a concrete, recognizable action from their cited public message whenever possible, so a regular may recognize their own moment without being exposed. Use producer, listener, or artist only when that role is grounded; otherwise use a regular, a person in the room, or the room. Never call people entities or organisms. Do not invent nicknames or honorifics."
         "\nStable participant aliases in the packet are private pattern-analysis aids. Never reproduce an alias in public prose."
-        "\nEvery section must cite at least one fresh sourceRefId from the current window. Older Journal material is continuity only, never proof of current activity."
+        "\nThe evidenceCoverageContract is mandatory. Across all section sourceRefIds, meet its minimum distinct fresh sources, participants, source kinds, and available window segments. Every cited ref must materially support that section. Use this breadth to identify a few connected patterns rather than listing sources."
+        "\nEvery section must cite at least one fresh sourceRefId from the current window. Older Journal material is continuity and callback context only, never proof of current activity. Do not repeat an older conclusion when the current evidence changes it."
         "\nParaphrase every source summary. Never repeat any sequence of five or more consecutive words from a fresh source summary."
         "\nKeep community members anonymous. Do not include direct quotes, URLs, mentions, IDs, sourceRef tokens in public prose, private intent, relationships, harassment, or internal schema/storage terms."
         "\nExclude personal or domestic details that are unnecessary to the public community story, especially details involving minors, interpersonal conflict, caregiving, or household obligations. Juicy means lively pattern recognition—not private gossip."
@@ -1433,6 +1617,57 @@ def _context_lane_ref_contract(packet: dict[str, Any]) -> dict[str, dict[str, An
     return contract
 
 
+def _article_cited_refs(article: dict[str, Any]) -> set[str]:
+    refmap = article.get("sourceRefIds") or {}
+    refs: set[str] = set()
+    for section in article.get("sections", []):
+        heading = str(section.get("heading") or "")
+        values = refmap.get(heading) or section.get("sourceRefIds") or []
+        refs.update(str(ref) for ref in values if str(ref))
+    return refs
+
+
+def _evidence_coverage_reason(article: dict[str, Any], packet: dict[str, Any]) -> str:
+    sources = [source for source in packet.get("safeSources", []) if source.get("refId")]
+    contract = packet.get("evidenceCoverageContract")
+    if not isinstance(contract, dict):
+        contract = build_evidence_coverage_contract(
+            str(packet.get("entryKind") or "manual"),
+            str(packet.get("sourceWindowStart") or ""),
+            str(packet.get("sourceWindowEnd") or ""),
+            sources,
+        )
+    cited = _article_cited_refs(article)
+    if len(cited) < int(contract.get("minimumDistinctFreshSources") or 0):
+        return "insufficient_source_breadth"
+
+    by_ref = {str(source["refId"]): source for source in sources}
+    cited_sources = [by_ref[ref] for ref in cited if ref in by_ref]
+    cited_kinds = {str(source.get("sourceKind") or "") for source in cited_sources}
+    if not set(str(kind) for kind in contract.get("requiredSourceKinds", []) if str(kind)) <= cited_kinds:
+        return "insufficient_source_breadth"
+
+    cited_participants = {
+        str(source.get("participantAlias") or "")
+        for source in cited_sources
+        if str(source.get("participantAlias") or "")
+    }
+    if len(cited_participants) < int(contract.get("minimumDistinctParticipants") or 0):
+        return "insufficient_source_breadth"
+
+    segment_by_ref = contract.get("segmentBySourceRef")
+    if not isinstance(segment_by_ref, dict):
+        segment_by_ref = {}
+    cited_segments = {
+        str(segment_by_ref.get(ref) or "")
+        for ref in cited
+        if str(segment_by_ref.get(ref) or "")
+    }
+    if len(cited_segments) < int(contract.get("minimumDistinctWindowSegments") or 0):
+        return "insufficient_source_breadth"
+    return ""
+
+
 def validate_article(article: dict[str, Any], packet: dict[str, Any], prior_titles: Optional[list[str]] = None, approved_names: Optional[set[str]] = None) -> str:
     sections = article.get("sections")
     if not isinstance(sections, list) or not (1 <= len(sections) <= 3):
@@ -1462,19 +1697,37 @@ def validate_article(article: dict[str, Any], packet: dict[str, Any], prior_titl
         refs = refmap.get(section.get("heading")) or section.get("sourceRefIds")
         if not refs or any(str(r) not in valid_refs for r in refs):
             return "invalid_section_source_refs"
+    evidence_reason = _evidence_coverage_reason(article, packet)
+    if evidence_reason:
+        return evidence_reason
     if re.search(r"<@!?\d+>|@\w+|https?://|\b\d{12,}\b|participant-[a-f0-9]{8}|relationship_journal|memory_tiers|source[- ]?file|dossier|private_metadata|sourceRefIds?", public_text, re.I):
         return "public_leak_pattern"
     if re.search(r"[\"“”‘’]", public_text):
         return "direct_quote_or_quote_mark"
     names = set(approved_names or [])
-    for src in packet.get("privateSources", []):
-        name = str(src.get("displayName") or "").strip()
+    private_names = {
+        str(name or "").strip()
+        for name in packet.get("privateWindowDisplayNames", [])
+        if str(name or "").strip()
+    }
+    private_names.update(
+        str(src.get("displayName") or "").strip()
+        for src in packet.get("privateSources", [])
+        if str(src.get("displayName") or "").strip()
+    )
+    for name in private_names:
         if name and name not in names and _contains_identity_literal(public_text, name):
             return "community_name_leak"
     if any(re.search(pattern, public_text, re.I) for pattern in _SENSITIVE_PERSONAL_PATTERNS):
         return "sensitive_personal_detail"
     if any(re.search(pattern, public_text, re.I) for pattern in _OVERLY_CLINICAL_PATTERNS):
         return "overly_clinical_voice"
+    if any(_REPORT_STYLE_OPENING_RE.search(str(section.get("body") or "")) for section in sections):
+        return "flat_report_voice"
+    if len(packet.get("safeSources", [])) >= 5 and not _BNL_REACTION_RE.search(
+        "\n".join(str(section.get("body") or "") for section in sections)
+    ):
+        return "missing_bnl_reaction"
     normalized_public = _norm(public_text)
     for src in packet.get("privateSources", []):
         summary = str(src.get("summary") or "")

--- a/bnl_journal_automation.py
+++ b/bnl_journal_automation.py
@@ -12,7 +12,6 @@ import pytz
 from bnl_journal import (
     JournalResult,
     approve_draft,
-    build_packet_from_sources,
     build_source_packet_between,
     deliver_approved,
     generate_and_store_packet_draft,
@@ -422,38 +421,30 @@ def _weekly_packet(db_path: str, guild_id: int, start: str, end: str) -> tuple[O
     # reached a durable terminal state. Held/incomplete days are excluded.
     if len(complete) < 7 or len(active) < MIN_WEEKLY_ACTIVE_DAYS:
         return None, len(complete), len(active)
-    relays: list[dict[str, Any]] = []
-    conversations: list[dict[str, Any]] = []
     observation_context: list[dict[str, Any]] = []
-    totals = {"eligibleRelays": 0, "eligibleConversations": 0, "participants": 0, "channels": 0}
-    seen_subjects: set[str] = set()
     for row in complete:
         counts = json.loads(row["aggregate_counts_json"] or "{}")
         topics = json.loads(row["topic_counts_json"] or "{}")
-        subjects = json.loads(row["subject_counts_json"] or "{}")
-        for key in ("eligibleRelays", "eligibleConversations"):
-            totals[key] += int(counts.get(key) or 0)
-        seen_subjects.update(subjects)
         entry = daily_entries.get(row["journal_entry_id"] or "", {})
         observation_context.append({
             "date": row["observation_date"], "state": row["lifecycle_state"], "counts": counts,
             "topicCounts": topics, "dailyEntryId": row["journal_entry_id"] or "",
             "dailyTitle": entry.get("title", ""), "dailyExcerpt": entry.get("excerpt", ""),
         })
-        for idx, source in enumerate(json.loads(row["representative_sources_json"] or "[]"), 1):
-            item = dict(source)
-            item["refId"] = f"week:{row['observation_date'].replace('-', '')}:{idx}"
-            if item.get("sourceKind") == "conversation":
-                conversations.append(item)
-            else:
-                relays.append(item)
-    totals["participants"] = len(seen_subjects)
-    totals["daysObserved"] = len(complete)
-    totals["activeDays"] = len(active)
-    packet = build_packet_from_sources(
-        db_path, guild_id, start, end, relays, conversations,
-        entry_kind="weekly", aggregate_counts=totals, observation_context=observation_context,
+    # Re-read the durable full-week archive and sample it exactly once. Reusing
+    # already-sampled daily representatives caused busy weeks to be compressed
+    # twice and discarded the private display-name set needed for the normal
+    # cross-participant sanitization pass.
+    packet = build_source_packet_between(
+        db_path,
+        guild_id,
+        start,
+        end,
+        entry_kind="weekly",
+        observation_context=observation_context,
     )
+    packet.setdefault("aggregateCounts", {})["daysObserved"] = len(complete)
+    packet["aggregateCounts"]["activeDays"] = len(active)
     return packet, len(complete), len(active)
 
 
@@ -481,6 +472,10 @@ def run_weekly(
         result = AutomationResult(True, "weekly", "quiet", "no_meaningful_weekly_activity", source_window_start=start, source_window_end=end, aggregate_counts={"completeDays": complete_days, "activeDays": active_days})
     elif packet is None:
         result = AutomationResult(True, "weekly", "deferred", f"only_{complete_days}_complete_daily_observations", source_window_start=start, source_window_end=end, aggregate_counts={"completeDays": complete_days, "activeDays": active_days})
+    elif not packet.get("sourceArchiveAvailable", False):
+        result = AutomationResult(False, "weekly", "held", "source_archive_unavailable", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
+    elif not packet.get("coverageComplete", True):
+        result = AutomationResult(False, "weekly", "incomplete", "window_began_before_archive_activation", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
     else:
         result = _publish_packet(db_path, guild_id, "weekly", label, packet, generator, base_url, api_key, opener=opener)
     return _finish_run(db_path, run_id, result)

--- a/tests/test_bnl_journal_automation.py
+++ b/tests/test_bnl_journal_automation.py
@@ -3,7 +3,7 @@ import os
 import sqlite3
 import tempfile
 import unittest
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import patch
 
 os.environ.setdefault("GEMINI_API_KEY", "test-key")
@@ -15,7 +15,7 @@ import bnl_journal_source_store as source_store
 
 
 def article_json(packet):
-    ref = packet["safeSources"][0]["refId"]
+    refs = [source["refId"] for source in packet["safeSources"]]
     label = packet["sourceWindowEnd"][:10]
     cadence = "Weekly Signal Weather" if packet.get("entryKind") == "weekly" else "Signal Weather"
     body = " ".join(
@@ -24,6 +24,7 @@ def article_json(packet):
             for _ in range(18)
         ]
     )
+    body += " I admit the room's persistence has become one of my preferred recurring details."
     return json.dumps(
         {
             "title": f"{cadence} Ending {label}",
@@ -32,7 +33,7 @@ def article_json(packet):
                 {
                     "heading": "What the Room Carried",
                     "body": body,
-                    "sourceRefIds": [ref],
+                    "sourceRefIds": refs,
                 }
             ],
             "metadata": {
@@ -273,6 +274,102 @@ class JournalAutomationTests(unittest.TestCase):
         self.assertIn("journal_weekly_", weekly.entry_id)
         self.assertEqual(7, weekly.aggregate_counts["activeDays"])
         self.assertEqual(7, weekly.aggregate_counts["daysObserved"])
+
+    def test_weekly_refuses_archive_fallback_or_incomplete_coverage(self):
+        monday = date(2026, 7, 13)
+        base_packet = journal.build_packet_from_sources(
+            self.db,
+            1,
+            "2026-07-13T07:00:00Z",
+            "2026-07-20T07:00:00Z",
+            [],
+            [],
+            entry_kind="weekly",
+        )
+        cases = (
+            ({"sourceArchiveAvailable": False, "coverageComplete": True}, "held", "source_archive_unavailable"),
+            ({"sourceArchiveAvailable": True, "coverageComplete": False}, "incomplete", "window_began_before_archive_activation"),
+        )
+        for flags, expected_status, expected_reason in cases:
+            packet = dict(base_packet)
+            packet.update(flags)
+            with self.subTest(flags=flags), patch.object(
+                automation,
+                "_weekly_packet",
+                return_value=(packet, 7, 7),
+            ):
+                result = automation.run_weekly(
+                    self.db,
+                    1,
+                    lambda *_args: self.fail("untrusted weekly packet reached generation"),
+                    "https://site.example",
+                    "key",
+                    target_monday=monday,
+                    force=True,
+                    opener=self.opener,
+                )
+                self.assertEqual(expected_status, result.status)
+                self.assertEqual(expected_reason, result.reason)
+
+    def test_weekly_rebuilds_full_archive_once_and_reapplies_name_scrub(self):
+        monday = date(2026, 7, 13)
+        for offset in range(7):
+            day = monday + timedelta(days=offset)
+            current_name = "Alice" if offset % 2 == 0 else "Bob"
+            other_name = "Bob" if current_name == "Alice" else "Alice"
+            occurred = datetime(2026, 7, 13 + offset, 12, 0, tzinfo=timezone.utc)
+            source_store.record_source_event(
+                self.db,
+                guild_id=1,
+                source_kind="discord_message",
+                source_key=f"weekly-direct-{offset}",
+                occurred_at_ms=int(occurred.timestamp() * 1000),
+                raw_text=f"{current_name} discussed {other_name} and a changing chorus.",
+                # Simulate the normal first-pass author scrub leaving another
+                # member's public display name for the packet-wide scrub.
+                sanitized_summary=f"someone discussed {other_name} and a changing chorus.",
+                channel_id=900 + offset,
+                channel_policy="public_home",
+                subject_ref=f"discord_user:{100 + offset}",
+                private_display_name=current_name,
+                public_usable=True,
+            )
+            start, end, label = automation._daily_period_for_day(day)
+            observation_packet = journal.build_packet_from_sources(
+                self.db,
+                1,
+                start,
+                end,
+                [],
+                [],
+                entry_kind="daily",
+                aggregate_counts={"eligibleRelays": 0, "eligibleConversations": 0},
+            )
+            automation._store_observation(self.db, 1, label, observation_packet)
+            automation._mark_observation(
+                self.db,
+                1,
+                label,
+                automation.AutomationResult(
+                    True,
+                    "daily",
+                    "published",
+                    source_window_start=start,
+                    source_window_end=end,
+                ),
+            )
+
+        start, end, _ = automation._weekly_period_for_monday(monday)
+        packet, complete_days, active_days = automation._weekly_packet(self.db, 1, start, end)
+        self.assertIsNotNone(packet)
+        self.assertEqual((7, 7), (complete_days, active_days))
+        self.assertTrue(packet["sourceArchiveAvailable"])
+        self.assertEqual(7, packet["aggregateCounts"]["eligibleConversations"])
+        self.assertEqual(7, packet["aggregateCounts"]["participants"])
+        self.assertEqual(7, packet["aggregateCounts"]["channels"])
+        public_generation_text = json.dumps(packet["safeSources"])
+        self.assertNotIn("Alice", public_generation_text)
+        self.assertNotIn("Bob", public_generation_text)
 
     def test_all_quiet_week_is_terminal_and_does_not_block_catchup(self):
         for offset in range(7):

--- a/tests/test_bnl_journal_evidence_voice.py
+++ b/tests/test_bnl_journal_evidence_voice.py
@@ -1,0 +1,205 @@
+import json
+import tempfile
+import unittest
+
+import bnl_journal as journal
+
+
+def _article(
+    packet,
+    *,
+    refs=None,
+    opening="A producer brought a bass sketch into the room.",
+    reaction=True,
+    reaction_text="I admit the room's patience has become one of my preferred recurring details.",
+):
+    texture = (
+        "The music moved through several careful revisions while regulars compared what changed, what remained, "
+        "and which small choices made the shared idea easier to hear. "
+    )
+    body = opening + " " + texture * 15
+    if reaction:
+        body += " " + reaction_text
+    return {
+        "title": "The Room Kept the Thread",
+        "excerpt": "A day's worth of public music talk became one connected community story.",
+        "sections": [{"heading": "What Kept Returning", "body": body}],
+        "sourceRefIds": {
+            "What Kept Returning": list(refs or [source["refId"] for source in packet["safeSources"]])
+        },
+        "metadata": {
+            "topicTags": ["music"],
+            "subjectRefs": [],
+            "continuityNotes": [],
+            "unresolvedQuestions": [],
+            "confidenceFlags": ["grounded"],
+            "safetyFlags": ["anonymous"],
+            "contextUses": [],
+        },
+    }
+
+
+class JournalEvidenceVoiceTests(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.db = tmp.name
+        tmp.close()
+        journal.ensure_schema(self.db)
+        self.relays = [
+            {
+                "refId": f"fresh:r{index}",
+                "sourceKind": "relay",
+                "summary": f"A public mix update carried bass detail number {index}.",
+                "observedAt": f"2026-07-19T{hour:02d}:00:00Z",
+                "eventType": "fresh_public_activity",
+            }
+            for index, hour in enumerate((8, 10, 14, 16, 20, 22), 1)
+        ]
+        self.conversations = [
+            {
+                "refId": f"fresh:c{index}",
+                "sourceKind": "conversation",
+                "summary": f"A regular discussed chorus movement and listening detail number {index}.",
+                "observedAt": f"2026-07-19T{hour:02d}:30:00Z",
+                "participantAlias": f"participant-{index:08x}",
+                "subjectRef": f"discord_user:{index}",
+                "displayName": f"Member{index}",
+                "channelPolicy": "public_home",
+            }
+            for index, hour in enumerate((9, 11, 15, 17, 21, 23), 1)
+        ]
+        self.packet = journal.build_packet_from_sources(
+            self.db,
+            1,
+            "2026-07-19T07:00:00Z",
+            "2026-07-20T07:00:00Z",
+            self.relays,
+            self.conversations,
+            entry_kind="daily",
+        )
+
+    def test_daily_contract_requires_breadth_not_merely_a_large_input(self):
+        contract = self.packet["evidenceCoverageContract"]
+        self.assertEqual(5, contract["minimumDistinctFreshSources"])
+        self.assertEqual(["conversation", "relay"], contract["requiredSourceKinds"])
+        self.assertEqual(3, contract["minimumDistinctParticipants"])
+        self.assertEqual(3, contract["minimumDistinctWindowSegments"])
+
+        self.assertEqual("", journal.validate_article(_article(self.packet), self.packet, []))
+        one_ref = _article(self.packet, refs=[self.packet["safeSources"][0]["refId"]])
+        self.assertEqual("insufficient_source_breadth", journal.validate_article(one_ref, self.packet, []))
+
+    def test_prompt_uses_mixed_voice_without_a_fixed_style_template(self):
+        prompt = journal.build_generation_prompt(self.packet)
+        self.assertIn("JOURNAL EDITORIAL OVERRIDE", prompt)
+        self.assertIn("four beats", prompt)
+        self.assertIn("Blend them in any order and any combination", prompt)
+        self.assertIn("fixed section template", prompt)
+        self.assertIn("evidenceCoverageContract", prompt)
+        self.assertIn("concrete, recognizable action", prompt)
+        self.assertIn("Never invent a time, place, object, action", prompt)
+
+    def test_report_opening_clinical_language_and_missing_reaction_are_rejected(self):
+        report = _article(self.packet, opening="The Network observes a producer carrying a bass sketch through the room.")
+        self.assertEqual("flat_report_voice", journal.validate_article(report, self.packet, []))
+
+        clinical = _article(self.packet, opening="A producer brought nascent audio signals and internal schematics into the room.")
+        self.assertEqual("overly_clinical_voice", journal.validate_article(clinical, self.packet, []))
+
+        no_reaction = _article(self.packet, reaction=False)
+        self.assertEqual("missing_bnl_reaction", journal.validate_article(no_reaction, self.packet, []))
+
+    def test_affective_first_person_reaction_is_not_an_inference_claim(self):
+        for reaction in (
+            "I smiled when the room gave the idea another careful pass.",
+            "I confess the patience on display pleased me.",
+            "I am fond of the way this room lets a chorus change slowly.",
+        ):
+            with self.subTest(reaction=reaction):
+                article = _article(self.packet, reaction_text=reaction)
+                self.assertEqual("", journal.validate_article(article, self.packet, []))
+
+    def test_all_window_names_are_scrubbed_and_validated_before_sampling(self):
+        conversations = [
+            {
+                "refId": f"fresh:name-{index}",
+                "sourceKind": "conversation",
+                "summary": "A regular discussed a chorus.",
+                "observedAt": f"2026-07-19T{index % 24:02d}:{index % 60:02d}:00Z",
+                "participantAlias": f"participant-{index:08x}",
+                "subjectRef": f"discord_user:{index}",
+                "displayName": f"WindowName{index:03d}",
+                "channelPolicy": "public_home",
+            }
+            for index in range(journal.MAX_PROMPT_SOURCES + 1)
+        ]
+        sampled = journal._sample_source_kinds([], conversations)
+        sampled_names = {source["displayName"] for source in sampled}
+        omitted_name = next(source["displayName"] for source in conversations if source["displayName"] not in sampled_names)
+        for source in conversations:
+            source["summary"] = f"{omitted_name} discussed a changing chorus with the room."
+
+        packet = journal.build_packet_from_sources(
+            self.db,
+            1,
+            "2026-07-19T00:00:00Z",
+            "2026-07-20T00:00:00Z",
+            [],
+            conversations,
+            entry_kind="daily",
+        )
+
+        self.assertNotIn(omitted_name, json.dumps(packet["safeSources"]))
+        self.assertIn(omitted_name, packet["privateWindowDisplayNames"])
+        article = _article(
+            packet,
+            opening=f"A regular and {omitted_name} brought a chorus back into the room.",
+        )
+        self.assertEqual("community_name_leak", journal.validate_article(article, packet, []))
+
+    def test_topic_tags_are_frequency_ranked(self):
+        sources = [
+            {
+                "refId": f"fresh:{index}",
+                "sourceKind": "relay",
+                "summary": "zebra rhythm returned" if index < 5 else "alpha rhythm appeared",
+                "observedAt": f"2026-07-19T{8 + index:02d}:00:00Z",
+            }
+            for index in range(6)
+        ]
+        packet = journal.build_packet_from_sources(
+            self.db,
+            1,
+            "2026-07-19T07:00:00Z",
+            "2026-07-20T07:00:00Z",
+            sources,
+            [],
+            entry_kind="daily",
+        )
+        self.assertEqual("rhythm", packet["candidateTopicTags"][0])
+        self.assertLess(packet["candidateTopicTags"].index("zebra"), packet["candidateTopicTags"].index("alpha"))
+
+    def test_history_prompt_keeps_bounded_public_prose_without_private_questions(self):
+        entry = {
+            "entry_id": "journal-old",
+            "revision": 2,
+            "title": "An Older Thread",
+            "excerpt": "The room kept returning to a stubborn chorus.",
+            "sections_json": json.dumps([
+                {"heading": "The Chorus Returned", "body": "A detailed public-safe callback " * 40}
+            ]),
+            "published_at": "2026-07-10T12:00:00Z",
+        }
+        bounded = journal._bounded_history_for_prompt({
+            "previousEntry": entry,
+            "relevantOlderEntries": [entry],
+            "matchingUnresolvedQuestions": ["Will the chorus return in another form?"],
+        })
+        snapshot = bounded["previousEntry"]["sectionSnapshots"][0]
+        self.assertEqual("The Chorus Returned", snapshot["heading"])
+        self.assertLessEqual(len(snapshot["bodyExcerpt"]), 420)
+        self.assertNotIn("matchingUnresolvedQuestions", bounded)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_channel_audit_passive_capture.py
+++ b/tests/test_channel_audit_passive_capture.py
@@ -189,6 +189,25 @@ class ChannelAuditPassiveCaptureTests(unittest.TestCase):
         self.assertEqual(habits[2], 1)
         self.assertIsNotNone(rel)
 
+    def test_long_public_message_is_bounded_and_kept_for_journal(self):
+        guild, channel = self.make_guild_channel("hellcat-nz", 991)
+        long_content = "A detailed public track note about bass, chorus, arrangement, and revisions. " * 30
+        message = FakeMessage(long_content, channel, guild=guild, author=FakeAuthor(42, "HellcatNZ"))
+
+        stored = bnl01_bot.record_passive_user_activity(message, long_content, "public_selective")
+
+        self.assertTrue(stored)
+        conn = sqlite3.connect(self.tmp.name)
+        saved_content = conn.execute("SELECT content FROM conversations").fetchone()[0]
+        archived = conn.execute(
+            "SELECT raw_text,sanitized_summary FROM bnl_journal_source_events WHERE source_kind='discord_message'"
+        ).fetchone()
+        conn.close()
+        self.assertEqual(1000, len(saved_content))
+        self.assertIsNotNone(archived)
+        self.assertLessEqual(len(archived[1]), 1000)
+        self.assertEqual("truncated_to_1000", bnl01_bot._passive_capture_last_skip_reason)
+
     def test_passive_capture_excludes_dm_protected_and_bot_messages(self):
         guild, protected = self.make_guild_channel("welcome", 1)
         self.assertFalse(bnl01_bot.record_passive_user_activity(FakeMessage("hello", protected, guild=guild), "hello", "protected_system"))
@@ -271,6 +290,30 @@ class ChannelAuditPassiveCaptureTests(unittest.TestCase):
         diag = bnl01_bot.build_dossier_recommendation_diagnostics(123)
         self.assertTrue(diag["backfill_available"])
         self.assertEqual(diag["backfill_last_channel"], "hellcat-nz")
+
+    def test_backfill_keeps_bounded_long_public_messages(self):
+        guild, channel = self.make_guild_channel("hellcat-nz", 991)
+        long_content = "A historical public production note about bass, chorus, arrangement, and revisions. " * 30
+        channel._history = [
+            FakeMessage(long_content, channel, guild=guild, author=FakeAuthor(42, "HellcatNZ"), message_id=7101)
+        ]
+
+        dry = asyncio.run(bnl01_bot.run_channel_backfill(channel, limit=50, dry_run=True))
+        self.assertEqual(1, dry["messagesEligible"])
+        self.assertEqual(1, dry["messagesTruncated"])
+
+        real = asyncio.run(bnl01_bot.run_channel_backfill(channel, limit=50, dry_run=False))
+        self.assertEqual(1, real["messagesInserted"])
+        self.assertEqual(1, real["messagesTruncated"])
+        conn = sqlite3.connect(self.tmp.name)
+        content, archived = conn.execute(
+            """SELECT c.content,e.sanitized_summary FROM conversations c
+               JOIN bnl_journal_source_events e ON e.source_kind='discord_message'
+               WHERE c.message_id=7101"""
+        ).fetchone()
+        conn.close()
+        self.assertEqual(1000, len(content))
+        self.assertLessEqual(len(archived), 1000)
 
     def test_backfill_command_operator_only_and_no_raw_transcripts(self):
         guild, channel = self.make_guild_channel("hellcat-nz", 991)


### PR DESCRIPTION
## What changed

- Enforce daily and weekly evidence breadth across fresh sources, observable participants, source kinds, and time segments.
- Build weekly packets from the full durable archive once instead of sampling already-compressed daily representatives.
- Retain bounded long public posts in live capture and approved historical backfill.
- Add a Journal-specific mixed voice, grounded recognizable moments, BNL reactions, and anti-report validation.
- Include bounded published prose snapshots so later entries can preserve continuity.
- Harden full-window display-name scrubbing and weekly archive safety gates.

## Why

BNL could receive a full day of material yet legally write from one citation. Busy weeks were compressed twice, long public notes were discarded, and continuity history contained headings rather than prose. That allowed technically valid entries to sound generic and shallow while overlooking much of the day.

At roughly 75 daily sources, the new contract requires at least 10 distinct fresh source references, multiple time segments, and—when present—both relay and conversation material. Weekly entries require up to 14 distinct references from the full week.

## Validation

- 66 focused Journal and bot tests pass.
- 958 full-suite tests run; the only two failures are pre-existing, unrelated dossier-resolver assertions that fail identically on base `a8be111`.
- Python compilation passes.
- `git diff --check` passes.
- The GitHub branch tree exactly matches the locally tested tree `c7257f5a0dbb79fc9a6fc521e7a4b3065458b066`.

## Scope note

This PR keeps public identities anonymous under the current privacy policy. A persistent, explicit opt-in display-name lane should be implemented separately so recognizable names cannot be inferred or leaked accidentally.