### PR TITLE
Honor Journal entry memory exclusions

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -5990,6 +5990,15 @@ def _journal_control_flags(control: dict | None, fallback: dict) -> dict:
             value = control.get(key, config.get(key))
             if isinstance(value, bool):
                 flags[key] = value
+        excluded = control.get("memoryExcludedEntryIds")
+        if isinstance(excluded, list):
+            flags["journalMemoryExcludedEntryIds"] = list(dict.fromkeys(
+                entry_id
+                for item in excluded
+                if isinstance(item, str)
+                for entry_id in [item.strip()]
+                if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,159}", entry_id)
+            ))
     return flags
 
 
@@ -6141,6 +6150,7 @@ async def run_journal_automation_once(
             effective_flags = flags
             if effective_flags is None:
                 effective_flags = await asyncio.to_thread(get_bnl_control_flags, force_refresh=force)
+            memory_excluded_entry_ids = set(effective_flags.get("journalMemoryExcludedEntryIds") or [])
             if not effective_flags.get("journalAutoPublishEnabled", True):
                 results = [_journal_control_result(cadence, "paused", "auto_publish_paused")]
             elif cadence == "daily" and not effective_flags.get("journalDailyEnabled", True):
@@ -6156,6 +6166,7 @@ async def run_journal_automation_once(
                     _journal_website_base_url(),
                     BNL_API_KEY,
                     force=force,
+                    memory_excluded_entry_ids=memory_excluded_entry_ids,
                 )
                 results = [journal_automation_result_dict(result)]
             elif cadence == "weekly":
@@ -6167,6 +6178,7 @@ async def run_journal_automation_once(
                     _journal_website_base_url(),
                     BNL_API_KEY,
                     force=force,
+                    memory_excluded_entry_ids=memory_excluded_entry_ids,
                 )
                 results = [journal_automation_result_dict(result)]
             else:
@@ -6336,7 +6348,16 @@ async def maybe_handle_journal_command(message: discord.Message, clean_content: 
             return True
         if action == "create":
             hours = _parse_journal_hours(options.get("hours") or options.get("window"))
-            result = await asyncio.to_thread(generate_and_store_journal_draft, DB_FILE, guild_id, hours, _generate_journal_json_sync)
+            control, _ = await asyncio.to_thread(_journal_control_request_sync, "GET")
+            flags = _journal_control_flags(control, {})
+            result = await asyncio.to_thread(
+                generate_and_store_journal_draft,
+                DB_FILE,
+                guild_id,
+                hours,
+                _generate_journal_json_sync,
+                excluded_history_entry_ids=set(flags.get("journalMemoryExcludedEntryIds") or []),
+            )
             if not result.ok:
                 await message.reply(f"Journal draft not created: `{result.reason}`")
                 return True
@@ -6345,7 +6366,17 @@ async def maybe_handle_journal_command(message: discord.Message, clean_content: 
         if action == "regenerate":
             entry_id = options.get("entry_id") or ""
             hours = _parse_journal_hours(options.get("hours") or options.get("window"))
-            result = await asyncio.to_thread(regenerate_journal_draft, DB_FILE, guild_id, entry_id, hours, _generate_journal_json_sync)
+            control, _ = await asyncio.to_thread(_journal_control_request_sync, "GET")
+            flags = _journal_control_flags(control, {})
+            result = await asyncio.to_thread(
+                regenerate_journal_draft,
+                DB_FILE,
+                guild_id,
+                entry_id,
+                hours,
+                _generate_journal_json_sync,
+                excluded_history_entry_ids=set(flags.get("journalMemoryExcludedEntryIds") or []),
+            )
             if not result.ok:
                 await message.reply(f"Journal regeneration failed: `{result.reason}`")
                 return True

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -1119,26 +1119,37 @@ def _subject_refs(packet: dict[str, Any]) -> set[str]:
     return {str(s.get("subjectRef")) for s in packet.get("privateSources", []) if s.get("subjectRef")}
 
 
-def retrieve_history(db_path: str, guild_id: int, current_packet: dict[str, Any], limit: int = 6) -> dict[str, Any]:
+def retrieve_history(
+    db_path: str,
+    guild_id: int,
+    current_packet: dict[str, Any],
+    limit: int = 6,
+    *,
+    excluded_entry_ids: Optional[set[str]] = None,
+) -> dict[str, Any]:
     ensure_schema(db_path)
+    excluded = {str(entry_id) for entry_id in (excluded_entry_ids or set()) if str(entry_id)}
     current_subjects = _subject_refs(current_packet)
     current_topics = set(current_packet.get("candidateTopicTags", []))
     terms = set(_norm(_json(current_packet.get("safeSources", []))).split())
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
-        prev = conn.execute("""SELECT entry_id,revision,title,excerpt,sections_json,published_at,created_at
+        prev_rows = conn.execute("""SELECT entry_id,revision,title,excerpt,sections_json,published_at,created_at
             FROM bnl_journal_entries WHERE guild_id=? AND lifecycle_state='published'
-            ORDER BY published_at DESC, created_at DESC LIMIT 1""", (guild_id,)).fetchone()
+            ORDER BY published_at DESC, created_at DESC""", (guild_id,)).fetchall()
         rows = conn.execute("""SELECT e.entry_id,e.revision,e.title,e.excerpt,e.sections_json,e.published_at,e.created_at,m.metadata_json
             FROM bnl_journal_entries e JOIN bnl_journal_private_metadata m
               ON m.entry_id=e.entry_id AND m.revision=e.revision
             WHERE e.guild_id=? AND e.lifecycle_state='published' AND m.lifecycle_state='published'""", (guild_id,)).fetchall()
+    prev = next((row for row in prev_rows if str(row["entry_id"]) not in excluded), None)
     recurring: dict[str, int] = {}
     scored = []
     notes = []
     unresolved = []
     prev_key = (prev["entry_id"], int(prev["revision"])) if prev else None
     for row in rows:
+        if str(row["entry_id"]) in excluded:
+            continue
         meta = json.loads(row["metadata_json"] or "{}")
         tags = {str(t) for t in meta.get("topicTags", [])}
         subjects = {str(s) for s in meta.get("subjectRefs", [])}
@@ -1198,6 +1209,7 @@ def build_packet_from_sources(
     aggregate_counts: Optional[dict[str, Any]] = None,
     observation_context: Optional[list[dict[str, Any]]] = None,
     coverage_complete: bool = True,
+    excluded_history_entry_ids: Optional[set[str]] = None,
 ) -> dict[str, Any]:
     # Scrub with the complete window's identity set before sampling. Otherwise
     # a selected source can mention a community member whose own source was the
@@ -1262,7 +1274,12 @@ def build_packet_from_sources(
     )
     packet["generationContextLanes"] = context_lanes
     packet["privateContextLaneProvenance"] = private_lane_provenance
-    packet["history"] = retrieve_history(db_path, guild_id, packet)
+    packet["history"] = retrieve_history(
+        db_path,
+        guild_id,
+        packet,
+        excluded_entry_ids=excluded_history_entry_ids,
+    )
     return packet
 
 
@@ -1274,6 +1291,7 @@ def build_source_packet_between(
     *,
     entry_kind: str = "daily",
     observation_context: Optional[list[dict[str, Any]]] = None,
+    excluded_history_entry_ids: Optional[set[str]] = None,
 ) -> dict[str, Any]:
     try:
         from bnl_journal_source_store import backfill_legacy_sources, query_source_events, timestamp_to_epoch_ms
@@ -1334,6 +1352,7 @@ def build_source_packet_between(
                 "archivedSourceEvents": int(archived.counts.get("total") or 0),
             },
             observation_context=observation_context,
+            excluded_history_entry_ids=excluded_history_entry_ids,
             # The archive activation watermark prevents the automatic
             # publisher from claiming a full day that began before durable
             # capture was enabled. Manual previews remain available during
@@ -1369,17 +1388,33 @@ def build_source_packet_between(
             "channels": len({x.get("channelPolicy") for x in conversations if x.get("channelPolicy")}),
         },
         observation_context=observation_context,
+        excluded_history_entry_ids=excluded_history_entry_ids,
         coverage_complete=relay_count <= MAX_RELAY_SOURCES_PER_WINDOW and conversation_count <= MAX_CONVERSATION_SOURCES_PER_WINDOW,
     )
     packet["sourceArchiveAvailable"] = False
     return packet
 
 
-def build_source_packet(db_path: str, guild_id: int, hours: int = 72, now: Optional[str] = None, *, entry_kind: str = "manual") -> dict[str, Any]:
+def build_source_packet(
+    db_path: str,
+    guild_id: int,
+    hours: int = 72,
+    now: Optional[str] = None,
+    *,
+    entry_kind: str = "manual",
+    excluded_history_entry_ids: Optional[set[str]] = None,
+) -> dict[str, Any]:
     bounded_hours = max(1, min(int(hours or 72), 168))
     end = now or utc_now_iso()
     start = (datetime.fromisoformat(end.replace("Z", "+00:00")) - timedelta(hours=bounded_hours)).isoformat().replace("+00:00", "Z")
-    return build_source_packet_between(db_path, guild_id, start, end, entry_kind=entry_kind)
+    return build_source_packet_between(
+        db_path,
+        guild_id,
+        start,
+        end,
+        entry_kind=entry_kind,
+        excluded_history_entry_ids=excluded_history_entry_ids,
+    )
 
 
 def _bounded_history_for_prompt(history: dict[str, Any]) -> dict[str, Any]:
@@ -2035,8 +2070,16 @@ def generate_and_store_draft(
     entry_id: str = "",
     entry_kind: str = "manual",
     now: Optional[str] = None,
+    excluded_history_entry_ids: Optional[set[str]] = None,
 ) -> JournalResult:
-    packet = build_source_packet(db_path, guild_id, hours, now, entry_kind=entry_kind)
+    packet = build_source_packet(
+        db_path,
+        guild_id,
+        hours,
+        now,
+        entry_kind=entry_kind,
+        excluded_history_entry_ids=excluded_history_entry_ids,
+    )
     return generate_and_store_packet_draft(db_path, guild_id, packet, generator, entry_id=entry_id)
 
 
@@ -2079,7 +2122,15 @@ def reject_draft(db_path: str, guild_id: int, entry_id: str, reason: str = "", r
 
 
 
-def regenerate_draft(db_path: str, guild_id: int, entry_id: str, hours: int, generator: Callable[[dict[str, Any], str], str]) -> JournalResult:
+def regenerate_draft(
+    db_path: str,
+    guild_id: int,
+    entry_id: str,
+    hours: int,
+    generator: Callable[[dict[str, Any], str], str],
+    *,
+    excluded_history_entry_ids: Optional[set[str]] = None,
+) -> JournalResult:
     ensure_schema(db_path)
     with sqlite3.connect(db_path) as conn:
         row = conn.execute(
@@ -2113,7 +2164,10 @@ def regenerate_draft(db_path: str, guild_id: int, entry_id: str, hours: int, gen
         except (AttributeError, TypeError, ValueError):
             original_entry_kind = None
     original_entry_kind = original_entry_kind or "manual"
-    packet = build_source_packet(db_path, guild_id, hours, entry_kind=original_entry_kind)
+    packet_kwargs: dict[str, Any] = {"entry_kind": original_entry_kind}
+    if excluded_history_entry_ids is not None:
+        packet_kwargs["excluded_history_entry_ids"] = excluded_history_entry_ids
+    packet = build_source_packet(db_path, guild_id, hours, **packet_kwargs)
     last_reason = ""
     previous_output = ""
     article: Optional[dict[str, Any]] = None

--- a/bnl_journal_automation.py
+++ b/bnl_journal_automation.py
@@ -379,6 +379,7 @@ def run_daily(
     target_day: Optional[date] = None,
     force: bool = False,
     opener=None,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
 ) -> AutomationResult:
     ensure_schema(db_path)
     start, end, label = _daily_period_for_day(target_day) if target_day else daily_period(now_utc)
@@ -387,7 +388,14 @@ def run_daily(
     claim, run_id, row = _claim_run(db_path, guild_id, "daily", start, end, force=force)
     if claim != "claimed":
         return _result_from_existing("daily", row, claim=claim)
-    packet = build_source_packet_between(db_path, guild_id, start, end, entry_kind="daily")
+    packet = build_source_packet_between(
+        db_path,
+        guild_id,
+        start,
+        end,
+        entry_kind="daily",
+        excluded_history_entry_ids=memory_excluded_entry_ids,
+    )
     _store_observation(db_path, guild_id, label, packet)
     if not packet.get("sourceArchiveAvailable", False):
         result = AutomationResult(False, "daily", "held", "source_archive_unavailable", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
@@ -403,8 +411,16 @@ def run_daily(
     return _finish_run(db_path, run_id, result)
 
 
-def _weekly_packet(db_path: str, guild_id: int, start: str, end: str) -> tuple[Optional[dict[str, Any]], int, int]:
+def _weekly_packet(
+    db_path: str,
+    guild_id: int,
+    start: str,
+    end: str,
+    *,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
+) -> tuple[Optional[dict[str, Any]], int, int]:
     ensure_schema(db_path)
+    excluded = {str(entry_id) for entry_id in (memory_excluded_entry_ids or set()) if str(entry_id)}
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
         observations = conn.execute("""SELECT * FROM bnl_journal_observations
@@ -425,10 +441,11 @@ def _weekly_packet(db_path: str, guild_id: int, start: str, end: str) -> tuple[O
     for row in complete:
         counts = json.loads(row["aggregate_counts_json"] or "{}")
         topics = json.loads(row["topic_counts_json"] or "{}")
-        entry = daily_entries.get(row["journal_entry_id"] or "", {})
+        daily_entry_id = str(row["journal_entry_id"] or "")
+        entry = daily_entries.get(daily_entry_id, {}) if daily_entry_id not in excluded else {}
         observation_context.append({
             "date": row["observation_date"], "state": row["lifecycle_state"], "counts": counts,
-            "topicCounts": topics, "dailyEntryId": row["journal_entry_id"] or "",
+            "topicCounts": topics, "dailyEntryId": "" if daily_entry_id in excluded else daily_entry_id,
             "dailyTitle": entry.get("title", ""), "dailyExcerpt": entry.get("excerpt", ""),
         })
     # Re-read the durable full-week archive and sample it exactly once. Reusing
@@ -442,6 +459,7 @@ def _weekly_packet(db_path: str, guild_id: int, start: str, end: str) -> tuple[O
         end,
         entry_kind="weekly",
         observation_context=observation_context,
+        excluded_history_entry_ids=excluded,
     )
     packet.setdefault("aggregateCounts", {})["daysObserved"] = len(complete)
     packet["aggregateCounts"]["activeDays"] = len(active)
@@ -459,6 +477,7 @@ def run_weekly(
     target_monday: Optional[date] = None,
     force: bool = False,
     opener=None,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
 ) -> AutomationResult:
     ensure_schema(db_path)
     start, end, label = _weekly_period_for_monday(target_monday) if target_monday else weekly_period(now_utc)
@@ -467,7 +486,13 @@ def run_weekly(
     claim, run_id, row = _claim_run(db_path, guild_id, "weekly", start, end, force=force)
     if claim != "claimed":
         return _result_from_existing("weekly", row, claim=claim)
-    packet, complete_days, active_days = _weekly_packet(db_path, guild_id, start, end)
+    packet, complete_days, active_days = _weekly_packet(
+        db_path,
+        guild_id,
+        start,
+        end,
+        memory_excluded_entry_ids=memory_excluded_entry_ids,
+    )
     if packet is None and complete_days == 7 and active_days == 0:
         result = AutomationResult(True, "weekly", "quiet", "no_meaningful_weekly_activity", source_window_start=start, source_window_end=end, aggregate_counts={"completeDays": complete_days, "activeDays": active_days})
     elif packet is None:
@@ -573,6 +598,11 @@ def run_scheduled(
     opener=None,
 ) -> list[AutomationResult]:
     controls = flags or {}
+    memory_excluded_entry_ids = {
+        str(entry_id)
+        for entry_id in controls.get("journalMemoryExcludedEntryIds", [])
+        if str(entry_id)
+    }
     if not bool(controls.get("journalAutoPublishEnabled", True)):
         return [AutomationResult(False, "all", "paused", "auto_publish_paused")]
     try:
@@ -585,11 +615,11 @@ def run_scheduled(
     if bool(controls.get("journalDailyEnabled", True)):
         target_day = _pending_daily_day(db_path, guild_id, now_utc)
         if target_day is not None:
-            results.append(run_daily(db_path, guild_id, generator, base_url, api_key, now_utc=now_utc, target_day=target_day, opener=opener))
+            results.append(run_daily(db_path, guild_id, generator, base_url, api_key, now_utc=now_utc, target_day=target_day, opener=opener, memory_excluded_entry_ids=memory_excluded_entry_ids))
     if bool(controls.get("journalWeeklyEnabled", True)):
         target_monday = _pending_week_monday(db_path, guild_id, now_utc)
         if target_monday is not None:
-            results.append(run_weekly(db_path, guild_id, generator, base_url, api_key, now_utc=now_utc, target_monday=target_monday, opener=opener))
+            results.append(run_weekly(db_path, guild_id, generator, base_url, api_key, now_utc=now_utc, target_monday=target_monday, opener=opener, memory_excluded_entry_ids=memory_excluded_entry_ids))
     return results or [AutomationResult(False, "all", "not_due", "no_schedule_due")]
 
 

--- a/tests/test_bnl_journal_evidence_voice.py
+++ b/tests/test_bnl_journal_evidence_voice.py
@@ -179,6 +179,35 @@ class JournalEvidenceVoiceTests(unittest.TestCase):
         self.assertEqual("rhythm", packet["candidateTopicTags"][0])
         self.assertLess(packet["candidateTopicTags"].index("zebra"), packet["candidateTopicTags"].index("alpha"))
 
+    def test_memory_ineligible_entries_are_absent_from_all_history_lanes(self):
+        first = journal.store_validated_draft(self.db, 1, self.packet, _article(self.packet))
+        self.assertTrue(first.ok, first.reason)
+        with journal.sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_entries SET lifecycle_state='published',published_at='2026-07-20T08:00:00Z' WHERE entry_id=?",
+                (first.entry_id,),
+            )
+            conn.execute(
+                "UPDATE bnl_journal_private_metadata SET lifecycle_state='published' WHERE entry_id=?",
+                (first.entry_id,),
+            )
+
+        included = journal.retrieve_history(self.db, 1, self.packet)
+        self.assertEqual(first.entry_id, included["previousEntry"]["entry_id"])
+        self.assertTrue(included["recurringTopicCounts"])
+
+        excluded = journal.retrieve_history(
+            self.db,
+            1,
+            self.packet,
+            excluded_entry_ids={first.entry_id},
+        )
+        self.assertIsNone(excluded["previousEntry"])
+        self.assertEqual([], excluded["relevantOlderEntries"])
+        self.assertEqual({}, excluded["recurringTopicCounts"])
+        self.assertEqual([], excluded["matchingContinuityNotes"])
+        self.assertEqual([], excluded["matchingUnresolvedQuestions"])
+
     def test_history_prompt_keeps_bounded_public_prose_without_private_questions(self):
         entry = {
             "entry_id": "journal-old",

--- a/tests/test_bnl_journal_runtime_controls.py
+++ b/tests/test_bnl_journal_runtime_controls.py
@@ -7,6 +7,7 @@ import unittest
 from unittest import mock
 
 import bnl_journal_source_store as source_store
+from bnl_journal_automation import AutomationResult
 
 os.environ.setdefault("GEMINI_API_KEY", "test-key")
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
@@ -142,6 +143,37 @@ class JournalRuntimeControlTests(unittest.TestCase):
         daily.assert_not_called()
         self.assertEqual("paused", results[0]["status"])
         self.assertEqual("daily_automation_paused", results[0]["reason"])
+
+    def test_entry_memory_exclusions_are_sanitized_and_forwarded(self):
+        flags = bnl01_bot._journal_control_flags(
+            {
+                "config": {},
+                "memoryExcludedEntryIds": [
+                    " journal_valid-1 ",
+                    "journal_valid-1",
+                    "../invalid",
+                    "",
+                    123,
+                ],
+            },
+            {
+                "journalAutoPublishEnabled": True,
+                "journalDailyEnabled": True,
+                "journalWeeklyEnabled": True,
+            },
+        )
+        self.assertEqual(["journal_valid-1"], flags["journalMemoryExcludedEntryIds"])
+
+        result = AutomationResult(True, "daily", "quiet", aggregate_counts={})
+        with mock.patch.object(bnl01_bot, "BNL_JOURNAL_AUTOMATION_ENABLED", True), \
+             mock.patch.object(bnl01_bot, "BNL_PRIMARY_GUILD_ID", 0), \
+             mock.patch.object(bnl01_bot, "run_daily_journal_automation", return_value=result) as daily:
+            asyncio.run(bnl01_bot.run_journal_automation_once(1, cadence="daily", force=True, flags=flags))
+
+        self.assertEqual(
+            {"journal_valid-1"},
+            daily.call_args.kwargs["memory_excluded_entry_ids"],
+        )
 
     def test_control_flag_fetch_failure_retains_confirmed_pause(self):
         paused = {


### PR DESCRIPTION
## Summary
- consume the website's authenticated list of Journal entry IDs marked ineligible for BNL memory
- exclude those entries from previous-entry callbacks, relevant history, recurring topics, continuity notes, unresolved questions, and weekly daily-entry synthesis
- apply the exclusion to scheduled, forced, manual-create, and regenerate paths
- leave the underlying relay/conversation evidence untouched; this controls reuse of the Journal entry itself

## Validation
- focused Journal/runtime suite: 43 passed
- broader targeted compatibility suite: 25 passed
- full suite: 960 tests run; the Journal regression was corrected and only the two pre-existing unrelated `test_subject_memory_resolver` failures remain