### PR TITLE
Close conversational batching and payload guard races

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -9958,6 +9958,14 @@ def get_restricted_channel_recall_guard_response(channel_policy: str, user_text:
     return restricted_channel_recall_boundary_response()
 
 
+def get_conversation_recall_guard_response(channel_policy: str, user_text: str, guild_id: int, channel_id: int) -> str:
+    """Apply sealed-test and restricted-channel recall boundaries in one order."""
+    return (
+        get_sealed_test_recall_guard_response(channel_policy, user_text, guild_id, channel_id)
+        or get_restricted_channel_recall_guard_response(channel_policy, user_text, guild_id, channel_id)
+    )
+
+
 def try_repair_response(user_text: str) -> str:
     t = (user_text or "").lower().strip()
     if not t:
@@ -16656,16 +16664,30 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
 
     batch_max_wait = _batch_max_wait_seconds(channel_id)
     last_msg_at = _channel_last_message_at.get(channel_id)
+    resumed_interrupted_handoff = False
     if last_msg_at and (now - last_msg_at).total_seconds() > batch_max_wait:
-        stale_reason = "extended_payload_stale_batch" if _channel_payload_wait_extended.get(channel_id) else "stale_batch"
-        _log_batch_event(logging.INFO, "stale_batch_allowed_extended_payload", guild_id, channel_id, message_count, f"extended={int(_channel_payload_wait_extended.get(channel_id))};max_wait={batch_max_wait}")
-        buf.clear()
-        _channel_first_seen.pop(channel_id, None)
-        _channel_last_message_at.pop(channel_id, None)
-        _log_batch_event(logging.INFO, "skip", guild_id, channel_id, message_count, stale_reason)
-        return
+        if handoff_items is None:
+            stale_reason = "extended_payload_stale_batch" if _channel_payload_wait_extended.get(channel_id) else "stale_batch"
+            _log_batch_event(logging.INFO, "stale_batch_allowed_extended_payload", guild_id, channel_id, message_count, f"extended={int(_channel_payload_wait_extended.get(channel_id))};max_wait={batch_max_wait}")
+            buf.clear()
+            _channel_first_seen.pop(channel_id, None)
+            _channel_last_message_at.pop(channel_id, None)
+            _log_batch_event(logging.INFO, "skip", guild_id, channel_id, message_count, stale_reason)
+            return
+        # These messages were waiting behind an in-flight generation, not abandoned.
+        # Flush them immediately with the preserved packet and give the replacement
+        # generation its own deadline instead of deleting user input as stale.
+        resumed_interrupted_handoff = True
+        _log_batch_event(
+            logging.INFO,
+            "stale_batch_allowed_interrupt_handoff",
+            guild_id,
+            channel_id,
+            message_count,
+            f"blocked_by_generation=1;max_wait={batch_max_wait}",
+        )
 
-    batch_start = _channel_first_seen.get(channel_id, now)
+    batch_start = now if resumed_interrupted_handoff else _channel_first_seen.get(channel_id, now)
     selected_wait_seconds = float(BATCH_WINDOW_SECONDS)
     if scheduler_wait_state and isinstance(scheduler_wait_state, dict):
         selected_wait_seconds = float(scheduler_wait_state.get("selected_wait_seconds", selected_wait_seconds))
@@ -17244,6 +17266,22 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             if pending_after_discard > 0 or interrupted_by_message:
                 _log_batch_event(logging.INFO, "stale_response_discarded", guild_id, channel_id, len(items), "interrupted_preempted")
             if pending_after_discard > 0:
+                # The generated response covered ``items`` but cannot be sent after a
+                # newer fragment arrived. Preserve that full packet for the successor
+                # flush; requeueing only the newest buffer loses the conversation that
+                # the discarded response was answering.
+                _channel_interrupt_handoff[channel_id] = list(items)
+                _channel_first_seen[channel_id] = datetime.now(PACIFIC_TZ)
+                _channel_preempted_generation_id[channel_id] = 0
+                _channel_message_interrupt_generation_id[channel_id] = 0
+                _log_batch_event(
+                    logging.INFO,
+                    "hard_interrupt_packet_handoff",
+                    guild_id,
+                    channel_id,
+                    len(items) + pending_after_discard,
+                    "full_context_preserved_after_regeneration",
+                )
                 _log_batch_event(
                     logging.INFO,
                     "generation_requeued_after_interruption",
@@ -18088,6 +18126,21 @@ async def _maybe_start_deferred_payload_session(
     ):
         return False
     await _preempt_pending_batch_for_deferred_session(message.channel)
+    recall_guard = get_conversation_recall_guard_response(
+        channel_policy,
+        request_text,
+        message.guild.id,
+        message.channel.id,
+    )
+    if recall_guard:
+        await message.reply(recall_guard, allowed_mentions=discord.AllowedMentions.none())
+        logging.info(
+            "direct_payload_session_start_blocked reason=recall_guard guild_id=%s channel_id=%s user_id=%s",
+            message.guild.id,
+            message.channel.id,
+            message.author.id,
+        )
+        return True
     _start_direct_payload_session(
         message,
         channel_policy=channel_policy,
@@ -18126,12 +18179,15 @@ def close_direct_payload_session_after_failed_generation(session_key, session: d
     session["generating"] = False
     session["completed"] = True
     session["generation_invalidated"] = False
-    _direct_payload_sessions.pop(session_key, None)
+    removed_current_session = _direct_payload_sessions.get(session_key) is session
+    if removed_current_session:
+        _direct_payload_sessions.pop(session_key, None)
     logging.info(
-        "direct_payload_session_closed reason=%s revision=%s payload_count=%s",
+        "direct_payload_session_closed reason=%s revision=%s payload_count=%s removed_current_session=%s",
         reason,
         int(session.get("revision", 0)),
         len(session.get("payload_lines", [])),
+        int(removed_current_session),
     )
 
 
@@ -18352,6 +18408,27 @@ async def _generate_direct_payload_session(session_key, reason: str):
     if delta_mode:
         logging.info(f"direct_session_delta_continuation_started from_payload_count={last_committed_payload_count} to_payload_count={payload_count}")
     direct_content = session["original_request_text"] + "\n" + "\n".join(generation_lines)
+    recall_guard_content = session["original_request_text"] + "\n" + "\n".join(payload_lines)
+    recall_guard = get_conversation_recall_guard_response(
+        session.get("channel_policy", "unknown"),
+        recall_guard_content,
+        session["guild_id"],
+        session.get("channel_id", 0),
+    )
+    if recall_guard:
+        # Remove this exact guarded revision before yielding to Discord. A new
+        # request may create a replacement session while the boundary reply sends.
+        close_direct_payload_session_after_failed_generation(session_key, session, "recall_guard")
+        try:
+            await anchor_message.reply(recall_guard, allowed_mentions=discord.AllowedMentions.none())
+        except Exception as exc:
+            logging.error(
+                "response_send_failed route=%s channel_id=%s discord_error_type=%s",
+                "direct_payload_session_recall_guard",
+                session.get("channel_id", 0),
+                type(exc).__name__,
+            )
+        return
     direct_payload_items = []
     seen = set()
     for line in generation_lines:
@@ -19459,6 +19536,31 @@ async def on_message(message: discord.Message):
                         f"payload_count={payload_count};last_committed_payload_count={last_committed_payload_count}"
                     )
                 else:
+                    recall_guard_content = "\n".join(
+                        [
+                            active_direct_session.get("original_request_text", ""),
+                            *active_direct_session.get("payload_lines", []),
+                            line,
+                        ]
+                    )
+                    recall_guard = get_conversation_recall_guard_response(
+                        active_direct_session.get("channel_policy", channel_policy),
+                        recall_guard_content,
+                        active_direct_session.get("guild_id", message.guild.id),
+                        active_direct_session.get("channel_id", message.channel.id),
+                    )
+                    if recall_guard:
+                        active_direct_session["generation_invalidated"] = True
+                        active_direct_session["completed"] = True
+                        _direct_payload_sessions.pop(session_key, None)
+                        await message.reply(recall_guard, allowed_mentions=discord.AllowedMentions.none())
+                        logging.info(
+                            "direct_payload_session_payload_blocked reason=recall_guard guild_id=%s channel_id=%s user_id=%s",
+                            message.guild.id,
+                            message.channel.id,
+                            message.author.id,
+                        )
+                        return
                     append_direct_payload_session_turn(
                         active_direct_session,
                         line,
@@ -19619,9 +19721,13 @@ async def on_message(message: discord.Message):
                 _channel_preempted_generation_id[message.channel.id] = _channel_generation_id[message.channel.id]
                 _channel_message_interrupt_generation_id[message.channel.id] = _channel_generation_id[message.channel.id]
                 _log_batch_event(logging.INFO, "stale_response_discarded", message.guild.id, message.channel.id, len(_channel_buffers[message.channel.id]), "direct_reply_preempted_generation")
-            pending_count = len(_channel_buffers[message.channel.id])
+            pending_count = (
+                len(_channel_buffers[message.channel.id])
+                + len(_channel_interrupt_handoff.get(message.channel.id, []))
+            )
             if pending_count:
                 _channel_buffers[message.channel.id].clear()
+                _channel_interrupt_handoff.pop(message.channel.id, None)
                 _channel_first_seen.pop(message.channel.id, None)
                 _channel_last_message_at.pop(message.channel.id, None)
                 pending_task = _channel_tasks.get(message.channel.id)

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -92,6 +92,18 @@ class FakeMessage:
         self.reactions.append(emoji)
 
 
+class BlockingReplyMessage(FakeMessage):
+    def __init__(self, channel, content, *, author=None, mentions=None):
+        super().__init__(channel, content, author=author, mentions=mentions)
+        self.reply_started = asyncio.Event()
+        self.release_reply = asyncio.Event()
+
+    async def reply(self, text, **_kwargs):
+        self.reply_started.set()
+        await self.release_reply.wait()
+        self.replies.append(text)
+
+
 class BlockingSendChannel(FakeChannel):
     def __init__(self, channel_id, *, name="bnl-testing", guild=None):
         super().__init__(channel_id, name=name, guild=guild)
@@ -421,6 +433,74 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(channel.sent, ["Fresh combined response."])
         self.assertEqual(list(bnl01_bot._channel_buffers[channel.id]), [])
 
+    async def test_second_late_fragment_survives_slow_regeneration_and_keeps_full_context(self):
+        channel = self._channel(8112)
+        first_generation_started = asyncio.Event()
+        release_first_generation = asyncio.Event()
+        regenerated_generation_started = asyncio.Event()
+        release_regenerated_generation = asyncio.Event()
+        prompts = []
+        batch_events = []
+
+        async def generate(prompt, **_kwargs):
+            prompts.append(prompt)
+            if len(prompts) == 1:
+                first_generation_started.set()
+                await release_first_generation.wait()
+                return "Stale first draft."
+            if len(prompts) == 2:
+                regenerated_generation_started.set()
+                await release_regenerated_generation.wait()
+                return "Stale regenerated draft."
+            return "Fresh response covering all three fragments."
+
+        self._prime_flush(channel, "hey BNL")
+        with (
+            self._flush_runtime(channel.id, generate),
+            mock.patch.object(bnl01_bot, "_batch_max_wait_seconds", return_value=0.2),
+            mock.patch.object(
+                bnl01_bot,
+                "_log_batch_event",
+                side_effect=lambda _level, event, _guild_id, _channel_id, _count, reason: batch_events.append((event, reason)),
+            ),
+        ):
+            first_task = asyncio.create_task(bnl01_bot._flush_channel_buffer(channel))
+            bnl01_bot._channel_tasks[channel.id] = first_task
+            await asyncio.wait_for(first_generation_started.wait(), timeout=0.5)
+
+            generation_id = bnl01_bot._channel_generation_id[channel.id]
+            bnl01_bot._channel_preempted_generation_id[channel.id] = generation_id
+            bnl01_bot._channel_message_interrupt_generation_id[channel.id] = generation_id
+            self._append(channel, "you still sound like a nerd")
+            bnl01_bot._reset_debounce(channel)
+            release_first_generation.set()
+
+            await asyncio.wait_for(regenerated_generation_started.wait(), timeout=0.5)
+            self.assertIn(("regenerated_batch_once", "retry"), batch_events)
+            bnl01_bot._channel_preempted_generation_id[channel.id] = generation_id
+            bnl01_bot._channel_message_interrupt_generation_id[channel.id] = generation_id
+            self._append(channel, "but I know you're trying")
+            bnl01_bot._reset_debounce(channel)
+
+            # Hold the retry past the original batch deadline, as the live provider
+            # plus glitch-rewrite path did, without making the test wait ten seconds.
+            await asyncio.sleep(0.25)
+            release_regenerated_generation.set()
+            await asyncio.wait_for(first_task, timeout=1)
+
+            successor = bnl01_bot._channel_tasks[channel.id]
+            self.assertIsNot(successor, first_task)
+            await asyncio.wait_for(successor, timeout=1)
+
+        self.assertEqual(len(prompts), 3)
+        self.assertIn("hey BNL", prompts[2])
+        self.assertIn("you still sound like a nerd", prompts[2])
+        self.assertIn("but I know you're trying", prompts[2])
+        self.assertEqual(channel.sent, ["Fresh response covering all three fragments."])
+        self.assertEqual(list(bnl01_bot._channel_buffers[channel.id]), [])
+        self.assertNotIn(channel.id, bnl01_bot._channel_interrupt_handoff)
+        self.assertNotIn(("skip", "stale_batch"), batch_events)
+
     async def test_interrupt_handoff_merges_with_newer_buffered_fragment(self):
         channel = self._channel(8107)
         prompts = []
@@ -528,6 +608,44 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(message.replies, [])
         self.assertEqual(list(bnl01_bot._channel_buffers[channel.id]), [])
 
+    async def test_paced_direct_reply_clears_preserved_interrupt_handoff(self):
+        channel = self._channel(8114)
+        message = FakeMessage(channel, "BNL, answer this now")
+        now = bnl01_bot.datetime.now(bnl01_bot.PACIFIC_TZ)
+        bnl01_bot._channel_interrupt_handoff[channel.id] = [
+            ("Jon", "an older interrupted fragment", 100),
+        ]
+        bnl01_bot._channel_first_seen[channel.id] = now
+        bnl01_bot._channel_last_message_at[channel.id] = now
+        never_release = asyncio.Event()
+        pending_task = asyncio.create_task(never_release.wait())
+        bnl01_bot._channel_tasks[channel.id] = pending_task
+        plan = SimpleNamespace(
+            route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            should_reply=True,
+            response_timing=bnl01_bot.RESPONSE_TIMING_PACED_DIRECT,
+        )
+
+        with (
+            self._on_message_runtime(channel.id, followup_candidate=False),
+            mock.patch.object(bnl01_bot, "is_direct_bnl_target", return_value=True),
+            mock.patch.object(bnl01_bot, "plan_conversation_response", return_value=plan),
+            mock.patch.object(bnl01_bot, "try_repair_response", return_value="Direct reply."),
+            mock.patch.object(
+                bnl01_bot,
+                "send_reply_then_save_model",
+                new=mock.AsyncMock(),
+            ) as send_reply,
+        ):
+            await bnl01_bot.on_message(message)
+            await asyncio.sleep(0)
+
+        self.assertTrue(pending_task.cancelled())
+        self.assertNotIn(channel.id, bnl01_bot._channel_interrupt_handoff)
+        self.assertNotIn(channel.id, bnl01_bot._channel_first_seen)
+        self.assertNotIn(channel.id, bnl01_bot._channel_last_message_at)
+        send_reply.assert_awaited_once()
+
     async def test_on_message_plain_name_request_preempts_batch_and_accepts_tag_payload(self):
         channel = self._channel(8110)
         author = FakeAuthor()
@@ -563,6 +681,124 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(channel.sent, [])
         self.assertEqual(request.replies, [])
         self.assertEqual(payload.replies, [])
+
+    async def test_deferred_payload_request_runs_recall_guards_before_starting_session(self):
+        channel = self._channel(8113)
+        request = FakeMessage(
+            channel,
+            "BNL, summarize each of these people from #research-and-development",
+        )
+        plan = SimpleNamespace(
+            should_reply=True,
+            response_timing=bnl01_bot.RESPONSE_TIMING_DEFERRED_PAYLOAD_SESSION,
+        )
+
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "_preempt_pending_batch_for_deferred_session",
+                new=mock.AsyncMock(return_value=0),
+            ) as preempt,
+            mock.patch.object(bnl01_bot, "_start_direct_payload_session") as start_session,
+        ):
+            handled = await bnl01_bot._maybe_start_deferred_payload_session(
+                request,
+                plan,
+                channel_policy="public_home",
+                request_text=request.content,
+                current_turn_context="",
+            )
+
+        self.assertTrue(handled)
+        preempt.assert_awaited_once_with(channel)
+        start_session.assert_not_called()
+        self.assertEqual(
+            request.replies,
+            [bnl01_bot.restricted_channel_recall_boundary_response()],
+        )
+
+    async def test_deferred_payload_session_blocks_restricted_recall_in_followup(self):
+        channel = self._channel(8115)
+        author = FakeAuthor()
+        request = FakeMessage(
+            channel,
+            "BNL, summarize each of these things",
+            author=author,
+        )
+        payload = FakeMessage(
+            channel,
+            "what happened in #research-and-development?",
+            author=author,
+        )
+
+        with mock.patch.object(
+            bnl01_bot,
+            "_direct_session_timer",
+            new=mock.AsyncMock(return_value=None),
+        ):
+            session = bnl01_bot._start_direct_payload_session(
+                request,
+                channel_policy="public_home",
+                request_text=request.content,
+                current_turn_context="",
+            )
+            await asyncio.sleep(0)
+
+        key = (channel.guild.id, channel.id, author.id)
+        with (
+            self._on_message_runtime(channel.id, followup_candidate=True),
+            mock.patch.object(bnl01_bot, "resolve_channel_policy", return_value="public_home"),
+        ):
+            await bnl01_bot.on_message(payload)
+
+        self.assertTrue(session["completed"])
+        self.assertTrue(session["generation_invalidated"])
+        self.assertNotIn(key, bnl01_bot._direct_payload_sessions)
+        self.assertEqual(session["payload_lines"], [])
+        self.assertEqual(
+            payload.replies,
+            [bnl01_bot.restricted_channel_recall_boundary_response()],
+        )
+
+    async def test_generation_recall_guard_cannot_delete_replacement_session_during_reply(self):
+        channel = self._channel(8116)
+        anchor = BlockingReplyMessage(
+            channel,
+            "BNL, summarize each of these things",
+        )
+        key = (channel.guild.id, channel.id, anchor.author.id)
+        guarded_session = {
+            "guild_id": channel.guild.id,
+            "channel_id": channel.id,
+            "channel_policy": "public_home",
+            "original_request_text": anchor.content,
+            "payload_lines": ["what happened in #research-and-development?"],
+            "anchor_message": anchor,
+            "completed": False,
+            "generating": False,
+            "generation_invalidated": False,
+            "revision": 0,
+            "last_committed_payload_count": 0,
+            "last_bot_response_at": None,
+        }
+        bnl01_bot._direct_payload_sessions[key] = guarded_session
+
+        generation_task = asyncio.create_task(
+            bnl01_bot._generate_direct_payload_session(key, "quiet_timeout")
+        )
+        await asyncio.wait_for(anchor.reply_started.wait(), timeout=0.5)
+        self.assertNotIn(key, bnl01_bot._direct_payload_sessions)
+
+        replacement_session = {"replacement": True}
+        bnl01_bot._direct_payload_sessions[key] = replacement_session
+        anchor.release_reply.set()
+        await asyncio.wait_for(generation_task, timeout=0.5)
+
+        self.assertIs(bnl01_bot._direct_payload_sessions[key], replacement_session)
+        self.assertEqual(
+            anchor.replies,
+            [bnl01_bot.restricted_channel_recall_boundary_response()],
+        )
 
     async def test_buffer_max_never_starts_an_overlapping_flush(self):
         channel = self._channel(8106)


### PR DESCRIPTION
## What changed

- Preserve every interrupted conversation fragment when a replacement batch is scheduled, and refresh successor timing so provider delay cannot make valid work expire as a stale batch.
- Reapply restricted-channel recall protection before opening a deferred payload session and again before generation.
- Close guarded payload sessions with identity-safe ordering so a newer replacement session cannot be deleted by an older blocked send.
- Add regression coverage for the exact live three-message race and both deferred-payload recall-boundary cases.

## Why

The first supervised live test after PR #355 received all three Discord messages and generated drafts, but each newer fragment invalidated the older draft. The final replacement inherited expired batch timing and deleted itself as `stale_batch`, so Discord received no response.

A late review also identified that the new deferred list waiter could bypass an existing restricted-channel recall guard, including when the restricted request arrived in the follow-up payload.

## Impact

BNL should keep all fragments and send one combined response for the tested sequence. Deferred payload requests retain the existing protected-recall boundary. Batching remains default-off and must stay disabled until this draft is reviewed, merged, deployed, and deliberately re-enabled for supervised testing.

No queue, website, dossier, Journal, Relay, or live-memory-gate behavior is changed.

## Validation

- 131 focused conversation/routing tests passed.
- Full repository suite passed: 1,126 tests.
- Exact live race regression passed repeatedly.
- Concurrency and security/privacy reviews: GO.
