### PR TITLE
Close remember directive review edge cases

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -12946,20 +12946,15 @@ def extract_user_facts(text: str):
         or re.search(r"\bremember\b[^.!?\n]{0,80}\?", lower, flags=re.IGNORECASE)
     )
 
-    remembered_number = None
+    remembered_number = REMEMBERED_NUMBER_INSTRUCTION_RE.search(content)
     directive_note = None
     directive_patterns = (
         r"\b(?:please\s+)?remember\s+(?:this\s*:|that\s+)([^.!?\n]{3,140})",
         r"\b(?:please\s+)?remember\s+((?:my|i\s+prefer|i\s+like|i\s+want|i\s+need|i\s+am|i'm|[0-9])[^.!?\n]{2,140})",
     )
+    if remembered_number:
+        facts.append(("remembered_number", remembered_number.group(1), 0.9))
     if not interrogative_remember:
-        remembered_number = re.search(
-            r"\b(?:please\s+)?remember\s+(?:(?:that\s+)?(?:(?:this|the)\s+)?number\s*(?::|-|is)?|this\s*:)\s*(\d{1,12})(?!\d)\b",
-            content,
-            flags=re.IGNORECASE,
-        )
-        if remembered_number:
-            facts.append(("remembered_number", remembered_number.group(1), 0.9))
         for pattern in directive_patterns:
             m = re.search(pattern, content, flags=re.IGNORECASE)
             if m:
@@ -13695,14 +13690,22 @@ def _conversation_continuity_user_lines(context: str) -> list[str]:
     return [line.strip() for line in (context or "").splitlines() if re.match(r"(?i)^User/member(?:\s*\([^)]*\))?:", line.strip())]
 
 
-REMEMBERED_NUMBER_INSTRUCTION_RE = re.compile(r"(?i)\bremember\s+(?:this\s+)?number\s*[:\-]?\s*(\d{1,12})\b")
+REMEMBERED_NUMBER_INSTRUCTION_RE = re.compile(
+    r"(?i)(?:^|\s/\s)\s*(?:[,;:\-]\s*)?"
+    r"(?:(?:hey\s*,?\s+)?bnl(?:-01)?\b(?:\s*[,;:\-]\s*|\s+))?"
+    r"(?:please\s+)?remember\s+"
+    r"(?:(?:(?:that\s+(?:the\s+)?|(?:this|the)\s+)?number)\s*(?::|-|is)?\s*|this\s*:\s*)?"
+    r"(\d{1,12})(?!\d)(?:\s*(?:,\s*)?(?:please|for\s+(?:me|later)))?"
+    r"(?=\s*[.!]?(?:\s*/\s|\s*$))"
+)
 
 
 def resolve_latest_remembered_number_from_conversation_context(prompt_or_context: str) -> str:
     context = _extract_conversation_continuity_context(prompt_or_context) or (prompt_or_context or "")
     latest = ""
     for line in _conversation_continuity_user_lines(context):
-        match = REMEMBERED_NUMBER_INSTRUCTION_RE.search(line)
+        user_text = re.sub(r"(?i)^User/member(?:\s*\([^)]*\))?:\s*", "", line)
+        match = REMEMBERED_NUMBER_INSTRUCTION_RE.search(user_text)
         if match:
             latest = match.group(1)
     return latest
