### PR TITLE
Restore conversational debounce parity

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -6866,8 +6866,6 @@ def is_operator_authority_context(channel_policy: str, channel_name: str = "") -
     normalized_name = _normalize_channel_name(channel_name)
     if policy == "broadcast_memory" or normalized_name == "bnl-broadcast-memory":
         return True
-    if policy == "sealed_test" or normalized_name == "bnl-testing":
-        return True
     if policy == "internal_controlled" and normalized_name == "research-and-development":
         return True
     return False
@@ -7348,8 +7346,18 @@ def decide_reply_eligibility(
             True,
             bool(contract.get("reply_when_mentioned", False)),
         )
-    if followup_candidate:
+    if followup_candidate and not (plain_text_name_seen and free_speak_surface):
         allowed = policy in CONVERSATIONAL_POLICIES and bool(contract.get("reply_when_mentioned", False))
+        if allowed and batching and free_speak_surface:
+            return ReplyEligibility(
+                False,
+                f"{surface}_recent_followup_entered_batch",
+                "recent_followup",
+                "batched_followup",
+                True,
+                False,
+                True,
+            )
         return ReplyEligibility(
             allowed,
             "recent_direct_followup_allowed" if allowed else f"{policy}_followup_blocked",
@@ -7495,8 +7503,9 @@ def plan_conversation_response(
     Pipeline audit map:
     - Commands/protected hooks are immediate_command/operator handlers and stay outside
       normal chat generation.
-    - Direct mentions, replies, recent direct follow-ups, and batching-disabled free-speak
-      fallbacks enter paced_direct unless they intentionally start/continue a deferred payload session.
+    - Direct mentions and replies enter paced_direct. On free-speak surfaces, recent
+      unaddressed follow-ups re-enter the debounce coordinator when batching is enabled;
+      batching-disabled fallbacks remain paced direct.
     - Active-channel non-direct messages, free-speak passive room conversation, and
       free-speak plain-text name calls enter debounce batching when batching is enabled;
       non-free-speak passive channels stay quiet when batching is disabled.
@@ -7580,7 +7589,12 @@ def plan_conversation_response(
             "free_speak_conversation",
         }
     )
-    if direct_like and payload_expected and payload_count == 0:
+    plain_name_payload_request = bool(
+        eligibility.policy_reply_class == "batched_plain_name"
+        and eligibility.generation_allowed
+        and conversation_surface_allows_free_speak(surface)
+    )
+    if (direct_like or plain_name_payload_request) and payload_expected and payload_count == 0:
         plan = ConversationPlan(
             ROUTE_MODE_DIRECT_PAYLOAD,
             channel_policy,
@@ -7620,7 +7634,7 @@ def plan_conversation_response(
         plan = _attach_reply_eligibility(plan, eligibility, batching, surface)
         _conversation_plan_log(plan)
         return plan
-    if eligibility.policy_reply_class in {"batched_passive", "batched_plain_name", "silent_observe"} and (active_channel or conversation_surface_allows_free_speak(surface)) and not direct_like:
+    if eligibility.policy_reply_class in {"batched_passive", "batched_plain_name", "batched_followup", "silent_observe"} and (active_channel or conversation_surface_allows_free_speak(surface)) and not direct_like:
         if eligibility.batch_allowed:
             plan = ConversationPlan(
                 mode,
@@ -16591,6 +16605,33 @@ def build_active_batch_conversation_context_v2_prompt(
         is_deferred_payload_session=bool(pending_state or pending_anchor),
     )
 
+
+def _ensure_pending_batch_scheduled(channel: discord.TextChannel, *, reason: str) -> bool:
+    """Schedule buffered work after the task that owned the prior generation exits."""
+    channel_id = channel.id
+    if not _channel_buffers[channel_id] and channel_id not in _channel_interrupt_handoff:
+        return False
+
+    current_task = asyncio.current_task()
+    pending_task = _channel_tasks.get(channel_id)
+    if pending_task and pending_task is not current_task and not pending_task.done():
+        return False
+
+    now = datetime.now(PACIFIC_TZ)
+    _channel_first_seen.setdefault(channel_id, now)
+    _channel_last_message_at.setdefault(channel_id, now)
+    _channel_tasks[channel_id] = asyncio.create_task(_schedule_flush(channel))
+    _log_batch_event(
+        logging.INFO,
+        "pending_batch_rescheduled",
+        channel.guild.id,
+        channel_id,
+        len(_channel_buffers[channel_id]),
+        reason,
+    )
+    return True
+
+
 async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_state=None):
     channel_id = channel.id
     guild_id = channel.guild.id
@@ -16599,7 +16640,8 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
     now = datetime.now(PACIFIC_TZ)
     handoff_items = _channel_interrupt_handoff.pop(channel_id, None)
     buf = _channel_buffers[channel_id]
-    message_count = len(handoff_items) if handoff_items is not None else len(buf)
+    buffered_items = list(buf)
+    message_count = len(handoff_items or []) + len(buffered_items)
 
     if handoff_items is None and not buf:
         _log_batch_event(logging.INFO, "skip", guild_id, channel_id, 0, "empty_buffer")
@@ -16630,7 +16672,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
     elif _channel_payload_wait_extended.get(channel_id):
         selected_wait_seconds = ADAPTIVE_PAYLOAD_WAIT_WITH_ITEMS_SECONDS
     cycle_deadline = batch_start + timedelta(seconds=batch_max_wait)
-    items = list(handoff_items) if handoff_items is not None else list(buf)
+    items = list(handoff_items or []) + buffered_items
     if BNL_ACTIVE_BATCHING_ENABLED:
         pending_state = _consume_pending_request_intent(channel_id, now)
         pending_anchor = _consume_pending_request_anchor(channel_id, now)
@@ -17391,6 +17433,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
     finally:
         _channel_payload_wait_extended[channel_id] = False
         _clear_generation_state(channel_id, local_generation_id)
+        _ensure_pending_batch_scheduled(channel, reason="generation_exit_with_pending_work")
 
 async def _schedule_flush(channel: discord.TextChannel):
     """
@@ -17441,6 +17484,36 @@ async def _schedule_flush(channel: discord.TextChannel):
         sleep_time = min(max(0.1, remaining_quiet), max(0.1, remaining_deadline), float(BATCH_WINDOW_SECONDS))
         await asyncio.sleep(sleep_time)
 
+
+async def _flush_channel_buffer_now(channel: discord.TextChannel) -> bool:
+    """Flush a full buffer without overlapping an active scheduled generation."""
+    channel_id = channel.id
+    if _channel_generating[channel_id]:
+        _log_batch_event(
+            logging.INFO,
+            "buffer_max_deferred",
+            channel.guild.id,
+            channel_id,
+            len(_channel_buffers[channel_id]),
+            "active_generation_preserved",
+        )
+        return False
+
+    scheduled_task = _channel_tasks.get(channel_id)
+    current_task = asyncio.current_task()
+    if scheduled_task and scheduled_task is not current_task and not scheduled_task.done():
+        scheduled_task.cancel()
+        try:
+            await scheduled_task
+        except asyncio.CancelledError:
+            pass
+
+    flush_task = asyncio.create_task(_flush_channel_buffer(channel))
+    _channel_tasks[channel_id] = flush_task
+    await flush_task
+    return True
+
+
 def _reset_debounce(channel: discord.TextChannel):
     cid = channel.id
     if cid not in _channel_first_seen:
@@ -17466,6 +17539,17 @@ def _reset_debounce(channel: discord.TextChannel):
         anchor_uid = raw_items[-1][2] if raw_items[-1][2] else 0
         _set_pending_request_anchor(cid, channel.guild.id, anchor_uid, "request_payload", datetime.now(PACIFIC_TZ), payload_reason)
         _log_batch_event(logging.INFO, "pending_request_anchor_preserved", channel.guild.id, cid, len(raw_items), f"payload_expected=1;count={len(raw_items)}")
+
+    if _channel_generating[cid]:
+        _log_batch_event(
+            logging.INFO,
+            "debounce_reset_deferred",
+            channel.guild.id,
+            cid,
+            len(_channel_buffers[cid]),
+            "active_generation_task_preserved",
+        )
+        return
 
     t = _channel_tasks.get(cid)
     if t and not t.done():
@@ -17790,6 +17874,19 @@ async def on_typing(channel, user, when):
     _log_batch_event(logging.DEBUG, "typing_signal_observed", channel.guild.id, channel.id, len(_channel_buffers[channel.id]), "reason=active_generation")
 
 
+def _is_deictic_payload_placeholder(text: str) -> bool:
+    normalized = re.sub(r"\s+", " ", (text or "").strip().lower()).strip(" .,!?:;")
+    if not normalized:
+        return False
+    return bool(
+        re.fullmatch(
+            r"(?:each|all)?\s*(?:of\s+)?(?:these|those|the\s+following)"
+            r"(?:\s+(?:people|names|items|characters|folks|entries|ones))?",
+            normalized,
+        )
+    )
+
+
 def _collect_inline_direct_payload_items(clean_content: str):
     payload_items = []
     multiline = _extract_multiline_request_payload(clean_content)
@@ -17808,6 +17905,8 @@ def _collect_inline_direct_payload_items(clean_content: str):
     unique = []
     seen = set()
     for raw_item in payload_items:
+        if _is_deictic_payload_placeholder(raw_item):
+            continue
         key = _normalize_payload_item_key(raw_item)
         if not key or key in seen:
             continue
@@ -17887,6 +17986,115 @@ CONVERSATION_CONTINUATION_TTL_SECONDS = max(60, int(os.getenv("BNL_CONVERSATION_
 BNL_QUESTION_ANSWER_TTL_SECONDS = max(60, int(os.getenv("BNL_QUESTION_ANSWER_TTL_SECONDS", "1200") or 1200))
 CONVERSATION_RETRANSMISSION_TTL_SECONDS = max(60, int(os.getenv("BNL_RETRANSMISSION_LATCH_TTL_SECONDS", "180") or 180))
 _conversation_continuation_state = {}
+
+
+def _start_direct_payload_session(
+    message: discord.Message,
+    *,
+    channel_policy: str,
+    request_text: str,
+    current_turn_context: str,
+):
+    """Start the existing protected waiter for a request whose payload is still coming."""
+    session_key = _direct_session_key(message)
+    now = datetime.now(timezone.utc)
+    session = {
+        "guild_id": message.guild.id,
+        "guild": message.guild,
+        "channel_id": message.channel.id,
+        "requester_user_id": message.author.id,
+        "requester_display_name": message.author.display_name,
+        "requester_member": message.author,
+        "channel_policy": channel_policy,
+        "request_text": request_text,
+        "original_request_text": request_text,
+        "anchor_message_id": message.id,
+        "anchor_message": message,
+        "payload_lines": [],
+        "payload_turn_contexts": [],
+        "created_at": now,
+        "last_payload_at": None,
+        "hard_deadline": now + timedelta(seconds=DIRECT_PAYLOAD_HARD_CAP_SECONDS),
+        "completed": False,
+        "generating": False,
+        "generation_invalidated": False,
+        "revision": 0,
+        "last_generation_snapshot_revision": 0,
+        "last_committed_revision": 0,
+        "last_committed_payload_count": 0,
+        "last_bot_response_at": None,
+        "current_turn_context": current_turn_context,
+    }
+    _direct_payload_sessions[session_key] = session
+    session["timer_task"] = asyncio.create_task(_direct_session_timer(session_key))
+    logging.info(
+        "direct_payload_session_created guild_id=%s channel_id=%s user_id=%s channel_policy=%s",
+        message.guild.id,
+        message.channel.id,
+        message.author.id,
+        channel_policy,
+    )
+    return session
+
+
+async def _preempt_pending_batch_for_deferred_session(channel: discord.TextChannel) -> int:
+    """Give an explicit protected payload request sole ownership of the next reply."""
+    channel_id = channel.id
+    pending_count = len(_channel_buffers[channel_id]) + len(_channel_interrupt_handoff.get(channel_id, []))
+    scheduled_task = _channel_tasks.get(channel_id)
+
+    _channel_buffers[channel_id].clear()
+    _channel_interrupt_handoff.pop(channel_id, None)
+    _channel_first_seen.pop(channel_id, None)
+    _channel_last_message_at.pop(channel_id, None)
+    _channel_payload_wait_extended[channel_id] = False
+    _channel_pending_request_intent.pop(channel_id, None)
+    _channel_pending_request_anchor.pop(channel_id, None)
+
+    if scheduled_task and scheduled_task is not asyncio.current_task() and not scheduled_task.done():
+        scheduled_task.cancel()
+        try:
+            await scheduled_task
+        except asyncio.CancelledError:
+            pass
+    if _channel_tasks.get(channel_id) is scheduled_task:
+        _channel_tasks.pop(channel_id, None)
+    _channel_preempted_generation_id[channel_id] = 0
+    _channel_message_interrupt_generation_id[channel_id] = 0
+    if pending_count or scheduled_task:
+        _log_batch_event(
+            logging.INFO,
+            "preempt",
+            channel.guild.id,
+            channel_id,
+            pending_count,
+            "explicit_deferred_payload_session",
+        )
+    return pending_count
+
+
+async def _maybe_start_deferred_payload_session(
+    message: discord.Message,
+    conversation_plan: ConversationPlan,
+    *,
+    channel_policy: str,
+    request_text: str,
+    current_turn_context: str,
+) -> bool:
+    """Connect the coordinator's deferred decision to the existing session waiter."""
+    if not (
+        conversation_plan.should_reply
+        and conversation_plan.response_timing == RESPONSE_TIMING_DEFERRED_PAYLOAD_SESSION
+    ):
+        return False
+    await _preempt_pending_batch_for_deferred_session(message.channel)
+    _start_direct_payload_session(
+        message,
+        channel_policy=channel_policy,
+        request_text=request_text,
+        current_turn_context=current_turn_context,
+    )
+    return True
 
 
 def append_direct_payload_session_turn(session: dict, resolved_text: str, turn_context: str) -> bool:
@@ -19375,6 +19583,15 @@ async def on_message(message: discord.Message):
         )
         save_decision = save_user_message(message.author.id, message.author.display_name, message.guild.id, conversation_content, channel_name=getattr(message.channel, "name", ""), channel_policy=channel_policy, channel_id=getattr(message.channel, "id", 0), message_id=getattr(message, "id", None), route_mode=conversation_plan.route_mode, directed_to_bnl=bool(conversation_plan.should_reply or real_direct_target or is_reply))
 
+        if await _maybe_start_deferred_payload_session(
+            message,
+            conversation_plan,
+            channel_policy=channel_policy,
+            request_text=direct_content,
+            current_turn_context=current_turn_context,
+        ):
+            return
+
         # Direct/direct-like traffic is planned independently from passive batching;
         # non-direct active-channel traffic falls through to the batch planner below.
         if conversation_plan.should_reply and conversation_plan.response_timing == RESPONSE_TIMING_PACED_DIRECT:
@@ -19436,36 +19653,12 @@ async def on_message(message: discord.Message):
             if payload_expected:
                 route_mode = ROUTE_MODE_DIRECT_PAYLOAD
             if payload_expected and len(direct_payload_items) == 0:
-                session = {
-                    "guild_id": message.guild.id,
-                    "guild": message.guild,
-                    "channel_id": message.channel.id,
-                    "requester_user_id": message.author.id,
-                    "requester_display_name": message.author.display_name,
-                    "requester_member": message.author,
-                    "channel_policy": channel_policy,
-                    "request_text": direct_content,
-                    "original_request_text": direct_content,
-                    "anchor_message_id": message.id,
-                    "anchor_message": message,
-                    "payload_lines": [],
-                    "payload_turn_contexts": [],
-                    "created_at": datetime.now(timezone.utc),
-                    "last_payload_at": None,
-                    "hard_deadline": datetime.now(timezone.utc) + timedelta(seconds=DIRECT_PAYLOAD_HARD_CAP_SECONDS),
-                    "completed": False,
-                    "generating": False,
-                    "generation_invalidated": False,
-                    "revision": 0,
-                    "last_generation_snapshot_revision": 0,
-                    "last_committed_revision": 0,
-                    "last_committed_payload_count": 0,
-                    "last_bot_response_at": None,
-                    "current_turn_context": current_turn_context,
-                }
-                _direct_payload_sessions[session_key] = session
-                session["timer_task"] = asyncio.create_task(_direct_session_timer(session_key))
-                logging.info("direct_payload_session_created")
+                _start_direct_payload_session(
+                    message,
+                    channel_policy=channel_policy,
+                    request_text=direct_content,
+                    current_turn_context=current_turn_context,
+                )
                 return
 
             show_state_ctx = build_show_state_override_context(message.guild.id, direct_content)
@@ -19641,7 +19834,7 @@ async def on_message(message: discord.Message):
         )
         _channel_last_message_at[message.channel.id] = datetime.now(PACIFIC_TZ)
         if len(_channel_buffers[message.channel.id]) >= BATCH_MAX_MESSAGES:
-            await _flush_channel_buffer(message.channel)
+            await _flush_channel_buffer_now(message.channel)
             return
         _reset_debounce(message.channel)
         return

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -1,0 +1,595 @@
+import asyncio
+import os
+import subprocess
+import sys
+import time
+import unittest
+from contextlib import ExitStack
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+
+
+class ConversationBatchConfigTests(unittest.TestCase):
+    def test_batching_remains_default_off_in_a_clean_process(self):
+        env = os.environ.copy()
+        env.pop("BNL_ACTIVE_BATCHING_ENABLED", None)
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import bnl01_bot; print(int(bnl01_bot.BNL_ACTIVE_BATCHING_ENABLED))",
+            ],
+            cwd=Path(__file__).resolve().parents[1],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.stdout.strip().splitlines()[-1], "0")
+
+
+class FakeGuild:
+    def __init__(self, guild_id=7700):
+        self.id = guild_id
+
+    def get_member(self, user_id):
+        return SimpleNamespace(
+            id=user_id,
+            roles=[],
+            guild_permissions=SimpleNamespace(administrator=False, manage_guild=False),
+        )
+
+
+class FakeChannel:
+    def __init__(self, channel_id, *, name="bnl-testing", guild=None):
+        self.id = channel_id
+        self.name = name
+        self.guild = guild or FakeGuild()
+        self.sent = []
+
+    async def send(self, text, **_kwargs):
+        self.sent.append(text)
+
+
+class FakeAuthor:
+    def __init__(self, user_id=100, display_name="Jon"):
+        self.id = user_id
+        self.display_name = display_name
+        self.bot = False
+
+
+class FakeMessage:
+    _next_id = 9000
+
+    def __init__(self, channel, content, *, author=None, mentions=None):
+        FakeMessage._next_id += 1
+        self.id = FakeMessage._next_id
+        self.channel = channel
+        self.guild = channel.guild
+        self.content = content
+        self.author = author or FakeAuthor()
+        self.mentions = list(mentions or [])
+        self.raw_mentions = [member.id for member in self.mentions]
+        self.role_mentions = []
+        self.channel_mentions = []
+        self.attachments = []
+        self.embeds = []
+        self.stickers = []
+        self.reference = None
+        self.replies = []
+        self.reactions = []
+
+    async def reply(self, text, **_kwargs):
+        self.replies.append(text)
+
+    async def add_reaction(self, emoji):
+        self.reactions.append(emoji)
+
+
+class BlockingSendChannel(FakeChannel):
+    def __init__(self, channel_id, *, name="bnl-testing", guild=None):
+        super().__init__(channel_id, name=name, guild=guild)
+        self.send_started = asyncio.Event()
+        self.release_send = asyncio.Event()
+
+    async def send(self, text, **_kwargs):
+        self.send_started.set()
+        await self.release_send.wait()
+        self.sent.append(text)
+
+
+class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.channel_ids = set()
+        self.original_batching_enabled = bnl01_bot.BNL_ACTIVE_BATCHING_ENABLED
+        bnl01_bot.BNL_ACTIVE_BATCHING_ENABLED = True
+
+    async def asyncTearDown(self):
+        for channel_id in self.channel_ids:
+            task = bnl01_bot._channel_tasks.get(channel_id)
+            if task and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+            for state in (
+                bnl01_bot._channel_buffers,
+                bnl01_bot._channel_tasks,
+                bnl01_bot._channel_first_seen,
+                bnl01_bot._channel_last_message_at,
+                bnl01_bot._channel_last_reply_at,
+                bnl01_bot._channel_generating,
+                bnl01_bot._channel_generation_id,
+                bnl01_bot._channel_preempted_generation_id,
+                bnl01_bot._channel_message_interrupt_generation_id,
+                bnl01_bot._channel_interrupt_handoff,
+                bnl01_bot._channel_payload_wait_extended,
+                bnl01_bot._channel_pending_request_intent,
+                bnl01_bot._channel_pending_request_anchor,
+                bnl01_bot._channel_generation_typing_pause_used,
+            ):
+                state.pop(channel_id, None)
+            for key in list(bnl01_bot._conversation_continuation_state):
+                if len(key) >= 2 and key[1] == channel_id:
+                    bnl01_bot._conversation_continuation_state.pop(key, None)
+            for key, session in list(bnl01_bot._direct_payload_sessions.items()):
+                if len(key) >= 2 and key[1] == channel_id:
+                    timer_task = session.get("timer_task")
+                    if timer_task and not timer_task.done():
+                        timer_task.cancel()
+                        try:
+                            await timer_task
+                        except asyncio.CancelledError:
+                            pass
+                    bnl01_bot._direct_payload_sessions.pop(key, None)
+        bnl01_bot.BNL_ACTIVE_BATCHING_ENABLED = self.original_batching_enabled
+
+    def _channel(self, channel_id, *, blocking_send=False):
+        self.channel_ids.add(channel_id)
+        channel_type = BlockingSendChannel if blocking_send else FakeChannel
+        return channel_type(channel_id)
+
+    def _append(self, channel, text, *, user_id=100, name="Jon"):
+        bnl01_bot._channel_buffers[channel.id].append((name, text, user_id))
+        bnl01_bot._channel_last_message_at[channel.id] = bnl01_bot.datetime.now(bnl01_bot.PACIFIC_TZ)
+
+    def _prime_flush(self, channel, *texts):
+        now = bnl01_bot.datetime.now(bnl01_bot.PACIFIC_TZ)
+        for text in texts:
+            bnl01_bot._channel_buffers[channel.id].append(("Jon", text, 100))
+        bnl01_bot._channel_first_seen[channel.id] = now
+        bnl01_bot._channel_last_message_at[channel.id] = now
+        bnl01_bot._channel_last_reply_at[channel.id] = now - bnl01_bot.timedelta(hours=2)
+
+    def _flush_runtime(self, channel_id, generation_side_effect):
+        async def guarded(response, **_kwargs):
+            return response, {
+                "suppressed": False,
+                "scripted_mode_leak_guard_triggered": False,
+                "source_grounding_guard_triggered": False,
+                "regenerated_for_mode_leak": False,
+            }
+
+        stack = ExitStack()
+        fake_bot = SimpleNamespace(id=999, display_name="BNL-01")
+        stack.enter_context(
+            mock.patch.object(type(bnl01_bot.client), "user", new_callable=mock.PropertyMock, return_value=fake_bot)
+        )
+        for patcher in (
+            mock.patch.object(bnl01_bot, "resolve_channel_policy", return_value="sealed_test"),
+            mock.patch.object(bnl01_bot, "get_sealed_test_recall_guard_response", return_value=None),
+            mock.patch.object(bnl01_bot, "get_restricted_channel_recall_guard_response", return_value=None),
+            mock.patch.object(bnl01_bot, "try_self_reflection_response", return_value=None),
+            mock.patch.object(bnl01_bot, "try_repair_response", return_value=None),
+            mock.patch.object(bnl01_bot, "resolve_recent_media_followup", return_value=None),
+            mock.patch.object(bnl01_bot, "try_memory_recall_response", return_value=None),
+            mock.patch.object(bnl01_bot, "choose_response_style", return_value=("balanced", "")),
+            mock.patch.object(bnl01_bot, "log_response_style"),
+            mock.patch.object(bnl01_bot, "conversation_context_v2_enabled", return_value=False),
+            mock.patch.object(bnl01_bot, "build_recent_text_room_context_for_prompt", return_value=""),
+            mock.patch.object(bnl01_bot, "current_batch_references_recent_media", return_value=False),
+            mock.patch.object(
+                bnl01_bot,
+                "get_gemini_response",
+                new=mock.AsyncMock(side_effect=generation_side_effect),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "suppress_stale_media_fallback",
+                side_effect=lambda response, **_kwargs: response,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "apply_guarded_response_regeneration",
+                new=mock.AsyncMock(side_effect=guarded),
+            ),
+            mock.patch.object(bnl01_bot, "_contains_unsupported_source_authority_claim", return_value=False),
+            mock.patch.object(bnl01_bot, "save_model_message"),
+            mock.patch.object(bnl01_bot, "mark_recent_media_events_response_state"),
+            mock.patch.object(bnl01_bot, "update_last_route_debug"),
+            mock.patch.object(bnl01_bot, "get_guild_config", return_value=channel_id),
+            mock.patch.object(bnl01_bot, "POST_GENERATION_CAPTURE_GRACE_SECONDS", 0),
+            mock.patch.object(bnl01_bot, "HARD_INTERRUPT_REEVALUATE_PAUSE_MIN_SECONDS", 0),
+            mock.patch.object(bnl01_bot, "HARD_INTERRUPT_REEVALUATE_PAUSE_MAX_SECONDS", 0),
+        ):
+            stack.enter_context(patcher)
+        return stack
+
+    def _on_message_runtime(self, channel_id, *, followup_candidate=True):
+        stack = ExitStack()
+        fake_bot = SimpleNamespace(id=999, display_name="BNL-01")
+        stack.enter_context(
+            mock.patch.object(type(bnl01_bot.client), "user", new_callable=mock.PropertyMock, return_value=fake_bot)
+        )
+        async_false_handlers = (
+            "maybe_handle_provider_status_command",
+            "maybe_handle_debug_last_route_command",
+            "maybe_handle_channel_audit_command",
+            "maybe_handle_backfill_command",
+            "maybe_handle_journal_command",
+            "maybe_handle_population_scan_command",
+            "maybe_handle_source_file_refresh_command",
+            "maybe_handle_source_file_enrichment_command",
+            "maybe_handle_source_file_lookup_command",
+            "maybe_handle_entity_context_resolver_command",
+            "maybe_handle_entity_activity_summary_command",
+            "maybe_handle_dossier_recommendation_command",
+        )
+        for name in async_false_handlers:
+            stack.enter_context(mock.patch.object(bnl01_bot, name, new=mock.AsyncMock(return_value=False)))
+        for patcher in (
+            mock.patch.object(bnl01_bot, "get_guild_config", return_value=channel_id),
+            mock.patch.object(bnl01_bot, "resolve_channel_policy", return_value="sealed_test"),
+            mock.patch.object(bnl01_bot, "upsert_user_profile"),
+            mock.patch.object(bnl01_bot, "is_direct_bnl_target", return_value=False),
+            mock.patch.object(
+                bnl01_bot,
+                "build_message_media_context",
+                return_value={"present": False, "included": False, "count": 0, "items": []},
+            ),
+            mock.patch.object(bnl01_bot, "record_recent_room_event_from_message"),
+            mock.patch.object(bnl01_bot, "_is_previous_message_request", return_value=False),
+            mock.patch.object(bnl01_bot, "maybe_record_live_community_presence"),
+            mock.patch.object(bnl01_bot, "_is_recent_direct_followup", return_value=followup_candidate),
+            mock.patch.object(bnl01_bot, "_is_recent_conversation_continuation", return_value=False),
+            mock.patch.object(bnl01_bot, "maybe_record_member_activity_event"),
+            mock.patch.object(bnl01_bot, "is_internal_channel_redirect_candidate", return_value=False),
+            mock.patch.object(bnl01_bot, "is_research_and_development_channel", return_value=False),
+            mock.patch.object(bnl01_bot.random, "random", return_value=1.0),
+            mock.patch.object(bnl01_bot, "record_passive_user_activity", return_value=False),
+            mock.patch.object(bnl01_bot, "save_user_message", return_value=SimpleNamespace()),
+        ):
+            stack.enter_context(patcher)
+        return stack
+
+    async def test_quiet_timer_restarts_when_a_second_fragment_arrives(self):
+        channel = self._channel(8101)
+        flushed = asyncio.Event()
+        snapshots = []
+        flush_times = []
+
+        async def fake_flush(_channel, scheduler_wait_state=None):
+            snapshots.append(list(bnl01_bot._channel_buffers[channel.id]))
+            flush_times.append(time.monotonic())
+            flushed.set()
+
+        wait_state = {
+            "selected_wait_seconds": 0.8,
+            "max_wait_seconds": 2.0,
+            "payload_count": 0,
+            "elapsed_seconds": 0,
+            "request_anchor": False,
+        }
+        with (
+            mock.patch.object(bnl01_bot, "_adaptive_batch_wait_seconds", return_value=wait_state),
+            mock.patch.object(bnl01_bot, "_batch_max_wait_seconds", return_value=2.0),
+            mock.patch.object(bnl01_bot, "_flush_channel_buffer", side_effect=fake_flush),
+        ):
+            self._append(channel, "first fragment")
+            bnl01_bot._reset_debounce(channel)
+            first_seen = bnl01_bot._channel_first_seen[channel.id]
+            await asyncio.sleep(0.35)
+
+            self._append(channel, "second fragment")
+            second_arrived_at = time.monotonic()
+            bnl01_bot._reset_debounce(channel)
+            self.assertEqual(first_seen, bnl01_bot._channel_first_seen[channel.id])
+
+            await asyncio.sleep(0.55)
+            self.assertFalse(flushed.is_set())
+            await asyncio.wait_for(flushed.wait(), timeout=0.5)
+
+        self.assertEqual(len(snapshots), 1)
+        self.assertEqual([item[1] for item in snapshots[0]], ["first fragment", "second fragment"])
+        self.assertGreaterEqual(flush_times[0] - second_arrived_at, 0.70)
+        self.assertLess(flush_times[0] - second_arrived_at, 1.20)
+
+    async def test_hard_cap_remains_anchored_to_the_first_fragment(self):
+        channel = self._channel(8102)
+        flushed = asyncio.Event()
+        batch_events = []
+        flush_times = []
+        started_at = time.monotonic()
+
+        async def fake_flush(_channel, scheduler_wait_state=None):
+            flush_times.append(time.monotonic())
+            flushed.set()
+
+        wait_state = {
+            "selected_wait_seconds": 2.0,
+            "max_wait_seconds": 0.8,
+            "payload_count": 0,
+            "elapsed_seconds": 0,
+            "request_anchor": False,
+        }
+        with (
+            mock.patch.object(bnl01_bot, "_adaptive_batch_wait_seconds", return_value=wait_state),
+            mock.patch.object(bnl01_bot, "_batch_max_wait_seconds", return_value=0.8),
+            mock.patch.object(bnl01_bot, "_flush_channel_buffer", side_effect=fake_flush),
+            mock.patch.object(
+                bnl01_bot,
+                "_log_batch_event",
+                side_effect=lambda _level, event, _guild_id, _channel_id, _count, reason: batch_events.append((event, reason)),
+            ),
+        ):
+            self._append(channel, "one")
+            bnl01_bot._reset_debounce(channel)
+            first_seen = bnl01_bot._channel_first_seen[channel.id]
+            await asyncio.sleep(0.20)
+            self._append(channel, "two")
+            bnl01_bot._reset_debounce(channel)
+            self.assertEqual(first_seen, bnl01_bot._channel_first_seen[channel.id])
+            await asyncio.sleep(0.20)
+            self._append(channel, "three")
+            bnl01_bot._reset_debounce(channel)
+            self.assertEqual(first_seen, bnl01_bot._channel_first_seen[channel.id])
+            await asyncio.wait_for(flushed.wait(), timeout=0.7)
+
+        self.assertIn(("flush", "hard_deadline"), batch_events)
+        elapsed = flush_times[0] - started_at
+        self.assertGreaterEqual(elapsed, 0.65)
+        self.assertLess(elapsed, 1.10)
+
+    async def test_scheduler_flushes_two_fragments_with_one_generation_and_send(self):
+        channel = self._channel(8103)
+        prompts = []
+
+        async def generate(prompt, **_kwargs):
+            prompts.append(prompt)
+            return "One combined response."
+
+        self._prime_flush(channel, "BNL, why are routers weird?", "and why do they blink?")
+        wait_state = {
+            "selected_wait_seconds": 0.01,
+            "max_wait_seconds": 1.0,
+            "payload_count": 0,
+            "elapsed_seconds": 0,
+            "request_anchor": False,
+        }
+        with self._flush_runtime(channel.id, generate), mock.patch.object(
+            bnl01_bot, "_adaptive_batch_wait_seconds", return_value=wait_state
+        ):
+            bnl01_bot._reset_debounce(channel)
+            await asyncio.wait_for(bnl01_bot._channel_tasks[channel.id], timeout=0.5)
+
+        self.assertEqual(len(prompts), 1)
+        self.assertIn("BNL, why are routers weird?", prompts[0])
+        self.assertIn("and why do they blink?", prompts[0])
+        self.assertEqual(channel.sent, ["One combined response."])
+
+    async def test_late_fragment_does_not_cancel_generation_and_rebuilds_once(self):
+        channel = self._channel(8104)
+        generation_started = asyncio.Event()
+        release_generation = asyncio.Event()
+        prompts = []
+
+        async def generate(prompt, **_kwargs):
+            prompts.append(prompt)
+            if len(prompts) == 1:
+                generation_started.set()
+                await release_generation.wait()
+                return "Stale first draft."
+            return "Fresh combined response."
+
+        self._prime_flush(channel, "BNL, why are routers weird?")
+        with self._flush_runtime(channel.id, generate):
+            task = asyncio.create_task(bnl01_bot._flush_channel_buffer(channel))
+            bnl01_bot._channel_tasks[channel.id] = task
+            await asyncio.wait_for(generation_started.wait(), timeout=0.5)
+
+            generation_id = bnl01_bot._channel_generation_id[channel.id]
+            bnl01_bot._channel_preempted_generation_id[channel.id] = generation_id
+            bnl01_bot._channel_message_interrupt_generation_id[channel.id] = generation_id
+            self._append(channel, "and why do they blink?")
+            bnl01_bot._reset_debounce(channel)
+
+            self.assertIs(bnl01_bot._channel_tasks[channel.id], task)
+            self.assertFalse(task.cancelled())
+            release_generation.set()
+            await asyncio.wait_for(task, timeout=1)
+
+        self.assertEqual(len(prompts), 2)
+        self.assertNotIn("and why do they blink?", prompts[0])
+        self.assertIn("and why do they blink?", prompts[1])
+        self.assertEqual(channel.sent, ["Fresh combined response."])
+        self.assertEqual(list(bnl01_bot._channel_buffers[channel.id]), [])
+
+    async def test_interrupt_handoff_merges_with_newer_buffered_fragment(self):
+        channel = self._channel(8107)
+        prompts = []
+
+        async def generate(prompt, **_kwargs):
+            prompts.append(prompt)
+            return "All three turns survived."
+
+        now = bnl01_bot.datetime.now(bnl01_bot.PACIFIC_TZ)
+        bnl01_bot._channel_interrupt_handoff[channel.id] = [
+            ("Jon", "BNL, why are routers weird?", 100),
+            ("Jon", "and why do they blink?", 100),
+        ]
+        bnl01_bot._channel_buffers[channel.id].append(("Jon", "also, why are they warm?", 100))
+        bnl01_bot._channel_first_seen[channel.id] = now
+        bnl01_bot._channel_last_message_at[channel.id] = now
+        bnl01_bot._channel_last_reply_at[channel.id] = now - bnl01_bot.timedelta(hours=2)
+
+        with self._flush_runtime(channel.id, generate):
+            await bnl01_bot._flush_channel_buffer(channel)
+
+        self.assertEqual(len(prompts), 1)
+        self.assertIn("BNL, why are routers weird?", prompts[0])
+        self.assertIn("and why do they blink?", prompts[0])
+        self.assertIn("also, why are they warm?", prompts[0])
+        self.assertEqual(channel.sent, ["All three turns survived."])
+        self.assertEqual(list(bnl01_bot._channel_buffers[channel.id]), [])
+        self.assertNotIn(channel.id, bnl01_bot._channel_interrupt_handoff)
+
+    async def test_message_after_send_commit_is_rescheduled_instead_of_orphaned(self):
+        channel = self._channel(8105, blocking_send=True)
+
+        async def generate(_prompt, **_kwargs):
+            return "Committed first response."
+
+        self._prime_flush(channel, "BNL, why are routers weird?")
+        with self._flush_runtime(channel.id, generate):
+            first_task = asyncio.create_task(bnl01_bot._flush_channel_buffer(channel))
+            bnl01_bot._channel_tasks[channel.id] = first_task
+            await asyncio.wait_for(channel.send_started.wait(), timeout=0.5)
+
+            generation_id = bnl01_bot._channel_generation_id[channel.id]
+            bnl01_bot._channel_preempted_generation_id[channel.id] = generation_id
+            bnl01_bot._channel_message_interrupt_generation_id[channel.id] = generation_id
+            self._append(channel, "one more thing")
+            bnl01_bot._reset_debounce(channel)
+            self.assertIs(bnl01_bot._channel_tasks[channel.id], first_task)
+
+            channel.release_send.set()
+            await asyncio.wait_for(first_task, timeout=1)
+            successor = bnl01_bot._channel_tasks[channel.id]
+
+        self.assertIsNot(successor, first_task)
+        self.assertFalse(successor.done())
+        self.assertEqual([item[1] for item in bnl01_bot._channel_buffers[channel.id]], ["one more thing"])
+        self.assertEqual(channel.sent, ["Committed first response."])
+
+    async def test_deferred_session_cancels_an_active_batch_generation(self):
+        channel = self._channel(8108)
+        generation_started = asyncio.Event()
+        never_release = asyncio.Event()
+
+        async def generate(_prompt, **_kwargs):
+            generation_started.set()
+            await never_release.wait()
+            return "must not send"
+
+        self._prime_flush(channel, "BNL, why are routers weird?")
+        with self._flush_runtime(channel.id, generate):
+            task = asyncio.create_task(bnl01_bot._flush_channel_buffer(channel))
+            bnl01_bot._channel_tasks[channel.id] = task
+            await asyncio.wait_for(generation_started.wait(), timeout=0.5)
+            self.assertTrue(bnl01_bot._channel_generating[channel.id])
+
+            await bnl01_bot._preempt_pending_batch_for_deferred_session(channel)
+
+        self.assertTrue(task.done())
+        self.assertFalse(bnl01_bot._channel_generating[channel.id])
+        self.assertNotIn(channel.id, bnl01_bot._channel_tasks)
+        self.assertEqual(channel.sent, [])
+
+    async def test_on_message_human_recipient_outranks_stale_followup(self):
+        channel = self._channel(8109)
+        author = FakeAuthor()
+        miss_bit = SimpleNamespace(id=456, display_name="Miss Bit", bot=False)
+        message = FakeMessage(
+            channel,
+            "<@456> what do you think about Friday's opener?",
+            author=author,
+            mentions=[miss_bit],
+        )
+
+        with self._on_message_runtime(channel.id, followup_candidate=True):
+            await bnl01_bot.on_message(message)
+            scheduled = bnl01_bot._channel_tasks[channel.id]
+            scheduled.cancel()
+            try:
+                await scheduled
+            except asyncio.CancelledError:
+                pass
+            bnl01_bot._channel_tasks.pop(channel.id, None)
+            await bnl01_bot._flush_channel_buffer(channel)
+
+        self.assertEqual(channel.sent, [])
+        self.assertEqual(message.replies, [])
+        self.assertEqual(list(bnl01_bot._channel_buffers[channel.id]), [])
+
+    async def test_on_message_plain_name_request_preempts_batch_and_accepts_tag_payload(self):
+        channel = self._channel(8110)
+        author = FakeAuthor()
+        miss_bit = SimpleNamespace(id=456, display_name="Miss Bit", bot=False)
+        first = FakeMessage(channel, "one setup fragment", author=author)
+        request = FakeMessage(
+            channel,
+            "BNL, tell me something about each of these people",
+            author=author,
+        )
+        payload = FakeMessage(channel, "<@456>", author=author, mentions=[miss_bit])
+
+        with self._on_message_runtime(channel.id, followup_candidate=True), mock.patch.object(
+            bnl01_bot,
+            "_direct_session_timer",
+            new=mock.AsyncMock(return_value=None),
+        ):
+            await bnl01_bot.on_message(first)
+            old_batch_task = bnl01_bot._channel_tasks[channel.id]
+            self.assertEqual(len(bnl01_bot._channel_buffers[channel.id]), 1)
+
+            await bnl01_bot.on_message(request)
+            key = (channel.guild.id, channel.id, author.id)
+            session = bnl01_bot._direct_payload_sessions[key]
+            self.assertTrue(old_batch_task.done())
+            self.assertEqual(list(bnl01_bot._channel_buffers[channel.id]), [])
+            self.assertNotIn(channel.id, bnl01_bot._channel_tasks)
+
+            await bnl01_bot.on_message(payload)
+
+        self.assertEqual(session["payload_lines"], ["@Miss Bit"])
+        self.assertEqual(len(session["payload_turn_contexts"]), 1)
+        self.assertEqual(channel.sent, [])
+        self.assertEqual(request.replies, [])
+        self.assertEqual(payload.replies, [])
+
+    async def test_buffer_max_never_starts_an_overlapping_flush(self):
+        channel = self._channel(8106)
+        bnl01_bot._channel_generating[channel.id] = True
+        self._append(channel, "late fragment")
+
+        with mock.patch.object(bnl01_bot, "_flush_channel_buffer", new=mock.AsyncMock()) as flush:
+            flushed = await bnl01_bot._flush_channel_buffer_now(channel)
+
+        self.assertFalse(flushed)
+        flush.assert_not_awaited()
+
+    async def test_buffer_max_cancels_waiter_and_flushes_once_when_idle(self):
+        channel = self._channel(8111)
+        waiter_block = asyncio.Event()
+        scheduled = asyncio.create_task(waiter_block.wait())
+        bnl01_bot._channel_tasks[channel.id] = scheduled
+        self._append(channel, "full buffer fragment")
+
+        with mock.patch.object(bnl01_bot, "_flush_channel_buffer", new=mock.AsyncMock()) as flush:
+            flushed = await bnl01_bot._flush_channel_buffer_now(channel)
+
+        self.assertTrue(flushed)
+        self.assertTrue(scheduled.cancelled())
+        flush.assert_awaited_once_with(channel)
+        self.assertTrue(bnl01_bot._channel_tasks[channel.id].done())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_route_memory_governance.py
+++ b/tests/test_route_memory_governance.py
@@ -314,6 +314,48 @@ class DirectPayloadAddressingTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(session["completed"])
         self.assertFalse(session["generating"])
 
