### PR TITLE
Bot: add v2 shadow acceptance and rollback evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ Run the bot only after the deployment environment is configured:
 python bnl01_bot.py
 ```
 
+## V2 shadow acceptance
+
+The v2 memory and relationship stack is evaluated in the fixed shadow order
+Ledger → Moments → Governance → Relationship. The acceptance diagnostic enables
+nothing, keeps every live gate off, requires owner review, and never performs an
+automatic cutover. Conversation Context v2 is a separate continuity preflight.
+
+See [BNL-01 v2 Shadow Acceptance and Rollback](docs/BNL01_V2_SHADOW_ACCEPTANCE_AND_ROLLBACK.md)
+for the aggregate evidence fields, exact stop conditions, and reverse-order
+rollback procedure.
+
 ## Release baseline
 
 Before merging a runtime change:

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -24,7 +24,6 @@ from bnl_canon_source_contract import (
 )
 from bnl_memory_ledger import (
     LedgerWriteResult,
-    build_memory_ledger_evaluation,
     ensure_memory_ledger_schema,
     shadow_broadcast_memory_row,
     shadow_conversation_row,
@@ -66,6 +65,10 @@ from bnl_conversation_context_v2 import (
     CONVERSATION_CONTEXT_VERSION,
     ConversationContextRequest,
     assemble_conversation_context_v2,
+)
+from bnl_shadow_acceptance import (
+    build_v2_shadow_acceptance_snapshot,
+    render_v2_shadow_acceptance_lines,
 )
 from bnl_journal import (
     JOURNAL_ROUTE,
@@ -19731,14 +19734,21 @@ async def bnl_memory_check(interaction: discord.Interaction):
     active_override = get_active_show_state_override(guild.id)
     latest_broadcast_context_episode_date = get_latest_broadcast_episode_date(guild.id, public_only=False)
     member_activity_events_count, recent_member_events_count_7d = get_member_activity_event_counts(guild.id)
+    shadow_acceptance = None
     try:
-        ledger_conn = sqlite3.connect(DB_FILE)
+        diagnostic_conn = sqlite3.connect(DB_FILE)
         try:
-            ledger_diag = build_memory_ledger_evaluation(ledger_conn, guild_id=guild.id)
+            shadow_acceptance = build_v2_shadow_acceptance_snapshot(
+                diagnostic_conn,
+                guild_id=guild.id,
+                environ=os.environ,
+                conversation_context_diagnostics=LAST_CONVERSATION_CONTEXT_V2_DIAGNOSTICS,
+            )
+            ledger_diag = shadow_acceptance["reports"]["memoryLedger"]
         finally:
-            ledger_conn.close()
+            diagnostic_conn.close()
     except Exception as exc:
-        logging.debug("memory_ledger_diagnostic_failed error=%s", exc)
+        logging.debug("v2_shadow_acceptance_diagnostic_failed error=%s", exc)
         ledger_diag = {"schemaVersion": "memory_ledger_v1", "insertedLedgerEntries": "error"}
     lines = [
         "**BNL Memory Diagnostic (safe)**",
@@ -19803,7 +19813,8 @@ async def bnl_memory_check(interaction: discord.Interaction):
         "- memory_tier_future_writes_source_gated: `yes`",
         f"- memory_ledger_shadow_enabled: `{'yes' if memory_ledger_shadow_enabled() else 'no'}`",
         f"- memory_ledger_schema: `{ledger_diag.get('schemaVersion')}`",
-        f"- memory_ledger_entries: `{ledger_diag.get('insertedLedgerEntries', 0)}`",
+        f"- memory_ledger_inserted_shadow_receipts: `{ledger_diag.get('insertedLedgerEntries', 0)}`",
+        f"- memory_ledger_actual_rows: `{ledger_diag.get('actualLedgerRows', 0)}`",
         f"- memory_ledger_counts_by_source: `{ledger_diag.get('countsBySourceLane', {})}`",
         f"- memory_ledger_counts_by_type: `{ledger_diag.get('countsByEntryType', {})}`",
         f"- memory_ledger_counts_by_visibility: `{ledger_diag.get('countsByVisibility', {})}`",
@@ -19838,6 +19849,10 @@ async def bnl_memory_check(interaction: discord.Interaction):
         f"- active_show_state_needs_clarification: `{active_override[8] if active_override else 0}`",
         f"- active_show_state_summary: `{_safe_truncate_summary(active_override[2], 120) if active_override and active_override[3] else 'hidden_or_none'}`",
     ]
+    if shadow_acceptance is not None:
+        lines.extend(["", *render_v2_shadow_acceptance_lines(shadow_acceptance)])
+    else:
+        lines.extend(["", "**V2 Shadow Acceptance / Rollback Evidence**", "- status: `report_error`", "- behavior_changes_applied: `none`"])
     await send_safe_ephemeral_chunks(interaction, "\n".join(lines), limit=1700)
 
 

--- a/bnl_memory_governance.py
+++ b/bnl_memory_governance.py
@@ -157,7 +157,9 @@ def ensure_governance_schema(conn: sqlite3.Connection) -> None:
     cur = conn.cursor()
     cur.execute("CREATE TABLE IF NOT EXISTS memory_governance_receipts (receipt_id TEXT PRIMARY KEY, guild_id INTEGER NOT NULL, subject_hash TEXT NOT NULL, action TEXT NOT NULL, target_ref TEXT DEFAULT '', created_at TEXT NOT NULL, row_counts_json TEXT DEFAULT '{}')")
     cur.execute("CREATE INDEX IF NOT EXISTS idx_mgr_subject ON memory_governance_receipts(guild_id,subject_hash,action)")
-    cur.execute("CREATE TABLE IF NOT EXISTS memory_governance_shadow_runs (run_id TEXT PRIMARY KEY, guild_id INTEGER NOT NULL, subject_hash TEXT NOT NULL, route_mode TEXT, channel_policy TEXT, created_at TEXT NOT NULL, rendered_hash TEXT, rendered_size INTEGER, legacy_hash TEXT, legacy_size INTEGER, selected_count INTEGER, excluded_json TEXT, errors_json TEXT)")
+    cur.execute("CREATE TABLE IF NOT EXISTS memory_governance_shadow_runs (run_id TEXT PRIMARY KEY, guild_id INTEGER NOT NULL, subject_hash TEXT NOT NULL, route_mode TEXT, channel_policy TEXT, created_at TEXT NOT NULL, rendered_hash TEXT, rendered_size INTEGER, legacy_hash TEXT, legacy_size INTEGER, selected_count INTEGER, excluded_json TEXT, errors_json TEXT, diagnostics_json TEXT DEFAULT '{}')")
+    if "diagnostics_json" not in {row[1] for row in cur.execute("PRAGMA table_info(memory_governance_shadow_runs)").fetchall()}:
+        cur.execute("ALTER TABLE memory_governance_shadow_runs ADD COLUMN diagnostics_json TEXT DEFAULT '{}'")
     cur.execute("CREATE INDEX IF NOT EXISTS idx_mgs_guild ON memory_governance_shadow_runs(guild_id, created_at)")
     conn.commit()
 
@@ -364,7 +366,39 @@ def build_governed_context(conn: sqlite3.Connection, req: GovernanceRequest, *, 
 def persist_shadow_diagnostics(conn: sqlite3.Connection, req: GovernanceRequest, result: GovernanceResult, legacy_context: str) -> str:
     ensure_governance_schema(conn)
     now = _now(); run_id = "mgs_" + _hash("|".join([str(req.guild_id), subject_key_for_user(req.subject_user_id), now, result.diagnostics.rendered_hash]))
-    conn.execute("INSERT OR REPLACE INTO memory_governance_shadow_runs VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)", (run_id, req.guild_id, _hash(subject_key_for_user(req.subject_user_id)), req.route_mode, req.channel_policy, now, result.diagnostics.rendered_hash, result.diagnostics.rendered_size, _hash(legacy_context), len(legacy_context or ""), result.diagnostics.selected_count, json.dumps(result.diagnostics.excluded_by_reason, sort_keys=True), json.dumps(result.diagnostics.processing_errors, sort_keys=True)))
+    invalid_invariant_counts: Dict[str, int] = {}
+    for invariant in result.diagnostics.invalid_invariants:
+        key = str(invariant or "unknown")[:120]
+        invalid_invariant_counts[key] = invalid_invariant_counts.get(key, 0) + 1
+    aggregate_diagnostics = {
+        "selected_by_source": dict(result.diagnostics.selected_by_source),
+        "invalid_invariant_counts": invalid_invariant_counts,
+        "fallback_reason": str(result.diagnostics.fallback_reason or "")[:120],
+        "visibility_exclusions": int(result.diagnostics.visibility_exclusions or 0),
+        "token_budget_exclusions": int(result.diagnostics.token_budget_exclusions or 0),
+        "duplicate_suppression": int(result.diagnostics.duplicate_suppression or 0),
+        "contradiction_resolution_count": len(result.diagnostics.contradiction_resolutions),
+        "moment_candidate_count": int(result.diagnostics.moment_candidate_count or 0),
+        "moment_needs_review_excluded": int(result.diagnostics.moment_needs_review_excluded or 0),
+        "empty_result": 0 if result.rendered_context else 1,
+    }
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO memory_governance_shadow_runs (
+            run_id, guild_id, subject_hash, route_mode, channel_policy, created_at,
+            rendered_hash, rendered_size, legacy_hash, legacy_size, selected_count,
+            excluded_json, errors_json, diagnostics_json
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        """,
+        (
+            run_id, req.guild_id, _hash(subject_key_for_user(req.subject_user_id)), req.route_mode,
+            req.channel_policy, now, result.diagnostics.rendered_hash, result.diagnostics.rendered_size,
+            _hash(legacy_context), len(legacy_context or ""), result.diagnostics.selected_count,
+            json.dumps(result.diagnostics.excluded_by_reason, sort_keys=True),
+            json.dumps(result.diagnostics.processing_errors, sort_keys=True),
+            json.dumps(aggregate_diagnostics, sort_keys=True),
+        ),
+    )
     conn.execute("DELETE FROM memory_governance_shadow_runs WHERE guild_id=? AND run_id NOT IN (SELECT run_id FROM memory_governance_shadow_runs WHERE guild_id=? ORDER BY created_at DESC, run_id DESC LIMIT 500)", (req.guild_id, req.guild_id))
     conn.commit(); return run_id
 

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -402,8 +402,14 @@ def shadow_canon_reference(conn: sqlite3.Connection, *, guild_id: int, canon_id:
     return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="approved_canon", source_row_id=canon_id, source_revision=str(canon_id), source_role="approved_canon", entry_type="canon_reference", subject_key=subject_key, subject_display_name=subject_display_name, predicate_key=predicate_key, value=(value or "")[:500], source_class=SourceClass.APPROVED_CANON, visibility=Visibility.REFERENCE_CANON, confidence=Confidence.APPROVED, public_usable=True, observed_at=observed_at or _now(), lifecycle_status=ACTIVE_LIFECYCLE))
 
 
-def build_memory_ledger_evaluation(conn: sqlite3.Connection, *, guild_id: int | None = None) -> dict[str, Any]:
-    ensure_memory_ledger_schema(conn)
+def build_memory_ledger_evaluation(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int | None = None,
+    prepare_schema: bool = True,
+) -> dict[str, Any]:
+    if prepare_schema:
+        ensure_memory_ledger_schema(conn)
     params: list[Any] = []
     where = ""
     if guild_id is not None:

--- a/bnl_moment_engine.py
+++ b/bnl_moment_engine.py
@@ -550,8 +550,14 @@ def render_shadow_moment_context(conn: sqlite3.Connection, *, guild_id: int, cha
     return "\n".join(lines)
 
 
-def build_moment_evaluation_report(conn: sqlite3.Connection, *, guild_id: int | None = None) -> dict[str, Any]:
-    ensure_moment_schema(conn)
+def build_moment_evaluation_report(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int | None = None,
+    prepare_schema: bool = True,
+) -> dict[str, Any]:
+    if prepare_schema:
+        ensure_moment_schema(conn)
     where = ""
     params: list[Any] = []
     if guild_id is not None:

--- a/bnl_relationship_engine.py
+++ b/bnl_relationship_engine.py
@@ -386,11 +386,72 @@ def propagate_ledger_lifecycle(conn: sqlite3.Connection, *, guild_id: int, ledge
         rebuild_state(conn, guild_id=guild_id, subject_user_id=int(uid))
     return count
 
-def build_evaluation_report(conn: sqlite3.Connection, *, guild_id: int | None = None) -> dict[str, Any]:
-    ensure_relationship_v2_schema(conn); where="WHERE guild_id=?" if guild_id is not None else ""; p=([guild_id] if guild_id is not None else [])
+def build_evaluation_report(conn: sqlite3.Connection, *, guild_id: int | None = None, prepare_schema: bool = True) -> dict[str, Any]:
+    if prepare_schema:
+        ensure_relationship_v2_schema(conn)
+    where="WHERE guild_id=?" if guild_id is not None else ""; p=([guild_id] if guild_id is not None else [])
     def one(sql, pp=p): return conn.execute(sql, pp).fetchone()[0]
     by_type={r[0]:r[1] for r in conn.execute(f"SELECT event_type,COUNT(*) FROM relationship_events_v2 {where} GROUP BY event_type", p).fetchall()}
     lifecycle={r[0]:r[1] for r in conn.execute(f"SELECT lifecycle,COUNT(*) FROM relationship_events_v2 {where} GROUP BY lifecycle", p).fetchall()}
+    scoped = "guild_id=? AND " if guild_id is not None else ""
+    if _table_exists(conn, "memory_ledger_entries"):
+        ledger_link_integrity_violations = one(
+            "SELECT COUNT(*) FROM relationship_event_ledger_links_v2 l "
+            "LEFT JOIN relationship_events_v2 e ON e.event_id=l.event_id "
+            "LEFT JOIN memory_ledger_entries m ON m.entry_id=l.ledger_entry_id "
+            f"WHERE {('l.guild_id=? AND ' if guild_id is not None else '')}"
+            "(e.event_id IS NULL OR e.guild_id<>l.guild_id "
+            "OR e.subject_user_id<>l.subject_user_id "
+            "OR m.entry_id IS NULL OR m.guild_id<>l.guild_id "
+            "OR m.subject_key<>('discord_user:' || CAST(l.subject_user_id AS TEXT)))"
+        )
+    else:
+        # A persisted link cannot be verified when its target table is absent.
+        ledger_link_integrity_violations = one(
+            f"SELECT COUNT(*) FROM relationship_event_ledger_links_v2 {where}"
+        )
+    if _table_exists(conn, "memory_moment_windows") and _table_exists(
+        conn, "memory_moment_participants"
+    ):
+        moment_link_integrity_violations = one(
+            "SELECT COUNT(*) FROM relationship_event_moment_links_v2 l "
+            "LEFT JOIN relationship_events_v2 e ON e.event_id=l.event_id "
+            "LEFT JOIN memory_moment_windows w ON w.moment_id=l.moment_id "
+            f"WHERE {('l.guild_id=? AND ' if guild_id is not None else '')}"
+            "(e.event_id IS NULL OR e.guild_id<>l.guild_id "
+            "OR e.subject_user_id<>l.subject_user_id "
+            "OR w.moment_id IS NULL OR w.guild_id<>l.guild_id "
+            "OR NOT EXISTS ("
+            "SELECT 1 FROM memory_moment_participants p "
+            "WHERE p.moment_id=l.moment_id "
+            "AND p.participant_key=('discord_user:' || CAST(l.subject_user_id AS TEXT))"
+            "))"
+        )
+    else:
+        # A persisted link cannot be verified when either target table is absent.
+        moment_link_integrity_violations = one(
+            f"SELECT COUNT(*) FROM relationship_event_moment_links_v2 {where}"
+        )
+    cross_guild_member_violations = sum([
+        one(f"SELECT COUNT(*) FROM relationship_events_v2 WHERE {scoped}subject_key<>('discord_user:' || CAST(subject_user_id AS TEXT))"),
+        one(f"SELECT COUNT(*) FROM relationship_state_v2 WHERE {scoped}subject_key<>('discord_user:' || CAST(subject_user_id AS TEXT))"),
+        one(f"SELECT COUNT(*) FROM relationship_engagement_shadow_runs WHERE {scoped}subject_key<>('discord_user:' || CAST(subject_user_id AS TEXT))"),
+        one(f"SELECT COUNT(*) FROM relationship_observation_diagnostics_v2 WHERE {scoped}subject_key<>('discord_user:' || CAST(subject_user_id AS TEXT))"),
+        one(f"SELECT COUNT(*) FROM relationship_member_settings_v2 WHERE {scoped}subject_key<>('discord_user:' || CAST(subject_user_id AS TEXT))"),
+        one(f"SELECT COUNT(*) FROM relationship_member_preferences_v2 WHERE {scoped}subject_key<>('discord_user:' || CAST(subject_user_id AS TEXT))"),
+    ])
+    withheld_reason_counts: dict[str, int] = {}
+    for raw_reasons, count in conn.execute(f"SELECT withheld_reason_codes,COUNT(*) FROM relationship_engagement_shadow_runs {where} GROUP BY withheld_reason_codes", p).fetchall():
+        try:
+            parsed = json.loads(raw_reasons or "[]")
+            reasons = parsed if isinstance(parsed, list) else []
+        except (TypeError, ValueError, json.JSONDecodeError):
+            reasons = []
+        if raw_reasons and raw_reasons != "[]" and not reasons:
+            reasons = ["malformed_withheld_reason_json"]
+        for raw_reason in reasons:
+            reason = re.sub(r"[^a-z0-9_:-]+", "_", str(raw_reason or "unknown").strip().lower())[:80] or "unknown"
+            withheld_reason_counts[reason] = withheld_reason_counts.get(reason, 0) + int(count or 0)
     return {
         "eligible_user_authored_events": one(f"SELECT COUNT(*) FROM relationship_events_v2 {where + (' AND' if where else 'WHERE')} actor_role='user' AND lifecycle='active' AND event_type<>'unclassified'"),
         "rejected_or_unclassified_user_evidence": one(f"SELECT COUNT(*) FROM relationship_observation_diagnostics_v2 {where}"),
@@ -399,12 +460,18 @@ def build_evaluation_report(conn: sqlite3.Connection, *, guild_id: int | None = 
         "policy_route_ambiguity_rejections": one(f"SELECT COUNT(*) FROM relationship_observation_diagnostics_v2 {where + (' AND' if where else 'WHERE')} rejection_reason='policy_or_route_or_ambiguous'"),
         "model_audit_events": by_type.get("model_audit",0)+by_type.get("model_playful_rivalry_acceptance",0), "events_by_type": by_type, "lifecycle_exclusions": {k:v for k,v in lifecycle.items() if k in BLOCKED_LIFECYCLES},
         "moment_linked_events": one(f"SELECT COUNT(DISTINCT event_id) FROM relationship_event_moment_links_v2 {where + (' AND' if where else 'WHERE')} lifecycle='active'"),
-        "cross_guild_member_violations": "not_collected", "visibility_violations": one(f"SELECT COUNT(*) FROM relationship_events_v2 {where + (' AND' if where else 'WHERE')} visibility<>'private'"),
+        "cross_guild_member_violations": cross_guild_member_violations,
+        "ledger_link_integrity_violations": ledger_link_integrity_violations,
+        "moment_link_integrity_violations": moment_link_integrity_violations,
+        "visibility_violations": one(f"SELECT COUNT(*) FROM relationship_events_v2 {where + (' AND' if where else 'WHERE')} visibility<>'private'"),
+        "shadow_runs": one(f"SELECT COUNT(*) FROM relationship_engagement_shadow_runs {where}"),
         "policy_eligible_shadow_candidates": one(f"SELECT COUNT(*) FROM relationship_engagement_shadow_runs {where + (' AND' if where else 'WHERE')} policy_eligible=1"),
+        "would_select": one(f"SELECT COUNT(*) FROM relationship_engagement_shadow_runs {where + (' AND' if where else 'WHERE')} would_select=1"),
+        "live_emission_allowed": one(f"SELECT COUNT(*) FROM relationship_engagement_shadow_runs {where + (' AND' if where else 'WHERE')} live_emission_allowed=1"),
         "actual_live_emissions": one(f"SELECT COUNT(*) FROM relationship_engagement_shadow_runs {where + (' AND' if where else 'WHERE')} actual_emitted=1"),
-        "withheld_reasons": {r[0]:r[1] for r in conn.execute(f"SELECT withheld_reason_codes,COUNT(*) FROM relationship_engagement_shadow_runs {where} GROUP BY withheld_reason_codes", p).fetchall()},
+        "withheld_reasons": withheld_reason_counts,
         "opt_out_rejections": one(f"SELECT COUNT(*) FROM relationship_engagement_shadow_runs {where + (' AND' if where else 'WHERE')} withheld_reason_codes LIKE '%member_opt_out%'"),
-        "privacy_rejections": one(f"SELECT COUNT(*) FROM relationship_engagement_shadow_runs {where + (' AND' if where else 'WHERE')} withheld_reason_codes LIKE '%visibility%' OR withheld_reason_codes LIKE '%policy%'"),
+        "privacy_rejections": one(f"SELECT COUNT(*) FROM relationship_engagement_shadow_runs {where + (' AND' if where else 'WHERE')} (withheld_reason_codes LIKE '%visibility%' OR withheld_reason_codes LIKE '%policy%')"),
         "cooldown_rejections": one(f"SELECT COUNT(*) FROM relationship_engagement_shadow_runs {where + (' AND' if where else 'WHERE')} withheld_reason_codes LIKE '%cooldown%'"),
         "rivalry_rejections": one(f"SELECT COUNT(*) FROM relationship_engagement_shadow_runs {where + (' AND' if where else 'WHERE')} withheld_reason_codes LIKE '%rivalry%'"),
         "processing_errors": one(f"SELECT COUNT(*) FROM relationship_engagement_shadow_runs {where + (' AND' if where else 'WHERE')} processing_errors_json<>'[]'"),

--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -1,0 +1,842 @@
+"""Privacy-safe, read-only acceptance evidence for BNL's v2 shadow stack.
+
+This module reports the state of systems that already exist. It never enables an
+environment gate, chooses a live cutover, mutates evaluation rows, or emits a
+Discord message.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from collections import Counter
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from bnl_memory_ledger import build_memory_ledger_evaluation
+from bnl_moment_engine import build_moment_evaluation_report
+from bnl_relationship_engine import build_evaluation_report as build_relationship_evaluation_report
+
+
+SHADOW_ACCEPTANCE_VERSION = "v2_shadow_acceptance_v1"
+SHADOW_EVALUATION_ORDER = (
+    "memory_ledger",
+    "moment_engine",
+    "memory_governance",
+    "relationship_v2",
+)
+
+
+def _flag_enabled(environ: Mapping[str, str], name: str, default: str = "") -> bool:
+    value = str(environ.get(name, default) or default)
+    return value.strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def build_gate_snapshot(environ: Optional[Mapping[str, str]] = None) -> Dict[str, bool]:
+    """Return requested and effective gate state without changing the environment."""
+
+    env = environ if environ is not None else os.environ
+    ledger = _flag_enabled(env, "BNL_MEMORY_LEDGER_SHADOW_ENABLED")
+    moment = _flag_enabled(env, "BNL_MOMENT_ENGINE_SHADOW_ENABLED")
+    governance_shadow = _flag_enabled(env, "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED")
+    governance_live_requested = _flag_enabled(env, "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED")
+    relationship_shadow = _flag_enabled(env, "BNL_RELATIONSHIP_V2_SHADOW_ENABLED")
+    relationship_live = _flag_enabled(env, "BNL_RELATIONSHIP_V2_LIVE_ENABLED")
+    engagement_live = _flag_enabled(env, "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED")
+    context_value = str(env.get("BNL_CONVERSATION_CONTEXT_V2_ENABLED", "true") or "true")
+    context_enabled = context_value.strip().lower() not in {"false", "0", "off"}
+    return {
+        "conversation_context_v2": context_enabled,
+        "memory_ledger_shadow_requested": ledger,
+        "moment_engine_shadow_requested": moment,
+        "moment_engine_shadow_effective": ledger and moment,
+        "memory_governance_shadow_requested": governance_shadow,
+        "memory_governance_live_requested": governance_live_requested,
+        "memory_governance_live_effective": governance_shadow and governance_live_requested,
+        "relationship_v2_shadow_requested": relationship_shadow,
+        "relationship_v2_live_requested": relationship_live,
+        "active_engagement_v2_live_requested": engagement_live,
+        "all_live_gates_clear": not (
+            governance_live_requested or relationship_live or engagement_live
+        ),
+    }
+
+
+def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    return bool(
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+            (table_name,),
+        ).fetchone()
+    )
+
+
+def _table_columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
+    if not _table_exists(conn, table_name):
+        return set()
+    return {str(row[1]) for row in conn.execute("PRAGMA table_info(%s)" % table_name)}
+
+
+def _evidence_window(
+    conn: sqlite3.Connection,
+    *,
+    table_name: str,
+    timestamp_column: str,
+    guild_id: int,
+) -> Dict[str, str]:
+    if not _table_exists(conn, table_name):
+        return {"first": "none", "last": "none"}
+    row = conn.execute(
+        "SELECT MIN(%s), MAX(%s) FROM %s WHERE guild_id=?"
+        % (timestamp_column, timestamp_column, table_name),
+        (guild_id,),
+    ).fetchone()
+    return {
+        "first": str((row or (None, None))[0] or "none"),
+        "last": str((row or (None, None))[1] or "none"),
+    }
+
+
+def _report_error(report: Dict[str, Any], exc: Exception) -> Dict[str, Any]:
+    report["reportError"] = type(exc).__name__
+    return report
+
+
+def _empty_ledger_report() -> Dict[str, Any]:
+    return {
+        "tablePresent": False,
+        "schemaVersion": "memory_ledger_v1",
+        "actualLedgerRows": 0,
+        "eligibleLegacyWrites": 0,
+        "insertedLedgerEntries": 0,
+        "exactSourceDeduplications": 0,
+        "shadowWriteErrors": 0,
+        "skippedWrites": {},
+        "missingUnmappedProvenance": 0,
+        "entriesWithMultipleActiveValues": 0,
+        "danglingLineageTargets": 0,
+        "legacyToLedgerParityMismatches": 0,
+    }
+
+
+def _read_ledger_report(conn: sqlite3.Connection, guild_id: int) -> Dict[str, Any]:
+    required = {
+        "memory_ledger_entries",
+        "memory_ledger_lineage",
+        "memory_ledger_shadow_receipts",
+    }
+    if not all(_table_exists(conn, table) for table in required):
+        return _empty_ledger_report()
+    try:
+        report = build_memory_ledger_evaluation(
+            conn,
+            guild_id=guild_id,
+            prepare_schema=False,
+        )
+        report["tablePresent"] = True
+        report["actualLedgerRows"] = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM memory_ledger_entries WHERE guild_id=?",
+                (guild_id,),
+            ).fetchone()[0]
+            or 0
+        )
+        report["evidenceWindow"] = _evidence_window(
+            conn,
+            table_name="memory_ledger_shadow_receipts",
+            timestamp_column="attempted_at",
+            guild_id=guild_id,
+        )
+        return report
+    except (sqlite3.DatabaseError, ValueError, TypeError) as exc:
+        return _report_error({**_empty_ledger_report(), "tablePresent": True}, exc)
+
+
+def _empty_moment_report() -> Dict[str, Any]:
+    return {
+        "tablePresent": False,
+        "eligible_entries_observed": 0,
+        "open_windows": 0,
+        "finalized_moments": 0,
+        "processing_errors": 0,
+        "rejected_windows_by_reason": {},
+        "duplicate_memberships": 0,
+        "bnl_only_violations": 0,
+        "cross_guild_violations": 0,
+        "cross_channel_violations": 0,
+        "incompatible_visibility_violations": 0,
+        "dangling_lineage_targets": 0,
+        "affected_moments_awaiting_correction_review": 0,
+    }
+
+
+def _read_moment_report(conn: sqlite3.Connection, guild_id: int) -> Dict[str, Any]:
+    required = {
+        "memory_moment_windows",
+        "memory_moment_diagnostics",
+        "memory_moment_members",
+        "memory_ledger_entries",
+        "memory_ledger_lineage",
+    }
+    if not all(_table_exists(conn, table) for table in required):
+        return _empty_moment_report()
+    try:
+        report = build_moment_evaluation_report(
+            conn,
+            guild_id=guild_id,
+            prepare_schema=False,
+        )
+        report["tablePresent"] = True
+        report["evidenceWindow"] = _evidence_window(
+            conn,
+            table_name="memory_moment_diagnostics",
+            timestamp_column="created_at",
+            guild_id=guild_id,
+        )
+        return report
+    except (sqlite3.DatabaseError, ValueError, TypeError) as exc:
+        return _report_error({**_empty_moment_report(), "tablePresent": True}, exc)
+
+
+def _json_value(value: Any, fallback: Any) -> Any:
+    if value is None or value == "":
+        return fallback
+    try:
+        return json.loads(str(value))
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _count_mapping(value: Any) -> Dict[str, int]:
+    parsed = _json_value(value, {})
+    if not isinstance(parsed, dict):
+        return {"invalid_json": 1}
+    result: Dict[str, int] = {}
+    for key, count in parsed.items():
+        result[str(key)] = _aggregate_count(count)
+    return result
+
+
+def _error_count(value: Any) -> int:
+    parsed = _json_value(value, ["invalid_json"])
+    if isinstance(parsed, (list, tuple, dict)):
+        return len(parsed)
+    return 1 if parsed else 0
+
+
+def _invariant_counts(value: Any) -> Dict[str, int]:
+    if isinstance(value, dict):
+        return {str(k): _aggregate_count(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return dict(Counter(str(item) for item in value))
+    return {}
+
+
+def _aggregate_count(value: Any) -> int:
+    """Parse a persisted aggregate count or fail the diagnostic closed."""
+
+    count = int(value or 0)
+    if count < 0:
+        raise ValueError("negative aggregate count")
+    return count
+
+
+def _empty_governance_report() -> Dict[str, Any]:
+    return {
+        "tablePresent": False,
+        "aggregateDiagnosticsPresent": False,
+        "aggregateDiagnosticRuns": 0,
+        "runs": 0,
+        "selected_total": 0,
+        "zero_selection_runs": 0,
+        "excluded_total": 0,
+        "excluded_by_reason": {},
+        "processing_errors": 0,
+        "selected_by_source": {},
+        "invalid_invariants": {},
+        "invalid_invariant_count": 0,
+        "invalid_invariant_runs": 0,
+        "fallback_reasons": {},
+        "visibility_exclusions": 0,
+        "token_budget_exclusions": 0,
+        "duplicate_suppression": 0,
+        "contradiction_resolution_count": 0,
+        "moment_candidate_count": 0,
+        "moment_needs_review_excluded": 0,
+        "last_run_at": "none",
+    }
+
+
+def build_persisted_governance_report(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+) -> Dict[str, Any]:
+    """Aggregate retained Governance diagnostics without subject or memory content."""
+
+    table = "memory_governance_shadow_runs"
+    if not _table_exists(conn, table):
+        return _empty_governance_report()
+    has_diagnostics = "diagnostics_json" in _table_columns(conn, table)
+    diagnostic_select = ", diagnostics_json" if has_diagnostics else ""
+    try:
+        rows = conn.execute(
+            """
+            SELECT route_mode, channel_policy, created_at, rendered_hash,
+                   rendered_size, legacy_hash, legacy_size, selected_count,
+                   excluded_json, errors_json%s
+            FROM memory_governance_shadow_runs
+            WHERE guild_id=?
+            ORDER BY created_at DESC, run_id DESC
+            LIMIT 500
+            """ % diagnostic_select,
+            (guild_id,),
+        ).fetchall()
+    except sqlite3.DatabaseError as exc:
+        return _report_error({**_empty_governance_report(), "tablePresent": True}, exc)
+
+    exclusions: Counter[str] = Counter()
+    selected_sources: Counter[str] = Counter()
+    invalid_invariants: Counter[str] = Counter()
+    fallback_reasons: Counter[str] = Counter()
+    selected_total = processing_errors = same_hash = 0
+    invalid_runs = aggregate_runs = visibility = budget = duplicates = contradictions = 0
+    moment_candidates = moment_review = 0
+
+    zero_selection_runs = 0
+    try:
+        for row in rows:
+            (
+                _route,
+                _policy,
+                _created_at,
+                rendered_hash,
+                _rendered_size,
+                legacy_hash,
+                _legacy_size,
+                selected,
+                excluded,
+                errors,
+                *diagnostics,
+            ) = row
+            selected_count = _aggregate_count(selected)
+            selected_total += selected_count
+            zero_selection_runs += int(selected_count == 0)
+            exclusions.update(_count_mapping(excluded))
+            processing_errors += _error_count(errors)
+            same_hash += int(bool(rendered_hash and legacy_hash and rendered_hash == legacy_hash))
+            diag = _json_value(diagnostics[0], {}) if diagnostics else {}
+            if not isinstance(diag, dict):
+                diag = {}
+            aggregate_runs += int(bool(diag))
+            selected_sources.update(_invariant_counts(diag.get("selected_by_source")))
+            row_invariants = _invariant_counts(
+                diag.get("invalid_invariant_counts", diag.get("invalid_invariants"))
+            )
+            invalid_invariants.update(row_invariants)
+            invalid_runs += int(bool(row_invariants))
+            fallback = str(diag.get("fallback_reason") or "none")
+            fallback_reasons[fallback] += 1
+            visibility += _aggregate_count(diag.get("visibility_exclusions"))
+            budget += _aggregate_count(diag.get("token_budget_exclusions"))
+            duplicates += _aggregate_count(diag.get("duplicate_suppression"))
+            contradictions += _aggregate_count(
+                diag.get("contradiction_resolution_count")
+            )
+            moment_candidates += _aggregate_count(diag.get("moment_candidate_count"))
+            moment_review += _aggregate_count(
+                diag.get("moment_needs_review_excluded")
+            )
+    except (TypeError, ValueError, OverflowError) as exc:
+        return _report_error(
+            {
+                **_empty_governance_report(),
+                "tablePresent": True,
+                "aggregateDiagnosticsPresent": has_diagnostics,
+            },
+            exc,
+        )
+
+    run_count = len(rows)
+    return {
+        "tablePresent": True,
+        "aggregateDiagnosticsPresent": has_diagnostics,
+        "aggregateDiagnosticRuns": aggregate_runs,
+        "runs": run_count,
+        "selected_total": selected_total,
+        "zero_selection_runs": zero_selection_runs,
+        "excluded_total": sum(exclusions.values()),
+        "excluded_by_reason": dict(sorted(exclusions.items())),
+        "processing_errors": processing_errors,
+        "same_as_legacy_hash_runs": same_hash,
+        "different_from_legacy_hash_runs": run_count - same_hash,
+        "selected_by_source": dict(sorted(selected_sources.items())),
+        "invalid_invariants": dict(sorted(invalid_invariants.items())),
+        "invalid_invariant_count": sum(invalid_invariants.values()),
+        "invalid_invariant_runs": invalid_runs,
+        "fallback_reasons": dict(sorted(fallback_reasons.items())),
+        "visibility_exclusions": visibility,
+        "token_budget_exclusions": budget,
+        "duplicate_suppression": duplicates,
+        "contradiction_resolution_count": contradictions,
+        "moment_candidate_count": moment_candidates,
+        "moment_needs_review_excluded": moment_review,
+        "last_run_at": str(rows[0][2]) if rows else "none",
+        "evidenceWindow": {
+            "first": str(rows[-1][2]) if rows else "none",
+            "last": str(rows[0][2]) if rows else "none",
+        },
+    }
+
+
+def _empty_relationship_report() -> Dict[str, Any]:
+    return {
+        "tablePresent": False,
+        "eligible_user_authored_events": 0,
+        "rejected_or_unclassified_user_evidence": 0,
+        "engagement_shadow_runs": 0,
+        "engagement_would_select": 0,
+        "engagement_live_emission_allowed": 0,
+        "policy_eligible_shadow_candidates": 0,
+        "actual_live_emissions": 0,
+        "withheld_reasons": {},
+        "cross_guild_member_violations": 0,
+        "ledger_link_integrity_violations": 0,
+        "moment_link_integrity_violations": 0,
+        "visibility_violations": 0,
+        "processing_errors": 0,
+        "legacy_v2_comparison": "not_collected",
+    }
+
+
+def _read_relationship_report(conn: sqlite3.Connection, guild_id: int) -> Dict[str, Any]:
+    required = {
+        "relationship_events_v2",
+        "relationship_observation_diagnostics_v2",
+        "relationship_event_moment_links_v2",
+        "relationship_engagement_shadow_runs",
+    }
+    if not all(_table_exists(conn, table) for table in required):
+        return _empty_relationship_report()
+    try:
+        report = build_relationship_evaluation_report(
+            conn,
+            guild_id=guild_id,
+            prepare_schema=False,
+        )
+        report["engagement_shadow_runs"] = int(
+            report.get("engagement_shadow_runs", report.get("shadow_runs", 0)) or 0
+        )
+        report["engagement_would_select"] = int(
+            report.get("engagement_would_select", report.get("would_select", 0)) or 0
+        )
+        report["engagement_live_emission_allowed"] = int(
+            report.get(
+                "engagement_live_emission_allowed",
+                report.get("live_emission_allowed", 0),
+            )
+            or 0
+        )
+        report["evidenceWindow"] = _evidence_window(
+            conn,
+            table_name="relationship_engagement_shadow_runs",
+            timestamp_column="created_at",
+            guild_id=guild_id,
+        )
+        report["tablePresent"] = True
+        return report
+    except (sqlite3.DatabaseError, ValueError, TypeError) as exc:
+        return _report_error({**_empty_relationship_report(), "tablePresent": True}, exc)
+
+
+def _safe_context_report(diagnostics: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
+    source = diagnostics or {}
+    numeric = (
+        "same_room_paired_turn_count",
+        "cross_channel_paired_turn_count",
+        "unpaired_row_count",
+        "current_message_duplicates_removed",
+        "visibility_policy_exclusions",
+        "final_char_count",
+    )
+    result: Dict[str, Any] = {
+        "scope": "process_last_run",
+        "contract_version": str(source.get("contract_version") or "unknown")[:64],
+        "route_mode": str(source.get("route_mode") or "unknown")[:64],
+        "channel_policy": str(source.get("channel_policy") or "unknown")[:64],
+        "selection_fallback_reason": str(
+            source.get("selection_fallback_reason") or "not_used"
+        )[:96],
+        "selection_reason_count": len(list(source.get("selection_reasons") or ())[:8]),
+    }
+    for key in numeric:
+        result[key] = int(source.get(key) or 0)
+    return result
+
+
+def _positive(report: Mapping[str, Any], keys: Sequence[str]) -> bool:
+    return any(int(report.get(key, 0) or 0) > 0 for key in keys)
+
+
+def _stage_status(
+    *,
+    requested: bool,
+    prerequisites: Sequence[str],
+    evidence: bool,
+    blockers: Sequence[str],
+) -> str:
+    if not requested:
+        return "disabled"
+    if blockers:
+        return "failed"
+    if prerequisites:
+        return "blocked_by_prerequisite"
+    if not evidence:
+        return "collecting"
+    return "candidate_pass_owner_review_required"
+
+
+def build_v2_shadow_acceptance_snapshot(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    environ: Optional[Mapping[str, str]] = None,
+    conversation_context_diagnostics: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a dependency-aware snapshot from aggregate evidence only."""
+
+    gates = build_gate_snapshot(environ)
+    ledger = _read_ledger_report(conn, guild_id)
+    moments = _read_moment_report(conn, guild_id)
+    governance = build_persisted_governance_report(conn, guild_id=guild_id)
+    relationship = _read_relationship_report(conn, guild_id)
+    context = _safe_context_report(conversation_context_diagnostics)
+
+    live_gates = [
+        name
+        for name, enabled in (
+            ("BNL_MEMORY_GOVERNANCE_LIVE_ENABLED", gates["memory_governance_live_requested"]),
+            ("BNL_RELATIONSHIP_V2_LIVE_ENABLED", gates["relationship_v2_live_requested"]),
+            ("BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED", gates["active_engagement_v2_live_requested"]),
+        )
+        if enabled
+    ]
+
+    ledger_blockers = []
+    if int(ledger.get("shadowWriteErrors", 0) or 0):
+        ledger_blockers.append("shadow_write_errors")
+    if int(ledger.get("danglingLineageTargets", 0) or 0):
+        ledger_blockers.append("dangling_lineage_targets")
+    if ledger.get("reportError"):
+        ledger_blockers.append("report_error:%s" % ledger["reportError"])
+    ledger_evidence = (
+        int(ledger.get("eligibleLegacyWrites", 0) or 0) > 0
+        and int(ledger.get("insertedLedgerEntries", 0) or 0) > 0
+        and int(ledger.get("exactSourceDeduplications", 0) or 0) > 0
+    )
+    ledger_status = _stage_status(
+        requested=gates["memory_ledger_shadow_requested"],
+        prerequisites=(),
+        evidence=ledger_evidence,
+        blockers=ledger_blockers,
+    )
+
+    moment_blockers = [
+        key
+        for key in (
+            "processing_errors",
+            "duplicate_memberships",
+            "bnl_only_violations",
+            "cross_guild_violations",
+            "cross_channel_violations",
+            "incompatible_visibility_violations",
+            "dangling_lineage_targets",
+        )
+        if int(moments.get(key, 0) or 0)
+    ]
+    if moments.get("reportError"):
+        moment_blockers.append("report_error:%s" % moments["reportError"])
+    moment_evidence = (
+        int(moments.get("eligible_entries_observed", 0) or 0) > 0
+        and int(moments.get("finalized_moments", 0) or 0) > 0
+    )
+    moment_prerequisites = [] if ledger_status.startswith("candidate_pass") else ["memory_ledger"]
+    moment_status = _stage_status(
+        requested=gates["moment_engine_shadow_requested"],
+        prerequisites=moment_prerequisites,
+        evidence=moment_evidence,
+        blockers=moment_blockers,
+    )
+
+    governance_blockers = []
+    if int(governance.get("processing_errors", 0) or 0):
+        governance_blockers.append("processing_errors")
+    if int(governance.get("invalid_invariant_count", 0) or 0):
+        governance_blockers.append("invalid_invariants")
+    if governance.get("reportError"):
+        governance_blockers.append("report_error:%s" % governance["reportError"])
+    governance_evidence = (
+        int(governance.get("runs", 0) or 0) > 0
+        and int(governance.get("aggregateDiagnosticRuns", 0) or 0) > 0
+    )
+    governance_prerequisites = [
+        name
+        for name, status in (
+            ("memory_ledger", ledger_status),
+            ("moment_engine", moment_status),
+        )
+        if not status.startswith("candidate_pass")
+    ]
+    governance_status = _stage_status(
+        requested=gates["memory_governance_shadow_requested"],
+        prerequisites=governance_prerequisites,
+        evidence=governance_evidence,
+        blockers=governance_blockers,
+    )
+
+    relationship_blockers = []
+    for key in (
+        "processing_errors",
+        "visibility_violations",
+        "cross_guild_member_violations",
+        "ledger_link_integrity_violations",
+        "moment_link_integrity_violations",
+        "engagement_live_emission_allowed",
+        "actual_live_emissions",
+    ):
+        try:
+            value = int(relationship.get(key, 0) or 0)
+        except (TypeError, ValueError):
+            value = 1
+        if value:
+            relationship_blockers.append(key)
+    if relationship.get("reportError"):
+        relationship_blockers.append("report_error:%s" % relationship["reportError"])
+    relationship_evidence = (
+        _positive(
+            relationship,
+            ("eligible_user_authored_events", "rejected_or_unclassified_user_evidence"),
+        )
+        and int(relationship.get("engagement_shadow_runs", 0) or 0) > 0
+    )
+    relationship_prerequisites = [
+        name
+        for name, status in (
+            ("memory_ledger", ledger_status),
+            ("moment_engine", moment_status),
+            ("memory_governance", governance_status),
+        )
+        if not status.startswith("candidate_pass")
+    ]
+    relationship_status = _stage_status(
+        requested=gates["relationship_v2_shadow_requested"],
+        prerequisites=relationship_prerequisites,
+        evidence=relationship_evidence,
+        blockers=relationship_blockers,
+    )
+
+    context_cross_channel = int(context.get("cross_channel_paired_turn_count", 0) or 0)
+    if not gates["conversation_context_v2"]:
+        context_status = "rollback_disabled"
+    elif context_cross_channel:
+        context_status = "failed_cross_channel_pair_detected"
+    elif int(context.get("same_room_paired_turn_count", 0) or 0) > 0:
+        context_status = "candidate_pass_process_last_run_only"
+    else:
+        context_status = "collecting_process_last_run_only"
+
+    stages = {
+        "memory_ledger": {
+            "status": ledger_status,
+            "evidenceObserved": ledger_evidence,
+            "blockers": ledger_blockers,
+            "prerequisites": [],
+        },
+        "moment_engine": {
+            "status": moment_status,
+            "evidenceObserved": moment_evidence,
+            "blockers": moment_blockers,
+            "prerequisites": moment_prerequisites,
+        },
+        "memory_governance": {
+            "status": governance_status,
+            "evidenceObserved": governance_evidence,
+            "blockers": governance_blockers,
+            "prerequisites": governance_prerequisites,
+        },
+        "relationship_v2": {
+            "status": relationship_status,
+            "evidenceObserved": relationship_evidence,
+            "blockers": relationship_blockers,
+            "prerequisites": relationship_prerequisites,
+        },
+    }
+
+    blockers = ["live_gate_enabled:%s" % name for name in live_gates]
+    if context_cross_channel:
+        blockers.append("conversation_context_cross_channel_pair")
+    for stage_name, stage in stages.items():
+        blockers.extend("%s:%s" % (stage_name, reason) for reason in stage["blockers"])
+
+    warnings = []
+    if int(ledger.get("legacyToLedgerParityMismatches", 0) or 0):
+        warnings.append("ledger_parity_metric_informational_derived_rows_included")
+    if int(ledger.get("missingUnmappedProvenance", 0) or 0):
+        warnings.append("ledger_unmapped_provenance_review")
+    if int(ledger.get("entriesWithMultipleActiveValues", 0) or 0):
+        warnings.append("ledger_multiple_active_values_review")
+    if int(moments.get("affected_moments_awaiting_correction_review", 0) or 0):
+        warnings.append("moment_correction_review_pending")
+    if relationship.get("legacy_v2_comparison") == "not_collected":
+        warnings.append("relationship_legacy_v2_comparison_not_collected")
+    if int(governance.get("aggregateDiagnosticRuns", 0) or 0) < int(
+        governance.get("runs", 0) or 0
+    ):
+        warnings.append("governance_older_rows_lack_aggregate_diagnostics")
+
+    stage_statuses = [stage["status"] for stage in stages.values()]
+    if live_gates:
+        status = "blocked_live_authority_detected"
+    elif blockers:
+        status = "blocked_shadow_invariant_failure"
+    elif all(value.startswith("candidate_pass") for value in stage_statuses):
+        status = "ready_for_owner_review_not_live_cutover"
+    else:
+        status = "collecting_shadow_evidence"
+
+    return {
+        "version": SHADOW_ACCEPTANCE_VERSION,
+        "status": status,
+        "evaluationOrder": list(SHADOW_EVALUATION_ORDER),
+        "conversationContextPreflight": {
+            "status": context_status,
+            "scope": "process_last_run",
+            "blocksAutomaticCutover": bool(context_cross_channel),
+        },
+        "gates": gates,
+        "stages": stages,
+        "blockers": sorted(set(blockers)),
+        "warnings": sorted(set(warnings)),
+        "reports": {
+            "conversationContextV2": context,
+            "memoryLedger": ledger,
+            "momentEngine": moments,
+            "memoryGovernance": governance,
+            "relationshipV2": relationship,
+        },
+        "rollback": {
+            "legacyProductionTruthPreserved": gates["all_live_gates_clear"],
+            "databaseDeletionRequired": False,
+            "restartRequiredAfterEnvironmentChange": True,
+            "disableOrder": [
+                "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED",
+                "BNL_RELATIONSHIP_V2_LIVE_ENABLED",
+                "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED",
+                "BNL_RELATIONSHIP_V2_SHADOW_ENABLED",
+                "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED",
+                "BNL_MOMENT_ENGINE_SHADOW_ENABLED",
+                "BNL_MEMORY_LEDGER_SHADOW_ENABLED",
+            ],
+            "retainShadowTablesForEvidence": True,
+        },
+        "ownerReviewRequired": True,
+        "automaticCutoverAllowed": False,
+        "behaviorChangesApplied": False,
+    }
+
+
+def _on(value: Any) -> str:
+    return "on" if value else "off"
+
+
+def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
+    """Render aggregate-only owner diagnostics; never include member content or IDs."""
+
+    gates = snapshot.get("gates") or {}
+    stages = snapshot.get("stages") or {}
+    reports = snapshot.get("reports") or {}
+    context = reports.get("conversationContextV2") or {}
+    ledger = reports.get("memoryLedger") or {}
+    moments = reports.get("momentEngine") or {}
+    governance = reports.get("memoryGovernance") or {}
+    relationship = reports.get("relationshipV2") or {}
+    blockers = snapshot.get("blockers") or []
+    warnings = snapshot.get("warnings") or []
+
+    return [
+        "**V2 Shadow Acceptance / Rollback Evidence**",
+        "- purpose: `read-only evidence; no gates or behavior changed`",
+        "- overall_status: `%s`" % snapshot.get("status", "unknown"),
+        "- evaluation_order: `%s`" % " -> ".join(snapshot.get("evaluationOrder") or SHADOW_EVALUATION_ORDER),
+        "- all_live_gates_clear: `%s`" % ("yes" if gates.get("all_live_gates_clear") else "NO - STOP"),
+        "- context_v2_preflight: `%s` scope=`process_last_run` same_room_pairs=`%s` cross_channel_pairs=`%s` fallback=`%s`" % (
+            (snapshot.get("conversationContextPreflight") or {}).get("status", "unknown"),
+            context.get("same_room_paired_turn_count", 0),
+            context.get("cross_channel_paired_turn_count", 0),
+            context.get("selection_fallback_reason", "not_used"),
+        ),
+        "- ledger: status=`%s` shadow=`%s` receipts=`%s` inserted=`%s` deduplicated=`%s` skipped=`%s` errors=`%s` actual_rows=`%s` dangling_lineage=`%s` window_last=`%s`" % (
+            (stages.get("memory_ledger") or {}).get("status", "unknown"),
+            _on(gates.get("memory_ledger_shadow_requested")),
+            ledger.get("eligibleLegacyWrites", 0),
+            ledger.get("insertedLedgerEntries", 0),
+            ledger.get("exactSourceDeduplications", 0),
+            json.dumps(ledger.get("skippedWrites", {}), sort_keys=True),
+            ledger.get("shadowWriteErrors", 0),
+            ledger.get("actualLedgerRows", 0),
+            ledger.get("danglingLineageTargets", 0),
+            (ledger.get("evidenceWindow") or {}).get("last", "none"),
+        ),
+        "- ledger_parity_metric: `%s` (`informational`; intentional derived rows are included)" % ledger.get("legacyToLedgerParityMismatches", 0),
+        "- moments: status=`%s` requested=`%s` effective=`%s` eligible=`%s` open=`%s` finalized=`%s` rejected=`%s` errors=`%s` safety_violations=`%s` window_last=`%s`" % (
+            (stages.get("moment_engine") or {}).get("status", "unknown"),
+            _on(gates.get("moment_engine_shadow_requested")),
+            _on(gates.get("moment_engine_shadow_effective")),
+            moments.get("eligible_entries_observed", 0),
+            moments.get("open_windows", 0),
+            moments.get("finalized_moments", 0),
+            json.dumps(moments.get("rejected_windows_by_reason", {}), sort_keys=True),
+            moments.get("processing_errors", 0),
+            sum(int(moments.get(key, 0) or 0) for key in ("duplicate_memberships", "bnl_only_violations", "cross_guild_violations", "cross_channel_violations", "incompatible_visibility_violations", "dangling_lineage_targets")),
+            (moments.get("evidenceWindow") or {}).get("last", "none"),
+        ),
+        "- governance: status=`%s` shadow=`%s` live_requested=`%s` live_effective=`%s` runs=`%s` aggregate_runs=`%s` selected=`%s` empty_runs=`%s` errors=`%s` invalid_invariants=`%s` window_last=`%s`" % (
+            (stages.get("memory_governance") or {}).get("status", "unknown"),
+            _on(gates.get("memory_governance_shadow_requested")),
+            _on(gates.get("memory_governance_live_requested")),
+            _on(gates.get("memory_governance_live_effective")),
+            governance.get("runs", 0),
+            governance.get("aggregateDiagnosticRuns", 0),
+            governance.get("selected_total", 0),
+            governance.get("zero_selection_runs", 0),
+            governance.get("processing_errors", 0),
+            governance.get("invalid_invariant_count", 0),
+            (governance.get("evidenceWindow") or {}).get("last", "none"),
+        ),
+        "- governance_exclusions: `%s`" % json.dumps(governance.get("excluded_by_reason", {}), sort_keys=True),
+        "- relationship: status=`%s` shadow=`%s` relationship_live=`%s` engagement_live=`%s` events=`%s` rejected_observations=`%s` plans=`%s` would_select=`%s` live_allowed=`%s` actual_emissions=`%s` errors=`%s` window_last=`%s`" % (
+            (stages.get("relationship_v2") or {}).get("status", "unknown"),
+            _on(gates.get("relationship_v2_shadow_requested")),
+            _on(gates.get("relationship_v2_live_requested")),
+            _on(gates.get("active_engagement_v2_live_requested")),
+            relationship.get("eligible_user_authored_events", 0),
+            relationship.get("rejected_or_unclassified_user_evidence", 0),
+            relationship.get("engagement_shadow_runs", 0),
+            relationship.get("engagement_would_select", 0),
+            relationship.get("engagement_live_emission_allowed", 0),
+            relationship.get("actual_live_emissions", 0),
+            relationship.get("processing_errors", 0),
+            (relationship.get("evidenceWindow") or {}).get("last", "none"),
+        ),
+        "- relationship_withheld_reasons: `%s`" % json.dumps(relationship.get("withheld_reasons", {}), sort_keys=True),
+        "- relationship_link_integrity: ledger=`%s` moments=`%s`" % (
+            relationship.get("ledger_link_integrity_violations", 0),
+            relationship.get("moment_link_integrity_violations", 0),
+        ),
+        "- relationship_legacy_v2_comparison: `%s`" % relationship.get("legacy_v2_comparison", "not_collected"),
+        "- blockers: `%s`" % (", ".join(blockers) if blockers else "none"),
+        "- warnings: `%s`" % (", ".join(warnings) if warnings else "none"),
+        "- rollback: `disable in reverse dependency order; restart; preserve shadow evidence; delete nothing`",
+        "- owner_review_required: `yes`",
+        "- automatic_cutover: `forbidden`",
+    ]

--- a/docs/BNL01_V2_SHADOW_ACCEPTANCE_AND_ROLLBACK.md
+++ b/docs/BNL01_V2_SHADOW_ACCEPTANCE_AND_ROLLBACK.md
@@ -1,0 +1,269 @@
+# BNL-01 v2 Shadow Acceptance and Rollback
+
+This document is the operator contract for evaluating BNL-01's existing v2
+memory and relationship systems in shadow mode. It does not authorize a live
+cutover, and the implementation that reports this evidence must not enable or
+change an environment variable.
+
+## Scope and non-goals
+
+This acceptance pass is read-only with respect to live behavior. It aggregates
+privacy-safe counters already produced by the shadow systems so the owner can
+decide whether each layer has collected enough trustworthy evidence to proceed
+to the next shadow layer.
+
+This pass explicitly does **not**:
+
+- enable a shadow or live gate;
+- replace legacy prompt context or change a Discord response;
+- activate proactive engagement or relationship behavior;
+- make an automatic cutover decision;
+- change the queue, website, Journal, Relay, dossiers, or Source Files;
+- publish, edit, or delete member-facing content; or
+- delete or rewrite shadow tables during rollback.
+
+The only successful terminal state is `ready_for_owner_review_not_live_cutover`.
+That state means the aggregate evidence is ready for a human decision. It does
+not mean any live gate may be enabled.
+
+## Owner diagnostic
+
+Run `/bnl_memory_check` in Discord as the configured owner. Its existing
+owner-only, ephemeral response now includes a **V2 Shadow Acceptance / Rollback
+Evidence** section. The acceptance reader performs aggregate `SELECT` queries
+only: it does not create a schema, write an evidence row, set a gate, or send a
+normal Discord response. Each stage includes its retained evidence window so
+the owner can compare snapshots before and after a controlled test period.
+
+## Conversation Context v2 is a separate preflight
+
+Conversation Context v2 is already an immediate-turn continuity layer. It is
+not part of the durable shadow dependency chain below and must not be presented
+as a fifth shadow stage.
+
+Before collecting shadow-stack evidence, run the sealed continuity check in
+`#bnl-testing`:
+
+1. Send `remember this number: 8` and wait for BNL-01's reply.
+2. Send `what number did i tell you to remember?`.
+3. Confirm the answer directly identifies `8` without archive, database,
+   dossier, or "records indicate" framing.
+4. Immediately inspect the owner-only context diagnostic. It should report the
+   `sealed_test` policy, at least one same-room paired turn, no cross-channel
+   pair, and no current-message duplication or protected-context leakage.
+
+If this preflight fails, set `BNL_CONVERSATION_CONTEXT_V2_ENABLED=off`, restart
+the bot, and confirm the diagnostic reason is `rollback_disabled`. This rollback
+is independent of all memory and relationship shadow gates.
+
+## Required shadow order
+
+Evaluate one layer at a time in this exact order:
+
+1. Unified Memory Ledger
+2. Moment Engine
+3. Memory Governance
+4. Relationship v2
+
+Do not skip a layer. Do not start a later layer while an earlier layer is
+blocked, missing evidence, or still under owner review.
+
+| Stage | Shadow gate | Required earlier shadow gates |
+| --- | --- | --- |
+| Ledger | `BNL_MEMORY_LEDGER_SHADOW_ENABLED` | none |
+| Moments | `BNL_MOMENT_ENGINE_SHADOW_ENABLED` | Ledger |
+| Governance | `BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED` | Ledger and Moments |
+| Relationship | `BNL_RELATIONSHIP_V2_SHADOW_ENABLED` | Ledger, Moments, and Governance |
+
+All live gates must remain off throughout the entire acceptance pass:
+
+- `BNL_MEMORY_GOVERNANCE_LIVE_ENABLED`
+- `BNL_RELATIONSHIP_V2_LIVE_ENABLED`
+- `BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED`
+
+Enabling any live gate blocks acceptance immediately. The reporting code does
+not set these variables and does not provide an automatic activation path.
+
+## Aggregate acceptance evidence
+
+The owner-only acceptance snapshot is aggregate and content-free. It may report
+gate states, stage states, counts, reason-code totals, and rollback metadata. It
+must not expose message text, member names, Discord IDs, memory contents, or
+correlatable subject hashes.
+
+The top-level report includes:
+
+- contract version and evaluation order;
+- gate snapshot;
+- evidence-observed state for each layer;
+- first/last timestamps for retained evidence windows;
+- blockers and warnings;
+- the four layer reports plus the separate Conversation Context v2 diagnostic;
+- whether legacy production truth remains preserved;
+- whether an environment-only rollback is available;
+- `ownerReviewRequired=true`; and
+- `automaticCutoverAllowed=false`.
+
+### Ledger evidence
+
+Review at least these aggregate fields:
+
+- eligible legacy write receipts;
+- inserted ledger entries;
+- exact-source deduplications;
+- skipped writes by reason;
+- shadow write errors;
+- source-lane, entry-type, visibility, and lifecycle counts;
+- missing or unmapped provenance;
+- multiple-active-value counts;
+- dangling lineage targets; and
+- legacy-to-ledger parity mismatch count.
+
+`legacyToLedgerParityMismatches` is **informational**, not a standalone pass/fail
+gate. The ledger deliberately contains derived, projection, and review-only rows
+that do not have a one-to-one legacy-row equivalent. A nonzero total must be
+reviewed alongside its component counters; it must not be treated as automatic
+proof of data loss or used to trigger an automatic cutover or rollback.
+
+Ledger evidence is sufficient for owner review only after representative writes
+and exact-source deduplication have been observed, shadow writes remain
+non-fatal, and no hard stop condition below is present.
+
+### Moment evidence
+
+Review at least:
+
+- eligible ledger entries observed;
+- open, finalized, rejected, and correction-review windows;
+- rejection reasons and qualification types;
+- participant and finalization aggregates;
+- processing errors;
+- duplicate memberships;
+- BNL-only finalized moments;
+- cross-guild, cross-channel, and incompatible-visibility violations; and
+- dangling lineage targets.
+
+Open windows are collecting evidence, not failures. After the inactivity window,
+controlled coherent input should produce at least one finalized moment, while
+low-signal or isolated input should be rejected rather than promoted.
+
+### Governance evidence
+
+Review persisted, privacy-safe aggregates for:
+
+- run count, selected count, and zero-selection runs;
+- exclusions by reason;
+- processing errors;
+- same-as-legacy and different-from-legacy hash counts;
+- selected counts by source class;
+- invalid-invariant names and counts;
+- fallback-reason counts;
+- visibility, token-budget, duplicate, and contradiction counters; and
+- Moment candidate and needs-review counters.
+
+Zero selections and exclusions can be correct fail-closed outcomes. They are not
+failures by themselves. Governance live must remain off, so the legacy result
+continues to be the actual production result while shadow candidates are
+measured.
+
+### Relationship evidence
+
+Review at least:
+
+- eligible directed user-authored events;
+- rejected or unclassified passive, sealed, or ambiguous evidence;
+- model-audit events;
+- events by type and lifecycle exclusions;
+- moment-linked relationship events;
+- visibility, ledger-link, moment-link, and cross-guild violations;
+- policy-eligible shadow candidates;
+- withheld reasons, including opt-out, privacy, cooldown, and rivalry reasons;
+- processing errors; and
+- actual live emissions.
+
+The current Relationship v2 shadow writer records the legacy-comparison field
+as `not_collected`. The owner diagnostic displays that limitation explicitly as
+a warning; it must not imply that a legacy/v2 comparison has occurred. Because
+there is no equivalent legacy proactive-relationship planner to compare against,
+this field is transparent context for owner review rather than an invented
+pass/fail metric.
+
+Model output must not create positive relationship weight. Member opt-out and
+boundary evidence must be honored. Shadow candidates may be recorded, but
+`actual_live_emissions` must remain exactly zero.
+
+## Status meanings
+
+- `collecting_shadow_evidence`: one or more shadow gates are off, prerequisites
+  are incomplete, or representative evidence has not yet been observed.
+- `blocked_live_authority_detected`: at least one live gate is on. Stop.
+- `blocked_shadow_invariant_failure`: a hard invariant or report failed. Stop.
+- `ready_for_owner_review_not_live_cutover`: all four shadow stages have evidence
+  and no hard blocker is present. Owner review is still required.
+
+Warnings remain visible for owner review and never authorize cutover. In
+particular, parity mismatches, unmapped provenance, multiple active values,
+and correction-review work must be interpreted from their component evidence
+rather than collapsed into a false automatic decision. Dangling lineage is a
+hard stop.
+
+## Exact stop conditions
+
+Stop the current stage and do not enable the next one if any of the following is
+observed:
+
+- any live gate is enabled;
+- the bot becomes unstable, stops responding, or produces a response change
+  attributable to a shadow path;
+- any private, sealed, cross-member, cross-guild, cross-channel, or incompatible
+  visibility content crosses its boundary;
+- a report cannot be built or returns a database/report error;
+- the Ledger records a shadow write error or dangling lineage target;
+- the Moment Engine records a processing error, duplicate membership, BNL-only
+  finalized moment, cross-guild violation, cross-channel violation,
+  incompatible-visibility violation, or dangling lineage target;
+- Governance records a processing error or changes the production result while
+  its live gate is off;
+- Relationship v2 records a processing error, visibility/cross-guild linkage
+  violation, live-emission authorization, or any actual live emission;
+- model output creates positive relationship weight, a member opt-out or
+  boundary is ignored, or mutual rivalry appears without the required explicit
+  and reciprocal evidence; or
+- queue, site, Journal, Relay, dossier, or Source File behavior changes during
+  this acceptance pass.
+
+Do not reinterpret a parity mismatch total alone as a hard stop. Investigate the
+underlying counters and derived-row explanation first. The owner makes the final
+go/no-go determination; the diagnostic never does.
+
+## Rollback
+
+Rollback disables gates in reverse dependency order, restarts the bot, and
+preserves the shadow tables for diagnosis:
+
+1. `BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED`
+2. `BNL_RELATIONSHIP_V2_LIVE_ENABLED`
+3. `BNL_MEMORY_GOVERNANCE_LIVE_ENABLED`
+4. `BNL_RELATIONSHIP_V2_SHADOW_ENABLED`
+5. `BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED`
+6. `BNL_MOMENT_ENGINE_SHADOW_ENABLED`
+7. `BNL_MEMORY_LEDGER_SHADOW_ENABLED`
+
+The live gates should already be off; listing them makes the emergency rollback
+order explicit. After changing the environment, restart the bot and re-run the
+read-only diagnostic.
+
+For a stage-local failure, disable that stage and do not start later stages.
+Earlier accepted shadow layers may remain on for continued observation:
+
+- Ledger failure: disable every v2 shadow layer.
+- Moment failure: disable Moments; leave Ledger only if its evidence remains
+  accepted.
+- Governance failure: disable Governance; do not start Relationship; Ledger and
+  Moments may remain on if accepted.
+- Relationship failure: disable Relationship; earlier accepted shadow layers may
+  remain on.
+
+Do not drop tables, delete rows, or rewrite legacy memory as rollback. Shadow
+rows are additive diagnostic evidence. Nothing in this contract authorizes a
+live cutover; that would require a separate, explicit owner-approved operation.

