### PR TITLE
Preserve exact Source File identity through refresh

### DIFF
--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -1,8 +1,10 @@
 """Review-only Source File enrichment helpers for BNL.
 
 This module builds structured case-file notes from approved local BNL stores and
-optionally posts them through the existing review-only dossier recommendation
-endpoint. It never publishes, promotes, merges, or overwrites Source Files.
+optionally posts them through the existing review-only dossier endpoints. When
+the protected read model explicitly identifies a public-dossier-only target, it
+may create that dossier's internal update workspace before attaching notes. It
+never publishes, promotes, merges identities, or changes public dossier copy.
 """
 
 from __future__ import annotations
@@ -11,8 +13,13 @@ import hashlib
 import inspect
 import json
 import logging
+import os
 import re
+import socket
 import sqlite3
+import urllib.error
+import urllib.parse
+import urllib.request
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from typing import Any, Callable
@@ -23,7 +30,7 @@ from bnl_entity_activity_summary import build_entity_activity_summary, refresh_e
 from bnl_entity_evidence import _website_safe_payload_text
 from bnl_entity_intelligence import build_entity_intelligence_profile, resolve_entity_context_for_surface, safe_text as _entity_safe_text
 from bnl_evidence_ownership import classify_evidence_ownership, subject_owned_text_fragments
-from bnl_source_file_lookup import lookup_source_file
+from bnl_source_file_lookup import get_source_file_read_url, lookup_source_file
 from bnl_source_refresh_context import refresh_generation_context
 from bnl_subject_memory_resolver import build_subject_analyst_read, normalize_source_file_resolution_context, resolve_subject_memory, _review_guidance
 
@@ -37,6 +44,7 @@ SITE_RAW_PROVENANCE_JSON_LIMIT = 20000
 SITE_RAW_PROVENANCE_JSON_TARGET = 18000
 SITE_LIST_ITEM_LIMIT = 500
 SITE_LIST_MAX_ITEMS = 25