+    async def test_deferred_plan_starts_existing_protected_payload_waiter(self):
+        author = SimpleNamespace(id=100, display_name="Jon")
+        guild = SimpleNamespace(id=1)
+        channel = SimpleNamespace(id=2, name="bnl-testing", guild=guild)
+        message = SimpleNamespace(id=10, guild=guild, channel=channel, author=author)
+        plan = bnl01_bot.plan_conversation_response(
+            "BNL, tell me something about each of these people",
+            "sealed_test",
+            route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            active_channel=True,
+            plain_text_name_seen=True,
+            followup_candidate=True,
+            channel_allows_conversation=True,
+            batching_enabled=True,
+            payload_expected=True,
+            payload_count=0,
+            conversation_surface=bnl01_bot.CONVERSATION_SURFACE_FREE_SPEAK_SEALED_MIRROR,
+        )
+
+        with mock.patch.object(
+            bnl01_bot,
+            "_direct_session_timer",
+            new=mock.AsyncMock(return_value=None),
+        ) as timer:
+            started = await bnl01_bot._maybe_start_deferred_payload_session(
+                message,
+                plan,
+                channel_policy="sealed_test",
+                request_text="BNL, tell me something about each of these people",
+                current_turn_context="anchor addressing",
+            )
+            session = bnl01_bot._direct_payload_sessions[(1, 2, 100)]
+            await session["timer_task"]
+
+        key = (1, 2, 100)
+        self.assertTrue(started)
+        self.assertIs(bnl01_bot._direct_payload_sessions[key], session)
+        self.assertEqual(session["original_request_text"], "BNL, tell me something about each of these people")
+        self.assertEqual(session["payload_lines"], [])
+        self.assertEqual(session["current_turn_context"], "anchor addressing")
+        timer.assert_awaited_once_with(key)
+
 
 class ConversationPlannerTests(unittest.TestCase):
     def test_simple_greeting_creates_paced_generated_response(self):