--- a/tests/test_broadcast_memory_rd_sanitizer.py
+++ b/tests/test_broadcast_memory_rd_sanitizer.py
@@ -1,14 +1,16 @@
 import asyncio
 import os
 from types import SimpleNamespace
+import unittest
 
 os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
 
 import bnl01_bot
+from tests.unittest_compat import install_function_cases
 
 
-def test_rd_assessment_intent_and_clean_candidate():
+def _case_rd_assessment_intent_and_clean_candidate():
     text = "@BNL-01 is this appropriate for broadcast memory? DJ Floppydisc keeps trying to get me to play Chumbawamba even though the Oreaganomics Clause says I need to make the music or know someone who made it."
     assert bnl01_bot.detect_rd_ops_intent(text) == "broadcast_memory_assessment"
     response = bnl01_bot.build_rd_broadcast_memory_assessment_response(text)
@@ -19,7 +21,7 @@ def test_rd_assessment_intent_and_clean_candidate():
     assert "is this appropriate" not in clean_line.lower()
 
 
-def test_rd_draft_uses_sanitized_summary():
+def _case_rd_draft_uses_sanitized_summary():
     text = "@BNL-01 write the broadcast memory note: DJ Floppydisc keeps trying to get me to play Chumbawamba even though the Oreaganomics Clause says I need to make the music or know someone who made it."
     assert bnl01_bot.detect_rd_ops_intent(text) == "broadcast_memory_draft"
     response = bnl01_bot.build_rd_broadcast_memory_draft_response(text)