@@ -15767,7 +15770,7 @@ def _detect_request_intent(text: str):
     if "?" in t:
         return True, "question_mark"
     patterns = [
-        r"^\s*(?:please\s+)?remember\b", r"\btell me\b", r"\bmake me\b", r"\bwrite\b", r"\bdraft\b",
+        r"(?:^|\s/\s)\s*(?:please\s+)?remember\b", r"\btell me\b", r"\bmake me\b", r"\bwrite\b", r"\bdraft\b",
         r"\bgive me\b", r"\bexplain\b", r"\bhelp\b", r"\bfix\b", r"\bsummarize\b",
         r"\bmake a joke\b", r"\btell me a joke\b", r"\babout each\b", r"\bfor each\b",
         r"\bcan you\b", r"\bcould you\b", r"\bplease\b", r"\bshow me\b",

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -42,7 +42,15 @@ REVIEW_ONLY_LIFECYCLE = "review_only"
 RESOLVED_LIFECYCLE = "resolved"
 REJECTED_LIFECYCLE = "rejected"
 
-_NUMBER_REMEMBER_RE = re.compile(r"\bremember\b[^\n]{0,80}?\bnumber\b\D+(\d{1,12})(?!\d)", re.I)
+_NUMBER_REMEMBER_RE = re.compile(
+    r"(?:^|\s/\s)\s*(?:[,;:\-]\s*)?"
+    r"(?:(?:hey\s*,?\s+)?bnl(?:-01)?\b(?:\s*[,;:\-]\s*|\s+))?"
+    r"(?:please\s+)?remember\s+"
+    r"(?:(?:(?:that\s+(?:the\s+)?|(?:this|the)\s+)?number)\s*(?::|-|is)?\s*|this\s*:\s*)?"
+    r"(\d{1,12})(?!\d)(?:\s*(?:,\s*)?(?:please|for\s+(?:me|later)))?"
+    r"(?=\s*[.!]?(?:\s*/\s|\s*$))",
+    re.I,
+)
 _REPLACE_NUMBER_RE = re.compile(r"\b(?:replace|supersede)\s+(\d{1,12})\s+\bwith\b\s+(\d{1,12})(?!\d)", re.I)
 _CORRECTION_NUMBER_RE = re.compile(r"\b(?:correction|actually|correcting|i meant)\b[^\n]{0,80}?\b(?:number\s+)?(?:is|was)?\s*(\d{1,12})\s*,?\s+not\s+(\d{1,12})(?!\d)", re.I)
 @dataclass(frozen=True)

--- a/tests/test_memory_ledger_v1.py
+++ b/tests/test_memory_ledger_v1.py
@@ -70,6 +70,35 @@ class MemoryLedgerV1Tests(unittest.TestCase):
         values = [r[0] for r in self.conn.execute("SELECT normalized_value FROM memory_ledger_entries ORDER BY source_sequence").fetchall()]
         self.assertEqual(values, ["8", "123456789012"])
 
+    def test_bare_remember_number_is_durable_but_declarative_and_questions_are_not(self):
+        ledger.shadow_conversation_row(self.conn, row_id=22, user_id=7, user_name="Crow", guild_id=1, role="user", content="remember 8", channel_policy="sealed_test")
+        ledger.shadow_conversation_row(self.conn, row_id=23, user_id=7, user_name="Crow", guild_id=1, role="user", content="do you remember 9?", channel_policy="sealed_test")
+        ledger.shadow_conversation_row(self.conn, row_id=24, user_id=7, user_name="Crow", guild_id=1, role="user", content="I remember 10 people", channel_policy="sealed_test")
+        ledger.shadow_conversation_row(self.conn, row_id=25, user_id=7, user_name="Crow", guild_id=1, role="user", content="I do not remember 11", channel_policy="sealed_test")
+        ledger.shadow_conversation_row(self.conn, row_id=26, user_id=7, user_name="Crow", guild_id=1, role="user", content="what's up? / remember 12", channel_policy="sealed_test")
+        ledger.shadow_conversation_row(self.conn, row_id=27, user_id=7, user_name="Crow", guild_id=1, role="user", content="remember 13 / what's up?", channel_policy="sealed_test")
+        ledger.shadow_conversation_row(self.conn, row_id=28, user_id=7, user_name="Crow", guild_id=1, role="user", content="hey BNL, please remember the number 14", channel_policy="sealed_test")
+        ledger.shadow_conversation_row(self.conn, row_id=29, user_id=7, user_name="Crow", guild_id=1, role="user", content="remember 15 for me", channel_policy="sealed_test")
+        ledger.shadow_conversation_row(self.conn, row_id=30, user_id=7, user_name="Crow", guild_id=1, role="user", content=", remember 16", channel_policy="sealed_test")
+        ledger.shadow_conversation_row(self.conn, row_id=31, user_id=7, user_name="Crow", guild_id=1, role="user", content="Hey, BNL, remember 17", channel_policy="sealed_test")
+        ledger.shadow_conversation_row(self.conn, row_id=32, user_id=7, user_name="Crow", guild_id=1, role="user", content="bnlremember 18", channel_policy="sealed_test")
+        ledger.shadow_conversation_row(self.conn, row_id=33, user_id=7, user_name="Crow", guild_id=1, role="user", content="bnlplease remember 19", channel_policy="sealed_test")
+        rows = self.conn.execute(
+            "SELECT predicate_key, normalized_value FROM memory_ledger_entries ORDER BY source_sequence"
+        ).fetchall()
+        self.assertEqual(rows[0], ("remembered_number", "8"))
+        self.assertEqual(rows[1], ("conversation", "do you remember 9?"))
+        self.assertEqual(rows[2], ("conversation", "I remember 10 people"))
+        self.assertEqual(rows[3], ("conversation", "I do not remember 11"))
+        self.assertEqual(rows[4], ("remembered_number", "12"))
+        self.assertEqual(rows[5], ("remembered_number", "13"))
+        self.assertEqual(rows[6], ("remembered_number", "14"))
+        self.assertEqual(rows[7], ("remembered_number", "15"))
+        self.assertEqual(rows[8], ("remembered_number", "16"))
+        self.assertEqual(rows[9], ("remembered_number", "17"))
+        self.assertEqual(rows[10], ("conversation", "bnlremember 18"))
+        self.assertEqual(rows[11], ("conversation", "bnlplease remember 19"))
+
     def test_explicit_unique_correction_links_and_ambiguous_does_not(self):
         ledger.shadow_conversation_row(self.conn, row_id=30, user_id=7, user_name="Crow", guild_id=1, role="user", content="remember this number: 731946", channel_policy="sealed_test")
         linked = ledger.shadow_conversation_row(self.conn, row_id=31, user_id=7, user_name="Crow", guild_id=1, role="user", content="Correction: the number is 284517, not 731946", channel_policy="sealed_test")

--- a/tests/test_route_memory_governance.py
+++ b/tests/test_route_memory_governance.py
@@ -860,7 +860,7 @@ class RegressionExamplesTests(unittest.TestCase):
         text = "remember this number: 8"
         self.assertEqual(
             bnl01_bot._detect_request_intent(text),
-            (True, r"^\s*(?:please\s+)?remember\b"),
+            (True, r"(?:^|\s/\s)\s*(?:please\s+)?remember\b"),
         )
         packet = bnl01_bot._build_active_response_packet(
             123,
@@ -872,7 +872,7 @@ class RegressionExamplesTests(unittest.TestCase):
         self.assertEqual(packet["decision"], "answer")
         self.assertEqual(
             packet["reason"],
-            r"request_intent:^\s*(?:please\s+)?remember\b",
+            r"request_intent:(?:^|\s/\s)\s*(?:please\s+)?remember\b",
         )
 
     def test_remember_directive_variants_route_without_matching_declarative_chatter(self):
@@ -891,6 +891,109 @@ class RegressionExamplesTests(unittest.TestCase):
             bnl01_bot._detect_request_intent("I remember this song from Ohio."),
             (False, "none"),
         )
+
+    def test_remember_directive_in_second_collapsed_fragment_is_answered(self):
+        text = "okay / remember this number: 8"
+        self.assertTrue(bnl01_bot._detect_request_intent(text)[0])
+        collapsed = bnl01_bot._collapse_consecutive_batch_fragments(
+            [("6 Bit", "okay", 101), ("6 Bit", "remember this number: 8", 101)]
+        )
+        self.assertEqual(collapsed[0][1], text)
+        self.assertEqual(
+            bnl01_bot._classify_batch_engagement(collapsed)[0],
+            "answer",
+        )
+
+    def test_bare_remember_number_is_backed_by_fact_and_context_extractors(self):
+        self.assertIn(
+            ("remembered_number", "8", 0.9),
+            bnl01_bot.extract_user_facts("remember 8"),
+        )
+        context = (
+            "Conversation continuity (bounded; continuity-only, not canon/current-state evidence):\n"
+            "User/member: remember 8\n"
+            "Room-first context rules:\n"
+        )
+        self.assertEqual(
+            bnl01_bot.resolve_latest_remembered_number_from_conversation_context(context),
+            "8",
+        )
+
+    def test_bare_remember_number_extractors_reject_declarative_and_interrogative_uses(self):
+        for text in (
+            "I remember 8 people",
+            "I do not remember 8",
+            "do you remember 8",
+            "do you remember 8?",
+            "remember 8?",
+        ):
+            self.assertNotIn("remembered_number", {fact[0] for fact in bnl01_bot.extract_user_facts(text)}, text)
+            context = (
+                "Conversation continuity (bounded; continuity-only, not canon/current-state evidence):\n"
+                f"User/member: {text}\n"
+                "Room-first context rules:\n"
+            )
+            self.assertEqual(
+                bnl01_bot.resolve_latest_remembered_number_from_conversation_context(context),
+                "",
+                text,
+            )
+
+    def test_bare_remember_number_extractors_accept_supported_batch_fragment(self):
+        for text in (
+            "what's up? / remember 8",
+            "remember 8 / what's up?",
+            "BNL, remember this number: 8",
+            "BNL remember 8",
+            "hey BNL, please remember the number 8",
+            "Hey, BNL, remember 8",
+            "remember this number: 8, please",
+            "remember 8 for me",
+        ):
+            self.assertIn(
+                ("remembered_number", "8", 0.9),
+                bnl01_bot.extract_user_facts(text),
+                text,
+            )
+            context = (
+                "Conversation continuity (bounded; continuity-only, not canon/current-state evidence):\n"
+                f"User/member: {text}\n"
+                "Room-first context rules:\n"
+            )
+            self.assertEqual(
+                bnl01_bot.resolve_latest_remembered_number_from_conversation_context(context),
+                "8",
+                text,
+            )
+
+    def test_removed_bot_mention_punctuation_keeps_remember_directive_extractable(self):
+        bot = SimpleNamespace(id=999, display_name="BNL-01")
+        message = SimpleNamespace(
+            content="<@999>, remember this number: 8",
+            mentions=[bot],
+            raw_mentions=[999],
+            guild=SimpleNamespace(get_member=lambda user_id: bot if user_id == 999 else None),
+            role_mentions=[],
+            channel_mentions=[],
+        )
+        resolved = bnl01_bot.resolve_discord_user_mentions_for_conversation(
+            message,
+            message.content,
+            bot_user_id=999,
+            remove_bot_mention=True,
+        )
+        self.assertEqual(resolved, ", remember this number: 8")
+        self.assertIn(("remembered_number", "8", 0.9), bnl01_bot.extract_user_facts(resolved))
+
+    def test_concatenated_bnl_prefixes_are_not_remember_directives(self):
+        for text in ("bnlremember 8", "bnlplease remember 8", "hey BNLremember 8"):
+            self.assertNotIn("remembered_number", {fact[0] for fact in bnl01_bot.extract_user_facts(text)}, text)
+            context = (
+                "Conversation continuity (bounded; continuity-only, not canon/current-state evidence):\n"
+                f"User/member: {text}\n"
+                "Room-first context rules:\n"
+            )
+            self.assertEqual(bnl01_bot.resolve_latest_remembered_number_from_conversation_context(context), "", text)
 
     def test_lardcode_prompt_not_subject_candidate(self):
         text = "I had to go to another dimension on Friday where they have Lardcode radio. It's like Barcode but all songs are about baking. Is Barcode back this week?"


### PR DESCRIPTION
## What changed
- recognize singular `remember` directives in later collapsed fragments
- keep bare-number directives aligned across request routing, fact extraction, conversation continuity, and the shadow ledger
- preserve addressed, qualified, and normalized bot-mention forms
- reject declarative, interrogative, negated, and concatenated-prefix false positives

## Why
PR #351 fixed the production no-response case, but two late review threads identified uncovered batch and syntax edges. This follow-up closes those edges without changing prompts, channel policy, memory gates, or live authority.

## Validation
- 188 focused routing, continuity, ledger, media-grounding, and explicit-recall tests passed
- Python compilation passed
- `git diff --check` passed
- independent adversarial review: no blockers

Follow-up to #351 and its late inline review findings.