### PR TITLE
Bot: keep daily Journal relay-led across the full window

### DIFF
--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -24,6 +24,8 @@ ADVISORY_VALIDATION_REASONS = frozenset({
 MAX_RELAY_SOURCES_PER_WINDOW = 500
 MAX_CONVERSATION_SOURCES_PER_WINDOW = 2_000
 MAX_PROMPT_SOURCES = 180
+MAX_DAILY_DERIVATIVE_RELAY_PROMPT_SOURCES = 3
+DAILY_DERIVATIVE_RELAY_EVENT_TYPES = frozenset({"fresh_public_discord_activity"})
 MAX_BROADCAST_MEMORY_CONTEXT = 8
 MAX_RUMOR_CONTEXT = 4
 JOURNAL_PUBLIC_BROADCAST_SCOPES = {"ambient", "direct", "journal", "relay", "show_status"}
@@ -1001,6 +1003,83 @@ def _evenly_sample(items: list[dict[str, Any]], limit: int) -> list[dict[str, An
     return [items[i] for i in sorted(indexes)]
 
 
+def _source_sort_key(source: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(source.get("observedAt") or ""),
+        str(source.get("sourceKind") or ""),
+        str(source.get("refId") or ""),
+    )
+
+
+def _time_stratified_sample(
+    items: list[dict[str, Any]],
+    limit: int,
+    start: str,
+    end: str,
+    *,
+    segment_count: int = 3,
+) -> list[dict[str, Any]]:
+    """Reserve temporal breadth, then let remaining slots follow activity density."""
+    ordered = sorted(items, key=_source_sort_key)
+    if limit <= 0:
+        return []
+    if len(ordered) <= limit:
+        return ordered
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for source in ordered:
+        segment = _coverage_segment(source.get("observedAt"), start, end, segment_count)
+        if segment:
+            buckets.setdefault(segment, []).append(source)
+    active_segments = [
+        buckets.get(f"segment-{index}", [])
+        for index in range(1, max(1, int(segment_count)) + 1)
+        if buckets.get(f"segment-{index}")
+    ]
+    if not active_segments or limit < len(active_segments):
+        return _evenly_sample(ordered, limit)
+
+    # Half of the budget is available as an equal temporal floor. Quiet
+    # segments keep all of their material; the other half continues to follow
+    # real activity density, so a busy stretch may still lead the story.
+    floor = max(1, limit // (2 * len(active_segments)))
+    selected: list[dict[str, Any]] = []
+    for bucket in active_segments:
+        selected.extend(_evenly_sample(bucket, min(len(bucket), floor)))
+    selected_ids = {id(source) for source in selected}
+    remaining = [source for source in ordered if id(source) not in selected_ids]
+    remaining_quota = limit - len(selected)
+    if remaining_quota > 0:
+        selected.extend(_evenly_sample(remaining, remaining_quota))
+    return sorted(selected, key=_source_sort_key)
+
+
+def _window_segment_activity(
+    start: str,
+    end: str,
+    relays: list[dict[str, Any]],
+    conversations: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Expose non-identifying daily activity density without treating relays as people."""
+    labels = ("early", "middle", "late")
+    counts = {
+        f"segment-{index}": {"conversationSources": 0, "relaySources": 0}
+        for index in range(1, 4)
+    }
+    for source in [*relays, *conversations]:
+        segment = _coverage_segment(source.get("observedAt"), start, end, 3)
+        if segment not in counts:
+            continue
+        key = "conversationSources" if source.get("sourceKind") == "conversation" else "relaySources"
+        counts[segment][key] += 1
+    return [
+        {
+            "segment": label,
+            **counts[f"segment-{index}"],
+        }
+        for index, label in enumerate(labels, 1)
+    ]
+
+
 def _minimum_fresh_sources_for_entry(entry_kind: str, total: int) -> int:
     """Require representative breadth without turning a short Journal into a roll call."""
     if total <= 0:
@@ -1183,24 +1262,63 @@ def retrieve_history(
     }
 
 
-def _sample_source_kinds(relays: list[dict[str, Any]], conversations: list[dict[str, Any]], limit: int = MAX_PROMPT_SOURCES) -> list[dict[str, Any]]:
-    total = len(relays) + len(conversations)
+def _sample_source_kinds(
+    relays: list[dict[str, Any]],
+    conversations: list[dict[str, Any]],
+    limit: int = MAX_PROMPT_SOURCES,
+    *,
+    start: str = "",
+    end: str = "",
+    entry_kind: str = "manual",
+) -> list[dict[str, Any]]:
+    if limit <= 0:
+        return []
+
+    def sample(items: list[dict[str, Any]], quota: int) -> list[dict[str, Any]]:
+        if entry_kind == "daily" and start and end:
+            return _time_stratified_sample(items, quota, start, end)
+        return _evenly_sample(items, quota)
+
+    candidate_relays = list(relays)
+    if entry_kind == "daily" and conversations:
+        derivative_relays: list[dict[str, Any]] = []
+        independent_relays: list[dict[str, Any]] = []
+        for source in relays:
+            event_type = str(source.get("eventType") or "").strip().lower()
+            target = (
+                derivative_relays
+                if event_type in DAILY_DERIVATIVE_RELAY_EVENT_TYPES
+                else independent_relays
+            )
+            target.append(source)
+        # These scheduled relay readings paraphrase batches of public Discord
+        # activity whose original conversations are already present. One
+        # reading per daily segment preserves their connective context without
+        # giving the underlying moments a second vote. Relays with any other
+        # event type remain eligible as distinct status/canon.
+        derivative_quota = min(
+            len(derivative_relays),
+            MAX_DAILY_DERIVATIVE_RELAY_PROMPT_SOURCES,
+        )
+        candidate_relays = independent_relays + sample(derivative_relays, derivative_quota)
+
+    total = len(candidate_relays) + len(conversations)
     if total <= limit:
-        chosen = list(relays) + list(conversations)
-    elif not relays:
-        chosen = _evenly_sample(conversations, limit)
+        chosen = candidate_relays + list(conversations)
+    elif not candidate_relays:
+        chosen = sample(conversations, limit)
     elif not conversations:
-        chosen = _evenly_sample(relays, limit)
+        chosen = sample(candidate_relays, limit)
     else:
-        relay_quota = min(len(relays), max(1, limit // 2))
+        relay_quota = min(len(candidate_relays), max(1, limit // 2))
         conversation_quota = min(len(conversations), max(1, limit - relay_quota))
         spare = limit - relay_quota - conversation_quota
         if spare > 0:
-            add_relays = min(spare, len(relays) - relay_quota)
+            add_relays = min(spare, len(candidate_relays) - relay_quota)
             relay_quota += add_relays
             conversation_quota += min(spare - add_relays, len(conversations) - conversation_quota)
-        chosen = _evenly_sample(relays, relay_quota) + _evenly_sample(conversations, conversation_quota)
-    return sorted(chosen, key=lambda src: (str(src.get("observedAt") or ""), str(src.get("sourceKind") or ""), str(src.get("refId") or "")))
+        chosen = sample(candidate_relays, relay_quota) + sample(conversations, conversation_quota)
+    return sorted(chosen, key=_source_sort_key)
 
 
 def build_packet_from_sources(
@@ -1226,7 +1344,13 @@ def build_packet_from_sources(
         if str(source.get("displayName") or "").strip()
     ]
     window_display_names = list(dict.fromkeys(window_display_names))
-    private_sources = _sample_source_kinds(relays, conversations)
+    private_sources = _sample_source_kinds(
+        relays,
+        conversations,
+        start=start,
+        end=end,
+        entry_kind=entry_kind,
+    )
     safe_sources = []
     for source in private_sources:
         safe_source = _source_for_prompt(source)
@@ -1256,6 +1380,11 @@ def build_packet_from_sources(
         "aggregateCounts": counts,
         "coverageComplete": bool(coverage_complete),
         "observationContext": list(observation_context or []),
+        "windowSegmentActivity": (
+            _window_segment_activity(start, end, relays, conversations)
+            if entry_kind == "daily"
+            else []
+        ),
     }
     context_lanes, private_lane_provenance = build_generation_context_lanes(
         db_path,
@@ -1477,6 +1606,7 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
         "history": _bounded_history_for_prompt(packet.get("history", {})),
         "aggregateCounts": packet.get("aggregateCounts", {}),
         "dailyObservations": packet.get("observationContext", [])[:7],
+        "windowSegmentActivity": packet.get("windowSegmentActivity", []),
         "privateGenerationContextLanes": context_lanes,
     }
     cadence_rule = (
@@ -1521,6 +1651,8 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
         "\nStart at least one section with a grounded person, action, object, or moment—never The Network observes, Records indicate, Observations reveal, Analysis shows, or Data streams reveal."
         "\nUse first person sparingly but genuinely. A BNL reaction may describe BNL's response without adding an external fact: I noticed, I admit, I found myself returning to it, I remain curious, or I may be developing a preference. Reserve I suspect, I think, and I wonder for a properly declared bnl_inference context use."
         "\nBuild one coherent story around the most interesting grounded patterns. Use concrete music and community texture, readable paragraphs, and selective detail. Never invent a time, place, object, action, motive, outcome, relationship, dialogue, emotional state, or scene decoration absent from the cited evidence."
+        "\nTreat website relay sources as derivative readings, not additional community moments. They paraphrase batches whose original conversations are already supplied, so do not give the underlying activity a second vote. Prefer fresh conversation sources for what people did or said, and use a relay when it adds unique public status or connective context."
+        "\nFor a daily entry, keep the whole source window in view. Use windowSegmentActivity.conversationSources—not relaySources—to judge human activity density; relaySources records scheduled delivery volume. The busiest or strongest stretch may lead, but give meaningful earlier and middle activity proportionate narrative attention. Do not make a multi-segment day sound as though it began with the latest cluster."
         "\nUse a short, vivid title of about 4-10 words. Do not prefix it with Network Log. Keep the excerpt compact and inviting."
         "\nDescribe anonymous humans with a concrete, recognizable action from their cited public message whenever possible, so a regular may recognize their own moment without being exposed. Use producer, listener, or artist only when that role is grounded; otherwise use a regular, a person in the room, or the room. Never call people entities or organisms. Do not invent nicknames or honorifics."
         "\nStable participant aliases in the packet are private pattern-analysis aids. Never reproduce an alias in public prose."

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -24,8 +24,6 @@ ADVISORY_VALIDATION_REASONS = frozenset({
 MAX_RELAY_SOURCES_PER_WINDOW = 500
 MAX_CONVERSATION_SOURCES_PER_WINDOW = 2_000
 MAX_PROMPT_SOURCES = 180
-MAX_DAILY_DERIVATIVE_RELAY_PROMPT_SOURCES = 3
-DAILY_DERIVATIVE_RELAY_EVENT_TYPES = frozenset({"fresh_public_discord_activity"})
 MAX_BROADCAST_MEMORY_CONTEXT = 8
 MAX_RUMOR_CONTEXT = 4
 JOURNAL_PUBLIC_BROADCAST_SCOPES = {"ambient", "direct", "journal", "relay", "show_status"}
@@ -1059,7 +1057,7 @@ def _window_segment_activity(
     relays: list[dict[str, Any]],
     conversations: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Expose non-identifying daily activity density without treating relays as people."""
+    """Expose non-identifying daily activity across the relay and context streams."""
     labels = ("early", "middle", "late")
     counts = {
         f"segment-{index}": {"conversationSources": 0, "relaySources": 0}
@@ -1279,45 +1277,22 @@ def _sample_source_kinds(
             return _time_stratified_sample(items, quota, start, end)
         return _evenly_sample(items, quota)
 
-    candidate_relays = list(relays)
-    if entry_kind == "daily" and conversations:
-        derivative_relays: list[dict[str, Any]] = []
-        independent_relays: list[dict[str, Any]] = []
-        for source in relays:
-            event_type = str(source.get("eventType") or "").strip().lower()
-            target = (
-                derivative_relays
-                if event_type in DAILY_DERIVATIVE_RELAY_EVENT_TYPES
-                else independent_relays
-            )
-            target.append(source)
-        # These scheduled relay readings paraphrase batches of public Discord
-        # activity whose original conversations are already present. One
-        # reading per daily segment preserves their connective context without
-        # giving the underlying moments a second vote. Relays with any other
-        # event type remain eligible as distinct status/canon.
-        derivative_quota = min(
-            len(derivative_relays),
-            MAX_DAILY_DERIVATIVE_RELAY_PROMPT_SOURCES,
-        )
-        candidate_relays = independent_relays + sample(derivative_relays, derivative_quota)
-
-    total = len(candidate_relays) + len(conversations)
+    total = len(relays) + len(conversations)
     if total <= limit:
-        chosen = candidate_relays + list(conversations)
-    elif not candidate_relays:
+        chosen = list(relays) + list(conversations)
+    elif not relays:
         chosen = sample(conversations, limit)
     elif not conversations:
-        chosen = sample(candidate_relays, limit)
+        chosen = sample(relays, limit)
     else:
-        relay_quota = min(len(candidate_relays), max(1, limit // 2))
+        relay_quota = min(len(relays), max(1, limit // 2))
         conversation_quota = min(len(conversations), max(1, limit - relay_quota))
         spare = limit - relay_quota - conversation_quota
         if spare > 0:
-            add_relays = min(spare, len(candidate_relays) - relay_quota)
+            add_relays = min(spare, len(relays) - relay_quota)
             relay_quota += add_relays
             conversation_quota += min(spare - add_relays, len(conversations) - conversation_quota)
-        chosen = sample(candidate_relays, relay_quota) + sample(conversations, conversation_quota)
+        chosen = sample(relays, relay_quota) + sample(conversations, conversation_quota)
     return sorted(chosen, key=_source_sort_key)
 
 
@@ -1651,8 +1626,8 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
         "\nStart at least one section with a grounded person, action, object, or moment—never The Network observes, Records indicate, Observations reveal, Analysis shows, or Data streams reveal."
         "\nUse first person sparingly but genuinely. A BNL reaction may describe BNL's response without adding an external fact: I noticed, I admit, I found myself returning to it, I remain curious, or I may be developing a preference. Reserve I suspect, I think, and I wonder for a properly declared bnl_inference context use."
         "\nBuild one coherent story around the most interesting grounded patterns. Use concrete music and community texture, readable paragraphs, and selective detail. Never invent a time, place, object, action, motive, outcome, relationship, dialogue, emotional state, or scene decoration absent from the cited evidence."
-        "\nTreat website relay sources as derivative readings, not additional community moments. They paraphrase batches whose original conversations are already supplied, so do not give the underlying activity a second vote. Prefer fresh conversation sources for what people did or said, and use a relay when it adds unique public status or connective context."
-        "\nFor a daily entry, keep the whole source window in view. Use windowSegmentActivity.conversationSources—not relaySources—to judge human activity density; relaySources records scheduled delivery volume. The busiest or strongest stretch may lead, but give meaningful earlier and middle activity proportionate narrative attention. Do not make a multi-segment day sound as though it began with the latest cluster."
+        "\nFor a daily entry, the relay stream is the primary chronology and narrative spine. Conversation sources are supporting public context: use them to ground or explain the context surrounding the relays, and do not turn the Journal into a Discord digest. When relay and conversation sources describe the same episode, connect them instead of presenting them as unrelated events."
+        "\nKeep the whole daily source window in view. Use both relaySources and conversationSources in windowSegmentActivity: relaySources shows the relay arc and conversationSources shows its public context. The busiest or strongest stretch may lead, but give meaningful earlier and middle activity proportionate narrative attention. Do not make a multi-segment day sound as though it began with the latest cluster."
         "\nUse a short, vivid title of about 4-10 words. Do not prefix it with Network Log. Keep the excerpt compact and inviting."
         "\nDescribe anonymous humans with a concrete, recognizable action from their cited public message whenever possible, so a regular may recognize their own moment without being exposed. Use producer, listener, or artist only when that role is grounded; otherwise use a regular, a person in the room, or the room. Never call people entities or organisms. Do not invent nicknames or honorifics."
         "\nStable participant aliases in the packet are private pattern-analysis aids. Never reproduce an alias in public prose."

--- a/tests/test_bnl_journal_evidence_voice.py
+++ b/tests/test_bnl_journal_evidence_voice.py
@@ -52,7 +52,7 @@ class JournalEvidenceVoiceTests(unittest.TestCase):
                 "sourceKind": "relay",
                 "summary": f"A public mix update carried bass detail number {index}.",
                 "observedAt": f"2026-07-19T{hour:02d}:00:00Z",
-                "eventType": "canon",
+                "eventType": "fresh_public_activity",
             }
             for index, hour in enumerate((8, 10, 14, 16, 20, 22), 1)
         ]
@@ -100,14 +100,15 @@ class JournalEvidenceVoiceTests(unittest.TestCase):
         self.assertIn("concrete, recognizable action", prompt)
         self.assertIn("Never invent a time, place, object, action", prompt)
         self.assertIn("Use a direct quote only rarely", prompt)
-        self.assertIn("website relay sources as derivative readings", prompt)
-        self.assertIn("do not give the underlying activity a second vote", prompt)
-        self.assertIn("keep the whole source window in view", prompt)
-        self.assertIn("conversationSources—not relaySources", prompt)
+        self.assertIn("relay stream is the primary chronology and narrative spine", prompt)
+        self.assertIn("Conversation sources are supporting public context", prompt)
+        self.assertIn("do not turn the Journal into a Discord digest", prompt)
+        self.assertIn("Keep the whole daily source window in view", prompt)
+        self.assertIn("Use both relaySources and conversationSources", prompt)
         self.assertIn("windowSegmentActivity", prompt)
         self.assertNotIn("Do not include direct quotes", prompt)
 
-    def test_daily_packet_discounts_relay_echoes_and_reports_full_window_density(self):
+    def test_daily_packet_keeps_relay_spine_and_balances_conversation_context(self):
         start_at = datetime(2026, 7, 19, tzinfo=timezone.utc)
 
         def stamp(segment, index, count):
@@ -154,12 +155,16 @@ class JournalEvidenceVoiceTests(unittest.TestCase):
 
         prompt_relays = [source for source in packet["privateSources"] if source["sourceKind"] == "relay"]
         prompt_conversations = [source for source in packet["privateSources"] if source["sourceKind"] == "conversation"]
-        self.assertEqual(journal.MAX_DAILY_DERIVATIVE_RELAY_PROMPT_SOURCES, len(prompt_relays))
-        self.assertEqual(sum(conversation_counts), len(prompt_conversations))
+        safe_relays = [source for source in packet["safeSources"] if source["sourceKind"] == "relay"]
+        safe_conversations = [source for source in packet["safeSources"] if source["sourceKind"] == "conversation"]
+        self.assertEqual(sum(relay_counts), len(prompt_relays))
+        self.assertEqual(journal.MAX_PROMPT_SOURCES - sum(relay_counts), len(prompt_conversations))
+        self.assertEqual(71, len(safe_relays))
+        self.assertEqual(109, len(safe_conversations))
         self.assertEqual(71, packet["aggregateCounts"]["eligibleRelays"])
         self.assertEqual(138, packet["aggregateCounts"]["eligibleConversations"])
-        self.assertEqual(3, packet["aggregateCounts"]["promptRelays"])
-        self.assertEqual(138, packet["aggregateCounts"]["promptConversations"])
+        self.assertEqual(71, packet["aggregateCounts"]["promptRelays"])
+        self.assertEqual(109, packet["aggregateCounts"]["promptConversations"])
         self.assertEqual(
             [
                 {"segment": "early", "conversationSources": 37, "relaySources": 23},
@@ -178,6 +183,23 @@ class JournalEvidenceVoiceTests(unittest.TestCase):
             for source in prompt_relays
         }
         self.assertEqual({"segment-1", "segment-2", "segment-3"}, relay_segments)
+        conversation_segment_counts = {
+            segment: len([
+                source
+                for source in prompt_conversations
+                if journal._coverage_segment(
+                    source["observedAt"],
+                    packet["sourceWindowStart"],
+                    packet["sourceWindowEnd"],
+                    3,
+                ) == segment
+            ])
+            for segment in ("segment-1", "segment-2", "segment-3")
+        }
+        self.assertEqual(
+            {"segment-1": 31, "segment-2": 9, "segment-3": 69},
+            conversation_segment_counts,
+        )
 
     def test_daily_conversation_sampling_preserves_quiet_segments_without_flattening_busy_one(self):
         start_at = datetime(2026, 7, 19, tzinfo=timezone.utc)
@@ -233,7 +255,7 @@ class JournalEvidenceVoiceTests(unittest.TestCase):
         self.assertEqual(3, len(sampled_by_segment[1]))
         self.assertGreater(len(sampled_by_segment[2]), len(sampled_by_segment[0]))
 
-    def test_daily_keeps_distinct_relay_status_while_discounting_repeated_echoes(self):
+    def test_daily_keeps_full_mixed_relay_history_below_prompt_cap(self):
         start_at = datetime(2026, 7, 19, tzinfo=timezone.utc)
         relays = [
             {
@@ -276,7 +298,7 @@ class JournalEvidenceVoiceTests(unittest.TestCase):
 
         self.assertIn("fresh:distinct-status", {source["refId"] for source in sampled})
         self.assertEqual(
-            3,
+            30,
             len([
                 source
                 for source in sampled

--- a/tests/test_bnl_journal_evidence_voice.py
+++ b/tests/test_bnl_journal_evidence_voice.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 
 import bnl_journal as journal
 
@@ -51,7 +52,7 @@ class JournalEvidenceVoiceTests(unittest.TestCase):
                 "sourceKind": "relay",
                 "summary": f"A public mix update carried bass detail number {index}.",
                 "observedAt": f"2026-07-19T{hour:02d}:00:00Z",
-                "eventType": "fresh_public_activity",
+                "eventType": "canon",
             }
             for index, hour in enumerate((8, 10, 14, 16, 20, 22), 1)
         ]
@@ -99,7 +100,227 @@ class JournalEvidenceVoiceTests(unittest.TestCase):
         self.assertIn("concrete, recognizable action", prompt)
         self.assertIn("Never invent a time, place, object, action", prompt)
         self.assertIn("Use a direct quote only rarely", prompt)
+        self.assertIn("website relay sources as derivative readings", prompt)
+        self.assertIn("do not give the underlying activity a second vote", prompt)
+        self.assertIn("keep the whole source window in view", prompt)
+        self.assertIn("conversationSources—not relaySources", prompt)
+        self.assertIn("windowSegmentActivity", prompt)
         self.assertNotIn("Do not include direct quotes", prompt)
+
+    def test_daily_packet_discounts_relay_echoes_and_reports_full_window_density(self):
+        start_at = datetime(2026, 7, 19, tzinfo=timezone.utc)
+
+        def stamp(segment, index, count):
+            offset = int((index + 1) * 8 * 60 / (count + 1))
+            return (start_at + timedelta(hours=segment * 8, minutes=offset)).isoformat().replace("+00:00", "Z")
+
+        relay_counts = (23, 24, 24)
+        relays = [
+            {
+                "refId": f"fresh:relay-{segment}-{index}",
+                "sourceKind": "relay",
+                "summary": "A scheduled relay paraphrased a batch of public conversations.",
+                "observedAt": stamp(segment, index, count),
+                "eventType": "fresh_public_discord_activity",
+            }
+            for segment, count in enumerate(relay_counts)
+            for index in range(count)
+        ]
+        conversation_counts = (37, 9, 92)
+        conversations = [
+            {
+                "refId": f"fresh:conversation-{segment}-{index}",
+                "sourceKind": "conversation",
+                "summary": f"A regular shared a distinct public moment {segment}-{index}.",
+                "observedAt": stamp(segment, index, count),
+                "participantAlias": f"participant-{segment}-{index}",
+                "subjectRef": f"discord_user:{segment * 1000 + index}",
+                "displayName": f"WindowMember{segment:01d}{index:03d}",
+                "channelPolicy": "public_home",
+            }
+            for segment, count in enumerate(conversation_counts)
+            for index in range(count)
+        ]
+
+        packet = journal.build_packet_from_sources(
+            self.db,
+            1,
+            "2026-07-19T00:00:00Z",
+            "2026-07-20T00:00:00Z",
+            relays,
+            conversations,
+            entry_kind="daily",
+        )
+
+        prompt_relays = [source for source in packet["privateSources"] if source["sourceKind"] == "relay"]
+        prompt_conversations = [source for source in packet["privateSources"] if source["sourceKind"] == "conversation"]
+        self.assertEqual(journal.MAX_DAILY_DERIVATIVE_RELAY_PROMPT_SOURCES, len(prompt_relays))
+        self.assertEqual(sum(conversation_counts), len(prompt_conversations))
+        self.assertEqual(71, packet["aggregateCounts"]["eligibleRelays"])
+        self.assertEqual(138, packet["aggregateCounts"]["eligibleConversations"])
+        self.assertEqual(3, packet["aggregateCounts"]["promptRelays"])
+        self.assertEqual(138, packet["aggregateCounts"]["promptConversations"])
+        self.assertEqual(
+            [
+                {"segment": "early", "conversationSources": 37, "relaySources": 23},
+                {"segment": "middle", "conversationSources": 9, "relaySources": 24},
+                {"segment": "late", "conversationSources": 92, "relaySources": 24},
+            ],
+            packet["windowSegmentActivity"],
+        )
+        relay_segments = {
+            journal._coverage_segment(
+                source["observedAt"],
+                packet["sourceWindowStart"],
+                packet["sourceWindowEnd"],
+                3,
+            )
+            for source in prompt_relays
+        }
+        self.assertEqual({"segment-1", "segment-2", "segment-3"}, relay_segments)
+
+    def test_daily_conversation_sampling_preserves_quiet_segments_without_flattening_busy_one(self):
+        start_at = datetime(2026, 7, 19, tzinfo=timezone.utc)
+        counts = (20, 3, 220)
+        conversations = []
+        for segment, count in enumerate(counts):
+            for index in range(count):
+                offset = int((index + 1) * 8 * 60 / (count + 1))
+                conversations.append({
+                    "refId": f"fresh:conversation-{segment}-{index}",
+                    "sourceKind": "conversation",
+                    "summary": f"A regular shared moment {segment}-{index}.",
+                    "observedAt": (
+                        start_at + timedelta(hours=segment * 8, minutes=offset)
+                    ).isoformat().replace("+00:00", "Z"),
+                    "participantAlias": f"participant-{segment}-{index}",
+                    "subjectRef": f"discord_user:{segment * 1000 + index}",
+                    "displayName": f"Member{segment:01d}{index:03d}",
+                    "channelPolicy": "public_home",
+                })
+        relays = [
+            {
+                "refId": f"fresh:relay-{index}",
+                "sourceKind": "relay",
+                "summary": "A derivative relay summarized public activity.",
+                "observedAt": (
+                    start_at + timedelta(minutes=index * 120)
+                ).isoformat().replace("+00:00", "Z"),
+                "eventType": "fresh_public_discord_activity",
+            }
+            for index in range(12)
+        ]
+
+        sampled = journal._sample_source_kinds(
+            relays,
+            conversations,
+            start="2026-07-19T00:00:00Z",
+            end="2026-07-20T00:00:00Z",
+            entry_kind="daily",
+        )
+        sampled_conversations = [source for source in sampled if source["sourceKind"] == "conversation"]
+        sampled_by_segment = {
+            segment: [
+                source
+                for source in sampled_conversations
+                if source["refId"].startswith(f"fresh:conversation-{segment}-")
+            ]
+            for segment in range(3)
+        }
+
+        self.assertEqual(180, len(sampled))
+        self.assertEqual(20, len(sampled_by_segment[0]))
+        self.assertEqual(3, len(sampled_by_segment[1]))
+        self.assertGreater(len(sampled_by_segment[2]), len(sampled_by_segment[0]))
+
+    def test_daily_keeps_distinct_relay_status_while_discounting_repeated_echoes(self):
+        start_at = datetime(2026, 7, 19, tzinfo=timezone.utc)
+        relays = [
+            {
+                "refId": f"fresh:echo-{index}",
+                "sourceKind": "relay",
+                "summary": "A scheduled relay paraphrased public Discord activity.",
+                "observedAt": (
+                    start_at + timedelta(minutes=(index + 1) * 45)
+                ).isoformat().replace("+00:00", "Z"),
+                "eventType": "fresh_public_discord_activity",
+            }
+            for index in range(30)
+        ]
+        relays.insert(15, {
+            "refId": "fresh:distinct-status",
+            "sourceKind": "relay",
+            "summary": "A distinct public Network status changed.",
+            "observedAt": "2026-07-19T12:00:00Z",
+            "eventType": "status_change",
+        })
+        conversations = [
+            {
+                "refId": f"fresh:conversation-{index}",
+                "sourceKind": "conversation",
+                "summary": f"A regular shared public moment {index}.",
+                "observedAt": (
+                    start_at + timedelta(minutes=(index + 1) * 100)
+                ).isoformat().replace("+00:00", "Z"),
+            }
+            for index in range(12)
+        ]
+
+        sampled = journal._sample_source_kinds(
+            relays,
+            conversations,
+            start="2026-07-19T00:00:00Z",
+            end="2026-07-20T00:00:00Z",
+            entry_kind="daily",
+        )
+
+        self.assertIn("fresh:distinct-status", {source["refId"] for source in sampled})
+        self.assertEqual(
+            3,
+            len([
+                source
+                for source in sampled
+                if source.get("eventType") == "fresh_public_discord_activity"
+            ]),
+        )
+        self.assertEqual(12, len([source for source in sampled if source["sourceKind"] == "conversation"]))
+
+    def test_relay_only_daily_window_keeps_existing_source_breadth(self):
+        start_at = datetime(2026, 7, 19, tzinfo=timezone.utc)
+        relays = [
+            {
+                "refId": f"fresh:relay-only-{index}",
+                "sourceKind": "relay",
+                "summary": f"Unique relay status {index}.",
+                "observedAt": (
+                    start_at + timedelta(minutes=(index + 0.5) * 24 * 60 / 200)
+                ).isoformat().replace("+00:00", "Z"),
+                "eventType": "fresh_public_discord_activity",
+            }
+            for index in range(200)
+        ]
+        sampled = journal._sample_source_kinds(
+            relays,
+            [],
+            start="2026-07-19T00:00:00Z",
+            end="2026-07-20T00:00:00Z",
+            entry_kind="daily",
+        )
+        self.assertEqual(journal.MAX_PROMPT_SOURCES, len(sampled))
+        self.assertEqual("fresh:relay-only-0", sampled[0]["refId"])
+        self.assertEqual("fresh:relay-only-199", sampled[-1]["refId"])
+        self.assertEqual(
+            {"segment-1", "segment-2", "segment-3"},
+            {
+                journal._coverage_segment(
+                    source["observedAt"],
+                    "2026-07-19T00:00:00Z",
+                    "2026-07-20T00:00:00Z",
+                    3,
+                )
+                for source in sampled
+            },
+        )
 
     def test_report_opening_clinical_language_and_missing_reaction_are_rejected(self):
         report = _article(self.packet, opening="The Network observes a producer carrying a bass sketch through the room.")


### PR DESCRIPTION
## Summary

- keep the relay stream as the daily Journal's primary chronology and narrative spine
- use public Discord conversations as supporting context around the relays, without turning the Journal into a Discord digest
- preserve meaningful early, middle, and late material when daily sources exceed the existing prompt budget, while still allowing genuinely busy periods to lead
- expose raw per-segment relay and conversation counts to generation so BNL can understand the complete window

## Production-shaped evidence

The incident-shaped regression uses the observed full-window distribution:

- 71 relay rows: 23 / 24 / 24
- 138 conversation rows: 37 / 9 / 92
- generation packet: all 71 relays plus 109 temporally distributed conversations: 31 / 9 / 69

The existing 180-source prompt limit is unchanged. Raw eligible counts remain intact for diagnostics. Relay-only, weekly, and manual behavior retain their existing paths.

## Validation

- `make check` / full repository suite — 1,047 tests passed
- focused Journal evidence and automation tests — 26 passed
- `py_compile` and `git diff --check` — passed

## Scope

Bot Journal source selection, prompt context, and regression tests only. No validator/hold changes, gates enabled, control changes, scheduling changes, or deployment.