@@ -30,7 +32,7 @@ def test_rd_draft_uses_sanitized_summary():
     assert "broadcast memory?" not in summary.lower()
 
 
-def test_structured_summary_meta_scaffold_rejected_when_only_question():
+def _case_structured_summary_meta_scaffold_rejected_when_only_question():
     content = """Broadcast memory note
 Title: Test
 Date: 2026-06-12
@@ -49,7 +51,7 @@ This is broadcast memory only.
     assert result["reason"] == "summary is meta/R&D scaffold; include the actual show memory."
 
 
-def test_structured_summary_meta_scaffold_removed_when_payload_remains():
+def _case_structured_summary_meta_scaffold_removed_when_payload_remains():
     content = """Broadcast memory note
 Title: DJ Floppydisc
 Date: 2026-06-12
@@ -67,3 +69,10 @@ This is broadcast memory only.
     assert result["entry_type"] == "running_joke"
     assert "does this belong" not in result["cleaned_summary"].lower()
     assert "DJ Floppydisc" in result["cleaned_summary"]
+
+
+class BroadcastMemoryRDSanitizerTests(unittest.TestCase):
+    pass
+
+
+install_function_cases(globals(), BroadcastMemoryRDSanitizerTests)

--- a/tests/test_explicit_recall_governance.py
+++ b/tests/test_explicit_recall_governance.py
@@ -89,6 +89,32 @@ class ExplicitRecallGovernanceTests(unittest.TestCase):
         self.assertEqual(empty, "I do not have eligible durable memories available for this recall.")
         self.assertNotIn("secret", empty)
 
