### PR TITLE
Keep unmatched governance invariants blocking

### DIFF
--- a/bnl_memory_governance.py
+++ b/bnl_memory_governance.py
@@ -278,8 +278,8 @@ def build_governed_context(conn: sqlite3.Connection, req: GovernanceRequest, *, 
             restricted_policies = {"sealed_test", "protected_system", "internal_controlled", "reference_canon", "ai_image_tool"}
             if source_policy in restricted_policies and source_policy != str(req.channel_policy or "").lower():
                 # Keep the conservative runtime marker until live-governance
-                # behavior is reviewed separately. Persisted owner diagnostics
-                # reclassify the corroborated pre-selection exclusion below.
+                # behavior is reviewed separately. The acceptance reader
+                # reclassifies a corroborated pre-selection exclusion once.
                 diag.invalid_invariants.append("invalid_route_channel_policy_selected")
                 exclude("invalid_route_channel_policy"); continue
             if source_route in {"operator_command", "internal_control", "protected_system"} and source_route != str(req.route_mode or "").lower():
@@ -373,27 +373,10 @@ def persist_shadow_diagnostics(conn: sqlite3.Connection, req: GovernanceRequest,
     for invariant in result.diagnostics.invalid_invariants:
         key = str(invariant or "unknown")[:120]
         invalid_invariant_counts[key] = invalid_invariant_counts.get(key, 0) + 1
-    # The runtime keeps this conservative marker because it participates in a
-    # dormant live-governance fallback. For reporting, a matching exclusion
-    # proves the candidate was rejected before selection, so do not persist it
-    # as a selected invariant. Any unmatched remainder still fails closed.
-    route_marker = "invalid_route_channel_policy_selected"
-    safe_route_exclusions = int(
-        result.diagnostics.excluded_by_reason.get(
-            "invalid_route_channel_policy", 0
-        )
-        or 0
-    )
-    matched = min(
-        int(invalid_invariant_counts.get(route_marker, 0) or 0),
-        safe_route_exclusions,
-    )
-    if matched:
-        remaining = int(invalid_invariant_counts[route_marker]) - matched
-        if remaining:
-            invalid_invariant_counts[route_marker] = remaining
-        else:
-            invalid_invariant_counts.pop(route_marker, None)
+    # Persist the raw aggregate counts. The acceptance reader owns the one
+    # compatibility reclassification pass for the historical route-policy
+    # marker. Keeping that operation in one layer preserves any unmatched
+    # remainder as a fail-closed blocker.
     aggregate_diagnostics = {
         "selected_by_source": dict(result.diagnostics.selected_by_source),
         "invalid_invariant_counts": invalid_invariant_counts,

--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -243,7 +243,7 @@ def _partition_legacy_preselection_labels(
     invariants: Mapping[str, int],
     exclusions: Mapping[str, int],
 ) -> tuple[Dict[str, int], Dict[str, int]]:
-    """Reclassify only labels corroborated by a same-run safe exclusion."""
+    """Reclassify corroborated legacy labels exactly once at report time."""
 
     active = dict(invariants)
     reclassified: Dict[str, int] = {}

--- a/docs/BNL01_V2_SHADOW_ACCEPTANCE_AND_ROLLBACK.md
+++ b/docs/BNL01_V2_SHADOW_ACCEPTANCE_AND_ROLLBACK.md
@@ -176,10 +176,12 @@ as a selected-invariant failure. An unmatched count, any remainder, and every
 other invalid-invariant label continue to fail closed as hard stops. No retained
 row is rewritten or deleted.
 
-New shadow rows omit the corroborated count from persisted selected-invariant
-diagnostics while preserving the `invalid_route_channel_policy` exclusion.
-The conservative in-process runtime marker and live-governance fallback remain
-unchanged; revising that dormant behavior requires a separate reviewed change.
+Shadow rows preserve the raw aggregate marker and exclusion counts. The
+acceptance reader performs the compatibility reclassification exactly once at
+report time, so a one-marker/one-exclusion row is safely reclassified while a
+two-marker/one-exclusion row retains one hard blocker. The conservative
+in-process runtime marker and live-governance fallback remain unchanged;
+revising that dormant behavior requires a separate reviewed change.
 
 ### Relationship evidence
 

--- a/tests/test_memory_governance_v1.py
+++ b/tests/test_memory_governance_v1.py
@@ -435,7 +435,9 @@ def _case_route_policy_violations_and_shadow_retention_are_real():
     persist_shadow_diagnostics(c, req(), r, 'legacy')
     saved_exclusions, saved_diagnostics = c.execute("SELECT excluded_json, diagnostics_json FROM memory_governance_shadow_runs ORDER BY created_at DESC LIMIT 1").fetchone()
     assert json.loads(saved_exclusions) == {'invalid_route_channel_policy': 1}
-    assert json.loads(saved_diagnostics)['invalid_invariant_counts'] == {}
+    assert json.loads(saved_diagnostics)['invalid_invariant_counts'] == {
+        'invalid_route_channel_policy_selected': 1,
+    }
     for i in range(504):
         persist_shadow_diagnostics(c, req(), r, 'legacy')
     assert c.execute("SELECT COUNT(*) FROM memory_governance_shadow_runs WHERE guild_id=1").fetchone()[0] <= 500
@@ -458,7 +460,9 @@ def _case_route_policy_violations_and_shadow_retention_are_real():
     persist_shadow_diagnostics(c, req(user_text='operator modular synths'), route_mismatch, 'legacy')
     route_exclusions, route_diagnostics = c.execute("SELECT excluded_json, diagnostics_json FROM memory_governance_shadow_runs ORDER BY created_at DESC, run_id DESC LIMIT 1").fetchone()
     assert json.loads(route_exclusions)['invalid_route_channel_policy'] == 2
-    assert json.loads(route_diagnostics)['invalid_invariant_counts'] == {}
+    assert json.loads(route_diagnostics)['invalid_invariant_counts'] == {
+        'invalid_route_channel_policy_selected': 2,
+    }
 
 
 class MemoryGovernanceV1Tests(unittest.TestCase):

--- a/tests/test_v2_shadow_acceptance.py
+++ b/tests/test_v2_shadow_acceptance.py
@@ -65,23 +65,6 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
             conversation_context_diagnostics=context,
         )
 
-    def restore_legacy_route_marker(self, count):
-        run_id, diagnostics_json = self.conn.execute(
-            "SELECT run_id, diagnostics_json "
-            "FROM memory_governance_shadow_runs "
-            "ORDER BY created_at DESC, run_id DESC LIMIT 1"
-        ).fetchone()
-        diagnostics = json.loads(diagnostics_json)
-        diagnostics["invalid_invariant_counts"] = {
-            "invalid_route_channel_policy_selected": count,
-        }
-        self.conn.execute(
-            "UPDATE memory_governance_shadow_runs "
-            "SET diagnostics_json=? WHERE run_id=?",
-            (json.dumps(diagnostics, sort_keys=True), run_id),
-        )
-        self.conn.commit()
-
     def test_defaults_are_reporting_only_and_all_shadow_stages_are_disabled(self):
         before_changes = self.conn.total_changes
         before_schema = self.conn.execute(
@@ -207,7 +190,7 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
         ).fetchone()[0]
         self.assertNotIn(subject_hash, encoded)
 
-    def test_legacy_route_policy_label_is_preserved_but_not_a_hard_blocker(self):
+    def test_route_policy_label_is_reclassified_once_and_not_a_hard_blocker(self):
         request = GovernanceRequest(
             guild_id=1,
             subject_user_id=99,
@@ -229,7 +212,6 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
             ),
             "legacy",
         )
-        self.restore_legacy_route_marker(1)
         before_row = self.conn.execute(
             "SELECT excluded_json, diagnostics_json "
             "FROM memory_governance_shadow_runs"
@@ -278,7 +260,7 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
             rendered,
         )
 
-    def test_unmatched_legacy_label_remains_a_hard_blocker(self):
+    def test_persisted_unmatched_route_policy_label_remains_a_hard_blocker(self):
         persist_shadow_diagnostics(
             self.conn,
             GovernanceRequest(
@@ -302,7 +284,18 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
             ),
             "legacy",
         )
-        self.restore_legacy_route_marker(2)
+        stored = self.conn.execute(
+            "SELECT excluded_json, diagnostics_json "
+            "FROM memory_governance_shadow_runs"
+        ).fetchone()
+        self.assertEqual(
+            json.loads(stored[0]),
+            {"invalid_route_channel_policy": 1},
+        )
+        self.assertEqual(
+            json.loads(stored[1])["invalid_invariant_counts"],
+            {"invalid_route_channel_policy_selected": 2},
+        )
 
         snapshot = self.snapshot(
             {"BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true"}


### PR DESCRIPTION
## Why

Follow-up to #347 and its post-merge P1 review. Route-policy diagnostic labels were reclassified once while persisting and then a second time while reading retained evidence. A mixed `2 markers / 1 safe exclusion` row could therefore be reported as zero invalid invariants instead of preserving one hard blocker.

## What changed

- Persist raw aggregate invariant counts.
- Keep the acceptance reader as the single compatibility reclassification layer.
- Preserve the normal `1 marker / 1 safe exclusion` historical classification.
- Preserve a `2 / 1` unmatched remainder as a fail-closed blocker.
- Update the operator contract and remove stale test scaffolding.

No prompt, response, Journal, queue, Source File, memory-selection, live-gate, or database-row behavior changes.

## Validation

- `make check PYTHON=../BNL01-Bot/.venv/bin/python`
- Full suite: 1,075 tests passed
- Focused governance/acceptance suite: 35 tests passed
- `compileall` passed
- `git diff --check` passed
- Independent review: go, no blockers