### PR TITLE
Bot: treat Journal word count as guidance

### DIFF
--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -12,7 +12,6 @@ from typing import Any, Callable, Optional
 
 PUBLIC_POLICIES = {"public_home", "public_context", "public_selective"}
 STATES = {"draft", "rejected", "approved_pending_delivery", "published", "delivery_failed"}
-WORD_MIN, WORD_MAX = 250, 500
 JOURNAL_ROUTE = "bnl_journal_generation"
 JOURNAL_GENERATION_ATTEMPTS = 4
 ADVISORY_VALIDATION_REASONS = frozenset({
@@ -83,7 +82,6 @@ _REPAIR_GUIDANCE = {
     "community_name_leak": "Remove every community member name and replace personal references with anonymous descriptions.",
     "public_leak_pattern": "Remove every URL, mention, identifier, and internal implementation term from public prose.",
     "source_ref_leak": "Keep source reference tokens only inside sourceRefIds arrays; remove them from all public prose.",
-    "invalid_word_count": "Rewrite the complete article so its total public word count is between 250 and 500 words.",
     "insufficient_source_breadth": (
         "Use the supplied evidenceCoverageContract. Ground the article in the required number of distinct fresh sources, "
         "participants, source kinds, and available parts of the window. Synthesize them into a few meaningful patterns; "
@@ -1838,9 +1836,6 @@ def validate_article(
         if _norm(heading) in headings:
             return "duplicate_section_heading"
         headings.append(_norm(heading))
-    wc = public_word_count(article)
-    if wc < WORD_MIN or wc > WORD_MAX:
-        return "invalid_word_count"
     valid_refs = {s["refId"] for s in packet.get("safeSources", []) if s.get("refId")}
     if not valid_refs:
         return "no_new_source"
@@ -2090,6 +2085,7 @@ def _draft_records(guild_id: int, packet: dict[str, Any], article: dict[str, Any
     lane_candidates = packet.get("generationContextLanes") if isinstance(packet.get("generationContextLanes"), dict) else {}
     meta.update({
         "entryKind": packet.get("entryKind", "manual"),
+        "publicWordCount": public_word_count(article),
         "sourceWindowStart": packet["sourceWindowStart"],
         "sourceWindowEnd": packet["sourceWindowEnd"],
         "coverageComplete": bool(packet.get("coverageComplete", True)),

--- a/tests/test_bnl_journal.py
+++ b/tests/test_bnl_journal.py
@@ -414,7 +414,7 @@ class BotJournalCommandTests(unittest.IsolatedAsyncioTestCase):
             packet = j.build_source_packet(bnl01_bot.DB_FILE, 1, 24, '2026-07-18T01:00:00Z')
             response = Mock(candidates=[Mock(content=Mock(parts=[Mock(text=article_json(packet))]))], usage_metadata=Mock(total_token_count=None))
             msg = Mock(); msg.guild = Mock(id=1, get_member=Mock(return_value=Mock())); msg.author = Mock(id=1); msg.channel = Mock(name='research-and-development'); msg.reply = AsyncMock()
-            with patch.object(bnl01_bot, 'resolve_channel_policy', return_value='internal_controlled'), patch.object(bnl01_bot, 'can_send_dossier_recommendation', return_value=True), patch.object(bnl01_bot, 'check_quota_availability', return_value=True), patch.object(bnl01_bot, '_generate_gemini_content_with_fallback', return_value=response):
+            with patch.object(j, 'utc_now_iso', return_value='2026-07-18T01:00:00Z'), patch.object(bnl01_bot, 'resolve_channel_policy', return_value='internal_controlled'), patch.object(bnl01_bot, 'can_send_dossier_recommendation', return_value=True), patch.object(bnl01_bot, 'check_quota_availability', return_value=True), patch.object(bnl01_bot, '_generate_gemini_content_with_fallback', return_value=response):
                 handled = await bnl01_bot.maybe_handle_journal_command(msg, '!bnl journal create | hours=bad')
             self.assertTrue(handled)
             with sqlite3.connect(bnl01_bot.DB_FILE) as c:

--- a/tests/test_bnl_journal_automation.py
+++ b/tests/test_bnl_journal_automation.py
@@ -245,6 +245,71 @@ class JournalAutomationTests(unittest.TestCase):
             self.assertEqual("published", conn.execute("SELECT lifecycle_state FROM bnl_journal_observations").fetchone()[0])
             self.assertEqual(1, conn.execute("SELECT COUNT(*) FROM bnl_journal_entries WHERE lifecycle_state='published'").fetchone()[0])
 
+    def test_word_count_target_is_guidance_and_never_retries(self):
+        self.add_day("2026-07-19")
+        self.add_day("2026-07-20")
+        calls = []
+
+        def outside_target(packet, prompt):
+            calls.append(prompt)
+            article = json.loads(article_json(packet))
+            if packet["sourceWindowStart"].startswith("2026-07-20"):
+                article["sections"][0]["body"] = (
+                    "A producer brought a mix into the public music room, and listeners kept the rhythm moving. "
+                    "I admit the small exchange still gave the day a shape worth keeping."
+                )
+            else:
+                article["sections"][0]["body"] = " ".join(
+                    [
+                        "A producer brought another grounded mix into the public music room while listeners kept the rhythm moving and the community answered with its own careful mischief."
+                        for _ in range(50)
+                    ]
+                )
+                article["sections"][0]["body"] += (
+                    " I admit the room's persistence has become one of my preferred recurring details."
+                )
+            return json.dumps(article)
+
+        short_result = automation.run_daily(
+            self.db,
+            1,
+            outside_target,
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 19),
+            force=True,
+            opener=self.opener,
+        )
+        long_result = automation.run_daily(
+            self.db,
+            1,
+            outside_target,
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 20),
+            force=True,
+            opener=self.opener,
+        )
+
+        self.assertEqual(("published", "published"), (short_result.status, long_result.status))
+        self.assertEqual(2, len(calls))
+        self.assertTrue(
+            all(
+                "Write 1-3 sections and 250-500 total words; prefer 2 sections and roughly 300-420 words."
+                in prompt
+                for prompt in calls
+            )
+        )
+        with sqlite3.connect(self.db) as conn:
+            word_counts = {
+                entry_id: json.loads(metadata_json)["publicWordCount"]
+                for entry_id, metadata_json in conn.execute(
+                    "SELECT entry_id,metadata_json FROM bnl_journal_private_metadata"
+                ).fetchall()
+            }
+        self.assertLess(word_counts[short_result.entry_id], 250)
+        self.assertGreater(word_counts[long_result.entry_id], 500)
+
     def test_editorial_polish_cannot_hold_daily_publication(self):
         self.add_day("2026-07-19")
         calls = []


### PR DESCRIPTION
## Summary

- Keep the existing Journal prompt unchanged, including the 250–500-word target and preferred 300–420-word range.
- Stop rejecting an otherwise valid Journal solely because it lands outside that target.
- Record the actual public word count in private Journal metadata for diagnostics.
- Prove both sub-250 and 500+ word entries publish on their first generation attempt.

## Root cause

The editorial target was also enforced as a blocking validator. A usable draft outside 250–500 words was discarded and regenerated until a later attempt happened to fit, delaying publication without improving safety or grounding.

## Deliberately unchanged

Journal voice, prompt, source selection, evidence coverage, context lanes, scheduling, retries, quiet-window behavior, delivery, and the website's real transport ceiling are untouched.

## Validation

- Full repository suite passed: 1,072 tests
- Journal suite passed: 37 tests
- Python compilation passed
- `git diff --check` passed
- Independent implementation and test reviews: go

## Supersedes

This replaces #348 with the proven micro-fix. The #348 branch remains intact so its separate findings can be considered later in isolated PRs.