### PR TITLE
Fix remember directive response routing

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -15767,7 +15767,7 @@ def _detect_request_intent(text: str):
     if "?" in t:
         return True, "question_mark"
     patterns = [
-        r"\bremember these\b", r"\btell me\b", r"\bmake me\b", r"\bwrite\b", r"\bdraft\b",
+        r"^\s*(?:please\s+)?remember\b", r"\btell me\b", r"\bmake me\b", r"\bwrite\b", r"\bdraft\b",
         r"\bgive me\b", r"\bexplain\b", r"\bhelp\b", r"\bfix\b", r"\bsummarize\b",
         r"\bmake a joke\b", r"\btell me a joke\b", r"\babout each\b", r"\bfor each\b",
         r"\bcan you\b", r"\bcould you\b", r"\bplease\b", r"\bshow me\b",

--- a/tests/test_route_memory_governance.py
+++ b/tests/test_route_memory_governance.py
@@ -856,6 +856,42 @@ class LeakGuardTests(unittest.TestCase):
 
 
 class RegressionExamplesTests(unittest.TestCase):
+    def test_singular_remember_directive_is_answered_in_batched_sealed_test(self):
+        text = "remember this number: 8"
+        self.assertEqual(
+            bnl01_bot._detect_request_intent(text),
+            (True, r"^\s*(?:please\s+)?remember\b"),
+        )
+        packet = bnl01_bot._build_active_response_packet(
+            123,
+            [("6 Bit", text, 101)],
+            pending_state=False,
+            guild_id=1,
+            channel_policy="sealed_test",
+        )
+        self.assertEqual(packet["decision"], "answer")
+        self.assertEqual(
+            packet["reason"],
+            r"request_intent:^\s*(?:please\s+)?remember\b",
+        )
+
+    def test_remember_directive_variants_route_without_matching_declarative_chatter(self):
+        for text in (
+            "remember these names",
+            "please remember that number: 8",
+            "remember 8",
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(bnl01_bot._detect_request_intent(text)[0])
+                self.assertEqual(
+                    bnl01_bot._classify_batch_engagement([("6 Bit", text, 101)])[0],
+                    "answer",
+                )
+        self.assertEqual(
+            bnl01_bot._detect_request_intent("I remember this song from Ohio."),
+            (False, "none"),
+        )
+
     def test_lardcode_prompt_not_subject_candidate(self):
         text = "I had to go to another dimension on Friday where they have Lardcode radio. It's like Barcode but all songs are about baking. Is Barcode back this week?"
         self.assertFalse(bnl01_bot.is_valid_subject_candidate_for_memory_or_scouting(text, bnl01_bot.ROUTE_MODE_NORMAL_CHAT, "public_context"))


### PR DESCRIPTION
## What changed

- Treat a direct instruction beginning with `remember` (including `please remember`) as an answer-required request.
- Preserve ordinary declarative chatter such as “I remember this song” as non-request conversation.
- Add focused sealed-test and classifier regression coverage.

## Root cause

The batching request classifier matched `remember these`, but not a singular directive such as `remember this number: 8`. That routed the message into the acknowledgment path, whose empty generic acknowledgment was intentionally suppressed, so BNL sent no response.

## Impact

BNL now generates a normal response to singular remember directives. This does not change memory gates, prompts, Journal behavior, queue behavior, or sealed-test isolation.

## Validation

- Focused routing/continuity/recall/behavior/ledger tests: 189 passed.
- Full bot suite before publication: 1,077 passed.
- Published Git tree matches the frozen tested local commit byte-for-byte.