### PR TITLE
Bot: repair Journal reaction and quote handling

### DIFF
--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -75,11 +75,9 @@ _STRONG_INFERENCE_CUE_RE = re.compile(
 
 _REPAIR_GUIDANCE = {
     "discord_phrase_copy": (
-        "Rewrite the entire public article from scratch. Do not repeat any sequence of five or more "
-        "consecutive words from any fresh source summary. Preserve only the grounded meaning, and use "
-        "new sentence structure and vocabulary throughout."
+        "Rewrite the copied passage in new language, or preserve exact public-safe wording as a brief direct "
+        "quote inside clear double quotation marks. Keep the speaker anonymous."
     ),
-    "direct_quote_or_quote_mark": "Remove all quotation marks and paraphrase every quoted or quote-like passage.",
     "community_name_leak": "Remove every community member name and replace personal references with anonymous descriptions.",
     "public_leak_pattern": "Remove every URL, mention, identifier, and internal implementation term from public prose.",
     "source_ref_leak": "Keep source reference tokens only inside sourceRefIds arrays; remove them from all public prose.",
@@ -99,8 +97,9 @@ _REPAIR_GUIDANCE = {
     ),
     "missing_bnl_reaction": (
         "Add one brief first-person BNL reaction that expresses curiosity, amusement, attachment, uncertainty, or mild "
-        "unease without asserting a new external fact. Do not use I suspect, I think, or I wonder unless a valid "
-        "bnl_inference context lane supports it."
+        "unease without asserting a new external fact. Natural openings include I admit, I noticed, I found myself, "
+        "I smiled, I laughed, I remain curious, I am fond of, and I felt. Do not use I suspect, I think, or I wonder "
+        "unless a valid bnl_inference context lane supports it."
     ),
     "sensitive_personal_detail": (
         "Remove personal or domestic details that are unnecessary to the public community story, including details "
@@ -154,10 +153,15 @@ _REPORT_STYLE_OPENING_RE = re.compile(
 
 _BNL_REACTION_RE = re.compile(
     r"\bI\s+(?:admit|confess|noticed|watched|found(?:\s+myself)?|caught\s+myself|remain|smiled|enjoyed|"
-    r"appreciated|liked|was\s+(?:amused|curious|fond|uneasy|surprised|pleased|glad)|"
+    r"appreciated|liked|laughed|grinned|chuckled|felt|feel|"
+    r"was\s+(?:amused|curious|fond|uneasy|surprised|pleased|glad|drawn)|"
     r"am\s+(?:amused|curious|fond|uneasy|pleased|glad)|have\s+(?:begun|grown)|am\s+beginning|"
     r"may\s+be\s+developing|keep\s+returning|cannot\s+quite|could\s+not\s+help|do\s+not\s+mind)\b",
     re.IGNORECASE,
+)
+
+_DIRECT_QUOTE_SPAN_RE = re.compile(
+    r'"[^"\n]+"|“[^”\n]+”'
 )
 
 _SENSITIVE_PERSONAL_PATTERNS = (
@@ -1520,8 +1524,8 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
         "\nStable participant aliases in the packet are private pattern-analysis aids. Never reproduce an alias in public prose."
         "\nThe evidenceCoverageContract is mandatory. Across all section sourceRefIds, meet its minimum distinct fresh sources, participants, source kinds, and available window segments. Every cited ref must materially support that section. Use this breadth to identify a few connected patterns rather than listing sources."
         "\nEvery section must cite at least one fresh sourceRefId from the current window. Older Journal material is continuity and callback context only, never proof of current activity. Do not repeat an older conclusion when the current evidence changes it."
-        "\nParaphrase every source summary. Never repeat any sequence of five or more consecutive words from a fresh source summary."
-        "\nKeep community members anonymous. Do not include direct quotes, URLs, mentions, IDs, sourceRef tokens in public prose, private intent, relationships, harassment, or internal schema/storage terms."
+        "\nParaphrase source summaries by default. A brief direct quote is welcome when exact public-safe wording improves the story, especially when the line is funny. Put quoted wording inside clear double quotation marks, cite its fresh source in that section, and keep the speaker anonymous. Never repeat any sequence of five or more consecutive source words outside a clear direct quote."
+        "\nKeep community members anonymous. Do not include URLs, mentions, IDs, sourceRef tokens in public prose, private intent, relationships, harassment, or internal schema/storage terms."
         "\nExclude personal or domestic details that are unnecessary to the public community story, especially details involving minors, interpersonal conflict, caregiving, or household obligations. Juicy means lively pattern recognition—not private gossip."
         f"{cadence_rule}{context_rule}{repair}\nGeneration-safe packet:\n{json.dumps(safe_packet, ensure_ascii=False, sort_keys=True)}"
     )
@@ -1737,8 +1741,6 @@ def validate_article(article: dict[str, Any], packet: dict[str, Any], prior_titl
         return evidence_reason
     if re.search(r"<@!?\d+>|@\w+|https?://|\b\d{12,}\b|participant-[a-f0-9]{8}|relationship_journal|memory_tiers|source[- ]?file|dossier|private_metadata|sourceRefIds?", public_text, re.I):
         return "public_leak_pattern"
-    if re.search(r"[\"“”‘’]", public_text):
-        return "direct_quote_or_quote_mark"
     names = set(approved_names or [])
     private_names = {
         str(name or "").strip()
@@ -1755,15 +1757,19 @@ def validate_article(article: dict[str, Any], packet: dict[str, Any], prior_titl
             return "community_name_leak"
     if any(re.search(pattern, public_text, re.I) for pattern in _SENSITIVE_PERSONAL_PATTERNS):
         return "sensitive_personal_detail"
-    if any(re.search(pattern, public_text, re.I) for pattern in _OVERLY_CLINICAL_PATTERNS):
+    narrative_text = _DIRECT_QUOTE_SPAN_RE.sub(" ", public_text)
+    if any(re.search(pattern, narrative_text, re.I) for pattern in _OVERLY_CLINICAL_PATTERNS):
         return "overly_clinical_voice"
     if any(_REPORT_STYLE_OPENING_RE.search(str(section.get("body") or "")) for section in sections):
         return "flat_report_voice"
     if len(packet.get("safeSources", [])) >= 5 and not _BNL_REACTION_RE.search(
-        "\n".join(str(section.get("body") or "") for section in sections)
+        "\n".join(
+            _DIRECT_QUOTE_SPAN_RE.sub(" ", str(section.get("body") or ""))
+            for section in sections
+        )
     ):
         return "missing_bnl_reaction"
-    normalized_public = _norm(public_text)
+    normalized_public = _norm(narrative_text)
     for src in packet.get("privateSources", []):
         summary = str(src.get("summary") or "")
         words = _norm(summary).split()

--- a/tests/test_bnl_journal.py
+++ b/tests/test_bnl_journal.py
@@ -90,7 +90,7 @@ class JournalTests(unittest.TestCase):
             calls.append(prompt)
             if len(calls) == 1:
                 return article_json(packet, title='Copied First Pass', leak=copied)
-            return article_json(packet, title='Fully Rewritten Pass')
+            return article_json(packet, title='Quoted Second Pass', leak=f' "{copied.strip()}"')
 
         packet = self.packet()
         invalid = j.parse_generated_json(article_json(packet, title='Guard Check', leak=copied))
@@ -99,7 +99,7 @@ class JournalTests(unittest.TestCase):
         res = j.generate_and_store_draft(self.db, 1, 24, gen)
         self.assertTrue(res.ok, res.reason)
         self.assertEqual(2, len(calls))
-        self.assertIn('five or more consecutive words', calls[1])
+        self.assertIn('brief direct quote', calls[1])
         self.assertIn('Previous rejected JSON', calls[1])
         with sqlite3.connect(self.db) as c:
             self.assertEqual(
@@ -147,12 +147,32 @@ class JournalTests(unittest.TestCase):
         self.assertEqual(hist['recurringTopicCounts']['bass'], 11)
         self.assertFalse(any(r['entry_id'] == 'e10' for r in hist['relevantOlderEntries']))
 
-    def test_validation_rejects_names_refs_urls_mentions_ids_quotes_and_copied_phrases(self):
+    def test_validation_rejects_names_refs_urls_mentions_ids_and_unquoted_copied_phrases(self):
         packet = self.packet(); good = j.parse_generated_json(article_json(packet))
         self.assertEqual('', j.validate_article(good, packet, []))
-        for leak, reason in [(' KnownUser', 'community_name_leak'), (' fresh:101', 'source_ref_leak'), (' https://x.test', 'public_leak_pattern'), (' @KnownUser', 'public_leak_pattern'), (' 1234567890123', 'public_leak_pattern'), (' "quoted"', 'direct_quote_or_quote_mark'), (' people discuss bass chaos and a hook', 'discord_phrase_copy')]:
+        for leak, reason in [(' KnownUser', 'community_name_leak'), (' fresh:101', 'source_ref_leak'), (' https://x.test', 'public_leak_pattern'), (' @KnownUser', 'public_leak_pattern'), (' 1234567890123', 'public_leak_pattern'), (' people discuss bass chaos and a hook', 'discord_phrase_copy')]:
             bad = j.parse_generated_json(article_json(packet, title='Unique ' + reason, leak=leak))
             self.assertEqual(reason, j.validate_article(bad, packet, []), leak)
+
+    def test_direct_quotes_and_curly_apostrophes_do_not_hold_generation(self):
+        quote = '“people discuss bass chaos and a hook”'
+        packet = self.packet()
+        article = j.parse_generated_json(
+            article_json(packet, title='The Room’s Quoted Line', leak=f' {quote}')
+        )
+        self.assertEqual('', j.validate_article(article, packet, []))
+
+        calls = []
+
+        def gen(source_packet, prompt):
+            calls.append(prompt)
+            return article_json(source_packet, title='The Room’s Quoted Line', leak=f' {quote}')
+
+        result = j.generate_and_store_draft(self.db, 1, 24, gen)
+        self.assertTrue(result.ok, result.reason)
+        self.assertEqual(1, len(calls))
+        self.assertIn('direct quote is welcome', calls[0])
+        self.assertNotIn('Do not include direct quotes', calls[0])
 
     def test_approved_entry_cannot_be_rejected_and_tables_remain_approved(self):
         res = j.generate_and_store_draft(self.db, 1, 24, lambda p, pr: article_json(p)); self.assertTrue(res.ok)

--- a/tests/test_bnl_journal_evidence_voice.py
+++ b/tests/test_bnl_journal_evidence_voice.py
@@ -98,6 +98,8 @@ class JournalEvidenceVoiceTests(unittest.TestCase):
         self.assertIn("evidenceCoverageContract", prompt)
         self.assertIn("concrete, recognizable action", prompt)
         self.assertIn("Never invent a time, place, object, action", prompt)
+        self.assertIn("direct quote is welcome", prompt)
+        self.assertNotIn("Do not include direct quotes", prompt)
 
     def test_report_opening_clinical_language_and_missing_reaction_are_rejected(self):
         report = _article(self.packet, opening="The Network observes a producer carrying a bass sketch through the room.")
@@ -114,10 +116,29 @@ class JournalEvidenceVoiceTests(unittest.TestCase):
             "I smiled when the room gave the idea another careful pass.",
             "I confess the patience on display pleased me.",
             "I am fond of the way this room lets a chorus change slowly.",
+            "I felt the room's patience settle in.",
+            "I laughed when the smallest change became the evening's main event.",
         ):
             with self.subTest(reaction=reaction):
                 article = _article(self.packet, reaction_text=reaction)
                 self.assertEqual("", journal.validate_article(article, self.packet, []))
+
+    def test_quoted_first_person_line_does_not_replace_bnl_reaction(self):
+        article = _article(
+            self.packet,
+            reaction=False,
+            opening='A producer brought a bass sketch and said “I smiled when the loop finally landed.”',
+        )
+        self.assertEqual("missing_bnl_reaction", journal.validate_article(article, self.packet, []))
+
+    def test_reaction_repair_names_natural_validator_compatible_stems(self):
+        prompt = journal.build_generation_prompt(
+            self.packet,
+            repair_reason="missing_bnl_reaction",
+            previous_output="{}",
+        )
+        self.assertIn("I laughed", prompt)
+        self.assertIn("I felt", prompt)
 
     def test_all_window_names_are_scrubbed_and_validated_before_sampling(self):
         conversations = [


### PR DESCRIPTION
## Summary

- recognize natural first-person BNL reactions such as laughter and `I felt ...`
- stop treating curly apostrophes and brief anonymous public quotes as a blanket Journal failure
- keep quoted participant speech from satisfying BNL's own reaction requirement
- retain the existing full-text checks for names, sensitive details, mentions, URLs, IDs, and source references

## Validation

- `python -m compileall -q .`
- full bot suite: 1,034 tests passed
- focused Journal suites: 42 tests passed
- `git diff --check`
- independent scoped review: approved

## Scope

No gates, schedules, automation activation, delivery configuration, deployment, queue/payment behavior, API/auth, or schema changes.