### PR TITLE
Bot: correct v2 shadow diagnostic classifications

### DIFF
--- a/bnl_memory_governance.py
+++ b/bnl_memory_governance.py
@@ -277,6 +277,9 @@ def build_governed_context(conn: sqlite3.Connection, req: GovernanceRequest, *, 
             source_policy = str(d.get("channel_policy") or "unknown").lower()
             restricted_policies = {"sealed_test", "protected_system", "internal_controlled", "reference_canon", "ai_image_tool"}
             if source_policy in restricted_policies and source_policy != str(req.channel_policy or "").lower():
+                # Keep the conservative runtime marker until live-governance
+                # behavior is reviewed separately. Persisted owner diagnostics
+                # reclassify the corroborated pre-selection exclusion below.
                 diag.invalid_invariants.append("invalid_route_channel_policy_selected")
                 exclude("invalid_route_channel_policy"); continue
             if source_route in {"operator_command", "internal_control", "protected_system"} and source_route != str(req.route_mode or "").lower():
@@ -370,6 +373,27 @@ def persist_shadow_diagnostics(conn: sqlite3.Connection, req: GovernanceRequest,
     for invariant in result.diagnostics.invalid_invariants:
         key = str(invariant or "unknown")[:120]
         invalid_invariant_counts[key] = invalid_invariant_counts.get(key, 0) + 1
+    # The runtime keeps this conservative marker because it participates in a
+    # dormant live-governance fallback. For reporting, a matching exclusion
+    # proves the candidate was rejected before selection, so do not persist it
+    # as a selected invariant. Any unmatched remainder still fails closed.
+    route_marker = "invalid_route_channel_policy_selected"
+    safe_route_exclusions = int(
+        result.diagnostics.excluded_by_reason.get(
+            "invalid_route_channel_policy", 0
+        )
+        or 0
+    )
+    matched = min(
+        int(invalid_invariant_counts.get(route_marker, 0) or 0),
+        safe_route_exclusions,
+    )
+    if matched:
+        remaining = int(invalid_invariant_counts[route_marker]) - matched
+        if remaining:
+            invalid_invariant_counts[route_marker] = remaining
+        else:
+            invalid_invariant_counts.pop(route_marker, None)
     aggregate_diagnostics = {
         "selected_by_source": dict(result.diagnostics.selected_by_source),
         "invalid_invariant_counts": invalid_invariant_counts,
@@ -419,11 +443,20 @@ def build_evaluation_report(results: List[GovernanceResult], guild_id: int) -> D
         report["empty_result_frequency"] += 1 if not r.rendered_context else 0
         report["processing_errors"] += len(r.diagnostics.processing_errors)
         report["legacy_vs_governed"].append(r.diagnostics.legacy_vs_governed)
+        route_policy_markers = 0
         for inv in r.diagnostics.invalid_invariants:
             if inv == "cross_subject_selected": report["cross_member_violations"] += 1
             if inv == "cross_guild_selected": report["cross_guild_violations"] += 1
             if inv == "visibility_selected": report["visibility_violations"] += 1
-            if inv == "invalid_route_channel_policy_selected": report["invalid_route_channel_policy_selections"] += 1
+            if inv == "invalid_route_channel_policy_selected": route_policy_markers += 1
+        # A route-policy mismatch is rejected before candidates reach the
+        # selected set. Reclassify only the count corroborated by matching safe
+        # exclusions; any unmatched remainder still fails closed.
+        report["invalid_route_channel_policy_selections"] += max(
+            0,
+            route_policy_markers
+            - int(r.diagnostics.excluded_by_reason.get("invalid_route_channel_policy", 0) or 0),
+        )
     if report["processing_errors"] or report["visibility_violations"] or report["cross_member_violations"] or report["cross_guild_violations"] or report["invalid_route_channel_policy_selections"]:
         report["rollback_readiness"] = "fallback_required_before_live"
     return report

--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -18,13 +18,20 @@ from bnl_moment_engine import build_moment_evaluation_report
 from bnl_relationship_engine import build_evaluation_report as build_relationship_evaluation_report
 
 
-SHADOW_ACCEPTANCE_VERSION = "v2_shadow_acceptance_v1"
+SHADOW_ACCEPTANCE_VERSION = "v2_shadow_acceptance_v2"
 SHADOW_EVALUATION_ORDER = (
     "memory_ledger",
     "moment_engine",
     "memory_governance",
     "relationship_v2",
 )
+
+# Older Governance writers used this selected-invariant label when a candidate
+# was safely rejected before selection. Keep the retained evidence visible, but
+# do not let that known historical classification create a false hard blocker.
+LEGACY_RECLASSIFIED_SAFE_EXCLUSIONS = {
+    "invalid_route_channel_policy_selected": "invalid_route_channel_policy",
+}
 
 
 def _flag_enabled(environ: Mapping[str, str], name: str, default: str = "") -> bool:
@@ -232,6 +239,30 @@ def _invariant_counts(value: Any) -> Dict[str, int]:
     return {}
 
 
+def _partition_legacy_preselection_labels(
+    invariants: Mapping[str, int],
+    exclusions: Mapping[str, int],
+) -> tuple[Dict[str, int], Dict[str, int]]:
+    """Reclassify only labels corroborated by a same-run safe exclusion."""
+
+    active = dict(invariants)
+    reclassified: Dict[str, int] = {}
+    for marker, exclusion_reason in LEGACY_RECLASSIFIED_SAFE_EXCLUSIONS.items():
+        matched = min(
+            int(active.get(marker, 0) or 0),
+            int(exclusions.get(exclusion_reason, 0) or 0),
+        )
+        if not matched:
+            continue
+        reclassified[marker] = matched
+        remaining = int(active[marker]) - matched
+        if remaining:
+            active[marker] = remaining
+        else:
+            active.pop(marker, None)
+    return active, reclassified
+
+
 def _aggregate_count(value: Any) -> int:
     """Parse a persisted aggregate count or fail the diagnostic closed."""
 
@@ -256,6 +287,9 @@ def _empty_governance_report() -> Dict[str, Any]:
         "invalid_invariants": {},
         "invalid_invariant_count": 0,
         "invalid_invariant_runs": 0,
+        "legacy_reclassified_exclusions": {},
+        "legacy_reclassified_exclusion_count": 0,
+        "legacy_reclassified_exclusion_runs": 0,
         "fallback_reasons": {},
         "visibility_exclusions": 0,
         "token_budget_exclusions": 0,
@@ -298,9 +332,10 @@ def build_persisted_governance_report(
     exclusions: Counter[str] = Counter()
     selected_sources: Counter[str] = Counter()
     invalid_invariants: Counter[str] = Counter()
+    legacy_reclassified_exclusions: Counter[str] = Counter()
     fallback_reasons: Counter[str] = Counter()
     selected_total = processing_errors = same_hash = 0
-    invalid_runs = aggregate_runs = visibility = budget = duplicates = contradictions = 0
+    invalid_runs = legacy_reclassified_runs = aggregate_runs = visibility = budget = duplicates = contradictions = 0
     moment_candidates = moment_review = 0
 
     zero_selection_runs = 0
@@ -322,7 +357,8 @@ def build_persisted_governance_report(
             selected_count = _aggregate_count(selected)
             selected_total += selected_count
             zero_selection_runs += int(selected_count == 0)
-            exclusions.update(_count_mapping(excluded))
+            row_exclusions = _count_mapping(excluded)
+            exclusions.update(row_exclusions)
             processing_errors += _error_count(errors)
             same_hash += int(bool(rendered_hash and legacy_hash and rendered_hash == legacy_hash))
             diag = _json_value(diagnostics[0], {}) if diagnostics else {}
@@ -333,8 +369,16 @@ def build_persisted_governance_report(
             row_invariants = _invariant_counts(
                 diag.get("invalid_invariant_counts", diag.get("invalid_invariants"))
             )
-            invalid_invariants.update(row_invariants)
-            invalid_runs += int(bool(row_invariants))
+            row_actual_invariants, row_reclassified = (
+                _partition_legacy_preselection_labels(
+                    row_invariants,
+                    row_exclusions,
+                )
+            )
+            legacy_reclassified_exclusions.update(row_reclassified)
+            legacy_reclassified_runs += int(bool(row_reclassified))
+            invalid_invariants.update(row_actual_invariants)
+            invalid_runs += int(bool(row_actual_invariants))
             fallback = str(diag.get("fallback_reason") or "none")
             fallback_reasons[fallback] += 1
             visibility += _aggregate_count(diag.get("visibility_exclusions"))
@@ -374,6 +418,13 @@ def build_persisted_governance_report(
         "invalid_invariants": dict(sorted(invalid_invariants.items())),
         "invalid_invariant_count": sum(invalid_invariants.values()),
         "invalid_invariant_runs": invalid_runs,
+        "legacy_reclassified_exclusions": dict(
+            sorted(legacy_reclassified_exclusions.items())
+        ),
+        "legacy_reclassified_exclusion_count": sum(
+            legacy_reclassified_exclusions.values()
+        ),
+        "legacy_reclassified_exclusion_runs": legacy_reclassified_runs,
         "fallback_reasons": dict(sorted(fallback_reasons.items())),
         "visibility_exclusions": visibility,
         "token_budget_exclusions": budget,
@@ -693,6 +744,8 @@ def build_v2_shadow_acceptance_snapshot(
         governance.get("runs", 0) or 0
     ):
         warnings.append("governance_older_rows_lack_aggregate_diagnostics")
+    if int(governance.get("legacy_reclassified_exclusion_count", 0) or 0):
+        warnings.append("governance_legacy_safe_exclusions_reclassified")
 
     stage_statuses = [stage["status"] for stage in stages.values()]
     if live_gates:
@@ -813,6 +866,8 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             governance.get("invalid_invariant_count", 0),
             (governance.get("evidenceWindow") or {}).get("last", "none"),
         ),
+        "- governance_invalid_invariants: `%s`" % json.dumps(governance.get("invalid_invariants", {}), sort_keys=True),
+        "- governance_legacy_reclassified_exclusions: `%s`" % json.dumps(governance.get("legacy_reclassified_exclusions", {}), sort_keys=True),
         "- governance_exclusions: `%s`" % json.dumps(governance.get("excluded_by_reason", {}), sort_keys=True),
         "- relationship: status=`%s` shadow=`%s` relationship_live=`%s` engagement_live=`%s` events=`%s` rejected_observations=`%s` plans=`%s` would_select=`%s` live_allowed=`%s` actual_emissions=`%s` errors=`%s` window_last=`%s`" % (
             (stages.get("relationship_v2") or {}).get("status", "unknown"),

--- a/docs/BNL01_V2_SHADOW_ACCEPTANCE_AND_ROLLBACK.md
+++ b/docs/BNL01_V2_SHADOW_ACCEPTANCE_AND_ROLLBACK.md
@@ -166,6 +166,21 @@ failures by themselves. Governance live must remain off, so the legacy result
 continues to be the actual production result while shadow candidates are
 measured.
 
+Retained v1 rows may contain `invalid_route_channel_policy_selected`. The v1
+writer emitted that label when a mismatched route or restricted channel-policy
+candidate was safely excluded *before* selection. The v2 acceptance reader
+preserves a historical count under `legacy_reclassified_exclusions` only when
+the same retained run contains a matching `invalid_route_channel_policy`
+exclusion. It shows a review warning but does not treat that corroborated count
+as a selected-invariant failure. An unmatched count, any remainder, and every
+other invalid-invariant label continue to fail closed as hard stops. No retained
+row is rewritten or deleted.
+
+New shadow rows omit the corroborated count from persisted selected-invariant
+diagnostics while preserving the `invalid_route_channel_policy` exclusion.
+The conservative in-process runtime marker and live-governance fallback remain
+unchanged; revising that dormant behavior requires a separate reviewed change.
+
 ### Relationship evidence
 
 Review at least:

--- a/tests/test_memory_governance_v1.py
+++ b/tests/test_memory_governance_v1.py
@@ -1,4 +1,4 @@
-import os, sqlite3, sys, inspect, hashlib, unittest
+import json, os, sqlite3, sys, inspect, hashlib, unittest
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -415,11 +415,50 @@ def _case_route_policy_violations_and_shadow_retention_are_real():
     c.execute("UPDATE memory_ledger_entries SET channel_policy='sealed_test' WHERE entry_id='sealed'"); c.commit()
     r = build_governed_context(c, req(user_text='remember synths', channel_policy='public_home'))
     assert r.rendered_context == '' and 'invalid_route_channel_policy' in r.diagnostics.excluded_by_reason
+    # The conservative runtime marker remains until the live-governance path
+    # is reviewed separately; this PR changes only persisted owner reporting.
+    assert r.diagnostics.invalid_invariants == ['invalid_route_channel_policy_selected']
     report = build_evaluation_report([r], guild_id=1)
-    assert report['invalid_route_channel_policy_selections'] >= 1
-    for i in range(505):
+    assert report['invalid_route_channel_policy_selections'] == 0
+    assert report['rollback_readiness'] == 'ready_env_disable_live'
+    unmatched = GovernanceResult(
+        '',
+        (),
+        (),
+        GovernanceDiagnostics(
+            invalid_invariants=['invalid_route_channel_policy_selected'],
+        ),
+    )
+    unmatched_report = build_evaluation_report([unmatched], guild_id=1)
+    assert unmatched_report['invalid_route_channel_policy_selections'] == 1
+    assert unmatched_report['rollback_readiness'] == 'fallback_required_before_live'
+    persist_shadow_diagnostics(c, req(), r, 'legacy')
+    saved_exclusions, saved_diagnostics = c.execute("SELECT excluded_json, diagnostics_json FROM memory_governance_shadow_runs ORDER BY created_at DESC LIMIT 1").fetchone()
+    assert json.loads(saved_exclusions) == {'invalid_route_channel_policy': 1}
+    assert json.loads(saved_diagnostics)['invalid_invariant_counts'] == {}
+    for i in range(504):
         persist_shadow_diagnostics(c, req(), r, 'legacy')
     assert c.execute("SELECT COUNT(*) FROM memory_governance_shadow_runs WHERE guild_id=1").fetchone()[0] <= 500
+
+    insert(c, eid='public', value='public modular synths preference', pred='preference')
+    mixed = build_governed_context(c, req(user_text='remember synths', channel_policy='public_home'))
+    assert [candidate.entry_id for candidate in mixed.selected] == ['public']
+    assert mixed.diagnostics.excluded_by_reason['invalid_route_channel_policy'] == 1
+    assert mixed.diagnostics.invalid_invariants == ['invalid_route_channel_policy_selected']
+
+    insert(c, eid='operator', value='operator modular synths preference', pred='preference')
+    c.execute("UPDATE memory_ledger_entries SET route_mode='operator_command' WHERE entry_id='operator'"); c.commit()
+    route_mismatch = build_governed_context(c, req(user_text='operator modular synths', channel_policy='public_home'))
+    assert 'operator modular synths preference' not in route_mismatch.rendered_context
+    assert route_mismatch.diagnostics.excluded_by_reason['invalid_route_channel_policy'] == 2
+    assert route_mismatch.diagnostics.invalid_invariants == [
+        'invalid_route_channel_policy_selected',
+        'invalid_route_channel_policy_selected',
+    ]
+    persist_shadow_diagnostics(c, req(user_text='operator modular synths'), route_mismatch, 'legacy')
+    route_exclusions, route_diagnostics = c.execute("SELECT excluded_json, diagnostics_json FROM memory_governance_shadow_runs ORDER BY created_at DESC, run_id DESC LIMIT 1").fetchone()
+    assert json.loads(route_exclusions)['invalid_route_channel_policy'] == 2
+    assert json.loads(route_diagnostics)['invalid_invariant_counts'] == {}
 
 
 class MemoryGovernanceV1Tests(unittest.TestCase):

--- a/tests/test_v2_shadow_acceptance.py
+++ b/tests/test_v2_shadow_acceptance.py
@@ -65,6 +65,23 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
             conversation_context_diagnostics=context,
         )
 
+    def restore_legacy_route_marker(self, count):
+        run_id, diagnostics_json = self.conn.execute(
+            "SELECT run_id, diagnostics_json "
+            "FROM memory_governance_shadow_runs "
+            "ORDER BY created_at DESC, run_id DESC LIMIT 1"
+        ).fetchone()
+        diagnostics = json.loads(diagnostics_json)
+        diagnostics["invalid_invariant_counts"] = {
+            "invalid_route_channel_policy_selected": count,
+        }
+        self.conn.execute(
+            "UPDATE memory_governance_shadow_runs "
+            "SET diagnostics_json=? WHERE run_id=?",
+            (json.dumps(diagnostics, sort_keys=True), run_id),
+        )
+        self.conn.commit()
+
     def test_defaults_are_reporting_only_and_all_shadow_stages_are_disabled(self):
         before_changes = self.conn.total_changes
         before_schema = self.conn.execute(
@@ -189,6 +206,155 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
             "SELECT subject_hash FROM memory_governance_shadow_runs"
         ).fetchone()[0]
         self.assertNotIn(subject_hash, encoded)
+
+    def test_legacy_route_policy_label_is_preserved_but_not_a_hard_blocker(self):
+        request = GovernanceRequest(
+            guild_id=1,
+            subject_user_id=99,
+            route_mode="normal_chat",
+            conversation_surface="test",
+            channel_policy="public_home",
+        )
+        persist_shadow_diagnostics(
+            self.conn,
+            request,
+            GovernanceResult(
+                "",
+                (),
+                (),
+                GovernanceDiagnostics(
+                    invalid_invariants=["invalid_route_channel_policy_selected"],
+                    excluded_by_reason={"invalid_route_channel_policy": 1},
+                ),
+            ),
+            "legacy",
+        )
+        self.restore_legacy_route_marker(1)
+        before_row = self.conn.execute(
+            "SELECT excluded_json, diagnostics_json "
+            "FROM memory_governance_shadow_runs"
+        ).fetchone()
+        before_changes = self.conn.total_changes
+
+        snapshot = self.snapshot(
+            {"BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true"}
+        )
+        report = snapshot["reports"]["memoryGovernance"]
+
+        self.assertEqual(report["invalid_invariants"], {})
+        self.assertEqual(report["invalid_invariant_count"], 0)
+        self.assertEqual(report["invalid_invariant_runs"], 0)
+        self.assertEqual(
+            report["legacy_reclassified_exclusions"],
+            {"invalid_route_channel_policy_selected": 1},
+        )
+        self.assertEqual(report["legacy_reclassified_exclusion_count"], 1)
+        self.assertEqual(report["legacy_reclassified_exclusion_runs"], 1)
+        self.assertNotIn(
+            "memory_governance:invalid_invariants", snapshot["blockers"]
+        )
+        self.assertEqual(
+            snapshot["stages"]["memory_governance"]["status"],
+            "blocked_by_prerequisite",
+        )
+        self.assertIn(
+            "governance_legacy_safe_exclusions_reclassified",
+            snapshot["warnings"],
+        )
+        self.assertEqual(snapshot["status"], "collecting_shadow_evidence")
+        self.assertEqual(self.conn.total_changes, before_changes)
+        self.assertEqual(
+            self.conn.execute(
+                "SELECT excluded_json, diagnostics_json "
+                "FROM memory_governance_shadow_runs"
+            ).fetchone(),
+            before_row,
+        )
+
+        rendered = "\n".join(render_v2_shadow_acceptance_lines(snapshot))
+        self.assertIn("governance_invalid_invariants: `{}`", rendered)
+        self.assertIn(
+            'governance_legacy_reclassified_exclusions: `{"invalid_route_channel_policy_selected": 1}`',
+            rendered,
+        )
+
+    def test_unmatched_legacy_label_remains_a_hard_blocker(self):
+        persist_shadow_diagnostics(
+            self.conn,
+            GovernanceRequest(
+                guild_id=1,
+                subject_user_id=99,
+                route_mode="normal_chat",
+                conversation_surface="test",
+                channel_policy="public_home",
+            ),
+            GovernanceResult(
+                "",
+                (),
+                (),
+                GovernanceDiagnostics(
+                    invalid_invariants=[
+                        "invalid_route_channel_policy_selected",
+                        "invalid_route_channel_policy_selected",
+                    ],
+                    excluded_by_reason={"invalid_route_channel_policy": 1},
+                ),
+            ),
+            "legacy",
+        )
+        self.restore_legacy_route_marker(2)
+
+        snapshot = self.snapshot(
+            {"BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true"}
+        )
+        report = snapshot["reports"]["memoryGovernance"]
+        self.assertEqual(
+            report["legacy_reclassified_exclusions"],
+            {"invalid_route_channel_policy_selected": 1},
+        )
+        self.assertEqual(
+            report["invalid_invariants"],
+            {"invalid_route_channel_policy_selected": 1},
+        )
+        self.assertEqual(report["invalid_invariant_count"], 1)
+        self.assertIn("memory_governance:invalid_invariants", snapshot["blockers"])
+        self.assertEqual(snapshot["status"], "blocked_shadow_invariant_failure")
+
+    def test_true_governance_invariant_remains_a_hard_blocker(self):
+        persist_shadow_diagnostics(
+            self.conn,
+            GovernanceRequest(
+                guild_id=1,
+                subject_user_id=99,
+                route_mode="normal_chat",
+                conversation_surface="test",
+                channel_policy="public_home",
+            ),
+            GovernanceResult(
+                "",
+                (),
+                (),
+                GovernanceDiagnostics(
+                    invalid_invariants=[
+                        "cross_guild_selected",
+                        "future_unknown_selected",
+                    ]
+                ),
+            ),
+            "legacy",
+        )
+
+        snapshot = self.snapshot(
+            {"BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true"}
+        )
+        report = snapshot["reports"]["memoryGovernance"]
+        self.assertEqual(
+            report["invalid_invariants"],
+            {"cross_guild_selected": 1, "future_unknown_selected": 1},
+        )
+        self.assertEqual(report["invalid_invariant_count"], 2)
+        self.assertIn("memory_governance:invalid_invariants", snapshot["blockers"])
+        self.assertEqual(snapshot["status"], "blocked_shadow_invariant_failure")
 
     def test_governance_schema_migration_preserves_old_rows_and_accepts_new_aggregates(self):
         migrated = sqlite3.connect(":memory:")


### PR DESCRIPTION
## Summary

- keep the conservative in-process governance fallback marker unchanged while preventing a safely rejected route-policy candidate from being persisted or reported as a selected-invariant failure
- reclassify retained v1 labels only when the same run contains the corroborating safe exclusion; preserve the historical count and warning without rewriting or deleting evidence
- keep unmatched counts and every other invariant fail-closed
- distinguish actual invalid invariants from legacy reclassified exclusions in the owner-only v2 shadow report

## Safety

- refreshed directly onto current `main` at `22862bdb` (Journal PR #349)
- no live gates enabled
- no live selection, fallback, prompt, memory, Journal, Discord, or publication behavior changed
- no persisted rows rewritten or deleted
- Journal word-count guidance behavior remains unchanged and its focused regression test passes

## Validation

- full suite: 1,075 passed
- Python compile checks passed
- `git diff --check` passed
- focused Journal loose-target regression test passed