+SOURCE_FILE_TARGET_SETUP_TIMEOUT_SECONDS = 8
 COMPACT_RECOMMENDATION_LIST_MAX_ITEMS = 8
 COMPACT_RECOMMENDATION_LIST_ITEM_LIMIT = 220
 COMPACT_RECOMMENDATION_TEXT_FIELD_LIMITS = {
@@ -1113,6 +1121,108 @@ def _source_file_obj(lookup_result: dict[str, Any]) -> dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
+def _lookup_data(lookup_result: dict[str, Any]) -> dict[str, Any]:
+    return lookup_result.get("data") if isinstance(lookup_result.get("data"), dict) else {}
+
+
+def _has_public_dossier_only_label(lookup_result: dict[str, Any]) -> bool:
+    """Recognize the site's non-attachable sentinel without trusting its contract."""
+
+    data = _lookup_data(lookup_result)
+    labels = {
+        str(lookup_result.get("matchKind") or "").strip().lower(),
+        str(data.get("matchKind") or "").strip().lower(),
+    }
+    return "public_dossier_only" in labels
+
+
+def _is_public_dossier_only_lookup(lookup_result: dict[str, Any]) -> bool:
+    data = _lookup_data(lookup_result)
+    return bool(
+        lookup_result.get("ok")
+        and lookup_result.get("found")
+        and _has_public_dossier_only_label(lookup_result)
+        and data.get("workflowLane") == "public_dossier_update_target"
+        and data.get("recommendedAction") == "create_existing_dossier_update"
+        and "sourceFile" in data
+        and data.get("sourceFile") is None
+        and str(data.get("targetDossierId") or "").strip()
+    )
+
+
+def create_existing_dossier_update_target(
+    lookup_result: dict[str, Any],
+    requested_subject: str,
+    environ: dict[str, str] | None = None,
+    opener=None,
+) -> dict[str, Any]:
+    """Create the site's protected internal update target for an exact public dossier."""
+
+    data = _lookup_data(lookup_result)
+    if not _is_public_dossier_only_lookup(lookup_result):
+        return {"ok": False, "error": "public_dossier_only_contract_not_confirmed", "retryable": False}
+    target_dossier_id = str(data.get("targetDossierId") or "").strip()[:200]
+    env = environ if environ is not None else os.environ
+    token = (env.get("BNL_SOURCE_FILE_READ_TOKEN") or "").strip()
+    configured_url = get_source_file_read_url(env)
+    parsed_url = urllib.parse.urlsplit(configured_url)
+    endpoint = urllib.parse.urlunsplit((parsed_url.scheme, parsed_url.netloc, parsed_url.path, "", ""))
+    if not token or parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc or not endpoint:
+        return {"ok": False, "error": "source_file_target_setup_not_configured", "retryable": False}
+    payload = {
+        "action": "create_existing_dossier_update",
+        "targetDossierId": target_dossier_id,
+        "requestedSubject": _safe_text(requested_subject, 200),
+    }
+    request = urllib.request.Request(
+        endpoint,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Accept": "application/json", "Content-Type": "application/json", "x-bnl-source-file-read-token": token},
+        method="POST",
+    )
+    urlopen = opener.open if opener is not None else urllib.request.urlopen
+    try:
+        with urlopen(request, timeout=SOURCE_FILE_TARGET_SETUP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", None) or response.getcode()
+            raw = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        status = int(exc.code or 0)
+        logging.warning("source_file_target_setup_failed status=%s", status or "unknown")
+        return {"ok": False, "error": f"source_file_target_setup_http_{status or 'error'}", "status": status, "retryable": status >= 500}
+    except (urllib.error.URLError, TimeoutError, socket.timeout):
+        logging.warning("source_file_target_setup_failed reason=network_or_timeout")
+        return {"ok": False, "error": "source_file_target_setup_network_or_timeout", "retryable": True}
+    except Exception:
+        logging.warning("source_file_target_setup_failed reason=unexpected_error")
+        return {"ok": False, "error": "source_file_target_setup_unexpected_error", "retryable": True}
+    try:
+        response_data = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        return {"ok": False, "error": "source_file_target_setup_invalid_json", "status": status, "retryable": True}
+    candidate = response_data.get("candidate") if isinstance(response_data.get("candidate"), dict) else {}
+    candidate_match = candidate.get("existingDossierMatch") if isinstance(candidate.get("existingDossierMatch"), dict) else {}
+    candidate_id = str(candidate.get("id") or "").strip()[:200]
+    contract_ok = bool(
+        200 <= int(status or 0) < 300
+        and response_data.get("ok") is True
+        and response_data.get("mutation") == "internal_workflow_only"
+        and response_data.get("publishesPublicDossier") is False
+        and response_data.get("publicDossierMutated") is False
+        and response_data.get("workflowLane") == "existing_dossier_update"
+        and response_data.get("sourceFileActive") is False
+        and response_data.get("existingDossierUpdateLane") is True
+        and str(response_data.get("targetDossierId") or "") == target_dossier_id
+        and candidate_id
+        and candidate.get("status") == "existing_dossier_update"
+        and str(candidate_match.get("id") or "") == target_dossier_id
+    )
+    if not contract_ok:
+        logging.warning("source_file_target_setup_failed reason=invalid_response_contract")
+        return {"ok": False, "error": "source_file_target_setup_invalid_response", "status": status, "retryable": False}
+    logging.info("source_file_target_setup_succeeded target_type=existing_dossier_update")
+    return {"ok": True, "candidateId": candidate_id, "targetDossierId": target_dossier_id, "status": status}
+
+
 def _first(obj: dict[str, Any], keys: tuple[str, ...]) -> Any:
     for key in keys:
         if obj.get(key) not in (None, "", []):
@@ -1192,6 +1302,8 @@ def classify_source_match(lookup_result: dict[str, Any]) -> tuple[str, str, dict
         return "error", _safe_text(lookup_result.get("error") or "lookup failed", 140), {}
     if not lookup_result.get("found"):
         return "none", "No active Source File, Candidate Intake item, or existing dossier target was confirmed.", {}
+    if _has_public_dossier_only_label(lookup_result):
+        return "public_dossier_only", "An exact public dossier exists, but its protected internal update target must be created before enrichment can attach.", {}
     obj = _source_file_obj(lookup_result)
     data = lookup_result.get("data") if isinstance(lookup_result.get("data"), dict) else {}
     raw = " ".join(str(x or "") for x in (
@@ -6003,7 +6115,7 @@ def build_enrichment_recommendation_payload(packet: dict[str, Any], *, environ: 
     subject = str(packet.get("subject") or "").strip()
     match_kind = str(packet.get("matchKind") or "none")
     source_file = packet.get("sourceFile") if isinstance(packet.get("sourceFile"), dict) else {}
-    target_candidate_id = _first(source_file, ("candidateId", "targetCandidateId", "id")) if match_kind in {"candidate_intake", "active_source_file"} else None
+    target_candidate_id = _first(source_file, ("candidateId", "targetCandidateId", "id")) if match_kind in {"candidate_intake", "active_source_file", "existing_dossier_update"} else None
     target_dossier_id = _first(source_file, ("targetDossierId", "dossierId", "publicDossierId")) if match_kind == "existing_dossier_update" else None
     _validate_source_payload_fields(packet)
     evidence = build_compact_enrichment_evidence_summary(packet)
@@ -6094,6 +6206,27 @@ def _call_site_sender(sender: Callable[..., dict[str, Any]], payload: dict[str, 
     return sender(payload, **kwargs) if kwargs else sender(payload)
 
 
+def _target_setup_result(subject: str, *, dry_run: bool, status: str, error: str = "") -> dict[str, Any]:
+    return {
+        "ok": not bool(error),
+        "dryRun": dry_run,
+        "subject": _safe_text(subject, 90),
+        "status": status,
+        "matchKind": "public_dossier_only",
+        "matchNote": "A protected Existing Dossier Update target is required before enrichment can attach.",
+        "recommendedAction": "create_existing_dossier_update",
+        "resolutionMode": "public_dossier_only",
+        "sections": {},
+        "sourceCounts": {},
+        "warningCounts": {},
+        "sourceTypes": [],
+        "warnings": [error] if error else [],
+        "sent": False,
+        "sendResult": {"ok": False, "error": error} if error else {},
+        "runTime": datetime.now(timezone.utc).isoformat(),
+    }
+
+
 def run_source_file_enrichment(
     db_path: str,
     guild_id: int | None,
@@ -6110,6 +6243,7 @@ def run_source_file_enrichment(
     force: bool = False,
     diagnostics: bool = False,
     callback_base_url: str | None = None,
+    workspace_creator: Callable[[dict[str, Any], str, dict[str, str] | None], dict[str, Any]] = create_existing_dossier_update_target,
 ) -> dict[str, Any]:
     canonical_key = lookup_key if lookup_key in {"subject", "alias", "candidateId", "normalizedName"} else "subject"
     target_value = (lookup_value if lookup_value is not None else subject) or ""
@@ -6117,6 +6251,45 @@ def run_source_file_enrichment(
     lookup_result = lookup_func(query)
     match_kind, match_note, source_file = classify_source_match(lookup_result)
     resolution_mode = {"subject": "exact", "candidateId": "candidateId", "alias": "alias", "normalizedName": "exact"}.get(canonical_key, "exact")
+
+    if match_kind == "public_dossier_only":
+        if not _is_public_dossier_only_lookup(lookup_result):
+            return _target_setup_result(
+                target_value,
+                dry_run=dry_run,
+                status="target_setup_failed",
+                error="public_dossier_only_contract_not_confirmed",
+            )
+        if dry_run:
+            return _target_setup_result(target_value, dry_run=True, status="target_setup_required")
+        setup_result = workspace_creator(lookup_result, str(target_value), environ)
+        if not setup_result.get("ok"):
+            return _target_setup_result(
+                target_value,
+                dry_run=False,
+                status="target_setup_failed",
+                error=_safe_text(setup_result.get("error") or "source_file_target_setup_failed", 180),
+            )
+        candidate_id = str(setup_result.get("candidateId") or "").strip()
+        canonical_query = {"lookupKey": "candidateId", "lookupValue": candidate_id, "candidateId": candidate_id}
+        canonical_lookup = lookup_func(canonical_query)
+        canonical_match_kind, canonical_match_note, canonical_source_file = classify_source_match(canonical_lookup)
+        canonical_data = _lookup_data(canonical_lookup)
+        canonical_source_id = str(_first(canonical_source_file, ("candidateId", "candidate_id", "id")) or "").strip()
+        if canonical_match_kind != "existing_dossier_update" or canonical_data.get("workflowLane") != "existing_dossier_update" or not candidate_id or canonical_source_id != candidate_id:
+            return _target_setup_result(
+                target_value,
+                dry_run=False,
+                status="target_setup_lookup_failed",
+                error="source_file_target_setup_canonical_lookup_mismatch",
+            )
+        lookup_result = canonical_lookup
+        match_kind = canonical_match_kind
+        match_note = canonical_match_note
+        source_file = canonical_source_file
+        canonical_key = "candidateId"
+        target_value = candidate_id
+        resolution_mode = "candidateId"
 
     if match_kind == "none":
         possible_matches = _possible_match_items(lookup_result)
@@ -6345,6 +6518,14 @@ def format_source_enrichment_response(result: dict[str, Any]) -> str:
     if result.get("status") == "no_target":
         return (f"Source enrichment: No confirmed target found for “{subject}.”\n"
                 "Next: create/promote a Candidate Intake item first or run candidate bridge/discovery. No notes were sent.")
+    if result.get("status") == "target_setup_required":
+        return (
+            f"Dry run Source File enrichment for “{subject}.”\n"
+            "An exact public dossier exists, but no protected Existing Dossier Update workspace exists yet.\n"
+            "A live refresh would create that internal review-only target, re-check its candidateId, and only then attach notes. No notes were sent."
+        )
+    if result.get("status") in {"target_setup_failed", "target_setup_lookup_failed"}:
+        return f"Source enrichment target setup failed safely for “{subject}”: {_safe_text((result.get('sendResult') or {}).get('error') or result.get('matchNote'), 180)} No notes were sent."
     if result.get("status") == "lookup_failed":
         return f"Source enrichment lookup failed for “{subject}”: {_safe_text(result.get('matchNote'), 140)}"
     sections = result.get("sections") or {}

--- a/bnl_source_file_refresh.py
+++ b/bnl_source_file_refresh.py
@@ -122,10 +122,13 @@ def ensure_source_file_refresh_schema(conn: sqlite3.Connection) -> None:
             attempts INTEGER NOT NULL DEFAULT 0,
             last_error TEXT,
             refresh_mode TEXT NOT NULL DEFAULT 'automatic',
-            created_by TEXT
+            created_by TEXT,
+            candidate_id TEXT
         )
         """
     )
+    if "candidate_id" not in _columns(conn, QUEUE_TABLE):
+        conn.execute(f"ALTER TABLE {QUEUE_TABLE} ADD COLUMN candidate_id TEXT")
     conn.execute(
         f"""
         CREATE TABLE IF NOT EXISTS {STATE_TABLE} (
@@ -141,11 +144,14 @@ def ensure_source_file_refresh_schema(conn: sqlite3.Connection) -> None:
             last_failure_at TEXT,
             last_error TEXT,
             cooldown_until TEXT,
+            candidate_id TEXT,
             updated_at TEXT NOT NULL,
             PRIMARY KEY (guild_id, subject_key)
         )
         """
     )
+    if "candidate_id" not in _columns(conn, STATE_TABLE):
+        conn.execute(f"ALTER TABLE {STATE_TABLE} ADD COLUMN candidate_id TEXT")
     conn.execute(f"CREATE INDEX IF NOT EXISTS idx_source_refresh_queue_status ON {QUEUE_TABLE} (status, not_before_at, priority, queued_at)")
     conn.execute(f"CREATE INDEX IF NOT EXISTS idx_source_refresh_queue_subject ON {QUEUE_TABLE} (guild_id, subject_key, status)")
     conn.execute(f"CREATE INDEX IF NOT EXISTS idx_source_refresh_state_subject ON {STATE_TABLE} (guild_id, subject_key)")
@@ -225,37 +231,55 @@ def mark_subject_dirty_for_evidence(db_path: str, *, guild_id: int | None, subje
     )
 
 
-def enqueue_source_file_refresh(db_path: str, *, guild_id: int | None, subject_name: str, reason: str, evidence_source: str = "unknown", priority: int = 50, refresh_mode: str = "automatic", created_by: str = "system", not_before_at: str | None = None, evidence_count: int = 1) -> dict[str, Any]:
+def _safe_candidate_id(value: Any, limit: int = 200) -> str:
+    """Bound an opaque site identifier without rewriting its exact contents."""
+
+    return str(value or "").strip()[:limit]
+
+
+def enqueue_source_file_refresh(db_path: str, *, guild_id: int | None, subject_name: str, reason: str, evidence_source: str = "unknown", priority: int = 50, refresh_mode: str = "automatic", created_by: str = "system", not_before_at: str | None = None, evidence_count: int = 1, candidate_id: str | None = None) -> dict[str, Any]:
     subject = _safe_text(subject_name, 90)
     skey = source_refresh_subject_key(subject)
     mode = refresh_mode if refresh_mode in VALID_REFRESH_MODES else "automatic"
+    canonical_candidate_id = _safe_candidate_id(candidate_id) or None
     now = utc_now()
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     try:
         ensure_source_file_refresh_schema(conn)
-        existing = conn.execute(
-            f"SELECT * FROM {QUEUE_TABLE} WHERE (guild_id IS ? OR guild_id=?) AND subject_key=? AND status IN ('queued','deferred','cooldown','failed','running') ORDER BY id DESC LIMIT 1",
-            (guild_id, guild_id, skey),
-        ).fetchone()
+        if canonical_candidate_id:
+            existing = conn.execute(
+                f"SELECT * FROM {QUEUE_TABLE} WHERE (guild_id IS ? OR guild_id=?) AND subject_key=? AND candidate_id=? AND status IN ('queued','deferred','cooldown','failed','running') ORDER BY id DESC LIMIT 1",
+                (guild_id, guild_id, skey, canonical_candidate_id),
+            ).fetchone()
+            if not existing:
+                existing = conn.execute(
+                    f"SELECT * FROM {QUEUE_TABLE} WHERE (guild_id IS ? OR guild_id=?) AND subject_key=? AND (candidate_id IS NULL OR TRIM(candidate_id)='') AND status IN ('queued','deferred','cooldown','failed') ORDER BY id DESC LIMIT 1",
+                    (guild_id, guild_id, skey),
+                ).fetchone()
+        else:
+            existing = conn.execute(
+                f"SELECT * FROM {QUEUE_TABLE} WHERE (guild_id IS ? OR guild_id=?) AND subject_key=? AND (candidate_id IS NULL OR TRIM(candidate_id)='') AND status IN ('queued','deferred','cooldown','failed','running') ORDER BY id DESC LIMIT 1",
+                (guild_id, guild_id, skey),
+            ).fetchone()
         if existing:
             new_count = int(existing["evidence_count"] or 0) + max(1, int(evidence_count or 1))
             new_priority = max(int(existing["priority"] or 0), int(priority or 0))
             merged_reason = _safe_text(f"{existing['reason']}; {reason}", 260)
             status = "queued" if existing["status"] in {"failed", "deferred", "cooldown"} else existing["status"]
             conn.execute(
-                f"UPDATE {QUEUE_TABLE} SET reason=?, evidence_source=?, evidence_count=?, priority=?, status=?, updated_at=?, not_before_at=COALESCE(?, not_before_at), refresh_mode=?, created_by=? WHERE id=?",
-                (merged_reason, _safe_text(evidence_source, 80), new_count, new_priority, status, now, not_before_at, mode, _safe_text(created_by, 80), existing["id"]),
+                f"UPDATE {QUEUE_TABLE} SET reason=?, evidence_source=?, evidence_count=?, priority=?, status=?, updated_at=?, not_before_at=COALESCE(?, not_before_at), refresh_mode=?, created_by=?, candidate_id=COALESCE(?, candidate_id) WHERE id=?",
+                (merged_reason, _safe_text(evidence_source, 80), new_count, new_priority, status, now, not_before_at, mode, _safe_text(created_by, 80), canonical_candidate_id, existing["id"]),
             )
             conn.commit()
             logging.info("source_refresh_queued subject_key=%s priority=%s", skey, new_priority)
             return {"ok": True, "queued": True, "deduped": True, "id": existing["id"], "subject_key": skey, "status": status, "evidence_count": new_count}
         cur = conn.execute(
             f"""
-            INSERT INTO {QUEUE_TABLE} (guild_id, subject_key, subject_name, reason, evidence_source, evidence_count, priority, status, queued_at, updated_at, not_before_at, attempts, refresh_mode, created_by)
-            VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, 0, ?, ?)
+            INSERT INTO {QUEUE_TABLE} (guild_id, subject_key, subject_name, reason, evidence_source, evidence_count, priority, status, queued_at, updated_at, not_before_at, attempts, refresh_mode, created_by, candidate_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, 0, ?, ?, ?)
             """,
-            (guild_id, skey, subject, _safe_text(reason, 260), _safe_text(evidence_source, 80), max(1, int(evidence_count or 1)), int(priority or 50), now, now, not_before_at, mode, _safe_text(created_by, 80)),
+            (guild_id, skey, subject, _safe_text(reason, 260), _safe_text(evidence_source, 80), max(1, int(evidence_count or 1)), int(priority or 50), now, now, not_before_at, mode, _safe_text(created_by, 80), canonical_candidate_id),
         )
         conn.commit()
         logging.info("source_refresh_queued subject_key=%s priority=%s", skey, int(priority or 50))
@@ -364,7 +388,7 @@ def is_source_refresh_now_token_valid(provided_token: str | None, *, environ: di
 
 
 def _site_refresh_lookup_parts(site_request: dict[str, Any]) -> tuple[str, str]:
-    candidate_id = _safe_text(site_request.get("candidateId") or site_request.get("candidate_id") or "", 120)
+    candidate_id = _safe_candidate_id(site_request.get("candidateId") or site_request.get("candidate_id") or "")
     subject = _site_refresh_subject_name(site_request)
     skey = _site_refresh_subject_key(site_request)
     if candidate_id:
@@ -399,8 +423,24 @@ def _mark_site_request_terminal(request_id: str, item: dict[str, Any], *, enviro
     return result
 
 
-def _state_has_current_success(state: dict[str, Any] | sqlite3.Row | None) -> bool:
+def _state_candidate_id(state: dict[str, Any] | sqlite3.Row | None) -> str:
     if not state:
+        return ""
+    if isinstance(state, sqlite3.Row):
+        value = state["candidate_id"] if "candidate_id" in state.keys() else None
+    else:
+        value = state.get("candidate_id")
+    return _safe_candidate_id(value)
+
+
+def _state_identity_matches(state: dict[str, Any] | sqlite3.Row | None, candidate_id: str | None) -> bool:
+    return _state_candidate_id(state) == _safe_candidate_id(candidate_id)
+
+
+def _state_has_current_success(state: dict[str, Any] | sqlite3.Row | None, *, candidate_id: str | None = None) -> bool:
+    if not state:
+        return False
+    if not _state_identity_matches(state, candidate_id):
         return False
     if isinstance(state, sqlite3.Row):
         status_value = state["last_refresh_status"]
@@ -492,8 +532,9 @@ def _lookup_source_file_report_missing(
     *,
     lookup_func: Callable[[dict[str, str]], dict[str, Any]],
 ) -> bool:
+    lookup_key, lookup_value = _queue_refresh_lookup_parts(row)
     try:
-        lookup_result = lookup_func({"lookupKey": "subject", "lookupValue": row["subject_name"], "subject": row["subject_name"]})
+        lookup_result = lookup_func({"lookupKey": lookup_key, "lookupValue": lookup_value, lookup_key: lookup_value})
     except Exception as exc:
         logging.warning("source_case_report_backfill_failed subject_key=%s error=%s", row["subject_key"], _safe_text(exc, 160))
         return False
@@ -501,6 +542,13 @@ def _lookup_source_file_report_missing(
     if missing:
         logging.info("source_case_report_missing subject_key=%s reason=%s", row["subject_key"], CASE_REPORT_MISSING_REASON)
     return missing
+
+
+def _queue_refresh_lookup_parts(row: sqlite3.Row) -> tuple[str, str]:
+    candidate_id = _safe_candidate_id(row["candidate_id"] if "candidate_id" in row.keys() else "")
+    if candidate_id:
+        return "candidateId", candidate_id
+    return "subject", str(row["subject_name"])
 
 
 def site_request_requires_case_report_backfill(site_request: dict[str, Any] | None) -> bool:
@@ -567,13 +615,13 @@ def _item_generation_status(item: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _mark_current_cooldown_terminal(db_path: str, *, guild_id: int | None, subject_key: str, reason: str = "cooldown_current") -> None:
+def _mark_current_cooldown_terminal(db_path: str, *, queue_id: int, reason: str = "cooldown_current") -> None:
     conn = sqlite3.connect(db_path)
     try:
         ensure_source_file_refresh_schema(conn)
         conn.execute(
-            f"UPDATE {QUEUE_TABLE} SET status='skipped', updated_at=?, last_error=? WHERE (guild_id IS ? OR guild_id=?) AND subject_key=? AND status IN ('queued','deferred','cooldown','failed') AND evidence_source='source_refresh_now'",
-            (utc_now(), reason, guild_id, guild_id, source_refresh_subject_key(subject_key)),
+            f"UPDATE {QUEUE_TABLE} SET status='skipped', updated_at=?, last_error=? WHERE id=? AND status IN ('queued','deferred','cooldown','failed') AND evidence_source='source_refresh_now'",
+            (utc_now(), reason, int(queue_id)),
         )
         conn.commit()
     finally:
@@ -593,7 +641,7 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
     request_id = _site_refresh_request_id(site_request)
     subject = _site_refresh_subject_name(site_request)
     skey = _site_refresh_subject_key(site_request)
-    candidate_id = _safe_text(site_request.get("candidateId") or site_request.get("candidate_id") or "", 120)
+    candidate_id = _safe_candidate_id(site_request.get("candidateId") or site_request.get("candidate_id") or "")
     mode = _site_refresh_mode(site_request)
     source = _safe_text(site_request.get("source") or "", 80)
     reason = _safe_text(site_request.get("reason") or "", 80)
@@ -634,7 +682,7 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
                 conn = sqlite3.connect(db_path)
                 try:
                     ensure_source_file_refresh_schema(conn)
-                    _state_upsert(conn, guild_id=guild_id, subject_key=skey, subject_name=subject or lookup_value, fields={"last_refresh_completed_at": utc_now(), "last_refresh_status": "no_target", "last_failure_at": utc_now(), "last_error": "no_target"})
+                    _state_upsert(conn, guild_id=guild_id, subject_key=skey, subject_name=subject or lookup_value, fields={"last_refresh_completed_at": utc_now(), "last_refresh_status": "no_target", "last_failure_at": utc_now(), "last_error": "no_target", "candidate_id": candidate_id or None})
                     conn.commit()
                 finally:
                     conn.close()
@@ -654,7 +702,7 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
         return summary
 
     immediate_not_before = utc_now()
-    enqueue_source_file_refresh(
+    queued = enqueue_source_file_refresh(
         db_path,
         guild_id=guild_id,
         subject_name=subject or lookup_value,
@@ -665,6 +713,7 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
         created_by=source or "source_refresh_now",
         not_before_at=immediate_not_before,
         evidence_count=1,
+        candidate_id=candidate_id,
     )
     local = process_source_file_refresh_queue(
         db_path,
@@ -677,13 +726,14 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
         bypass_cooldown=explicit_case_report_backfill or report_missing or source in {"admin_manual_retry"} or reason in {"manual_retry", "file_not_updated"},
         refresh_mode=mode,
         subject_key=skey,
+        queue_id=queued.get("id"),
         callback_base_url=callback_base_url or None,
     )
     item = (local.get("items") or [{}])[0]
     if not item:
         state = get_refresh_state(db_path, guild_id, skey)
-        if _state_has_current_success(state):
-            _mark_current_cooldown_terminal(db_path, guild_id=guild_id, subject_key=skey, reason="cooldown_current_no_item")
+        if _state_has_current_success(state, candidate_id=candidate_id or None):
+            _mark_current_cooldown_terminal(db_path, queue_id=int(queued["id"]), reason="cooldown_current_no_item")
             item = {
                 "subject": subject or lookup_value,
                 "status": "current",
@@ -698,8 +748,8 @@ def process_source_file_refresh_now(db_path: str, payload: dict[str, Any], *, gu
             local["items"] = [item]
     if str(item.get("status") or "").lower() == "cooldown":
         state = get_refresh_state(db_path, guild_id, skey)
-        if _state_has_current_success(state):
-            _mark_current_cooldown_terminal(db_path, guild_id=guild_id, subject_key=skey, reason="cooldown_current")
+        if _state_has_current_success(state, candidate_id=candidate_id or None):
+            _mark_current_cooldown_terminal(db_path, queue_id=int(queued["id"]), reason="cooldown_current")
             item = {
                 **item,
                 "status": "current",
@@ -843,7 +893,7 @@ def _state_upsert(conn: sqlite3.Connection, *, guild_id: int | None, subject_key
         conn.execute(f"INSERT INTO {STATE_TABLE} ({cols}) VALUES ({placeholders})", list(base.values()))
 
 
-def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = None, dry_run: bool = False, max_items: int = DEFAULT_MAX_AUTOMATIC_PER_CYCLE, cooldown_minutes: int = DEFAULT_COOLDOWN_MINUTES, lookup_func: Callable[[dict[str, str]], dict[str, Any]] = lookup_source_file, sender: Callable[[dict[str, Any]], dict[str, Any]] = send_dossier_recommendation, environ: dict[str, str] | None = None, force: bool = False, bypass_cooldown: bool = False, refresh_mode: str = "automatic", subject_key: str | None = None, callback_base_url: str | None = None) -> dict[str, Any]:
+def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = None, dry_run: bool = False, max_items: int = DEFAULT_MAX_AUTOMATIC_PER_CYCLE, cooldown_minutes: int = DEFAULT_COOLDOWN_MINUTES, lookup_func: Callable[[dict[str, str]], dict[str, Any]] = lookup_source_file, sender: Callable[[dict[str, Any]], dict[str, Any]] = send_dossier_recommendation, environ: dict[str, str] | None = None, force: bool = False, bypass_cooldown: bool = False, refresh_mode: str = "automatic", subject_key: str | None = None, queue_id: int | None = None, callback_base_url: str | None = None) -> dict[str, Any]:
     now_dt = datetime.now(timezone.utc).replace(microsecond=0)
     now = now_dt.isoformat()
     env = environ if environ is not None else os.environ
@@ -861,6 +911,9 @@ def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = No
         if subject_key:
             where += " AND subject_key=?"
             params.append(source_refresh_subject_key(subject_key))
+        if queue_id is not None:
+            where += " AND id=?"
+            params.append(int(queue_id))
         rows = conn.execute(f"SELECT * FROM {QUEUE_TABLE} WHERE {where} ORDER BY priority DESC, queued_at ASC LIMIT ?", [*params, max(1, int(max_items or 1))]).fetchall()
         if not rows:
             return summary
@@ -878,7 +931,9 @@ def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = No
                 summary["items"].append({"subject": row["subject_name"], "status": "dry_run", "reason": row["reason"], "evidenceCount": row["evidence_count"], "wouldSend": True})
                 continue
             state = conn.execute(f"SELECT * FROM {STATE_TABLE} WHERE (guild_id IS ? OR guild_id=?) AND subject_key=? LIMIT 1", (row["guild_id"], row["guild_id"], row["subject_key"])).fetchone()
-            cooldown_until = parse_iso(state["cooldown_until"] if state else None)
+            row_candidate_id = _safe_candidate_id(row["candidate_id"])
+            state_identity_matches = _state_identity_matches(state, row_candidate_id or None)
+            cooldown_until = parse_iso(state["cooldown_until"] if state and state_identity_matches else None)
             queue_reason_missing = _queue_reason_has_case_report_missing(row["reason"])
             report_missing = queue_reason_missing
             backfill_trigger = _case_report_backfill_trigger(queue_reason=row["reason"], evidence_source=row["evidence_source"])
@@ -900,12 +955,14 @@ def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = No
                 summary["items"].append({"subject": row["subject_name"], "status": "cooldown", "reason": "cooldown", "cooldownUntil": cooldown_until.isoformat()})
                 continue
             conn.execute(f"UPDATE {QUEUE_TABLE} SET status='running', updated_at=?, last_attempt_at=?, attempts=attempts+1, last_error=NULL WHERE id=?", (now, now, row["id"]))
-            _state_upsert(conn, guild_id=row["guild_id"], subject_key=row["subject_key"], subject_name=row["subject_name"], fields={"last_refresh_started_at": now, "last_refresh_status": "running"})
+            _state_upsert(conn, guild_id=row["guild_id"], subject_key=row["subject_key"], subject_name=row["subject_name"], fields={"last_refresh_started_at": now, "last_refresh_status": "running", "candidate_id": row_candidate_id or None})
             conn.commit()
             logging.info("source_refresh_started subject_key=%s mode=%s", row["subject_key"], mode)
             if report_missing:
                 logging.info("source_case_report_backfill_started subject_key=%s reason=%s trigger=%s", row["subject_key"], CASE_REPORT_BACKFILL_REASON, backfill_trigger)
             try:
+                lookup_key, lookup_value = _queue_refresh_lookup_parts(row)
+                logging.info("source_refresh_identity_mode subject_key=%s mode=%s", row["subject_key"], "candidate_id" if lookup_key == "candidateId" else "subject")
                 with refresh_generation_context(row["subject_key"]):
                     result = run_source_file_enrichment(
                         db_path,
@@ -918,10 +975,12 @@ def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = No
                         force=force,
                         diagnostics=False,
                         callback_base_url=callback_base_url or None,
+                        lookup_key=lookup_key,
+                        lookup_value=lookup_value,
                     )
                 if result.get("status") == "no_target":
                     conn.execute(f"UPDATE {QUEUE_TABLE} SET status='skipped', updated_at=?, last_error='no_target' WHERE id=?", (utc_now(), row["id"]))
-                    _state_upsert(conn, guild_id=row["guild_id"], subject_key=row["subject_key"], subject_name=row["subject_name"], fields={"last_refresh_completed_at": utc_now(), "last_refresh_status": "no_target", "last_failure_at": utc_now(), "last_error": "no_target"})
+                    _state_upsert(conn, guild_id=row["guild_id"], subject_key=row["subject_key"], subject_name=row["subject_name"], fields={"last_refresh_completed_at": utc_now(), "last_refresh_status": "no_target", "last_failure_at": utc_now(), "last_error": "no_target", "candidate_id": row_candidate_id or None})
                     conn.commit()
                     logging.info("source_refresh_skipped subject_key=%s reason=no_target", row["subject_key"])
                     summary["skipped"] += 1
@@ -938,7 +997,7 @@ def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = No
                     partial_reason = "compact_recommendation_rejected" if partial_success else ""
                     item_reason = CASE_REPORT_BACKFILL_REASON if report_missing and not partial_reason else partial_reason
                     conn.execute(f"UPDATE {QUEUE_TABLE} SET status='succeeded', updated_at=?, last_error=NULL WHERE id=?", (utc_now(), row["id"]))
-                    _state_upsert(conn, guild_id=row["guild_id"], subject_key=row["subject_key"], subject_name=row["subject_name"], fields={"last_refresh_completed_at": utc_now(), "last_refresh_status": item_status, "last_recommendation_id": recommendation_id, "last_evidence_hash": _evidence_hash_for_result(result), "last_evidence_count": evidence_count, "last_error": partial_reason or None, "cooldown_until": cooldown_until_text})
+                    _state_upsert(conn, guild_id=row["guild_id"], subject_key=row["subject_key"], subject_name=row["subject_name"], fields={"last_refresh_completed_at": utc_now(), "last_refresh_status": item_status, "last_recommendation_id": recommendation_id, "last_evidence_hash": _evidence_hash_for_result(result), "last_evidence_count": evidence_count, "last_error": partial_reason or None, "cooldown_until": cooldown_until_text, "candidate_id": row_candidate_id or None})
                     conn.commit()
                     if partial_success:
                         logging.warning("source_refresh_partial_success subject_key=%s archive_ok=true compact_recommendation_ok=false reason=compact_recommendation_rejected archive_id=%s", row["subject_key"], archive_id or "none")
@@ -958,7 +1017,7 @@ def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = No
                     else:
                         err = _safe_text(send_result.get("error") or archive_result.get("error") or result.get("suppressedReason") or result.get("status") or "send_failed", 240)
                     conn.execute(f"UPDATE {QUEUE_TABLE} SET status='failed', updated_at=?, last_error=? WHERE id=?", (utc_now(), err, row["id"]))
-                    _state_upsert(conn, guild_id=row["guild_id"], subject_key=row["subject_key"], subject_name=row["subject_name"], fields={"last_refresh_status": "failed", "last_failure_at": utc_now(), "last_error": err})
+                    _state_upsert(conn, guild_id=row["guild_id"], subject_key=row["subject_key"], subject_name=row["subject_name"], fields={"last_refresh_status": "failed", "last_failure_at": utc_now(), "last_error": err, "candidate_id": row_candidate_id or None})
                     conn.commit()
                     logging.warning("source_refresh_failed subject_key=%s error=%s", row["subject_key"], err)
                     if report_missing:
@@ -968,7 +1027,7 @@ def process_source_file_refresh_queue(db_path: str, *, guild_id: int | None = No
             except Exception as exc:
                 err = _safe_text(exc, 240)
                 conn.execute(f"UPDATE {QUEUE_TABLE} SET status='failed', updated_at=?, last_error=? WHERE id=?", (utc_now(), err, row["id"]))
-                _state_upsert(conn, guild_id=row["guild_id"], subject_key=row["subject_key"], subject_name=row["subject_name"], fields={"last_refresh_status": "failed", "last_failure_at": utc_now(), "last_error": err})
+                _state_upsert(conn, guild_id=row["guild_id"], subject_key=row["subject_key"], subject_name=row["subject_name"], fields={"last_refresh_status": "failed", "last_failure_at": utc_now(), "last_error": err, "candidate_id": row_candidate_id or None})
                 conn.commit()
                 logging.warning("source_refresh_failed subject_key=%s error=%s", row["subject_key"], err)
                 if report_missing:
@@ -1024,8 +1083,7 @@ def process_site_refresh_requests(db_path: str, *, guild_id: int | None = None, 
             summary["items"].append({"subject": subject or skey, "subjectKey": skey, "requestId": request_id, "status": "failed", "error": reason})
             continue
         logging.info("source_refresh_site_request_claimed request_id=%s", request_id)
-        lookup_key = "normalizedName" if (site_request.get("normalizedSubjectKey") or site_request.get("subjectKey")) and not site_request.get("subjectName") else "subject"
-        lookup_value = str(site_request.get("normalizedSubjectKey") or site_request.get("subjectKey") or subject or skey)
+        lookup_key, lookup_value = _site_refresh_lookup_parts(site_request)
         report_missing = bool(explicit_case_report_backfill)
         try:
             target_check = lookup_func({"lookupKey": lookup_key, "lookupValue": lookup_value, lookup_key: lookup_value})
@@ -1040,7 +1098,7 @@ def process_site_refresh_requests(db_path: str, *, guild_id: int | None = None, 
                     conn = sqlite3.connect(db_path)
                     try:
                         ensure_source_file_refresh_schema(conn)
-                        _state_upsert(conn, guild_id=guild_id, subject_key=skey, subject_name=subject or lookup_value, fields={"last_refresh_completed_at": utc_now(), "last_refresh_status": "no_target", "last_failure_at": utc_now(), "last_error": "no_target"})
+                        _state_upsert(conn, guild_id=guild_id, subject_key=skey, subject_name=subject or lookup_value, fields={"last_refresh_completed_at": utc_now(), "last_refresh_status": "no_target", "last_failure_at": utc_now(), "last_error": "no_target", "candidate_id": _safe_candidate_id(site_request.get("candidateId") or site_request.get("candidate_id") or "") or None})
                         conn.commit()
                     finally:
                         conn.close()
@@ -1058,7 +1116,7 @@ def process_site_refresh_requests(db_path: str, *, guild_id: int | None = None, 
             summary["items"].append({"subject": subject or skey, "subjectKey": skey, "requestId": request_id, "status": "failed", "error": reason})
             continue
         callback_base_url, callback_source = _select_and_log_source_refresh_callback_base(site_request, environ=env)
-        enqueue_source_file_refresh(
+        queued = enqueue_source_file_refresh(
             db_path,
             guild_id=guild_id,
             subject_name=subject or lookup_value,
@@ -1068,6 +1126,7 @@ def process_site_refresh_requests(db_path: str, *, guild_id: int | None = None, 
             refresh_mode=mode,
             created_by="site_refresh_request",
             evidence_count=1,
+            candidate_id=_safe_candidate_id(site_request.get("candidateId") or site_request.get("candidate_id") or "") or None,
         )
         local = process_source_file_refresh_queue(
             db_path,
@@ -1080,6 +1139,7 @@ def process_site_refresh_requests(db_path: str, *, guild_id: int | None = None, 
             bypass_cooldown=explicit_case_report_backfill or report_missing or (mode == "site_manual_request"),
             refresh_mode=mode,
             subject_key=skey,
+            queue_id=queued.get("id"),
             callback_base_url=callback_base_url or None,
         )
         item = (local.get("items") or [{}])[0]

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -218,6 +218,197 @@ class SourceFileEnrichmentTests(unittest.TestCase):
         self.assertEqual(dossier["matchKind"], "existing_dossier_update")
         self.assertIn("Existing Dossier Update", enrich.format_source_enrichment_response(dossier))
 
+    def _public_dossier_only_lookup(self):
+        return {
+            "ok": True,
+            "found": True,
+            "matchKind": "public_dossier_only",
+            "data": {
+                "matchKind": "public_dossier_only",
+                "workflowLane": "public_dossier_update_target",
+                "recommendedAction": "create_existing_dossier_update",
+                "targetDossierId": "EN-004",
+                "publicDossierName": "DJ Floppydisc",
+                "sourceFile": None,
+            },
+        }
+
+    def test_public_dossier_only_is_nonattachable_and_dry_run_does_not_create(self):
+        lookup = self._public_dossier_only_lookup()
+        match_kind, _note, source_file = enrich.classify_source_match(lookup)
+        self.assertEqual(match_kind, "public_dossier_only")
+        self.assertEqual(source_file, {})
+        creator = mock.Mock()
+        result = enrich.run_source_file_enrichment(
+            self.db,
+            1,
+            "DJ Floppydisc",
+            dry_run=True,
+            lookup_func=lambda query: lookup,
+            workspace_creator=creator,
+        )
+        creator.assert_not_called()
+        self.assertEqual(result["status"], "target_setup_required")
+        self.assertFalse(result["sent"])
+        response = enrich.format_source_enrichment_response(result)
+        self.assertIn("would create that internal review-only target", response)
+        self.assertIn("No notes were sent", response)
+        self.assertNotIn("Would send as BNL Source File Enrichment: yes", response)
+
+    def test_malformed_public_dossier_only_contract_fails_closed_without_mutation(self):
+        lookup = self._public_dossier_only_lookup()
+        del lookup["data"]["recommendedAction"]
+        creator = mock.Mock()
+        compact_sender = mock.Mock()
+        archive_sender = mock.Mock()
+
+        match_kind, _note, source_file = enrich.classify_source_match(lookup)
+        self.assertEqual(match_kind, "public_dossier_only")
+        self.assertEqual(source_file, {})
+        result = enrich.run_source_file_enrichment(
+            self.db,
+            1,
+            "DJ Floppydisc",
+            lookup_func=lambda query: lookup,
+            workspace_creator=creator,
+            sender=compact_sender,
+            archive_sender=archive_sender,
+        )
+
+        self.assertEqual(result["status"], "target_setup_failed")
+        self.assertIn("contract_not_confirmed", result["sendResult"]["error"])
+        creator.assert_not_called()
+        compact_sender.assert_not_called()
+        archive_sender.assert_not_called()
+
+        dry_run = enrich.run_source_file_enrichment(
+            self.db,
+            1,
+            "DJ Floppydisc",
+            dry_run=True,
+            lookup_func=lambda query: lookup,
+            workspace_creator=creator,
+        )
+        self.assertEqual(dry_run["status"], "target_setup_failed")
+        self.assertNotIn("would create", enrich.format_source_enrichment_response(dry_run).lower())
+        creator.assert_not_called()
+
+    def test_public_dossier_only_creates_exact_internal_target_then_sends_by_candidate_id(self):
+        self.conn.execute("INSERT INTO broadcast_memory VALUES (NULL,1,'2026-07-17','DJ Floppydisc appeared in a public-safe BARCODE Radio note.','show_note',1,'ambient,direct','active','now')")
+        self.conn.commit()
+        lookups = []
+
+        def lookup(query):
+            lookups.append(query)
+            if query["lookupKey"] == "subject":
+                return self._public_dossier_only_lookup()
+            return {
+                "ok": True,
+                "found": True,
+                "matchKind": "existing_dossier_update_name",
+                "data": {
+                    "workflowLane": "existing_dossier_update",
+                    "sourceFile": {
+                        "candidateId": "cand_dj",
+                        "id": "cand_dj",
+                        "name": "DJ Floppydisc",
+                        "status": "existing_dossier_update",
+                    },
+                },
+            }
+
+        compact_calls = []
+        archive_calls = []
+        result = enrich.run_source_file_enrichment(
+            self.db,
+            1,
+            "DJ Floppydisc",
+            dry_run=False,
+            force=True,
+            lookup_func=lookup,
+            workspace_creator=lambda lookup_result, subject, environ: {"ok": True, "candidateId": "cand_dj", "targetDossierId": "EN-004"},
+            sender=lambda payload: compact_calls.append(payload) or {"ok": True, "recommendationId": "rec_dj"},
+            archive_sender=lambda payload: archive_calls.append(payload) or {"ok": True, "archiveId": "arc_dj", "status": 200},
+            environ={"BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+        )
+        self.assertTrue(result["sent"])
+        self.assertEqual([query["lookupKey"] for query in lookups], ["subject", "candidateId"])
+        self.assertEqual(lookups[-1]["lookupValue"], "cand_dj")
+        self.assertEqual(archive_calls[0]["candidateId"], "cand_dj")
+        self.assertEqual(compact_calls[0]["targetCandidateId"], "cand_dj")
+
+    def test_public_dossier_only_creation_or_canonical_lookup_failure_sends_nothing(self):
+        compact_calls = []
+        archive_calls = []
+        failed = enrich.run_source_file_enrichment(
+            self.db,
+            1,
+            "DJ Floppydisc",
+            lookup_func=lambda query: self._public_dossier_only_lookup(),
+            workspace_creator=lambda lookup_result, subject, environ: {"ok": False, "error": "source_file_target_setup_http_500"},
+            sender=lambda payload: compact_calls.append(payload) or {"ok": True},
+            archive_sender=lambda payload: archive_calls.append(payload) or {"ok": True},
+        )
+        self.assertEqual(failed["status"], "target_setup_failed")
+
+        def mismatched_lookup(query):
+            if query["lookupKey"] == "subject":
+                return self._public_dossier_only_lookup()
+            return {"ok": True, "found": True, "matchKind": "existing_dossier_update_name", "data": {"sourceFile": {"candidateId": "wrong", "name": "DJ Floppydisc", "status": "existing_dossier_update"}}}
+
+        mismatched = enrich.run_source_file_enrichment(
+            self.db,
+            1,
+            "DJ Floppydisc",
+            lookup_func=mismatched_lookup,
+            workspace_creator=lambda lookup_result, subject, environ: {"ok": True, "candidateId": "cand_dj"},
+            sender=lambda payload: compact_calls.append(payload) or {"ok": True},
+            archive_sender=lambda payload: archive_calls.append(payload) or {"ok": True},
+        )
+        self.assertEqual(mismatched["status"], "target_setup_lookup_failed")
+        self.assertEqual(compact_calls, [])
+        self.assertEqual(archive_calls, [])
+
+    def test_protected_target_creator_validates_internal_only_contract(self):
+        payload = {
+            "ok": True,
+            "mutation": "internal_workflow_only",
+            "publishesPublicDossier": False,
+            "publicDossierMutated": False,
+            "workflowLane": "existing_dossier_update",
+            "sourceFileActive": False,
+            "existingDossierUpdateLane": True,
+            "targetDossierId": "EN-004",
+            "candidate": {"id": "cand_dj", "status": "existing_dossier_update", "existingDossierMatch": {"id": "EN-004"}},
+        }
+        response = mock.MagicMock()
+        response.status = 200
+        response.read.return_value = json.dumps(payload).encode("utf-8")
+        response.__enter__.return_value = response
+        opener = mock.Mock()
+        opener.open.return_value = response
+        result = enrich.create_existing_dossier_update_target(
+            self._public_dossier_only_lookup(),
+            "DJ Floppydisc",
+            {"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_SOURCE_FILE_READ_URL": "https://site.test/api/bnl/source-files?ignored=1"},
+            opener=opener,
+        )
+        self.assertEqual(result["candidateId"], "cand_dj")
+        request = opener.open.call_args.args[0]
+        self.assertEqual(request.full_url, "https://site.test/api/bnl/source-files")
+        self.assertEqual(json.loads(request.data), {"action": "create_existing_dossier_update", "targetDossierId": "EN-004", "requestedSubject": "DJ Floppydisc"})
+
+        payload["publicDossierMutated"] = True
+        response.read.return_value = json.dumps(payload).encode("utf-8")
+        rejected = enrich.create_existing_dossier_update_target(
+            self._public_dossier_only_lookup(),
+            "DJ Floppydisc",
+            {"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_SOURCE_FILE_READ_URL": "https://site.test/api/bnl/source-files"},
+            opener=opener,
+        )
+        self.assertFalse(rejected["ok"])
+        self.assertEqual(rejected["error"], "source_file_target_setup_invalid_response")
+
     def test_no_match_returns_bounded_no_target_response(self):
         result = enrich.run_source_file_enrichment(self.db, 1, "Unknown", dry_run=True, lookup_func=lambda query: {"ok": True, "found": False, "data": {}})
         response = enrich.format_source_enrichment_response(result)

--- a/tests/test_source_file_refresh.py
+++ b/tests/test_source_file_refresh.py
@@ -140,6 +140,109 @@ class SourceFileRefreshTests(unittest.TestCase):
         self.assertEqual(rows[0]["evidence_count"], 2)
         self.assertIn("subject_activity_link_signal", rows[0]["reason"])
 
+    def test_existing_queue_schema_migrates_candidate_id_without_data_loss(self):
+        old = tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False)
+        old.close()
+        try:
+            conn = sqlite3.connect(old.name)
+            conn.execute(
+                f"""CREATE TABLE {refresh.QUEUE_TABLE} (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT, guild_id INTEGER,
+                    subject_key TEXT NOT NULL, subject_name TEXT NOT NULL,
+                    reason TEXT NOT NULL, evidence_source TEXT,
+                    evidence_count INTEGER NOT NULL DEFAULT 1,
+                    priority INTEGER NOT NULL DEFAULT 50,
+                    status TEXT NOT NULL DEFAULT 'queued', queued_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL, not_before_at TEXT, last_attempt_at TEXT,
+                    attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT,
+                    refresh_mode TEXT NOT NULL DEFAULT 'automatic', created_by TEXT
+                )"""
+            )
+            conn.execute(
+                f"INSERT INTO {refresh.QUEUE_TABLE} (guild_id, subject_key, subject_name, reason, queued_at, updated_at) VALUES (1, 'signal-fox', 'Signal Fox', 'old', 'now', 'now')"
+            )
+            refresh.ensure_source_file_refresh_schema(conn)
+            refresh.ensure_source_file_refresh_schema(conn)
+            conn.commit()
+            columns = {row[1] for row in conn.execute(f"PRAGMA table_info({refresh.QUEUE_TABLE})")}
+            row = conn.execute(f"SELECT subject_name, candidate_id FROM {refresh.QUEUE_TABLE}").fetchone()
+            conn.close()
+            self.assertIn("candidate_id", columns)
+            self.assertEqual(row, ("Signal Fox", None))
+        finally:
+            os.unlink(old.name)
+
+    def test_existing_state_schema_migrates_candidate_id_without_data_loss(self):
+        old = tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False)
+        old.close()
+        try:
+            conn = sqlite3.connect(old.name)
+            conn.execute(
+                f"""CREATE TABLE {refresh.STATE_TABLE} (
+                    guild_id INTEGER, subject_key TEXT NOT NULL,
+                    subject_name TEXT NOT NULL, last_refresh_status TEXT,
+                    last_recommendation_id TEXT, cooldown_until TEXT,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (guild_id, subject_key)
+                )"""
+            )
+            conn.execute(
+                f"INSERT INTO {refresh.STATE_TABLE} (guild_id, subject_key, subject_name, last_refresh_status, last_recommendation_id, cooldown_until, updated_at) VALUES (1, 'signal-fox', 'Signal Fox', 'succeeded', 'rec_old', '2999-01-01T00:00:00+00:00', 'now')"
+            )
+            refresh.ensure_source_file_refresh_schema(conn)
+            refresh.ensure_source_file_refresh_schema(conn)
+            conn.commit()
+            columns = {row[1] for row in conn.execute(f"PRAGMA table_info({refresh.STATE_TABLE})")}
+            row = conn.execute(f"SELECT subject_name, last_recommendation_id, candidate_id FROM {refresh.STATE_TABLE}").fetchone()
+            conn.close()
+            self.assertIn("candidate_id", columns)
+            self.assertEqual(row, ("Signal Fox", "rec_old", None))
+        finally:
+            os.unlink(old.name)
+
+    def test_candidate_identity_survives_dedupe_and_upgrades_failed_row(self):
+        refresh.enqueue_source_file_refresh(self.db, guild_id=1, subject_name="Signal Fox", reason="automatic", evidence_source="test")
+        conn = sqlite3.connect(self.db)
+        conn.execute(f"UPDATE {refresh.QUEUE_TABLE} SET status='failed' WHERE subject_key='signal-fox'")
+        conn.commit()
+        conn.close()
+        upgraded = refresh.enqueue_source_file_refresh(
+            self.db,
+            guild_id=1,
+            subject_name="Signal Fox",
+            reason="site retry",
+            evidence_source="site_refresh_request",
+            candidate_id="cand_exact",
+        )
+        self.assertTrue(upgraded["deduped"])
+        self.assertEqual(self.rows()[0]["candidate_id"], "cand_exact")
+        refresh.enqueue_source_file_refresh(self.db, guild_id=1, subject_name="Signal Fox", reason="later evidence", evidence_source="test")
+        rows = self.all_queue_rows()
+        self.assertEqual(len(rows), 2)
+        self.assertEqual({row["candidate_id"] for row in rows}, {"cand_exact", None})
+
+    def test_conflicting_candidate_identities_are_never_merged_or_replaced(self):
+        refresh.enqueue_source_file_refresh(
+            self.db,
+            guild_id=1,
+            subject_name="Signal Fox",
+            reason="first exact request",
+            evidence_source="site_refresh_request",
+            candidate_id="cand_a",
+        )
+        refresh.enqueue_source_file_refresh(
+            self.db,
+            guild_id=1,
+            subject_name="Signal Fox",
+            reason="different exact request",
+            evidence_source="site_refresh_request",
+            candidate_id="cand_b",
+        )
+        rows = self.all_queue_rows()
+        self.assertEqual(len(rows), 2)
+        self.assertEqual({row["candidate_id"] for row in rows}, {"cand_a", "cand_b"})
+        self.assertEqual({row["evidence_count"] for row in rows}, {1})
+
     def test_entity_evidence_upsert_marks_subject_dirty(self):
         conn = sqlite3.connect(self.db)
         conn.row_factory = sqlite3.Row
@@ -547,6 +650,42 @@ class SourceFileRefreshTests(unittest.TestCase):
         self.assertEqual(state["last_refresh_status"], "succeeded")
         self.assertEqual(self.rows(), [])
 
+    def test_site_polling_uses_candidate_identity_for_preflight_and_worker(self):
+        opener = FakeOpener({"ok": True, "requests": [{"id": "req_1", "candidateId": "cand_exact", "subjectName": "Signal Fox", "status": "pending"}]})
+        queries = []
+        lookup = lambda query: queries.append(query) or {"ok": True, "found": True, "sourceFile": {"candidateId": "cand_exact", "subjectName": "Signal Fox"}}
+        result = {"sent": True, "sendResult": {"recommendationId": "rec_1"}, "sourceCounts": {}, "subject": "Signal Fox"}
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value=result) as mocked:
+            summary = refresh.process_site_refresh_requests(
+                self.db,
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+        self.assertEqual(summary["processed"], 1)
+        self.assertTrue(queries)
+        self.assertTrue(all(query["lookupKey"] == "candidateId" for query in queries))
+        self.assertEqual(mocked.call_args.kwargs["lookup_key"], "candidateId")
+        self.assertEqual(mocked.call_args.kwargs["lookup_value"], "cand_exact")
+
+    def test_site_candidate_identity_is_opaque_and_preserved_to_200_characters(self):
+        candidate_id = "cand_" + ("x" * 145) + "_123456789012345678"
+        self.assertEqual(len(candidate_id), 169)
+        lookup_key, lookup_value = refresh._site_refresh_lookup_parts({"candidateId": candidate_id, "subjectName": "Signal Fox"})
+        self.assertEqual(lookup_key, "candidateId")
+        self.assertEqual(lookup_value, candidate_id)
+        queued = refresh.enqueue_source_file_refresh(
+            self.db,
+            guild_id=1,
+            subject_name="Signal Fox",
+            reason="exact site request",
+            evidence_source="site_refresh_request",
+            candidate_id=candidate_id,
+        )
+        self.assertTrue(queued["queued"])
+        self.assertEqual(self.rows()[0]["candidate_id"], candidate_id)
+
     def test_site_polling_failure_marks_failed(self):
         opener = FakeOpener({"ok": True, "requests": [{"id": "req_1", "subjectName": "Signal Fox", "status": "pending"}]})
         lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
@@ -635,8 +774,147 @@ class SourceFileRefreshTests(unittest.TestCase):
         self.assertTrue(result["archiveSent"])
         self.assertEqual(result["archiveId"], "arc_now")
         self.assertEqual(mocked.call_count, 1)
+        self.assertEqual(mocked.call_args.kwargs["lookup_key"], "candidateId")
+        self.assertEqual(mocked.call_args.kwargs["lookup_value"], "cand_1")
         self.assertEqual([p["status"] for p in opener.posts], ["claimed", "completed"])
         self.assertEqual(opener.posts[-1]["completedByRecommendationId"], "rec_now")
+
+    def test_refresh_now_targets_exact_candidate_row_and_ignores_subject_cooldown(self):
+        refresh.enqueue_source_file_refresh(
+            self.db,
+            guild_id=1,
+            subject_name="Signal Fox",
+            reason="older exact request",
+            evidence_source="site_refresh_request",
+            priority=100,
+            candidate_id="cand_a",
+        )
+        conn = sqlite3.connect(self.db)
+        try:
+            conn.execute(
+                f"INSERT OR REPLACE INTO {refresh.STATE_TABLE} (guild_id, subject_key, subject_name, last_refresh_completed_at, last_refresh_status, last_recommendation_id, cooldown_until, candidate_id, updated_at) VALUES (1, 'signal-fox', 'Signal Fox', '2026-07-21T00:00:00+00:00', 'succeeded', 'rec_a', '2999-01-01T00:00:00+00:00', 'cand_a', '2026-07-21T00:00:00+00:00')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        opener = FakeOpener({"ok": True, "requests": []})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"candidateId": query["lookupValue"], "subjectName": "Signal Fox"}}
+        result = {"sent": True, "sendResult": {"recommendationId": "rec_b"}, "sourceCounts": {}, "subject": "Signal Fox"}
+
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value=result) as mocked:
+            response = refresh.process_source_file_refresh_now(
+                self.db,
+                {"requestId": "req_b", "candidateId": "cand_b", "subjectName": "Signal Fox"},
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+
+        self.assertEqual(response["status"], "success")
+        self.assertEqual(response["recommendationId"], "rec_b")
+        self.assertEqual(mocked.call_args.kwargs["lookup_value"], "cand_b")
+        rows = self.all_queue_rows()
+        self.assertEqual({row["candidate_id"]: row["status"] for row in rows}, {"cand_a": "queued", "cand_b": "succeeded"})
+        self.assertEqual([post["status"] for post in opener.posts], ["claimed", "completed"])
+
+    def test_refresh_now_current_marks_only_its_exact_candidate_row_terminal(self):
+        refresh.enqueue_source_file_refresh(
+            self.db,
+            guild_id=1,
+            subject_name="Signal Fox",
+            reason="different exact request",
+            evidence_source="source_refresh_now",
+            priority=100,
+            candidate_id="cand_b",
+        )
+        conn = sqlite3.connect(self.db)
+        try:
+            conn.execute(
+                f"INSERT OR REPLACE INTO {refresh.STATE_TABLE} (guild_id, subject_key, subject_name, last_refresh_completed_at, last_refresh_status, last_recommendation_id, cooldown_until, candidate_id, updated_at) VALUES (1, 'signal-fox', 'Signal Fox', '2026-07-21T00:00:00+00:00', 'succeeded', 'rec_a', '2999-01-01T00:00:00+00:00', 'cand_a', '2026-07-21T00:00:00+00:00')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        opener = FakeOpener({"ok": True, "requests": []})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"candidateId": query["lookupValue"], "subjectName": "Signal Fox"}}
+
+        with mock.patch.object(refresh, "run_source_file_enrichment") as mocked:
+            response = refresh.process_source_file_refresh_now(
+                self.db,
+                {"requestId": "req_a", "candidateId": "cand_a", "subjectName": "Signal Fox"},
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+
+        mocked.assert_not_called()
+        self.assertEqual(response["status"], "success")
+        self.assertEqual(response["recommendationId"], "rec_a")
+        rows = self.all_queue_rows()
+        self.assertEqual({row["candidate_id"]: row["status"] for row in rows}, {"cand_b": "queued", "cand_a": "skipped"})
+        self.assertEqual([post["status"] for post in opener.posts], ["claimed", "completed"])
+
+    def test_site_polling_targets_the_row_enqueued_for_each_candidate_request(self):
+        refresh.enqueue_source_file_refresh(
+            self.db,
+            guild_id=1,
+            subject_name="Signal Fox",
+            reason="older exact request",
+            evidence_source="site_refresh_request",
+            priority=95,
+            candidate_id="cand_a",
+        )
+        opener = FakeOpener({"ok": True, "requests": [{"id": "req_b", "candidateId": "cand_b", "subjectName": "Signal Fox", "status": "pending"}]})
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"candidateId": query["lookupValue"], "subjectName": "Signal Fox"}}
+        result = {"sent": True, "sendResult": {"recommendationId": "rec_b"}, "sourceCounts": {}, "subject": "Signal Fox"}
+
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value=result) as mocked:
+            summary = refresh.process_site_refresh_requests(
+                self.db,
+                guild_id=1,
+                environ={"BNL_SOURCE_FILE_READ_TOKEN": "read", "BNL_WEBSITE_BASE_URL": "https://site.test", "BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+                opener=opener,
+                lookup_func=lookup,
+            )
+
+        self.assertEqual(summary["processed"], 1)
+        self.assertEqual(mocked.call_args.kwargs["lookup_value"], "cand_b")
+        rows = self.all_queue_rows()
+        self.assertEqual({row["candidate_id"]: row["status"] for row in rows}, {"cand_a": "queued", "cand_b": "succeeded"})
+        self.assertEqual([post["status"] for post in opener.posts], ["claimed", "completed"])
+
+    def test_worker_reuses_persisted_candidate_identity_after_database_reopen(self):
+        refresh.enqueue_source_file_refresh(
+            self.db,
+            guild_id=1,
+            subject_name="Signal Fox",
+            reason="site retry",
+            evidence_source="site_refresh_request",
+            candidate_id="cand_restart",
+        )
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"candidateId": "cand_restart"}}
+        result = {"sent": True, "sendResult": {"recommendationId": "rec_restart"}, "sourceCounts": {}, "subject": "Signal Fox"}
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value=result) as mocked:
+            summary = refresh.process_source_file_refresh_queue(
+                self.db,
+                guild_id=1,
+                lookup_func=lookup,
+                environ={"BNL_DOSSIER_INGEST_TOKEN": "ingest"},
+            )
+        self.assertEqual(summary["processed"], 1)
+        self.assertEqual(mocked.call_args.kwargs["lookup_key"], "candidateId")
+        self.assertEqual(mocked.call_args.kwargs["lookup_value"], "cand_restart")
+
+    def test_worker_without_candidate_identity_uses_subject_lookup(self):
+        refresh.enqueue_source_file_refresh(self.db, guild_id=1, subject_name="Signal Fox", reason="automatic", evidence_source="test")
+        lookup = lambda query: {"ok": True, "found": True, "sourceFile": {"subjectName": "Signal Fox"}}
+        result = {"sent": True, "sendResult": {"recommendationId": "rec_subject"}, "sourceCounts": {}, "subject": "Signal Fox"}
+        with mock.patch.object(refresh, "run_source_file_enrichment", return_value=result) as mocked:
+            refresh.process_source_file_refresh_queue(self.db, guild_id=1, lookup_func=lookup, environ={"BNL_DOSSIER_INGEST_TOKEN": "ingest"})
+        self.assertEqual(mocked.call_args.kwargs["lookup_key"], "subject")
+        self.assertEqual(mocked.call_args.kwargs["lookup_value"], "Signal Fox")
 
     def test_refresh_now_failed_refresh_marks_site_failed(self):
         opener = FakeOpener({"ok": True, "requests": []})


### PR DESCRIPTION
## Summary
- preserve canonical candidate IDs through immediate, polling, queued, and restarted Source File refreshes
- treat `public_dossier_only` as non-attachable and create only the site's protected internal Existing Dossier Update workspace under its strict response contract
- archive and compact recommendation payloads against the same re-verified candidate ID while keeping the website's exact-match guard fail closed
- isolate same-name candidate rows and make cooldown/current/result correlation candidate-exact

## Validation
- 173 focused Source File enrichment/archive/refresh tests pass
- Python compilation and `git diff --check` pass
- two independent adversarial reviews returned GO

No public dossier copy, publishing behavior, memory gates, Journal behavior, or queue-production gates are changed.