### PR TITLE
Preserve the first complete 7 PM Journal window

### DIFF
--- a/bnl_journal_automation.py
+++ b/bnl_journal_automation.py
@@ -525,8 +525,12 @@ def _archive_activation_day(db_path: str, guild_id: int) -> Optional[date]:
     if not row:
         return None
     activated = datetime.fromtimestamp(int(row[0]) / 1000.0, tz=timezone.utc).astimezone(PACIFIC)
-    # Activation normally occurs mid-day. Only the following local day is a
-    # guaranteed complete 24-hour window.
+    same_day_cutoff = _pacific_journal_cutoff(activated.date())
+    # The first fully covered window starts at the first 7 PM cutoff at or
+    # after activation. An activation later that evening must wait until the
+    # following day's cutoff.
+    if activated <= same_day_cutoff:
+        return activated.date()
     return activated.date() + timedelta(days=1)
 
 

--- a/tests/test_bnl_journal_automation.py
+++ b/tests/test_bnl_journal_automation.py
@@ -194,6 +194,25 @@ class JournalAutomationTests(unittest.TestCase):
         self.assertEqual("2026-07-14T02:00:00Z", weekly_start)
         self.assertEqual("2026-07-21T02:00:00Z", weekly_end)
 
+    def test_archive_activation_keeps_first_fully_covered_seven_pm_window(self):
+        self.set_archive_activation("2026-07-16T19:00:00Z")  # Noon PDT.
+        self.assertEqual(
+            date(2026, 7, 16),
+            automation._archive_activation_day(self.db, 1),
+        )
+
+        self.set_archive_activation("2026-07-17T02:00:00Z")  # 7 PM PDT.
+        self.assertEqual(
+            date(2026, 7, 16),
+            automation._archive_activation_day(self.db, 1),
+        )
+
+        self.set_archive_activation("2026-07-17T02:00:01Z")  # Just after 7 PM PDT.
+        self.assertEqual(
+            date(2026, 7, 17),
+            automation._archive_activation_day(self.db, 1),
+        )
+
     def test_daily_auto_publishes_once_and_persists_observation(self):
         self.add_day("2026-07-19")
         now = datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc)
@@ -266,7 +285,7 @@ class JournalAutomationTests(unittest.TestCase):
         for day in ("2026-07-17", "2026-07-18", "2026-07-19"):
             self.add_day(day)
         source_store.backfill_legacy_sources(self.db, 1)
-        self.set_archive_activation("2026-07-16T19:00:00Z")
+        self.set_archive_activation("2026-07-17T03:00:00Z")  # 8 PM PDT.
         now = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
 
         first = automation.run_scheduled(


### PR DESCRIPTION
## What changed

- Selects the first 7 PM Journal window whose start is at or after durable archive activation.
- Preserves the same-day 7 PM window when activation occurred before or exactly at the cutoff.
- Defers to the following day's cutoff only when activation occurred after 7 PM.
- Adds boundary coverage for before, exactly at, and immediately after 7 PM Pacific.

## Why

This addresses the post-merge review finding on #338. The previous activation-day rule always added one calendar day, which could permanently skip a fully covered first window after the schedule moved from midnight to 7 PM.

## Validation

- Scheduler suite: **10 tests passed**.
- Focused Journal suite: **58 tests passed**.
- `git diff --check` clean.