### PR TITLE
Bot: make Journal publishing reliable at 7 PM

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -224,7 +224,8 @@ from bnl_source_file_refresh import (
 )
 from collections import Counter, defaultdict, deque
 from dataclasses import dataclass, replace
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, time as datetime_time, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import pytz
 import discord
@@ -335,6 +336,11 @@ BNL_COMMUNITY_SCOUTING_MIN_SIGNALS = community_min_signals()
 
 DAILY_TOKEN_LIMIT = 1_350_000
 PACIFIC_TZ = pytz.timezone("US/Pacific")
+JOURNAL_DAILY_SCHEDULE_TIME = datetime_time(
+    hour=19,
+    minute=0,
+    tzinfo=ZoneInfo("America/Los_Angeles"),
+)
 DB_FILE = "bnl01_conversations.db"
 
 # The provider client owns HTTP transports and proxy discovery. Keep module
@@ -6179,8 +6185,6 @@ async def run_journal_automation_once(
     guild_id = resolve_network_guild_id(int(guild_id))
     cadence = str(cadence or "scheduled").lower()
     lock = _journal_automation_lock(guild_id)
-    if lock.locked():
-        return [_journal_control_result(cadence, "busy", "journal_automation_already_running")]
     async with lock:
         runtime = _journal_automation_runtime_by_guild.setdefault(guild_id, {})
         runtime.update({"lastStartedAt": _utc_now_iso(), "lastError": "", "lastCadence": cadence})
@@ -6260,18 +6264,28 @@ async def run_journal_automation_control_cycle(guild_id: int) -> list[dict]:
     flags = _journal_control_flags(control, base_flags)
     if control is None:
         reason = "control_plane_unavailable:%s" % (control_error or "control_get_failed")
-        results = [_journal_control_result("scheduled", "held", reason)]
+        # The control endpoint is useful for remote Run Now requests, but it
+        # must not be a single point of failure for the local 7 PM schedule.
+        # get_bnl_control_flags() retains the last confirmed pause state, so
+        # the local fallback still honors operator controls.
+        results = await run_journal_automation_once(
+            guild_id,
+            cadence="scheduled",
+            force=False,
+            flags=flags,
+        )
+        local_status = await asyncio.to_thread(journal_automation_status, DB_FILE, guild_id)
         runtime = _journal_automation_runtime_by_guild.setdefault(guild_id, {})
         runtime.update({
-            "lastCompletedAt": _utc_now_iso(),
-            "lastResults": results,
-            "lastDetail": reason[:240],
+            "nextDailyAt": local_status.get("nextDailyAt") or "",
+            "nextWeeklyAt": local_status.get("nextWeeklyAt") or "",
             "lastError": reason[:240],
         })
         logging.warning(
-            "journal_automation_cycle_held guild=%s reason=%s",
+            "journal_control_plane_unavailable_local_schedule_continued guild=%s reason=%s results=%s",
             guild_id,
             reason,
+            ",".join(f"{item.get('cadence')}:{item.get('status')}" for item in results),
         )
         await asyncio.to_thread(_journal_heartbeat_sync, runtime, flags)
         return results
@@ -14508,6 +14522,29 @@ tree = app_commands.CommandTree(client)
 _ambient_post_locks = {}
 
 
+async def _run_journal_automation_for_managed_guilds(trigger: str) -> None:
+    """Run the idempotent Journal scheduler for each configured Discord guild."""
+    for guild in iter_managed_guilds():
+        guild_id = int(getattr(guild, "id", 0) or 0)
+        if not guild_id:
+            continue
+        try:
+            logging.info(
+                "journal_automation_trigger guild=%s trigger=%s",
+                guild_id,
+                trigger,
+            )
+            await run_journal_automation_control_cycle(guild_id)
+        except Exception as exc:
+            runtime = _journal_automation_runtime_by_guild.setdefault(guild_id, {})
+            runtime.update({"lastCompletedAt": _utc_now_iso(), "lastError": type(exc).__name__})
+            logging.exception(
+                "journal_automation_cycle_failed guild=%s trigger=%s error_type=%s",
+                guild_id,
+                trigger,
+                type(exc).__name__,
+            )
+
 
 @tasks.loop(minutes=DEFAULT_PROCESS_INTERVAL_MINUTES)
 async def source_file_refresh_worker_task():
@@ -14548,20 +14585,13 @@ async def source_file_refresh_worker_task():
     except Exception as exc:
         logging.warning("source_refresh_worker_cycle processed=0 skipped=0 failed=1 error=%s", exc)
 
-    for guild in iter_managed_guilds():
-        guild_id = int(getattr(guild, "id", 0) or 0)
-        if not guild_id:
-            continue
-        try:
-            await run_journal_automation_control_cycle(guild_id)
-        except Exception as exc:
-            runtime = _journal_automation_runtime_by_guild.setdefault(guild_id, {})
-            runtime.update({"lastCompletedAt": _utc_now_iso(), "lastError": type(exc).__name__})
-            logging.exception(
-                "journal_automation_cycle_failed guild=%s error_type=%s",
-                guild_id,
-                type(exc).__name__,
-            )
+    await _run_journal_automation_for_managed_guilds("interval_catch_up")
+
+
+@tasks.loop(time=JOURNAL_DAILY_SCHEDULE_TIME)
+async def journal_daily_schedule_task():
+    """Start the daily Journal cycle at exactly 7:00 PM Pacific."""
+    await _run_journal_automation_for_managed_guilds("daily_7pm_pacific")
 
 # ==================== AMBIENT MESSAGE TASK ====================
 
@@ -16964,6 +16994,9 @@ async def on_ready():
 
     if not source_file_refresh_worker_task.is_running():
         source_file_refresh_worker_task.start()
+
+    if not journal_daily_schedule_task.is_running():
+        journal_daily_schedule_task.start()
 
     logging.info(f"🎯 BNL-01 online as {client.user.name} ({client.user.id})")
     logging.info(f"📡 Monitoring {len(client.guilds)} server(s)")

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -15,6 +15,12 @@ STATES = {"draft", "rejected", "approved_pending_delivery", "published", "delive
 WORD_MIN, WORD_MAX = 250, 500
 JOURNAL_ROUTE = "bnl_journal_generation"
 JOURNAL_GENERATION_ATTEMPTS = 4
+ADVISORY_VALIDATION_REASONS = frozenset({
+    "overly_clinical_voice",
+    "flat_report_voice",
+    "missing_bnl_reaction",
+    "duplicate_title",
+})
 MAX_RELAY_SOURCES_PER_WINDOW = 500
 MAX_CONVERSATION_SOURCES_PER_WINDOW = 2_000
 MAX_PROMPT_SOURCES = 180
@@ -74,10 +80,6 @@ _STRONG_INFERENCE_CUE_RE = re.compile(
 )
 
 _REPAIR_GUIDANCE = {
-    "discord_phrase_copy": (
-        "Rewrite the copied passage in new language, or preserve exact public-safe wording as a brief direct "
-        "quote inside clear double quotation marks. Keep the speaker anonymous."
-    ),
     "community_name_leak": "Remove every community member name and replace personal references with anonymous descriptions.",
     "public_leak_pattern": "Remove every URL, mention, identifier, and internal implementation term from public prose.",
     "source_ref_leak": "Keep source reference tokens only inside sourceRefIds arrays; remove them from all public prose.",
@@ -1524,7 +1526,7 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
         "\nStable participant aliases in the packet are private pattern-analysis aids. Never reproduce an alias in public prose."
         "\nThe evidenceCoverageContract is mandatory. Across all section sourceRefIds, meet its minimum distinct fresh sources, participants, source kinds, and available window segments. Every cited ref must materially support that section. Use this breadth to identify a few connected patterns rather than listing sources."
         "\nEvery section must cite at least one fresh sourceRefId from the current window. Older Journal material is continuity and callback context only, never proof of current activity. Do not repeat an older conclusion when the current evidence changes it."
-        "\nParaphrase source summaries by default. A brief direct quote is welcome when exact public-safe wording improves the story, especially when the line is funny. Put quoted wording inside clear double quotation marks, cite its fresh source in that section, and keep the speaker anonymous. Never repeat any sequence of five or more consecutive source words outside a clear direct quote."
+        "\nParaphrase source summaries by default. Use a direct quote only rarely, when one brief public-safe line is unusually worth preserving. Put quoted wording inside clear double quotation marks, cite its fresh source in that section, and keep the speaker anonymous."
         "\nKeep community members anonymous. Do not include URLs, mentions, IDs, sourceRef tokens in public prose, private intent, relationships, harassment, or internal schema/storage terms."
         "\nExclude personal or domestic details that are unnecessary to the public community story, especially details involving minors, interpersonal conflict, caregiving, or household obligations. Juicy means lively pattern recognition—not private gossip."
         f"{cadence_rule}{context_rule}{repair}\nGeneration-safe packet:\n{json.dumps(safe_packet, ensure_ascii=False, sort_keys=True)}"
@@ -1707,7 +1709,14 @@ def _evidence_coverage_reason(article: dict[str, Any], packet: dict[str, Any]) -
     return ""
 
 
-def validate_article(article: dict[str, Any], packet: dict[str, Any], prior_titles: Optional[list[str]] = None, approved_names: Optional[set[str]] = None) -> str:
+def validate_article(
+    article: dict[str, Any],
+    packet: dict[str, Any],
+    prior_titles: Optional[list[str]] = None,
+    approved_names: Optional[set[str]] = None,
+    *,
+    blocking_only: bool = False,
+) -> str:
     sections = article.get("sections")
     if not isinstance(sections, list) or not (1 <= len(sections) <= 3):
         return "invalid_section_count"
@@ -1758,25 +1767,17 @@ def validate_article(article: dict[str, Any], packet: dict[str, Any], prior_titl
     if any(re.search(pattern, public_text, re.I) for pattern in _SENSITIVE_PERSONAL_PATTERNS):
         return "sensitive_personal_detail"
     narrative_text = _DIRECT_QUOTE_SPAN_RE.sub(" ", public_text)
-    if any(re.search(pattern, narrative_text, re.I) for pattern in _OVERLY_CLINICAL_PATTERNS):
+    if not blocking_only and any(re.search(pattern, narrative_text, re.I) for pattern in _OVERLY_CLINICAL_PATTERNS):
         return "overly_clinical_voice"
-    if any(_REPORT_STYLE_OPENING_RE.search(str(section.get("body") or "")) for section in sections):
+    if not blocking_only and any(_REPORT_STYLE_OPENING_RE.search(str(section.get("body") or "")) for section in sections):
         return "flat_report_voice"
-    if len(packet.get("safeSources", [])) >= 5 and not _BNL_REACTION_RE.search(
+    if not blocking_only and len(packet.get("safeSources", [])) >= 5 and not _BNL_REACTION_RE.search(
         "\n".join(
             _DIRECT_QUOTE_SPAN_RE.sub(" ", str(section.get("body") or ""))
             for section in sections
         )
     ):
         return "missing_bnl_reaction"
-    normalized_public = _norm(narrative_text)
-    for src in packet.get("privateSources", []):
-        summary = str(src.get("summary") or "")
-        words = _norm(summary).split()
-        for size in range(5, min(10, len(words)) + 1):
-            for i in range(0, len(words) - size + 1):
-                if " ".join(words[i:i + size]) in normalized_public:
-                    return "discord_phrase_copy"
     context_contract = _context_lane_ref_contract(packet)
     section_text = {
         str(section.get("heading") or ""): str(section.get("body") or "")
@@ -1909,7 +1910,7 @@ def validate_article(article: dict[str, Any], packet: dict[str, Any], prior_titl
                     return "undeclared_context_use"
     norm_title = _norm(article.get("title", ""))
     for title in prior_titles or []:
-        if norm_title and norm_title == _norm(title):
+        if not blocking_only and norm_title and norm_title == _norm(title):
             return "duplicate_title"
     return ""
 
@@ -2013,10 +2014,81 @@ def _insert_draft_rows(conn: sqlite3.Connection, entry_row: tuple[Any, ...], met
     conn.execute("INSERT INTO bnl_journal_private_metadata VALUES (?,?,?,?,?,?,?,?)", meta_row)
 
 
-def store_validated_draft(db_path: str, guild_id: int, packet: dict[str, Any], article: dict[str, Any], *, entry_id: str = "", revision: int = 1) -> JournalResult:
+def _generate_article_with_repairs(
+    packet: dict[str, Any],
+    generator: Callable[[dict[str, Any], str], str],
+    prior_titles: list[str],
+) -> tuple[Optional[dict[str, Any]], str, bool]:
+    """Return the best blocking-clean article without letting polish cancel publication."""
+    last_reason = ""
+    previous_output = ""
+    retained_publishable: Optional[dict[str, Any]] = None
+    for attempt in range(JOURNAL_GENERATION_ATTEMPTS):
+        try:
+            raw = generator(
+                packet,
+                build_generation_prompt(
+                    packet,
+                    repair_reason=last_reason,
+                    previous_output=previous_output,
+                ) if attempt else build_generation_prompt(packet),
+            )
+        except Exception as exc:
+            if retained_publishable is not None:
+                return retained_publishable, "", True
+            reason = "quota_unavailable" if "quota" in str(exc).lower() else "provider_failure"
+            return None, reason, False
+        previous_output = raw
+        try:
+            article = parse_generated_json(raw)
+        except ValueError as exc:
+            last_reason = str(exc)
+            continue
+
+        blocking_reason = validate_article(
+            article,
+            packet,
+            prior_titles,
+            blocking_only=True,
+        )
+        if blocking_reason:
+            last_reason = blocking_reason
+            continue
+
+        validation = validate_article(article, packet, prior_titles)
+        if not validation:
+            return article, "", False
+        if validation not in ADVISORY_VALIDATION_REASONS:
+            # Future validation reasons remain blocking unless explicitly
+            # classified as editorial guidance above.
+            last_reason = validation
+            continue
+        retained_publishable = article
+        last_reason = validation
+
+    if retained_publishable is not None:
+        return retained_publishable, "", True
+    return None, last_reason or "generation_failed", False
+
+
+def store_validated_draft(
+    db_path: str,
+    guild_id: int,
+    packet: dict[str, Any],
+    article: dict[str, Any],
+    *,
+    entry_id: str = "",
+    revision: int = 1,
+    allow_advisory: bool = False,
+) -> JournalResult:
     ensure_schema(db_path)
     with sqlite3.connect(db_path) as conn:
-        reason = validate_article(article, packet, _prior_titles(conn, guild_id))
+        reason = validate_article(
+            article,
+            packet,
+            _prior_titles(conn, guild_id),
+            blocking_only=allow_advisory,
+        )
         if reason:
             return JournalResult(False, "no_draft", reason, entry_id=entry_id, revision=revision)
         entry_row, meta_row, result = _draft_records(guild_id, packet, article, entry_id=entry_id, revision=revision)
@@ -2037,34 +2109,23 @@ def generate_and_store_packet_draft(
         return JournalResult(False, "no_draft", "incomplete_source_window", entry_id=entry_id)
     if not packet.get("safeSources"):
         return JournalResult(False, "no_draft", "insufficient_grounded_material", entry_id=entry_id)
-    prompt = build_generation_prompt(packet)
-    last_reason = ""
-    previous_output = ""
-    for attempt in range(JOURNAL_GENERATION_ATTEMPTS):
-        try:
-            raw = generator(
-                packet,
-                prompt if attempt == 0 else build_generation_prompt(
-                    packet,
-                    repair_reason=last_reason,
-                    previous_output=previous_output,
-                ),
-            )
-        except Exception as exc:
-            reason = "quota_unavailable" if "quota" in str(exc).lower() else "provider_failure"
-            return JournalResult(False, "no_draft", reason, entry_id=entry_id)
-        previous_output = raw
-        try:
-            article = parse_generated_json(raw)
-        except ValueError as exc:
-            last_reason = str(exc)
-            continue
-        with sqlite3.connect(db_path) as conn:
-            validation = validate_article(article, packet, _prior_titles(conn, guild_id))
-        if not validation:
-            return store_validated_draft(db_path, guild_id, packet, article, entry_id=entry_id)
-        last_reason = validation
-    return JournalResult(False, "no_draft", last_reason or "generation_failed", entry_id=entry_id)
+    with sqlite3.connect(db_path) as conn:
+        prior_titles = _prior_titles(conn, guild_id)
+    article, reason, allow_advisory = _generate_article_with_repairs(
+        packet,
+        generator,
+        prior_titles,
+    )
+    if article is None:
+        return JournalResult(False, "no_draft", reason, entry_id=entry_id)
+    return store_validated_draft(
+        db_path,
+        guild_id,
+        packet,
+        article,
+        entry_id=entry_id,
+        allow_advisory=allow_advisory,
+    )
 
 
 def generate_and_store_draft(
@@ -2174,39 +2235,22 @@ def regenerate_draft(
     if excluded_history_entry_ids is not None:
         packet_kwargs["excluded_history_entry_ids"] = excluded_history_entry_ids
     packet = build_source_packet(db_path, guild_id, hours, **packet_kwargs)
-    last_reason = ""
-    previous_output = ""
-    article: Optional[dict[str, Any]] = None
-    for attempt in range(JOURNAL_GENERATION_ATTEMPTS):
-        try:
-            raw = generator(
-                packet,
-                build_generation_prompt(
-                    packet,
-                    repair_reason=last_reason,
-                    previous_output=previous_output,
-                ) if attempt else build_generation_prompt(packet),
-            )
-        except Exception as exc:
-            reason = "quota_unavailable" if "quota" in str(exc).lower() else "provider_failure"
-            return JournalResult(False, "no_draft", reason, entry_id, old_revision)
-        previous_output = raw
-        try:
-            candidate = parse_generated_json(raw)
-        except ValueError as exc:
-            last_reason = str(exc)
-            continue
-        with sqlite3.connect(db_path) as conn:
-            validation = validate_article(candidate, packet, _prior_titles(conn, guild_id))
-        if validation:
-            last_reason = validation
-            continue
-        article = candidate
-        break
-    if article is None:
-        return JournalResult(False, "no_draft", last_reason or "generation_failed", entry_id, old_revision)
     with sqlite3.connect(db_path) as conn:
-        reason = validate_article(article, packet, _prior_titles(conn, guild_id))
+        prior_titles = _prior_titles(conn, guild_id)
+    article, reason, allow_advisory = _generate_article_with_repairs(
+        packet,
+        generator,
+        prior_titles,
+    )
+    if article is None:
+        return JournalResult(False, "no_draft", reason, entry_id, old_revision)
+    with sqlite3.connect(db_path) as conn:
+        reason = validate_article(
+            article,
+            packet,
+            _prior_titles(conn, guild_id),
+            blocking_only=allow_advisory,
+        )
         if reason:
             return JournalResult(False, "no_draft", reason, entry_id, old_revision)
         entry_row, meta_row, result = _draft_records(guild_id, packet, article, entry_id=entry_id, revision=old_revision + 1)

--- a/bnl_journal_automation.py
+++ b/bnl_journal_automation.py
@@ -555,12 +555,15 @@ def _pending_daily_day(db_path: str, guild_id: int, now_utc: Optional[datetime])
                 (guild_id,),
             ).fetchall()
         }
-    current = first
-    while current <= latest:
+    # Always give the newly closed 7-to-7 window first priority. Once that
+    # window is terminal, the interval worker walks backward through any
+    # older backlog without letting an old held run starve today's Journal.
+    current = latest
+    while current >= first:
         start, end, _ = _daily_period_for_day(current)
         if rows.get(("daily", start, end)) not in TERMINAL_RUN_STATES:
             return current
-        current += timedelta(days=1)
+        current -= timedelta(days=1)
     return None
 
 

--- a/tests/test_bnl_journal.py
+++ b/tests/test_bnl_journal.py
@@ -82,25 +82,22 @@ class JournalTests(unittest.TestCase):
         with sqlite3.connect(self.db) as c:
             self.assertEqual(c.execute("SELECT COUNT(*) FROM bnl_journal_entries").fetchone()[0], 0)
 
-    def test_phrase_copy_gets_actionable_rewrite_without_weakening_guard(self):
+    def test_public_safe_wording_overlap_is_not_a_publish_blocker(self):
         calls = []
         copied = ' people discuss bass chaos and a hook'
 
         def gen(packet, prompt):
             calls.append(prompt)
-            if len(calls) == 1:
-                return article_json(packet, title='Copied First Pass', leak=copied)
-            return article_json(packet, title='Quoted Second Pass', leak=f' "{copied.strip()}"')
+            return article_json(packet, title='Public Wording Pass', leak=copied)
 
         packet = self.packet()
-        invalid = j.parse_generated_json(article_json(packet, title='Guard Check', leak=copied))
-        self.assertEqual('discord_phrase_copy', j.validate_article(invalid, packet, []))
+        article = j.parse_generated_json(article_json(packet, title='Guard Check', leak=copied))
+        self.assertEqual('', j.validate_article(article, packet, []))
 
         res = j.generate_and_store_draft(self.db, 1, 24, gen)
         self.assertTrue(res.ok, res.reason)
-        self.assertEqual(2, len(calls))
-        self.assertIn('brief direct quote', calls[1])
-        self.assertIn('Previous rejected JSON', calls[1])
+        self.assertEqual(1, len(calls))
+        self.assertIn('Use a direct quote only rarely', calls[0])
         with sqlite3.connect(self.db) as c:
             self.assertEqual(
                 1,
@@ -127,6 +124,67 @@ class JournalTests(unittest.TestCase):
         self.assertIn('overly_clinical_voice', calls[1])
         self.assertIn('lively, concrete community chronicle', calls[1])
 
+    def test_editorial_polish_cannot_cancel_a_blocking_clean_entry(self):
+        calls = []
+
+        def gen(packet, prompt):
+            calls.append(prompt)
+            return article_json(
+                packet,
+                title='Persistent Clinical Voice',
+                leak=' Records indicate continuous effort across entities.',
+            )
+
+        result = j.generate_and_store_draft(self.db, 1, 24, gen)
+        self.assertTrue(result.ok, result.reason)
+        self.assertEqual(j.JOURNAL_GENERATION_ATTEMPTS, len(calls))
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(
+                [('draft', 'Persistent Clinical Voice')],
+                conn.execute(
+                    "SELECT lifecycle_state,title FROM bnl_journal_entries"
+                ).fetchall(),
+            )
+
+    def test_retained_publishable_entry_survives_later_provider_failure(self):
+        calls = []
+
+        def gen(packet, prompt):
+            calls.append(prompt)
+            if len(calls) == 1:
+                return article_json(
+                    packet,
+                    title='Retained Safe Candidate',
+                    leak=' Records indicate continuous effort across entities.',
+                )
+            raise RuntimeError('provider down during polish')
+
+        result = j.generate_and_store_draft(self.db, 1, 24, gen)
+        self.assertTrue(result.ok, result.reason)
+        self.assertEqual(2, len(calls))
+
+    def test_advisory_style_never_hides_a_blocking_context_failure(self):
+        def gen(packet, prompt):
+            article = json.loads(article_json(
+                packet,
+                title='Clinical But Unsupported',
+                leak=' Records indicate continuous effort across entities.',
+            ))
+            article['metadata']['contextUses'] = [{
+                'laneType': 'bnl_inference',
+                'laneRefId': 'inference:not-supplied',
+                'sectionHeading': 'Public Noise, Carefully Labeled',
+                'claim': 'I think this proves a larger plan.',
+                'basisRefIds': [packet['safeSources'][0]['refId']],
+            }]
+            return json.dumps(article)
+
+        result = j.generate_and_store_draft(self.db, 1, 24, gen)
+        self.assertFalse(result.ok)
+        self.assertEqual('invalid_context_use', result.reason)
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(0, conn.execute("SELECT COUNT(*) FROM bnl_journal_entries").fetchone()[0])
+
     def test_source_specific_generated_json_creates_draft(self):
         def gen(packet, prompt): return article_json(packet)
         res = j.generate_and_store_draft(self.db, 1, 24, gen)
@@ -147,10 +205,10 @@ class JournalTests(unittest.TestCase):
         self.assertEqual(hist['recurringTopicCounts']['bass'], 11)
         self.assertFalse(any(r['entry_id'] == 'e10' for r in hist['relevantOlderEntries']))
 
-    def test_validation_rejects_names_refs_urls_mentions_ids_and_unquoted_copied_phrases(self):
+    def test_validation_rejects_names_refs_urls_mentions_and_ids(self):
         packet = self.packet(); good = j.parse_generated_json(article_json(packet))
         self.assertEqual('', j.validate_article(good, packet, []))
-        for leak, reason in [(' KnownUser', 'community_name_leak'), (' fresh:101', 'source_ref_leak'), (' https://x.test', 'public_leak_pattern'), (' @KnownUser', 'public_leak_pattern'), (' 1234567890123', 'public_leak_pattern'), (' people discuss bass chaos and a hook', 'discord_phrase_copy')]:
+        for leak, reason in [(' KnownUser', 'community_name_leak'), (' fresh:101', 'source_ref_leak'), (' https://x.test', 'public_leak_pattern'), (' @KnownUser', 'public_leak_pattern'), (' 1234567890123', 'public_leak_pattern')]:
             bad = j.parse_generated_json(article_json(packet, title='Unique ' + reason, leak=leak))
             self.assertEqual(reason, j.validate_article(bad, packet, []), leak)
 
@@ -171,7 +229,7 @@ class JournalTests(unittest.TestCase):
         result = j.generate_and_store_draft(self.db, 1, 24, gen)
         self.assertTrue(result.ok, result.reason)
         self.assertEqual(1, len(calls))
-        self.assertIn('direct quote is welcome', calls[0])
+        self.assertIn('Use a direct quote only rarely', calls[0])
         self.assertNotIn('Do not include direct quotes', calls[0])
 
     def test_approved_entry_cannot_be_rejected_and_tables_remain_approved(self):
@@ -192,6 +250,45 @@ class JournalTests(unittest.TestCase):
             metas = c.execute("SELECT revision,lifecycle_state FROM bnl_journal_private_metadata WHERE entry_id=? ORDER BY revision", (res.entry_id,)).fetchall()
         self.assertEqual(rows, [(1, 'rejected', 'First Title'), (2, 'draft', 'Second Title')])
         self.assertEqual(metas, [(1, 'rejected'), (2, 'draft')])
+
+    def test_editorial_polish_cannot_cancel_regeneration(self):
+        first = j.generate_and_store_draft(
+            self.db,
+            1,
+            24,
+            lambda packet, prompt: article_json(packet, 'First Draft'),
+        )
+        self.assertTrue(first.ok, first.reason)
+        calls = []
+
+        def clinical_regeneration(packet, prompt):
+            calls.append(prompt)
+            return article_json(
+                packet,
+                'Regenerated Clinical Draft',
+                ' Records indicate continuous effort across entities.',
+            )
+
+        regenerated = j.regenerate_draft(
+            self.db,
+            1,
+            first.entry_id,
+            24,
+            clinical_regeneration,
+        )
+
+        self.assertTrue(regenerated.ok, regenerated.reason)
+        self.assertEqual(2, regenerated.revision)
+        self.assertEqual(j.JOURNAL_GENERATION_ATTEMPTS, len(calls))
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(
+                [(1, 'rejected'), (2, 'draft')],
+                conn.execute(
+                    "SELECT revision,lifecycle_state FROM bnl_journal_entries "
+                    "WHERE entry_id=? ORDER BY revision",
+                    (first.entry_id,),
+                ).fetchall(),
+            )
 
 
     def test_provider_exception_create_no_rows_and_regen_preserves_old(self):

--- a/tests/test_bnl_journal_automation.py
+++ b/tests/test_bnl_journal_automation.py
@@ -245,6 +245,104 @@ class JournalAutomationTests(unittest.TestCase):
             self.assertEqual("published", conn.execute("SELECT lifecycle_state FROM bnl_journal_observations").fetchone()[0])
             self.assertEqual(1, conn.execute("SELECT COUNT(*) FROM bnl_journal_entries WHERE lifecycle_state='published'").fetchone()[0])
 
+    def test_editorial_polish_cannot_hold_daily_publication(self):
+        self.add_day("2026-07-19")
+        calls = []
+
+        def persistent_clinical_style(packet, prompt):
+            calls.append(prompt)
+            article = json.loads(article_json(packet))
+            article["title"] = "Persistent Clinical Daily"
+            article["sections"][0]["body"] += (
+                " Records indicate continuous effort across entities."
+            )
+            return json.dumps(article)
+
+        first = automation.run_daily(
+            self.db,
+            1,
+            persistent_clinical_style,
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+        second = automation.run_daily(
+            self.db,
+            1,
+            lambda *_args: self.fail("published daily window generated twice"),
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+
+        self.assertTrue(first.ok, first)
+        self.assertEqual("published", first.status)
+        self.assertEqual(journal.JOURNAL_GENERATION_ATTEMPTS, len(calls))
+        self.assertEqual(first.entry_id, second.entry_id)
+        self.assertEqual("published", second.status)
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(
+                1,
+                conn.execute(
+                    "SELECT COUNT(*) FROM bnl_journal_entries WHERE lifecycle_state='published'"
+                ).fetchone()[0],
+            )
+
+    def test_newly_closed_day_publishes_before_an_older_held_backlog(self):
+        self.add_day("2026-07-18")
+        self.add_day("2026-07-19")
+        self.set_archive_activation("2026-07-18T02:00:01Z")
+
+        def provider_down(_packet, _prompt):
+            raise RuntimeError("provider down")
+
+        held = automation.run_daily(
+            self.db,
+            1,
+            provider_down,
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 18),
+            force=True,
+            opener=self.opener,
+        )
+        self.assertEqual("held", held.status)
+
+        results = automation.run_scheduled(
+            self.db,
+            1,
+            lambda packet, prompt: article_json(packet),
+            "https://site.example",
+            "key",
+            {
+                "journalAutoPublishEnabled": True,
+                "journalDailyEnabled": True,
+                "journalWeeklyEnabled": False,
+            },
+            now_utc=datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc),
+            opener=self.opener,
+        )
+
+        self.assertEqual(1, len(results))
+        self.assertEqual("published", results[0].status)
+        expected_start, expected_end, _ = automation._daily_period_for_day(
+            date(2026, 7, 19)
+        )
+        self.assertEqual(expected_start, results[0].source_window_start)
+        self.assertEqual(expected_end, results[0].source_window_end)
+        self.assertEqual(
+            date(2026, 7, 18),
+            automation._pending_daily_day(
+                self.db,
+                1,
+                datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc),
+            ),
+        )
+
     def test_daily_uses_complete_half_open_window_and_far_more_than_25(self):
         with sqlite3.connect(self.db) as conn:
             for index in range(90):
@@ -281,7 +379,7 @@ class JournalAutomationTests(unittest.TestCase):
         self.assertEqual(90, len(packet["safeSources"]))
         self.assertFalse(any(source.get("relayId") == "boundary" for source in packet["privateSources"]))
 
-    def test_scheduler_catches_up_oldest_missing_complete_day(self):
+    def test_scheduler_publishes_newest_day_then_catches_up_older_day(self):
         for day in ("2026-07-17", "2026-07-18", "2026-07-19"):
             self.add_day(day)
         source_store.backfill_legacy_sources(self.db, 1)
@@ -297,9 +395,9 @@ class JournalAutomationTests(unittest.TestCase):
             "https://site.example", "key", now_utc=now, opener=self.opener,
         )
 
-        self.assertEqual("2026-07-18T02:00:00Z", first[0].source_window_start)
+        self.assertEqual("2026-07-19T02:00:00Z", first[0].source_window_start)
         self.assertEqual("published", first[0].status)
-        self.assertEqual("2026-07-19T02:00:00Z", second[0].source_window_start)
+        self.assertEqual("2026-07-18T02:00:00Z", second[0].source_window_start)
         self.assertEqual("published", second[0].status)
 
     def test_weekly_uses_durable_daily_observations(self):

--- a/tests/test_bnl_journal_evidence_voice.py
+++ b/tests/test_bnl_journal_evidence_voice.py
@@ -98,7 +98,7 @@ class JournalEvidenceVoiceTests(unittest.TestCase):
         self.assertIn("evidenceCoverageContract", prompt)
         self.assertIn("concrete, recognizable action", prompt)
         self.assertIn("Never invent a time, place, object, action", prompt)
-        self.assertIn("direct quote is welcome", prompt)
+        self.assertIn("Use a direct quote only rarely", prompt)
         self.assertNotIn("Do not include direct quotes", prompt)
 
     def test_report_opening_clinical_language_and_missing_reaction_are_rejected(self):

--- a/tests/test_bnl_journal_runtime_controls.py
+++ b/tests/test_bnl_journal_runtime_controls.py
@@ -57,6 +57,13 @@ class JournalRuntimeControlTests(unittest.TestCase):
             self.assertEqual(action, options["action"])
             self.assertEqual("", error)
 
+    def test_daily_worker_is_pinned_to_seven_pm_pacific(self):
+        scheduled_times = bnl01_bot.journal_daily_schedule_task.time
+        self.assertEqual(1, len(scheduled_times))
+        scheduled = scheduled_times[0]
+        self.assertEqual((19, 0), (scheduled.hour, scheduled.minute))
+        self.assertEqual("America/Los_Angeles", getattr(scheduled.tzinfo, "key", ""))
+
     def test_control_get_uses_api_key_and_expected_endpoint(self):
         captured = []
 
@@ -205,26 +212,84 @@ class JournalRuntimeControlTests(unittest.TestCase):
         self.assertTrue(flags["journalDailyEnabled"])
         self.assertTrue(flags["journalWeeklyEnabled"])
 
-    def test_control_get_failure_holds_without_running_scheduler(self):
-        runner = mock.AsyncMock()
+    def test_control_get_failure_runs_local_schedule_with_cached_flags(self):
+        cached_flags = {
+            "journalAutoPublishEnabled": True,
+            "journalDailyEnabled": True,
+            "journalWeeklyEnabled": True,
+        }
+        runner = mock.AsyncMock(return_value=[{
+            "cadence": "all",
+            "status": "not_due",
+            "reason": "no_schedule_due",
+        }])
         with mock.patch.object(bnl01_bot, "resolve_network_guild_id", return_value=1), \
-             mock.patch.object(bnl01_bot, "get_bnl_control_flags", return_value={
-                 "journalAutoPublishEnabled": True,
-                 "journalDailyEnabled": True,
-                 "journalWeeklyEnabled": True,
-             }), \
+             mock.patch.object(bnl01_bot, "get_bnl_control_flags", return_value=cached_flags), \
              mock.patch.object(bnl01_bot, "_journal_control_request_sync", return_value=(None, "control_plane_timeout")), \
              mock.patch.object(bnl01_bot, "_journal_heartbeat_sync", return_value=(None, "")), \
+             mock.patch.object(bnl01_bot, "journal_automation_status", return_value={}), \
              mock.patch.object(bnl01_bot, "run_journal_automation_once", new=runner):
             results = asyncio.run(bnl01_bot.run_journal_automation_control_cycle(1))
 
-        runner.assert_not_awaited()
-        self.assertEqual("held", results[0]["status"])
+        runner.assert_awaited_once_with(
+            1,
+            cadence="scheduled",
+            force=False,
+            flags=cached_flags,
+        )
+        self.assertEqual("not_due", results[0]["status"])
+        self.assertEqual("no_schedule_due", results[0]["reason"])
         self.assertEqual(
             "control_plane_unavailable:control_plane_timeout",
-            results[0]["reason"],
+            bnl01_bot._journal_automation_runtime_by_guild[1]["lastError"],
         )
-        self.assertEqual(results[0]["reason"], bnl01_bot._journal_automation_runtime_by_guild[1]["lastError"])
+
+    def test_control_get_failure_still_honors_cached_publish_pause(self):
+        cached_flags = {
+            "journalAutoPublishEnabled": False,
+            "journalDailyEnabled": False,
+            "journalWeeklyEnabled": True,
+        }
+        with mock.patch.object(bnl01_bot, "resolve_network_guild_id", return_value=1), \
+             mock.patch.object(bnl01_bot, "BNL_JOURNAL_AUTOMATION_ENABLED", True), \
+             mock.patch.object(bnl01_bot, "get_bnl_control_flags", return_value=cached_flags), \
+             mock.patch.object(bnl01_bot, "_journal_control_request_sync", return_value=(None, "control_plane_timeout")), \
+             mock.patch.object(bnl01_bot, "_journal_heartbeat_sync", return_value=(None, "")), \
+             mock.patch.object(bnl01_bot, "journal_automation_status", return_value={}), \
+             mock.patch.object(bnl01_bot, "run_scheduled_journal_automation") as scheduled:
+            results = asyncio.run(bnl01_bot.run_journal_automation_control_cycle(1))
+
+        scheduled.assert_not_called()
+        self.assertEqual("paused", results[0]["status"])
+        self.assertEqual("auto_publish_paused", results[0]["reason"])
+
+    def test_overlapping_schedule_waits_instead_of_returning_busy(self):
+        async def scenario():
+            lock = bnl01_bot._journal_automation_lock(1)
+            await lock.acquire()
+            try:
+                pending = asyncio.create_task(
+                    bnl01_bot.run_journal_automation_once(
+                        1,
+                        cadence="daily",
+                        flags={
+                            "journalAutoPublishEnabled": False,
+                            "journalDailyEnabled": True,
+                            "journalWeeklyEnabled": True,
+                        },
+                    )
+                )
+                await asyncio.sleep(0)
+                self.assertFalse(pending.done())
+            finally:
+                lock.release()
+            return await pending
+
+        with mock.patch.object(bnl01_bot, "resolve_network_guild_id", return_value=1):
+            results = asyncio.run(scenario())
+
+        self.assertEqual("paused", results[0]["status"])
+        self.assertEqual("auto_publish_paused", results[0]["reason"])
 
     def test_clear_history_also_purges_durable_journal_discord_sources(self):
         temp = tempfile.NamedTemporaryFile(delete=False)


### PR DESCRIPTION
## Summary

- run the Journal scheduler at exactly 7:00 PM Pacific, with the existing interval worker retained as catch-up
- continue the local schedule from cached confirmed flags when only the site control-plane read is unavailable
- prioritize the newly closed 7-to-7 daily window before older held backlog and wait through overlapping triggers
- remove the five-word Discord phrase-overlap veto; paraphrase by default and use direct quotes only rarely
- keep privacy, payload, evidence, context, and grounding failures blocking while making editorial polish advisory
- retain a blocking-clean candidate so failed polish retries or a later provider error cannot discard the Journal

## Validation

- `make check PYTHON=/tmp/bnl-journal-reliability-venv/bin/python`
- 1,042 tests passed
- focused Journal/runtime suite passed
- `git diff --check` and Python compilation passed
- independent review found no blocking regressions

## Scope

Bot and Journal tests only. No gates enabled, no environment or site configuration changed, and nothing deployed.