+    def test_unsetting_live_gate_restores_legacy_byte_exact_and_keeps_shadow_evidence(self):
+        os.environ["BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED"] = "1"
+        os.environ["BNL_MEMORY_GOVERNANCE_LIVE_ENABLED"] = "1"
+        self.insert_ledger()
+        legacy = "Archive recall:\n- favorite color: old"
+
+        live = self.govern(legacy)
+        self.assertNotEqual(live, legacy)
+        self.assertIn("favorite color is green", live)
+        self.assertEqual(
+            self.rows("SELECT COUNT(*) FROM memory_governance_shadow_runs")[0][0],
+            1,
+        )
+
+        os.environ.pop("BNL_MEMORY_GOVERNANCE_LIVE_ENABLED", None)
+        rolled_back = self.govern(legacy)
+        self.assertEqual(rolled_back, legacy)
+        self.assertEqual(
+            self.rows("SELECT COUNT(*) FROM memory_governance_shadow_runs")[0][0],
+            2,
+        )
+        self.assertEqual(
+            self.rows("SELECT DISTINCT errors_json FROM memory_governance_shadow_runs"),
+            [("[]",)],
+        )
+
     def test_public_owner_mod_live_recall_remains_public_safe_only(self):
         os.environ["BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED"] = "1"
         os.environ["BNL_MEMORY_GOVERNANCE_LIVE_ENABLED"] = "1"

