### PR TITLE
Respect Source File lane on candidate lookup

### DIFF
--- a/bnl_source_file_enrichment.py
+++ b/bnl_source_file_enrichment.py
@@ -1306,6 +1306,42 @@ def classify_source_match(lookup_result: dict[str, Any]) -> tuple[str, str, dict
         return "public_dossier_only", "An exact public dossier exists, but its protected internal update target must be created before enrichment can attach.", {}
     obj = _source_file_obj(lookup_result)
     data = lookup_result.get("data") if isinstance(lookup_result.get("data"), dict) else {}
+    lane_map = {
+        "active": "active_source_file",
+        "active_source_file": "active_source_file",
+        "candidate_intake": "candidate_intake",
+        "existing_dossier_update": "existing_dossier_update",
+    }
+    lane_signals = {
+        lane_map[value]
+        for value in (
+            str(data.get("workflowLane") or "").strip().lower(),
+            str(obj.get("workflowLane") or "").strip().lower(),
+            str(obj.get("status") or "").strip().lower(),
+            str(obj.get("state") or "").strip().lower(),
+        )
+        if value in lane_map
+    }
+    active_flags = [value for value in (data.get("sourceFileActive"), obj.get("sourceFileActive")) if isinstance(value, bool)]
+    existing_flags = [value for value in (data.get("existingDossierUpdateLane"), obj.get("existingDossierUpdateLane")) if isinstance(value, bool)]
+    if len(lane_signals) > 1:
+        return "error", "Source File workflow lane metadata conflicted; enrichment was stopped safely.", {}
+    if len(set(active_flags)) > 1 or len(set(existing_flags)) > 1:
+        return "error", "Source File workflow flags conflicted; enrichment was stopped safely.", {}
+    explicit_lane = next(iter(lane_signals), "")
+    if active_flags and explicit_lane and any(value != (explicit_lane == "active_source_file") for value in active_flags):
+        return "error", "Source File active-state metadata conflicted; enrichment was stopped safely.", {}
+    if existing_flags and explicit_lane and any(value != (explicit_lane == "existing_dossier_update") for value in existing_flags):
+        return "error", "Source File dossier-lane metadata conflicted; enrichment was stopped safely.", {}
+    if not explicit_lane and True in active_flags and True in existing_flags:
+        return "error", "Source File workflow flags conflicted; enrichment was stopped safely.", {}
+    explicit_lane = explicit_lane or ("existing_dossier_update" if True in existing_flags else "active_source_file" if True in active_flags else "")
+    if explicit_lane == "existing_dossier_update":
+        return explicit_lane, "Existing Dossier Update material for admin review.", obj
+    if explicit_lane == "candidate_intake":
+        return explicit_lane, "Candidate Intake enrichment only — not active case-file fact.", obj
+    if explicit_lane == "active_source_file":
+        return explicit_lane, "Active Source File enrichment target.", obj
     raw = " ".join(str(x or "") for x in (
         lookup_result.get("matchKind"), data.get("matchKind"), obj.get("status"), obj.get("state"), obj.get("reviewStatus"),
         obj.get("kind"), obj.get("type"), obj.get("candidateType"), obj.get("sourceType"), obj.get("dossierStatus"),

--- a/tests/test_source_file_enrichment.py
+++ b/tests/test_source_file_enrichment.py
@@ -148,6 +148,61 @@ class SourceFileEnrichmentTests(unittest.TestCase):
         self.assertEqual(result["status"], "dry_run")
         self.assertEqual(result["resolutionMode"], "candidateId")
         self.assertEqual(result["subject"], "HellcatNZ")
+        self.assertEqual(result["matchKind"], "active_source_file")
+
+    def test_candidate_id_lookup_uses_record_workflow_lane(self):
+        for workflow_lane, status, expected in (
+            ("active_source_file", "active", "active_source_file"),
+            ("candidate_intake", "candidate_intake", "candidate_intake"),
+            ("existing_dossier_update", "existing_dossier_update", "existing_dossier_update"),
+        ):
+            with self.subTest(workflow_lane=workflow_lane):
+                result = enrich.classify_source_match({
+                    "ok": True,
+                    "found": True,
+                    "matchKind": "candidate_id",
+                    "data": {
+                        "workflowLane": workflow_lane,
+                        "sourceFile": {
+                            "candidateId": "cand_exact",
+                            "name": "Exact Subject",
+                            "status": status,
+                            "workflowLane": workflow_lane,
+                        },
+                    },
+                })
+                self.assertEqual(result[0], expected)
+
+        conflict = enrich.classify_source_match({
+            "ok": True,
+            "found": True,
+            "matchKind": "candidate_id",
+            "data": {
+                "workflowLane": "active_source_file",
+                "sourceFileActive": False,
+                "sourceFile": {"candidateId": "cand_exact", "status": "active"},
+            },
+        })
+        self.assertEqual(conflict[0], "error")
+
+        duplicate_flag_conflict = enrich.classify_source_match({
+            "ok": True,
+            "found": True,
+            "matchKind": "candidate_id",
+            "data": {
+                "sourceFileActive": True,
+                "sourceFile": {"candidateId": "cand_exact", "sourceFileActive": False},
+            },
+        })
+        self.assertEqual(duplicate_flag_conflict[0], "error")
+
+        incomplete = enrich.classify_source_match({
+            "ok": True,
+            "found": True,
+            "matchKind": "candidate_id",
+            "data": {"sourceFile": {"candidateId": "cand_exact"}},
+        })
+        self.assertEqual(incomplete[0], "candidate_intake")
 
     def test_alias_confirmed_proceeds_but_unconfirmed_alias_is_review_only(self):
         confirmed = enrich.run_source_file_enrichment(
@@ -305,7 +360,7 @@ class SourceFileEnrichmentTests(unittest.TestCase):
             return {
                 "ok": True,
                 "found": True,
-                "matchKind": "existing_dossier_update_name",
+                "matchKind": "candidate_id",
                 "data": {
                     "workflowLane": "existing_dossier_update",
                     "sourceFile": {


### PR DESCRIPTION
## What changed

- Prefer explicit Source File workflow lane/status metadata over the `candidate_id` lookup label.
- Preserve distinct handling for active Source Files, Candidate Intake, and Existing Dossier Update targets.
- Fail closed when lane or workflow flags conflict.
- Add regressions matching the live DJ Floppydisc candidate response and malformed/contradictory contracts.

## Why

The exact-candidate refresh returned `matchKind=candidate_id` with `workflowLane=existing_dossier_update`. The lookup label was being mistaken for Candidate Intake before the record's actual lane was evaluated, so the archive could succeed with HTTP 200 while the refresh still ended as failed.

## Validation

- 137 Source File enrichment/refresh tests passed locally.
- Independent focused review: GO.
- Remote tree matches the tested two-file local tree exactly.

No website code, memory gates, prompts, or public archive protections are changed.