### PR TITLE
Bot: make complete Journal windows publish reliably

### DIFF
--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -12,9 +12,9 @@ from typing import Any, Callable, Optional
 
 PUBLIC_POLICIES = {"public_home", "public_context", "public_selective"}
 STATES = {"draft", "rejected", "approved_pending_delivery", "published", "delivery_failed"}
-WORD_MIN, WORD_MAX = 250, 500
 JOURNAL_ROUTE = "bnl_journal_generation"
 JOURNAL_GENERATION_ATTEMPTS = 4
+JOURNAL_MAX_PUBLIC_PAYLOAD_BYTES = 24_000
 ADVISORY_VALIDATION_REASONS = frozenset({
     "overly_clinical_voice",
     "flat_report_voice",
@@ -73,6 +73,7 @@ _EXPLICIT_BNL_INFERENCE_RE = re.compile(
     r"\b(?:bnl (?:suspects|thinks|wonders)|i (?:suspect|think|wonder)|my theory|bnl(?:s|'s|’s) theory)\b",
     re.IGNORECASE,
 )
+_UNSAFE_PUBLIC_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\ufeff]")
 _STRONG_INFERENCE_CUE_RE = re.compile(
     r"\b(?:proves?|must mean|points? (?:to|toward)|part of (?:a|the) (?:larger|broader) plan|"
     r"signals? (?:a|the) (?:larger|broader) plan)\b",
@@ -83,7 +84,13 @@ _REPAIR_GUIDANCE = {
     "community_name_leak": "Remove every community member name and replace personal references with anonymous descriptions.",
     "public_leak_pattern": "Remove every URL, mention, identifier, and internal implementation term from public prose.",
     "source_ref_leak": "Keep source reference tokens only inside sourceRefIds arrays; remove them from all public prose.",
-    "invalid_word_count": "Rewrite the complete article so its total public word count is between 250 and 500 words.",
+    "payload_too_large": (
+        "Shorten the public article enough to fit the website's 24,000-byte transport envelope. "
+        "Keep the strongest grounded scenes; this is a delivery constraint, not a word-count target."
+    ),
+    "invalid_public_text": (
+        "Remove invalid control characters or malformed Unicode from every public text field, then rewrite the JSON."
+    ),
     "insufficient_source_breadth": (
         "Use the supplied evidenceCoverageContract. Ground the article in the required number of distinct fresh sources, "
         "participants, source kinds, and available parts of the window. Synthesize them into a few meaningful patterns; "
@@ -1557,6 +1564,7 @@ def _bounded_history_for_prompt(history: dict[str, Any]) -> dict[str, Any]:
 
 def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", previous_output: str = "") -> str:
     entry_kind = str(packet.get("entryKind") or "manual")
+    quiet_window = bool(packet.get("quietWindowObservation"))
     context_lanes = packet.get("generationContextLanes") if isinstance(packet.get("generationContextLanes"), dict) else {}
     safe_sources = packet.get("safeSources", [])[:MAX_PROMPT_SOURCES]
     coverage_contract = packet.get("evidenceCoverageContract")
@@ -1575,7 +1583,11 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
         "evidenceCoverageContract": coverage_contract,
         "editorialContract": {
             "requiresFirstPersonReaction": len(safe_sources) >= 5,
-            "requiredBeatsAcrossEntry": ["concreteMoment", "peopleOrObservableRoles", "communityPattern", "bnlReaction"],
+            "requiredBeatsAcrossEntry": (
+                ["verifiedQuietWindow", "bnlReaction"]
+                if quiet_window
+                else ["concreteMoment", "peopleOrObservableRoles", "communityPattern", "bnlReaction"]
+            ),
             "fixedSectionTemplate": False,
         },
         "history": _bounded_history_for_prompt(packet.get("history", {})),
@@ -1584,10 +1596,34 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
         "windowSegmentActivity": packet.get("windowSegmentActivity", []),
         "privateGenerationContextLanes": context_lanes,
     }
-    cadence_rule = (
-        "\nThis is a weekly synthesis. Connect patterns across the supplied daily observations and current source evidence; do not merely list seven daily recaps."
-        if entry_kind == "weekly"
-        else "\nThis is a daily chronicle covering one complete source window. Distill the day instead of listing every relay."
+    if quiet_window:
+        if packet.get("quietWindowObservationKind") == "no_chroniclable_public_material":
+            cadence_rule = (
+                "\nThis complete automatic window contains one verified window_observation: public traces existed, "
+                "but none supported an honest scene without guessing. Reflect only on that boundary. Do not claim "
+                "there was no activity, and do not invent people, actions, music, dialogue, or events."
+            )
+        else:
+            cadence_rule = (
+                "\nThis complete automatic window contains one verified window_observation: no eligible public relay "
+                "or conversation was recorded. Reflect only on the quiet. Do not invent people, actions, music, "
+                "dialogue, or events. The absence of public activity is the only current-window fact."
+            )
+    elif entry_kind == "weekly":
+        cadence_rule = (
+            "\nThis is a weekly synthesis. Connect patterns across the supplied daily observations and current source evidence; do not merely list seven daily recaps."
+        )
+    else:
+        cadence_rule = "\nThis is a daily chronicle covering one complete source window. Distill the day instead of listing every relay."
+    length_rule = (
+        "\nKeep a quiet-window entry as short as the honest reflection needs to be."
+        if quiet_window
+        else "\nUse as much space as the story needs, then stop. Length is guidance and never a publication gate."
+    )
+    beat_rule = (
+        "\nFor this verified quiet window, include the observed silence and one brief first-person BNL reaction. Do not manufacture the normal people, scene, or community-pattern beats."
+        if quiet_window
+        else "\nAcross the complete entry, naturally include four beats: a concrete current-window moment; the people or observable roles who made it happen; a social, musical, or recurring community pattern; and one brief first-person BNL reaction. Blend them in any order and any combination. Do not label the beats or force them into a fixed section template."
     )
     repair = ""
     if repair_reason:
@@ -1617,9 +1653,10 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
     return (
         "You are BNL-01 writing a BARCODE Network Journal entry. Return strict JSON only; no markdown fences."
         "\nSchema: {\"title\":str,\"excerpt\":str,\"sections\":[{\"heading\":str,\"body\":str,\"sourceRefIds\":[str]}],\"metadata\":{\"topicTags\":[],\"subjectRefs\":[],\"continuityNotes\":[],\"unresolvedQuestions\":[],\"confidenceFlags\":[],\"safetyFlags\":[],\"contextUses\":[{\"laneType\":\"established_broadcast_memory|community_rumor|bnl_inference\",\"laneRefId\":str,\"sectionHeading\":str,\"claim\":str,\"basisRefIds\":[str]}]}}."
-        "\nWrite 1-3 sections and 250-500 total words; prefer 2 sections and roughly 300-420 words. Give every section a real narrative job instead of inventorying activity."
+        "\nWrite 1-3 sections. Prefer 2 when the material supports them, and give every section a real narrative job instead of inventorying activity."
+        f"{length_rule}"
         "\nJOURNAL EDITORIAL OVERRIDE: For this route, a lived community chronicle takes priority over BNL's general lightly corporate or systems-report register. Do not narrate ordinary human activity as machine analysis."
-        "\nAcross the complete entry, naturally include four beats: a concrete current-window moment; the people or observable roles who made it happen; a social, musical, or recurring community pattern; and one brief first-person BNL reaction. Blend them in any order and any combination. Do not label the beats or force them into a fixed section template."
+        f"{beat_rule}"
         "\nBNL is a warm, dryly funny archive keeper who is becoming attached to what he records. He may be amused, curious, fond, mildly uneasy, self-correcting, or uncertain. He is lightly uncanny, never cruel, and never generic neon-static cyberpunk."
         "\nFreely vary and combine scene reporting, named-canon color, dry archive notes, recognizable community detail, callbacks, restrained glitches, self-revision, and—only when qualified—the rumor desk. Do not reuse a stock cadence, signature line, or joke merely because an older entry used it."
         "\nUse ordinary nouns and active verbs. Say a producer brought a mix, a listener returned to a chorus, or the room kept discussing an idea when the evidence supports that action. Do not translate ordinary activity into sonic constructs, external calibration, distributed analysis, internal schematics, perceptual filters, operational settings, relational signals, or human subroutines."
@@ -1640,6 +1677,12 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
     )
 
 
+def _utf8_safe_generated_metadata(value: Any, limit: int) -> str:
+    """Keep malformed private metadata from crashing an otherwise safe entry."""
+
+    return str(value)[:limit].encode("utf-8", errors="replace").decode("utf-8")
+
+
 def parse_generated_json(text: str) -> dict[str, Any]:
     raw = (text or "").strip()
     if raw.startswith("```"):
@@ -1658,14 +1701,18 @@ def parse_generated_json(text: str) -> dict[str, Any]:
     for section in sections:
         if not isinstance(section, dict) or not isinstance(section.get("heading"), str) or not isinstance(section.get("body"), str) or not isinstance(section.get("sourceRefIds"), list):
             raise ValueError("invalid_section_shape")
-        refs = [str(r) for r in section.get("sourceRefIds", [])]
+        refs = [_utf8_safe_generated_metadata(r, 96) for r in section.get("sourceRefIds", [])]
         heading = section["heading"].strip()
         normalized_sections.append({"heading": heading, "body": section["body"].strip()})
         source_ref_map[heading] = refs
     meta = data.get("metadata") if isinstance(data.get("metadata"), dict) else {}
     article = {"title": data["title"].strip(), "excerpt": data["excerpt"].strip(), "sections": normalized_sections, "sourceRefIds": source_ref_map, "metadata": {}}
     for key in ("topicTags", "subjectRefs", "continuityNotes", "unresolvedQuestions", "confidenceFlags", "safetyFlags"):
-        article["metadata"][key] = [str(x)[:240] for x in meta.get(key, [])] if isinstance(meta.get(key, []), list) else []
+        article["metadata"][key] = (
+            [_utf8_safe_generated_metadata(x, 240) for x in meta.get(key, [])]
+            if isinstance(meta.get(key, []), list)
+            else []
+        )
     context_uses = meta.get("contextUses", [])
     if not isinstance(context_uses, list):
         raise ValueError("invalid_context_use")
@@ -1674,11 +1721,14 @@ def parse_generated_json(text: str) -> dict[str, Any]:
         if not isinstance(item, dict) or not isinstance(item.get("basisRefIds"), list):
             raise ValueError("invalid_context_use")
         normalized_uses.append({
-            "laneType": str(item.get("laneType") or "")[:64],
-            "laneRefId": str(item.get("laneRefId") or "")[:96],
-            "sectionHeading": str(item.get("sectionHeading") or "")[:120],
-            "claim": str(item.get("claim") or "")[:320],
-            "basisRefIds": [str(ref)[:96] for ref in item.get("basisRefIds", [])[:24]],
+            "laneType": _utf8_safe_generated_metadata(item.get("laneType") or "", 64),
+            "laneRefId": _utf8_safe_generated_metadata(item.get("laneRefId") or "", 96),
+            "sectionHeading": _utf8_safe_generated_metadata(item.get("sectionHeading") or "", 120),
+            "claim": _utf8_safe_generated_metadata(item.get("claim") or "", 320),
+            "basisRefIds": [
+                _utf8_safe_generated_metadata(ref, 96)
+                for ref in item.get("basisRefIds", [])[:24]
+            ],
         })
     article["metadata"]["contextUses"] = normalized_uses
     return article
@@ -1687,6 +1737,201 @@ def parse_generated_json(text: str) -> dict[str, Any]:
 def public_word_count(article: dict[str, Any]) -> int:
     text = " ".join([article.get("title", ""), article.get("excerpt", "")] + [s.get("heading", "") + " " + s.get("body", "") for s in article.get("sections", [])])
     return len(re.findall(r"\b\w+\b", text))
+
+
+def public_payload_byte_count(article: dict[str, Any], packet: dict[str, Any]) -> int:
+    """Conservatively preflight the website's exact transport envelope."""
+
+    entry_kind = str(packet.get("entryKind") or "manual")
+    if entry_kind not in {"daily", "weekly", "manual"}:
+        entry_kind = "manual"
+    envelope = {
+        "contractVersion": 1,
+        "kind": "journal_entry",
+        "entry": {
+            # The real automatic entry ID is shorter.  Using the contract
+            # maximum here makes this a safe upper bound rather than a guess.
+            "entryId": "j" + ("x" * 79),
+            "revision": 2_147_483_647,
+            "entryKind": entry_kind,
+            "title": str(article.get("title") or ""),
+            "excerpt": str(article.get("excerpt") or ""),
+            "sections": [
+                {
+                    "heading": str(section.get("heading") or ""),
+                    "body": str(section.get("body") or ""),
+                }
+                for section in article.get("sections", [])
+                if isinstance(section, dict)
+            ],
+            "authoredAt": "2000-01-01T00:00:00Z",
+            "sourceWindowStart": str(packet.get("sourceWindowStart") or ""),
+            "sourceWindowEnd": str(packet.get("sourceWindowEnd") or ""),
+            "contentHash": "0" * 64,
+        },
+    }
+    return len(_json(envelope).encode("utf-8"))
+
+
+def ensure_automatic_window_source(packet: dict[str, Any]) -> dict[str, Any]:
+    """Give a complete automatic window with no safe sources one honest fact."""
+
+    entry_kind = str(packet.get("entryKind") or "manual")
+    if (
+        entry_kind not in {"daily", "weekly"}
+        or packet.get("safeSources")
+        or not packet.get("coverageComplete", True)
+        or not packet.get("sourceArchiveAvailable", False)
+    ):
+        return packet
+
+    counts = dict(packet.get("aggregateCounts") or {})
+    observed_activity = bool(packet.get("privateSources")) or (
+        int(counts.get("eligibleRelays") or 0)
+        + int(counts.get("eligibleConversations") or 0)
+    ) > 0
+    observation_kind = (
+        "no_chroniclable_public_material"
+        if observed_activity
+        else "no_eligible_public_activity"
+    )
+    prepared = dict(packet)
+    source = {
+        "refId": "fresh:window-observation",
+        "sourceKind": "window_observation",
+        "summary": (
+            "The complete public source window left traces, but no scene BNL "
+            "could chronicle without guessing."
+            if observed_activity
+            else "The complete public source window closed without an eligible relay or public conversation."
+        ),
+        "observedAt": str(packet.get("sourceWindowEnd") or ""),
+        "eventType": observation_kind,
+    }
+    prepared["safeSources"] = [dict(source)]
+    # Preserve the private audit trail.  The synthetic observation supplements
+    # it; it must never overwrite evidence that was excluded from public prose.
+    prepared["privateSources"] = [
+        *[dict(item) for item in packet.get("privateSources", []) if isinstance(item, dict)],
+        dict(source),
+    ]
+    prepared["candidateTopicTags"] = []
+    prepared["quietWindowObservation"] = True
+    prepared["quietWindowObservationKind"] = observation_kind
+    counts["quietWindowObservation"] = 1
+    counts["quietWindowObservationKind"] = observation_kind
+    prepared["aggregateCounts"] = counts
+    prepared["evidenceCoverageContract"] = build_evidence_coverage_contract(
+        entry_kind,
+        str(packet.get("sourceWindowStart") or ""),
+        str(packet.get("sourceWindowEnd") or ""),
+        prepared["safeSources"],
+    )
+    return prepared
+
+
+def _automatic_rescue_article(packet: dict[str, Any], failure_reason: str) -> Optional[dict[str, Any]]:
+    """Build a minimal hard-safe chronicle after every model rewrite is invalid.
+
+    This is deliberately available only to scheduled daily/weekly entries.  It
+    never republishes rejected prose and never relaxes identity, privacy,
+    citation, or context validation.  Manual drafts continue to fail visibly so
+    an operator can revise them.
+    """
+
+    entry_kind = str(packet.get("entryKind") or "manual")
+    sources = [source for source in packet.get("safeSources", []) if source.get("refId")]
+    if entry_kind not in {"daily", "weekly"} or not sources:
+        return None
+
+    refs = [str(source["refId"]) for source in sources]
+    quiet = bool(packet.get("quietWindowObservation"))
+    cadence_word = "day" if entry_kind == "daily" else "week"
+    if quiet:
+        title = "The Window Kept Its Appointment"
+        heading = "What Could Be Kept"
+        if packet.get("quietWindowObservationKind") == "no_chroniclable_public_material":
+            excerpt = f"The {cadence_word} left traces, but no honest scene could be made from them."
+            body = (
+                f"The complete public {cadence_word} left traces, but none that could be turned into a scene "
+                "without guessing. I kept that boundary instead of dressing uncertainty up as an event. "
+                f"The {cadence_word} still belongs in the record: present, unresolved, and not erased."
+            )
+        else:
+            excerpt = f"The public {cadence_word} went quiet, and BNL kept the appointment."
+            body = (
+                f"The complete public {cadence_word} closed without a relay or conversation to turn into a scene. "
+                f"That does not make the {cadence_word} missing; the silence is the honest part of its record. "
+                "I noticed the open space, kept its place, and left the next signal somewhere to arrive."
+            )
+    else:
+        kinds = {str(source.get("sourceKind") or "") for source in sources}
+        if {"relay", "conversation"} <= kinds:
+            trace = "Relay and conversation sources both left public traces"
+        elif "relay" in kinds:
+            trace = "At least one relay left a public trace"
+        elif "conversation" in kinds:
+            trace = "At least one public conversation left a trace"
+        else:
+            trace = "At least one grounded public trace remained"
+        segments = [
+            item
+            for item in packet.get("windowSegmentActivity", [])
+            if isinstance(item, dict)
+            and (int(item.get("relaySources") or 0) + int(item.get("conversationSources") or 0)) > 0
+        ]
+        span = (
+            " from early through late"
+            if len(segments) >= 3
+            else " across more than one stretch of the window"
+            if len(segments) >= 2
+            else " during the window"
+        )
+        title = "The Day Kept Its Place" if entry_kind == "daily" else "The Week Kept Its Place"
+        excerpt = "At least one public trace remained, even when it refused to become one neat scene."
+        heading = "The Trace That Remained"
+        cadence_preference = "day" if entry_kind == "daily" else "week"
+        body = (
+            f"{trace}{span}. The available details did not resolve into one clean scene, but that trace "
+            f"still belongs to the record. I prefer a {cadence_preference} that resists neat filing. "
+            "The archive keeps it without adding a scene, a motive, or an exchange that the sources did "
+            "not establish."
+        )
+
+    safe_reason = re.sub(r"[^a-z0-9_]+", "_", str(failure_reason or "generation_failed").lower()).strip("_")[:80]
+    return {
+        "title": title,
+        "excerpt": excerpt,
+        "sections": [{"heading": heading, "body": body}],
+        "sourceRefIds": {heading: refs},
+        "metadata": {
+            "topicTags": [],
+            "subjectRefs": [],
+            "continuityNotes": [],
+            "unresolvedQuestions": [],
+            "confidenceFlags": ["automatic_rescue"],
+            "safetyFlags": [f"automatic_rescue_after_{safe_reason}"],
+            "contextUses": [],
+        },
+    }
+
+
+def _static_rescue_validation_packet(packet: dict[str, Any]) -> dict[str, Any]:
+    """Remove identity literals only when validating our own hard-coded copy.
+
+    Model prose never uses this path.  The rescue text is source-independent,
+    so a member named ``Room`` or ``Day`` cannot turn a safe static fallback
+    into a permanent false-positive hold.
+    """
+
+    prepared = dict(packet)
+    prepared["privateWindowDisplayNames"] = []
+    prepared["privateSources"] = [
+        {key: value for key, value in source.items() if key != "displayName"}
+        for source in packet.get("privateSources", [])
+        if isinstance(source, dict)
+    ]
+    return prepared
 
 
 def _public_text(article: dict[str, Any]) -> str:
@@ -1838,9 +2083,24 @@ def validate_article(
         if _norm(heading) in headings:
             return "duplicate_section_heading"
         headings.append(_norm(heading))
-    wc = public_word_count(article)
-    if wc < WORD_MIN or wc > WORD_MAX:
-        return "invalid_word_count"
+    public_fields = [
+        str(article.get("title") or ""),
+        str(article.get("excerpt") or ""),
+        *[
+            str(section.get(key) or "")
+            for section in sections
+            for key in ("heading", "body")
+        ],
+    ]
+    try:
+        if any(_UNSAFE_PUBLIC_CONTROL_RE.search(value) for value in public_fields):
+            return "invalid_public_text"
+        for value in public_fields:
+            value.encode("utf-8")
+    except UnicodeEncodeError:
+        return "invalid_public_text"
+    if public_payload_byte_count(article, packet) > JOURNAL_MAX_PUBLIC_PAYLOAD_BYTES:
+        return "payload_too_large"
     valid_refs = {s["refId"] for s in packet.get("safeSources", []) if s.get("refId")}
     if not valid_refs:
         return "no_new_source"
@@ -2090,6 +2350,8 @@ def _draft_records(guild_id: int, packet: dict[str, Any], article: dict[str, Any
     lane_candidates = packet.get("generationContextLanes") if isinstance(packet.get("generationContextLanes"), dict) else {}
     meta.update({
         "entryKind": packet.get("entryKind", "manual"),
+        "publicWordCount": public_word_count(article),
+        "publicPayloadBytes": len(canonical),
         "sourceWindowStart": packet["sourceWindowStart"],
         "sourceWindowEnd": packet["sourceWindowEnd"],
         "coverageComplete": bool(packet.get("coverageComplete", True)),
@@ -2125,8 +2387,34 @@ def _generate_article_with_repairs(
     packet: dict[str, Any],
     generator: Callable[[dict[str, Any], str], str],
     prior_titles: list[str],
-) -> tuple[Optional[dict[str, Any]], str, bool]:
+) -> tuple[Optional[dict[str, Any]], str, bool, str, bool]:
     """Return the best blocking-clean article without letting polish cancel publication."""
+
+    def static_rescue(reason: str) -> Optional[dict[str, Any]]:
+        rescue = _automatic_rescue_article(packet, reason)
+        if rescue is None:
+            return None
+        # The hard-coded rescue makes no memory, rumor, inference, or identity
+        # claim.  Keep all other hard validators, including citations,
+        # sensitive-detail patterns, and the 24 KB transport preflight.
+        packet["generationContextLanes"] = {}
+        packet["privateContextLaneProvenance"] = {}
+        validation_packet = _static_rescue_validation_packet(packet)
+        if validate_article(
+            rescue,
+            validation_packet,
+            prior_titles,
+            blocking_only=True,
+        ):
+            return None
+        return rescue
+
+    if packet.get("quietWindowObservation"):
+        rescue = static_rescue("quiet_window")
+        if rescue is not None:
+            return rescue, "", True, "automatic_quiet_window", True
+        return None, "quiet_window_rescue_invalid", False, "", False
+
     last_reason = ""
     previous_output = ""
     retained_publishable: Optional[dict[str, Any]] = None
@@ -2142,9 +2430,12 @@ def _generate_article_with_repairs(
             )
         except Exception as exc:
             if retained_publishable is not None:
-                return retained_publishable, "", True
+                return retained_publishable, "", True, "", False
             reason = "quota_unavailable" if "quota" in str(exc).lower() else "provider_failure"
-            return None, reason, False
+            rescue = static_rescue(reason)
+            if rescue is not None:
+                return rescue, "", True, f"automatic_rescue_after_{reason}", True
+            return None, reason, False, "", False
         previous_output = raw
         try:
             article = parse_generated_json(raw)
@@ -2164,7 +2455,7 @@ def _generate_article_with_repairs(
 
         validation = validate_article(article, packet, prior_titles)
         if not validation:
-            return article, "", False
+            return article, "", False, "", False
         if validation not in ADVISORY_VALIDATION_REASONS:
             # Future validation reasons remain blocking unless explicitly
             # classified as editorial guidance above.
@@ -2174,8 +2465,12 @@ def _generate_article_with_repairs(
         last_reason = validation
 
     if retained_publishable is not None:
-        return retained_publishable, "", True
-    return None, last_reason or "generation_failed", False
+        return retained_publishable, "", True, "", False
+    rescue_reason = last_reason or "generation_failed"
+    rescue = static_rescue(rescue_reason)
+    if rescue is not None:
+        return rescue, "", True, f"automatic_rescue_after_{rescue_reason}", True
+    return None, rescue_reason, False, "", False
 
 
 def store_validated_draft(
@@ -2187,12 +2482,15 @@ def store_validated_draft(
     entry_id: str = "",
     revision: int = 1,
     allow_advisory: bool = False,
+    identity_independent_static_copy: bool = False,
 ) -> JournalResult:
     ensure_schema(db_path)
     with sqlite3.connect(db_path) as conn:
         reason = validate_article(
             article,
-            packet,
+            _static_rescue_validation_packet(packet)
+            if identity_independent_static_copy
+            else packet,
             _prior_titles(conn, guild_id),
             blocking_only=allow_advisory,
         )
@@ -2211,28 +2509,35 @@ def generate_and_store_packet_draft(
     generator: Callable[[dict[str, Any], str], str],
     *,
     entry_id: str = "",
+    revision: int = 1,
 ) -> JournalResult:
+    packet = ensure_automatic_window_source(packet)
     if not packet.get("coverageComplete", True):
         return JournalResult(False, "no_draft", "incomplete_source_window", entry_id=entry_id)
     if not packet.get("safeSources"):
         return JournalResult(False, "no_draft", "insufficient_grounded_material", entry_id=entry_id)
     with sqlite3.connect(db_path) as conn:
         prior_titles = _prior_titles(conn, guild_id)
-    article, reason, allow_advisory = _generate_article_with_repairs(
+    article, reason, allow_advisory, recovery_detail, static_copy = _generate_article_with_repairs(
         packet,
         generator,
         prior_titles,
     )
     if article is None:
         return JournalResult(False, "no_draft", reason, entry_id=entry_id)
-    return store_validated_draft(
+    stored = store_validated_draft(
         db_path,
         guild_id,
         packet,
         article,
         entry_id=entry_id,
+        revision=revision,
         allow_advisory=allow_advisory,
+        identity_independent_static_copy=static_copy,
     )
+    if stored.ok and recovery_detail:
+        stored.reason = recovery_detail
+    return stored
 
 
 def generate_and_store_draft(
@@ -2344,7 +2649,7 @@ def regenerate_draft(
     packet = build_source_packet(db_path, guild_id, hours, **packet_kwargs)
     with sqlite3.connect(db_path) as conn:
         prior_titles = _prior_titles(conn, guild_id)
-    article, reason, allow_advisory = _generate_article_with_repairs(
+    article, reason, allow_advisory, recovery_detail, static_copy = _generate_article_with_repairs(
         packet,
         generator,
         prior_titles,
@@ -2354,7 +2659,7 @@ def regenerate_draft(
     with sqlite3.connect(db_path) as conn:
         reason = validate_article(
             article,
-            packet,
+            _static_rescue_validation_packet(packet) if static_copy else packet,
             _prior_titles(conn, guild_id),
             blocking_only=allow_advisory,
         )
@@ -2371,6 +2676,8 @@ def regenerate_draft(
             if cur1.rowcount != 1 or cur2.rowcount != 1:
                 raise sqlite3.IntegrityError("journal_regenerate_sync_failed")
             _insert_draft_rows(conn, entry_row, meta_row)
+    if recovery_detail:
+        result.reason = recovery_detail
     return result
 
 

--- a/bnl_journal_automation.py
+++ b/bnl_journal_automation.py
@@ -14,6 +14,7 @@ from bnl_journal import (
     approve_draft,
     build_source_packet_between,
     deliver_approved,
+    ensure_automatic_window_source,
     generate_and_store_packet_draft,
     journal_topic_counts,
     utc_now_iso,
@@ -24,10 +25,8 @@ DAILY_READY_HOUR = 19
 DAILY_READY_MINUTE = 0
 WEEKLY_READY_WEEKDAY = 0  # Monday, covering the prior Monday-Sunday week.
 WEEKLY_READY_HOUR = 19
-MIN_DAILY_SOURCE_COUNT = 5
-MIN_WEEKLY_ACTIVE_DAYS = 1
 LEASE_MINUTES = 30
-RETRY_MINUTES = 60
+RETRY_MINUTES = 15
 TERMINAL_RUN_STATES = {"published", "quiet", "incomplete"}
 
 
@@ -325,17 +324,6 @@ def _mark_observation(db_path: str, guild_id: int, label: str, result: Automatio
         ))
 
 
-def _has_meaningful_daily_activity(packet: dict[str, Any]) -> bool:
-    counts = packet.get("aggregateCounts") or {}
-    total = int(counts.get("eligibleRelays") or 0) + int(counts.get("eligibleConversations") or 0)
-    if total < MIN_DAILY_SOURCE_COUNT:
-        return False
-    if int(counts.get("eligibleConversations") or 0) > 0:
-        return True
-    quiet_markers = {"quiet", "quiet_source", "non_event_stock", "heartbeat", "hydrated"}
-    return any(str(source.get("eventType") or "").lower() not in quiet_markers for source in packet.get("privateSources", []))
-
-
 def _publish_packet(
     db_path: str,
     guild_id: int,
@@ -365,14 +353,50 @@ def _publish_packet(
             return AutomationResult(False, cadence, "held", approved.reason, entry_id, int(existing[0]), packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
         delivered = deliver_approved(db_path, guild_id, entry_id, base_url, api_key, opener=opener, revision=int(existing[0]))
         return AutomationResult(delivered.ok, cadence, delivered.status, delivered.reason, entry_id, delivered.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
-    generated = generate_and_store_packet_draft(db_path, guild_id, packet, generator, entry_id=entry_id)
+    next_revision = int(existing[0]) + 1 if existing and existing[1] == "rejected" else 1
+    generated = generate_and_store_packet_draft(
+        db_path,
+        guild_id,
+        packet,
+        generator,
+        entry_id=entry_id,
+        revision=next_revision,
+    )
     if not generated.ok:
         return AutomationResult(False, cadence, "held", generated.reason, entry_id, generated.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
     approved = approve_draft(db_path, guild_id, entry_id, generated.content_hash, revision=generated.revision)
     if not approved.ok:
         return AutomationResult(False, cadence, "held", approved.reason, entry_id, generated.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
     delivered = deliver_approved(db_path, guild_id, entry_id, base_url, api_key, opener=opener, revision=generated.revision)
-    return AutomationResult(delivered.ok, cadence, delivered.status, delivered.reason, entry_id, delivered.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
+    detail = generated.reason if delivered.ok and generated.reason else delivered.reason
+    return AutomationResult(delivered.ok, cadence, delivered.status, detail, entry_id, delivered.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
+
+
+def _forced_retry_daily_day(
+    db_path: str,
+    guild_id: int,
+    now_utc: Optional[datetime],
+) -> Optional[date]:
+    """Prefer an existing held window when an operator explicitly runs now."""
+
+    now = now_utc or datetime.now(timezone.utc)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            """SELECT source_window_start,source_window_end
+               FROM bnl_journal_automation_runs
+               WHERE guild_id=? AND cadence='daily'
+                 AND lifecycle_state IN ('held','delivery_failed','deferred')
+               ORDER BY source_window_start DESC""",
+            (guild_id,),
+        ).fetchall()
+    for start, end in rows:
+        try:
+            if _parse_utc(str(end)) > now:
+                continue
+            return _parse_utc(str(start)).astimezone(PACIFIC).date()
+        except (TypeError, ValueError):
+            continue
+    return None
 
 
 def run_daily(
@@ -389,6 +413,8 @@ def run_daily(
     memory_excluded_entry_ids: Optional[set[str]] = None,
 ) -> AutomationResult:
     ensure_schema(db_path)
+    if force and target_day is None:
+        target_day = _forced_retry_daily_day(db_path, guild_id, now_utc)
     start, end, label = _daily_period_for_day(target_day) if target_day else daily_period(now_utc)
     if not force and target_day is None and not daily_due(now_utc):
         return AutomationResult(False, "daily", "not_due", "before_daily_publish_time", source_window_start=start, source_window_end=end)
@@ -403,6 +429,7 @@ def run_daily(
         entry_kind="daily",
         excluded_history_entry_ids=memory_excluded_entry_ids,
     )
+    packet = ensure_automatic_window_source(packet)
     _store_observation(db_path, guild_id, label, packet)
     if not packet.get("sourceArchiveAvailable", False):
         result = AutomationResult(False, "daily", "held", "source_archive_unavailable", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
@@ -410,8 +437,6 @@ def run_daily(
         # Time cannot make a pre-archive window complete. Record it explicitly
         # and move on instead of blocking every later catch-up day forever.
         result = AutomationResult(False, "daily", "incomplete", "window_began_before_archive_activation", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
-    elif not _has_meaningful_daily_activity(packet):
-        result = AutomationResult(True, "daily", "quiet", "insufficient_meaningful_activity", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
     else:
         result = _publish_packet(db_path, guild_id, "daily", label, packet, generator, base_url, api_key, opener=opener)
     _mark_observation(db_path, guild_id, label, result)
@@ -439,10 +464,15 @@ def _weekly_packet(
                 WHERE guild_id=? AND lifecycle_state='published' AND source_window_start>=? AND source_window_end<=?""", (guild_id, start, end)).fetchall()
         }
     complete = [row for row in observations if row["lifecycle_state"] in {"published", "quiet"}]
-    active = [row for row in complete if row["lifecycle_state"] == "published"]
+    active = [
+        row
+        for row in complete
+        if row["lifecycle_state"] == "published"
+        and not int((json.loads(row["aggregate_counts_json"] or "{}") or {}).get("quietWindowObservation") or 0)
+    ]
     # A weekly synthesis is only grounded once all seven daily windows have
     # reached a durable terminal state. Held/incomplete days are excluded.
-    if len(complete) < 7 or len(active) < MIN_WEEKLY_ACTIVE_DAYS:
+    if len(complete) < 7:
         return None, len(complete), len(active)
     observation_context: list[dict[str, Any]] = []
     for row in complete:
@@ -500,9 +530,9 @@ def run_weekly(
         end,
         memory_excluded_entry_ids=memory_excluded_entry_ids,
     )
-    if packet is None and complete_days == 7 and active_days == 0:
-        result = AutomationResult(True, "weekly", "quiet", "no_meaningful_weekly_activity", source_window_start=start, source_window_end=end, aggregate_counts={"completeDays": complete_days, "activeDays": active_days})
-    elif packet is None:
+    if packet is not None:
+        packet = ensure_automatic_window_source(packet)
+    if packet is None:
         result = AutomationResult(True, "weekly", "deferred", f"only_{complete_days}_complete_daily_observations", source_window_start=start, source_window_end=end, aggregate_counts={"completeDays": complete_days, "activeDays": active_days})
     elif not packet.get("sourceArchiveAvailable", False):
         result = AutomationResult(False, "weekly", "held", "source_archive_unavailable", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))

--- a/tests/test_bnl_journal.py
+++ b/tests/test_bnl_journal.py
@@ -104,6 +104,46 @@ class JournalTests(unittest.TestCase):
                 c.execute("SELECT COUNT(*) FROM bnl_journal_entries WHERE lifecycle_state='draft'").fetchone()[0],
             )
 
+    def test_word_count_is_guidance_only_at_both_extremes(self):
+        packet = self.packet()
+        cases = (
+            (
+                "Short Honest Entry",
+                "A public track discussion left a trace. I admit, I kept listening.",
+            ),
+            (
+                "Long Honest Entry",
+                " ".join(
+                    "A public track discussion kept changing shape while the room listened."
+                    for _ in range(90)
+                ),
+            ),
+        )
+
+        for title, body in cases:
+            with self.subTest(title=title):
+                raw = json.loads(article_json(packet, title=title))
+                raw["sections"][0]["body"] = body
+                article = j.parse_generated_json(json.dumps(raw))
+                self.assertEqual("", j.validate_article(article, packet, []))
+                result = j.generate_and_store_packet_draft(
+                    self.db,
+                    1,
+                    packet,
+                    lambda *_args, payload=json.dumps(raw): payload,
+                )
+                self.assertTrue(result.ok, result)
+
+        with sqlite3.connect(self.db) as conn:
+            stored_counts = [
+                json.loads(row[0])["publicWordCount"]
+                for row in conn.execute(
+                    "SELECT metadata_json FROM bnl_journal_private_metadata ORDER BY created_at"
+                ).fetchall()
+            ]
+        self.assertLess(stored_counts[0], 250)
+        self.assertGreater(stored_counts[1], 500)
+
     def test_clinical_or_sensitive_copy_gets_rejected_and_rewritten(self):
         packet = self.packet()
         clinical = j.parse_generated_json(article_json(packet, title='Clinical Pass', leak=' Records indicate continuous effort across entities.'))
@@ -414,7 +454,7 @@ class BotJournalCommandTests(unittest.IsolatedAsyncioTestCase):
             packet = j.build_source_packet(bnl01_bot.DB_FILE, 1, 24, '2026-07-18T01:00:00Z')
             response = Mock(candidates=[Mock(content=Mock(parts=[Mock(text=article_json(packet))]))], usage_metadata=Mock(total_token_count=None))
             msg = Mock(); msg.guild = Mock(id=1, get_member=Mock(return_value=Mock())); msg.author = Mock(id=1); msg.channel = Mock(name='research-and-development'); msg.reply = AsyncMock()
-            with patch.object(bnl01_bot, 'resolve_channel_policy', return_value='internal_controlled'), patch.object(bnl01_bot, 'can_send_dossier_recommendation', return_value=True), patch.object(bnl01_bot, 'check_quota_availability', return_value=True), patch.object(bnl01_bot, '_generate_gemini_content_with_fallback', return_value=response):
+            with patch.object(j, 'utc_now_iso', return_value='2026-07-18T01:00:00Z'), patch.object(bnl01_bot, 'resolve_channel_policy', return_value='internal_controlled'), patch.object(bnl01_bot, 'can_send_dossier_recommendation', return_value=True), patch.object(bnl01_bot, 'check_quota_availability', return_value=True), patch.object(bnl01_bot, '_generate_gemini_content_with_fallback', return_value=response):
                 handled = await bnl01_bot.maybe_handle_journal_command(msg, '!bnl journal create | hours=bad')
             self.assertTrue(handled)
             with sqlite3.connect(bnl01_bot.DB_FILE) as c:

--- a/tests/test_bnl_journal_automation.py
+++ b/tests/test_bnl_journal_automation.py
@@ -292,19 +292,326 @@ class JournalAutomationTests(unittest.TestCase):
                 ).fetchone()[0],
             )
 
+    def test_out_of_range_daily_length_publishes_in_the_same_attempt(self):
+        self.add_day("2026-07-19")
+        calls = []
+
+        def very_long_but_safe(packet, _prompt):
+            calls.append(1)
+            article = json.loads(article_json(packet))
+            article["title"] = "A Long Day Still Publishes"
+            article["sections"][0]["body"] += " " + " ".join(
+                "The public music room kept another grounded detail in view."
+                for _ in range(80)
+            )
+            return json.dumps(article)
+
+        result = automation.run_daily(
+            self.db,
+            1,
+            very_long_but_safe,
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+
+        self.assertTrue(result.ok, result)
+        self.assertEqual("published", result.status)
+        self.assertEqual(1, len(calls))
+        with sqlite3.connect(self.db) as conn:
+            metadata = json.loads(
+                conn.execute(
+                    "SELECT metadata_json FROM bnl_journal_private_metadata WHERE entry_id=?",
+                    (result.entry_id,),
+                ).fetchone()[0]
+            )
+        self.assertGreater(metadata["publicWordCount"], 500)
+
+    def test_repeated_privacy_failure_uses_safe_rescue_and_still_publishes(self):
+        self.add_day("2026-07-19")
+        calls = []
+
+        def leaking_generator(packet, _prompt):
+            calls.append(1)
+            article = json.loads(article_json(packet))
+            article["title"] = "Rejected Private Candidate"
+            article["sections"][0]["body"] += " Member0 carried the private version."
+            return json.dumps(article)
+
+        result = automation.run_daily(
+            self.db,
+            1,
+            leaking_generator,
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+
+        self.assertTrue(result.ok, result)
+        self.assertEqual("published", result.status)
+        self.assertEqual(
+            "automatic_rescue_after_community_name_leak",
+            result.reason,
+        )
+        self.assertEqual(journal.JOURNAL_GENERATION_ATTEMPTS, len(calls))
+        with sqlite3.connect(self.db) as conn:
+            payload = conn.execute(
+                "SELECT public_payload_json FROM bnl_journal_entries WHERE entry_id=?",
+                (result.entry_id,),
+            ).fetchone()[0]
+        self.assertNotIn("Member0", payload)
+        self.assertNotIn("Rejected Private Candidate", payload)
+
+    def test_provider_failure_uses_grounded_static_rescue_in_the_same_run(self):
+        self.add_day("2026-07-19")
+        calls = []
+
+        def provider_down(_packet, _prompt):
+            calls.append(1)
+            raise RuntimeError("provider down")
+
+        result = automation.run_daily(
+            self.db,
+            1,
+            provider_down,
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+
+        self.assertTrue(result.ok, result)
+        self.assertEqual("published", result.status)
+        self.assertEqual("automatic_rescue_after_provider_failure", result.reason)
+        self.assertEqual(1, len(calls))
+
+    def test_static_rescue_cannot_be_blocked_by_a_common_display_name(self):
+        self.add_day("2026-07-19")
+        with sqlite3.connect(self.db) as conn:
+            conn.execute("UPDATE conversations SET user_name='Room'")
+
+        result = automation.run_daily(
+            self.db,
+            1,
+            lambda *_args: "not-json",
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+
+        self.assertTrue(result.ok, result)
+        self.assertEqual("published", result.status)
+        self.assertTrue(result.reason.startswith("automatic_rescue_after_"), result)
+
+    def test_oversized_model_output_is_repaired_before_site_delivery(self):
+        self.add_day("2026-07-19")
+        calls = []
+        delivered_sizes = []
+
+        def oversized(packet, _prompt):
+            calls.append(1)
+            article = json.loads(article_json(packet))
+            article["sections"][0]["body"] = "signal " * 5_000
+            return json.dumps(article)
+
+        def bounded_opener(request, timeout=10):
+            delivered_sizes.append(len(request.data))
+            self.assertLessEqual(len(request.data), journal.JOURNAL_MAX_PUBLIC_PAYLOAD_BYTES)
+            return Response(request)
+
+        result = automation.run_daily(
+            self.db,
+            1,
+            oversized,
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=bounded_opener,
+        )
+
+        self.assertTrue(result.ok, result)
+        self.assertEqual("automatic_rescue_after_payload_too_large", result.reason)
+        self.assertEqual(journal.JOURNAL_GENERATION_ATTEMPTS, len(calls))
+        self.assertEqual(1, len(delivered_sizes))
+
+    def test_site_unsafe_public_text_repairs_to_static_rescue(self):
+        self.add_day("2026-07-19")
+        calls = []
+
+        def unsafe_text(packet, _prompt):
+            article = json.loads(article_json(packet))
+            unsafe = ("\x00", "\ud800", "\ufeff")[len(calls) % 3]
+            calls.append(unsafe)
+            article["sections"][0]["body"] += unsafe
+            return json.dumps(article)
+
+        result = automation.run_daily(
+            self.db,
+            1,
+            unsafe_text,
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+
+        self.assertTrue(result.ok, result)
+        self.assertEqual("published", result.status)
+        self.assertEqual("automatic_rescue_after_invalid_public_text", result.reason)
+        self.assertEqual(journal.JOURNAL_GENERATION_ATTEMPTS, len(calls))
+
+    def test_malformed_private_metadata_is_sanitized_without_canceling_publication(self):
+        self.add_day("2026-07-19")
+
+        def malformed_metadata(packet, _prompt):
+            article = json.loads(article_json(packet))
+            article["metadata"]["topicTags"] = ["music", "\ud800"]
+            return json.dumps(article)
+
+        result = automation.run_daily(
+            self.db,
+            1,
+            malformed_metadata,
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+
+        self.assertTrue(result.ok, result)
+        self.assertEqual("published", result.status)
+        with sqlite3.connect(self.db) as conn:
+            metadata = json.loads(
+                conn.execute(
+                    "SELECT metadata_json FROM bnl_journal_private_metadata WHERE entry_id=?",
+                    (result.entry_id,),
+                ).fetchone()[0]
+            )
+        self.assertEqual(["music", "?"], metadata["topicTags"])
+
+    def test_one_source_static_rescue_does_not_invent_multiple_exchanges(self):
+        self.add_day("2026-07-19")
+        with sqlite3.connect(self.db) as conn:
+            conn.execute("DELETE FROM website_relay_history WHERE relay_id NOT LIKE '%-0'")
+            conn.execute("DELETE FROM conversations")
+
+        result = automation.run_daily(
+            self.db,
+            1,
+            lambda *_args: (_ for _ in ()).throw(RuntimeError("provider down")),
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+
+        self.assertTrue(result.ok, result)
+        with sqlite3.connect(self.db) as conn:
+            payload = json.loads(
+                conn.execute(
+                    "SELECT public_payload_json FROM bnl_journal_entries WHERE entry_id=?",
+                    (result.entry_id,),
+                ).fetchone()[0]
+            )
+        public_text = json.dumps(payload["entry"], sort_keys=True)
+        self.assertIn("At least one relay left a public trace", public_text)
+        self.assertNotIn("one exchange to the next", public_text)
+
+    def test_filtered_activity_is_not_misreported_as_no_activity(self):
+        packet = {
+            "entryKind": "daily",
+            "sourceWindowStart": "2026-07-20T02:00:00Z",
+            "sourceWindowEnd": "2026-07-21T02:00:00Z",
+            "safeSources": [],
+            "privateSources": [{"refId": "fresh:9", "sourceKind": "conversation", "displayName": "Room"}],
+            "privateWindowDisplayNames": ["Room"],
+            "aggregateCounts": {"eligibleRelays": 0, "eligibleConversations": 1},
+            "coverageComplete": True,
+            "sourceArchiveAvailable": True,
+            "history": {},
+            "generationContextLanes": {},
+            "privateContextLaneProvenance": {},
+            "windowSegmentActivity": [],
+        }
+
+        prepared = journal.ensure_automatic_window_source(packet)
+
+        self.assertEqual("no_chroniclable_public_material", prepared["quietWindowObservationKind"])
+        self.assertEqual(2, len(prepared["privateSources"]))
+        self.assertEqual("Room", prepared["privateSources"][0]["displayName"])
+        article = journal._automatic_rescue_article(prepared, "quiet_window")
+        public_text = journal._public_text(article)
+        self.assertIn("left traces", public_text)
+        self.assertNotIn("without a relay or conversation", public_text)
+
+    def test_complete_zero_activity_day_publishes_an_honest_quiet_entry(self):
+        self.set_archive_activation("2026-07-19T02:00:00Z")
+
+        result = automation.run_daily(
+            self.db,
+            1,
+            lambda *_args: self.fail("a zero-source window must not ask the model to invent a scene"),
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+
+        self.assertTrue(result.ok, result)
+        self.assertEqual("published", result.status)
+        self.assertEqual("automatic_quiet_window", result.reason)
+        self.assertEqual(1, result.aggregate_counts["quietWindowObservation"])
+        with sqlite3.connect(self.db) as conn:
+            observation = conn.execute(
+                "SELECT lifecycle_state,aggregate_counts_json FROM bnl_journal_observations"
+            ).fetchone()
+        self.assertEqual("published", observation[0])
+        self.assertEqual(1, json.loads(observation[1])["quietWindowObservation"])
+
+    def test_low_activity_day_is_not_silently_skipped(self):
+        self.add_day("2026-07-19")
+        with sqlite3.connect(self.db) as conn:
+            conn.execute("DELETE FROM website_relay_history WHERE relay_id NOT LIKE '%-0'")
+            conn.execute("DELETE FROM conversations WHERE content NOT LIKE '%number 0.%'")
+
+        result = automation.run_daily(
+            self.db,
+            1,
+            lambda packet, _prompt: article_json(packet),
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+
+        self.assertTrue(result.ok, result)
+        self.assertEqual("published", result.status)
+        self.assertEqual(1, result.aggregate_counts["eligibleRelays"])
+        self.assertEqual(1, result.aggregate_counts["eligibleConversations"])
+
     def test_newly_closed_day_publishes_before_an_older_held_backlog(self):
         self.add_day("2026-07-18")
         self.add_day("2026-07-19")
         self.set_archive_activation("2026-07-18T02:00:01Z")
 
-        def provider_down(_packet, _prompt):
-            raise RuntimeError("provider down")
-
         held = automation.run_daily(
             self.db,
             1,
-            provider_down,
-            "https://site.example",
+            lambda *_args: self.fail("missing website configuration must hold before generation"),
+            "",
             "key",
             target_day=date(2026, 7, 18),
             force=True,
@@ -342,6 +649,130 @@ class JournalAutomationTests(unittest.TestCase):
                 datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc),
             ),
         )
+
+    def test_force_run_recovers_the_same_held_window_without_a_duplicate(self):
+        self.add_day("2026-07-19")
+
+        held = automation.run_daily(
+            self.db,
+            1,
+            lambda *_args: self.fail("missing website configuration must hold before generation"),
+            "",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+        recovered = automation.run_daily(
+            self.db,
+            1,
+            lambda packet, _prompt: article_json(packet),
+            "https://site.example",
+            "key",
+            now_utc=datetime(2026, 7, 22, 3, 0, tzinfo=timezone.utc),
+            force=True,
+            opener=self.opener,
+        )
+        repeated = automation.run_daily(
+            self.db,
+            1,
+            lambda *_args: self.fail("published recovery generated twice"),
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+
+        self.assertEqual(("held", "website_configuration_missing"), (held.status, held.reason))
+        self.assertEqual("published", recovered.status)
+        expected_start, expected_end, _ = automation._daily_period_for_day(date(2026, 7, 19))
+        self.assertEqual(expected_start, recovered.source_window_start)
+        self.assertEqual(expected_end, recovered.source_window_end)
+        self.assertEqual("published", repeated.status)
+        self.assertEqual(recovered.entry_id, repeated.entry_id)
+        with sqlite3.connect(self.db) as conn:
+            run = conn.execute(
+                "SELECT lifecycle_state,attempt_count FROM bnl_journal_automation_runs"
+            ).fetchone()
+            published = conn.execute(
+                "SELECT COUNT(*) FROM bnl_journal_entries WHERE lifecycle_state='published'"
+            ).fetchone()[0]
+        self.assertEqual(("published", 2), run)
+        self.assertEqual(1, published)
+
+    def test_force_run_prefers_the_most_recent_held_window(self):
+        self.add_day("2026-07-18")
+        self.add_day("2026-07-19")
+        for held_day in (date(2026, 7, 18), date(2026, 7, 19)):
+            held = automation.run_daily(
+                self.db,
+                1,
+                lambda *_args: self.fail("missing configuration holds before generation"),
+                "",
+                "key",
+                target_day=held_day,
+                force=True,
+                opener=self.opener,
+            )
+            self.assertEqual("held", held.status)
+
+        recovered = automation.run_daily(
+            self.db,
+            1,
+            lambda packet, _prompt: article_json(packet),
+            "https://site.example",
+            "key",
+            now_utc=datetime(2026, 7, 22, 3, 0, tzinfo=timezone.utc),
+            force=True,
+            opener=self.opener,
+        )
+
+        expected_start, _, _ = automation._daily_period_for_day(date(2026, 7, 19))
+        self.assertEqual("published", recovered.status)
+        self.assertEqual(expected_start, recovered.source_window_start)
+
+    def test_rejected_automatic_revision_is_replaced_instead_of_deadlocking(self):
+        self.add_day("2026-07-19")
+        start, end, label = automation._daily_period_for_day(date(2026, 7, 19))
+        packet = journal.build_source_packet_between(
+            self.db,
+            1,
+            start,
+            end,
+            entry_kind="daily",
+        )
+        entry_id = automation._entry_id(1, "daily", label)
+        draft = journal.generate_and_store_packet_draft(
+            self.db,
+            1,
+            packet,
+            lambda source_packet, _prompt: article_json(source_packet),
+            entry_id=entry_id,
+        )
+        self.assertTrue(draft.ok, draft)
+        self.assertTrue(journal.reject_draft(self.db, 1, entry_id, "revise").ok)
+
+        result = automation.run_daily(
+            self.db,
+            1,
+            lambda source_packet, _prompt: article_json(source_packet),
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+
+        self.assertTrue(result.ok, result)
+        self.assertEqual("published", result.status)
+        self.assertEqual(2, result.revision)
+        with sqlite3.connect(self.db) as conn:
+            states = conn.execute(
+                "SELECT revision,lifecycle_state FROM bnl_journal_entries WHERE entry_id=? ORDER BY revision",
+                (entry_id,),
+            ).fetchall()
+        self.assertEqual([(1, "rejected"), (2, "published")], states)
 
     def test_daily_uses_complete_half_open_window_and_far_more_than_25(self):
         with sqlite3.connect(self.db) as conn:
@@ -535,7 +966,7 @@ class JournalAutomationTests(unittest.TestCase):
         self.assertNotIn("Alice", public_generation_text)
         self.assertNotIn("Bob", public_generation_text)
 
-    def test_all_quiet_week_is_terminal_and_does_not_block_catchup(self):
+    def test_all_quiet_week_still_publishes_once(self):
         for offset in range(7):
             day = datetime(2026, 7, 13, tzinfo=timezone.utc).date() + timedelta(days=offset)
             start, end, label = automation._daily_period_for_day(day)
@@ -549,17 +980,18 @@ class JournalAutomationTests(unittest.TestCase):
                 automation.AutomationResult(True, "daily", "quiet", source_window_start=start, source_window_end=end),
             )
         now = datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc)
+
         first = automation.run_weekly(
-            self.db, 1, lambda *_args: self.fail("quiet week must not generate"),
+            self.db, 1, lambda *_args: self.fail("an all-quiet week must use deterministic copy"),
             "https://site.example", "key", now_utc=now, force=True, opener=self.opener,
         )
         second = automation.run_weekly(
-            self.db, 1, lambda *_args: self.fail("completed quiet week must not rerun"),
+            self.db, 1, lambda *_args: self.fail("published quiet week generated twice"),
             "https://site.example", "key", now_utc=now, opener=self.opener,
         )
-        self.assertEqual("quiet", first.status)
-        self.assertEqual("no_meaningful_weekly_activity", first.reason)
-        self.assertEqual("quiet", second.status)
+        self.assertEqual("published", first.status)
+        self.assertEqual("published", second.status)
+        self.assertEqual(first.entry_id, second.entry_id)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Treat Journal length as editorial guidance rather than a publication gate.
- Publish honest deterministic entries for complete low-activity or quiet daily and weekly windows instead of recording success without a post.
- Fall back to a minimal evidence-grounded replacement when automatic generation repeatedly fails because of provider errors, malformed output, blocking public-output/privacy validation, or unsafe/oversized text.
- Preserve the existing identity, privacy, evidence, citation, context, and source-window validators.
- Preflight the website's exact 24,000-byte transport envelope before delivery.
- Make a forced daily run recover the most recent held complete window idempotently.
- Allow a rejected automatic revision to be replaced without deadlocking the window.
- Keep genuine site delivery outages queued for retry.

Manual drafts remain review-oriented. Unavailable or incomplete source archives remain visible failures rather than invented entries.

## Root cause

The automatic path still treated the 250–500-word target as a hard hold, and its low-activity path could finish without publishing. Backoff/retry behavior then left the completed window unrecovered. This change makes complete automatic windows converge on a safe publication while keeping real evidence and public-output protections intact.

## Validation

- 1,086 tests passed
- Python compilation passed
- Git diff checks passed
- Focused production-path coverage includes long/short entries, quiet windows, provider failure, malformed output, repeated anonymity rejection, invalid Unicode/control text, exact payload limits, delivery retry, force recovery, and duplicate prevention

## Deployment and recovery

1. Merge and finish deploying the coordinated website PR first.
2. Merge this PR.
3. Deploy/restart BNL.
4. Force-run the held daily window; the command prioritizes the most recent completed held window and is idempotent.