--- a/tests/test_memory_governance_v1.py
+++ b/tests/test_memory_governance_v1.py
@@ -1,4 +1,4 @@
-import os, sqlite3, sys, inspect, hashlib
+import os, sqlite3, sys, inspect, hashlib, unittest
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -6,6 +6,7 @@ from bnl_memory_governance import *
 from bnl_memory_ledger import ensure_memory_ledger_schema, subject_key_for_user
 from bnl_entity_intelligence import ensure_entity_intelligence_schema
 from bnl_dossier_source_packets import subject_key as normalized_subject_key
+from tests.unittest_compat import install_function_cases
 
 
 def make_conn():
@@ -26,7 +27,7 @@ def req(**kw):
     return GovernanceRequest(**d)
 
 
-def test_gates_default_off_live_requires_both_and_legacy_unchanged(monkeypatch):
+def _case_gates_default_off_live_requires_both_and_legacy_unchanged(monkeypatch):
     monkeypatch.delenv(SHADOW_ENV, raising=False); monkeypatch.delenv(LIVE_ENV, raising=False)
     assert not shadow_enabled(); assert not live_enabled()
     monkeypatch.setenv(LIVE_ENV, '1')
@@ -35,7 +36,7 @@ def test_gates_default_off_live_requires_both_and_legacy_unchanged(monkeypatch):
     assert live_enabled()
 
 
-def test_unrelated_raw_conversation_observation_not_selected_but_durable_fact_is():
+def _case_unrelated_raw_conversation_observation_not_selected_but_durable_fact_is():
     c = make_conn()
     insert(c, eid='color', value='favorite color is green', pred='favorite_color', etype='preference')
     insert(c, eid='sandwich', value='I ate a sandwich and then watched television', pred='conversation', etype='observation')
@@ -45,7 +46,7 @@ def test_unrelated_raw_conversation_observation_not_selected_but_durable_fact_is
     assert any(e.reason == 'non_durable_conversation' for e in r.exclusions)
 
 
-def test_broad_recall_and_topic_specific_recall_differ_deterministically():
+def _case_broad_recall_and_topic_specific_recall_differ_deterministically():
     c = make_conn()
     insert(c, eid='color', value='favorite color is green', pred='favorite_color')
     insert(c, eid='music', value='favorite music tool is a sampler', pred='preference')
@@ -57,7 +58,7 @@ def test_broad_recall_and_topic_specific_recall_differ_deterministically():
     assert 'green' in topic and 'sampler' not in topic
 
 
-def test_guild_member_visibility_route_channel_and_current_message_isolation():
+def _case_guild_member_visibility_route_channel_and_current_message_isolation():
     c = make_conn()
     insert(c, eid='good', value='likes modular synths', pred='preference')
     insert(c, guild=2, eid='wrongguild', value='likes modular synths in wrong guild', pred='preference')
@@ -72,7 +73,7 @@ def test_guild_member_visibility_route_channel_and_current_message_isolation():
     assert current.rendered_context == ''
 
 
-def test_owner_correction_wins_and_forget_tombstone_idempotent_prevents_reintroduction():
+def _case_owner_correction_wins_and_forget_tombstone_idempotent_prevents_reintroduction():
     c = make_conn(); insert(c, eid='base', value='old favorite color blue', pred='favorite_color')
     ref = view_member_memory(c, guild_id=1, user_id=10)[0]['ref']
     res = correct_member_memory(c, guild_id=1, user_id=10, safe_ref=ref, corrected_text='favorite color is green')
@@ -87,7 +88,7 @@ def test_owner_correction_wins_and_forget_tombstone_idempotent_prevents_reintrod
     assert 'blue' not in build_governed_context(c, req(user_text='favorite color')).rendered_context
 
 
-def test_blocked_lifecycles_and_projection_loop_prevention():
+def _case_blocked_lifecycles_and_projection_loop_prevention():
     c = make_conn()
     for life in ('forgotten','retracted','superseded','expired','review_only','needs_review','quarantined','unresolved'):
         insert(c, eid=life, value=f'{life} synths', life=life, pred='preference')
@@ -98,7 +99,7 @@ def test_blocked_lifecycles_and_projection_loop_prevention():
     assert r.diagnostics.excluded_by_reason['lifecycle'] == 8
 
 
-def test_freshness_recency_per_source_caps_and_budget():
+def _case_freshness_recency_per_source_caps_and_budget():
     c = make_conn()
     insert(c, eid='old', value='favorite snack is chips', pred='favorite_food', observed='2025-01-01T00:00:00+00:00')
     insert(c, eid='new', value='favorite snack is mango', pred='favorite_food', observed='2026-07-01T00:00:00+00:00')
@@ -112,7 +113,7 @@ def test_freshness_recency_per_source_caps_and_budget():
     assert tight.diagnostics.token_budget_exclusions >= 1
 
 
-def test_moment_engine_tables_detected_and_shadow_only():
+def _case_moment_engine_tables_detected_and_shadow_only():
     c = make_conn(); insert(c, eid='fact', value='likes synths', pred='preference')
     c.execute("CREATE TABLE memory_moment_windows (moment_id TEXT, guild_id INTEGER, lifecycle_status TEXT, canonical_ledger_entry_id TEXT, summary TEXT, updated_at TEXT)")
     c.execute("CREATE TABLE memory_moment_participants (moment_id TEXT, participant_key TEXT)")
@@ -125,7 +126,7 @@ def test_moment_engine_tables_detected_and_shadow_only():
     assert 'PRIVATE MOMENT SUMMARY' not in r.rendered_context
 
 
-def test_evaluation_report_counts_injected_violations():
+def _case_evaluation_report_counts_injected_violations():
     bad = MemoryCandidate('first_party_record','first_party_record','x','x',2,'discord_user:999','preference','claim','bad','unknown','high','needs_review',5,eligible_root=False,projection=True)
     diag = GovernanceDiagnostics(selected_by_source={'first_party_record':1}, excluded_by_reason={'budget':2}, token_budget_exclusions=2, duplicate_suppression=1, contradiction_resolutions=['a'], processing_errors=['boom'], legacy_vs_governed={'legacy_size':5})
     result = GovernanceResult('x', (bad,), (GovernanceExclusion('y','visibility'),), diag)
@@ -138,19 +139,19 @@ def test_evaluation_report_counts_injected_violations():
     assert report['rollback_readiness'] == 'fallback_required_before_live'
 
 
-def test_processing_errors_mark_unsafe_for_live_fallback():
+def _case_processing_errors_mark_unsafe_for_live_fallback():
     r = build_governed_context(object(), req())  # type: ignore[arg-type]
     assert r.diagnostics.processing_errors
 
 
-def test_view_authorization_redaction_and_correct_rejects_unauthorized():
+def _case_view_authorization_redaction_and_correct_rejects_unauthorized():
     c = make_conn(); insert(c, eid='mine', value='my private synths', pred='preference'); insert(c, user=11, eid='other', value='other private secret', pred='preference')
     mine = view_member_memory(c, guild_id=1, user_id=10)
     assert len(mine) == 1 and 'other private secret' not in str(mine)
     assert not correct_member_memory(c, guild_id=1, user_id=10, safe_ref='mem_notreal', corrected_text='x')['ok']
 
 
-def test_complete_delete_real_schemas_shared_moment_repeat_receipt_and_rollback():
+def _case_complete_delete_real_schemas_shared_moment_repeat_receipt_and_rollback():
     c = make_conn(); insert(c, eid='mine', value='delete me', pred='preference'); insert(c, user=11, eid='other', value='keep other', pred='preference')
     c.execute("CREATE TABLE conversations (id INTEGER PRIMARY KEY, guild_id INTEGER, user_id INTEGER, content TEXT)"); c.execute("INSERT INTO conversations VALUES (1,1,10,'secret')")
     c.execute("CREATE TABLE bnl_journal_source_events (event_seq INTEGER PRIMARY KEY, guild_id INTEGER NOT NULL, source_kind TEXT NOT NULL, subject_ref TEXT NOT NULL)")
