### PR TITLE
Bot: align native queue canon and show-day copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ Configure secrets in the process environment; do not commit them. Core variables
 - `GEMINI_API_KEY`
 - BNL website URLs, API keys, Relay controls, and feature flags used by the deployed runtime
 
+Native queue context has two independent production gates. The local bot variable `BNL_QUEUE_PRODUCTION_ENABLED` defaults off and accepts only `true` (case-insensitive); the website read model must also report `capabilities.queueProduction=true`. Queue/session/track context is stripped unless both gates agree. Merging queue-aware code does not enable either gate.
+
+Activation order is site first, bot second:
+
+1. Keep the bot gate disabled while the website native-queue cutover is verified.
+2. Confirm the website capability is true and its public queue state is sanitized and accurate.
+3. Only after explicit owner approval, set `BNL_QUEUE_PRODUCTION_ENABLED=true` and restart the bot.
+4. Roll back the bot first by unsetting the variable or changing it away from `true`; the website can then be rolled back independently.
+
+Show-day copy follows the same boundary. The 6:40 PM Pacific intake message names the native queue only when both gates are usable; otherwise it uses provider-neutral public-intake wording. The 7:00 PM message describes the scheduled broadcast window without claiming unverified live state, and the later sponsor message remains optional and host-controlled.
+
 Importing `bnl01_bot` does not create a Gemini client or open provider transports. The client is created and cached on the first generation request, so tests, diagnostics, and tooling can import the runtime without valid provider networking.
 
 Run the bot only after the deployment environment is configured:

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from bnl_canon_source_contract import (
     CANON_SOURCE_CONTRACT_VERSION,
     diagnostics as canon_source_diagnostics,
+    queue_usability,
     render_concise_public_schedule,
     render_founders,
     render_prompt_canon_block,
@@ -1385,6 +1386,22 @@ def _first_list(*values):
     return []
 
 
+def _public_source_context_items(read_model: dict) -> list[dict]:
+    """Return bounded public site-canon entries from either supported shape."""
+    sections = _read_model_sections(read_model)
+    raw = sections.get("sourceContext")
+    if raw is None and isinstance(read_model, dict):
+        raw = read_model.get("sourceContext")
+    if isinstance(raw, list):
+        return [item for item in raw if isinstance(item, dict)][:8]
+    if isinstance(raw, dict):
+        nested = _first_list(raw.get("items"), raw.get("entries"), raw.get("context"))
+        if nested:
+            return [item for item in nested if isinstance(item, dict)][:8]
+        return [raw]
+    return []
+
+
 def _compact_public_text(value, limit: int = 140) -> str:
     if value is None:
         return ""
@@ -1453,15 +1470,23 @@ def build_bnl_read_model_context(read_model: dict, user_text: str, channel_polic
     artists_section = sections.get("artists") if sections.get("artists") is not None else read_model.get("artists")
     dossiers_section = sections.get("dossiers") if sections.get("dossiers") is not None else read_model.get("dossiers")
     rules_section = sections.get("rules") if sections.get("rules") is not None else read_model.get("rules")
-    source_context = _first_mapping(sections.get("sourceContext"), read_model.get("sourceContext"))
+    source_context_items = _public_source_context_items(read_model)
 
     lines = [
         "Website public read model context:",
-        f"Source: {_compact_public_text(source_context.get('source') or 'barcode-network-site', 80)} / publicOnly=true / version=1",
+        f"Source: {_compact_public_text(read_model.get('source') or 'barcode-network-site', 80)} / publicOnly=true / version=1",
     ]
     schema_revision = _compact_public_text(read_model.get("schemaRevision"), 40)
     if schema_revision:
         lines[-1] += f" / schemaRevision={schema_revision}"
+
+    if source_context_items:
+        lines.append("\nPublic site canon:")
+        for item in source_context_items[:6]:
+            title = _compact_public_text(item.get("title") or item.get("name") or item.get("id"), 80)
+            summary = _compact_public_text(item.get("summary") or item.get("description"), 220)
+            if title and summary:
+                lines.append(f"- {title}: {summary}")
 
     if queue:
         session = _first_mapping(queue.get("session"), queue.get("currentSession"))
@@ -14645,26 +14670,96 @@ FRIDAY_SHOW_PHASES = [
     {"key": "sponsor_window", "hour": 21, "minute": 0, "window_min": SHOWDAY_WINDOW_MINUTES},
 ]
 
-SHOWDAY_FALLBACKS = {
-    "submissions_open": [
-        "📡 Intake corridor open. Auxchord routing is active; submission pressure can now be transmitted.",
-        "Signal intake has commenced. BNL-01 is routing inbound track traffic through the Friday relay.",
-        "Auxchord channels are now accepting payloads. Submit while the pre-broadcast gate is stable.",
+SHOWDAY_INTAKE_FALLBACKS = {
+    "public_intake": [
+        "📡 The Friday BARCODE Radio intake window has begun. Submit your original track through the current public submission route for tonight’s host-led broadcast.",
+        "BARCODE Radio’s Friday submission window is in place. Original music can enter through the public intake route while the pre-broadcast gate is open.",
+        "Signal intake has commenced for BARCODE Radio. Use the current public submission route during the scheduled Friday intake window.",
     ],
-    "show_live": [
-        "🎛️ Broadcast deployment confirmed. BARCODE Radio is now active and 6 Bit is on-air.",
-        "Carrier lock acquired. Friday transmission is live; 6 Bit has entered broadcast posture.",
-        "BARCODE Radio is now transmitting. Signal integrity is nominal and the host stack is online.",
-    ],
-    "sponsor_window": [
-        "📼 Sponsor relay window is active. Commercial packets require 6 Bit for compliant execution.",
-        "Funding cycle check: sponsor transmissions are due, and the host channel must process them.",
-        "Network obligations are now in rotation. Sponsor payloads should be run through 6 Bit’s lane.",
+    "native_queue": [
+        "📡 The Friday BARCODE Radio intake window has begun. Submit your original track through the native Network queue for tonight’s host-led broadcast.",
+        "BARCODE Radio’s native queue is the active submission route for the Friday intake window. Original music can enter while the pre-broadcast gate is open.",
+        "Signal intake has commenced through the native BARCODE Radio queue. Submit during the scheduled Friday intake window.",
     ],
 }
 
-def _pick_varied_fallback(phase_key: str, avoid: str = "") -> str:
-    options = SHOWDAY_FALLBACKS.get(phase_key, [])
+SHOWDAY_FALLBACKS = {
+    "show_live": [
+        "🎛️ The scheduled BARCODE Radio broadcast window has begun. 6 Bit remains the host; confirm the live signal through the public broadcast channel.",
+        "Friday transmission time has arrived. BARCODE Radio remains host-led, with current live state confirmed by the public broadcast surface.",
+        "The 7:00 PM Pacific broadcast window is in place. Follow BARCODE Radio’s public live channel for the confirmed signal.",
+    ],
+    "sponsor_window": [
+        "📼 The optional sponsor reminder window is in range. Any commercial break remains host-controlled and tied to the live production state.",
+        "Sponsor acknowledgements may enter the later broadcast window; timing remains with 6 Bit and the live production state.",
+        "The later-show sponsor window is available. No commercial break is implied until the host calls it.",
+    ],
+}
+
+def showday_submission_canon(read_model: dict | None = None) -> dict[str, str]:
+    """Resolve announcement wording without exposing or persisting queue state."""
+    usability = queue_usability(read_model or {})
+    if usability["usable"]:
+        return {
+            "mode": "native_queue",
+            "routeLabel": "native BARCODE Radio queue",
+            "promptRule": "Name the native BARCODE Radio queue as the submission route. BNL observes it but does not operate, reorder, or approve submissions.",
+        }
+    return {
+        "mode": "public_intake",
+        "routeLabel": "current public BARCODE Radio submission route",
+        "promptRule": "Refer to BARCODE Radio’s public submission intake generically. Do not name Auxchord, claim the native queue is active, or imply BNL operates submissions.",
+    }
+
+
+def _showday_phase_prompt_rule(phase_key: str, read_model: dict | None = None) -> str:
+    if phase_key == "submissions_open":
+        canon = showday_submission_canon(read_model)
+        return f"Submission route: {canon['routeLabel']}. {canon['promptRule']}"
+    if phase_key == "show_live":
+        return "This is the scheduled broadcast window, not proof of current live state. Keep the update restrained and direct listeners to the public broadcast channel for confirmation."
+    if phase_key == "sponsor_window":
+        return "This is an optional later-show sponsor reminder. Do not claim a commercial break is active, due, required, or already called; timing remains host-controlled."
+    return "Do not invent current operational state."
+
+
+def _showday_output_matches_canon(message: str, phase_key: str, read_model: dict | None = None) -> bool:
+    lowered = str(message or "").lower()
+    if not lowered or "auxchord" in lowered:
+        return False
+    if phase_key == "submissions_open":
+        canon = showday_submission_canon(read_model)
+        if canon["mode"] != "native_queue" and "queue" in lowered:
+            return False
+        if any(term in lowered for term in (
+            "bnl routes", "bnl is routing", "bnl operates", "bnl is operating",
+            "bnl processes", "bnl is processing", "bnl approves", "bnl is approving",
+            "bnl accepts submissions", "bnl is accepting submissions", "submit to bnl",
+            "bnl manages", "bnl is managing", "bnl controls", "bnl is controlling",
+            "bnl reorders", "bnl reordered", "bnl has reordered", "bnl owns",
+            "bnl runs the queue", "bnl runs submissions",
+        )):
+            return False
+    elif phase_key == "show_live" and any(term in lowered for term in (
+        "now active", "on-air", "on air", "now live", "now transmitting", "deployment confirmed", "carrier lock acquired",
+        "currently live", "live now", "is live", "are live", "we're live", "we are live",
+        "broadcast has begun", "broadcast has started", "transmission is live", "signal is live",
+    )):
+        return False
+    elif phase_key == "sponsor_window" and any(term in lowered for term in (
+        "window is active", "are due", "is due", "must process", "requires 6 bit", "should be run",
+        "break is active", "break is required", "break is mandatory", "already called", "has been called",
+    )):
+        return False
+    return True
+
+
+def _pick_varied_fallback(phase_key: str, avoid: str = "", read_model: dict | None = None) -> str:
+    if phase_key == "submissions_open":
+        mode = showday_submission_canon(read_model)["mode"]
+        options = list(SHOWDAY_INTAKE_FALLBACKS.get(mode, []))
+    else:
+        options = list(SHOWDAY_FALLBACKS.get(phase_key, []))
     if not options:
         return "Signal update acknowledged."
     random.shuffle(options)
@@ -14676,11 +14771,13 @@ def _pick_varied_fallback(phase_key: str, avoid: str = "") -> str:
 
 async def generate_showday_messages(guild_id: int, phase_key: str):
     signal_context = get_recent_signal_summary(guild_id)
+    read_model = await asyncio.to_thread(fetch_bnl_read_model) if phase_key == "submissions_open" else {}
     phase_desc = {
-        "submissions_open": "Friday 6:40 PM Pacific intake window opens for submissions",
-        "show_live": "Friday 7:00 PM Pacific live broadcast begins",
-        "sponsor_window": "around Friday 9:00 PM Pacific sponsor/commercial obligations window",
+        "submissions_open": "Friday 6:40 PM Pacific scheduled intake window begins",
+        "show_live": "Friday 7:00 PM Pacific scheduled broadcast window begins",
+        "sponsor_window": "optional later-show sponsor reminder window",
     }.get(phase_key, phase_key)
+    phase_rule = _showday_phase_prompt_rule(phase_key, read_model)
 
     prompt = (
         "You are BNL-01. Generate exactly two lines.\n"
@@ -14688,6 +14785,7 @@ async def generate_showday_messages(guild_id: int, phase_key: str):
         "Line 2: Website status message about 220-360 chars, complete sentence(s), no mid-word or mid-sentence cuts.\n"
         "Voice: concise, corporate, lightly sinister, signal-analysis.\n"
         f"Event: {phase_desc}.\n"
+        f"Truth boundary: {phase_rule}\n"
         f"Room context (optional): {signal_context or 'none'}.\n"
         "Do not quote users. No usernames. No emojis except optional one at start.\n"
         "Do not repeat generic stock wording. Keep it fresh.\n"
@@ -14696,11 +14794,16 @@ async def generate_showday_messages(guild_id: int, phase_key: str):
     lines = [ln.strip(" -•\t") for ln in text.splitlines() if ln.strip()]
     if len(lines) >= 2:
         discord_msg = lines[0][:320]
-        website_msg = fit_complete_statement(lines[1], limit=360, min_chars=220, fallback=_pick_varied_fallback(phase_key))
-        if discord_msg and website_msg:
+        website_msg = fit_complete_statement(lines[1], limit=360, min_chars=220, fallback=_pick_varied_fallback(phase_key, read_model=read_model))
+        if (
+            discord_msg
+            and website_msg
+            and _showday_output_matches_canon(discord_msg, phase_key, read_model)
+            and _showday_output_matches_canon(website_msg, phase_key, read_model)
+        ):
             return discord_msg, website_msg
-    fallback = _pick_varied_fallback(phase_key)
-    return fallback[:320], fit_complete_statement(fallback, limit=360, min_chars=220, fallback=_pick_varied_fallback(phase_key, avoid=fallback))
+    fallback = _pick_varied_fallback(phase_key, read_model=read_model)
+    return fallback[:320], fit_complete_statement(fallback, limit=360, min_chars=220, fallback=_pick_varied_fallback(phase_key, avoid=fallback, read_model=read_model))
 
 
 def iter_managed_guilds():

--- a/docs/canon_source_contract_v1.md
+++ b/docs/canon_source_contract_v1.md
@@ -22,6 +22,8 @@ When queue production is disabled, the contract strips queue/session/payment/ava
 
 Queue production remains disabled unless both gates are explicit: local `BNL_QUEUE_PRODUCTION_ENABLED=true` and website `capabilities.queueProduction=true`. Missing or malformed capability data fails closed.
 
+The website's bounded `sections.sourceContext` list remains public site canon, not live queue state. BNL may load those public summaries for an explicit site/read-model question even while live queue context is disabled. Queue/session/track values are still removed before prompt assembly.
+
 ## Vocabulary and compatibility coverage
 
 The contract defines source class, authority, visibility, confidence, freshness/currentness, subject identity, correction, contradiction/supersession, invalidity/retraction, public usability, derived/projection status, and current-time claim eligibility. Existing route/source/channel labels map through compatibility adapters; no persisted values are renamed.
@@ -48,6 +50,14 @@ Static approved canon and schedule facts cannot prove live/open/current/now stat
 - `/about` consumes contract schedule/founder render helpers instead of hardcoding the old 6:40 PM show-time wording.
 - Website read-model prompt context and R&D/operator read-model intent responses consume the sanitized view.
 - Safe diagnostics expose the active contract version, adapter state, local queue capability, observed site queue capability, and effective queue usability reason without raw queue values.
+
+## Native queue and show-day alignment
+
+Show-day announcement canon consumes the same two-gate decision without persisting queue data. The scheduled 6:40 PM Pacific intake message names the native BARCODE Radio queue only when the local bot gate and website capability are both true. Otherwise it uses provider-neutral public-intake wording; stock and generated announcements may not fall back to Auxchord-specific copy or imply BNL operates submissions.
+
+The 7:00 PM Pacific announcement is deliberately restrained: the schedule proves the broadcast window, not a current live/on-air state. The optional later-show sponsor reminder does not claim that a commercial break is active, due, required, or already called. Current state still requires fresh public runtime evidence and host control.
+
+This alignment does not write queue context to memory, relationships, dossiers, Source Files, Relay, recaps, the Journal, or public copy lanes. It does not enable show-day Discord posts, proactive engagement, queue write power, or either production gate.
 
 ## Not migrated
 

--- a/tests/test_showday_queue_alignment.py
+++ b/tests/test_showday_queue_alignment.py
@@ -1,0 +1,173 @@
+import os
+import unittest
+from unittest import mock
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+
+
+def read_model(queue_production: bool, *, radio_summary: str = "") -> dict:
+    source_context = []
+    if radio_summary:
+        source_context.append({
+            "id": "barcode_radio",
+            "title": "BARCODE Radio",
+            "summary": radio_summary,
+        })
+    return {
+        "ok": True,
+        "version": 1,
+        "source": "barcode-network-site",
+        "publicOnly": True,
+        "capabilities": {"queueProduction": queue_production},
+        "sections": {
+            "sourceContext": source_context,
+            "queue": {
+                "nowPlaying": {"title": "PRIVATE_TEST_QUEUE_TITLE"},
+            },
+        },
+    }
+
+
+class ShowdayQueueAlignmentTests(unittest.IsolatedAsyncioTestCase):
+    def test_native_announcement_canon_requires_local_and_site_gates(self):
+        remote_true = read_model(True)
+        remote_false = read_model(False)
+
+        with mock.patch.dict(os.environ, {"BNL_QUEUE_PRODUCTION_ENABLED": "false"}, clear=False):
+            self.assertEqual(bnl01_bot.showday_submission_canon(remote_true)["mode"], "public_intake")
+        with mock.patch.dict(os.environ, {"BNL_QUEUE_PRODUCTION_ENABLED": "true"}, clear=False):
+            self.assertEqual(bnl01_bot.showday_submission_canon(remote_false)["mode"], "public_intake")
+            self.assertEqual(bnl01_bot.showday_submission_canon(remote_true)["mode"], "native_queue")
+
+    def test_all_stock_showday_copy_removes_auxchord_and_current_state_overclaims(self):
+        stock = [
+            *bnl01_bot.SHOWDAY_INTAKE_FALLBACKS["public_intake"],
+            *bnl01_bot.SHOWDAY_INTAKE_FALLBACKS["native_queue"],
+            *bnl01_bot.SHOWDAY_FALLBACKS["show_live"],
+            *bnl01_bot.SHOWDAY_FALLBACKS["sponsor_window"],
+        ]
+        self.assertTrue(stock)
+        self.assertNotIn("auxchord", "\n".join(stock).lower())
+
+        for message in bnl01_bot.SHOWDAY_FALLBACKS["show_live"]:
+            self.assertTrue(bnl01_bot._showday_output_matches_canon(message, "show_live"))
+        for message in bnl01_bot.SHOWDAY_FALLBACKS["sponsor_window"]:
+            self.assertTrue(bnl01_bot._showday_output_matches_canon(message, "sponsor_window"))
+
+        self.assertFalse(bnl01_bot._showday_output_matches_canon(
+            "BARCODE Radio is now live and 6 Bit is on-air.",
+            "show_live",
+        ))
+        self.assertFalse(bnl01_bot._showday_output_matches_canon(
+            "The BARCODE Radio broadcast is live.",
+            "show_live",
+        ))
+        self.assertFalse(bnl01_bot._showday_output_matches_canon(
+            "Sponsor transmissions are due and must process now.",
+            "sponsor_window",
+        ))
+        self.assertFalse(bnl01_bot._showday_output_matches_canon(
+            "The commercial break is required and has been called.",
+            "sponsor_window",
+        ))
+
+    def test_intake_copy_cannot_claim_bnl_operates_submissions(self):
+        model = read_model(True)
+        with mock.patch.dict(os.environ, {"BNL_QUEUE_PRODUCTION_ENABLED": "true"}, clear=False):
+            self.assertFalse(bnl01_bot._showday_output_matches_canon(
+                "BNL routes the native queue and accepts submissions.",
+                "submissions_open",
+                model,
+            ))
+            self.assertFalse(bnl01_bot._showday_output_matches_canon(
+                "BNL manages and controls the native queue.",
+                "submissions_open",
+                model,
+            ))
+
+    def test_public_intake_copy_rejects_all_queue_specific_generated_wording(self):
+        model = read_model(False)
+        with mock.patch.dict(os.environ, {"BNL_QUEUE_PRODUCTION_ENABLED": "true"}, clear=False):
+            self.assertFalse(bnl01_bot._showday_output_matches_canon(
+                "Use the BARCODE Radio queue during the Friday intake window.",
+                "submissions_open",
+                model,
+            ))
+            self.assertTrue(bnl01_bot._showday_output_matches_canon(
+                "Use the current public submission route during the Friday intake window.",
+                "submissions_open",
+                model,
+            ))
+
+    def test_public_site_canon_survives_while_live_queue_values_remain_stripped(self):
+        model = read_model(
+            True,
+            radio_summary="Public submissions enter through the native BARCODE Radio queue.",
+        )
+        with mock.patch.dict(os.environ, {"BNL_QUEUE_PRODUCTION_ENABLED": "false"}, clear=False):
+            context = bnl01_bot.build_bnl_read_model_context(
+                model,
+                "what does the website say about BARCODE Radio?",
+                "public_home",
+            )
+
+        self.assertIn("Public site canon:", context)
+        self.assertIn("Public submissions enter through the native BARCODE Radio queue.", context)
+        self.assertNotIn("PRIVATE_TEST_QUEUE_TITLE", context)
+        self.assertNotIn("Now playing:", context)
+
+    def test_unrelated_chat_does_not_fetch_or_inject_queue_context(self):
+        with mock.patch.dict(os.environ, {"BNL_QUEUE_PRODUCTION_ENABLED": "true"}, clear=False), \
+             mock.patch.object(bnl01_bot, "fetch_bnl_read_model", return_value=read_model(True)) as fetch:
+            context = bnl01_bot.maybe_build_bnl_read_model_context(
+                "How are you doing today?",
+                "public_home",
+            )
+
+        self.assertEqual(context, "")
+        fetch.assert_not_called()
+
+    async def test_auxchord_generation_is_rejected_for_native_intake(self):
+        generated = (
+            "Auxchord channels are accepting submissions now.\n"
+            "Auxchord is the active Friday route. Submit there while BNL routes the queue."
+        )
+        with mock.patch.dict(os.environ, {"BNL_QUEUE_PRODUCTION_ENABLED": "true"}, clear=False), \
+             mock.patch.object(bnl01_bot, "fetch_bnl_read_model", return_value=read_model(True)), \
+             mock.patch.object(bnl01_bot, "get_recent_signal_summary", return_value=""), \
+             mock.patch.object(bnl01_bot, "get_gemini_response", new=mock.AsyncMock(return_value=generated)):
+            discord_message, website_message = await bnl01_bot.generate_showday_messages(1, "submissions_open")
+
+        combined = f"{discord_message}\n{website_message}".lower()
+        self.assertNotIn("auxchord", combined)
+        self.assertIn("native", combined)
+        self.assertIn("queue", combined)
+
+    async def test_generation_prompts_carry_each_showday_truth_boundary(self):
+        prompts = []
+
+        async def capture(prompt, **_kwargs):
+            prompts.append(prompt)
+            return ""
+
+        with mock.patch.dict(os.environ, {"BNL_QUEUE_PRODUCTION_ENABLED": "true"}, clear=False), \
+             mock.patch.object(bnl01_bot, "fetch_bnl_read_model", return_value=read_model(True)), \
+             mock.patch.object(bnl01_bot, "get_recent_signal_summary", return_value=""), \
+             mock.patch.object(bnl01_bot, "get_gemini_response", new=capture):
+            await bnl01_bot.generate_showday_messages(1, "submissions_open")
+            await bnl01_bot.generate_showday_messages(1, "show_live")
+            await bnl01_bot.generate_showday_messages(1, "sponsor_window")
+
+        self.assertEqual(len(prompts), 3)
+        self.assertIn("native BARCODE Radio queue", prompts[0])
+        self.assertIn("BNL observes it but does not operate", prompts[0])
+        self.assertIn("scheduled broadcast window, not proof of current live state", prompts[1])
+        self.assertIn("optional later-show sponsor reminder", prompts[2])
+        self.assertIn("timing remains host-controlled", prompts[2])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Replaced the remaining Auxchord-specific show-day fallback announcements with provider-neutral or native-queue wording selected by the existing two-gate contract.
- Kept native queue context fail-closed: the local bot gate must be exactly `BNL_QUEUE_PRODUCTION_ENABLED=true` (case-insensitive) and the website read model must report boolean `capabilities.queueProduction=true`.
- Added bounded, prompt-only public site canon from `sections.sourceContext` for explicitly relevant website/read-model questions while retaining the existing live queue sanitizer.
- Restrained the 7:00 PM announcement to the scheduled broadcast window instead of claiming unverified live/on-air state.
- Kept the later sponsor reminder optional and host-controlled, without claiming a break is active, due, required, or already called.
- Added generated-copy guards that reject Auxchord fallback, queue-specific wording while the native route is unavailable, and claims that BNL operates, routes, approves, manages, controls, owns, or reorders submissions.
- Documented activation and rollback order and added focused regression coverage.

## Why

The bot still carried legacy Auxchord announcement language and show-day copy that could overstate current broadcast or sponsor state. This aligns the bot with the site's native queue cutover while preserving the existing public-canon/live-state boundary.

## Safety and scope

- Both production gates remain off by default; this PR does not activate either gate.
- No queue ordering, submission acceptance, payment, playback, upload, storage, or queue-write mechanics changed.
- No memory, relationship, dossier, Source Files, Relay, Journal, recap, or public-copy write path changed.
- No proactive engagement or automatic show-day Discord posting flag was enabled.
- Queue data remains temporary prompt context only, is stripped unless both gates agree, and is not fetched for unrelated chat.
- The read-model request is offloaded from the event loop and remains read-only.

## Validation

- `make check PYTHON=/tmp/bnl-bot-pr3b-venv/bin/python`
- 973 tests passed on local Python 3.12
- Focused queue/canon/show-day suite: 42 tests passed
- Compile check passed
- `git diff --check` passed
- GitHub Actions passed the full suite on Python 3.9 and 3.12
- Published tree SHA exactly matches the locally validated tree: `6488a48d3df38a606c3e07b776eb7f535f46e224`

## Activation and rollback

Activation remains a separate owner-approved operation:

1. Merge and verify the site cutover first.
2. Confirm the website reports `capabilities.queueProduction=true` and its public queue state is accurate.
3. Only then set the bot gate to `BNL_QUEUE_PRODUCTION_ENABLED=true` and restart the bot.
4. Roll back the bot first by unsetting or changing that variable away from `true`; roll back the website independently afterward.
