### PR TITLE
Bot — Establish a green release baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bot-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.12"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Use Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install pinned runtime dependencies
+        run: python -m pip install --disable-pip-version-check -r requirements.txt
+
+      - name: Verify source and tests
+        run: make check PYTHON=python

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv/
+.venv/
 venv_backup/
 __pycache__/
 *.db

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+PYTHON ?= python3
+
+.PHONY: compile test check
+
+compile:
+	$(PYTHON) -m compileall -q bnl01_bot.py bnl_*.py tests
+
+test:
+	$(PYTHON) -m unittest discover -s tests -p 'test_*.py'
+
+check: compile test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# BNL01 Bot
+
+The production Discord runtime for BNL-01, including governed conversation memory, Presence/Relay v2, the BNL Journal, Source File and dossier assistance, relationship/moment systems, and owner-operated internal controls.
+
+## Supported Python
+
+- Python 3.9 is the current deployment compatibility floor.
+- Python 3.12 is the modern development target.
+- CI runs the complete suite on both versions.
+
+Runtime dependencies are pinned in `requirements.txt` to versions that support both Python targets. Tests use the Python standard-library `unittest` runner and require no separate test framework.
+
+## Local setup
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+python -m pip install -r requirements.txt
+make check PYTHON=python
+```
+
+The direct full-suite command is:
+
+```bash
+python -m unittest discover -s tests -p 'test_*.py'
+```
+
+`make check` first compiles the bot, support modules, and tests, then runs the full suite.
+
+## Runtime configuration
+
+Configure secrets in the process environment; do not commit them. Core variables include:
+
+- `DISCORD_BOT_TOKEN`
+- `GEMINI_API_KEY`
+- BNL website URLs, API keys, Relay controls, and feature flags used by the deployed runtime
+
+Importing `bnl01_bot` does not create a Gemini client or open provider transports. The client is created and cached on the first generation request, so tests, diagnostics, and tooling can import the runtime without valid provider networking.
+
+Run the bot only after the deployment environment is configured:
+
+```bash
+python bnl01_bot.py
+```
+
+## Release baseline
+
+Before merging a runtime change:
+
+1. Install the committed dependency versions.
+2. Run `make check` on a supported Python version.
+3. Confirm CI passes on Python 3.9 and 3.12.
+4. Keep live behavior, memory governance, public/private evidence boundaries, and website contract changes in explicitly scoped PRs.

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -120,6 +120,7 @@ import urllib.error
 import urllib.parse
 import calendar
 import time
+import threading
 
 from bnl_dossier_candidate_discovery import (
     DEFAULT_DISCOVERY_LANES,
@@ -332,8 +333,19 @@ DAILY_TOKEN_LIMIT = 1_350_000
 PACIFIC_TZ = pytz.timezone("US/Pacific")
 DB_FILE = "bnl01_conversations.db"
 
-# Initialize Gemini client once
-gemini_client = genai.Client(api_key=GEMINI_API_KEY)
+# The provider client owns HTTP transports and proxy discovery. Keep module
+# import side-effect free; construct and cache it only when generation starts.
+gemini_client = None
+_gemini_client_lock = threading.Lock()
+
+
+def get_gemini_client():
+    global gemini_client
+    if gemini_client is None:
+        with _gemini_client_lock:
+            if gemini_client is None:
+                gemini_client = genai.Client(api_key=GEMINI_API_KEY)
+    return gemini_client
 
 # ======== BATCHED REPLY CONFIG (ACTIVE CHANNEL) ========
 BATCH_WINDOW_SECONDS = 4
@@ -13194,9 +13206,10 @@ async def _generate_gemini_content_result_async(contents: str, route: str) -> Ge
 
 
 def _generate_gemini_content_with_fallback(contents: str, route: str):
+    client = get_gemini_client()
     logging.info(f"gemini_model_attempt model={GEMINI_MODEL} route={route}")
     try:
-        return gemini_client.models.generate_content(
+        return client.models.generate_content(
             model=_gemini_model_resource_name(GEMINI_MODEL),
             contents=contents
         )
@@ -13210,7 +13223,7 @@ def _generate_gemini_content_with_fallback(contents: str, route: str):
         )
         logging.info(f"gemini_model_attempt model={GEMINI_FALLBACK_MODEL} route={route}")
         try:
-            response = gemini_client.models.generate_content(
+            response = client.models.generate_content(
                 model=_gemini_model_resource_name(GEMINI_FALLBACK_MODEL),
                 contents=contents
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-aiohttp
-discord.py
-google-genai
-pytz
+# Direct runtime dependencies pinned to releases compatible with Python 3.9 and 3.12.
+aiohttp==3.13.5
+discord.py==2.7.1
+google-genai==1.47.0
+pytz==2026.2

--- a/tests/test_async_relay_offload.py
+++ b/tests/test_async_relay_offload.py
@@ -1,5 +1,7 @@
 import asyncio
 import os
+import subprocess
+import sys
 import threading
 import unittest
 from types import SimpleNamespace
@@ -16,6 +18,34 @@ def gemini_response(text="BNL relay response.", tokens=17):
         candidates=[SimpleNamespace(content=SimpleNamespace(parts=[SimpleNamespace(text=text)]))],
         usage_metadata=SimpleNamespace(total_token_count=tokens),
     )
+
+
+class GeminiClientLifecycleTests(unittest.TestCase):
+    def test_module_import_does_not_construct_gemini_client(self):
+        probe = """
+from google import genai
+def fail_if_constructed(*args, **kwargs):
+    raise RuntimeError('Gemini client constructed during import')
+genai.Client = fail_if_constructed
+import bnl01_bot
+assert bnl01_bot.gemini_client is None
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", probe],
+            cwd=os.path.dirname(os.path.dirname(__file__)),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    def test_gemini_client_is_created_once_on_first_generation(self):
+        fake_client = SimpleNamespace(models=SimpleNamespace(generate_content=mock.Mock()))
+        with mock.patch.object(bnl01_bot, "gemini_client", None), \
+             mock.patch.object(bnl01_bot.genai, "Client", return_value=fake_client) as factory:
+            self.assertIs(bnl01_bot.get_gemini_client(), fake_client)
+            self.assertIs(bnl01_bot.get_gemini_client(), fake_client)
+        factory.assert_called_once_with(api_key=bnl01_bot.GEMINI_API_KEY)
 
 
 class GeminiOffloadTests(unittest.IsolatedAsyncioTestCase):
@@ -49,7 +79,8 @@ class GeminiOffloadTests(unittest.IsolatedAsyncioTestCase):
                 raise Exception("503 service unavailable")
             return gemini_response("fallback ok", 5)
 
-        with mock.patch.object(bnl01_bot.gemini_client.models, "generate_content", side_effect=fake_generate_content):
+        fake_client = SimpleNamespace(models=SimpleNamespace(generate_content=mock.Mock(side_effect=fake_generate_content)))
+        with mock.patch.object(bnl01_bot, "gemini_client", fake_client):
             response = await bnl01_bot._generate_gemini_content_with_fallback_async("contents", "fallback_route")
 
         self.assertEqual(bnl01_bot._extract_text_and_tokens(response), ("fallback ok", 5))

--- a/tests/test_subject_memory_resolver.py
+++ b/tests/test_subject_memory_resolver.py
@@ -608,7 +608,8 @@ class SubjectMemoryResolverTests(unittest.TestCase):
             }
             result = draft.generate_dossier_draft(p, tmp.name)["draft"]
             self.assertNotEqual(result["role"], "Music artist")
-            self.assertIn("limited public-safe source detail", result["summary"])
+            self.assertIn("public-facing details still being confirmed", result["summary"])
+            self.assertNotIn("unconfirmed music artist", result["summary"])
             self.assertTrue(any("resolver scanned" in x for x in result["ownerReviewWarnings"]))
 
     def test_draft_music_role_requires_public_safe_music(self):
@@ -620,7 +621,8 @@ class SubjectMemoryResolverTests(unittest.TestCase):
             p = {"requestType": "bnl_proposed_dossier_draft", "version": "1.0", "candidate": {"sourceFileId": "sf_crow", "subjectName": "Crow"}, "publicSafeFacts": [], "publicSafeNotes": [], "stylePacket": {}, "fieldRequirements": ["summary"], "safeClassification": {"category": "Unknown", "kind": "Person", "ecosystemLane": "Unknown"}}
             result = draft.generate_dossier_draft(p, tmp.name)["draft"]
             self.assertEqual(result["role"], "Music artist")
-            self.assertIn("subject memory resolver", result["sourceUsageSummary"])
+            self.assertIn("public-safe structured entity evidence summary", result["sourceUsageSummary"])
+            self.assertNotIn("subject memory resolver", result["sourceUsageSummary"])
 
     def test_contest_context_lanes_do_not_infer_organizer_and_humanize_labels(self):
         analyst = build_subject_analyst_read("Crow", {

--- a/tests/test_website_relay_event_driven.py
+++ b/tests/test_website_relay_event_driven.py
@@ -239,23 +239,27 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
     def test_timed_out_generation_is_cancelled_and_cannot_publish_late(self):
         original_timeout = bnl01_bot.BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS
         bnl01_bot.BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS = 0.01
-        cancelled = asyncio.Event()
-        async def slow_generation(guild_id):
-            try:
-                await asyncio.sleep(1)
-            except asyncio.CancelledError:
-                cancelled.set()
-                raise
         async def run_one():
+            cancelled = asyncio.Event()
+
+            async def slow_generation(guild_id):
+                try:
+                    await asyncio.sleep(1)
+                except asyncio.CancelledError:
+                    cancelled.set()
+                    raise
+
             with mock.patch.object(bnl01_bot, "generate_dynamic_website_relay", side_effect=slow_generation), \
                  mock.patch.object(bnl01_bot, "update_website_status_controlled_async", side_effect=AssertionError("posted late")):
-                return await bnl01_bot._execute_website_relay_transaction(42, source="relay")
+                decision = await bnl01_bot._execute_website_relay_transaction(42, source="relay")
+                return decision, cancelled.is_set()
         try:
-            decision = asyncio.run(run_one())
+            decision, was_cancelled = asyncio.run(run_one())
         finally:
             bnl01_bot.BNL_WEBSITE_RELAY_GENERATION_TIMEOUT_SECONDS = original_timeout
         self.assertFalse(decision.publish)
         self.assertEqual(decision.skipReason, "relay_generation_timeout")
+        self.assertTrue(was_cancelled)
 
     def test_restart_hydration_uses_newest_eight_lanes(self):
         lanes = [f"lane_{i}" for i in range(10)]


### PR DESCRIPTION
## Summary

Establishes a reproducible green release baseline for BNL01-Bot without changing memory policy, public behavior, prompts, routing, or live feature flags.

- adds CI for the deployed Python 3.9 floor and modern Python 3.12
- pins direct runtime dependencies to releases compatible with both versions
- makes Gemini client construction lazy, cached, and thread-safe
- aligns two stale subject-memory resolver assertions with the current public-copy safety contract
- adds one documented `make check` command for compilation and the complete test suite

## Import and provider lifecycle

`bnl01_bot` no longer constructs Google’s HTTP client during module import. The provider client is created on the first generation request and reused afterward. Primary/fallback model selection, token accounting, offloading, and error handling are unchanged.

Lifecycle tests prove that:

- importing the module does not call `genai.Client`
- first use constructs exactly one client
- subsequent generation reuses it
- the existing 503 fallback path still calls the same primary and fallback models

## Test-contract reconciliation

The two prior resolver failures were stale expectations for process-oriented public text:

- weak evidence now asserts the current confirmation-based fallback and proves review-only music wording does not leak
- safe music evidence now asserts the generic public-safe evidence summary and proves the internal “subject memory resolver” label does not leak into `sourceUsageSummary`

No resolver, dossier generation, memory, or evidence-selection behavior was changed.

## Dependency and release contract

Direct pins:

- `aiohttp==3.13.5`
- `discord.py==2.7.1`
- `google-genai==1.47.0`
- `pytz==2026.2`

These are the newest selected releases that retain the Python 3.9 deployment floor while running on Python 3.12. Tests use standard-library `unittest`; no separate test framework is required.

## Validation

- GitHub Actions on actual Python 3.9: **965 passed, 0 failed**
- GitHub Actions on actual Python 3.12: **965 passed, 0 failed**
- pinned dependency install and local `make check PYTHON=python3`: **965 passed, 0 failed**
- import with configured test credentials and proxy-only networking: pass; client remains uninitialized
- real pinned `google-genai` client API/cache smoke test: pass
- Python 3.9 grammar parse and dependency-resolution dry run: pass
- remote branch tree SHA matches the locally tested tree exactly

The first matrix run exposed one Python 3.9-only test-harness incompatibility: an `asyncio.Event` was constructed before the managed event loop existed. The test now constructs it inside the loop and explicitly proves timeout cancellation, and the replacement 3.9/3.12 matrix is green.

## Boundaries

This PR does not alter live Discord routing, Relay behavior, Journal activation, memory governance, evidence ownership, prompts, model names, feature flags, or deployment configuration. It introduces neither a separate Field Log nor a Relay Archive.