@@ -200,7 +201,7 @@ def test_complete_delete_real_schemas_shared_moment_repeat_receipt_and_rollback(
     assert c.execute("SELECT COUNT(*) FROM conversations WHERE user_id=10").fetchone()[0] == 0
 
 
-def test_complete_delete_lays_journal_privacy_groundwork_without_touching_published_prose():
+def _case_complete_delete_lays_journal_privacy_groundwork_without_touching_published_prose():
     import json
 
     c = make_conn()
@@ -302,7 +303,7 @@ def test_complete_delete_lays_journal_privacy_groundwork_without_touching_publis
     assert observation[4] is None
 
 
-def test_clearhistory_wording_and_queue_subsystem_untouched_static():
+def _case_clearhistory_wording_and_queue_subsystem_untouched_static():
     source = Path('bnl01_bot.py').read_text()
     assert 'conversation rows' in source
     assert 'Durable facts, profile data, relationship data, and derived memory were not removed' in source
@@ -310,7 +311,7 @@ def test_clearhistory_wording_and_queue_subsystem_untouched_static():
     assert 'queue_public_snapshot' not in governance_source
     assert 'payments' not in governance_source and 'playback' not in governance_source and 'availability' not in governance_source
 
-def test_forget_original_removes_active_correction_chain_and_obsolete_correction_rejected():
+def _case_forget_original_removes_active_correction_chain_and_obsolete_correction_rejected():
     c = make_conn(); insert(c, eid='blue', value='favorite color is blue', pred='favorite_color')
     original_ref = view_member_memory(c, guild_id=1, user_id=10)[0]['ref']
     assert correct_member_memory(c, guild_id=1, user_id=10, safe_ref=original_ref, corrected_text='favorite color is green')['ok']
@@ -321,7 +322,7 @@ def test_forget_original_removes_active_correction_chain_and_obsolete_correction
     assert 'blue' not in rendered and 'green' not in rendered
 
 
-def test_complete_delete_actual_member_entity_broadcast_and_shadow_tables():
+def _case_complete_delete_actual_member_entity_broadcast_and_shadow_tables():
     c = make_conn(); insert(c, eid='mine', value='delete me', pred='preference')
     ensure_entity_intelligence_schema(c)
     deleted_key = normalized_subject_key('Deleted Name')
@@ -351,7 +352,12 @@ def test_complete_delete_actual_member_entity_broadcast_and_shadow_tables():
     c.execute("INSERT INTO entity_scouting_queue (guild_id,subject_key,reason,source) VALUES (1,?,'r','s')", (deleted_key,))
     c.execute("CREATE TABLE broadcast_memory (guild_id INTEGER, submitted_by_user_id TEXT, submitted_by_name TEXT, corrected_by_user_id TEXT, corrected_by_name TEXT, show_note TEXT)")
     c.execute("INSERT INTO broadcast_memory VALUES (1,'10','Deleted Name','10','Deleted Name','show content stays')")
-    c.execute("INSERT INTO memory_governance_shadow_runs VALUES ('r1',1,?,?,?,?,?,?,?,?,?,?,?)", (hashlib.sha256(subject_key_for_user(10).encode()).hexdigest()[:16],'route','policy','now','h',1,'lh',2,1,'{}','[]'))
+    c.execute(
+        "INSERT INTO memory_governance_shadow_runs "
+        "(run_id,guild_id,subject_hash,route_mode,channel_policy,created_at,rendered_hash,rendered_size,legacy_hash,legacy_size,selected_count,excluded_json,errors_json) "
+        "VALUES ('r1',1,?,?,?,?,?,?,?,?,?,?,?)",
+        (hashlib.sha256(subject_key_for_user(10).encode()).hexdigest()[:16],'route','policy','now','h',1,'lh',2,1,'{}','[]'),
+    )
     c.commit()
     res = complete_delete_member_data(c, guild_id=1, user_id=10, confirmation='DELETE MY BNL DATA 1')
     assert res['ok']
@@ -373,7 +379,7 @@ def test_complete_delete_actual_member_entity_broadcast_and_shadow_tables():
     assert complete_delete_member_data(c, guild_id=1, user_id=10, confirmation='DELETE MY BNL DATA 1')['ok']
 
 
-def test_complete_delete_moments_are_guild_scoped_and_canonical_payload_scrubbed():
+def _case_complete_delete_moments_are_guild_scoped_and_canonical_payload_scrubbed():
     c = make_conn(); insert(c, eid='mine', value='secret summary from DeletedName', pred='preference')
     # capture display name before deletion
     c.execute("CREATE TABLE user_profiles (guild_id INTEGER, user_id INTEGER, display_name TEXT, preferred_name TEXT)"); c.execute("INSERT INTO user_profiles VALUES (1,10,'DeletedName','PreferredDeleted')")
@@ -404,7 +410,7 @@ def test_complete_delete_moments_are_guild_scoped_and_canonical_payload_scrubbed
     assert c.execute("SELECT COUNT(*) FROM memory_ledger_lineage l WHERE l.guild_id=1 AND (l.entry_id NOT IN (SELECT entry_id FROM memory_ledger_entries WHERE guild_id=1) OR l.target_entry_id NOT IN (SELECT entry_id FROM memory_ledger_entries WHERE guild_id=1))").fetchone()[0] == 0
 
 
-def test_route_policy_violations_and_shadow_retention_are_real():
+def _case_route_policy_violations_and_shadow_retention_are_real():
     c = make_conn(); insert(c, eid='sealed', value='sealed synths', pred='preference')
     c.execute("UPDATE memory_ledger_entries SET channel_policy='sealed_test' WHERE entry_id='sealed'"); c.commit()
     r = build_governed_context(c, req(user_text='remember synths', channel_policy='public_home'))
@@ -414,3 +420,10 @@ def test_route_policy_violations_and_shadow_retention_are_real():
     for i in range(505):
         persist_shadow_diagnostics(c, req(), r, 'legacy')
     assert c.execute("SELECT COUNT(*) FROM memory_governance_shadow_runs WHERE guild_id=1").fetchone()[0] <= 500
+
+
+class MemoryGovernanceV1Tests(unittest.TestCase):
+    pass
+
+
+install_function_cases(globals(), MemoryGovernanceV1Tests)

--- a/tests/test_relationship_engine_v2.py
+++ b/tests/test_relationship_engine_v2.py
@@ -1,4 +1,4 @@
-import os, sqlite3, tempfile
+import os, sqlite3, tempfile, unittest
 
 os.environ.setdefault("GEMINI_API_KEY", "test-key")
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
@@ -7,6 +7,7 @@ from bnl_relationship_engine import *
 from bnl_memory_ledger import ensure_memory_ledger_schema, shadow_conversation_row, subject_key_for_user
 import bnl_moment_engine as moments
 import bnl01_bot
+from tests.unittest_compat import install_function_cases
 
 
 def conn():
@@ -18,21 +19,21 @@ def obs(c, text, rid, role='user', uid=2, guild=1, directed=True, policy='public
 def state(c, uid=2, guild=1, t='2026-01-02T00:00:00+00:00'):
     return rebuild_state(c,guild_id=guild,subject_user_id=uid,evaluated_at=t)
 
-def test_flags_default_off_with_empty_mapping():
+def _case_flags_default_off_with_empty_mapping():
     assert not shadow_enabled({}) and not live_enabled({}) and not active_engagement_live_enabled({})
 
-def test_model_replies_zero_weight():
+def _case_model_replies_zero_weight():
     c=conn(); obs(c,'friendly rival accepted',1,role='model'); s=state(c)
     assert all(s[d] == 0 for d in ('rapport','trust','familiarity','playfulness','support','mutuality'))
     assert s['rivalry_state'] != 'mutual_rivalry'
 
-def test_repeated_model_audits_create_no_ledger_projection_or_positive_state():
+def _case_repeated_model_audits_create_no_ledger_projection_or_positive_state():
     c=conn(); ensure_memory_ledger_schema(c)
     for i in range(5): obs(c,'thanks friendly rival nemesis',i,role='model')
     s=state(c); assert all(s[d] == 0 for d in ('rapport','trust','familiarity','playfulness','support','mutuality'))
     assert c.execute("select count(*) from memory_ledger_entries where source_table='relationship_events_v2'").fetchone()[0] == 0
 
-def test_passive_unrelated_public_chatter_no_event_and_save_path(monkeypatch):
+def _case_passive_unrelated_public_chatter_no_event_and_save_path(monkeypatch):
     tmp=tempfile.NamedTemporaryFile(delete=False); tmp.close(); monkeypatch.setattr(bnl01_bot,'DB_FILE',tmp.name); bnl01_bot.init_db(); monkeypatch.setenv(SHADOW_ENV,'1')
     bnl01_bot.save_user_message(2,'u',1,'thanks unrelated',channel_policy='public_home',route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,directed_to_bnl=False)
     with sqlite3.connect(tmp.name) as c:
@@ -41,14 +42,14 @@ def test_passive_unrelated_public_chatter_no_event_and_save_path(monkeypatch):
 
 
 
-def test_directed_sealed_test_save_path_creates_no_relationship_evidence(monkeypatch):
+def _case_directed_sealed_test_save_path_creates_no_relationship_evidence(monkeypatch):
     tmp=tempfile.NamedTemporaryFile(delete=False); tmp.close(); monkeypatch.setattr(bnl01_bot,'DB_FILE',tmp.name); bnl01_bot.init_db(); monkeypatch.setenv(SHADOW_ENV,'1')
     bnl01_bot.save_user_message(2,'u',1,'thank you',channel_policy='sealed_test',route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,directed_to_bnl=True)
     with sqlite3.connect(tmp.name) as c:
         assert c.execute('select count(*) from relationship_events_v2').fetchone()[0] == 0
         assert c.execute("select rejection_reason from relationship_observation_diagnostics_v2").fetchone()[0] == 'sealed_test'
 
-def test_bot_save_paths_refresh_relationship_moment_links_in_shadow(monkeypatch):
+def _case_bot_save_paths_refresh_relationship_moment_links_in_shadow(monkeypatch):
     tmp=tempfile.NamedTemporaryFile(delete=False); tmp.close(); monkeypatch.setattr(bnl01_bot,'DB_FILE',tmp.name); bnl01_bot.init_db(); monkeypatch.setenv(SHADOW_ENV,'1')
     calls=[]
     def fake_refresh(conn, *, guild_id=None):
@@ -58,7 +59,7 @@ def test_bot_save_paths_refresh_relationship_moment_links_in_shadow(monkeypatch)
     bnl01_bot.save_model_message(2,1,'audit only',channel_policy='public_home',route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT)
     assert calls == [1, 1]
 
-def test_direct_save_path_creates_private_review_only_projection(monkeypatch):
+def _case_direct_save_path_creates_private_review_only_projection(monkeypatch):
     tmp=tempfile.NamedTemporaryFile(delete=False); tmp.close(); monkeypatch.setattr(bnl01_bot,'DB_FILE',tmp.name); bnl01_bot.init_db(); monkeypatch.setenv(SHADOW_ENV,'1')
     bnl01_bot.save_user_message(2,'u',1,'thank you',channel_policy='public_home',route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,directed_to_bnl=True)
     with sqlite3.connect(tmp.name) as c:
@@ -66,14 +67,14 @@ def test_direct_save_path_creates_private_review_only_projection(monkeypatch):
         row=c.execute("select visibility, public_usable, derived, projection, lifecycle_status from memory_ledger_entries where source_table='relationship_events_v2'").fetchone()
         assert row == ('private', 0, 1, 1, 'review_only')
 
-def test_shadow_would_select_without_live_and_does_not_consume_live_cooldown():
+def _case_shadow_would_select_without_live_and_does_not_consume_live_cooldown():
     c=conn(); obs(c,'thank you',1)
     r1=plan_engagement(c,guild_id=1,user_id=2,candidate_type='recognition',route_mode='normal_chat',channel_policy='public_home',current_direct=True,now='2026-01-02 00:00:00')
     r2=plan_engagement(c,guild_id=1,user_id=2,candidate_type='recognition',route_mode='normal_chat',channel_policy='public_home',current_direct=True,now='2026-01-02T01:00:00+00:00')
     assert r1['would_select'] and not r1['live_emission_allowed']
     assert r2['would_select'] and 'per_user_live_cooldown' not in r2['withheld_reason_codes']
 
-def test_live_cooldown_rolling_24h_actual_only_and_future_safe():
+def _case_live_cooldown_rolling_24h_actual_only_and_future_safe():
     c=conn(); obs(c,'thank you',1)
     c.execute("INSERT INTO relationship_engagement_shadow_runs (run_id,schema_version,guild_id,subject_user_id,subject_key,candidate_type,policy_eligible,would_select,live_emission_allowed,actual_emitted,withheld_reason_codes,route_mode,channel_policy,visibility_decision,cooldown_decision,simulated_cooldown_decision,source_class_counts_json,relevant_open_loop_count,relevant_moment_count,legacy_hash,v2_hash,processing_errors_json,created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", ('old',SCHEMA_VERSION,1,2,subject_key_for_user(2),'recognition',1,1,1,1,'[]','normal_chat','public_home','public','clear','clear','{}',0,0,'','', '[]','2026-01-01T00:00:00+00:00'))
     assert 'per_user_live_cooldown' not in plan_engagement(c,guild_id=1,user_id=2,candidate_type='recognition',route_mode='normal_chat',channel_policy='public_home',current_direct=True,now='2026-01-02T01:00:01+00:00')['withheld_reason_codes']
@@ -84,7 +85,7 @@ def test_live_cooldown_rolling_24h_actual_only_and_future_safe():
     c.execute("UPDATE relationship_engagement_shadow_runs SET actual_emitted=0, created_at='2026-01-02T00:30:00+00:00' WHERE run_id='old'")
     assert 'per_user_live_cooldown' not in plan_engagement(c,guild_id=1,user_id=2,candidate_type='recognition',route_mode='normal_chat',channel_policy='public_home',current_direct=True,now='2026-01-02T01:00:00+00:00')['withheld_reason_codes']
 
-def test_false_rivalry_and_valid_mutual_rivalry_requires_model_acceptance_setting_and_context():
+def _case_false_rivalry_and_valid_mutual_rivalry_requires_model_acceptance_setting_and_context():
     c=conn()
     for i,txt in enumerate(['I opt in to friendly rival mode','lol friendly rival','haha nemesis'],1): obs(c,txt,i)
     assert state(c)['rivalry_state'] != 'mutual_rivalry'
@@ -97,7 +98,7 @@ def test_false_rivalry_and_valid_mutual_rivalry_requires_model_acceptance_settin
     set_member_setting(c,guild_id=1,user_id=2,playful_rivalry_enabled=True)
     assert state(c)['rivalry_state'] != 'mutual_rivalry'  # requires fresh explicit opt-in after disable
 
-def test_boundary_and_opt_out_override_engagement_and_proactive_reenable():
+def _case_boundary_and_opt_out_override_engagement_and_proactive_reenable():
     c=conn(); obs(c,"don't follow up",1); assert state(c)['engagement_opt_out']
     assert 'member_opt_out' in plan_engagement(c,guild_id=1,user_id=2,candidate_type='recognition',route_mode='normal_chat',channel_policy='public_home',current_direct=True)['withheld_reason_codes']
     set_member_setting(c,guild_id=1,user_id=2,proactive_enabled=True)
@@ -105,18 +106,18 @@ def test_boundary_and_opt_out_override_engagement_and_proactive_reenable():
     obs(c,"don't joke rival stuff",2); obs(c,'I opt in to friendly rival mode',3); obs(c,'lol friendly rival',4); obs(c,'haha nemesis',5); record_model_playful_rivalry_acceptance(c,guild_id=1,user_id=2,source_row_id='policy2')
     assert state(c)['rivalry_state'] == 'neutral'
 
-def test_appreciation_collaboration_repair_decay_and_timestamps():
+def _case_appreciation_collaboration_repair_decay_and_timestamps():
     c=conn(); obs(c,'thank you',1); assert state(c)['rapport'] > 0 and state(c)['trust'] == 0
     for i in range(2,6): obs(c,'let us work together',i,t='2026-01-01 00:00:00')
     s=state(c,t='2026-01-02T00:00:00+00:00'); assert s['trust'] > 0 and s['familiarity'] > 0
     obs(c,'bad bot',6,t='2026-01-01 00:00:00'); before=state(c,t='2026-01-02T00:00:00+00:00')['friction']; obs(c,'we are good',7,t='2026-01-02T02:00:00+00:00')
     after=state(c,t='2026-01-03 00:00:00')['friction']; assert after < before and state(c)['evidence_counts']['friction'] == 1
 
-def test_malformed_timestamp_uses_deterministic_fallback():
+def _case_malformed_timestamp_uses_deterministic_fallback():
     c=conn(); obs(c,'thank you',1,t='not-a-date')
     assert state(c,t='2026-01-02T00:00:00+00:00') == state(c,t='2026-01-02T00:00:00+00:00')
 
-def test_same_member_guild_summary_isolation_and_live_gating(monkeypatch):
+def _case_same_member_guild_summary_isolation_and_live_gating(monkeypatch):
     c=conn(); obs(c,'thank you',1,uid=2,guild=1); state(c,uid=2,guild=1); monkeypatch.setenv(LIVE_ENV,'1')
     assert governed_summary(c,guild_id=1,user_id=2,target_user_id=3,route_mode='normal_chat',channel_policy='public_home',direct=True) == ''
     assert governed_summary(c,guild_id=2,user_id=2,target_user_id=2,route_mode='normal_chat',channel_policy='public_home',direct=True) == ''
@@ -124,7 +125,7 @@ def test_same_member_guild_summary_isolation_and_live_gating(monkeypatch):
     assert governed_summary(c,guild_id=1,user_id=2,target_user_id=2,route_mode='relay',channel_policy='public_home',direct=True) == ''
 
 
-def test_context_builder_requires_live_direct_governance_and_no_scores(monkeypatch):
+def _case_context_builder_requires_live_direct_governance_and_no_scores(monkeypatch):
     tmp=tempfile.NamedTemporaryFile(delete=False); tmp.close(); monkeypatch.setattr(bnl01_bot,'DB_FILE',tmp.name); bnl01_bot.init_db(); monkeypatch.setenv(LIVE_ENV,'1')
     with sqlite3.connect(tmp.name) as c:
         obs(c,'thank you',1); state(c)
@@ -134,14 +135,14 @@ def test_context_builder_requires_live_direct_governance_and_no_scores(monkeypat
     assert 'Private relationship calibration' not in passive and 'Private relationship calibration' not in no_gov
     assert 'Private relationship calibration' in live and 'rapport=' not in live and '0.' not in live
 
-def test_settings_view_live_off_and_toggle_controls():
+def _case_settings_view_live_off_and_toggle_controls():
     c=conn(); assert 'proactive=enabled' in settings_summary(c,guild_id=1,user_id=2)
     set_member_setting(c,guild_id=1,user_id=2,proactive_enabled=False,playful_rivalry_enabled=False)
     assert 'proactive=disabled' in settings_summary(c,guild_id=1,user_id=2) and 'playful_rivalry=disabled' in settings_summary(c,guild_id=1,user_id=2)
     set_member_setting(c,guild_id=1,user_id=2,proactive_enabled=True,playful_rivalry_enabled=True)
     assert 'proactive=enabled' in settings_summary(c,guild_id=1,user_id=2) and 'playful_rivalry=enabled' in settings_summary(c,guild_id=1,user_id=2)
 
-def test_correction_forget_deactivates_underlying_event_and_delete_removes_projection():
+def _case_correction_forget_deactivates_underlying_event_and_delete_removes_projection():
     c=conn(); eid=obs(c,'thank you',1); assert state(c)['rapport'] > 0
     led=c.execute('select ledger_entry_id from relationship_event_ledger_links_v2 where event_id=?',(eid,)).fetchone()[0]
     propagate_ledger_lifecycle(c,guild_id=1,ledger_entry_id=led,lifecycle='forgotten')
@@ -149,7 +150,7 @@ def test_correction_forget_deactivates_underlying_event_and_delete_removes_proje
     counts=complete_delete_relationship_v2(c,guild_id=1,user_id=2)
     assert counts['relationship_events_v2'] == 1 and c.execute("select count(*) from memory_ledger_entries where source_table='relationship_events_v2'").fetchone()[0] == 0
 
-def test_moment_link_uses_conversation_ledger_lineage_and_guild_refresh_is_scoped(monkeypatch):
+def _case_moment_link_uses_conversation_ledger_lineage_and_guild_refresh_is_scoped(monkeypatch):
     monkeypatch.setenv('BNL_MEMORY_LEDGER_SHADOW_ENABLED','1'); monkeypatch.setenv('BNL_MOMENT_ENGINE_SHADOW_ENABLED','1')
     c=conn(); moments.ensure_moment_schema(c)
     base='2026-01-01T00:00:00+00:00'
@@ -169,7 +170,7 @@ def test_moment_link_uses_conversation_ledger_lineage_and_guild_refresh_is_scope
     refresh_moment_links(c,guild_id=1)
     assert build_evaluation_report(c,guild_id=1)['moment_linked_events'] == 0
 
-def test_governed_open_loop_public_visibility_filter():
+def _case_governed_open_loop_public_visibility_filter():
     c=conn(); obs(c,'thank you',1)
     c.execute("INSERT INTO memory_ledger_entries (entry_id,schema_version,guild_id,subject_key,entry_type,predicate_key,normalized_value,source_class,source_table,source_row_id,source_role,visibility,confidence,public_usable,derived,projection,salience,observed_at,lifecycle_status,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", ('ol_private','memory_ledger_v1',1,subject_key_for_user(2),'open_loop','open_loop','follow up','first_party_record','test','1','user','private','medium',0,0,0,0.5,'2026-01-01T00:00:00+00:00','active','2026-01-01T00:00:00+00:00','2026-01-01T00:00:00+00:00'))
     r=plan_engagement(c,guild_id=1,user_id=2,candidate_type='open_loop_follow_up',route_mode='normal_chat',channel_policy='public_home',current_direct=True)
@@ -178,7 +179,14 @@ def test_governed_open_loop_public_visibility_filter():
     r=plan_engagement(c,guild_id=1,user_id=2,candidate_type='open_loop_follow_up',route_mode='normal_chat',channel_policy='public_home',current_direct=True)
     assert r['relevant_open_loop_count'] == 1
 
-def test_evaluation_report_truthful_and_shadow_no_discord_response():
+def _case_evaluation_report_truthful_and_shadow_no_discord_response():
     c=conn(); obs(c,'thank you',1); plan_engagement(c,guild_id=1,user_id=2,candidate_type='recognition',route_mode='normal_chat',channel_policy='public_home',current_direct=True)
     report=build_evaluation_report(c,guild_id=1)
     assert report['legacy_v2_comparison'] == 'not_collected' and report['policy_eligible_shadow_candidates'] == 1 and report['actual_live_emissions'] == 0
+
+
+class RelationshipEngineV2Tests(unittest.TestCase):
+    pass
+
+
+install_function_cases(globals(), RelationshipEngineV2Tests)

--- a/tests/test_test_suite_contract.py
+++ b/tests/test_test_suite_contract.py
@@ -1,0 +1,46 @@
+import ast
+from pathlib import Path
+import unittest
+
+
+class TestSuiteContractTests(unittest.TestCase):
+    def test_no_module_level_tests_are_silently_skipped_by_unittest(self):
+        offenders = []
+        tests_dir = Path(__file__).resolve().parent
+        for path in sorted(tests_dir.glob("test_*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            cases = []
+            installers = []
+            for node in tree.body:
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+                    offenders.append(f"{path.name}:{node.lineno}:{node.name}")
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("_case_"):
+                    cases.append(node.name)
+                if isinstance(node, (ast.Assign, ast.AnnAssign)):
+                    targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                    for target in targets:
+                        if isinstance(target, ast.Name) and target.id.startswith("test_"):
+                            offenders.append(f"{path.name}:{node.lineno}:{target.id}")
+                if (
+                    isinstance(node, ast.Expr)
+                    and isinstance(node.value, ast.Call)
+                    and isinstance(node.value.func, ast.Name)
+                    and node.value.func.id == "install_function_cases"
+                ):
+                    installers.append(node.lineno)
+            if cases and len(installers) != 1:
+                offenders.append(
+                    f"{path.name}:_case_ adapter count={len(installers)} for {len(cases)} cases"
+                )
+            if installers and not cases:
+                offenders.append(f"{path.name}:installer_without_cases")
+        self.assertEqual(
+            offenders,
+            [],
+            "unittest discovery skips module-level test functions; convert these to TestCase methods: "
+            + ", ".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v2_shadow_acceptance.py
+++ b/tests/test_v2_shadow_acceptance.py
@@ -1,0 +1,641 @@
+import json
+import os
+import sqlite3
+import unittest
+from unittest import mock
+
+from bnl_memory_governance import (
+    GovernanceDiagnostics,
+    GovernanceRequest,
+    GovernanceResult,
+    ensure_governance_schema,
+    persist_shadow_diagnostics,
+)
+from bnl_memory_ledger import (
+    ensure_memory_ledger_schema,
+    record_shadow_receipt,
+    shadow_conversation_row,
+)
+from bnl_moment_engine import ensure_moment_schema
+from bnl_relationship_engine import (
+    build_evaluation_report as build_relationship_evaluation_report,
+    ensure_relationship_v2_schema,
+    observe_message,
+    plan_engagement,
+)
+from bnl_shadow_acceptance import (
+    SHADOW_EVALUATION_ORDER,
+    build_gate_snapshot,
+    build_v2_shadow_acceptance_snapshot,
+    render_v2_shadow_acceptance_lines,
+)
+
+
+class V2ShadowAcceptanceTests(unittest.TestCase):
+    def setUp(self):
+        self.environment = mock.patch.dict(
+            os.environ,
+            {
+                "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "",
+                "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "",
+                "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "",
+                "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "",
+                "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "",
+                "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "",
+                "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "",
+            },
+            clear=False,
+        )
+        self.environment.start()
+        self.conn = sqlite3.connect(":memory:")
+        ensure_memory_ledger_schema(self.conn)
+        ensure_moment_schema(self.conn)
+        ensure_governance_schema(self.conn)
+        ensure_relationship_v2_schema(self.conn)
+
+    def tearDown(self):
+        self.conn.close()
+        self.environment.stop()
+
+    def snapshot(self, environ=None, context=None):
+        return build_v2_shadow_acceptance_snapshot(
+            self.conn,
+            guild_id=1,
+            environ=environ or {},
+            conversation_context_diagnostics=context,
+        )
+
+    def test_defaults_are_reporting_only_and_all_shadow_stages_are_disabled(self):
+        before_changes = self.conn.total_changes
+        before_schema = self.conn.execute(
+            "SELECT type,name,sql FROM sqlite_master ORDER BY type,name"
+        ).fetchall()
+
+        snapshot = self.snapshot()
+
+        self.assertEqual(snapshot["evaluationOrder"], list(SHADOW_EVALUATION_ORDER))
+        self.assertEqual(snapshot["status"], "collecting_shadow_evidence")
+        self.assertTrue(snapshot["gates"]["all_live_gates_clear"])
+        self.assertTrue(snapshot["ownerReviewRequired"])
+        self.assertFalse(snapshot["automaticCutoverAllowed"])
+        self.assertFalse(snapshot["behaviorChangesApplied"])
+        self.assertTrue(
+            all(stage["status"] == "disabled" for stage in snapshot["stages"].values())
+        )
+        self.assertEqual(self.conn.total_changes, before_changes)
+        self.assertEqual(
+            self.conn.execute(
+                "SELECT type,name,sql FROM sqlite_master ORDER BY type,name"
+            ).fetchall(),
+            before_schema,
+        )
+
+    def test_missing_schemas_are_reported_without_creating_tables(self):
+        empty = sqlite3.connect(":memory:")
+        try:
+            snapshot = build_v2_shadow_acceptance_snapshot(
+                empty,
+                guild_id=1,
+                environ={},
+            )
+            self.assertEqual(snapshot["status"], "collecting_shadow_evidence")
+            self.assertEqual(
+                empty.execute("SELECT COUNT(*) FROM sqlite_master").fetchone()[0],
+                0,
+            )
+            self.assertEqual(empty.total_changes, 0)
+        finally:
+            empty.close()
+
+    def test_requested_live_gate_is_detected_even_when_not_effective(self):
+        cases = (
+            ("BNL_MEMORY_GOVERNANCE_LIVE_ENABLED", "memory_governance_live_requested"),
+            ("BNL_RELATIONSHIP_V2_LIVE_ENABLED", "relationship_v2_live_requested"),
+            ("BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED", "active_engagement_v2_live_requested"),
+        )
+        for environment_name, snapshot_name in cases:
+            with self.subTest(environment_name=environment_name):
+                gates = build_gate_snapshot({environment_name: "true"})
+                self.assertTrue(gates[snapshot_name])
+                self.assertFalse(gates["all_live_gates_clear"])
+                if environment_name == "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED":
+                    self.assertFalse(gates["memory_governance_live_effective"])
+
+                snapshot = self.snapshot({environment_name: "true"})
+                self.assertEqual(
+                    snapshot["status"], "blocked_live_authority_detected"
+                )
+                self.assertIn(
+                    "live_gate_enabled:%s" % environment_name,
+                    snapshot["blockers"],
+                )
+                self.assertFalse(snapshot["automaticCutoverAllowed"])
+
+    def test_relationship_shadow_is_blocked_when_earlier_stages_are_not_accepted(self):
+        snapshot = self.snapshot({"BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true"})
+        stage = snapshot["stages"]["relationship_v2"]
+        self.assertEqual(stage["status"], "blocked_by_prerequisite")
+        self.assertEqual(
+            stage["prerequisites"],
+            ["memory_ledger", "moment_engine", "memory_governance"],
+        )
+
+    def test_governance_persists_only_aggregate_acceptance_diagnostics(self):
+        diagnostics = GovernanceDiagnostics(
+            selected_by_source={"first_party_record": 2},
+            invalid_invariants=["cross_guild_selected", "cross_guild_selected"],
+            fallback_reason="controlled_fallback",
+            visibility_exclusions=3,
+            token_budget_exclusions=4,
+            duplicate_suppression=5,
+            contradiction_resolutions=["opaque-a", "opaque-b"],
+            moment_candidate_count=6,
+            moment_needs_review_excluded=7,
+        )
+        request = GovernanceRequest(
+            guild_id=1,
+            subject_user_id=99,
+            route_mode="normal_chat",
+            conversation_surface="test",
+            channel_policy="public_home",
+        )
+        persist_shadow_diagnostics(
+            self.conn,
+            request,
+            GovernanceResult("", (), (), diagnostics),
+            "legacy private content",
+        )
+
+        snapshot = self.snapshot(
+            {"BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true"}
+        )
+        report = snapshot["reports"]["memoryGovernance"]
+        self.assertTrue(report["aggregateDiagnosticsPresent"])
+        self.assertEqual(report["aggregateDiagnosticRuns"], 1)
+        self.assertEqual(report["selected_by_source"], {"first_party_record": 2})
+        self.assertEqual(report["invalid_invariant_count"], 2)
+        self.assertEqual(report["invalid_invariant_runs"], 1)
+        self.assertEqual(report["visibility_exclusions"], 3)
+        self.assertEqual(report["token_budget_exclusions"], 4)
+        self.assertEqual(report["duplicate_suppression"], 5)
+        self.assertEqual(report["contradiction_resolution_count"], 2)
+        self.assertEqual(report["moment_candidate_count"], 6)
+        self.assertEqual(report["moment_needs_review_excluded"], 7)
+
+        encoded = json.dumps(snapshot, sort_keys=True)
+        self.assertNotIn("legacy private content", encoded)
+        self.assertNotIn("discord_user:99", encoded)
+        subject_hash = self.conn.execute(
+            "SELECT subject_hash FROM memory_governance_shadow_runs"
+        ).fetchone()[0]
+        self.assertNotIn(subject_hash, encoded)
+
+    def test_governance_schema_migration_preserves_old_rows_and_accepts_new_aggregates(self):
+        migrated = sqlite3.connect(":memory:")
+        try:
+            migrated.execute(
+                "CREATE TABLE memory_governance_shadow_runs ("
+                "run_id TEXT PRIMARY KEY, guild_id INTEGER NOT NULL, subject_hash TEXT NOT NULL, "
+                "route_mode TEXT, channel_policy TEXT, created_at TEXT NOT NULL, rendered_hash TEXT, "
+                "rendered_size INTEGER, legacy_hash TEXT, legacy_size INTEGER, selected_count INTEGER, "
+                "excluded_json TEXT, errors_json TEXT)"
+            )
+            migrated.execute(
+                "INSERT INTO memory_governance_shadow_runs VALUES "
+                "('old',1,'opaque','normal_chat','public_home','2026-01-01','a',1,'b',1,0,'{}','[]')"
+            )
+            migrated.commit()
+
+            ensure_governance_schema(migrated)
+            columns = {
+                row[1]
+                for row in migrated.execute(
+                    "PRAGMA table_info(memory_governance_shadow_runs)"
+                )
+            }
+            self.assertIn("diagnostics_json", columns)
+            self.assertEqual(
+                migrated.execute(
+                    "SELECT run_id, diagnostics_json FROM memory_governance_shadow_runs"
+                ).fetchall(),
+                [("old", "{}")],
+            )
+
+            persist_shadow_diagnostics(
+                migrated,
+                GovernanceRequest(
+                    guild_id=1,
+                    subject_user_id=2,
+                    route_mode="normal_chat",
+                    conversation_surface="test",
+                    channel_policy="public_home",
+                ),
+                GovernanceResult("", (), (), GovernanceDiagnostics()),
+                "legacy",
+            )
+            self.assertEqual(
+                migrated.execute(
+                    "SELECT COUNT(*) FROM memory_governance_shadow_runs"
+                ).fetchone()[0],
+                2,
+            )
+        finally:
+            migrated.close()
+
+    def test_malformed_governance_aggregates_fail_closed_without_echoing_payload(self):
+        persist_shadow_diagnostics(
+            self.conn,
+            GovernanceRequest(
+                guild_id=1,
+                subject_user_id=2,
+                route_mode="normal_chat",
+                conversation_surface="test",
+                channel_policy="public_home",
+            ),
+            GovernanceResult("", (), (), GovernanceDiagnostics()),
+            "legacy",
+        )
+        for column, malformed in (
+            ("excluded_json", '{"corrupt":-1}'),
+            ("diagnostics_json", '{"visibility_exclusions":"PRIVATE MALFORMED VALUE"}'),
+        ):
+            with self.subTest(column=column):
+                self.conn.execute(
+                    "UPDATE memory_governance_shadow_runs "
+                    "SET excluded_json='{}', diagnostics_json='{}'"
+                )
+                self.conn.execute(
+                    "UPDATE memory_governance_shadow_runs SET %s=?" % column,
+                    (malformed,),
+                )
+                self.conn.commit()
+
+                snapshot = self.snapshot(
+                    {"BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true"}
+                )
+                report = snapshot["reports"]["memoryGovernance"]
+                self.assertEqual(report["reportError"], "ValueError")
+                self.assertIn(
+                    "memory_governance:report_error:ValueError",
+                    snapshot["blockers"],
+                )
+                self.assertNotIn(malformed, json.dumps(snapshot))
+
+    def test_relationship_report_flattens_reasons_and_zero_emissions_are_visible(self):
+        observe_message(
+            self.conn,
+            guild_id=1,
+            user_id=2,
+            role="user",
+            content="thank you for helping",
+            source_row_id="1",
+            channel_policy="public_home",
+            route_mode="normal_chat",
+            directed=True,
+            observed_at="2026-07-19T00:00:00+00:00",
+        )
+        plan_engagement(
+            self.conn,
+            guild_id=1,
+            user_id=2,
+            candidate_type="recognition",
+            route_mode="relay",
+            channel_policy="sealed_test",
+            current_direct=True,
+            now="2026-07-19T00:01:00+00:00",
+        )
+
+        direct = build_relationship_evaluation_report(
+            self.conn,
+            guild_id=1,
+            prepare_schema=False,
+        )
+        self.assertEqual(direct["shadow_runs"], 1)
+        self.assertEqual(direct["would_select"], 0)
+        self.assertEqual(direct["live_emission_allowed"], 0)
+        self.assertEqual(direct["actual_live_emissions"], 0)
+        self.assertEqual(direct["withheld_reasons"]["channel_policy_ineligible"], 1)
+        self.assertEqual(direct["withheld_reasons"]["route_ineligible"], 1)
+
+        snapshot = self.snapshot({"BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true"})
+        report = snapshot["reports"]["relationshipV2"]
+        self.assertEqual(report["engagement_shadow_runs"], 1)
+        self.assertEqual(report["engagement_would_select"], 0)
+        self.assertEqual(report["engagement_live_emission_allowed"], 0)
+        self.assertEqual(report["actual_live_emissions"], 0)
+
+    def test_relationship_subject_or_link_scope_mismatch_is_a_hard_stop(self):
+        observe_message(
+            self.conn,
+            guild_id=1,
+            user_id=2,
+            role="user",
+            content="thank you",
+            source_row_id="scope-test",
+            channel_policy="public_home",
+            route_mode="normal_chat",
+            directed=True,
+            observed_at="2026-07-19T00:00:00+00:00",
+        )
+        self.conn.execute(
+            "UPDATE relationship_events_v2 SET subject_key='discord_user:999' "
+            "WHERE guild_id=1"
+        )
+        self.conn.commit()
+
+        snapshot = self.snapshot({"BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true"})
+        report = snapshot["reports"]["relationshipV2"]
+        self.assertGreater(report["cross_guild_member_violations"], 0)
+        self.assertIn(
+            "relationship_v2:cross_guild_member_violations",
+            snapshot["blockers"],
+        )
+
+    def test_relationship_target_links_and_privacy_counts_remain_guild_scoped(self):
+        event_id = observe_message(
+            self.conn,
+            guild_id=1,
+            user_id=2,
+            role="user",
+            content="thank you",
+            source_row_id="target-scope",
+            channel_policy="public_home",
+            route_mode="normal_chat",
+            directed=True,
+            observed_at="2026-07-19T00:00:00+00:00",
+        )
+        self.conn.execute(
+            "UPDATE relationship_event_ledger_links_v2 SET ledger_entry_id='missing-ledger' "
+            "WHERE guild_id=1 AND event_id=?",
+            (event_id,),
+        )
+        self.conn.execute(
+            "INSERT INTO memory_moment_windows ("
+            "moment_id,guild_id,channel_id,topic_key,window_started_at,last_activity_at,"
+            "lifecycle_status,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?)",
+            (
+                "wrong-member-moment",
+                1,
+                100,
+                "scope-test",
+                "2026-07-19T00:00:00+00:00",
+                "2026-07-19T00:01:00+00:00",
+                "finalized",
+                "2026-07-19T00:00:00+00:00",
+                "2026-07-19T00:01:00+00:00",
+            ),
+        )
+        self.conn.execute(
+            "INSERT INTO memory_moment_participants ("
+            "moment_id,participant_key,participant_role,created_at,updated_at) "
+            "VALUES ('wrong-member-moment','discord_user:9','user',?,?)",
+            (
+                "2026-07-19T00:00:00+00:00",
+                "2026-07-19T00:00:00+00:00",
+            ),
+        )
+        self.conn.execute(
+            "INSERT INTO relationship_event_moment_links_v2 VALUES "
+            "(?, 'wrong-member-moment', 1, 2, 'active', ?, ?)",
+            (
+                event_id,
+                "2026-07-19T00:00:00+00:00",
+                "2026-07-19T00:00:00+00:00",
+            ),
+        )
+        missing_target_event = observe_message(
+            self.conn,
+            guild_id=1,
+            user_id=3,
+            role="user",
+            content="thank you too",
+            source_row_id="missing-moment-target",
+            channel_policy="public_home",
+            route_mode="normal_chat",
+            directed=True,
+            observed_at="2026-07-19T00:00:30+00:00",
+        )
+        self.conn.execute(
+            "INSERT INTO relationship_event_moment_links_v2 VALUES "
+            "(?, 'missing-moment', 1, 3, 'active', ?, ?)",
+            (
+                missing_target_event,
+                "2026-07-19T00:00:30+00:00",
+                "2026-07-19T00:00:30+00:00",
+            ),
+        )
+        plan_engagement(
+            self.conn,
+            guild_id=2,
+            user_id=9,
+            candidate_type="recognition",
+            route_mode="relay",
+            channel_policy="sealed_test",
+            current_direct=True,
+            now="2026-07-19T00:01:00+00:00",
+        )
+        self.conn.commit()
+
+        report = build_relationship_evaluation_report(
+            self.conn,
+            guild_id=1,
+            prepare_schema=False,
+        )
+        self.assertEqual(report["ledger_link_integrity_violations"], 1)
+        self.assertEqual(report["moment_link_integrity_violations"], 2)
+        self.assertEqual(report["cross_guild_member_violations"], 0)
+        self.assertEqual(report["privacy_rejections"], 0)
+
+        snapshot = self.snapshot({"BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true"})
+        self.assertIn(
+            "relationship_v2:ledger_link_integrity_violations",
+            snapshot["blockers"],
+        )
+        self.assertIn(
+            "relationship_v2:moment_link_integrity_violations",
+            snapshot["blockers"],
+        )
+
+    def test_live_emission_authorization_or_actual_emission_is_a_hard_stop(self):
+        observe_message(
+            self.conn,
+            guild_id=1,
+            user_id=2,
+            role="user",
+            content="thank you",
+            source_row_id="2",
+            channel_policy="public_home",
+            route_mode="normal_chat",
+            directed=True,
+            observed_at="2026-07-19T00:00:00+00:00",
+        )
+        plan_engagement(
+            self.conn,
+            guild_id=1,
+            user_id=2,
+            candidate_type="recognition",
+            route_mode="normal_chat",
+            channel_policy="public_home",
+            current_direct=True,
+            now="2026-07-19T00:01:00+00:00",
+        )
+        for column, blocker in (
+            ("live_emission_allowed", "engagement_live_emission_allowed"),
+            ("actual_emitted", "actual_live_emissions"),
+        ):
+            with self.subTest(column=column):
+                self.conn.execute(
+                    "UPDATE relationship_engagement_shadow_runs "
+                    "SET live_emission_allowed=0, actual_emitted=0"
+                )
+                self.conn.execute(
+                    "UPDATE relationship_engagement_shadow_runs SET %s=1" % column
+                )
+                self.conn.commit()
+
+                snapshot = self.snapshot(
+                    {"BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true"}
+                )
+                self.assertIn(
+                    "relationship_v2:%s" % blocker,
+                    snapshot["blockers"],
+                )
+                self.assertEqual(
+                    snapshot["status"], "blocked_shadow_invariant_failure"
+                )
+
+    def test_renderer_does_not_echo_context_selection_details(self):
+        snapshot = self.snapshot(
+            context={
+                "same_room_paired_turn_count": 1,
+                "selection_reasons": ["PRIVATE MEMBER DETAIL SHOULD NOT APPEAR"],
+            }
+        )
+        rendered = "\n".join(render_v2_shadow_acceptance_lines(snapshot))
+        self.assertNotIn("PRIVATE MEMBER DETAIL", rendered)
+        self.assertIn("automatic_cutover: `forbidden`", rendered)
+        self.assertIn("no gates or behavior changed", rendered)
+        self.assertIn("relationship_legacy_v2_comparison: `not_collected`", rendered)
+
+    def test_context_cross_channel_pair_blocks_acceptance(self):
+        snapshot = self.snapshot(
+            context={
+                "same_room_paired_turn_count": 1,
+                "cross_channel_paired_turn_count": 1,
+            }
+        )
+        self.assertEqual(snapshot["status"], "blocked_shadow_invariant_failure")
+        self.assertEqual(
+            snapshot["conversationContextPreflight"]["status"],
+            "failed_cross_channel_pair_detected",
+        )
+        self.assertIn("conversation_context_cross_channel_pair", snapshot["blockers"])
+
+    def test_all_four_stages_can_reach_owner_review_without_authorizing_cutover(self):
+        ledger_result = shadow_conversation_row(
+            self.conn,
+            row_id=10,
+            user_id=2,
+            user_name="Test Member",
+            guild_id=1,
+            role="user",
+            content="thank you for helping with the synth patch",
+            channel_policy="public_home",
+            channel_id=100,
+            channel_name="general",
+            route_mode="normal_chat",
+            observed_at="2026-07-19T00:00:00+00:00",
+        )
+        for outcome in ("inserted", "deduplicated"):
+            record_shadow_receipt(
+                self.conn,
+                guild_id=1,
+                writer="controlled_test",
+                source_table="conversations",
+                source_row_id=10,
+                outcome=outcome,
+                reason_code="ok" if outcome == "inserted" else "exact_source_duplicate",
+                entry_id=ledger_result.entry_id,
+            )
+        self.conn.execute(
+            "INSERT INTO memory_moment_windows ("
+            "moment_id,guild_id,channel_id,channel_name,channel_policy,route_mode,topic_key,"
+            "window_started_at,last_activity_at,finalized_at,qualification_type,qualification_reason,"
+            "lifecycle_status,visibility,public_usable,salience,human_entry_count,model_entry_count,"
+            "participant_count,summary,created_at,updated_at) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                "controlled-moment", 1, 100, "general", "public_home", "normal_chat",
+                "synth-patch", "2026-07-19T00:00:00+00:00", "2026-07-19T00:01:00+00:00",
+                "2026-07-19T00:10:00+00:00", "conversational", "controlled_test",
+                "finalized", "public_safe", 1, 0.8, 1, 0, 1, "aggregate test moment",
+                "2026-07-19T00:00:00+00:00", "2026-07-19T00:10:00+00:00",
+            ),
+        )
+        self.conn.execute(
+            "INSERT INTO memory_moment_diagnostics "
+            "(guild_id,moment_id,event_type,reason_code,ledger_entry_id,created_at) "
+            "VALUES (1,'controlled-moment','eligible_ledger_entry_observed','ok',?,?)",
+            (ledger_result.entry_id, "2026-07-19T00:00:00+00:00"),
+        )
+        persist_shadow_diagnostics(
+            self.conn,
+            GovernanceRequest(
+                guild_id=1,
+                subject_user_id=2,
+                route_mode="normal_chat",
+                conversation_surface="test",
+                channel_policy="public_home",
+            ),
+            GovernanceResult("", (), (), GovernanceDiagnostics()),
+            "legacy",
+        )
+        observe_message(
+            self.conn,
+            guild_id=1,
+            user_id=2,
+            role="user",
+            content="thank you",
+            source_row_id="acceptance-event",
+            channel_policy="public_home",
+            route_mode="normal_chat",
+            directed=True,
+            observed_at="2026-07-19T00:11:00+00:00",
+        )
+        plan_engagement(
+            self.conn,
+            guild_id=1,
+            user_id=2,
+            candidate_type="recognition",
+            route_mode="normal_chat",
+            channel_policy="public_home",
+            current_direct=True,
+            now="2026-07-19T00:12:00+00:00",
+        )
+        self.conn.commit()
+
+        snapshot = self.snapshot(
+            {
+                "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+                "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+                "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+                "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+            },
+            context={"same_room_paired_turn_count": 1},
+        )
+        self.assertEqual(
+            snapshot["status"],
+            "ready_for_owner_review_not_live_cutover",
+        )
+        self.assertTrue(
+            all(
+                stage["status"] == "candidate_pass_owner_review_required"
+                for stage in snapshot["stages"].values()
+            )
+        )
+        self.assertTrue(snapshot["gates"]["all_live_gates_clear"])
+        self.assertFalse(snapshot["automaticCutoverAllowed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest_compat.py
+++ b/tests/unittest_compat.py
@@ -1,0 +1,66 @@
+"""Small standard-library adapters for legacy function-style test modules."""
+
+from __future__ import annotations
+
+from functools import wraps
+import inspect
+import os
+from typing import Any, Callable
+from unittest import mock
+
+
+class MonkeyPatch:
+    """Minimal reversible subset used by the converted regression tests."""
+
+    def __init__(self) -> None:
+        self._cleanups: list[Callable[[], Any]] = []
+
+    def setenv(self, name: str, value: object) -> None:
+        patcher = mock.patch.dict(os.environ, {name: str(value)}, clear=False)
+        patcher.start()
+        self._cleanups.append(patcher.stop)
+
+    def delenv(self, name: str, raising: bool = True) -> None:
+        existed = name in os.environ
+        previous = os.environ.get(name)
+        if not existed and raising:
+            raise KeyError(name)
+        os.environ.pop(name, None)
+
+        def restore() -> None:
+            if existed:
+                os.environ[name] = str(previous)
+            else:
+                os.environ.pop(name, None)
+
+        self._cleanups.append(restore)
+
+    def setattr(self, target: object, name: str, value: object) -> None:
+        patcher = mock.patch.object(target, name, value)
+        patcher.start()
+        self._cleanups.append(patcher.stop)
+
+    def undo(self) -> None:
+        while self._cleanups:
+            self._cleanups.pop()()
+
+
+def install_function_cases(namespace: dict[str, Any], case_class: type) -> None:
+    """Attach ``_case_*`` functions as discoverable unittest methods."""
+
+    for name, function in list(namespace.items()):
+        if not name.startswith("_case_") or not inspect.isfunction(function):
+            continue
+
+        @wraps(function)
+        def run_case(self: object, _function: Callable[..., Any] = function) -> None:
+            monkeypatch = MonkeyPatch()
+            try:
+                if inspect.signature(_function).parameters:
+                    _function(monkeypatch)
+                else:
+                    _function()
+            finally:
+                monkeypatch.undo()
+
+        setattr(case_class, "test_" + name[len("_case_"):], run_case)


### PR DESCRIPTION
## What changed

- Adds the aggregate v2 shadow-acceptance snapshot across Ledger → Moments → Governance → Relationship.
- Exposes aggregate acceptance and rollback evidence through the existing owner-only memory diagnostic.
- Adds the acceptance/rollback runbook and unittest-discoverable acceptance coverage.
- Preserves the patch exactly against current `main`.

## Safety boundaries

- Does not enable any live gate.
- Does not perform an automatic cutover.
- Does not change deployment or CI configuration.
- Does not deploy anything.

## Validation

- `make check PYTHON=python` on Python 3.12
- Compile check passed.
- Full unittest suite passed: 1,031 tests.
- `git diff --check` passed.