@@ -471,6 +513,102 @@ class ConversationPlannerTests(unittest.TestCase):
         self.assertEqual(plans[0].response_timing, plans[1].response_timing)
         self.assertEqual(plans[0].response_generation, plans[1].response_generation)
         self.assertEqual(plans[0].batch_behavior, plans[1].batch_behavior)
+
+    def test_recent_free_speak_followups_reenter_debounce_when_enabled(self):
+        for policy in ("public_home", "sealed_test"):
+            plan = bnl01_bot.plan_conversation_response(
+                "you still sound like a nerd",
+                policy,
+                route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                followup_candidate=True,
+                channel_allows_conversation=True,
+                batching_enabled=True,
+            )
+            self.assertFalse(plan.should_reply, policy)
+            self.assertTrue(plan.batch_allowed, policy)
+            self.assertEqual(plan.directness, "recent_followup", policy)
+            self.assertEqual(plan.policy_reply_class, "batched_followup", policy)
+            self.assertEqual(plan.response_timing, bnl01_bot.RESPONSE_TIMING_BATCHED_CHANNEL, policy)
+            self.assertEqual(plan.batch_behavior, bnl01_bot.BATCH_BEHAVIOR_ENTER_BATCH, policy)
+
+    def test_plain_name_list_request_starts_protected_payload_waiter(self):
+        plan = bnl01_bot.plan_conversation_response(
+            "BNL, tell me something about each of these people",
+            "sealed_test",
+            route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            active_channel=True,
+            plain_text_name_seen=True,
+            followup_candidate=True,
+            channel_allows_conversation=True,
+            batching_enabled=True,
+            payload_expected=True,
+            payload_count=0,
+            conversation_surface=bnl01_bot.CONVERSATION_SURFACE_FREE_SPEAK_SEALED_MIRROR,
+        )
+        self.assertTrue(plan.should_reply)
+        self.assertTrue(plan.direct_session_used)
+        self.assertEqual(plan.route_mode, bnl01_bot.ROUTE_MODE_DIRECT_PAYLOAD)
+        self.assertEqual(plan.response_timing, bnl01_bot.RESPONSE_TIMING_DEFERRED_PAYLOAD_SESSION)
+        self.assertEqual(plan.batch_behavior, bnl01_bot.BATCH_BEHAVIOR_DO_NOT_BATCH)
+
+    def test_deictic_list_request_does_not_count_as_inline_payload(self):
+        for text in (
+            "BNL, tell me something about each of these people",
+            "BNL, tell me something about these people",
+            "BNL, write one for each of the following",
+            "BNL, tell me about those names",
+        ):
+            self.assertEqual(bnl01_bot._collect_inline_direct_payload_items(text), [], text)
+
+    def test_inline_list_request_still_collects_actual_names(self):
+        self.assertEqual(
+            bnl01_bot._collect_inline_direct_payload_items("BNL, tell me about these people: Chris and Pat"),
+            ["Chris", "Pat"],
+        )
+
+    def test_unaddressed_list_shaped_room_chat_stays_in_normal_batching(self):
+        plan = bnl01_bot.plan_conversation_response(
+            "tell me something about each of these people",
+            "sealed_test",
+            route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            active_channel=True,
+            channel_allows_conversation=True,
+            batching_enabled=True,
+            payload_expected=True,
+            payload_count=0,
+            conversation_surface=bnl01_bot.CONVERSATION_SURFACE_FREE_SPEAK_SEALED_MIRROR,
+        )
+        self.assertFalse(plan.should_reply)
+        self.assertFalse(plan.direct_session_used)
+        self.assertEqual(plan.response_timing, bnl01_bot.RESPONSE_TIMING_BATCHED_CHANNEL)
+        self.assertEqual(plan.batch_behavior, bnl01_bot.BATCH_BEHAVIOR_ENTER_BATCH)
+
+    def test_real_mentions_and_replies_still_outrank_followup_batching(self):
+        mention = bnl01_bot.plan_conversation_response(
+            "actual mention",
+            "sealed_test",
+            route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            real_direct_target=True,
+            followup_candidate=True,
+            batching_enabled=True,
+        )
+        reply = bnl01_bot.plan_conversation_response(
+            "reply to BNL",
+            "public_home",
+            route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            reply_to_bot=True,
+            followup_candidate=True,
+            batching_enabled=True,
+        )
+        for plan in (mention, reply):
+            self.assertTrue(plan.should_reply)
+            self.assertEqual(plan.response_timing, bnl01_bot.RESPONSE_TIMING_PACED_DIRECT)
+            self.assertEqual(plan.batch_behavior, bnl01_bot.BATCH_BEHAVIOR_PREEMPT_BATCH)
+
+    def test_sealed_test_chat_is_not_prompt_operator_authority(self):
+        self.assertFalse(bnl01_bot.is_operator_authority_context("sealed_test", "bnl-testing"))
+        self.assertTrue(bnl01_bot.is_operator_authority_context("internal_controlled", "research-and-development"))
+        self.assertTrue(bnl01_bot.is_operator_authority_context("broadcast_memory", "bnl-broadcast-memory"))
 
     def test_public_home_and_sealed_test_free_speak_parity_examples(self):
         cases = [


### PR DESCRIPTION
## What changed

- routes recent unaddressed follow-ups back through the existing quiet-window conversation batcher when batching is enabled
- preserves direct handling for real BNL mentions and replies
- makes explicit human recipients outrank stale BNL follow-up state
- connects explicit list requests to the existing protected payload waiter, including tag-only follow-ups
- repairs coordinator races so newer fragments are neither discarded nor left without a future flush
- removes operator-authority prompt framing from ordinary `#bnl-testing` conversation while preserving sealed-room isolation

## Why

The existing debounce coordinator still existed, but several current runtime routes bypassed it. In addition, the protected follow-up waiter was planned without actually being started for the tested list-request path. That produced immediate fragmented replies, interruptions of human-directed questions, and lost tag-only payloads.

## Impact and boundaries

This is a bot-only conversational routing repair. It does not enable batching by default and does not touch the website, queue, dossiers, Source Files, Journal, relay transport, or live memory/relationship gates. `#bnl-testing` remains sealed; it mirrors the primary room's timing, routing, and conversational voice only when batching is deliberately enabled for supervised acceptance.

## Validation

- 148 focused conversation/routing tests passed, including repeated asynchronous timing runs
- full repository suite passed: 1,121 tests
- three independent local reviews: GO
- remote branch is one commit ahead of `main`, with exactly three changed files
