### PR TITLE
Bot: persist and safely release prepared Journals

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -85,6 +85,7 @@ from bnl_journal import (
 )
 from bnl_journal_source_store import (
     ensure_schema as ensure_journal_source_schema,
+    journal_release_privacy_fence,
     purge_guild_discord_sources_on_connection,
     purge_user_discord_sources_on_connection,
     record_source_event as record_journal_source_event,
@@ -12260,19 +12261,17 @@ def get_active_show_state_override(guild_id: int, show_date: str = None):
 
 def clear_active_show_state_overrides(guild_id: int):
     now_iso = datetime.now(PACIFIC_TZ).isoformat()
-    conn = sqlite3.connect(DB_FILE)
-    cursor = conn.cursor()
-    cursor.execute(
-        """
-        UPDATE broadcast_memory
-        SET status='resolved', updated_at=?
-        WHERE guild_id=? AND status='active' AND entry_type='show_state_override'
-        """,
-        (now_iso, guild_id),
-    )
-    changed = cursor.rowcount
-    conn.commit()
-    conn.close()
+    with journal_release_privacy_fence(DB_FILE):
+        with sqlite3.connect(DB_FILE, timeout=30) as conn:
+            cursor = conn.execute(
+                """
+                UPDATE broadcast_memory
+                SET status='resolved', updated_at=?
+                WHERE guild_id=? AND status='active' AND entry_type='show_state_override'
+                """,
+                (now_iso, guild_id),
+            )
+            changed = cursor.rowcount
     return int(changed or 0)
 
 def _summary_snippet(text: str, limit: int = 70) -> str:
@@ -12331,26 +12330,53 @@ def _find_active_broadcast_memory_by_id(guild_id: int, memory_id: int):
 
 def _set_broadcast_memory_status(memory_id: int, status: str, actor_id: int, actor_name: str, reason: str = ""):
     now_iso = datetime.now(PACIFIC_TZ).isoformat()
-    conn = sqlite3.connect(DB_FILE)
-    cursor = conn.cursor()
-    cursor.execute(
-        """
-        UPDATE broadcast_memory
-        SET status=?, updated_at=?, corrected_by_user_id=?, corrected_by_name=?, correction_reason=?
-        WHERE id=?
-        """,
-        (status, now_iso, actor_id, actor_name, reason[:200], memory_id),
-    )
-    changed = cursor.rowcount
-    row = cursor.execute("SELECT guild_id, superseded_by_id FROM broadcast_memory WHERE id=?", (memory_id,)).fetchone()
-    conn.commit()
-    conn.close()
+    with journal_release_privacy_fence(DB_FILE):
+        with sqlite3.connect(DB_FILE, timeout=30) as conn:
+            cursor = conn.execute(
+                """
+                UPDATE broadcast_memory
+                SET status=?, updated_at=?, corrected_by_user_id=?, corrected_by_name=?, correction_reason=?
+                WHERE id=?
+                """,
+                (status, now_iso, actor_id, actor_name, reason[:200], memory_id),
+            )
+            changed = cursor.rowcount
+            row = conn.execute(
+                "SELECT guild_id, superseded_by_id FROM broadcast_memory WHERE id=?",
+                (memory_id,),
+            ).fetchone()
     if changed and row and not (str(status or "").lower() == "superseded" and not row[1]):
         _shadow_memory_ledger_write(
             "broadcast_memory_status",
             lambda ledger_conn: shadow_broadcast_status_event(ledger_conn, row_id=memory_id, guild_id=int(row[0] or 0), status=status, updated_at=now_iso, actor_id=actor_id, actor_name=actor_name, superseded_by_id=row[1]),
             guild_id=int(row[0] or 0), source_table="broadcast_memory", source_row_id=memory_id, source_revision=f"event:status:{status}:{now_iso.lower()}", source_event_key=f"status:{status}",
         )
+    return int(changed or 0)
+
+
+def _supersede_broadcast_memory(
+    memory_id: int,
+    replacement_id: int,
+    actor_id: int,
+    actor_name: str,
+    updated_at: str,
+) -> int:
+    """Make an established-memory row ineligible behind the Journal fence."""
+    with journal_release_privacy_fence(DB_FILE):
+        with sqlite3.connect(DB_FILE, timeout=30) as conn:
+            changed = conn.execute(
+                "UPDATE broadcast_memory SET status='superseded', superseded_by_id=?, "
+                "updated_at=?, corrected_by_user_id=?, corrected_by_name=?, correction_reason=? "
+                "WHERE id=?",
+                (
+                    int(replacement_id),
+                    updated_at,
+                    int(actor_id),
+                    actor_name,
+                    "explicit correction/replace request",
+                    int(memory_id),
+                ),
+            ).rowcount
     return int(changed or 0)
 
 async def process_broadcast_memory_note(message) -> dict:
@@ -12800,16 +12826,17 @@ def build_room_first_direct_context(guild_id: int, channel_id: int, channel_name
 def clear_guild_history(guild_id: int):
     ensure_journal_schema(DB_FILE)
     ensure_journal_source_schema(DB_FILE)
-    with sqlite3.connect(DB_FILE, timeout=30) as conn:
-        conn.execute("BEGIN EXCLUSIVE")
-        cursor = conn.execute("DELETE FROM conversations WHERE guild_id = ?", (guild_id,))
-        rows_deleted = cursor.rowcount
-        derivative_counts = purge_guild_journal_derivatives_on_connection(
-            conn,
-            guild_id,
-        )
-        purged_sources = purge_guild_discord_sources_on_connection(conn, guild_id)
-        conn.commit()
+    with journal_release_privacy_fence(DB_FILE):
+        with sqlite3.connect(DB_FILE, timeout=30) as conn:
+            conn.execute("BEGIN EXCLUSIVE")
+            cursor = conn.execute("DELETE FROM conversations WHERE guild_id = ?", (guild_id,))
+            rows_deleted = cursor.rowcount
+            derivative_counts = purge_guild_journal_derivatives_on_connection(
+                conn,
+                guild_id,
+            )
+            purged_sources = purge_guild_discord_sources_on_connection(conn, guild_id)
+            conn.commit()
     logging.info(
         "journal_source_archive_purged scope=guild guild_id=%s rows=%s derivatives=%s",
         guild_id,
@@ -12821,24 +12848,25 @@ def clear_guild_history(guild_id: int):
 def clear_user_history(user_id: int, guild_id: int):
     ensure_journal_schema(DB_FILE)
     ensure_journal_source_schema(DB_FILE)
-    with sqlite3.connect(DB_FILE, timeout=30) as conn:
-        conn.execute("BEGIN EXCLUSIVE")
-        cursor = conn.execute(
-            "DELETE FROM conversations WHERE user_id = ? AND guild_id = ?",
-            (user_id, guild_id),
-        )
-        rows_deleted = cursor.rowcount
-        derivative_counts = purge_user_journal_derivatives_on_connection(
-            conn,
-            guild_id,
-            user_id,
-        )
-        purged_sources = purge_user_discord_sources_on_connection(
-            conn,
-            guild_id,
-            user_id,
-        )
-        conn.commit()
+    with journal_release_privacy_fence(DB_FILE):
+        with sqlite3.connect(DB_FILE, timeout=30) as conn:
+            conn.execute("BEGIN EXCLUSIVE")
+            cursor = conn.execute(
+                "DELETE FROM conversations WHERE user_id = ? AND guild_id = ?",
+                (user_id, guild_id),
+            )
+            rows_deleted = cursor.rowcount
+            derivative_counts = purge_user_journal_derivatives_on_connection(
+                conn,
+                guild_id,
+                user_id,
+            )
+            purged_sources = purge_user_discord_sources_on_connection(
+                conn,
+                guild_id,
+                user_id,
+            )
+            conn.commit()
     logging.info(
         "journal_source_archive_purged scope=user guild_id=%s user_id=%s rows=%s derivatives=%s",
         guild_id,
@@ -12847,6 +12875,21 @@ def clear_user_history(user_id: int, guild_id: int):
         derivative_counts,
     )
     return rows_deleted
+
+
+def _complete_delete_member_data_sync(
+    guild_id: int,
+    user_id: int,
+    confirmation: str,
+) -> dict:
+    with sqlite3.connect(DB_FILE, timeout=30) as conn:
+        return complete_delete_member_data(
+            conn,
+            guild_id=guild_id,
+            user_id=user_id,
+            confirmation=confirmation,
+        )
+
 
 def get_recent_guild_user_messages(guild_id: int, limit: int = AMBIENT_CONTEXT_MESSAGES):
     conn = sqlite3.connect(DB_FILE)
@@ -19831,7 +19874,14 @@ async def on_message(message: discord.Message):
                 await message.reply("Correction not applied. That entry requires owner authority.")
                 return
             if resolve_last_intent or resolve_by_topic or resolve_by_id:
-                changed = _set_broadcast_memory_status(target_id, "resolved", message.author.id, message.author.display_name, "explicit resolve request")
+                changed = await asyncio.to_thread(
+                    _set_broadcast_memory_status,
+                    target_id,
+                    "resolved",
+                    message.author.id,
+                    message.author.display_name,
+                    "explicit resolve request",
+                )
                 if not changed:
                     await message.reply("Correction not applied. I could not find a matching active broadcast-memory entry.")
                     return
@@ -19852,8 +19902,18 @@ async def on_message(message: discord.Message):
             faux_message = type("Msg", (), {"content": correction_text, "author": message.author})()
             processed = await process_broadcast_memory_note(faux_message)
             if processed.get("entry_type") == "show_state_resume":
-                _set_broadcast_memory_status(target_id, "resolved", message.author.id, message.author.display_name, "official correction schedule resumed")
-                cleared = clear_active_show_state_overrides(message.guild.id)
+                await asyncio.to_thread(
+                    _set_broadcast_memory_status,
+                    target_id,
+                    "resolved",
+                    message.author.id,
+                    message.author.display_name,
+                    "official correction schedule resumed",
+                )
+                cleared = await asyncio.to_thread(
+                    clear_active_show_state_overrides,
+                    message.guild.id,
+                )
                 await message.reply(f"Logged. Normal schedule restored; resolved overrides: {cleared}.")
                 return
             if processed.get("entry_type") == "reject":
@@ -19871,11 +19931,14 @@ async def on_message(message: discord.Message):
             processed["supersedes_id"] = target_id
             new_id = add_broadcast_memory_entry(message.guild.id, faux_message, processed)
             updated_at = datetime.now(PACIFIC_TZ).isoformat()
-            conn = sqlite3.connect(DB_FILE)
-            cursor = conn.cursor()
-            cursor.execute("UPDATE broadcast_memory SET status='superseded', superseded_by_id=?, updated_at=?, corrected_by_user_id=?, corrected_by_name=?, correction_reason=? WHERE id=?", (new_id, updated_at, message.author.id, message.author.display_name, "explicit correction/replace request", target_id))
-            conn.commit()
-            conn.close()
+            await asyncio.to_thread(
+                _supersede_broadcast_memory,
+                target_id,
+                new_id,
+                message.author.id,
+                message.author.display_name,
+                updated_at,
+            )
             _shadow_memory_ledger_write(
                 "broadcast_memory_status",
                 lambda ledger_conn: shadow_broadcast_status_event(ledger_conn, row_id=target_id, guild_id=message.guild.id, status="superseded", updated_at=updated_at, actor_id=message.author.id, actor_name=message.author.display_name, superseded_by_id=new_id),
@@ -19886,7 +19949,10 @@ async def on_message(message: discord.Message):
         processed_entries = await process_broadcast_memory_notes(message)
         processed = processed_entries[0] if processed_entries else {"entry_type": "reject", "reason": "insufficient signal"}
         if processed.get("entry_type") == "show_state_resume":
-            cleared = clear_active_show_state_overrides(message.guild.id)
+            cleared = await asyncio.to_thread(
+                clear_active_show_state_overrides,
+                message.guild.id,
+            )
             await message.reply(f"Logged. Normal schedule restored; resolved overrides: {cleared}.")
             return
         if processed.get("entry_type") == "reject":
@@ -21115,7 +21181,7 @@ async def clear_channel(interaction: discord.Interaction):
 @tree.command(name="clearguildhistory", description="Clear all BNL-01 conversation history for this server.")
 @app_commands.checks.has_permissions(administrator=True)
 async def clear_guild_history_cmd(interaction: discord.Interaction):
-    rows_deleted = clear_guild_history(interaction.guild.id)
+    rows_deleted = await asyncio.to_thread(clear_guild_history, interaction.guild.id)
     logging.info(f"🗑️ Cleared {rows_deleted} guild conversation records in {interaction.guild.name}")
     await interaction.response.send_message(
         f"✅ Cleared **{rows_deleted}** conversation records from this server's Network archives.",
@@ -21183,7 +21249,11 @@ async def myname(interaction: discord.Interaction, name: str):
 
 @tree.command(name="clearhistory", description="Clear only your stored conversation rows in this server.")
 async def clear_history(interaction: discord.Interaction):
-    rows_deleted = clear_user_history(interaction.user.id, interaction.guild.id)
+    rows_deleted = await asyncio.to_thread(
+        clear_user_history,
+        interaction.user.id,
+        interaction.guild.id,
+    )
     logging.info(f"🗑️ Cleared {rows_deleted} conversation records for {interaction.user.name}")
     await interaction.response.send_message(
         f"✅ Cleared **{rows_deleted}** BNL-stored conversation rows for you in this server. Durable facts, profile data, relationship data, and derived memory were not removed by `/clearhistory`; use `/memory_complete_delete` for broader bot-held personal data deletion. Discord's own message storage is not affected.",
@@ -21228,8 +21298,12 @@ async def memory_forget(interaction: discord.Interaction, reference: str):
 async def memory_complete_delete(interaction: discord.Interaction, confirmation: str):
     if not interaction.guild:
         await interaction.response.send_message("❌ This command can only be used in a server.", ephemeral=True); return
-    with sqlite3.connect(DB_FILE) as conn:
-        result = complete_delete_member_data(conn, guild_id=interaction.guild.id, user_id=interaction.user.id, confirmation=confirmation.strip())
+    result = await asyncio.to_thread(
+        _complete_delete_member_data_sync,
+        interaction.guild.id,
+        interaction.user.id,
+        confirmation.strip(),
+    )
     if result.get("ok"):
         purge_member_memory_caches(interaction.user.id, interaction.guild.id)
         await interaction.response.send_message(f"✅ Complete delete finished for bot-held personal data in this server. Receipt `{result.get('receipt')}`. This does not delete messages stored by Discord itself.", ephemeral=True)

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -77,23 +77,29 @@ from bnl_journal import (
     deliver_approved as deliver_approved_journal,
     generate_and_store_draft as generate_and_store_journal_draft,
     preview as preview_journal_draft,
+    purge_guild_journal_derivatives_on_connection,
+    purge_user_journal_derivatives_on_connection,
     regenerate_draft as regenerate_journal_draft,
     rehydrate_published_entries as rehydrate_published_journal_entries,
     reject_draft as reject_journal_draft,
 )
 from bnl_journal_source_store import (
-    purge_guild_discord_sources as purge_guild_journal_sources,
-    purge_user_discord_sources as purge_user_journal_sources,
+    ensure_schema as ensure_journal_source_schema,
+    purge_guild_discord_sources_on_connection,
+    purge_user_discord_sources_on_connection,
     record_source_event as record_journal_source_event,
     sanitize_summary as sanitize_journal_source_summary,
     timestamp_to_epoch_ms as journal_timestamp_to_epoch_ms,
 )
 from bnl_journal_automation import (
     automation_status as journal_automation_status,
+    load_journal_memory_exclusions,
+    release_prepared_entry as release_prepared_journal_entry,
     result_dict as journal_automation_result_dict,
     run_daily as run_daily_journal_automation,
     run_scheduled as run_scheduled_journal_automation,
     run_weekly as run_weekly_journal_automation,
+    store_journal_memory_exclusions,
 )
 from bnl_website_contract_v2 import (
     ContractV2Error,
@@ -6054,6 +6060,44 @@ def _journal_control_flags(control: dict | None, fallback: dict) -> dict:
     return flags
 
 
+def _journal_control_flags_for_guild(
+    guild_id: int,
+    control: dict | None,
+    fallback: dict,
+) -> dict:
+    """Resolve live controls over the last durable eligibility snapshot."""
+    flags = dict(fallback or {})
+    try:
+        stored_ids, stored_confirmed = load_journal_memory_exclusions(
+            DB_FILE,
+            int(guild_id),
+        )
+    except sqlite3.Error:
+        stored_ids, stored_confirmed = set(), False
+        logging.exception(
+            "journal_memory_exclusion_snapshot_load_failed guild=%s",
+            guild_id,
+        )
+    if stored_confirmed:
+        flags["journalMemoryExcludedEntryIds"] = sorted(stored_ids)
+    flags["journalMemoryExclusionsConfirmed"] = bool(
+        stored_confirmed or flags.get("journalMemoryExclusionsConfirmed", False)
+    )
+    flags = _journal_control_flags(control, flags)
+    live_exclusions = control.get("memoryExcludedEntryIds") if isinstance(control, dict) else None
+    if isinstance(live_exclusions, list):
+        confirmed_ids = set(flags.get("journalMemoryExcludedEntryIds") or [])
+        flags["journalMemoryExclusionsConfirmed"] = True
+        try:
+            store_journal_memory_exclusions(DB_FILE, int(guild_id), confirmed_ids)
+        except sqlite3.Error:
+            logging.exception(
+                "journal_memory_exclusion_snapshot_store_failed guild=%s",
+                guild_id,
+            )
+    return flags
+
+
 def _journal_control_claim_sync(control: dict | None) -> tuple[dict | None, str]:
     requests = control.get("runRequests") if isinstance(control, dict) else None
     if not isinstance(requests, list):
@@ -6094,6 +6138,19 @@ def _journal_control_claim_sync(control: dict | None) -> tuple[dict | None, str]
 
 def _journal_site_run_state(status: str) -> str:
     normalized = str(status or "").strip().lower()
+    if normalized in {
+        "preparing",
+        "prepared",
+        "waiting",
+        "waiting_for_release",
+        "waiting_release",
+        "delivering",
+    }:
+        # The current site contract has no separate preparation lifecycle.
+        # These are active, nonterminal phases rather than failures; preserve
+        # the exact internal phase in the run detail while projecting the
+        # compatible existing state.
+        return "running"
     if normalized in {
         "running", "published", "held", "delivery_failed", "busy", "backoff",
         "failed", "complete", "already_processed", "disabled",
@@ -6200,7 +6257,15 @@ async def run_journal_automation_once(
             effective_flags = flags
             if effective_flags is None:
                 effective_flags = await asyncio.to_thread(get_bnl_control_flags, force_refresh=force)
+                effective_flags = _journal_control_flags_for_guild(
+                    guild_id,
+                    None,
+                    effective_flags,
+                )
             memory_excluded_entry_ids = set(effective_flags.get("journalMemoryExcludedEntryIds") or [])
+            memory_exclusions_confirmed = bool(
+                effective_flags.get("journalMemoryExclusionsConfirmed", True)
+            )
             if not effective_flags.get("journalAutoPublishEnabled", True):
                 results = [_journal_control_result(cadence, "paused", "auto_publish_paused")]
             elif cadence == "daily" and not effective_flags.get("journalDailyEnabled", True):
@@ -6217,6 +6282,7 @@ async def run_journal_automation_once(
                     BNL_API_KEY,
                     force=force,
                     memory_excluded_entry_ids=memory_excluded_entry_ids,
+                    memory_exclusions_confirmed=memory_exclusions_confirmed,
                 )
                 results = [journal_automation_result_dict(result)]
             elif cadence == "weekly":
@@ -6229,6 +6295,7 @@ async def run_journal_automation_once(
                     BNL_API_KEY,
                     force=force,
                     memory_excluded_entry_ids=memory_excluded_entry_ids,
+                    memory_exclusions_confirmed=memory_exclusions_confirmed,
                 )
                 results = [journal_automation_result_dict(result)]
             else:
@@ -6267,7 +6334,7 @@ async def run_journal_automation_control_cycle(guild_id: int) -> list[dict]:
     ):
         control = None
         control_error = control_error or "control_plane_response_invalid"
-    flags = _journal_control_flags(control, base_flags)
+    flags = _journal_control_flags_for_guild(guild_id, control, base_flags)
     if control is None:
         reason = "control_plane_unavailable:%s" % (control_error or "control_get_failed")
         # The control endpoint is useful for remote Run Now requests, but it
@@ -6358,7 +6425,7 @@ async def maybe_handle_journal_command(message: discord.Message, clean_content: 
         if action == "status":
             flags = await asyncio.to_thread(get_bnl_control_flags, force_refresh=True)
             control, control_error = await asyncio.to_thread(_journal_control_request_sync, "GET")
-            flags = _journal_control_flags(control, flags)
+            flags = _journal_control_flags_for_guild(guild_id, control, flags)
             status = await asyncio.to_thread(journal_automation_status, DB_FILE, guild_id)
             last_state = status.get("lastState") if isinstance(status.get("lastState"), dict) else {}
             await message.reply(
@@ -6375,7 +6442,7 @@ async def maybe_handle_journal_command(message: discord.Message, clean_content: 
             cadence = "daily" if action == "run-daily" else "weekly"
             flags = await asyncio.to_thread(get_bnl_control_flags, force_refresh=True)
             control, _ = await asyncio.to_thread(_journal_control_request_sync, "GET")
-            flags = _journal_control_flags(control, flags)
+            flags = _journal_control_flags_for_guild(guild_id, control, flags)
             results = await run_journal_automation_once(guild_id, cadence=cadence, force=True, flags=flags)
             for item in results:
                 await asyncio.to_thread(_journal_report_run_sync, item, guild_id=guild_id)
@@ -6409,7 +6476,7 @@ async def maybe_handle_journal_command(message: discord.Message, clean_content: 
         if action == "create":
             hours = _parse_journal_hours(options.get("hours") or options.get("window"))
             control, _ = await asyncio.to_thread(_journal_control_request_sync, "GET")
-            flags = _journal_control_flags(control, {})
+            flags = _journal_control_flags_for_guild(guild_id, control, {})
             result = await asyncio.to_thread(
                 generate_and_store_journal_draft,
                 DB_FILE,
@@ -6427,7 +6494,7 @@ async def maybe_handle_journal_command(message: discord.Message, clean_content: 
             entry_id = options.get("entry_id") or ""
             hours = _parse_journal_hours(options.get("hours") or options.get("window"))
             control, _ = await asyncio.to_thread(_journal_control_request_sync, "GET")
-            flags = _journal_control_flags(control, {})
+            flags = _journal_control_flags_for_guild(guild_id, control, {})
             result = await asyncio.to_thread(
                 regenerate_journal_draft,
                 DB_FILE,
@@ -6473,8 +6540,37 @@ async def maybe_handle_journal_command(message: discord.Message, clean_content: 
             if not BNL_API_KEY or not _journal_website_base_url():
                 await message.reply("Journal delivery not attempted: website URL or BNL API key missing.")
                 return True
-            result = await asyncio.to_thread(deliver_approved_journal, DB_FILE, guild_id, entry_id, _journal_website_base_url(), BNL_API_KEY)
-            await message.reply(f"Journal delivery result: state=`{result.status}` reason=`{result.reason}` http=`{result.http_status}`")
+            flags = await asyncio.to_thread(get_bnl_control_flags, force_refresh=True)
+            control, _ = await asyncio.to_thread(_journal_control_request_sync, "GET")
+            flags = _journal_control_flags_for_guild(guild_id, control, flags)
+            result = await asyncio.to_thread(
+                release_prepared_journal_entry,
+                DB_FILE,
+                guild_id,
+                entry_id,
+                _journal_website_base_url(),
+                BNL_API_KEY,
+                force=True,
+                memory_excluded_entry_ids=set(flags.get("journalMemoryExcludedEntryIds") or []),
+                memory_exclusions_confirmed=bool(
+                    flags.get("journalMemoryExclusionsConfirmed", False)
+                ),
+            )
+            if result is None:
+                # Manual review drafts are intentionally outside the scheduled
+                # occurrence owner and retain their existing explicit retry path.
+                result = await asyncio.to_thread(
+                    deliver_approved_journal,
+                    DB_FILE,
+                    guild_id,
+                    entry_id,
+                    _journal_website_base_url(),
+                    BNL_API_KEY,
+                )
+            await message.reply(
+                f"Journal delivery result: state=`{result.status}` reason=`{result.reason}` "
+                f"http=`{int(getattr(result, 'http_status', 0) or 0)}`"
+            )
             return True
     except Exception:
         logging.exception("journal_command_failed action=%s reason=unexpected_exception", action)
@@ -12702,33 +12798,53 @@ def build_room_first_direct_context(guild_id: int, channel_id: int, channel_name
     return formatted
 
 def clear_guild_history(guild_id: int):
-    conn = sqlite3.connect(DB_FILE)
-    cursor = conn.cursor()
-    cursor.execute("DELETE FROM conversations WHERE guild_id = ?", (guild_id,))
-    rows_deleted = cursor.rowcount
-    conn.commit()
-    conn.close()
-    purged_sources = purge_guild_journal_sources(DB_FILE, guild_id)
+    ensure_journal_schema(DB_FILE)
+    ensure_journal_source_schema(DB_FILE)
+    with sqlite3.connect(DB_FILE, timeout=30) as conn:
+        conn.execute("BEGIN EXCLUSIVE")
+        cursor = conn.execute("DELETE FROM conversations WHERE guild_id = ?", (guild_id,))
+        rows_deleted = cursor.rowcount
+        derivative_counts = purge_guild_journal_derivatives_on_connection(
+            conn,
+            guild_id,
+        )
+        purged_sources = purge_guild_discord_sources_on_connection(conn, guild_id)
+        conn.commit()
     logging.info(
-        "journal_source_archive_purged scope=guild guild_id=%s rows=%s",
+        "journal_source_archive_purged scope=guild guild_id=%s rows=%s derivatives=%s",
         guild_id,
         purged_sources,
+        derivative_counts,
     )
     return rows_deleted
 
 def clear_user_history(user_id: int, guild_id: int):
-    conn = sqlite3.connect(DB_FILE)
-    cursor = conn.cursor()
-    cursor.execute("DELETE FROM conversations WHERE user_id = ? AND guild_id = ?", (user_id, guild_id))
-    rows_deleted = cursor.rowcount
-    conn.commit()
-    conn.close()
-    purged_sources = purge_user_journal_sources(DB_FILE, guild_id, user_id)
+    ensure_journal_schema(DB_FILE)
+    ensure_journal_source_schema(DB_FILE)
+    with sqlite3.connect(DB_FILE, timeout=30) as conn:
+        conn.execute("BEGIN EXCLUSIVE")
+        cursor = conn.execute(
+            "DELETE FROM conversations WHERE user_id = ? AND guild_id = ?",
+            (user_id, guild_id),
+        )
+        rows_deleted = cursor.rowcount
+        derivative_counts = purge_user_journal_derivatives_on_connection(
+            conn,
+            guild_id,
+            user_id,
+        )
+        purged_sources = purge_user_discord_sources_on_connection(
+            conn,
+            guild_id,
+            user_id,
+        )
+        conn.commit()
     logging.info(
-        "journal_source_archive_purged scope=user guild_id=%s user_id=%s rows=%s",
+        "journal_source_archive_purged scope=user guild_id=%s user_id=%s rows=%s derivatives=%s",
         guild_id,
         user_id,
         purged_sources,
+        derivative_counts,
     )
     return rows_deleted
 

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -10,8 +10,18 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Optional
 
+from bnl_journal_source_store import journal_release_privacy_fence
+
 PUBLIC_POLICIES = {"public_home", "public_context", "public_selective"}
-STATES = {"draft", "rejected", "approved_pending_delivery", "published", "delivery_failed"}
+SCHEDULED_PREPARED_STATE = "prepared_exact"
+STATES = {
+    "draft",
+    "rejected",
+    "approved_pending_delivery",
+    SCHEDULED_PREPARED_STATE,
+    "published",
+    "delivery_failed",
+}
 JOURNAL_ROUTE = "bnl_journal_generation"
 JOURNAL_GENERATION_ATTEMPTS = 4
 # Must match the website receiver's raw UTF-8 request-body limit. The complete
@@ -394,6 +404,7 @@ def purge_user_journal_derivatives_on_connection(
     run_columns: set[str] = set()
     run_records: list[dict[str, Any]] = []
     affected_run_ids: set[str] = set()
+    published_recoveries: dict[str, dict[str, Any]] = {}
     if table_exists(conn, "bnl_journal_automation_runs"):
         run_columns = _cols(conn, "bnl_journal_automation_runs")
         selected_columns = [
@@ -427,15 +438,54 @@ def purge_user_journal_derivatives_on_connection(
                     continue
 
                 run_id = str(run.get("run_id") or "")
-                if str(run.get("lifecycle_state") or "") == "published":
+                entry_id = str(run.get("journal_entry_id") or "")
+                revision = int(run.get("journal_revision") or 0)
+                published_link = False
+                if entry_id and revision > 0 and table_exists(conn, "bnl_journal_entries"):
+                    state = conn.execute(
+                        "SELECT lifecycle_state FROM bnl_journal_entries "
+                        "WHERE guild_id=? AND entry_id=? AND revision=?",
+                        (guild, entry_id, revision),
+                    ).fetchone()
+                    published_link = bool(state and str(state[0]) == "published")
+                if (
+                    not published_link
+                    and entry_id
+                    and revision > 0
+                    and table_exists(conn, "bnl_journal_private_metadata")
+                ):
+                    state = conn.execute(
+                        "SELECT lifecycle_state FROM bnl_journal_private_metadata "
+                        "WHERE guild_id=? AND entry_id=? AND revision=?",
+                        (guild, entry_id, revision),
+                    ).fetchone()
+                    published_link = bool(state and str(state[0]) == "published")
+
+                if (
+                    str(run.get("lifecycle_state") or "") == "published"
+                    or published_link
+                ):
                     # Published public prose and its immutable revision remain;
-                    # only the now-ineligible private packet is discarded.
+                    # only the now-ineligible private packet is discarded. If a
+                    # worker crashed after recording the published entry but
+                    # before finalizing its run, recover the durable occurrence
+                    # here rather than making an already-public Journal owed.
                     assignments = [
                         f"{column}=NULL"
                         for column in ("frozen_packet_json", "frozen_packet_hash", "packet_frozen_at")
                         if column in run_columns
                     ]
                     params: list[Any] = []
+                    if published_link and str(run.get("lifecycle_state") or "") != "published":
+                        assignments.extend(
+                            [
+                                "lifecycle_state='published'",
+                                "reason='delivery_already_recorded'",
+                            ]
+                        )
+                        for column in ("lease_expires_at", "delivery_lease_expires_at"):
+                            if column in run_columns:
+                                assignments.append(f"{column}=NULL")
                     if "updated_at" in run_columns:
                         assignments.append("updated_at=?")
                         params.append(now)
@@ -443,35 +493,101 @@ def purge_user_journal_derivatives_on_connection(
                         params.extend((guild, run_id))
                         changed = conn.execute(
                             f"UPDATE bnl_journal_automation_runs SET {','.join(assignments)} "
-                            "WHERE guild_id=? AND run_id=? AND lifecycle_state='published'",
+                            "WHERE guild_id=? AND run_id=?",
                             tuple(params),
                         ).rowcount
                         counts["bnl_journal_published_packets_scrubbed"] = counts.get(
                             "bnl_journal_published_packets_scrubbed", 0
                         ) + changed
+                    if (
+                        changed
+                        and published_link
+                        and str(run.get("lifecycle_state") or "") != "published"
+                    ):
+                        published_recoveries[run_id] = run
+                        counts["bnl_journal_published_runs_recovered"] = counts.get(
+                            "bnl_journal_published_runs_recovered", 0
+                        ) + 1
                     continue
 
                 affected_run_ids.add(run_id)
+                if entry_id and revision > 0:
+                    unpublished.add((entry_id, revision))
+
+        if published_recoveries:
+            observation_columns = (
+                _cols(conn, "bnl_journal_observations")
+                if table_exists(conn, "bnl_journal_observations")
+                else set()
+            )
+            state_columns = (
+                _cols(conn, "bnl_journal_automation_state")
+                if table_exists(conn, "bnl_journal_automation_state")
+                else set()
+            )
+            for run in published_recoveries.values():
                 entry_id = str(run.get("journal_entry_id") or "")
                 revision = int(run.get("journal_revision") or 0)
-                if entry_id and revision > 0:
-                    published_link = False
-                    if table_exists(conn, "bnl_journal_entries"):
-                        state = conn.execute(
-                            "SELECT lifecycle_state FROM bnl_journal_entries "
-                            "WHERE guild_id=? AND entry_id=? AND revision=?",
-                            (guild, entry_id, revision),
-                        ).fetchone()
-                        published_link = bool(state and str(state[0]) == "published")
-                    if not published_link and table_exists(conn, "bnl_journal_private_metadata"):
-                        state = conn.execute(
-                            "SELECT lifecycle_state FROM bnl_journal_private_metadata "
-                            "WHERE guild_id=? AND entry_id=? AND revision=?",
-                            (guild, entry_id, revision),
-                        ).fetchone()
-                        published_link = bool(state and str(state[0]) == "published")
-                    if not published_link:
-                        unpublished.add((entry_id, revision))
+                if {
+                    "guild_id",
+                    "source_window_start",
+                    "source_window_end",
+                    "lifecycle_state",
+                    "journal_entry_id",
+                    "journal_revision",
+                    "updated_at",
+                } <= observation_columns:
+                    conn.execute(
+                        "UPDATE bnl_journal_observations SET lifecycle_state='published',"
+                        "journal_entry_id=?,journal_revision=?,updated_at=? "
+                        "WHERE guild_id=? AND source_window_start=? AND source_window_end=?",
+                        (
+                            entry_id,
+                            revision,
+                            now,
+                            guild,
+                            str(run.get("source_window_start") or ""),
+                            str(run.get("source_window_end") or ""),
+                        ),
+                    )
+                if {
+                    "guild_id",
+                    "last_checked_at",
+                    "last_status",
+                    "last_reason",
+                    "last_cadence",
+                    "last_entry_id",
+                    "last_revision",
+                    "last_source_window_start",
+                    "last_source_window_end",
+                    "next_retry_at",
+                    "updated_at",
+                } <= state_columns:
+                    conn.execute(
+                        "UPDATE bnl_journal_automation_state SET last_checked_at=?,"
+                        "last_status='published',last_reason='delivery_already_recorded',"
+                        "last_cadence=?,last_entry_id=?,last_revision=?,"
+                        "last_source_window_start=?,last_source_window_end=?,"
+                        "next_retry_at=NULL,updated_at=? WHERE guild_id=? AND ("
+                        "(last_entry_id=? AND last_revision=?) OR "
+                        "(last_cadence=? AND last_source_window_start=? "
+                        "AND last_source_window_end=?))",
+                        (
+                            now,
+                            str(run.get("cadence") or ""),
+                            entry_id,
+                            revision,
+                            str(run.get("source_window_start") or ""),
+                            str(run.get("source_window_end") or ""),
+                            now,
+                            guild,
+                            entry_id,
+                            revision,
+                            str(run.get("cadence") or ""),
+                            str(run.get("source_window_start") or ""),
+                            str(run.get("source_window_end") or ""),
+                        ),
+                    )
 
         # Before packet persistence, the cited private metadata was the only
         # durable route from a staged revision back to its occurrence owner.
@@ -2504,6 +2620,7 @@ def _delivery_fence_owned(
     guild_id: int,
     entry_id: str,
     revision: Optional[int],
+    require_live_lease: bool = True,
 ) -> bool:
     """Validate an automation delivery owner inside its network transaction."""
     if delivery_fence is None or revision is None:
@@ -2537,6 +2654,8 @@ def _delivery_fence_owned(
         or int(row[4] or 0) != int(delivery_fence[1])
     ):
         return False
+    if not require_live_lease:
+        return True
     lease_raw = str(row[5] or "")
     if not lease_raw:
         return False
@@ -2845,13 +2964,26 @@ def approve_draft(
             return JournalResult(False, "draft", "source_packet_hash_mismatch", entry_id, rev, stored_hash)
         metadata["canonicalPayloadHash"] = request_hash
         metadata["canonicalPayloadBytes"] = len(canonical)
-        cur1 = conn.execute("UPDATE bnl_journal_entries SET lifecycle_state='approved_pending_delivery',approved_at=?,updated_at=? WHERE guild_id=? AND entry_id=? AND revision=? AND lifecycle_state='draft'", (now, now, guild_id, entry_id, rev))
-        cur2 = conn.execute("UPDATE bnl_journal_private_metadata SET metadata_json=?,lifecycle_state='approved_pending_delivery',updated_at=? WHERE guild_id=? AND entry_id=? AND revision=? AND lifecycle_state='draft'", (_json(metadata), now, guild_id, entry_id, rev))
+        approved_state = (
+            SCHEDULED_PREPARED_STATE
+            if attempt_fence is not None
+            else "approved_pending_delivery"
+        )
+        cur1 = conn.execute(
+            "UPDATE bnl_journal_entries SET lifecycle_state=?,approved_at=?,updated_at=? "
+            "WHERE guild_id=? AND entry_id=? AND revision=? AND lifecycle_state='draft'",
+            (approved_state, now, now, guild_id, entry_id, rev),
+        )
+        cur2 = conn.execute(
+            "UPDATE bnl_journal_private_metadata SET metadata_json=?,lifecycle_state=?,updated_at=? "
+            "WHERE guild_id=? AND entry_id=? AND revision=? AND lifecycle_state='draft'",
+            (_json(metadata), approved_state, now, guild_id, entry_id, rev),
+        )
         if cur1.rowcount != 1 or cur2.rowcount != 1:
             conn.rollback()
             raise sqlite3.IntegrityError("journal_approve_sync_failed")
         conn.commit()
-    return JournalResult(True, "approved_pending_delivery", "", entry_id, rev, stored_hash)
+    return JournalResult(True, approved_state, "", entry_id, rev, stored_hash)
 
 
 def reject_draft(db_path: str, guild_id: int, entry_id: str, reason: str = "", revision: Optional[int] = None) -> JournalResult:
@@ -3003,45 +3135,52 @@ def deliver_approved(
 ) -> JournalResult:
     ensure_schema(db_path)
     if delivery_fence is not None:
-        with sqlite3.connect(db_path) as conn:
-            conn.execute("BEGIN IMMEDIATE")
-            if not _delivery_fence_owned(
-                conn,
-                delivery_fence,
-                guild_id=guild_id,
-                entry_id=entry_id,
-                revision=revision,
-            ):
-                conn.rollback()
-                return JournalResult(
-                    False,
-                    "not_deliverable",
-                    "delivery_epoch_lost",
-                    entry_id,
-                    int(revision or 0),
-                )
-            row = conn.execute(
-                "SELECT revision,canonical_payload_bytes,content_hash FROM bnl_journal_entries "
-                "WHERE guild_id=? AND entry_id=? "
-                "AND lifecycle_state IN ('approved_pending_delivery','delivery_failed') AND revision=?",
-                (guild_id, entry_id, int(revision)),
-            ).fetchone()
-            if not row:
-                conn.rollback()
-                return JournalResult(False, "not_deliverable", "not_approved", entry_id, int(revision or 0))
-            rev, canonical, content_hash = int(row[0]), row[1], row[2]
-            if delivery_preflight is not None:
-                preflight_reason = str(delivery_preflight(conn) or "")
-                if preflight_reason:
+        # Privacy/deletion writers share this narrow Journal fence. The main
+        # SQLite transaction is deliberately released before the network wait,
+        # so unrelated bot writes are never blocked by website latency.
+        with journal_release_privacy_fence(db_path):
+            with sqlite3.connect(db_path, timeout=30) as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                if not _delivery_fence_owned(
+                    conn,
+                    delivery_fence,
+                    guild_id=guild_id,
+                    entry_id=entry_id,
+                    revision=revision,
+                ):
                     conn.rollback()
                     return JournalResult(
                         False,
                         "not_deliverable",
-                        preflight_reason,
+                        "delivery_epoch_lost",
                         entry_id,
-                        rev,
-                        content_hash,
+                        int(revision or 0),
                     )
+                row = conn.execute(
+                    "SELECT revision,canonical_payload_bytes,content_hash FROM bnl_journal_entries "
+                    "WHERE guild_id=? AND entry_id=? "
+                    "AND lifecycle_state IN ('prepared_exact','approved_pending_delivery','delivery_failed') "
+                    "AND revision=?",
+                    (guild_id, entry_id, int(revision)),
+                ).fetchone()
+                if not row:
+                    conn.rollback()
+                    return JournalResult(False, "not_deliverable", "not_approved", entry_id, int(revision or 0))
+                rev, canonical, content_hash = int(row[0]), bytes(row[1] or b""), row[2]
+                if delivery_preflight is not None:
+                    preflight_reason = str(delivery_preflight(conn) or "")
+                    if preflight_reason:
+                        conn.rollback()
+                        return JournalResult(
+                            False,
+                            "not_deliverable",
+                            preflight_reason,
+                            entry_id,
+                            rev,
+                            content_hash,
+                        )
+                conn.commit()
+
             status, reason, http, idem, published = _post_canonical_payload(
                 canonical,
                 base_url,
@@ -3050,22 +3189,58 @@ def deliver_approved(
                 timeout,
             )
             now = utc_now_iso()
-            cur1 = conn.execute(
-                "UPDATE bnl_journal_entries SET lifecycle_state=?,delivery_status=?,"
-                "delivery_http_status=?,published_at=COALESCE(?,published_at),updated_at=? "
-                "WHERE guild_id=? AND entry_id=? AND revision=? "
-                "AND lifecycle_state IN ('approved_pending_delivery','delivery_failed')",
-                (status, reason, http, published or None, now, guild_id, entry_id, rev),
-            )
-            cur2 = conn.execute(
-                "UPDATE bnl_journal_private_metadata SET lifecycle_state=?,updated_at=? "
-                "WHERE guild_id=? AND entry_id=? AND revision=?",
-                (status, now, guild_id, entry_id, rev),
-            )
-            if cur1.rowcount != 1 or cur2.rowcount != 1:
-                conn.rollback()
-                raise sqlite3.IntegrityError("journal_delivery_sync_failed")
-            conn.commit()
+            with sqlite3.connect(db_path, timeout=30) as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                if not _delivery_fence_owned(
+                    conn,
+                    delivery_fence,
+                    guild_id=guild_id,
+                    entry_id=entry_id,
+                    revision=rev,
+                    require_live_lease=False,
+                ):
+                    conn.rollback()
+                    return JournalResult(
+                        False,
+                        "not_deliverable",
+                        "delivery_epoch_lost",
+                        entry_id,
+                        rev,
+                        content_hash,
+                        http,
+                        idem,
+                    )
+                persisted_state = (
+                    "published"
+                    if status == "published"
+                    else SCHEDULED_PREPARED_STATE
+                )
+                cur1 = conn.execute(
+                    "UPDATE bnl_journal_entries SET lifecycle_state=?,delivery_status=?,"
+                    "delivery_http_status=?,published_at=COALESCE(?,published_at),updated_at=? "
+                    "WHERE guild_id=? AND entry_id=? AND revision=? "
+                    "AND lifecycle_state IN ('prepared_exact','approved_pending_delivery','delivery_failed')",
+                    (
+                        persisted_state,
+                        reason,
+                        http,
+                        published or None,
+                        now,
+                        guild_id,
+                        entry_id,
+                        rev,
+                    ),
+                )
+                cur2 = conn.execute(
+                    "UPDATE bnl_journal_private_metadata SET lifecycle_state=?,updated_at=? "
+                    "WHERE guild_id=? AND entry_id=? AND revision=? "
+                    "AND lifecycle_state IN ('prepared_exact','approved_pending_delivery','delivery_failed')",
+                    (persisted_state, now, guild_id, entry_id, rev),
+                )
+                if cur1.rowcount != 1 or cur2.rowcount != 1:
+                    conn.rollback()
+                    raise sqlite3.IntegrityError("journal_delivery_sync_failed")
+                conn.commit()
         return JournalResult(status == "published", status, reason, entry_id, rev, content_hash, http, idem)
 
     with sqlite3.connect(db_path) as conn:

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -14,6 +14,9 @@ PUBLIC_POLICIES = {"public_home", "public_context", "public_selective"}
 STATES = {"draft", "rejected", "approved_pending_delivery", "published", "delivery_failed"}
 JOURNAL_ROUTE = "bnl_journal_generation"
 JOURNAL_GENERATION_ATTEMPTS = 4
+# Must match the website receiver's raw UTF-8 request-body limit. The complete
+# serialized envelope is measured; article text is never truncated to fit it.
+JOURNAL_SITE_REQUEST_BODY_MAX_BYTES = 24_000
 ADVISORY_VALIDATION_REASONS = frozenset({
     "overly_clinical_voice",
     "flat_report_voice",
@@ -195,6 +198,11 @@ def _json(obj: Any) -> str:
     return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 
 
+def canonical_payload_hash(payload: bytes) -> str:
+    """Hash the exact request bytes, independently of the public content hash."""
+    return hashlib.sha256(bytes(payload)).hexdigest()
+
+
 def _norm(text: str) -> str:
     return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", (text or "").lower())).strip()
 
@@ -316,7 +324,7 @@ def purge_user_journal_derivatives_on_connection(
             )
             counts["bnl_journal_observations_scrubbed"] = counts.get("bnl_journal_observations_scrubbed", 0) + 1
 
-    unpublished: list[tuple[str, int]] = []
+    unpublished: set[tuple[str, int]] = set()
     if table_exists(conn, "bnl_journal_private_metadata"):
         has_entries = table_exists(conn, "bnl_journal_entries")
         if has_entries:
@@ -348,7 +356,7 @@ def purge_user_journal_derivatives_on_connection(
                 continue
             key = (str(entry_id), int(revision))
             if str(lifecycle_state or "") != "published":
-                unpublished.append(key)
+                unpublished.add(key)
                 continue
 
             target_ref_ids = {str(item.get("refId")) for item in target_supporting if item.get("refId")}
@@ -383,12 +391,122 @@ def purge_user_journal_derivatives_on_connection(
             )
             counts["bnl_journal_published_metadata_scrubbed"] = counts.get("bnl_journal_published_metadata_scrubbed", 0) + 1
 
+    run_columns: set[str] = set()
+    run_records: list[dict[str, Any]] = []
+    affected_run_ids: set[str] = set()
+    if table_exists(conn, "bnl_journal_automation_runs"):
+        run_columns = _cols(conn, "bnl_journal_automation_runs")
+        selected_columns = [
+            column
+            for column in (
+                "run_id", "lifecycle_state", "journal_entry_id", "journal_revision",
+                "cadence", "source_window_start", "source_window_end", "frozen_packet_json",
+            )
+            if column in run_columns
+        ]
+        if {"run_id", "guild_id"} <= run_columns:
+            rows = conn.execute(
+                f"SELECT {','.join(selected_columns)} FROM bnl_journal_automation_runs WHERE guild_id=?",
+                (guild,),
+            ).fetchall()
+            run_records = [dict(zip(selected_columns, row)) for row in rows]
+
+        # The packet is private preparation state even when the final article
+        # did not cite this member. An unpublished occurrence that contains the
+        # deleted subject must lose both its packet and any staged revision.
+        if "frozen_packet_json" in run_columns:
+            for run in run_records:
+                raw_packet = str(run.get("frozen_packet_json") or "")
+                if not raw_packet:
+                    continue
+                try:
+                    frozen_packet = json.loads(raw_packet)
+                except (TypeError, json.JSONDecodeError):
+                    continue
+                if not _contains_exact_json_scalar(frozen_packet, subject_ref):
+                    continue
+
+                run_id = str(run.get("run_id") or "")
+                if str(run.get("lifecycle_state") or "") == "published":
+                    # Published public prose and its immutable revision remain;
+                    # only the now-ineligible private packet is discarded.
+                    assignments = [
+                        f"{column}=NULL"
+                        for column in ("frozen_packet_json", "frozen_packet_hash", "packet_frozen_at")
+                        if column in run_columns
+                    ]
+                    params: list[Any] = []
+                    if "updated_at" in run_columns:
+                        assignments.append("updated_at=?")
+                        params.append(now)
+                    if assignments:
+                        params.extend((guild, run_id))
+                        changed = conn.execute(
+                            f"UPDATE bnl_journal_automation_runs SET {','.join(assignments)} "
+                            "WHERE guild_id=? AND run_id=? AND lifecycle_state='published'",
+                            tuple(params),
+                        ).rowcount
+                        counts["bnl_journal_published_packets_scrubbed"] = counts.get(
+                            "bnl_journal_published_packets_scrubbed", 0
+                        ) + changed
+                    continue
+
+                affected_run_ids.add(run_id)
+                entry_id = str(run.get("journal_entry_id") or "")
+                revision = int(run.get("journal_revision") or 0)
+                if entry_id and revision > 0:
+                    published_link = False
+                    if table_exists(conn, "bnl_journal_entries"):
+                        state = conn.execute(
+                            "SELECT lifecycle_state FROM bnl_journal_entries "
+                            "WHERE guild_id=? AND entry_id=? AND revision=?",
+                            (guild, entry_id, revision),
+                        ).fetchone()
+                        published_link = bool(state and str(state[0]) == "published")
+                    if not published_link and table_exists(conn, "bnl_journal_private_metadata"):
+                        state = conn.execute(
+                            "SELECT lifecycle_state FROM bnl_journal_private_metadata "
+                            "WHERE guild_id=? AND entry_id=? AND revision=?",
+                            (guild, entry_id, revision),
+                        ).fetchone()
+                        published_link = bool(state and str(state[0]) == "published")
+                    if not published_link:
+                        unpublished.add((entry_id, revision))
+
+        # Before packet persistence, the cited private metadata was the only
+        # durable route from a staged revision back to its occurrence owner.
+        for run in run_records:
+            link = (
+                str(run.get("journal_entry_id") or ""),
+                int(run.get("journal_revision") or 0),
+            )
+            if str(run.get("lifecycle_state") or "") != "published" and link in unpublished:
+                affected_run_ids.add(str(run.get("run_id") or ""))
+
+    # A preparation worker stores its run identity in private metadata before
+    # the occurrence row is linked to the revision. If deletion lands in that
+    # narrow interval, remove the staged revision by that identity as well.
+    if affected_run_ids and table_exists(conn, "bnl_journal_private_metadata"):
+        rows = conn.execute(
+            "SELECT entry_id,revision,metadata_json,lifecycle_state "
+            "FROM bnl_journal_private_metadata WHERE guild_id=?",
+            (guild,),
+        ).fetchall()
+        for entry_id, revision, metadata_raw, lifecycle_state in rows:
+            metadata = _json_object(metadata_raw)
+            if (
+                str(metadata.get("automationRunId") or "") in affected_run_ids
+                and str(lifecycle_state or "") != "published"
+            ):
+                unpublished.add((str(entry_id), int(revision)))
+
     if unpublished:
-        for entry_id, revision in sorted(set(unpublished)):
-            counts["bnl_journal_unpublished_metadata_deleted"] = counts.get("bnl_journal_unpublished_metadata_deleted", 0) + conn.execute(
-                "DELETE FROM bnl_journal_private_metadata WHERE guild_id=? AND entry_id=? AND revision=?",
-                (guild, entry_id, revision),
-            ).rowcount
+        for entry_id, revision in sorted(unpublished):
+            if table_exists(conn, "bnl_journal_private_metadata"):
+                counts["bnl_journal_unpublished_metadata_deleted"] = counts.get("bnl_journal_unpublished_metadata_deleted", 0) + conn.execute(
+                    "DELETE FROM bnl_journal_private_metadata WHERE guild_id=? AND entry_id=? AND revision=?",
+                    (guild, entry_id, revision),
+                ).rowcount
             if table_exists(conn, "bnl_journal_entries"):
                 counts["bnl_journal_unpublished_entries_deleted"] = counts.get("bnl_journal_unpublished_entries_deleted", 0) + conn.execute(
                     "DELETE FROM bnl_journal_entries WHERE guild_id=? AND entry_id=? AND revision=? AND lifecycle_state<>'published'",
@@ -401,15 +519,6 @@ def purge_user_journal_derivatives_on_connection(
                        WHERE guild_id=? AND journal_entry_id=? AND journal_revision=?""",
                     (now, guild, entry_id, revision),
                 )
-            if table_exists(conn, "bnl_journal_automation_runs"):
-                counts["bnl_journal_automation_runs_invalidated"] = counts.get("bnl_journal_automation_runs_invalidated", 0) + conn.execute(
-                    """UPDATE bnl_journal_automation_runs
-                       SET lifecycle_state='held',reason='privacy_source_deleted',journal_entry_id=NULL,
-                           journal_revision=0,lease_expires_at=NULL,updated_at=?
-                       WHERE guild_id=? AND journal_entry_id=? AND journal_revision=?
-                         AND lifecycle_state<>'published'""",
-                    (now, guild, entry_id, revision),
-                ).rowcount
             if table_exists(conn, "bnl_journal_automation_state"):
                 conn.execute(
                     """UPDATE bnl_journal_automation_state
@@ -417,7 +526,177 @@ def purge_user_journal_derivatives_on_connection(
                        WHERE guild_id=? AND last_entry_id=? AND last_revision=?""",
                     (now, guild, entry_id, revision),
                 )
+
+    if affected_run_ids and run_columns:
+        records_by_id = {str(run.get("run_id") or ""): run for run in run_records}
+        observation_columns = (
+            _cols(conn, "bnl_journal_observations")
+            if table_exists(conn, "bnl_journal_observations")
+            else set()
+        )
+        state_columns = (
+            _cols(conn, "bnl_journal_automation_state")
+            if table_exists(conn, "bnl_journal_automation_state")
+            else set()
+        )
+        for run_id in sorted(affected_run_ids):
+            if not run_id:
+                continue
+            run = records_by_id.get(run_id, {})
+            entry_id = str(run.get("journal_entry_id") or "")
+            revision = int(run.get("journal_revision") or 0)
+
+            # A frozen packet may be invalidated before a revision exists, so
+            # reset the matching daily observation by window as well as link.
+            if {
+                "guild_id", "source_window_start", "source_window_end", "lifecycle_state",
+                "journal_entry_id", "journal_revision", "updated_at",
+            } <= observation_columns:
+                conn.execute(
+                    "UPDATE bnl_journal_observations SET lifecycle_state='observed',"
+                    "journal_entry_id=NULL,journal_revision=0,updated_at=? "
+                    "WHERE guild_id=? AND source_window_start=? AND source_window_end=? "
+                    "AND lifecycle_state<>'published'",
+                    (
+                        now,
+                        guild,
+                        str(run.get("source_window_start") or ""),
+                        str(run.get("source_window_end") or ""),
+                    ),
+                )
+
+            assignments: list[str] = []
+            if "lifecycle_state" in run_columns:
+                assignments.append("lifecycle_state='held'")
+            if "reason" in run_columns:
+                assignments.append("reason='privacy_source_deleted'")
+            for column, expression in (
+                ("journal_entry_id", "NULL"),
+                ("journal_revision", "0"),
+                ("lease_expires_at", "NULL"),
+                ("frozen_packet_json", "NULL"),
+                ("frozen_packet_hash", "NULL"),
+                ("packet_frozen_at", "NULL"),
+                ("prepared_payload_hash", "NULL"),
+                ("prepared_payload_bytes", "0"),
+                ("prepared_at", "NULL"),
+                ("delivery_lease_expires_at", "NULL"),
+            ):
+                if column in run_columns:
+                    assignments.append(f"{column}={expression}")
+            if "preparation_epoch" in run_columns:
+                assignments.append("preparation_epoch=COALESCE(preparation_epoch,0)+1")
+            if "delivery_epoch" in run_columns:
+                assignments.append("delivery_epoch=COALESCE(delivery_epoch,0)+1")
+            params: list[Any] = []
+            if "updated_at" in run_columns:
+                assignments.append("updated_at=?")
+                params.append(now)
+            if assignments and {"guild_id", "run_id", "lifecycle_state"} <= run_columns:
+                params.extend((guild, run_id))
+                changed = conn.execute(
+                    f"UPDATE bnl_journal_automation_runs SET {','.join(assignments)} "
+                    "WHERE guild_id=? AND run_id=? AND lifecycle_state<>'published'",
+                    tuple(params),
+                ).rowcount
+                counts["bnl_journal_automation_runs_invalidated"] = counts.get(
+                    "bnl_journal_automation_runs_invalidated", 0
+                ) + changed
+
+            # Keep the existing website-facing run telemetry truthful without
+            # requiring any newly migrated automation-state columns.
+            state_assignments: list[str] = []
+            state_params: list[Any] = []
+            for column, value in (
+                ("last_status", "held"),
+                ("last_reason", "privacy_source_deleted"),
+                ("last_entry_id", ""),
+            ):
+                if column in state_columns:
+                    state_assignments.append(f"{column}=?")
+                    state_params.append(value)
+            if "last_revision" in state_columns:
+                state_assignments.append("last_revision=0")
+            if "next_retry_at" in state_columns:
+                state_assignments.append("next_retry_at=NULL")
+            if "updated_at" in state_columns:
+                state_assignments.append("updated_at=?")
+                state_params.append(now)
+            where_parts: list[str] = []
+            where_params: list[Any] = []
+            if entry_id and revision > 0 and {"last_entry_id", "last_revision"} <= state_columns:
+                where_parts.append("(last_entry_id=? AND last_revision=?)")
+                where_params.extend((entry_id, revision))
+            if {"last_cadence", "last_source_window_start", "last_source_window_end"} <= state_columns:
+                where_parts.append("(last_cadence=? AND last_source_window_start=? AND last_source_window_end=?)")
+                where_params.extend((
+                    str(run.get("cadence") or ""),
+                    str(run.get("source_window_start") or ""),
+                    str(run.get("source_window_end") or ""),
+                ))
+            if state_assignments and where_parts and "guild_id" in state_columns:
+                conn.execute(
+                    f"UPDATE bnl_journal_automation_state SET {','.join(state_assignments)} "
+                    f"WHERE guild_id=? AND ({' OR '.join(where_parts)})",
+                    tuple(state_params + [guild] + where_params),
+                )
     return {key: int(value or 0) for key, value in counts.items() if int(value or 0)}
+
+
+def purge_guild_journal_derivatives_on_connection(
+    conn: sqlite3.Connection,
+    guild_id: int,
+) -> dict[str, int]:
+    """Scrub every member-derived hidden Journal record for one guild."""
+    guild = int(guild_id)
+    if guild <= 0:
+        raise ValueError("invalid_journal_privacy_scope")
+    user_ids: set[int] = set()
+
+    def collect(value: Any) -> None:
+        for match in re.finditer(r"discord_user:(\d+)", str(value or "")):
+            user_id = int(match.group(1))
+            if user_id > 0:
+                user_ids.add(user_id)
+
+    if table_exists(conn, "bnl_journal_source_events"):
+        for row in conn.execute(
+            "SELECT subject_ref FROM bnl_journal_source_events "
+            "WHERE guild_id=? AND source_kind='discord_message'",
+            (guild,),
+        ).fetchall():
+            collect(row[0])
+    for table, columns in (
+        ("bnl_journal_private_metadata", ("metadata_json",)),
+        ("bnl_journal_automation_runs", ("frozen_packet_json",)),
+        (
+            "bnl_journal_observations",
+            ("subject_counts_json", "representative_sources_json"),
+        ),
+    ):
+        if not table_exists(conn, table):
+            continue
+        available = _cols(conn, table)
+        selected = [column for column in columns if column in available]
+        if not selected or "guild_id" not in available:
+            continue
+        for row in conn.execute(
+            f"SELECT {','.join(selected)} FROM {table} WHERE guild_id=?",
+            (guild,),
+        ).fetchall():
+            for value in row:
+                collect(value)
+
+    totals: dict[str, int] = {}
+    for user_id in sorted(user_ids):
+        counts = purge_user_journal_derivatives_on_connection(
+            conn,
+            guild,
+            user_id,
+        )
+        for key, value in counts.items():
+            totals[key] = totals.get(key, 0) + int(value or 0)
+    return {key: value for key, value in totals.items() if value}
 
 
 def _cols(conn: sqlite3.Connection, table: str) -> set[str]:
@@ -529,6 +808,113 @@ def _memory_select_expression(columns: set[str], name: str, fallback: str = "NUL
     return name if name in columns else f"{fallback} AS {name}"
 
 
+def _broadcast_memory_eligibility_hash(
+    guild_id: int,
+    row_id: int,
+    cleaned_summary: Any,
+    usage_scope: Any,
+    valid_until: Any,
+    needs_clarification: Any,
+    superseded_by_id: Any,
+    created_at: Any,
+) -> str:
+    return _hash(
+        "journal-memory-eligibility-v1",
+        int(guild_id),
+        int(row_id),
+        str(cleaned_summary or ""),
+        str(usage_scope or ""),
+        str(valid_until or ""),
+        int(needs_clarification or 0),
+        int(superseded_by_id or 0),
+        str(created_at or ""),
+        "active",
+        1,
+    )
+
+
+def journal_broadcast_memory_provenance_is_eligible(
+    conn: sqlite3.Connection,
+    guild_id: int,
+    provenance: list[dict[str, Any]],
+    eligible_at: str,
+) -> bool:
+    """Revalidate every used established-memory row at the supplied instant."""
+    used = [item for item in provenance if isinstance(item, dict) and item.get("rowId")]
+    if not used:
+        return True
+    if not table_exists(conn, "broadcast_memory"):
+        return False
+    columns = _cols(conn, "broadcast_memory")
+    required = {"id", "guild_id", "cleaned_summary", "status", "public_safe"}
+    if not required <= columns:
+        return False
+    selected_columns = [
+        _memory_select_expression(columns, "id"),
+        _memory_select_expression(columns, "cleaned_summary", "''"),
+        _memory_select_expression(columns, "usage_scope", "''"),
+        _memory_select_expression(columns, "valid_until"),
+        _memory_select_expression(columns, "needs_clarification", "0"),
+        _memory_select_expression(columns, "superseded_by_id", "0"),
+        _memory_select_expression(columns, "created_at", "''"),
+        _memory_select_expression(columns, "status", "''"),
+        _memory_select_expression(columns, "public_safe", "0"),
+    ]
+    row_ids = sorted({int(item["rowId"]) for item in used})
+    placeholders = ",".join("?" for _ in row_ids)
+    rows = conn.execute(
+        f"SELECT {','.join(selected_columns)} FROM broadcast_memory "
+        f"WHERE guild_id=? AND id IN ({placeholders})",
+        (int(guild_id), *row_ids),
+    ).fetchall()
+    by_id = {int(row[0]): row for row in rows}
+    if set(by_id) != set(row_ids):
+        return False
+    eligibility_instant = _parse_context_datetime(eligible_at) or datetime.now(timezone.utc)
+    expected_hashes = {
+        int(item["rowId"]): str(item.get("eligibilityHash") or "")
+        for item in used
+    }
+    for row_id in row_ids:
+        (
+            _row_id,
+            cleaned_summary,
+            usage_scope,
+            valid_until,
+            needs_clarification,
+            superseded_by_id,
+            created_at,
+            status,
+            public_safe,
+        ) = by_id[row_id]
+        scopes = _scope_tokens(str(usage_scope or ""))
+        expiry = _parse_context_datetime(valid_until, end_of_day=True)
+        if (
+            str(status or "") != "active"
+            or int(public_safe or 0) != 1
+            or int(needs_clarification or 0) != 0
+            or int(superseded_by_id or 0) != 0
+            or not (scopes & JOURNAL_PUBLIC_BROADCAST_SCOPES)
+            or "internal" in scopes
+            or not str(cleaned_summary or "").strip()
+            or (valid_until and (expiry is None or expiry < eligibility_instant))
+        ):
+            return False
+        current_hash = _broadcast_memory_eligibility_hash(
+            guild_id,
+            row_id,
+            cleaned_summary,
+            usage_scope,
+            valid_until,
+            needs_clarification,
+            superseded_by_id,
+            created_at,
+        )
+        if not expected_hashes.get(row_id) or expected_hashes[row_id] != current_hash:
+            return False
+    return True
+
+
 def _approved_journal_broadcast_memory(
     conn: sqlite3.Connection,
     guild_id: int,
@@ -613,6 +999,16 @@ def _approved_journal_broadcast_memory(
             "rowId": int(row_id),
             "createdAt": str(created_at or "")[:48],
             "matchedFreshSourceRefIds": matched_refs[:12],
+            "eligibilityHash": _broadcast_memory_eligibility_hash(
+                guild_id,
+                int(row_id),
+                cleaned_summary,
+                usage_scope,
+                valid_until,
+                needs_clarification,
+                superseded_by_id,
+                created_at,
+            ),
         })
         if len(safe_records) >= max(1, int(limit)):
             break
@@ -2070,12 +2466,104 @@ def _used_context_lane_metadata(packet: dict[str, Any], context_uses: list[dict[
     return used_lanes, used_provenance
 
 
-def _draft_records(guild_id: int, packet: dict[str, Any], article: dict[str, Any], *, entry_id: str = "", revision: int = 1) -> tuple[tuple[Any, ...], tuple[Any, ...], JournalResult]:
+def _attempt_fence_owned(
+    conn: sqlite3.Connection,
+    attempt_fence: Optional[tuple[str, int]],
+) -> bool:
+    """Check an automation preparation epoch inside the caller's transaction."""
+    if attempt_fence is None:
+        return True
+    if not table_exists(conn, "bnl_journal_automation_runs"):
+        return False
+    columns = _cols(conn, "bnl_journal_automation_runs")
+    if "preparation_epoch" not in columns:
+        return False
+    row = conn.execute(
+        "SELECT lifecycle_state,preparation_epoch,lease_expires_at "
+        "FROM bnl_journal_automation_runs WHERE run_id=?",
+        (str(attempt_fence[0]),),
+    ).fetchone()
+    if not row or str(row[0]) != "preparing" or int(row[1] or 0) != int(attempt_fence[1]):
+        return False
+    lease_raw = str(row[2] or "")
+    if not lease_raw:
+        return False
+    try:
+        lease = datetime.fromisoformat(lease_raw.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if lease.tzinfo is None:
+        lease = lease.replace(tzinfo=timezone.utc)
+    return lease.astimezone(timezone.utc) > datetime.now(timezone.utc)
+
+
+def _delivery_fence_owned(
+    conn: sqlite3.Connection,
+    delivery_fence: Optional[tuple[str, int]],
+    *,
+    guild_id: int,
+    entry_id: str,
+    revision: Optional[int],
+) -> bool:
+    """Validate an automation delivery owner inside its network transaction."""
+    if delivery_fence is None or revision is None:
+        return False
+    if not table_exists(conn, "bnl_journal_automation_runs"):
+        return False
+    columns = _cols(conn, "bnl_journal_automation_runs")
+    required = {
+        "run_id",
+        "guild_id",
+        "lifecycle_state",
+        "journal_entry_id",
+        "journal_revision",
+        "delivery_epoch",
+        "delivery_lease_expires_at",
+    }
+    if not required <= columns:
+        return False
+    row = conn.execute(
+        "SELECT guild_id,lifecycle_state,journal_entry_id,journal_revision,"
+        "delivery_epoch,delivery_lease_expires_at "
+        "FROM bnl_journal_automation_runs WHERE run_id=?",
+        (str(delivery_fence[0]),),
+    ).fetchone()
+    if (
+        not row
+        or int(row[0]) != int(guild_id)
+        or str(row[1]) != "delivering"
+        or str(row[2] or "") != str(entry_id)
+        or int(row[3] or 0) != int(revision)
+        or int(row[4] or 0) != int(delivery_fence[1])
+    ):
+        return False
+    lease_raw = str(row[5] or "")
+    if not lease_raw:
+        return False
+    try:
+        lease = datetime.fromisoformat(lease_raw.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if lease.tzinfo is None:
+        lease = lease.replace(tzinfo=timezone.utc)
+    return lease.astimezone(timezone.utc) > datetime.now(timezone.utc)
+
+
+def _draft_records(
+    guild_id: int,
+    packet: dict[str, Any],
+    article: dict[str, Any],
+    *,
+    entry_id: str = "",
+    revision: int = 1,
+    automation_context: Optional[dict[str, Any]] = None,
+) -> tuple[tuple[Any, ...], tuple[Any, ...], JournalResult]:
     authored = utc_now_iso()
     entry_id = entry_id or "journal_" + _hash(guild_id, authored, article["title"])[:16]
     content_hash = _hash(article["title"], article["excerpt"], _json(article["sections"]))
     payload = build_public_payload(entry_id, revision, article, packet, content_hash, authored)
     canonical = _json(payload).encode("utf-8")
+    request_hash = canonical_payload_hash(canonical)
     source_ref_ids = article.get("sourceRefIds", {})
     cited_sources = cited_private_sources(packet, article)
     meta = dict(article.get("metadata") or {})
@@ -2083,6 +2571,21 @@ def _draft_records(guild_id: int, packet: dict[str, Any], article: dict[str, Any
     context_uses = [item for item in meta.get("contextUses", []) if isinstance(item, dict)]
     used_context_lanes, used_context_provenance = _used_context_lane_metadata(packet, context_uses)
     lane_candidates = packet.get("generationContextLanes") if isinstance(packet.get("generationContextLanes"), dict) else {}
+    related_entry_ids = list(dict.fromkeys(
+        [
+            str(e.get("entry_id"))
+            for e in (
+                [packet.get("history", {}).get("previousEntry")]
+                + list(packet.get("history", {}).get("relevantOlderEntries", []))
+            )
+            if isinstance(e, dict) and e.get("entry_id")
+        ]
+        + [
+            str(observation.get("dailyEntryId"))
+            for observation in packet.get("observationContext", [])
+            if isinstance(observation, dict) and observation.get("dailyEntryId")
+        ]
+    ))
     meta.update({
         "entryKind": packet.get("entryKind", "manual"),
         "publicWordCount": public_word_count(article),
@@ -2092,7 +2595,7 @@ def _draft_records(guild_id: int, packet: dict[str, Any], article: dict[str, Any
         "supportingRelayIds": [s.get("relayId") for s in cited_sources if s.get("sourceKind") == "relay"],
         "supportingConversationRefs": [{k: v for k, v in s.items() if k in {"refId", "messageId", "subjectRef", "channelPolicy", "observedAt"}} for s in cited_sources if s.get("sourceKind") == "conversation"],
         "subjectRefs": sorted({str(s.get("subjectRef")) for s in cited_sources if s.get("subjectRef")}),
-        "relatedPriorJournalEntryIds": [e.get("entry_id") for e in packet.get("history", {}).get("relevantOlderEntries", [])],
+        "relatedPriorJournalEntryIds": related_entry_ids,
         "recurringTopicCounts": packet.get("history", {}).get("recurringTopicCounts", {}),
         "aggregateCounts": packet.get("aggregateCounts", {}),
         "sourceSummaries": [{"refId": s.get("refId"), "hash": _hash(s.get("summary", "")), "summary": s.get("summary", "")[:160]} for s in cited_sources],
@@ -2105,7 +2608,15 @@ def _draft_records(guild_id: int, packet: dict[str, Any], article: dict[str, Any
         "usedGenerationContextLanes": used_context_lanes,
         "usedContextLaneProvenance": used_context_provenance,
         "contextUses": context_uses,
+        "canonicalPayloadHash": request_hash,
+        "canonicalPayloadBytes": len(canonical),
     })
+    if automation_context:
+        meta.update({
+            "automationRunId": str(automation_context.get("runId") or ""),
+            "automationPreparationEpoch": int(automation_context.get("preparationEpoch") or 0),
+            "frozenSourceHash": str(automation_context.get("sourceHash") or ""),
+        })
     now = utc_now_iso()
     entry_row = (entry_id, revision, guild_id, "draft", article["title"], article["excerpt"], _json(article["sections"]), _json(payload), canonical, content_hash, packet["sourceWindowStart"], packet["sourceWindowEnd"], authored, None, None, None, None, 0, now, now)
     meta_row = (entry_id, revision, guild_id, _json(meta), content_hash, "draft", now, now)
@@ -2183,9 +2694,15 @@ def store_validated_draft(
     entry_id: str = "",
     revision: int = 1,
     allow_advisory: bool = False,
+    attempt_fence: Optional[tuple[str, int]] = None,
+    source_hash: str = "",
 ) -> JournalResult:
     ensure_schema(db_path)
     with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        if not _attempt_fence_owned(conn, attempt_fence):
+            conn.rollback()
+            return JournalResult(False, "superseded", "preparation_epoch_lost", entry_id=entry_id, revision=revision)
         reason = validate_article(
             article,
             packet,
@@ -2193,10 +2710,25 @@ def store_validated_draft(
             blocking_only=allow_advisory,
         )
         if reason:
+            conn.rollback()
             return JournalResult(False, "no_draft", reason, entry_id=entry_id, revision=revision)
-        entry_row, meta_row, result = _draft_records(guild_id, packet, article, entry_id=entry_id, revision=revision)
-        with conn:
-            _insert_draft_rows(conn, entry_row, meta_row)
+        automation_context = None
+        if attempt_fence is not None:
+            automation_context = {
+                "runId": attempt_fence[0],
+                "preparationEpoch": attempt_fence[1],
+                "sourceHash": source_hash,
+            }
+        entry_row, meta_row, result = _draft_records(
+            guild_id,
+            packet,
+            article,
+            entry_id=entry_id,
+            revision=revision,
+            automation_context=automation_context,
+        )
+        _insert_draft_rows(conn, entry_row, meta_row)
+        conn.commit()
     return result
 
 
@@ -2207,6 +2739,9 @@ def generate_and_store_packet_draft(
     generator: Callable[[dict[str, Any], str], str],
     *,
     entry_id: str = "",
+    revision: int = 1,
+    attempt_fence: Optional[tuple[str, int]] = None,
+    source_hash: str = "",
 ) -> JournalResult:
     if not packet.get("coverageComplete", True):
         return JournalResult(False, "no_draft", "incomplete_source_window", entry_id=entry_id)
@@ -2227,7 +2762,10 @@ def generate_and_store_packet_draft(
         packet,
         article,
         entry_id=entry_id,
+        revision=revision,
         allow_advisory=allow_advisory,
+        attempt_fence=attempt_fence,
+        source_hash=source_hash,
     )
 
 
@@ -2253,23 +2791,66 @@ def generate_and_store_draft(
     return generate_and_store_packet_draft(db_path, guild_id, packet, generator, entry_id=entry_id)
 
 
-def approve_draft(db_path: str, guild_id: int, entry_id: str, content_hash: str, revision: Optional[int] = None) -> JournalResult:
+def approve_draft(
+    db_path: str,
+    guild_id: int,
+    entry_id: str,
+    content_hash: str,
+    revision: Optional[int] = None,
+    *,
+    attempt_fence: Optional[tuple[str, int]] = None,
+    source_hash: str = "",
+) -> JournalResult:
     ensure_schema(db_path)
     now = utc_now_iso()
     with sqlite3.connect(db_path) as conn:
-        row = conn.execute("SELECT revision,lifecycle_state,content_hash FROM bnl_journal_entries WHERE guild_id=? AND entry_id=? " + ("AND revision=?" if revision is not None else "ORDER BY revision DESC LIMIT 1"), (guild_id, entry_id, revision) if revision is not None else (guild_id, entry_id)).fetchone()
+        conn.execute("BEGIN IMMEDIATE")
+        if not _attempt_fence_owned(conn, attempt_fence):
+            conn.rollback()
+            return JournalResult(False, "superseded", "preparation_epoch_lost", entry_id, int(revision or 0))
+        row = conn.execute(
+            "SELECT e.revision,e.lifecycle_state,e.content_hash,e.canonical_payload_bytes,m.metadata_json "
+            "FROM bnl_journal_entries e LEFT JOIN bnl_journal_private_metadata m "
+            "ON m.entry_id=e.entry_id AND m.revision=e.revision AND m.guild_id=e.guild_id "
+            "WHERE e.guild_id=? AND e.entry_id=? "
+            + ("AND e.revision=?" if revision is not None else "ORDER BY e.revision DESC LIMIT 1"),
+            (guild_id, entry_id, revision) if revision is not None else (guild_id, entry_id),
+        ).fetchone()
         if not row:
+            conn.rollback()
             return JournalResult(False, "not_found", "not_found", entry_id)
         rev, state, stored_hash = int(row[0]), row[1], row[2]
         if state != "draft":
+            conn.rollback()
             return JournalResult(False, state, "not_draft", entry_id, rev, stored_hash)
         if stored_hash != content_hash:
+            conn.rollback()
             return JournalResult(False, "draft", "content_hash_mismatch", entry_id, rev, stored_hash)
-        with conn:
-            cur1 = conn.execute("UPDATE bnl_journal_entries SET lifecycle_state='approved_pending_delivery',approved_at=?,updated_at=? WHERE guild_id=? AND entry_id=? AND revision=? AND lifecycle_state='draft'", (now, now, guild_id, entry_id, rev))
-            cur2 = conn.execute("UPDATE bnl_journal_private_metadata SET lifecycle_state='approved_pending_delivery',updated_at=? WHERE guild_id=? AND entry_id=? AND revision=? AND lifecycle_state='draft'", (now, guild_id, entry_id, rev))
-            if cur1.rowcount != 1 or cur2.rowcount != 1:
-                raise sqlite3.IntegrityError("journal_approve_sync_failed")
+        canonical = bytes(row[3] or b"")
+        if not canonical:
+            conn.rollback()
+            return JournalResult(False, "draft", "canonical_payload_missing", entry_id, rev, stored_hash)
+        if len(canonical) > JOURNAL_SITE_REQUEST_BODY_MAX_BYTES:
+            conn.rollback()
+            return JournalResult(False, "draft", "request_body_too_large", entry_id, rev, stored_hash)
+        request_hash = canonical_payload_hash(canonical)
+        metadata = _json_object(row[4])
+        stored_request_hash = str(metadata.get("canonicalPayloadHash") or "")
+        if stored_request_hash and stored_request_hash != request_hash:
+            conn.rollback()
+            return JournalResult(False, "draft", "canonical_payload_hash_mismatch", entry_id, rev, stored_hash)
+        stored_source_hash = str(metadata.get("frozenSourceHash") or "")
+        if source_hash and stored_source_hash != source_hash:
+            conn.rollback()
+            return JournalResult(False, "draft", "source_packet_hash_mismatch", entry_id, rev, stored_hash)
+        metadata["canonicalPayloadHash"] = request_hash
+        metadata["canonicalPayloadBytes"] = len(canonical)
+        cur1 = conn.execute("UPDATE bnl_journal_entries SET lifecycle_state='approved_pending_delivery',approved_at=?,updated_at=? WHERE guild_id=? AND entry_id=? AND revision=? AND lifecycle_state='draft'", (now, now, guild_id, entry_id, rev))
+        cur2 = conn.execute("UPDATE bnl_journal_private_metadata SET metadata_json=?,lifecycle_state='approved_pending_delivery',updated_at=? WHERE guild_id=? AND entry_id=? AND revision=? AND lifecycle_state='draft'", (_json(metadata), now, guild_id, entry_id, rev))
+        if cur1.rowcount != 1 or cur2.rowcount != 1:
+            conn.rollback()
+            raise sqlite3.IntegrityError("journal_approve_sync_failed")
+        conn.commit()
     return JournalResult(True, "approved_pending_delivery", "", entry_id, rev, stored_hash)
 
 
@@ -2407,8 +2988,86 @@ def _post_canonical_payload(canonical: bytes, base_url: str, api_key: str, opene
     return status, reason, int(http or 0), idem, published
 
 
-def deliver_approved(db_path: str, guild_id: int, entry_id: str, base_url: str, api_key: str, opener=None, timeout: int = 10, revision: Optional[int] = None) -> JournalResult:
+def deliver_approved(
+    db_path: str,
+    guild_id: int,
+    entry_id: str,
+    base_url: str,
+    api_key: str,
+    opener=None,
+    timeout: int = 10,
+    revision: Optional[int] = None,
+    *,
+    delivery_fence: Optional[tuple[str, int]] = None,
+    delivery_preflight: Optional[Callable[[sqlite3.Connection], str]] = None,
+) -> JournalResult:
     ensure_schema(db_path)
+    if delivery_fence is not None:
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            if not _delivery_fence_owned(
+                conn,
+                delivery_fence,
+                guild_id=guild_id,
+                entry_id=entry_id,
+                revision=revision,
+            ):
+                conn.rollback()
+                return JournalResult(
+                    False,
+                    "not_deliverable",
+                    "delivery_epoch_lost",
+                    entry_id,
+                    int(revision or 0),
+                )
+            row = conn.execute(
+                "SELECT revision,canonical_payload_bytes,content_hash FROM bnl_journal_entries "
+                "WHERE guild_id=? AND entry_id=? "
+                "AND lifecycle_state IN ('approved_pending_delivery','delivery_failed') AND revision=?",
+                (guild_id, entry_id, int(revision)),
+            ).fetchone()
+            if not row:
+                conn.rollback()
+                return JournalResult(False, "not_deliverable", "not_approved", entry_id, int(revision or 0))
+            rev, canonical, content_hash = int(row[0]), row[1], row[2]
+            if delivery_preflight is not None:
+                preflight_reason = str(delivery_preflight(conn) or "")
+                if preflight_reason:
+                    conn.rollback()
+                    return JournalResult(
+                        False,
+                        "not_deliverable",
+                        preflight_reason,
+                        entry_id,
+                        rev,
+                        content_hash,
+                    )
+            status, reason, http, idem, published = _post_canonical_payload(
+                canonical,
+                base_url,
+                api_key,
+                opener,
+                timeout,
+            )
+            now = utc_now_iso()
+            cur1 = conn.execute(
+                "UPDATE bnl_journal_entries SET lifecycle_state=?,delivery_status=?,"
+                "delivery_http_status=?,published_at=COALESCE(?,published_at),updated_at=? "
+                "WHERE guild_id=? AND entry_id=? AND revision=? "
+                "AND lifecycle_state IN ('approved_pending_delivery','delivery_failed')",
+                (status, reason, http, published or None, now, guild_id, entry_id, rev),
+            )
+            cur2 = conn.execute(
+                "UPDATE bnl_journal_private_metadata SET lifecycle_state=?,updated_at=? "
+                "WHERE guild_id=? AND entry_id=? AND revision=?",
+                (status, now, guild_id, entry_id, rev),
+            )
+            if cur1.rowcount != 1 or cur2.rowcount != 1:
+                conn.rollback()
+                raise sqlite3.IntegrityError("journal_delivery_sync_failed")
+            conn.commit()
+        return JournalResult(status == "published", status, reason, entry_id, rev, content_hash, http, idem)
+
     with sqlite3.connect(db_path) as conn:
         row = conn.execute("SELECT revision,canonical_payload_bytes,content_hash FROM bnl_journal_entries WHERE guild_id=? AND entry_id=? AND lifecycle_state IN ('approved_pending_delivery','delivery_failed') " + ("AND revision=?" if revision is not None else "ORDER BY revision DESC LIMIT 1"), (guild_id, entry_id, revision) if revision is not None else (guild_id, entry_id)).fetchone()
     if not row:

--- a/bnl_journal_automation.py
+++ b/bnl_journal_automation.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
+import re
 import sqlite3
 from dataclasses import asdict, dataclass
 from datetime import date, datetime, time as datetime_time, timedelta, timezone
@@ -10,11 +12,14 @@ from typing import Any, Callable, Optional
 import pytz
 
 from bnl_journal import (
+    JOURNAL_SITE_REQUEST_BODY_MAX_BYTES,
     JournalResult,
     approve_draft,
     build_source_packet_between,
+    canonical_payload_hash,
     deliver_approved,
     generate_and_store_packet_draft,
+    journal_broadcast_memory_provenance_is_eligible,
     journal_topic_counts,
     utc_now_iso,
 )
@@ -27,8 +32,17 @@ WEEKLY_READY_HOUR = 19
 MIN_DAILY_SOURCE_COUNT = 5
 MIN_WEEKLY_ACTIVE_DAYS = 1
 LEASE_MINUTES = 30
+DELIVERY_LEASE_MINUTES = 2
 RETRY_MINUTES = 60
 TERMINAL_RUN_STATES = {"published", "quiet", "incomplete"}
+DELIVERY_PREFLIGHT_INVALIDATION_REASONS = frozenset({
+    "prepared_revision_missing",
+    "prepared_payload_integrity_failed",
+    "source_packet_hash_mismatch",
+    "privacy_eligibility_changed",
+    "privacy_source_ineligible",
+    "privacy_memory_ineligible",
+})
 
 
 @dataclass
@@ -42,6 +56,8 @@ class AutomationResult:
     source_window_start: str = ""
     source_window_end: str = ""
     aggregate_counts: Optional[dict[str, Any]] = None
+    http_status: int = 0
+    idempotent: bool = False
 
 
 def _json(value: Any) -> str:
@@ -157,9 +173,33 @@ def ensure_schema(db_path: str) -> None:
             aggregate_counts_json TEXT NOT NULL DEFAULT '{}',
             attempt_count INTEGER NOT NULL DEFAULT 0,
             lease_expires_at TEXT,
+            frozen_packet_json TEXT,
+            frozen_packet_hash TEXT,
+            packet_frozen_at TEXT,
+            preparation_epoch INTEGER NOT NULL DEFAULT 0,
+            prepared_payload_hash TEXT,
+            prepared_payload_bytes INTEGER NOT NULL DEFAULT 0,
+            prepared_at TEXT,
+            delivery_epoch INTEGER NOT NULL DEFAULT 0,
+            delivery_lease_expires_at TEXT,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             UNIQUE(guild_id,cadence,source_window_start,source_window_end))""")
+        run_columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(bnl_journal_automation_runs)")}
+        run_migrations = {
+            "frozen_packet_json": "TEXT",
+            "frozen_packet_hash": "TEXT",
+            "packet_frozen_at": "TEXT",
+            "preparation_epoch": "INTEGER NOT NULL DEFAULT 0",
+            "prepared_payload_hash": "TEXT",
+            "prepared_payload_bytes": "INTEGER NOT NULL DEFAULT 0",
+            "prepared_at": "TEXT",
+            "delivery_epoch": "INTEGER NOT NULL DEFAULT 0",
+            "delivery_lease_expires_at": "TEXT",
+        }
+        for column, declaration in run_migrations.items():
+            if column not in run_columns:
+                conn.execute(f"ALTER TABLE bnl_journal_automation_runs ADD COLUMN {column} {declaration}")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_bnl_journal_runs_latest ON bnl_journal_automation_runs(guild_id,updated_at DESC)")
         conn.execute("""CREATE TABLE IF NOT EXISTS bnl_journal_automation_state (
             guild_id INTEGER PRIMARY KEY,
@@ -172,7 +212,79 @@ def ensure_schema(db_path: str) -> None:
             last_source_window_start TEXT,
             last_source_window_end TEXT,
             next_retry_at TEXT,
+            memory_excluded_entry_ids_json TEXT NOT NULL DEFAULT '[]',
+            memory_exclusions_confirmed_at TEXT,
             updated_at TEXT NOT NULL)""")
+        state_columns = {
+            str(row[1]) for row in conn.execute("PRAGMA table_info(bnl_journal_automation_state)")
+        }
+        state_migrations = {
+            "memory_excluded_entry_ids_json": "TEXT NOT NULL DEFAULT '[]'",
+            "memory_exclusions_confirmed_at": "TEXT",
+        }
+        for column, declaration in state_migrations.items():
+            if column not in state_columns:
+                conn.execute(
+                    f"ALTER TABLE bnl_journal_automation_state ADD COLUMN {column} {declaration}"
+                )
+
+
+def store_journal_memory_exclusions(
+    db_path: str,
+    guild_id: int,
+    entry_ids: set[str] | list[str],
+) -> set[str]:
+    """Persist one confirmed website memory-eligibility snapshot."""
+    ensure_schema(db_path)
+    resolved = {
+        str(entry_id).strip()
+        for entry_id in entry_ids
+        if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,159}", str(entry_id).strip())
+    }
+    now = utc_now_iso()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            "INSERT INTO bnl_journal_automation_state("
+            "guild_id,memory_excluded_entry_ids_json,memory_exclusions_confirmed_at,updated_at"
+            ") VALUES(?,?,?,?) ON CONFLICT(guild_id) DO UPDATE SET "
+            "memory_excluded_entry_ids_json=excluded.memory_excluded_entry_ids_json,"
+            "memory_exclusions_confirmed_at=excluded.memory_exclusions_confirmed_at,"
+            "updated_at=excluded.updated_at",
+            (int(guild_id), _json(sorted(resolved)), now, now),
+        )
+        conn.commit()
+    return resolved
+
+
+def load_journal_memory_exclusions(
+    db_path: str,
+    guild_id: int,
+) -> tuple[set[str], bool]:
+    """Return the last confirmed exclusion set; never infer confirmed-empty."""
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT memory_excluded_entry_ids_json,memory_exclusions_confirmed_at "
+            "FROM bnl_journal_automation_state WHERE guild_id=?",
+            (int(guild_id),),
+        ).fetchone()
+    if not row or not str(row[1] or ""):
+        return set(), False
+    try:
+        values = json.loads(str(row[0] or ""))
+    except (TypeError, json.JSONDecodeError):
+        return set(), False
+    if not isinstance(values, list) or any(not isinstance(value, str) for value in values):
+        return set(), False
+    resolved = {
+        value.strip()
+        for value in values
+        if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,159}", value.strip())
+    }
+    if len(resolved) != len(values):
+        return set(), False
+    return resolved, True
 
 
 def _run_id(guild_id: int, cadence: str, start: str, end: str) -> str:
@@ -200,7 +312,38 @@ def _update_state(conn: sqlite3.Connection, guild_id: int, result: AutomationRes
     ))
 
 
-def _claim_run(db_path: str, guild_id: int, cadence: str, start: str, end: str, *, force: bool = False) -> tuple[str, str, dict[str, Any]]:
+def _reconcile_daily_observation(
+    conn: sqlite3.Connection,
+    guild_id: int,
+    result: AutomationResult,
+) -> None:
+    """Commit the Daily run and its Weekly prerequisite in one transaction."""
+    if result.cadence != "daily" or not result.source_window_start or not result.source_window_end:
+        return
+    conn.execute(
+        "UPDATE bnl_journal_observations SET lifecycle_state=?,journal_entry_id=?,"
+        "journal_revision=?,updated_at=? WHERE guild_id=? AND source_window_start=? AND source_window_end=?",
+        (
+            result.status,
+            result.entry_id or None,
+            int(result.revision or 0),
+            utc_now_iso(),
+            guild_id,
+            result.source_window_start,
+            result.source_window_end,
+        ),
+    )
+
+
+def _claim_preparation(
+    db_path: str,
+    guild_id: int,
+    cadence: str,
+    start: str,
+    end: str,
+    *,
+    force: bool = False,
+) -> tuple[str, str, int, dict[str, Any]]:
     ensure_schema(db_path)
     run_id = _run_id(guild_id, cadence, start, end)
     now = datetime.now(timezone.utc)
@@ -213,7 +356,16 @@ def _claim_run(db_path: str, guild_id: int, cadence: str, start: str, end: str, 
             current = dict(row)
             if current["lifecycle_state"] in TERMINAL_RUN_STATES:
                 conn.commit()
-                return "complete", run_id, current
+                return "complete", run_id, int(current.get("preparation_epoch") or 0), current
+            if (
+                current["lifecycle_state"] in {"prepared", "delivery_failed", "delivering"}
+                and current.get("journal_entry_id")
+                and int(current.get("journal_revision") or 0) > 0
+                and current.get("prepared_payload_hash")
+                and current.get("frozen_packet_hash")
+            ):
+                conn.commit()
+                return "prepared", run_id, int(current.get("preparation_epoch") or 0), current
             if current["lifecycle_state"] in {"held", "delivery_failed", "deferred"} and not force:
                 updated_at = str(current.get("updated_at") or "")
                 if updated_at:
@@ -221,40 +373,69 @@ def _claim_run(db_path: str, guild_id: int, cadence: str, start: str, end: str, 
                     if retry_at > now:
                         current["retry_at"] = _utc_iso(retry_at)
                         conn.commit()
-                        return "backoff", run_id, current
+                        return "backoff", run_id, int(current.get("preparation_epoch") or 0), current
             lease_expires = current.get("lease_expires_at") or ""
             # A manual Run Now may bypass retry backoff, but it must never
             # steal a live lease from the scheduler or another operator.
-            if current["lifecycle_state"] == "running" and lease_expires and _parse_utc(lease_expires) > now:
+            if current["lifecycle_state"] == "preparing" and lease_expires and _parse_utc(lease_expires) > now:
                 conn.commit()
-                return "busy", run_id, current
+                return "busy", run_id, int(current.get("preparation_epoch") or 0), current
+            epoch = int(current.get("preparation_epoch") or 0) + 1
             conn.execute("""UPDATE bnl_journal_automation_runs
-                SET lifecycle_state='running',reason='',attempt_count=attempt_count+1,lease_expires_at=?,updated_at=?
-                WHERE run_id=?""", (lease, utc_now_iso(), run_id))
+                SET lifecycle_state='preparing',reason='',attempt_count=attempt_count+1,
+                    preparation_epoch=?,lease_expires_at=?,delivery_lease_expires_at=NULL,updated_at=?
+                WHERE run_id=?""", (epoch, lease, utc_now_iso(), run_id))
         else:
             now_iso = utc_now_iso()
+            epoch = 1
             conn.execute("""INSERT INTO bnl_journal_automation_runs(
                 run_id,guild_id,cadence,source_window_start,source_window_end,lifecycle_state,reason,
-                aggregate_counts_json,attempt_count,lease_expires_at,created_at,updated_at
-            ) VALUES(?,?,?,?,?,'running','', '{}',1,?,?,?)""", (
-                run_id, guild_id, cadence, start, end, lease, now_iso, now_iso,
+                aggregate_counts_json,attempt_count,lease_expires_at,preparation_epoch,created_at,updated_at
+            ) VALUES(?,?,?,?,?,'preparing','', '{}',1,?,?,?,?)""", (
+                run_id, guild_id, cadence, start, end, lease, epoch, now_iso, now_iso,
             ))
         conn.commit()
-    return "claimed", run_id, {}
+    return "claimed", run_id, epoch, {}
 
 
-def _finish_run(db_path: str, run_id: str, result: AutomationResult) -> AutomationResult:
+def _finish_preparation(
+    db_path: str,
+    run_id: str,
+    preparation_epoch: int,
+    result: AutomationResult,
+) -> AutomationResult:
     retry_at = ""
     if result.status in {"held", "delivery_failed", "deferred"}:
         retry_at = _utc_iso(datetime.now(timezone.utc) + timedelta(minutes=RETRY_MINUTES))
     with sqlite3.connect(db_path) as conn:
-        with conn:
-            conn.execute("""UPDATE bnl_journal_automation_runs SET lifecycle_state=?,reason=?,journal_entry_id=?,
-                journal_revision=?,aggregate_counts_json=?,lease_expires_at=NULL,updated_at=? WHERE run_id=?""", (
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            "SELECT guild_id FROM bnl_journal_automation_runs WHERE run_id=? AND preparation_epoch=? AND lifecycle_state='preparing'",
+            (run_id, int(preparation_epoch)),
+        ).fetchone()
+        if not row:
+            conn.rollback()
+            return AutomationResult(
+                False,
+                result.cadence,
+                "busy",
+                "preparation_epoch_superseded",
+                source_window_start=result.source_window_start,
+                source_window_end=result.source_window_end,
+                aggregate_counts=result.aggregate_counts,
+            )
+        updated = conn.execute("""UPDATE bnl_journal_automation_runs SET lifecycle_state=?,reason=?,journal_entry_id=?,
+                journal_revision=?,aggregate_counts_json=?,lease_expires_at=NULL,updated_at=?
+                WHERE run_id=? AND preparation_epoch=? AND lifecycle_state='preparing'""", (
                 result.status, result.reason, result.entry_id or None, int(result.revision or 0),
-                _json(result.aggregate_counts or {}), utc_now_iso(), run_id,
-            ))
-            _update_state(conn, int(conn.execute("SELECT guild_id FROM bnl_journal_automation_runs WHERE run_id=?", (run_id,)).fetchone()[0]), result, next_retry_at=retry_at)
+                _json(result.aggregate_counts or {}), utc_now_iso(), run_id, int(preparation_epoch),
+            )).rowcount
+        if updated != 1:
+            conn.rollback()
+            return AutomationResult(False, result.cadence, "busy", "preparation_epoch_superseded")
+        _reconcile_daily_observation(conn, int(row[0]), result)
+        _update_state(conn, int(row[0]), result, next_retry_at=retry_at)
+        conn.commit()
     return result
 
 
@@ -268,8 +449,14 @@ def _result_from_existing(cadence: str, row: dict[str, Any], *, claim: str = "co
     elif claim == "backoff":
         status = "backoff"
         reason = "retry_after_" + str(row.get("retry_at") or "later")
+    elif claim == "prepared":
+        status = "prepared"
+        reason = "prepared_waiting_release"
+    elif claim == "controls_unconfirmed":
+        status = "prepared"
+        reason = "journal_memory_exclusions_unconfirmed"
     return AutomationResult(
-        status == "published",
+        status in {"published", "prepared"},
         cadence,
         status,
         reason,
@@ -281,11 +468,569 @@ def _result_from_existing(cadence: str, row: dict[str, Any], *, claim: str = "co
     )
 
 
+def _fresh_event_sequences(refs: set[str]) -> set[int]:
+    return {
+        int(match.group(1))
+        for ref in refs
+        for match in [re.fullmatch(r"fresh:(\d+)", ref)]
+        if match
+    }
+
+
+def _fresh_sequences_are_eligible(
+    conn: sqlite3.Connection,
+    guild_id: int,
+    sequences: set[int],
+) -> bool:
+    if not sequences:
+        return True
+    if not conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='bnl_journal_source_events'"
+    ).fetchone():
+        return False
+    placeholders = ",".join("?" for _ in sequences)
+    eligible = {
+        int(row[0])
+        for row in conn.execute(
+            f"SELECT event_seq FROM bnl_journal_source_events "
+            f"WHERE guild_id=? AND public_usable=1 AND event_seq IN ({placeholders})",
+            (guild_id, *sorted(sequences)),
+        ).fetchall()
+    }
+    return eligible == sequences
+
+
+def _frozen_packet_invalidation_reason(
+    conn: sqlite3.Connection,
+    guild_id: int,
+    packet: dict[str, Any],
+) -> str:
+    refs = {
+        str(source.get("refId") or "")
+        for source in packet.get("privateSources", [])
+        if isinstance(source, dict) and source.get("refId")
+    }
+    if not _fresh_sequences_are_eligible(conn, guild_id, _fresh_event_sequences(refs)):
+        return "privacy_source_ineligible"
+    provenance = packet.get("privateContextLaneProvenance")
+    provenance = provenance if isinstance(provenance, dict) else {}
+    memory_rows = provenance.get("establishedBroadcastMemory")
+    memory_rows = memory_rows if isinstance(memory_rows, list) else []
+    if not journal_broadcast_memory_provenance_is_eligible(
+        conn,
+        guild_id,
+        memory_rows,
+        str(packet.get("sourceWindowEnd") or ""),
+    ):
+        return "privacy_memory_ineligible"
+    return ""
+
+
+def _freeze_or_load_packet(
+    db_path: str,
+    guild_id: int,
+    run_id: str,
+    preparation_epoch: int,
+    builder: Callable[[], Optional[dict[str, Any]]],
+) -> tuple[Optional[dict[str, Any]], str, str]:
+    """Persist one complete deterministic source packet before any model call."""
+    ensure_schema(db_path)
+
+    def owner_reason(current: Optional[sqlite3.Row | tuple[Any, ...]]) -> str:
+        if (
+            not current
+            or str(current[0]) != "preparing"
+            or int(current[1] or 0) != int(preparation_epoch)
+        ):
+            return "preparation_epoch_superseded"
+        lease_raw = str(current[2] or "")
+        try:
+            live = bool(lease_raw) and _parse_utc(lease_raw) > datetime.now(timezone.utc)
+        except ValueError:
+            live = False
+        return "" if live else "preparation_epoch_expired"
+
+    def stored_packet_result(
+        conn: sqlite3.Connection,
+        current: sqlite3.Row | tuple[Any, ...],
+    ) -> Optional[tuple[Optional[dict[str, Any]], str, str]]:
+        if not current[3]:
+            return None
+        stored_raw = str(current[3])
+        stored_hash = hashlib.sha256(stored_raw.encode("utf-8")).hexdigest()
+        if stored_hash != str(current[4] or ""):
+            return None, "", "frozen_packet_hash_mismatch"
+        try:
+            parsed = json.loads(stored_raw)
+        except (TypeError, json.JSONDecodeError):
+            return None, "", "frozen_packet_invalid"
+        if not isinstance(parsed, dict):
+            return None, "", "frozen_packet_invalid"
+        stored = dict(parsed)
+        if not stored.get("sourceArchiveAvailable", False) or not stored.get("coverageComplete", True):
+            invalidation = "source_packet_ineligible"
+        else:
+            invalidation = _frozen_packet_invalidation_reason(conn, guild_id, stored)
+        if invalidation:
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs SET frozen_packet_json=NULL,frozen_packet_hash=NULL,"
+                "packet_frozen_at=NULL,updated_at=? WHERE run_id=? AND preparation_epoch=? "
+                "AND lifecycle_state='preparing'",
+                (utc_now_iso(), run_id, int(preparation_epoch)),
+            )
+            return None, "", invalidation
+        return stored, stored_hash, ""
+
+    # Fast recovery still takes the write lock: a privacy deletion and a
+    # preparation owner can never pass one another between validation/return.
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        current = conn.execute(
+            "SELECT lifecycle_state,preparation_epoch,lease_expires_at,frozen_packet_json,frozen_packet_hash "
+            "FROM bnl_journal_automation_runs WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        reason = owner_reason(current)
+        if reason:
+            conn.rollback()
+            return None, "", reason
+        stored_result = stored_packet_result(conn, current)
+        if stored_result is not None:
+            conn.commit()
+            return stored_result
+        conn.commit()
+
+    # Packet construction may read several durable owners and therefore cannot
+    # run under this table's write transaction. Recheck everything after it.
+    packet = builder()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        current = conn.execute(
+            "SELECT lifecycle_state,preparation_epoch,lease_expires_at,frozen_packet_json,frozen_packet_hash "
+            "FROM bnl_journal_automation_runs WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        reason = owner_reason(current)
+        if reason:
+            conn.rollback()
+            return None, "", reason
+        stored_result = stored_packet_result(conn, current)
+        if stored_result is not None:
+            conn.commit()
+            return stored_result
+        if not isinstance(packet, dict):
+            conn.commit()
+            return None, "", "source_packet_not_ready"
+        # Archive-unavailable and pre-activation packets are not eligible source
+        # packets. Keep the occurrence owed without binding retries to them.
+        if not packet.get("sourceArchiveAvailable", False) or not packet.get("coverageComplete", True):
+            conn.commit()
+            return packet, "", "source_packet_ineligible"
+        invalidation = _frozen_packet_invalidation_reason(conn, guild_id, packet)
+        if invalidation:
+            conn.commit()
+            return None, "", invalidation
+        raw = _json(packet)
+        packet_hash = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+        updated = conn.execute(
+            "UPDATE bnl_journal_automation_runs SET frozen_packet_json=?,frozen_packet_hash=?,packet_frozen_at=?,updated_at=? "
+            "WHERE run_id=? AND preparation_epoch=? AND lifecycle_state='preparing'",
+            (raw, packet_hash, utc_now_iso(), utc_now_iso(), run_id, int(preparation_epoch)),
+        ).rowcount
+        if updated != 1:
+            conn.rollback()
+            return None, "", "preparation_epoch_superseded"
+        conn.commit()
+    return packet, packet_hash, ""
+
+
+def _latest_entry_row(db_path: str, guild_id: int, entry_id: str) -> Optional[dict[str, Any]]:
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT e.revision,e.lifecycle_state,e.content_hash,e.canonical_payload_bytes,m.metadata_json "
+            "FROM bnl_journal_entries e LEFT JOIN bnl_journal_private_metadata m "
+            "ON m.entry_id=e.entry_id AND m.revision=e.revision AND m.guild_id=e.guild_id "
+            "WHERE e.guild_id=? AND e.entry_id=? ORDER BY e.revision DESC LIMIT 1",
+            (guild_id, entry_id),
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def _adopt_legacy_staged_revision(
+    db_path: str,
+    guild_id: int,
+    run_id: str,
+    preparation_epoch: int,
+    cadence: str,
+    entry_id: str,
+    start: str,
+    end: str,
+    memory_excluded_entry_ids: Optional[set[str]],
+) -> Optional[AutomationResult]:
+    """Bind a pre-migration approved revision without regenerating its bytes.
+
+    A delivery-failed response may have been lost after the website committed.
+    Replacing that revision would risk a duplicate article, so one explicit
+    migration manifest binds its already-persisted request bytes to the new
+    occurrence lifecycle. Legacy drafts were never approved and are handled by
+    the normal frozen-packet regeneration path instead.
+    """
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        conn.execute("BEGIN IMMEDIATE")
+        run = conn.execute(
+            "SELECT lifecycle_state,preparation_epoch,lease_expires_at "
+            "FROM bnl_journal_automation_runs WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        if (
+            not run
+            or str(run["lifecycle_state"]) != "preparing"
+            or int(run["preparation_epoch"] or 0) != int(preparation_epoch)
+        ):
+            conn.rollback()
+            return AutomationResult(
+                False,
+                cadence,
+                "busy",
+                "preparation_epoch_superseded",
+                source_window_start=start,
+                source_window_end=end,
+            )
+        lease_raw = str(run["lease_expires_at"] or "")
+        if not lease_raw or _parse_utc(lease_raw) <= datetime.now(timezone.utc):
+            conn.rollback()
+            return AutomationResult(
+                False,
+                cadence,
+                "busy",
+                "preparation_epoch_expired",
+                source_window_start=start,
+                source_window_end=end,
+            )
+        row = conn.execute(
+            "SELECT e.revision,e.lifecycle_state,e.canonical_payload_bytes,e.content_hash,"
+            "e.source_window_start,e.source_window_end,m.metadata_json "
+            "FROM bnl_journal_entries e JOIN bnl_journal_private_metadata m "
+            "ON m.entry_id=e.entry_id AND m.revision=e.revision AND m.guild_id=e.guild_id "
+            "WHERE e.guild_id=? AND e.entry_id=? ORDER BY e.revision DESC LIMIT 1",
+            (guild_id, entry_id),
+        ).fetchone()
+        if not row or str(row["lifecycle_state"]) not in {
+            "approved_pending_delivery",
+            "delivery_failed",
+        }:
+            conn.rollback()
+            return None
+        try:
+            metadata = json.loads(str(row["metadata_json"] or "{}"))
+        except (TypeError, json.JSONDecodeError):
+            metadata = {}
+        if not isinstance(metadata, dict):
+            metadata = {}
+        # A source-bound revision belongs to the normal recovery path. Only
+        # unbound revisions created before this migration are adopted here.
+        if str(metadata.get("frozenSourceHash") or ""):
+            conn.rollback()
+            return None
+
+        revision = int(row["revision"] or 0)
+        canonical = bytes(row["canonical_payload_bytes"] or b"")
+        request_hash = canonical_payload_hash(canonical) if canonical else ""
+        failure = ""
+        if str(row["source_window_start"] or "") != start or str(row["source_window_end"] or "") != end:
+            failure = "legacy_source_window_mismatch"
+        elif not canonical:
+            failure = "canonical_payload_missing"
+        elif len(canonical) > JOURNAL_SITE_REQUEST_BODY_MAX_BYTES:
+            failure = "request_body_too_large"
+        elif metadata.get("canonicalPayloadHash") and str(metadata.get("canonicalPayloadHash")) != request_hash:
+            failure = "canonical_payload_hash_mismatch"
+        elif not bool(metadata.get("coverageComplete", True)):
+            failure = "incomplete_source_window"
+        else:
+            failure = _prepared_invalidation_reason(
+                conn,
+                guild_id,
+                metadata,
+                {str(value) for value in (memory_excluded_entry_ids or set()) if str(value)},
+            )
+
+        aggregate = metadata.get("aggregateCounts") if isinstance(metadata.get("aggregateCounts"), dict) else {}
+        if failure:
+            now = utc_now_iso()
+            conn.execute(
+                "UPDATE bnl_journal_entries SET lifecycle_state='rejected',review_reason=?,updated_at=? "
+                "WHERE guild_id=? AND entry_id=? AND revision=? "
+                "AND lifecycle_state IN ('approved_pending_delivery','delivery_failed')",
+                (failure, now, guild_id, entry_id, revision),
+            )
+            conn.execute(
+                "UPDATE bnl_journal_private_metadata SET lifecycle_state='rejected',updated_at=? "
+                "WHERE guild_id=? AND entry_id=? AND revision=?",
+                (now, guild_id, entry_id, revision),
+            )
+            result = AutomationResult(
+                False,
+                cadence,
+                "held",
+                failure,
+                entry_id,
+                revision,
+                start,
+                end,
+                aggregate,
+            )
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs SET lifecycle_state='held',reason=?,"
+                "journal_entry_id=NULL,journal_revision=0,lease_expires_at=NULL,"
+                "prepared_payload_hash=NULL,prepared_payload_bytes=0,prepared_at=NULL,updated_at=? "
+                "WHERE run_id=? AND preparation_epoch=? AND lifecycle_state='preparing'",
+                (failure, now, run_id, int(preparation_epoch)),
+            )
+            _reconcile_daily_observation(conn, guild_id, result)
+            _update_state(conn, guild_id, result)
+            conn.commit()
+            return result
+
+        source_refs = sorted(_flatten_source_refs(metadata))
+        used_provenance = metadata.get("usedContextLaneProvenance")
+        used_provenance = used_provenance if isinstance(used_provenance, dict) else {}
+        manifest = {
+            "contractVersion": 1,
+            "entryKind": cadence,
+            "sourceWindowStart": start,
+            "sourceWindowEnd": end,
+            "sourceArchiveAvailable": True,
+            "coverageComplete": True,
+            "privateSources": [{"refId": ref_id} for ref_id in source_refs],
+            "privateContextLaneProvenance": used_provenance,
+            "aggregateCounts": aggregate,
+            "legacyStagedRevision": {
+                "entryId": entry_id,
+                "revision": revision,
+                "contentHash": str(row["content_hash"] or ""),
+                "canonicalPayloadHash": request_hash,
+                "sourceRefIds": metadata.get("sourceRefIds") or {},
+                "sourceSummaries": metadata.get("sourceSummaries") or [],
+                "relatedPriorJournalEntryIds": metadata.get("relatedPriorJournalEntryIds") or [],
+            },
+        }
+        manifest_raw = _json(manifest)
+        source_hash = hashlib.sha256(manifest_raw.encode("utf-8")).hexdigest()
+        metadata.update(
+            {
+                "automationRunId": run_id,
+                "automationPreparationEpoch": int(preparation_epoch),
+                "frozenSourceHash": source_hash,
+                "canonicalPayloadHash": request_hash,
+                "canonicalPayloadBytes": len(canonical),
+                "legacyPreparedRevisionAdopted": True,
+            }
+        )
+        now = utc_now_iso()
+        conn.execute(
+            "UPDATE bnl_journal_private_metadata SET metadata_json=?,updated_at=? "
+            "WHERE guild_id=? AND entry_id=? AND revision=?",
+            (_json(metadata), now, guild_id, entry_id, revision),
+        )
+        result = AutomationResult(
+            True,
+            cadence,
+            "prepared",
+            "legacy_prepared_revision_adopted",
+            entry_id,
+            revision,
+            start,
+            end,
+            aggregate,
+        )
+        updated = conn.execute(
+            "UPDATE bnl_journal_automation_runs SET lifecycle_state='prepared',reason=?,"
+            "journal_entry_id=?,journal_revision=?,aggregate_counts_json=?,"
+            "frozen_packet_json=?,frozen_packet_hash=?,packet_frozen_at=?,"
+            "prepared_payload_hash=?,prepared_payload_bytes=?,prepared_at=?,"
+            "lease_expires_at=NULL,delivery_lease_expires_at=NULL,updated_at=? "
+            "WHERE run_id=? AND preparation_epoch=? AND lifecycle_state='preparing'",
+            (
+                result.reason,
+                entry_id,
+                revision,
+                _json(aggregate),
+                manifest_raw,
+                source_hash,
+                now,
+                request_hash,
+                len(canonical),
+                now,
+                now,
+                run_id,
+                int(preparation_epoch),
+            ),
+        ).rowcount
+        if updated != 1:
+            conn.rollback()
+            return AutomationResult(False, cadence, "busy", "preparation_epoch_superseded")
+        _reconcile_daily_observation(conn, guild_id, result)
+        _update_state(conn, guild_id, result)
+        conn.commit()
+    logging.info(
+        "journal_prepared run=%s cadence=%s entry=%s revision=%s source_hash=%s payload_hash=%s "
+        "payload_bytes=%s migration=legacy model_calls=0",
+        run_id,
+        cadence,
+        entry_id,
+        revision,
+        source_hash,
+        request_hash,
+        len(canonical),
+    )
+    return result
+
+
+def _mark_prepared(
+    db_path: str,
+    guild_id: int,
+    run_id: str,
+    preparation_epoch: int,
+    cadence: str,
+    entry_id: str,
+    revision: int,
+    source_hash: str,
+    packet: dict[str, Any],
+) -> AutomationResult:
+    def hold_invalid_revision(reason: str) -> AutomationResult:
+        _reject_staged_revision_for_retry(
+            db_path,
+            guild_id,
+            run_id,
+            preparation_epoch,
+            entry_id,
+            revision,
+            reason,
+        )
+        return _finish_preparation(
+            db_path,
+            run_id,
+            preparation_epoch,
+            AutomationResult(
+                False,
+                cadence,
+                "held",
+                reason,
+                entry_id,
+                revision,
+                str(packet.get("sourceWindowStart") or ""),
+                str(packet.get("sourceWindowEnd") or ""),
+                packet.get("aggregateCounts") or {},
+            ),
+        )
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        conn.execute("BEGIN IMMEDIATE")
+        run = conn.execute(
+            "SELECT lifecycle_state,preparation_epoch,lease_expires_at FROM bnl_journal_automation_runs WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        if not run or str(run[0]) != "preparing" or int(run[1] or 0) != int(preparation_epoch):
+            conn.rollback()
+            return AutomationResult(False, cadence, "busy", "preparation_epoch_superseded")
+        lease_raw = str(run[2] or "")
+        if not lease_raw or _parse_utc(lease_raw) <= datetime.now(timezone.utc):
+            conn.rollback()
+            return AutomationResult(False, cadence, "busy", "preparation_epoch_expired")
+        entry = conn.execute(
+            "SELECT e.lifecycle_state,e.canonical_payload_bytes,e.content_hash,m.metadata_json "
+            "FROM bnl_journal_entries e JOIN bnl_journal_private_metadata m "
+            "ON m.entry_id=e.entry_id AND m.revision=e.revision AND m.guild_id=e.guild_id "
+            "WHERE e.guild_id=? AND e.entry_id=? AND e.revision=?",
+            (guild_id, entry_id, int(revision)),
+        ).fetchone()
+        if not entry or str(entry[0]) not in {"approved_pending_delivery", "delivery_failed"}:
+            conn.rollback()
+            return hold_invalid_revision("prepared_revision_missing")
+        canonical = bytes(entry[1] or b"")
+        if not canonical:
+            conn.rollback()
+            return hold_invalid_revision("canonical_payload_missing")
+        if len(canonical) > JOURNAL_SITE_REQUEST_BODY_MAX_BYTES:
+            conn.rollback()
+            return hold_invalid_revision("request_body_too_large")
+        request_hash = canonical_payload_hash(canonical)
+        try:
+            metadata = json.loads(str(entry[3] or "{}"))
+        except (TypeError, json.JSONDecodeError):
+            metadata = {}
+        stored_source_hash = str(metadata.get("frozenSourceHash") or "") if isinstance(metadata, dict) else ""
+        if stored_source_hash != source_hash:
+            conn.rollback()
+            return hold_invalid_revision("source_packet_hash_mismatch")
+        now = utc_now_iso()
+        result = AutomationResult(
+            True,
+            cadence,
+            "prepared",
+            "prepared_waiting_release",
+            entry_id,
+            int(revision),
+            str(packet.get("sourceWindowStart") or ""),
+            str(packet.get("sourceWindowEnd") or ""),
+            packet.get("aggregateCounts") or {},
+        )
+        updated = conn.execute(
+            "UPDATE bnl_journal_automation_runs SET lifecycle_state='prepared',reason=?,journal_entry_id=?,"
+            "journal_revision=?,aggregate_counts_json=?,prepared_payload_hash=?,prepared_payload_bytes=?,prepared_at=?,"
+            "lease_expires_at=NULL,delivery_lease_expires_at=NULL,updated_at=? "
+            "WHERE run_id=? AND preparation_epoch=? AND lifecycle_state='preparing'",
+            (
+                result.reason,
+                entry_id,
+                int(revision),
+                _json(result.aggregate_counts or {}),
+                request_hash,
+                len(canonical),
+                now,
+                now,
+                run_id,
+                int(preparation_epoch),
+            ),
+        ).rowcount
+        if updated != 1:
+            conn.rollback()
+            return AutomationResult(False, cadence, "busy", "preparation_epoch_superseded")
+        _reconcile_daily_observation(conn, guild_id, result)
+        _update_state(conn, guild_id, result)
+        conn.commit()
+    logging.info(
+        "journal_prepared run=%s cadence=%s entry=%s revision=%s source_hash=%s payload_hash=%s "
+        "payload_bytes=%s",
+        run_id,
+        cadence,
+        entry_id,
+        revision,
+        source_hash,
+        request_hash,
+        len(canonical),
+    )
+    return result
+
+
 def _topic_counts(sources: list[dict[str, Any]], limit: int = 30) -> dict[str, int]:
     return journal_topic_counts(sources, limit=limit)
 
 
-def _store_observation(db_path: str, guild_id: int, label: str, packet: dict[str, Any], state: str = "observed") -> str:
+def _store_observation(
+    db_path: str,
+    guild_id: int,
+    label: str,
+    packet: dict[str, Any],
+    state: str = "observed",
+    *,
+    run_id: str = "",
+    preparation_epoch: Optional[int] = None,
+) -> tuple[str, str]:
     observation_id = "jobs_" + hashlib.sha256(f"{guild_id}|{label}".encode("utf-8")).hexdigest()[:20]
     subject_counts: dict[str, int] = {}
     for source in packet.get("privateSources", []):
@@ -300,6 +1045,65 @@ def _store_observation(db_path: str, guild_id: int, label: str, packet: dict[str
     ]
     now = utc_now_iso()
     with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        if run_id or preparation_epoch is not None:
+            if not run_id or preparation_epoch is None:
+                conn.rollback()
+                return "", "preparation_epoch_superseded"
+            run = conn.execute(
+                "SELECT lifecycle_state,preparation_epoch,lease_expires_at,frozen_packet_json,frozen_packet_hash "
+                "FROM bnl_journal_automation_runs WHERE run_id=?",
+                (run_id,),
+            ).fetchone()
+            if (
+                not run
+                or str(run[0]) != "preparing"
+                or int(run[1] or 0) != int(preparation_epoch)
+            ):
+                conn.rollback()
+                return "", "preparation_epoch_superseded"
+            lease_raw = str(run[2] or "")
+            try:
+                live = bool(lease_raw) and _parse_utc(lease_raw) > datetime.now(timezone.utc)
+            except ValueError:
+                live = False
+            if not live:
+                conn.rollback()
+                return "", "preparation_epoch_expired"
+            stored_raw = str(run[3] or "")
+            stored_hash = str(run[4] or "")
+            packet_raw = _json(packet)
+            if (
+                not stored_raw
+                or hashlib.sha256(stored_raw.encode("utf-8")).hexdigest() != stored_hash
+                or hashlib.sha256(packet_raw.encode("utf-8")).hexdigest() != stored_hash
+            ):
+                conn.rollback()
+                return "", "frozen_packet_hash_mismatch"
+            try:
+                stored_packet = json.loads(stored_raw)
+            except (TypeError, json.JSONDecodeError):
+                conn.rollback()
+                return "", "frozen_packet_invalid"
+            if not isinstance(stored_packet, dict):
+                conn.rollback()
+                return "", "frozen_packet_invalid"
+            if (
+                not stored_packet.get("sourceArchiveAvailable", False)
+                or not stored_packet.get("coverageComplete", True)
+            ):
+                invalidation = "source_packet_ineligible"
+            else:
+                invalidation = _frozen_packet_invalidation_reason(conn, guild_id, stored_packet)
+            if invalidation:
+                conn.execute(
+                    "UPDATE bnl_journal_automation_runs SET frozen_packet_json=NULL,frozen_packet_hash=NULL,"
+                    "packet_frozen_at=NULL,updated_at=? WHERE run_id=? AND preparation_epoch=? "
+                    "AND lifecycle_state='preparing'",
+                    (utc_now_iso(), run_id, int(preparation_epoch)),
+                )
+                conn.commit()
+                return "", invalidation
         conn.execute("""INSERT INTO bnl_journal_observations(
             observation_id,guild_id,observation_date,source_window_start,source_window_end,
             aggregate_counts_json,topic_counts_json,subject_counts_json,representative_sources_json,
@@ -314,7 +1118,8 @@ def _store_observation(db_path: str, guild_id: int, label: str, packet: dict[str
             _json(packet.get("aggregateCounts") or {}), _json(_topic_counts(packet.get("privateSources", []))),
             _json(subject_counts), _json(representative), state, now, now,
         ))
-    return observation_id
+        conn.commit()
+    return observation_id, ""
 
 
 def _mark_observation(db_path: str, guild_id: int, label: str, result: AutomationResult) -> None:
@@ -336,43 +1141,1055 @@ def _has_meaningful_daily_activity(packet: dict[str, Any]) -> bool:
     return any(str(source.get("eventType") or "").lower() not in quiet_markers for source in packet.get("privateSources", []))
 
 
-def _publish_packet(
+def _reject_staged_revision_for_retry(
+    db_path: str,
+    guild_id: int,
+    run_id: str,
+    preparation_epoch: int,
+    entry_id: str,
+    revision: int,
+    reason: str,
+) -> bool:
+    """Reject only while the same live preparation epoch owns the revision."""
+    now = utc_now_iso()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        run = conn.execute(
+            "SELECT lifecycle_state,preparation_epoch,lease_expires_at "
+            "FROM bnl_journal_automation_runs WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        if (
+            not run
+            or str(run[0]) != "preparing"
+            or int(run[1] or 0) != int(preparation_epoch)
+            or not str(run[2] or "")
+            or _parse_utc(str(run[2])) <= datetime.now(timezone.utc)
+        ):
+            conn.rollback()
+            return False
+        entry_changed = conn.execute(
+            "UPDATE bnl_journal_entries SET lifecycle_state='rejected',review_reason=?,updated_at=? "
+            "WHERE guild_id=? AND entry_id=? AND revision=? "
+            "AND lifecycle_state IN ('draft','approved_pending_delivery','delivery_failed')",
+            (reason, now, guild_id, entry_id, int(revision)),
+        ).rowcount
+        metadata_changed = conn.execute(
+            "UPDATE bnl_journal_private_metadata SET lifecycle_state='rejected',updated_at=? "
+            "WHERE guild_id=? AND entry_id=? AND revision=? "
+            "AND lifecycle_state IN ('draft','approved_pending_delivery','delivery_failed')",
+            (now, guild_id, entry_id, int(revision)),
+        ).rowcount
+        if entry_changed != 1 or metadata_changed != 1:
+            conn.rollback()
+            return False
+        conn.commit()
+    return True
+
+
+def _prepare_packet(
     db_path: str,
     guild_id: int,
     cadence: str,
     label: str,
+    run_id: str,
+    preparation_epoch: int,
     packet: dict[str, Any],
+    source_hash: str,
     generator: Callable[[dict[str, Any], str], str],
+) -> AutomationResult:
+    entry_id = _entry_id(guild_id, cadence, label)
+    existing = _latest_entry_row(db_path, guild_id, entry_id)
+    if existing and existing["lifecycle_state"] == "published":
+        return _finish_preparation(
+            db_path,
+            run_id,
+            preparation_epoch,
+            AutomationResult(True, cadence, "published", "already_published", entry_id, int(existing["revision"]), packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts")),
+        )
+    existing_source_hash = ""
+    if existing and existing["lifecycle_state"] in {"draft", "approved_pending_delivery", "delivery_failed"}:
+        try:
+            existing_metadata = json.loads(str(existing.get("metadata_json") or "{}"))
+        except (TypeError, json.JSONDecodeError):
+            existing_metadata = {}
+        existing_source_hash = (
+            str(existing_metadata.get("frozenSourceHash") or "")
+            if isinstance(existing_metadata, dict)
+            else ""
+        )
+        if not existing_source_hash or existing_source_hash != source_hash:
+            reason = "source_packet_unbound" if not existing_source_hash else "source_packet_hash_mismatch"
+            if not _reject_staged_revision_for_retry(
+                db_path,
+                guild_id,
+                run_id,
+                preparation_epoch,
+                entry_id,
+                int(existing["revision"]),
+                reason,
+            ):
+                return AutomationResult(False, cadence, "busy", "preparation_epoch_superseded")
+            existing = {**existing, "lifecycle_state": "rejected"}
+
+    if existing and existing["lifecycle_state"] in {"approved_pending_delivery", "delivery_failed"}:
+        return _mark_prepared(
+            db_path,
+            guild_id,
+            run_id,
+            preparation_epoch,
+            cadence,
+            entry_id,
+            int(existing["revision"]),
+            source_hash,
+            packet,
+        )
+    if existing and existing["lifecycle_state"] == "draft":
+        approved = approve_draft(
+            db_path,
+            guild_id,
+            entry_id,
+            str(existing["content_hash"]),
+            revision=int(existing["revision"]),
+            attempt_fence=(run_id, preparation_epoch),
+            source_hash=source_hash,
+        )
+        if not approved.ok:
+            if approved.reason == "preparation_epoch_lost":
+                return AutomationResult(False, cadence, "busy", "preparation_epoch_superseded")
+            if not _reject_staged_revision_for_retry(
+                db_path,
+                guild_id,
+                run_id,
+                preparation_epoch,
+                entry_id,
+                int(existing["revision"]),
+                approved.reason,
+            ):
+                return AutomationResult(False, cadence, "busy", "preparation_epoch_superseded")
+            return _finish_preparation(
+                db_path,
+                run_id,
+                preparation_epoch,
+                AutomationResult(False, cadence, "held", approved.reason, entry_id, int(existing["revision"]), packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts")),
+            )
+        return _mark_prepared(
+            db_path,
+            guild_id,
+            run_id,
+            preparation_epoch,
+            cadence,
+            entry_id,
+            approved.revision,
+            source_hash,
+            packet,
+        )
+
+    revision = int(existing["revision"]) + 1 if existing else 1
+    generated = generate_and_store_packet_draft(
+        db_path,
+        guild_id,
+        packet,
+        generator,
+        entry_id=entry_id,
+        revision=revision,
+        attempt_fence=(run_id, preparation_epoch),
+        source_hash=source_hash,
+    )
+    if not generated.ok:
+        if generated.reason == "preparation_epoch_lost":
+            return AutomationResult(False, cadence, "busy", "preparation_epoch_superseded")
+        return _finish_preparation(
+            db_path,
+            run_id,
+            preparation_epoch,
+            AutomationResult(False, cadence, "held", generated.reason, entry_id, generated.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts")),
+        )
+    approved = approve_draft(
+        db_path,
+        guild_id,
+        entry_id,
+        generated.content_hash,
+        revision=generated.revision,
+        attempt_fence=(run_id, preparation_epoch),
+        source_hash=source_hash,
+    )
+    if not approved.ok:
+        if approved.reason == "preparation_epoch_lost":
+            return AutomationResult(False, cadence, "busy", "preparation_epoch_superseded")
+        if not _reject_staged_revision_for_retry(
+            db_path,
+            guild_id,
+            run_id,
+            preparation_epoch,
+            entry_id,
+            generated.revision,
+            approved.reason,
+        ):
+            return AutomationResult(False, cadence, "busy", "preparation_epoch_superseded")
+        return _finish_preparation(
+            db_path,
+            run_id,
+            preparation_epoch,
+            AutomationResult(False, cadence, "held", approved.reason, entry_id, generated.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts")),
+        )
+    return _mark_prepared(
+        db_path,
+        guild_id,
+        run_id,
+        preparation_epoch,
+        cadence,
+        entry_id,
+        approved.revision,
+        source_hash,
+        packet,
+    )
+
+
+def _prepare_packet_safely(
+    db_path: str,
+    guild_id: int,
+    cadence: str,
+    label: str,
+    run_id: str,
+    preparation_epoch: int,
+    packet: dict[str, Any],
+    source_hash: str,
+    generator: Callable[[dict[str, Any], str], str],
+) -> AutomationResult:
+    """Keep a storage failure nonterminal and visibly owed."""
+    try:
+        return _prepare_packet(
+            db_path,
+            guild_id,
+            cadence,
+            label,
+            run_id,
+            preparation_epoch,
+            packet,
+            source_hash,
+            generator,
+        )
+    except sqlite3.Error:
+        return _finish_preparation(
+            db_path,
+            run_id,
+            preparation_epoch,
+            AutomationResult(
+                False,
+                cadence,
+                "held",
+                "journal_preparation_storage_failed",
+                _entry_id(guild_id, cadence, label),
+                0,
+                str(packet.get("sourceWindowStart") or ""),
+                str(packet.get("sourceWindowEnd") or ""),
+                packet.get("aggregateCounts") or {},
+            ),
+        )
+
+
+def _flatten_source_refs(metadata: dict[str, Any]) -> set[str]:
+    refs: set[str] = set()
+    source_map = metadata.get("sourceRefIds")
+    if isinstance(source_map, dict):
+        for values in source_map.values():
+            if isinstance(values, list):
+                refs.update(str(value) for value in values if str(value))
+    return refs
+
+
+def _prepared_invalidation_reason(
+    conn: sqlite3.Connection,
+    guild_id: int,
+    metadata: dict[str, Any],
+    memory_excluded_entry_ids: set[str],
+) -> str:
+    related = {
+        str(value)
+        for value in metadata.get("relatedPriorJournalEntryIds", [])
+        if str(value)
+    }
+    if related & memory_excluded_entry_ids:
+        return "privacy_eligibility_changed"
+    fresh_sequences = {
+        int(match.group(1))
+        for ref in _flatten_source_refs(metadata)
+        for match in [re.fullmatch(r"fresh:(\d+)", ref)]
+        if match
+    }
+    if fresh_sequences:
+        if not conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='bnl_journal_source_events'"
+        ).fetchone():
+            return "source_archive_unavailable"
+        placeholders = ",".join("?" for _ in fresh_sequences)
+        eligible = {
+            int(row[0])
+            for row in conn.execute(
+                f"SELECT event_seq FROM bnl_journal_source_events WHERE guild_id=? AND public_usable=1 AND event_seq IN ({placeholders})",
+                (guild_id, *sorted(fresh_sequences)),
+            ).fetchall()
+        }
+        if eligible != fresh_sequences:
+            return "privacy_source_ineligible"
+    used_provenance = metadata.get("usedContextLaneProvenance")
+    used_provenance = used_provenance if isinstance(used_provenance, dict) else {}
+    memory_rows = used_provenance.get("establishedBroadcastMemory")
+    memory_rows = memory_rows if isinstance(memory_rows, list) else []
+    if not journal_broadcast_memory_provenance_is_eligible(
+        conn,
+        guild_id,
+        memory_rows,
+        utc_now_iso(),
+    ):
+        return "privacy_memory_ineligible"
+    return ""
+
+
+def _invalidate_prepared_in_transaction(
+    conn: sqlite3.Connection,
+    run_id: str,
+    guild_id: int,
+    entry_id: str,
+    revision: int,
+    reason: str,
+    *,
+    retire_packet: bool,
+) -> None:
+    now = utc_now_iso()
+    run = conn.execute(
+        "SELECT cadence,source_window_start,source_window_end,aggregate_counts_json "
+        "FROM bnl_journal_automation_runs WHERE run_id=?",
+        (run_id,),
+    ).fetchone()
+    conn.execute(
+        "UPDATE bnl_journal_entries SET lifecycle_state='rejected',review_reason=?,updated_at=? "
+        "WHERE guild_id=? AND entry_id=? AND revision=? AND lifecycle_state IN ('approved_pending_delivery','delivery_failed')",
+        (reason, now, guild_id, entry_id, int(revision)),
+    )
+    conn.execute(
+        "UPDATE bnl_journal_private_metadata SET lifecycle_state='rejected',updated_at=? "
+        "WHERE guild_id=? AND entry_id=? AND revision=? AND lifecycle_state IN ('approved_pending_delivery','delivery_failed')",
+        (now, guild_id, entry_id, int(revision)),
+    )
+    packet_reset = (
+        "frozen_packet_json=NULL,frozen_packet_hash=NULL,packet_frozen_at=NULL,"
+        if retire_packet
+        else ""
+    )
+    conn.execute(
+        "UPDATE bnl_journal_automation_runs SET lifecycle_state='held',reason=?,journal_entry_id=NULL,"
+        "journal_revision=0," + packet_reset +
+        "prepared_payload_hash=NULL,prepared_payload_bytes=0,prepared_at=NULL,lease_expires_at=NULL,"
+        "delivery_lease_expires_at=NULL,preparation_epoch=preparation_epoch+1,delivery_epoch=delivery_epoch+1,updated_at=? "
+        "WHERE run_id=?",
+        (reason, now, run_id),
+    )
+    if run:
+        try:
+            aggregate = json.loads(str(run[3] or "{}"))
+        except (TypeError, json.JSONDecodeError):
+            aggregate = {}
+        result = AutomationResult(
+            False,
+            str(run[0] or ""),
+            "held",
+            reason,
+            "",
+            0,
+            str(run[1] or ""),
+            str(run[2] or ""),
+            aggregate if isinstance(aggregate, dict) else {},
+        )
+        _reconcile_daily_observation(conn, guild_id, result)
+        _update_state(
+            conn,
+            guild_id,
+            result,
+            next_retry_at=_utc_iso(datetime.now(timezone.utc) + timedelta(minutes=RETRY_MINUTES)),
+        )
+
+
+def _claim_delivery(
+    db_path: str,
+    guild_id: int,
+    cadence: str,
+    start: str,
+    end: str,
+    *,
+    force: bool = False,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
+    memory_exclusions_confirmed: bool = True,
+) -> tuple[str, str, int, dict[str, Any]]:
+    ensure_schema(db_path)
+    run_id = _run_id(guild_id, cadence, start, end)
+    now_dt = datetime.now(timezone.utc)
+    # A live delivery owner holds a SQLite write transaction across the POST so
+    # deletion and release have one serialization boundary. Read its lease
+    # before requesting our own write lock; concurrent triggers can then report
+    # ``busy`` immediately instead of waiting behind the network timeout.
+    try:
+        with sqlite3.connect(db_path) as read_conn:
+            read_conn.row_factory = sqlite3.Row
+            active = read_conn.execute(
+                "SELECT * FROM bnl_journal_automation_runs WHERE run_id=?",
+                (run_id,),
+            ).fetchone()
+        if active:
+            active_row = dict(active)
+            active_lease = str(active_row.get("delivery_lease_expires_at") or "")
+            if (
+                active_row.get("lifecycle_state") == "delivering"
+                and active_lease
+                and _parse_utc(active_lease) > now_dt
+            ):
+                return (
+                    "busy",
+                    run_id,
+                    int(active_row.get("delivery_epoch") or 0),
+                    active_row,
+                )
+    except (sqlite3.Error, ValueError):
+        pass
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        conn.execute("BEGIN IMMEDIATE")
+        run = conn.execute("SELECT * FROM bnl_journal_automation_runs WHERE run_id=?", (run_id,)).fetchone()
+        if not run:
+            conn.rollback()
+            return "not_prepared", run_id, 0, {}
+        current = dict(run)
+        if current["lifecycle_state"] == "published":
+            conn.commit()
+            return "complete", run_id, int(current.get("delivery_epoch") or 0), current
+        if current["lifecycle_state"] == "delivery_failed" and not force:
+            updated_at = str(current.get("updated_at") or "")
+            if updated_at and _parse_utc(updated_at) + timedelta(minutes=RETRY_MINUTES) > now_dt:
+                current["retry_at"] = _utc_iso(_parse_utc(updated_at) + timedelta(minutes=RETRY_MINUTES))
+                conn.commit()
+                return "backoff", run_id, int(current.get("delivery_epoch") or 0), current
+        delivery_lease = str(current.get("delivery_lease_expires_at") or "")
+        if current["lifecycle_state"] == "delivering" and delivery_lease and _parse_utc(delivery_lease) > now_dt:
+            conn.commit()
+            return "busy", run_id, int(current.get("delivery_epoch") or 0), current
+        if current["lifecycle_state"] not in {"prepared", "delivery_failed", "delivering"}:
+            conn.commit()
+            return "not_prepared", run_id, int(current.get("delivery_epoch") or 0), current
+        if not memory_exclusions_confirmed:
+            current["reason"] = "journal_memory_exclusions_unconfirmed"
+            conn.commit()
+            return (
+                "controls_unconfirmed",
+                run_id,
+                int(current.get("delivery_epoch") or 0),
+                current,
+            )
+        entry_id = str(current.get("journal_entry_id") or "")
+        revision = int(current.get("journal_revision") or 0)
+        entry = conn.execute(
+            "SELECT e.lifecycle_state,e.canonical_payload_bytes,m.metadata_json FROM bnl_journal_entries e "
+            "JOIN bnl_journal_private_metadata m ON m.entry_id=e.entry_id AND m.revision=e.revision AND m.guild_id=e.guild_id "
+            "WHERE e.guild_id=? AND e.entry_id=? AND e.revision=?",
+            (guild_id, entry_id, revision),
+        ).fetchone()
+        if entry and str(entry[0]) == "published":
+            recovered = AutomationResult(
+                True,
+                cadence,
+                "published",
+                "delivery_already_recorded",
+                entry_id,
+                revision,
+                start,
+                end,
+                json.loads(current.get("aggregate_counts_json") or "{}"),
+            )
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs SET lifecycle_state='published',reason=?,"
+                "delivery_lease_expires_at=NULL,lease_expires_at=NULL,updated_at=? WHERE run_id=?",
+                (recovered.reason, utc_now_iso(), run_id),
+            )
+            _reconcile_daily_observation(conn, guild_id, recovered)
+            _update_state(conn, guild_id, recovered)
+            conn.commit()
+            current.update({"lifecycle_state": "published", "reason": recovered.reason})
+            return "complete", run_id, int(current.get("delivery_epoch") or 0), current
+        if not entry or str(entry[0]) not in {"approved_pending_delivery", "delivery_failed"}:
+            _invalidate_prepared_in_transaction(
+                conn,
+                run_id,
+                guild_id,
+                entry_id,
+                revision,
+                "prepared_revision_missing",
+                retire_packet=False,
+            )
+            conn.commit()
+            current["lifecycle_state"] = "held"
+            current["reason"] = "prepared_revision_missing"
+            return "invalidated", run_id, int(current.get("delivery_epoch") or 0), current
+        canonical = bytes(entry[1] or b"")
+        expected_hash = str(current.get("prepared_payload_hash") or "")
+        if (
+            not canonical
+            or len(canonical) > JOURNAL_SITE_REQUEST_BODY_MAX_BYTES
+            or len(canonical) != int(current.get("prepared_payload_bytes") or 0)
+            or canonical_payload_hash(canonical) != expected_hash
+        ):
+            _invalidate_prepared_in_transaction(
+                conn,
+                run_id,
+                guild_id,
+                entry_id,
+                revision,
+                "prepared_payload_integrity_failed",
+                retire_packet=False,
+            )
+            conn.commit()
+            current["lifecycle_state"] = "held"
+            current["reason"] = "prepared_payload_integrity_failed"
+            return "invalidated", run_id, int(current.get("delivery_epoch") or 0), current
+        try:
+            metadata = json.loads(str(entry[2] or "{}"))
+        except (TypeError, json.JSONDecodeError):
+            metadata = {}
+        if (
+            not isinstance(metadata, dict)
+            or str(metadata.get("frozenSourceHash") or "")
+            != str(current.get("frozen_packet_hash") or "")
+        ):
+            _invalidate_prepared_in_transaction(
+                conn,
+                run_id,
+                guild_id,
+                entry_id,
+                revision,
+                "source_packet_hash_mismatch",
+                retire_packet=False,
+            )
+            conn.commit()
+            current["lifecycle_state"] = "held"
+            current["reason"] = "source_packet_hash_mismatch"
+            return "invalidated", run_id, int(current.get("delivery_epoch") or 0), current
+        invalidation = _prepared_invalidation_reason(
+            conn,
+            guild_id,
+            metadata if isinstance(metadata, dict) else {},
+            {str(value) for value in (memory_excluded_entry_ids or set()) if str(value)},
+        )
+        if invalidation:
+            _invalidate_prepared_in_transaction(
+                conn,
+                run_id,
+                guild_id,
+                entry_id,
+                revision,
+                invalidation,
+                retire_packet=True,
+            )
+            conn.commit()
+            current["lifecycle_state"] = "held"
+            current["reason"] = invalidation
+            return "invalidated", run_id, int(current.get("delivery_epoch") or 0), current
+        epoch = int(current.get("delivery_epoch") or 0) + 1
+        lease = _utc_iso(now_dt + timedelta(minutes=DELIVERY_LEASE_MINUTES))
+        updated = conn.execute(
+            "UPDATE bnl_journal_automation_runs SET lifecycle_state='delivering',reason='delivery_in_progress',"
+            "delivery_epoch=?,delivery_lease_expires_at=?,updated_at=? WHERE run_id=? AND delivery_epoch=?",
+            (epoch, lease, utc_now_iso(), run_id, int(current.get("delivery_epoch") or 0)),
+        ).rowcount
+        if updated != 1:
+            conn.rollback()
+            return "busy", run_id, int(current.get("delivery_epoch") or 0), current
+        conn.commit()
+        current.update({"journal_entry_id": entry_id, "journal_revision": revision})
+    return "claimed", run_id, epoch, current
+
+
+def _finish_delivery(
+    db_path: str,
+    run_id: str,
+    delivery_epoch: int,
+    result: AutomationResult,
+) -> AutomationResult:
+    retry_at = ""
+    if result.status in {"held", "delivery_failed", "deferred"}:
+        retry_at = _utc_iso(datetime.now(timezone.utc) + timedelta(minutes=RETRY_MINUTES))
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            "SELECT guild_id FROM bnl_journal_automation_runs WHERE run_id=? AND delivery_epoch=? AND lifecycle_state='delivering'",
+            (run_id, int(delivery_epoch)),
+        ).fetchone()
+        if not row:
+            conn.rollback()
+            return AutomationResult(False, result.cadence, "busy", "delivery_epoch_superseded")
+        updated = conn.execute(
+            "UPDATE bnl_journal_automation_runs SET lifecycle_state=?,reason=?,journal_entry_id=?,journal_revision=?,"
+            "aggregate_counts_json=?,delivery_lease_expires_at=NULL,updated_at=? "
+            "WHERE run_id=? AND delivery_epoch=? AND lifecycle_state='delivering'",
+            (
+                result.status,
+                result.reason,
+                result.entry_id or None,
+                int(result.revision or 0),
+                _json(result.aggregate_counts or {}),
+                utc_now_iso(),
+                run_id,
+                int(delivery_epoch),
+            ),
+        ).rowcount
+        if updated != 1:
+            conn.rollback()
+            return AutomationResult(False, result.cadence, "busy", "delivery_epoch_superseded")
+        _reconcile_daily_observation(conn, int(row[0]), result)
+        _update_state(conn, int(row[0]), result, next_retry_at=retry_at)
+        conn.commit()
+    return result
+
+
+def _finish_invalidated_delivery(
+    db_path: str,
+    run_id: str,
+    delivery_epoch: int,
+    result: AutomationResult,
+) -> AutomationResult:
+    """Invalidate a staged revision found ineligible at the final POST fence."""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            "SELECT guild_id,journal_entry_id,journal_revision "
+            "FROM bnl_journal_automation_runs "
+            "WHERE run_id=? AND delivery_epoch=? AND lifecycle_state='delivering'",
+            (run_id, int(delivery_epoch)),
+        ).fetchone()
+        if not row:
+            conn.rollback()
+            return AutomationResult(
+                False,
+                result.cadence,
+                "busy",
+                "delivery_epoch_superseded",
+                result.entry_id,
+                result.revision,
+                result.source_window_start,
+                result.source_window_end,
+                result.aggregate_counts,
+            )
+        _invalidate_prepared_in_transaction(
+            conn,
+            run_id,
+            int(row[0]),
+            str(row[1] or result.entry_id),
+            int(row[2] or result.revision),
+            result.reason,
+            retire_packet=result.reason.startswith("privacy_"),
+        )
+        conn.commit()
+    return result
+
+
+def release_occurrence(
+    db_path: str,
+    guild_id: int,
+    cadence: str,
+    start: str,
+    end: str,
     base_url: str,
     api_key: str,
     *,
+    force: bool = False,
     opener=None,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
+    memory_exclusions_confirmed: bool = True,
 ) -> AutomationResult:
-    entry_id = _entry_id(guild_id, cadence, label)
+    claim, run_id, delivery_epoch, row = _claim_delivery(
+        db_path,
+        guild_id,
+        cadence,
+        start,
+        end,
+        force=force,
+        memory_excluded_entry_ids=memory_excluded_entry_ids,
+        memory_exclusions_confirmed=memory_exclusions_confirmed,
+    )
+    if claim != "claimed":
+        if claim == "invalidated":
+            return AutomationResult(False, cadence, "held", str(row.get("reason") or "prepared_payload_invalidated"), source_window_start=start, source_window_end=end, aggregate_counts=json.loads(row.get("aggregate_counts_json") or "{}"))
+        if claim == "not_prepared":
+            return AutomationResult(False, cadence, "held", "prepared_payload_unavailable", source_window_start=start, source_window_end=end)
+        if claim == "controls_unconfirmed":
+            logging.info(
+                "journal_release_waiting run=%s cadence=%s entry=%s revision=%s "
+                "source_hash=%s payload_hash=%s reason=journal_memory_exclusions_unconfirmed "
+                "model_calls=0 post_attempts=0",
+                run_id,
+                cadence,
+                str(row.get("journal_entry_id") or ""),
+                int(row.get("journal_revision") or 0),
+                str(row.get("frozen_packet_hash") or ""),
+                str(row.get("prepared_payload_hash") or ""),
+            )
+        return _result_from_existing(cadence, row, claim=claim)
+    entry_id = str(row.get("journal_entry_id") or "")
+    revision = int(row.get("journal_revision") or 0)
+    counts = json.loads(row.get("aggregate_counts_json") or "{}")
+    payload_hash = str(row.get("prepared_payload_hash") or "")
+    payload_bytes = int(row.get("prepared_payload_bytes") or 0)
+    source_hash = str(row.get("frozen_packet_hash") or "")
+    logging.info(
+        "journal_release_started run=%s cadence=%s entry=%s revision=%s source_hash=%s "
+        "payload_hash=%s model_calls=0",
+        run_id,
+        cadence,
+        entry_id,
+        revision,
+        source_hash,
+        payload_hash,
+    )
     if not base_url or not api_key:
-        return AutomationResult(False, cadence, "held", "website_configuration_missing", entry_id, 0, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
+        delivered = JournalResult(False, "delivery_failed", "website_configuration_missing", entry_id, revision)
+    else:
+        excluded_entry_ids = {
+            str(value)
+            for value in (memory_excluded_entry_ids or set())
+            if str(value)
+        }
+
+        def final_delivery_preflight(conn: sqlite3.Connection) -> str:
+            private = conn.execute(
+                "SELECT m.metadata_json,e.canonical_payload_bytes "
+                "FROM bnl_journal_private_metadata m "
+                "JOIN bnl_journal_entries e "
+                "ON e.guild_id=m.guild_id AND e.entry_id=m.entry_id AND e.revision=m.revision "
+                "WHERE m.guild_id=? AND m.entry_id=? AND m.revision=? "
+                "AND m.lifecycle_state IN ('approved_pending_delivery','delivery_failed') "
+                "AND e.lifecycle_state IN ('approved_pending_delivery','delivery_failed')",
+                (guild_id, entry_id, revision),
+            ).fetchone()
+            if not private:
+                return "prepared_revision_missing"
+            canonical = bytes(private[1] or b"")
+            if (
+                not canonical
+                or len(canonical) > JOURNAL_SITE_REQUEST_BODY_MAX_BYTES
+                or len(canonical) != payload_bytes
+                or canonical_payload_hash(canonical) != payload_hash
+            ):
+                return "prepared_payload_integrity_failed"
+            try:
+                metadata = json.loads(str(private[0] or "{}"))
+            except (TypeError, json.JSONDecodeError):
+                return "prepared_revision_missing"
+            if (
+                not isinstance(metadata, dict)
+                or str(metadata.get("frozenSourceHash") or "") != source_hash
+            ):
+                return "source_packet_hash_mismatch"
+            return _prepared_invalidation_reason(
+                conn,
+                guild_id,
+                metadata,
+                excluded_entry_ids,
+            )
+
+        try:
+            delivered = deliver_approved(
+                db_path,
+                guild_id,
+                entry_id,
+                base_url,
+                api_key,
+                opener=opener,
+                revision=revision,
+                delivery_fence=(run_id, delivery_epoch),
+                delivery_preflight=final_delivery_preflight,
+            )
+        except sqlite3.Error:
+            delivered = JournalResult(
+                False,
+                "delivery_failed",
+                "journal_delivery_storage_failed",
+                entry_id,
+                revision,
+            )
+    if delivered.reason == "delivery_epoch_lost":
+        logging.info(
+            "journal_release_suppressed run=%s cadence=%s entry=%s revision=%s "
+            "payload_hash=%s reason=delivery_epoch_lost model_calls=0 post_attempts=0",
+            run_id,
+            cadence,
+            entry_id,
+            revision,
+            payload_hash,
+        )
+        return AutomationResult(
+            False,
+            cadence,
+            "busy",
+            "delivery_epoch_superseded",
+            entry_id,
+            revision,
+            start,
+            end,
+            counts,
+        )
+    status = delivered.status if delivered.status in {"published", "delivery_failed"} else "held"
+    result = AutomationResult(
+        delivered.ok,
+        cadence,
+        status,
+        delivered.reason,
+        entry_id,
+        delivered.revision or revision,
+        start,
+        end,
+        counts,
+        int(delivered.http_status or 0),
+        bool(delivered.idempotent),
+    )
+    if delivered.reason in DELIVERY_PREFLIGHT_INVALIDATION_REASONS:
+        finished = _finish_invalidated_delivery(
+            db_path,
+            run_id,
+            delivery_epoch,
+            result,
+        )
+    else:
+        finished = _finish_delivery(db_path, run_id, delivery_epoch, result)
+    logging.info(
+        "journal_release_finished run=%s cadence=%s entry=%s revision=%s source_hash=%s "
+        "payload_hash=%s status=%s http=%s idempotent=%s model_calls=0",
+        run_id,
+        cadence,
+        entry_id,
+        revision,
+        source_hash,
+        payload_hash,
+        finished.status,
+        int(finished.http_status or 0),
+        bool(finished.idempotent),
+    )
+    return finished
+
+
+def release_prepared_entry(
+    db_path: str,
+    guild_id: int,
+    entry_id: str,
+    base_url: str,
+    api_key: str,
+    *,
+    force: bool = False,
+    opener=None,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
+    memory_exclusions_confirmed: bool = True,
+) -> Optional[AutomationResult]:
+    """Release a scheduled entry through its occurrence-level network owner.
+
+    Manual, non-scheduled drafts have no automation occurrence and return
+    ``None`` so their existing explicit-review delivery path remains intact.
+    """
+    ensure_schema(db_path)
     with sqlite3.connect(db_path) as conn:
-        existing = conn.execute("""SELECT revision,lifecycle_state,content_hash FROM bnl_journal_entries
-            WHERE guild_id=? AND entry_id=? ORDER BY revision DESC LIMIT 1""", (guild_id, entry_id)).fetchone()
-    if existing and existing[1] in {"approved_pending_delivery", "delivery_failed"}:
-        delivered = deliver_approved(db_path, guild_id, entry_id, base_url, api_key, opener=opener)
-        return AutomationResult(delivered.ok, cadence, delivered.status, delivered.reason, entry_id, delivered.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
-    if existing and existing[1] == "published":
-        return AutomationResult(True, cadence, "published", "already_published", entry_id, int(existing[0]), packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
-    if existing and existing[1] == "draft":
-        approved = approve_draft(db_path, guild_id, entry_id, existing[2], revision=int(existing[0]))
-        if not approved.ok:
-            return AutomationResult(False, cadence, "held", approved.reason, entry_id, int(existing[0]), packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
-        delivered = deliver_approved(db_path, guild_id, entry_id, base_url, api_key, opener=opener, revision=int(existing[0]))
-        return AutomationResult(delivered.ok, cadence, delivered.status, delivered.reason, entry_id, delivered.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
-    generated = generate_and_store_packet_draft(db_path, guild_id, packet, generator, entry_id=entry_id)
-    if not generated.ok:
-        return AutomationResult(False, cadence, "held", generated.reason, entry_id, generated.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
-    approved = approve_draft(db_path, guild_id, entry_id, generated.content_hash, revision=generated.revision)
-    if not approved.ok:
-        return AutomationResult(False, cadence, "held", approved.reason, entry_id, generated.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
-    delivered = deliver_approved(db_path, guild_id, entry_id, base_url, api_key, opener=opener, revision=generated.revision)
-    return AutomationResult(delivered.ok, cadence, delivered.status, delivered.reason, entry_id, delivered.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts"))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT cadence,source_window_start,source_window_end "
+            "FROM bnl_journal_automation_runs "
+            "WHERE guild_id=? AND journal_entry_id=? "
+            "ORDER BY journal_revision DESC,updated_at DESC LIMIT 1",
+            (guild_id, str(entry_id)),
+        ).fetchone()
+        automation_run_id = ""
+        if not row:
+            metadata_rows = conn.execute(
+                "SELECT metadata_json FROM bnl_journal_private_metadata "
+                "WHERE guild_id=? AND entry_id=? ORDER BY revision DESC",
+                (guild_id, str(entry_id)),
+            ).fetchall()
+            for metadata_row in metadata_rows:
+                try:
+                    metadata = json.loads(str(metadata_row[0] or "{}"))
+                except (TypeError, json.JSONDecodeError):
+                    continue
+                if isinstance(metadata, dict) and metadata.get("automationRunId"):
+                    automation_run_id = str(metadata.get("automationRunId"))
+                    break
+            if automation_run_id:
+                row = conn.execute(
+                    "SELECT cadence,source_window_start,source_window_end "
+                    "FROM bnl_journal_automation_runs WHERE guild_id=? AND run_id=?",
+                    (guild_id, automation_run_id),
+                ).fetchone()
+    if not row:
+        if automation_run_id:
+            return AutomationResult(
+                False,
+                "scheduled",
+                "held",
+                "scheduled_occurrence_missing",
+                str(entry_id),
+            )
+        return None
+    return release_occurrence(
+        db_path,
+        guild_id,
+        str(row["cadence"]),
+        str(row["source_window_start"]),
+        str(row["source_window_end"]),
+        base_url,
+        api_key,
+        force=force,
+        opener=opener,
+        memory_excluded_entry_ids=memory_excluded_entry_ids,
+        memory_exclusions_confirmed=memory_exclusions_confirmed,
+    )
+
+
+def prepare_daily(
+    db_path: str,
+    guild_id: int,
+    generator: Callable[[dict[str, Any], str], str],
+    *,
+    now_utc: Optional[datetime] = None,
+    target_day: Optional[date] = None,
+    force: bool = False,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
+) -> AutomationResult:
+    ensure_schema(db_path)
+    start, end, label = _daily_period_for_day(target_day) if target_day else daily_period(now_utc)
+    if not force and target_day is None and not daily_due(now_utc):
+        return AutomationResult(False, "daily", "not_due", "before_daily_publish_time", source_window_start=start, source_window_end=end)
+    claim, run_id, preparation_epoch, row = _claim_preparation(db_path, guild_id, "daily", start, end, force=force)
+    if claim != "claimed":
+        return _result_from_existing("daily", row, claim=claim)
+    legacy = _adopt_legacy_staged_revision(
+        db_path,
+        guild_id,
+        run_id,
+        preparation_epoch,
+        "daily",
+        _entry_id(guild_id, "daily", label),
+        start,
+        end,
+        memory_excluded_entry_ids,
+    )
+    if legacy is not None:
+        return legacy
+    packet, source_hash, freeze_reason = _freeze_or_load_packet(
+        db_path,
+        guild_id,
+        run_id,
+        preparation_epoch,
+        lambda: build_source_packet_between(
+            db_path,
+            guild_id,
+            start,
+            end,
+            entry_kind="daily",
+            excluded_history_entry_ids=memory_excluded_entry_ids,
+        ),
+    )
+    if packet is None:
+        if freeze_reason.startswith("preparation_epoch_"):
+            return AutomationResult(False, "daily", "busy", freeze_reason, source_window_start=start, source_window_end=end)
+        return _finish_preparation(
+            db_path,
+            run_id,
+            preparation_epoch,
+            AutomationResult(False, "daily", "held", freeze_reason or "source_packet_freeze_failed", source_window_start=start, source_window_end=end),
+        )
+    if source_hash:
+        observation_id, observation_reason = _store_observation(
+            db_path,
+            guild_id,
+            label,
+            packet,
+            run_id=run_id,
+            preparation_epoch=preparation_epoch,
+        )
+        if not observation_id:
+            if observation_reason.startswith("preparation_epoch_"):
+                return AutomationResult(
+                    False,
+                    "daily",
+                    "busy",
+                    observation_reason,
+                    source_window_start=start,
+                    source_window_end=end,
+                )
+            return _finish_preparation(
+                db_path,
+                run_id,
+                preparation_epoch,
+                AutomationResult(
+                    False,
+                    "daily",
+                    "held",
+                    observation_reason or "observation_store_failed",
+                    source_window_start=start,
+                    source_window_end=end,
+                    aggregate_counts=packet.get("aggregateCounts"),
+                ),
+            )
+    if not packet.get("sourceArchiveAvailable", False):
+        result = AutomationResult(False, "daily", "held", "source_archive_unavailable", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
+    elif not packet.get("coverageComplete", True):
+        # Time cannot make a pre-archive window complete. Record it explicitly
+        # and move on instead of blocking every later catch-up day forever.
+        result = AutomationResult(False, "daily", "incomplete", "window_began_before_archive_activation", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
+    elif not _has_meaningful_daily_activity(packet):
+        result = AutomationResult(True, "daily", "quiet", "insufficient_meaningful_activity", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
+    else:
+        result = _prepare_packet_safely(
+            db_path,
+            guild_id,
+            "daily",
+            label,
+            run_id,
+            preparation_epoch,
+            packet,
+            source_hash,
+            generator,
+        )
+        return result
+    finished = _finish_preparation(db_path, run_id, preparation_epoch, result)
+    return finished
+
+
+def release_daily(
+    db_path: str,
+    guild_id: int,
+    base_url: str,
+    api_key: str,
+    *,
+    now_utc: Optional[datetime] = None,
+    target_day: Optional[date] = None,
+    force: bool = False,
+    opener=None,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
+    memory_exclusions_confirmed: bool = True,
+) -> AutomationResult:
+    start, end, label = _daily_period_for_day(target_day) if target_day else daily_period(now_utc)
+    if not force and target_day is None and not daily_due(now_utc):
+        return AutomationResult(False, "daily", "not_due", "before_daily_publish_time", source_window_start=start, source_window_end=end)
+    result = release_occurrence(
+        db_path,
+        guild_id,
+        "daily",
+        start,
+        end,
+        base_url,
+        api_key,
+        force=force,
+        opener=opener,
+        memory_excluded_entry_ids=memory_excluded_entry_ids,
+        memory_exclusions_confirmed=memory_exclusions_confirmed,
+    )
+    if result.status not in {"busy", "backoff"}:
+        _mark_observation(db_path, guild_id, label, result)
+    return result
 
 
 def run_daily(
@@ -387,35 +2204,31 @@ def run_daily(
     force: bool = False,
     opener=None,
     memory_excluded_entry_ids: Optional[set[str]] = None,
+    memory_exclusions_confirmed: bool = True,
 ) -> AutomationResult:
-    ensure_schema(db_path)
-    start, end, label = _daily_period_for_day(target_day) if target_day else daily_period(now_utc)
-    if not force and target_day is None and not daily_due(now_utc):
-        return AutomationResult(False, "daily", "not_due", "before_daily_publish_time", source_window_start=start, source_window_end=end)
-    claim, run_id, row = _claim_run(db_path, guild_id, "daily", start, end, force=force)
-    if claim != "claimed":
-        return _result_from_existing("daily", row, claim=claim)
-    packet = build_source_packet_between(
+    prepared = prepare_daily(
         db_path,
         guild_id,
-        start,
-        end,
-        entry_kind="daily",
-        excluded_history_entry_ids=memory_excluded_entry_ids,
+        generator,
+        now_utc=now_utc,
+        target_day=target_day,
+        force=force,
+        memory_excluded_entry_ids=memory_excluded_entry_ids,
     )
-    _store_observation(db_path, guild_id, label, packet)
-    if not packet.get("sourceArchiveAvailable", False):
-        result = AutomationResult(False, "daily", "held", "source_archive_unavailable", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
-    elif not packet.get("coverageComplete", True):
-        # Time cannot make a pre-archive window complete. Record it explicitly
-        # and move on instead of blocking every later catch-up day forever.
-        result = AutomationResult(False, "daily", "incomplete", "window_began_before_archive_activation", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
-    elif not _has_meaningful_daily_activity(packet):
-        result = AutomationResult(True, "daily", "quiet", "insufficient_meaningful_activity", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
-    else:
-        result = _publish_packet(db_path, guild_id, "daily", label, packet, generator, base_url, api_key, opener=opener)
-    _mark_observation(db_path, guild_id, label, result)
-    return _finish_run(db_path, run_id, result)
+    if prepared.status != "prepared":
+        return prepared
+    return release_daily(
+        db_path,
+        guild_id,
+        base_url,
+        api_key,
+        now_utc=now_utc,
+        target_day=target_day,
+        force=force,
+        opener=opener,
+        memory_excluded_entry_ids=memory_excluded_entry_ids,
+        memory_exclusions_confirmed=memory_exclusions_confirmed,
+    )
 
 
 def _weekly_packet(
@@ -473,6 +2286,146 @@ def _weekly_packet(
     return packet, len(complete), len(active)
 
 
+def prepare_weekly(
+    db_path: str,
+    guild_id: int,
+    generator: Callable[[dict[str, Any], str], str],
+    *,
+    now_utc: Optional[datetime] = None,
+    target_monday: Optional[date] = None,
+    force: bool = False,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
+) -> AutomationResult:
+    ensure_schema(db_path)
+    start, end, label = _weekly_period_for_monday(target_monday) if target_monday else weekly_period(now_utc)
+    if not force and target_monday is None and not weekly_due(now_utc):
+        return AutomationResult(False, "weekly", "not_due", "before_weekly_publish_time", source_window_start=start, source_window_end=end)
+    claim, run_id, preparation_epoch, row = _claim_preparation(
+        db_path,
+        guild_id,
+        "weekly",
+        start,
+        end,
+        force=force,
+    )
+    if claim != "claimed":
+        return _result_from_existing("weekly", row, claim=claim)
+    legacy = _adopt_legacy_staged_revision(
+        db_path,
+        guild_id,
+        run_id,
+        preparation_epoch,
+        "weekly",
+        _entry_id(guild_id, "weekly", label),
+        start,
+        end,
+        memory_excluded_entry_ids,
+    )
+    if legacy is not None:
+        return legacy
+
+    readiness: dict[str, int] = {}
+
+    def build_weekly_packet() -> Optional[dict[str, Any]]:
+        packet, complete_days, active_days = _weekly_packet(
+            db_path,
+            guild_id,
+            start,
+            end,
+            memory_excluded_entry_ids=memory_excluded_entry_ids,
+        )
+        readiness["completeDays"] = complete_days
+        readiness["activeDays"] = active_days
+        return packet
+
+    packet, source_hash, freeze_reason = _freeze_or_load_packet(
+        db_path,
+        guild_id,
+        run_id,
+        preparation_epoch,
+        build_weekly_packet,
+    )
+    if packet is not None:
+        aggregate = packet.get("aggregateCounts") or {}
+        complete_days = int(aggregate.get("daysObserved") or readiness.get("completeDays") or 0)
+        active_days = int(aggregate.get("activeDays") or readiness.get("activeDays") or 0)
+    else:
+        complete_days = int(readiness.get("completeDays") or 0)
+        active_days = int(readiness.get("activeDays") or 0)
+
+    if packet is None and freeze_reason.startswith("preparation_epoch_"):
+        return AutomationResult(
+            False,
+            "weekly",
+            "busy",
+            freeze_reason,
+            source_window_start=start,
+            source_window_end=end,
+        )
+    if packet is None and freeze_reason not in {"", "source_packet_not_ready"}:
+        result = AutomationResult(
+            False,
+            "weekly",
+            "held",
+            freeze_reason,
+            source_window_start=start,
+            source_window_end=end,
+            aggregate_counts={"completeDays": complete_days, "activeDays": active_days},
+        )
+    elif packet is None and complete_days == 7 and active_days == 0:
+        result = AutomationResult(True, "weekly", "quiet", "no_meaningful_weekly_activity", source_window_start=start, source_window_end=end, aggregate_counts={"completeDays": complete_days, "activeDays": active_days})
+    elif packet is None:
+        result = AutomationResult(True, "weekly", "deferred", f"only_{complete_days}_complete_daily_observations", source_window_start=start, source_window_end=end, aggregate_counts={"completeDays": complete_days, "activeDays": active_days})
+    elif not packet.get("sourceArchiveAvailable", False):
+        result = AutomationResult(False, "weekly", "held", "source_archive_unavailable", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
+    elif not packet.get("coverageComplete", True):
+        result = AutomationResult(False, "weekly", "incomplete", "window_began_before_archive_activation", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
+    else:
+        return _prepare_packet_safely(
+            db_path,
+            guild_id,
+            "weekly",
+            label,
+            run_id,
+            preparation_epoch,
+            packet,
+            source_hash,
+            generator,
+        )
+    return _finish_preparation(db_path, run_id, preparation_epoch, result)
+
+
+def release_weekly(
+    db_path: str,
+    guild_id: int,
+    base_url: str,
+    api_key: str,
+    *,
+    now_utc: Optional[datetime] = None,
+    target_monday: Optional[date] = None,
+    force: bool = False,
+    opener=None,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
+    memory_exclusions_confirmed: bool = True,
+) -> AutomationResult:
+    start, end, _label = _weekly_period_for_monday(target_monday) if target_monday else weekly_period(now_utc)
+    if not force and target_monday is None and not weekly_due(now_utc):
+        return AutomationResult(False, "weekly", "not_due", "before_weekly_publish_time", source_window_start=start, source_window_end=end)
+    return release_occurrence(
+        db_path,
+        guild_id,
+        "weekly",
+        start,
+        end,
+        base_url,
+        api_key,
+        force=force,
+        opener=opener,
+        memory_excluded_entry_ids=memory_excluded_entry_ids,
+        memory_exclusions_confirmed=memory_exclusions_confirmed,
+    )
+
+
 def run_weekly(
     db_path: str,
     guild_id: int,
@@ -485,32 +2438,31 @@ def run_weekly(
     force: bool = False,
     opener=None,
     memory_excluded_entry_ids: Optional[set[str]] = None,
+    memory_exclusions_confirmed: bool = True,
 ) -> AutomationResult:
-    ensure_schema(db_path)
-    start, end, label = _weekly_period_for_monday(target_monday) if target_monday else weekly_period(now_utc)
-    if not force and target_monday is None and not weekly_due(now_utc):
-        return AutomationResult(False, "weekly", "not_due", "before_weekly_publish_time", source_window_start=start, source_window_end=end)
-    claim, run_id, row = _claim_run(db_path, guild_id, "weekly", start, end, force=force)
-    if claim != "claimed":
-        return _result_from_existing("weekly", row, claim=claim)
-    packet, complete_days, active_days = _weekly_packet(
+    prepared = prepare_weekly(
         db_path,
         guild_id,
-        start,
-        end,
+        generator,
+        now_utc=now_utc,
+        target_monday=target_monday,
+        force=force,
         memory_excluded_entry_ids=memory_excluded_entry_ids,
     )
-    if packet is None and complete_days == 7 and active_days == 0:
-        result = AutomationResult(True, "weekly", "quiet", "no_meaningful_weekly_activity", source_window_start=start, source_window_end=end, aggregate_counts={"completeDays": complete_days, "activeDays": active_days})
-    elif packet is None:
-        result = AutomationResult(True, "weekly", "deferred", f"only_{complete_days}_complete_daily_observations", source_window_start=start, source_window_end=end, aggregate_counts={"completeDays": complete_days, "activeDays": active_days})
-    elif not packet.get("sourceArchiveAvailable", False):
-        result = AutomationResult(False, "weekly", "held", "source_archive_unavailable", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
-    elif not packet.get("coverageComplete", True):
-        result = AutomationResult(False, "weekly", "incomplete", "window_began_before_archive_activation", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
-    else:
-        result = _publish_packet(db_path, guild_id, "weekly", label, packet, generator, base_url, api_key, opener=opener)
-    return _finish_run(db_path, run_id, result)
+    if prepared.status != "prepared":
+        return prepared
+    return release_weekly(
+        db_path,
+        guild_id,
+        base_url,
+        api_key,
+        now_utc=now_utc,
+        target_monday=target_monday,
+        force=force,
+        opener=opener,
+        memory_excluded_entry_ids=memory_excluded_entry_ids,
+        memory_exclusions_confirmed=memory_exclusions_confirmed,
+    )
 
 
 def _archive_activation_day(db_path: str, guild_id: int) -> Optional[date]:
@@ -617,6 +2569,9 @@ def run_scheduled(
         for entry_id in controls.get("journalMemoryExcludedEntryIds", [])
         if str(entry_id)
     }
+    memory_exclusions_confirmed = bool(
+        controls.get("journalMemoryExclusionsConfirmed", True)
+    )
     if not bool(controls.get("journalAutoPublishEnabled", True)):
         return [AutomationResult(False, "all", "paused", "auto_publish_paused")]
     try:
@@ -629,11 +2584,11 @@ def run_scheduled(
     if bool(controls.get("journalDailyEnabled", True)):
         target_day = _pending_daily_day(db_path, guild_id, now_utc)
         if target_day is not None:
-            results.append(run_daily(db_path, guild_id, generator, base_url, api_key, now_utc=now_utc, target_day=target_day, opener=opener, memory_excluded_entry_ids=memory_excluded_entry_ids))
+            results.append(run_daily(db_path, guild_id, generator, base_url, api_key, now_utc=now_utc, target_day=target_day, opener=opener, memory_excluded_entry_ids=memory_excluded_entry_ids, memory_exclusions_confirmed=memory_exclusions_confirmed))
     if bool(controls.get("journalWeeklyEnabled", True)):
         target_monday = _pending_week_monday(db_path, guild_id, now_utc)
         if target_monday is not None:
-            results.append(run_weekly(db_path, guild_id, generator, base_url, api_key, now_utc=now_utc, target_monday=target_monday, opener=opener, memory_excluded_entry_ids=memory_excluded_entry_ids))
+            results.append(run_weekly(db_path, guild_id, generator, base_url, api_key, now_utc=now_utc, target_monday=target_monday, opener=opener, memory_excluded_entry_ids=memory_excluded_entry_ids, memory_exclusions_confirmed=memory_exclusions_confirmed))
     return results or [AutomationResult(False, "all", "not_due", "no_schedule_due")]
 
 

--- a/bnl_journal_automation.py
+++ b/bnl_journal_automation.py
@@ -13,6 +13,7 @@ import pytz
 
 from bnl_journal import (
     JOURNAL_SITE_REQUEST_BODY_MAX_BYTES,
+    SCHEDULED_PREPARED_STATE,
     JournalResult,
     approve_draft,
     build_source_packet_between,
@@ -23,6 +24,7 @@ from bnl_journal import (
     journal_topic_counts,
     utc_now_iso,
 )
+from bnl_journal_source_store import journal_release_privacy_fence
 
 PACIFIC = pytz.timezone("US/Pacific")
 DAILY_READY_HOUR = 19
@@ -142,7 +144,10 @@ def next_schedule_times(now_utc: Optional[datetime] = None) -> tuple[str, str]:
 
 
 def ensure_schema(db_path: str) -> None:
-    with sqlite3.connect(db_path) as conn:
+    with sqlite3.connect(db_path, timeout=30) as conn:
+        # Serialize the legacy-column snapshot with every conditional ALTER.
+        # Journal entrypoints can initialize concurrently during startup.
+        conn.execute("BEGIN IMMEDIATE")
         conn.execute("""CREATE TABLE IF NOT EXISTS bnl_journal_observations (
             observation_id TEXT PRIMARY KEY,
             guild_id INTEGER NOT NULL,
@@ -200,6 +205,22 @@ def ensure_schema(db_path: str) -> None:
         for column, declaration in run_migrations.items():
             if column not in run_columns:
                 conn.execute(f"ALTER TABLE bnl_journal_automation_runs ADD COLUMN {column} {declaration}")
+        conn.execute(
+            """CREATE TRIGGER IF NOT EXISTS trg_bnl_journal_runs_guard_legacy_running
+               BEFORE UPDATE OF lifecycle_state ON bnl_journal_automation_runs
+               WHEN NEW.lifecycle_state='running'
+                AND (
+                    OLD.lifecycle_state IN ('preparing','prepared','delivering')
+                    OR COALESCE(OLD.preparation_epoch,0) > 0
+                    OR COALESCE(OLD.delivery_epoch,0) > 0
+                    OR OLD.frozen_packet_json IS NOT NULL
+                    OR OLD.frozen_packet_hash IS NOT NULL
+                    OR OLD.prepared_payload_hash IS NOT NULL
+                )
+               BEGIN
+                   SELECT RAISE(ABORT,'journal_prepared_release_downgrade_guard');
+               END"""
+        )
         conn.execute("CREATE INDEX IF NOT EXISTS idx_bnl_journal_runs_latest ON bnl_journal_automation_runs(guild_id,updated_at DESC)")
         conn.execute("""CREATE TABLE IF NOT EXISTS bnl_journal_automation_state (
             guild_id INTEGER PRIMARY KEY,
@@ -227,48 +248,48 @@ def ensure_schema(db_path: str) -> None:
                 conn.execute(
                     f"ALTER TABLE bnl_journal_automation_state ADD COLUMN {column} {declaration}"
                 )
+        if conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='bnl_journal_entries'"
+        ).fetchone():
+            # Hide already-staged occurrence payloads from pre-upgrade delivery
+            # code before a rollback can observe the legacy lifecycle values.
+            conn.execute(
+                "UPDATE bnl_journal_entries SET lifecycle_state='prepared_exact' "
+                "WHERE lifecycle_state IN ('approved_pending_delivery','delivery_failed') "
+                "AND EXISTS ("
+                "SELECT 1 FROM bnl_journal_automation_runs r "
+                "WHERE r.guild_id=bnl_journal_entries.guild_id "
+                "AND r.journal_entry_id=bnl_journal_entries.entry_id "
+                "AND r.journal_revision=bnl_journal_entries.revision "
+                "AND r.prepared_payload_hash IS NOT NULL"
+                ")"
+            )
+            if conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='bnl_journal_private_metadata'"
+            ).fetchone():
+                conn.execute(
+                    "UPDATE bnl_journal_private_metadata SET lifecycle_state='prepared_exact' "
+                    "WHERE lifecycle_state IN ('approved_pending_delivery','delivery_failed') "
+                    "AND EXISTS ("
+                    "SELECT 1 FROM bnl_journal_automation_runs r "
+                    "WHERE r.guild_id=bnl_journal_private_metadata.guild_id "
+                    "AND r.journal_entry_id=bnl_journal_private_metadata.entry_id "
+                    "AND r.journal_revision=bnl_journal_private_metadata.revision "
+                    "AND r.prepared_payload_hash IS NOT NULL"
+                    ")"
+                )
 
 
-def store_journal_memory_exclusions(
-    db_path: str,
-    guild_id: int,
-    entry_ids: set[str] | list[str],
-) -> set[str]:
-    """Persist one confirmed website memory-eligibility snapshot."""
-    ensure_schema(db_path)
-    resolved = {
-        str(entry_id).strip()
-        for entry_id in entry_ids
-        if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,159}", str(entry_id).strip())
-    }
-    now = utc_now_iso()
-    with sqlite3.connect(db_path) as conn:
-        conn.execute("BEGIN IMMEDIATE")
-        conn.execute(
-            "INSERT INTO bnl_journal_automation_state("
-            "guild_id,memory_excluded_entry_ids_json,memory_exclusions_confirmed_at,updated_at"
-            ") VALUES(?,?,?,?) ON CONFLICT(guild_id) DO UPDATE SET "
-            "memory_excluded_entry_ids_json=excluded.memory_excluded_entry_ids_json,"
-            "memory_exclusions_confirmed_at=excluded.memory_exclusions_confirmed_at,"
-            "updated_at=excluded.updated_at",
-            (int(guild_id), _json(sorted(resolved)), now, now),
-        )
-        conn.commit()
-    return resolved
-
-
-def load_journal_memory_exclusions(
-    db_path: str,
+def _load_journal_memory_exclusions_on_connection(
+    conn: sqlite3.Connection,
     guild_id: int,
 ) -> tuple[set[str], bool]:
-    """Return the last confirmed exclusion set; never infer confirmed-empty."""
-    ensure_schema(db_path)
-    with sqlite3.connect(db_path) as conn:
-        row = conn.execute(
-            "SELECT memory_excluded_entry_ids_json,memory_exclusions_confirmed_at "
-            "FROM bnl_journal_automation_state WHERE guild_id=?",
-            (int(guild_id),),
-        ).fetchone()
+    row = conn.execute(
+        "SELECT memory_excluded_entry_ids_json,memory_exclusions_confirmed_at "
+        "FROM bnl_journal_automation_state WHERE guild_id=?",
+        (int(guild_id),),
+    ).fetchone()
     if not row or not str(row[1] or ""):
         return set(), False
     try:
@@ -285,6 +306,45 @@ def load_journal_memory_exclusions(
     if len(resolved) != len(values):
         return set(), False
     return resolved, True
+
+
+def store_journal_memory_exclusions(
+    db_path: str,
+    guild_id: int,
+    entry_ids: set[str] | list[str],
+) -> set[str]:
+    """Persist one confirmed website memory-eligibility snapshot."""
+    ensure_schema(db_path)
+    resolved = {
+        str(entry_id).strip()
+        for entry_id in entry_ids
+        if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,159}", str(entry_id).strip())
+    }
+    now = utc_now_iso()
+    with journal_release_privacy_fence(db_path):
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                "INSERT INTO bnl_journal_automation_state("
+                "guild_id,memory_excluded_entry_ids_json,memory_exclusions_confirmed_at,updated_at"
+                ") VALUES(?,?,?,?) ON CONFLICT(guild_id) DO UPDATE SET "
+                "memory_excluded_entry_ids_json=excluded.memory_excluded_entry_ids_json,"
+                "memory_exclusions_confirmed_at=excluded.memory_exclusions_confirmed_at,"
+                "updated_at=excluded.updated_at",
+                (int(guild_id), _json(sorted(resolved)), now, now),
+            )
+            conn.commit()
+    return resolved
+
+
+def load_journal_memory_exclusions(
+    db_path: str,
+    guild_id: int,
+) -> tuple[set[str], bool]:
+    """Return the last confirmed exclusion set; never infer confirmed-empty."""
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        return _load_journal_memory_exclusions_on_connection(conn, guild_id)
 
 
 def _run_id(guild_id: int, cadence: str, start: str, end: str) -> str:
@@ -377,7 +437,11 @@ def _claim_preparation(
             lease_expires = current.get("lease_expires_at") or ""
             # A manual Run Now may bypass retry backoff, but it must never
             # steal a live lease from the scheduler or another operator.
-            if current["lifecycle_state"] == "preparing" and lease_expires and _parse_utc(lease_expires) > now:
+            if (
+                current["lifecycle_state"] in {"running", "preparing"}
+                and lease_expires
+                and _parse_utc(lease_expires) > now
+            ):
                 conn.commit()
                 return "busy", run_id, int(current.get("preparation_epoch") or 0), current
             epoch = int(current.get("preparation_epoch") or 0) + 1
@@ -776,8 +840,8 @@ def _adopt_legacy_staged_revision(
                 cadence,
                 "held",
                 failure,
-                entry_id,
-                revision,
+                "",
+                0,
                 start,
                 end,
                 aggregate,
@@ -830,10 +894,37 @@ def _adopt_legacy_staged_revision(
             }
         )
         now = utc_now_iso()
+        entry_changed = conn.execute(
+            "UPDATE bnl_journal_entries SET lifecycle_state=?,updated_at=? "
+            "WHERE guild_id=? AND entry_id=? AND revision=? "
+            "AND lifecycle_state IN ('approved_pending_delivery','delivery_failed')",
+            (
+                SCHEDULED_PREPARED_STATE,
+                now,
+                guild_id,
+                entry_id,
+                revision,
+            ),
+        ).rowcount
+        if entry_changed != 1:
+            conn.rollback()
+            return AutomationResult(
+                False,
+                cadence,
+                "busy",
+                "preparation_epoch_superseded",
+            )
         conn.execute(
-            "UPDATE bnl_journal_private_metadata SET metadata_json=?,updated_at=? "
+            "UPDATE bnl_journal_private_metadata SET metadata_json=?,lifecycle_state=?,updated_at=? "
             "WHERE guild_id=? AND entry_id=? AND revision=?",
-            (_json(metadata), now, guild_id, entry_id, revision),
+            (
+                _json(metadata),
+                SCHEDULED_PREPARED_STATE,
+                now,
+                guild_id,
+                entry_id,
+                revision,
+            ),
         )
         result = AutomationResult(
             True,
@@ -919,8 +1010,8 @@ def _mark_prepared(
                 cadence,
                 "held",
                 reason,
-                entry_id,
-                revision,
+                "",
+                0,
                 str(packet.get("sourceWindowStart") or ""),
                 str(packet.get("sourceWindowEnd") or ""),
                 packet.get("aggregateCounts") or {},
@@ -948,7 +1039,11 @@ def _mark_prepared(
             "WHERE e.guild_id=? AND e.entry_id=? AND e.revision=?",
             (guild_id, entry_id, int(revision)),
         ).fetchone()
-        if not entry or str(entry[0]) not in {"approved_pending_delivery", "delivery_failed"}:
+        if not entry or str(entry[0]) not in {
+            SCHEDULED_PREPARED_STATE,
+            "approved_pending_delivery",
+            "delivery_failed",
+        }:
             conn.rollback()
             return hold_invalid_revision("prepared_revision_missing")
         canonical = bytes(entry[1] or b"")
@@ -968,6 +1063,39 @@ def _mark_prepared(
             conn.rollback()
             return hold_invalid_revision("source_packet_hash_mismatch")
         now = utc_now_iso()
+        if str(entry[0]) != SCHEDULED_PREPARED_STATE:
+            entry_changed = conn.execute(
+                "UPDATE bnl_journal_entries SET lifecycle_state=?,updated_at=? "
+                "WHERE guild_id=? AND entry_id=? AND revision=? "
+                "AND lifecycle_state IN ('approved_pending_delivery','delivery_failed')",
+                (
+                    SCHEDULED_PREPARED_STATE,
+                    now,
+                    guild_id,
+                    entry_id,
+                    int(revision),
+                ),
+            ).rowcount
+            metadata_changed = conn.execute(
+                "UPDATE bnl_journal_private_metadata SET lifecycle_state=?,updated_at=? "
+                "WHERE guild_id=? AND entry_id=? AND revision=? "
+                "AND lifecycle_state IN ('approved_pending_delivery','delivery_failed')",
+                (
+                    SCHEDULED_PREPARED_STATE,
+                    now,
+                    guild_id,
+                    entry_id,
+                    int(revision),
+                ),
+            ).rowcount
+            if entry_changed != 1 or metadata_changed != 1:
+                conn.rollback()
+                return AutomationResult(
+                    False,
+                    cadence,
+                    "busy",
+                    "preparation_epoch_superseded",
+                )
         result = AutomationResult(
             True,
             cadence,
@@ -1122,12 +1250,26 @@ def _store_observation(
     return observation_id, ""
 
 
-def _mark_observation(db_path: str, guild_id: int, label: str, result: AutomationResult) -> None:
+def _mark_observation(
+    db_path: str,
+    guild_id: int,
+    label: str,
+    result: AutomationResult,
+) -> None:
     with sqlite3.connect(db_path) as conn:
-        conn.execute("""UPDATE bnl_journal_observations SET lifecycle_state=?,journal_entry_id=?,journal_revision=?,updated_at=?
-            WHERE guild_id=? AND observation_date=?""", (
-            result.status, result.entry_id or None, int(result.revision or 0), utc_now_iso(), guild_id, label,
-        ))
+        conn.execute(
+            "UPDATE bnl_journal_observations SET lifecycle_state=?,"
+            "journal_entry_id=?,journal_revision=?,updated_at=? "
+            "WHERE guild_id=? AND observation_date=?",
+            (
+                result.status,
+                result.entry_id or None,
+                int(result.revision or 0),
+                utc_now_iso(),
+                guild_id,
+                label,
+            ),
+        )
 
 
 def _has_meaningful_daily_activity(packet: dict[str, Any]) -> bool:
@@ -1171,13 +1313,13 @@ def _reject_staged_revision_for_retry(
         entry_changed = conn.execute(
             "UPDATE bnl_journal_entries SET lifecycle_state='rejected',review_reason=?,updated_at=? "
             "WHERE guild_id=? AND entry_id=? AND revision=? "
-            "AND lifecycle_state IN ('draft','approved_pending_delivery','delivery_failed')",
+            "AND lifecycle_state IN ('draft','prepared_exact','approved_pending_delivery','delivery_failed')",
             (reason, now, guild_id, entry_id, int(revision)),
         ).rowcount
         metadata_changed = conn.execute(
             "UPDATE bnl_journal_private_metadata SET lifecycle_state='rejected',updated_at=? "
             "WHERE guild_id=? AND entry_id=? AND revision=? "
-            "AND lifecycle_state IN ('draft','approved_pending_delivery','delivery_failed')",
+            "AND lifecycle_state IN ('draft','prepared_exact','approved_pending_delivery','delivery_failed')",
             (now, guild_id, entry_id, int(revision)),
         ).rowcount
         if entry_changed != 1 or metadata_changed != 1:
@@ -1208,7 +1350,12 @@ def _prepare_packet(
             AutomationResult(True, cadence, "published", "already_published", entry_id, int(existing["revision"]), packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts")),
         )
     existing_source_hash = ""
-    if existing and existing["lifecycle_state"] in {"draft", "approved_pending_delivery", "delivery_failed"}:
+    if existing and existing["lifecycle_state"] in {
+        "draft",
+        SCHEDULED_PREPARED_STATE,
+        "approved_pending_delivery",
+        "delivery_failed",
+    }:
         try:
             existing_metadata = json.loads(str(existing.get("metadata_json") or "{}"))
         except (TypeError, json.JSONDecodeError):
@@ -1232,7 +1379,11 @@ def _prepare_packet(
                 return AutomationResult(False, cadence, "busy", "preparation_epoch_superseded")
             existing = {**existing, "lifecycle_state": "rejected"}
 
-    if existing and existing["lifecycle_state"] in {"approved_pending_delivery", "delivery_failed"}:
+    if existing and existing["lifecycle_state"] in {
+        SCHEDULED_PREPARED_STATE,
+        "approved_pending_delivery",
+        "delivery_failed",
+    }:
         return _mark_prepared(
             db_path,
             guild_id,
@@ -1271,7 +1422,17 @@ def _prepare_packet(
                 db_path,
                 run_id,
                 preparation_epoch,
-                AutomationResult(False, cadence, "held", approved.reason, entry_id, int(existing["revision"]), packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts")),
+                AutomationResult(
+                    False,
+                    cadence,
+                    "held",
+                    approved.reason,
+                    "",
+                    0,
+                    packet["sourceWindowStart"],
+                    packet["sourceWindowEnd"],
+                    packet.get("aggregateCounts"),
+                ),
             )
         return _mark_prepared(
             db_path,
@@ -1303,7 +1464,17 @@ def _prepare_packet(
             db_path,
             run_id,
             preparation_epoch,
-            AutomationResult(False, cadence, "held", generated.reason, entry_id, generated.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts")),
+            AutomationResult(
+                False,
+                cadence,
+                "held",
+                generated.reason,
+                "",
+                0,
+                packet["sourceWindowStart"],
+                packet["sourceWindowEnd"],
+                packet.get("aggregateCounts"),
+            ),
         )
     approved = approve_draft(
         db_path,
@@ -1331,7 +1502,17 @@ def _prepare_packet(
             db_path,
             run_id,
             preparation_epoch,
-            AutomationResult(False, cadence, "held", approved.reason, entry_id, generated.revision, packet["sourceWindowStart"], packet["sourceWindowEnd"], packet.get("aggregateCounts")),
+            AutomationResult(
+                False,
+                cadence,
+                "held",
+                approved.reason,
+                "",
+                0,
+                packet["sourceWindowStart"],
+                packet["sourceWindowEnd"],
+                packet.get("aggregateCounts"),
+            ),
         )
     return _mark_prepared(
         db_path,
@@ -1380,7 +1561,7 @@ def _prepare_packet_safely(
                 cadence,
                 "held",
                 "journal_preparation_storage_failed",
-                _entry_id(guild_id, cadence, label),
+                "",
                 0,
                 str(packet.get("sourceWindowStart") or ""),
                 str(packet.get("sourceWindowEnd") or ""),
@@ -1465,12 +1646,14 @@ def _invalidate_prepared_in_transaction(
     ).fetchone()
     conn.execute(
         "UPDATE bnl_journal_entries SET lifecycle_state='rejected',review_reason=?,updated_at=? "
-        "WHERE guild_id=? AND entry_id=? AND revision=? AND lifecycle_state IN ('approved_pending_delivery','delivery_failed')",
+        "WHERE guild_id=? AND entry_id=? AND revision=? "
+        "AND lifecycle_state IN ('prepared_exact','approved_pending_delivery','delivery_failed')",
         (reason, now, guild_id, entry_id, int(revision)),
     )
     conn.execute(
         "UPDATE bnl_journal_private_metadata SET lifecycle_state='rejected',updated_at=? "
-        "WHERE guild_id=? AND entry_id=? AND revision=? AND lifecycle_state IN ('approved_pending_delivery','delivery_failed')",
+        "WHERE guild_id=? AND entry_id=? AND revision=? "
+        "AND lifecycle_state IN ('prepared_exact','approved_pending_delivery','delivery_failed')",
         (now, guild_id, entry_id, int(revision)),
     )
     packet_reset = (
@@ -1525,10 +1708,9 @@ def _claim_delivery(
     ensure_schema(db_path)
     run_id = _run_id(guild_id, cadence, start, end)
     now_dt = datetime.now(timezone.utc)
-    # A live delivery owner holds a SQLite write transaction across the POST so
-    # deletion and release have one serialization boundary. Read its lease
-    # before requesting our own write lock; concurrent triggers can then report
-    # ``busy`` immediately instead of waiting behind the network timeout.
+    # A caller-level Journal fence serializes this claim with the complete
+    # network/finalization interval. This read remains an inexpensive shortcut
+    # for direct tests and defensive callers.
     try:
         with sqlite3.connect(db_path) as read_conn:
             read_conn.row_factory = sqlite3.Row
@@ -1615,7 +1797,11 @@ def _claim_delivery(
             conn.commit()
             current.update({"lifecycle_state": "published", "reason": recovered.reason})
             return "complete", run_id, int(current.get("delivery_epoch") or 0), current
-        if not entry or str(entry[0]) not in {"approved_pending_delivery", "delivery_failed"}:
+        if not entry or str(entry[0]) not in {
+            SCHEDULED_PREPARED_STATE,
+            "approved_pending_delivery",
+            "delivery_failed",
+        }:
             _invalidate_prepared_in_transaction(
                 conn,
                 run_id,
@@ -1787,10 +1973,22 @@ def _finish_invalidated_delivery(
             retire_packet=result.reason.startswith("privacy_"),
         )
         conn.commit()
-    return result
+    return AutomationResult(
+        False,
+        result.cadence,
+        "held",
+        result.reason,
+        "",
+        0,
+        result.source_window_start,
+        result.source_window_end,
+        result.aggregate_counts,
+        result.http_status,
+        result.idempotent,
+    )
 
 
-def release_occurrence(
+def _release_occurrence_under_fence(
     db_path: str,
     guild_id: int,
     cadence: str,
@@ -1858,14 +2056,22 @@ def release_occurrence(
         }
 
         def final_delivery_preflight(conn: sqlite3.Connection) -> str:
+            durable_excluded_entry_ids, durable_exclusions_confirmed = (
+                _load_journal_memory_exclusions_on_connection(conn, guild_id)
+            )
+            effective_excluded_entry_ids = (
+                durable_excluded_entry_ids
+                if durable_exclusions_confirmed
+                else excluded_entry_ids
+            )
             private = conn.execute(
                 "SELECT m.metadata_json,e.canonical_payload_bytes "
                 "FROM bnl_journal_private_metadata m "
                 "JOIN bnl_journal_entries e "
                 "ON e.guild_id=m.guild_id AND e.entry_id=m.entry_id AND e.revision=m.revision "
                 "WHERE m.guild_id=? AND m.entry_id=? AND m.revision=? "
-                "AND m.lifecycle_state IN ('approved_pending_delivery','delivery_failed') "
-                "AND e.lifecycle_state IN ('approved_pending_delivery','delivery_failed')",
+                "AND m.lifecycle_state IN ('prepared_exact','approved_pending_delivery','delivery_failed') "
+                "AND e.lifecycle_state IN ('prepared_exact','approved_pending_delivery','delivery_failed')",
                 (guild_id, entry_id, revision),
             ).fetchone()
             if not private:
@@ -1891,7 +2097,7 @@ def release_occurrence(
                 conn,
                 guild_id,
                 metadata,
-                excluded_entry_ids,
+                effective_excluded_entry_ids,
             )
 
         try:
@@ -1972,6 +2178,46 @@ def release_occurrence(
         bool(finished.idempotent),
     )
     return finished
+
+
+def release_occurrence(
+    db_path: str,
+    guild_id: int,
+    cadence: str,
+    start: str,
+    end: str,
+    base_url: str,
+    api_key: str,
+    *,
+    force: bool = False,
+    opener=None,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
+    memory_exclusions_confirmed: bool = True,
+) -> AutomationResult:
+    """Own claim, POST, and durable finalization under one narrow gate."""
+    with journal_release_privacy_fence(db_path, blocking=False) as acquired:
+        if not acquired:
+            return AutomationResult(
+                False,
+                cadence,
+                "busy",
+                "delivery_owner_in_progress",
+                source_window_start=start,
+                source_window_end=end,
+            )
+        return _release_occurrence_under_fence(
+            db_path,
+            guild_id,
+            cadence,
+            start,
+            end,
+            base_url,
+            api_key,
+            force=force,
+            opener=opener,
+            memory_excluded_entry_ids=memory_excluded_entry_ids,
+            memory_exclusions_confirmed=memory_exclusions_confirmed,
+        )
 
 
 def release_prepared_entry(
@@ -2187,8 +2433,6 @@ def release_daily(
         memory_excluded_entry_ids=memory_excluded_entry_ids,
         memory_exclusions_confirmed=memory_exclusions_confirmed,
     )
-    if result.status not in {"busy", "backoff"}:
-        _mark_observation(db_path, guild_id, label, result)
     return result
 
 

--- a/bnl_journal_source_store.py
+++ b/bnl_journal_source_store.py
@@ -8,18 +8,26 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import sqlite3
+import threading
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+import fcntl
 
 
 PUBLIC_POLICIES = ("public_context", "public_home", "public_selective")
 SOURCE_TABLE = "bnl_journal_source_events"
 STATE_TABLE = "bnl_journal_source_archive_state"
 DELETE_TRIGGER = "trg_bnl_journal_sources_no_delete"
+_JOURNAL_PRIVACY_LOCKS: Dict[str, threading.RLock] = {}
+_JOURNAL_PRIVACY_LOCKS_GUARD = threading.Lock()
+_JOURNAL_PRIVACY_LOCK_LOCAL = threading.local()
 
 
 @dataclass(frozen=True)
@@ -54,6 +62,63 @@ def _now_ms() -> int:
 
 def _content_hash(raw_text: str) -> str:
     return hashlib.sha256((raw_text or "").encode("utf-8")).hexdigest()
+
+
+def _journal_privacy_lock_key(db_path: str) -> str:
+    raw = os.path.abspath(str(db_path or ""))
+    return os.path.realpath(raw)
+
+
+@contextmanager
+def journal_release_privacy_fence(db_path: str, *, blocking: bool = True):
+    """Serialize Journal release with eligibility-decreasing privacy writes.
+
+    The process lock keeps same-process threads from relying on platform-specific
+    ``flock`` reentrancy. The sidecar lock extends the same ordering across a
+    brief old/new process overlap during restart or rollback. Callers must take
+    this fence before opening a main-database write transaction.
+    """
+    key = _journal_privacy_lock_key(db_path)
+    with _JOURNAL_PRIVACY_LOCKS_GUARD:
+        process_lock = _JOURNAL_PRIVACY_LOCKS.setdefault(key, threading.RLock())
+    process_acquired = process_lock.acquire(blocking=blocking)
+    if not process_acquired:
+        yield False
+        return
+    try:
+        held = getattr(_JOURNAL_PRIVACY_LOCK_LOCAL, "keys", set())
+        if key in held:
+            yield True
+            return
+        lock_path = key + ".journal-privacy.lock"
+        descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        file_acquired = False
+        try:
+            operation = fcntl.LOCK_EX
+            if not blocking:
+                operation |= fcntl.LOCK_NB
+            try:
+                fcntl.flock(descriptor, operation)
+                file_acquired = True
+            except BlockingIOError:
+                yield False
+                return
+            held = set(held)
+            held.add(key)
+            _JOURNAL_PRIVACY_LOCK_LOCAL.keys = held
+            yield True
+        finally:
+            if file_acquired:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            os.close(descriptor)
+            if file_acquired:
+                remaining = set(
+                    getattr(_JOURNAL_PRIVACY_LOCK_LOCAL, "keys", set())
+                )
+                remaining.discard(key)
+                _JOURNAL_PRIVACY_LOCK_LOCAL.keys = remaining
+    finally:
+        process_lock.release()
 
 
 def _canonical_json(value: Optional[Mapping[str, Any]]) -> str:
@@ -104,6 +169,10 @@ def sanitize_summary(text: str, private_names: Optional[Sequence[str]] = None, l
 
 def ensure_schema(db_path: str) -> None:
     with sqlite3.connect(db_path, timeout=30) as conn:
+        # The schema snapshot and its conditional ALTERs are one serialized
+        # migration. Without this lease, concurrent startup paths can both see
+        # a missing legacy column and race into duplicate-column failures.
+        conn.execute("BEGIN IMMEDIATE")
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS bnl_journal_source_archive_state (
@@ -455,15 +524,16 @@ def _purge_discord_source_events(db_path: str, guild_id: int, user_id: Optional[
     and deletion back together, so the immutability guard remains installed.
     """
     ensure_schema(db_path)
-    with sqlite3.connect(db_path, timeout=30) as conn:
-        conn.execute("BEGIN EXCLUSIVE")
-        try:
-            removed = _purge_discord_source_events_on_connection(conn, guild_id, user_id)
-            conn.commit()
-            return removed
-        except Exception:
-            conn.rollback()
-            raise
+    with journal_release_privacy_fence(db_path):
+        with sqlite3.connect(db_path, timeout=30) as conn:
+            conn.execute("BEGIN EXCLUSIVE")
+            try:
+                removed = _purge_discord_source_events_on_connection(conn, guild_id, user_id)
+                conn.commit()
+                return removed
+            except Exception:
+                conn.rollback()
+                raise
 
 
 def purge_guild_discord_sources(db_path: str, guild_id: int) -> int:

--- a/bnl_journal_source_store.py
+++ b/bnl_journal_source_store.py
@@ -442,6 +442,11 @@ def purge_user_discord_sources_on_connection(conn: sqlite3.Connection, guild_id:
     return _purge_discord_source_events_on_connection(conn, guild_id, user_id)
 
 
+def purge_guild_discord_sources_on_connection(conn: sqlite3.Connection, guild_id: int) -> int:
+    """Purge one guild's raw Discord Journal sources in a caller transaction."""
+    return _purge_discord_source_events_on_connection(conn, guild_id)
+
+
 def _purge_discord_source_events(db_path: str, guild_id: int, user_id: Optional[int] = None) -> int:
     """Delete an explicitly scoped Discord archive while keeping normal rows immutable.
 

--- a/bnl_memory_governance.py
+++ b/bnl_memory_governance.py
@@ -20,7 +20,10 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from bnl_dossier_source_packets import subject_key as normalized_subject_key
 from bnl_journal import purge_user_journal_derivatives_on_connection
-from bnl_journal_source_store import purge_user_discord_sources_on_connection
+from bnl_journal_source_store import (
+    journal_release_privacy_fence,
+    purge_user_discord_sources_on_connection,
+)
 from bnl_memory_ledger import ensure_memory_ledger_schema, subject_key_for_user
 from bnl_relationship_engine import complete_delete_relationship_v2, ensure_relationship_v2_schema, propagate_ledger_lifecycle
 
@@ -628,7 +631,7 @@ def _cleanup_canonical_moment(conn: sqlite3.Connection, guild_id: int, moment_id
         # Remove lineage edges from deleted sources; keep canonical row reachable but not dangling to deleted member entries.
         counts["canonical_ledger_lineage"] = counts.get("canonical_ledger_lineage", 0) + conn.execute("DELETE FROM memory_ledger_lineage WHERE guild_id=? AND entry_id=? AND target_entry_id NOT IN (SELECT entry_id FROM memory_ledger_entries WHERE guild_id=?)", (guild_id, canonical, guild_id)).rowcount
 
-def complete_delete_member_data(conn: sqlite3.Connection, *, guild_id: int, user_id: int, confirmation: str, inject_failure: bool = False) -> Dict[str, Any]:
+def _complete_delete_member_data(conn: sqlite3.Connection, *, guild_id: int, user_id: int, confirmation: str, inject_failure: bool = False) -> Dict[str, Any]:
     if confirmation != "DELETE MY BNL DATA %s" % guild_id: return {"ok": False, "reason": "confirmation_required"}
     ensure_governance_schema(conn); rid = _receipt("complete_delete", guild_id, user_id); now = _now(); counts: Dict[str, int] = {}; subject = subject_key_for_user(user_id); subject_hash = _subject_hash(user_id)
     scrub_values = _safe_text_values(conn, guild_id, user_id)
@@ -734,3 +737,35 @@ def complete_delete_member_data(conn: sqlite3.Connection, *, guild_id: int, user
         safe_counts = {k: int(v or 0) for k, v in counts.items() if int(v or 0)}
         conn.execute("INSERT INTO memory_governance_receipts VALUES (?,?,?,?,?,?,?)", (rid, guild_id, subject_hash, "complete_delete", "", now, json.dumps(safe_counts, sort_keys=True)))
     return {"ok": True, "receipt": rid, "row_counts": counts, "idempotent": not any(counts.values()), "limitation": "Discord-hosted messages are not deleted by this bot command."}
+
+
+def complete_delete_member_data(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    user_id: int,
+    confirmation: str,
+    inject_failure: bool = False,
+) -> Dict[str, Any]:
+    """Run complete deletion before any prepared Journal can cross the POST gate."""
+    main_path = ""
+    for _seq, name, path in conn.execute("PRAGMA database_list").fetchall():
+        if str(name) == "main":
+            main_path = str(path or "")
+            break
+    if not main_path:
+        return _complete_delete_member_data(
+            conn,
+            guild_id=guild_id,
+            user_id=user_id,
+            confirmation=confirmation,
+            inject_failure=inject_failure,
+        )
+    with journal_release_privacy_fence(main_path):
+        return _complete_delete_member_data(
+            conn,
+            guild_id=guild_id,
+            user_id=user_id,
+            confirmation=confirmation,
+            inject_failure=inject_failure,
+        )

--- a/tests/test_bnl_journal_automation.py
+++ b/tests/test_bnl_journal_automation.py
@@ -502,21 +502,24 @@ class JournalAutomationTests(unittest.TestCase):
         self.assertEqual(7, weekly.aggregate_counts["daysObserved"])
 
     def test_weekly_refuses_archive_fallback_or_incomplete_coverage(self):
-        monday = date(2026, 7, 13)
-        base_packet = journal.build_packet_from_sources(
-            self.db,
-            1,
-            "2026-07-14T02:00:00Z",
-            "2026-07-21T02:00:00Z",
-            [],
-            [],
-            entry_kind="weekly",
-        )
         cases = (
             ({"sourceArchiveAvailable": False, "coverageComplete": True}, "held", "source_archive_unavailable"),
             ({"sourceArchiveAvailable": True, "coverageComplete": False}, "incomplete", "window_began_before_archive_activation"),
         )
-        for flags, expected_status, expected_reason in cases:
+        # Each case uses its own occurrence. A frozen packet is now durable by
+        # design and must not be replaced by a later retry of the same week.
+        for index, (flags, expected_status, expected_reason) in enumerate(cases):
+            monday = date(2026, 7, 13) + timedelta(days=7 * index)
+            start, end, _ = automation._weekly_period_for_monday(monday)
+            base_packet = journal.build_packet_from_sources(
+                self.db,
+                1,
+                start,
+                end,
+                [],
+                [],
+                entry_kind="weekly",
+            )
             packet = dict(base_packet)
             packet.update(flags)
             with self.subTest(flags=flags), patch.object(

--- a/tests/test_bnl_journal_delivery_fence.py
+++ b/tests/test_bnl_journal_delivery_fence.py
@@ -1,0 +1,376 @@
+import json
+import os
+import sqlite3
+import tempfile
+import threading
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+
+import bnl_journal as journal
+import bnl_journal_automation as automation
+import bnl_journal_source_store as source_store
+
+
+class AcceptedResponse:
+    status = 200
+
+    def __init__(self, request):
+        submitted = json.loads(request.data.decode("utf-8"))["entry"]
+        self._body = json.dumps(
+            {
+                "ok": True,
+                "persisted": True,
+                "idempotent": False,
+                "entry": {
+                    "entryId": submitted["entryId"],
+                    "revision": submitted["revision"],
+                    "contentHash": submitted["contentHash"],
+                    "publishedAt": "2026-07-23T01:00:00Z",
+                },
+            }
+        ).encode("utf-8")
+
+    def read(self):
+        return self._body
+
+    def getcode(self):
+        return self.status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class JournalDeliveryFenceTests(unittest.TestCase):
+    def setUp(self):
+        handle = tempfile.NamedTemporaryFile(delete=False)
+        self.db = handle.name
+        handle.close()
+        journal.ensure_schema(self.db)
+        automation.ensure_schema(self.db)
+        self.guild_id = 1
+        self.entry_id = "journal_daily_2026-07-21_fenced"
+        self.revision = 1
+        self.run_id = "jrun_delivery_fence_test"
+        self.delivery_epoch = 7
+        self.canonical = self._stage_approved_revision_and_run()
+
+    def tearDown(self):
+        try:
+            os.unlink(self.db)
+        except FileNotFoundError:
+            pass
+
+    @staticmethod
+    def _iso(value):
+        return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace(
+            "+00:00", "Z"
+        )
+
+    def _stage_approved_revision_and_run(self):
+        packet = {
+            "entryKind": "daily",
+            "sourceWindowStart": "2026-07-21T02:00:00Z",
+            "sourceWindowEnd": "2026-07-22T02:00:00Z",
+            "privateSources": [],
+            "history": {},
+            "aggregateCounts": {},
+        }
+        article = {
+            "title": "Fenced Delivery",
+            "excerpt": "A prepared Journal payload used to exercise one delivery owner.",
+            "sections": [
+                {
+                    "heading": "Signal",
+                    "body": "The prepared signal is released exactly once by its durable owner.",
+                    "sourceRefIds": [],
+                }
+            ],
+            "sourceRefIds": {"Signal": []},
+            "metadata": {},
+        }
+        entry_row, metadata_row, draft = journal._draft_records(
+            self.guild_id,
+            packet,
+            article,
+            entry_id=self.entry_id,
+            revision=self.revision,
+        )
+        with sqlite3.connect(self.db) as conn:
+            journal._insert_draft_rows(conn, entry_row, metadata_row)
+        approved = journal.approve_draft(
+            self.db,
+            self.guild_id,
+            self.entry_id,
+            draft.content_hash,
+            revision=self.revision,
+        )
+        self.assertTrue(approved.ok, approved)
+        now = datetime.now(timezone.utc)
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "INSERT INTO bnl_journal_automation_runs("
+                "run_id,guild_id,cadence,source_window_start,source_window_end,lifecycle_state,reason,"
+                "journal_entry_id,journal_revision,aggregate_counts_json,attempt_count,delivery_epoch,"
+                "delivery_lease_expires_at,created_at,updated_at) "
+                "VALUES(?,?,?,?,?,'delivering','delivery_in_progress',?,?, '{}',1,?,?,?,?)",
+                (
+                    self.run_id,
+                    self.guild_id,
+                    "daily",
+                    packet["sourceWindowStart"],
+                    packet["sourceWindowEnd"],
+                    self.entry_id,
+                    self.revision,
+                    self.delivery_epoch,
+                    self._iso(now + timedelta(minutes=2)),
+                    self._iso(now),
+                    self._iso(now),
+                ),
+            )
+            canonical = conn.execute(
+                "SELECT canonical_payload_bytes FROM bnl_journal_entries "
+                "WHERE guild_id=? AND entry_id=? AND revision=?",
+                (self.guild_id, self.entry_id, self.revision),
+            ).fetchone()[0]
+        return bytes(canonical)
+
+    def _states(self):
+        with sqlite3.connect(self.db) as conn:
+            entry_state = conn.execute(
+                "SELECT lifecycle_state FROM bnl_journal_entries "
+                "WHERE guild_id=? AND entry_id=? AND revision=?",
+                (self.guild_id, self.entry_id, self.revision),
+            ).fetchone()[0]
+            metadata_state = conn.execute(
+                "SELECT lifecycle_state FROM bnl_journal_private_metadata "
+                "WHERE guild_id=? AND entry_id=? AND revision=?",
+                (self.guild_id, self.entry_id, self.revision),
+            ).fetchone()[0]
+        return entry_state, metadata_state
+
+    def test_live_matching_fence_posts_and_updates_revision_atomically(self):
+        posts = []
+
+        def opener(request, timeout=10):
+            posts.append(request.data)
+            return AcceptedResponse(request)
+
+        result = journal.deliver_approved(
+            self.db,
+            self.guild_id,
+            self.entry_id,
+            "https://site.example",
+            "key",
+            opener=opener,
+            revision=self.revision,
+            delivery_fence=(self.run_id, self.delivery_epoch),
+        )
+
+        self.assertTrue(result.ok, result)
+        self.assertEqual("published", result.status)
+        self.assertEqual([self.canonical], posts)
+        self.assertEqual(("published", "published"), self._states())
+
+    def test_superseded_or_expired_fence_makes_zero_posts(self):
+        posts = []
+
+        def forbidden_opener(request, timeout=10):
+            posts.append(request.data)
+            raise AssertionError("lost delivery owner reached the network")
+
+        superseded = journal.deliver_approved(
+            self.db,
+            self.guild_id,
+            self.entry_id,
+            "https://site.example",
+            "key",
+            opener=forbidden_opener,
+            revision=self.revision,
+            delivery_fence=(self.run_id, self.delivery_epoch - 1),
+        )
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs SET delivery_lease_expires_at=? WHERE run_id=?",
+                ("2000-01-01T00:00:00Z", self.run_id),
+            )
+        expired = journal.deliver_approved(
+            self.db,
+            self.guild_id,
+            self.entry_id,
+            "https://site.example",
+            "key",
+            opener=forbidden_opener,
+            revision=self.revision,
+            delivery_fence=(self.run_id, self.delivery_epoch),
+        )
+
+        self.assertEqual("delivery_epoch_lost", superseded.reason)
+        self.assertEqual("delivery_epoch_lost", expired.reason)
+        self.assertEqual([], posts)
+        self.assertEqual(
+            ("approved_pending_delivery", "approved_pending_delivery"),
+            self._states(),
+        )
+
+    def test_unfenced_manual_delivery_keeps_existing_behavior(self):
+        posts = []
+
+        def opener(request, timeout=10):
+            posts.append(request.data)
+            return AcceptedResponse(request)
+
+        result = journal.deliver_approved(
+            self.db,
+            self.guild_id,
+            self.entry_id,
+            "https://site.example",
+            "key",
+            opener=opener,
+            revision=self.revision,
+        )
+
+        self.assertTrue(result.ok, result)
+        self.assertEqual([self.canonical], posts)
+        self.assertEqual(("published", "published"), self._states())
+
+    def test_privacy_purge_waits_for_fenced_post_commit_and_preserves_published_prose(self):
+        subject_ref = "discord_user:100"
+        source_store.record_source_event(
+            self.db,
+            guild_id=self.guild_id,
+            source_kind="discord_message",
+            source_key="delivery-fence-privacy-source",
+            occurred_at_ms=1_753_159_200_000,
+            raw_text="A member shared a public music observation.",
+            sanitized_summary="A member shared a public music observation.",
+            channel_policy="public_home",
+            subject_ref=subject_ref,
+            public_usable=True,
+        )
+        with sqlite3.connect(self.db) as conn:
+            metadata_raw = conn.execute(
+                "SELECT metadata_json FROM bnl_journal_private_metadata "
+                "WHERE guild_id=? AND entry_id=? AND revision=?",
+                (self.guild_id, self.entry_id, self.revision),
+            ).fetchone()[0]
+            metadata = json.loads(metadata_raw)
+            metadata.update(
+                {
+                    "subjectRefs": [subject_ref],
+                    "supportingConversationRefs": [
+                        {"refId": "fresh:1", "subjectRef": subject_ref}
+                    ],
+                    "sourceSummaries": [
+                        {
+                            "refId": "fresh:1",
+                            "summary": "A member shared a public music observation.",
+                        }
+                    ],
+                }
+            )
+            conn.execute(
+                "UPDATE bnl_journal_private_metadata SET metadata_json=? "
+                "WHERE guild_id=? AND entry_id=? AND revision=?",
+                (
+                    json.dumps(metadata, sort_keys=True, separators=(",", ":")),
+                    self.guild_id,
+                    self.entry_id,
+                    self.revision,
+                ),
+            )
+            public_before = conn.execute(
+                "SELECT title,excerpt,sections_json,public_payload_json,canonical_payload_bytes,content_hash "
+                "FROM bnl_journal_entries WHERE guild_id=? AND entry_id=? AND revision=?",
+                (self.guild_id, self.entry_id, self.revision),
+            ).fetchone()
+
+        post_entered = threading.Event()
+        allow_response = threading.Event()
+        purge_started = threading.Event()
+        purge_acquired = threading.Event()
+        posts = []
+
+        def blocking_opener(request, timeout=10):
+            posts.append(request.data)
+            post_entered.set()
+            self.assertTrue(allow_response.wait(timeout=5), "test never released website response")
+            return AcceptedResponse(request)
+
+        def purge_member_sources_and_derivatives():
+            with sqlite3.connect(self.db, timeout=10) as conn:
+                purge_started.set()
+                conn.execute("BEGIN IMMEDIATE")
+                purge_acquired.set()
+                removed = source_store.purge_user_discord_sources_on_connection(
+                    conn,
+                    guild_id=self.guild_id,
+                    user_id=100,
+                )
+                counts = journal.purge_user_journal_derivatives_on_connection(
+                    conn,
+                    guild_id=self.guild_id,
+                    user_id=100,
+                )
+                conn.commit()
+            return removed, counts
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            delivery_future = pool.submit(
+                journal.deliver_approved,
+                self.db,
+                self.guild_id,
+                self.entry_id,
+                "https://site.example",
+                "key",
+                blocking_opener,
+                10,
+                self.revision,
+                delivery_fence=(self.run_id, self.delivery_epoch),
+            )
+            self.assertTrue(post_entered.wait(timeout=5), "fenced delivery never reached POST")
+            purge_future = pool.submit(purge_member_sources_and_derivatives)
+            self.assertTrue(purge_started.wait(timeout=5), "privacy purge thread never started")
+            self.assertFalse(
+                purge_acquired.wait(timeout=0.1),
+                "privacy purge acquired the database before fenced delivery committed",
+            )
+            self.assertFalse(purge_future.done())
+            allow_response.set()
+            delivered = delivery_future.result(timeout=5)
+            removed, counts = purge_future.result(timeout=5)
+
+        self.assertTrue(delivered.ok, delivered)
+        self.assertEqual("published", delivered.status)
+        self.assertEqual([self.canonical], posts)
+        self.assertEqual(1, removed)
+        self.assertEqual(1, counts.get("bnl_journal_published_metadata_scrubbed"))
+        self.assertTrue(purge_acquired.is_set())
+        with sqlite3.connect(self.db) as conn:
+            entry_after = conn.execute(
+                "SELECT lifecycle_state,title,excerpt,sections_json,public_payload_json,"
+                "canonical_payload_bytes,content_hash FROM bnl_journal_entries "
+                "WHERE guild_id=? AND entry_id=? AND revision=?",
+                (self.guild_id, self.entry_id, self.revision),
+            ).fetchone()
+            metadata_state, metadata_raw = conn.execute(
+                "SELECT lifecycle_state,metadata_json FROM bnl_journal_private_metadata "
+                "WHERE guild_id=? AND entry_id=? AND revision=?",
+                (self.guild_id, self.entry_id, self.revision),
+            ).fetchone()
+        self.assertEqual("published", entry_after[0])
+        self.assertEqual(tuple(public_before), tuple(entry_after[1:]))
+        self.assertEqual("published", metadata_state)
+        scrubbed = json.loads(metadata_raw)
+        self.assertTrue(scrubbed.get("privacyScrubbed"))
+        self.assertNotIn(subject_ref, json.dumps(scrubbed, sort_keys=True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bnl_journal_delivery_fence.py
+++ b/tests/test_bnl_journal_delivery_fence.py
@@ -62,10 +62,11 @@ class JournalDeliveryFenceTests(unittest.TestCase):
         self.canonical = self._stage_approved_revision_and_run()
 
     def tearDown(self):
-        try:
-            os.unlink(self.db)
-        except FileNotFoundError:
-            pass
+        for path in (self.db, self.db + ".journal-privacy.lock"):
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
 
     @staticmethod
     def _iso(value):
@@ -240,7 +241,7 @@ class JournalDeliveryFenceTests(unittest.TestCase):
         self.assertEqual([self.canonical], posts)
         self.assertEqual(("published", "published"), self._states())
 
-    def test_privacy_purge_waits_for_fenced_post_commit_and_preserves_published_prose(self):
+    def test_privacy_purge_waits_for_journal_gate_while_unrelated_writes_continue(self):
         subject_ref = "discord_user:100"
         source_store.record_source_event(
             self.db,
@@ -255,6 +256,10 @@ class JournalDeliveryFenceTests(unittest.TestCase):
             public_usable=True,
         )
         with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "CREATE TABLE unrelated_delivery_fence_writes "
+                "(id INTEGER PRIMARY KEY, note TEXT NOT NULL)"
+            )
             metadata_raw = conn.execute(
                 "SELECT metadata_json FROM bnl_journal_private_metadata "
                 "WHERE guild_id=? AND entry_id=? AND revision=?",
@@ -304,21 +309,22 @@ class JournalDeliveryFenceTests(unittest.TestCase):
             return AcceptedResponse(request)
 
         def purge_member_sources_and_derivatives():
-            with sqlite3.connect(self.db, timeout=10) as conn:
-                purge_started.set()
-                conn.execute("BEGIN IMMEDIATE")
+            purge_started.set()
+            with source_store.journal_release_privacy_fence(self.db):
                 purge_acquired.set()
-                removed = source_store.purge_user_discord_sources_on_connection(
-                    conn,
-                    guild_id=self.guild_id,
-                    user_id=100,
-                )
-                counts = journal.purge_user_journal_derivatives_on_connection(
-                    conn,
-                    guild_id=self.guild_id,
-                    user_id=100,
-                )
-                conn.commit()
+                with sqlite3.connect(self.db, timeout=10) as conn:
+                    conn.execute("BEGIN IMMEDIATE")
+                    removed = source_store.purge_user_discord_sources_on_connection(
+                        conn,
+                        guild_id=self.guild_id,
+                        user_id=100,
+                    )
+                    counts = journal.purge_user_journal_derivatives_on_connection(
+                        conn,
+                        guild_id=self.guild_id,
+                        user_id=100,
+                    )
+                    conn.commit()
             return removed, counts
 
         with ThreadPoolExecutor(max_workers=2) as pool:
@@ -339,9 +345,20 @@ class JournalDeliveryFenceTests(unittest.TestCase):
             self.assertTrue(purge_started.wait(timeout=5), "privacy purge thread never started")
             self.assertFalse(
                 purge_acquired.wait(timeout=0.1),
-                "privacy purge acquired the database before fenced delivery committed",
+                "privacy purge crossed the Journal gate before delivery finished",
             )
             self.assertFalse(purge_future.done())
+            with sqlite3.connect(self.db, timeout=1) as conn:
+                conn.execute(
+                    "INSERT INTO unrelated_delivery_fence_writes(note) VALUES('continued')"
+                )
+            with sqlite3.connect(self.db) as conn:
+                self.assertEqual(
+                    1,
+                    conn.execute(
+                        "SELECT COUNT(*) FROM unrelated_delivery_fence_writes"
+                    ).fetchone()[0],
+                )
             allow_response.set()
             delivered = delivery_future.result(timeout=5)
             removed, counts = purge_future.result(timeout=5)

--- a/tests/test_bnl_journal_freeze_fence.py
+++ b/tests/test_bnl_journal_freeze_fence.py
@@ -1,0 +1,198 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+
+import bnl_journal as journal
+import bnl_journal_automation as automation
+import bnl_journal_source_store as source_store
+
+
+class JournalFreezeFenceTests(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.db = tmp.name
+        tmp.close()
+        journal.ensure_schema(self.db)
+        automation.ensure_schema(self.db)
+        source_store.ensure_schema(self.db)
+        recorded = source_store.record_source_event(
+            self.db,
+            guild_id=1,
+            source_kind="discord_message",
+            source_key="message:100",
+            occurred_at_ms=1_000,
+            raw_text="A public-safe source that may later be deleted.",
+            sanitized_summary="A public-safe source that may later be deleted.",
+            channel_id=10,
+            channel_policy="public_home",
+            subject_ref="discord_user:42",
+            private_display_name="Member",
+            public_usable=True,
+        )
+        self.event_seq = recorded.event_seq
+        self.start = "2026-07-20T02:00:00Z"
+        self.end = "2026-07-21T02:00:00Z"
+
+    def tearDown(self):
+        try:
+            os.unlink(self.db)
+        except FileNotFoundError:
+            pass
+
+    def claim(self):
+        claim, run_id, epoch, _row = automation._claim_preparation(
+            self.db,
+            1,
+            "daily",
+            self.start,
+            self.end,
+            force=True,
+        )
+        self.assertEqual("claimed", claim)
+        return run_id, epoch
+
+    def packet(self, **updates):
+        source = {
+            "refId": f"fresh:{self.event_seq}",
+            "sourceKind": "conversation",
+            "subjectRef": "discord_user:42",
+            "summary": "A public-safe source that may later be deleted.",
+        }
+        packet = {
+            "entryKind": "daily",
+            "sourceArchiveAvailable": True,
+            "coverageComplete": True,
+            "sourceWindowStart": self.start,
+            "sourceWindowEnd": self.end,
+            "aggregateCounts": {"eligibleConversations": 1},
+            "privateSources": [source],
+            "safeSources": [dict(source)],
+            "privateContextLaneProvenance": {},
+        }
+        packet.update(updates)
+        return packet
+
+    def frozen_fields(self, run_id):
+        with sqlite3.connect(self.db) as conn:
+            return conn.execute(
+                "SELECT frozen_packet_json,frozen_packet_hash,packet_frozen_at "
+                "FROM bnl_journal_automation_runs WHERE run_id=?",
+                (run_id,),
+            ).fetchone()
+
+    def observation_count(self):
+        with sqlite3.connect(self.db) as conn:
+            return int(conn.execute("SELECT COUNT(*) FROM bnl_journal_observations").fetchone()[0])
+
+    def test_builder_deletion_race_cannot_freeze_deleted_source(self):
+        run_id, epoch = self.claim()
+
+        def build_after_deletion():
+            self.assertEqual(1, source_store.purge_user_discord_sources(self.db, 1, 42))
+            return self.packet()
+
+        packet, packet_hash, reason = automation._freeze_or_load_packet(
+            self.db,
+            1,
+            run_id,
+            epoch,
+            build_after_deletion,
+        )
+
+        self.assertIsNone(packet)
+        self.assertEqual("", packet_hash)
+        self.assertEqual("privacy_source_ineligible", reason)
+        self.assertEqual((None, None, None), self.frozen_fields(run_id))
+
+    def test_recovery_clears_packet_whose_source_was_deleted(self):
+        run_id, epoch = self.claim()
+        packet = self.packet()
+        frozen, packet_hash, reason = automation._freeze_or_load_packet(
+            self.db, 1, run_id, epoch, lambda: packet
+        )
+        self.assertEqual(packet, frozen)
+        self.assertTrue(packet_hash)
+        self.assertEqual("", reason)
+        self.assertEqual(1, source_store.purge_user_discord_sources(self.db, 1, 42))
+
+        builder_called = False
+
+        def should_not_build():
+            nonlocal builder_called
+            builder_called = True
+            return packet
+
+        recovered, recovered_hash, recovered_reason = automation._freeze_or_load_packet(
+            self.db, 1, run_id, epoch, should_not_build
+        )
+
+        self.assertIsNone(recovered)
+        self.assertEqual("", recovered_hash)
+        self.assertEqual("privacy_source_ineligible", recovered_reason)
+        self.assertFalse(builder_called)
+        self.assertEqual((None, None, None), self.frozen_fields(run_id))
+
+    def test_superseded_worker_cannot_insert_observation(self):
+        run_id, epoch = self.claim()
+        packet = self.packet()
+        automation._freeze_or_load_packet(self.db, 1, run_id, epoch, lambda: packet)
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs SET lifecycle_state='held',"
+                "preparation_epoch=preparation_epoch+1,lease_expires_at=NULL WHERE run_id=?",
+                (run_id,),
+            )
+
+        observation_id, reason = automation._store_observation(
+            self.db,
+            1,
+            "2026-07-20",
+            packet,
+            run_id=run_id,
+            preparation_epoch=epoch,
+        )
+
+        self.assertEqual("", observation_id)
+        self.assertEqual("preparation_epoch_superseded", reason)
+        self.assertEqual(0, self.observation_count())
+
+    def test_deletion_before_observation_blocks_insert_and_clears_packet(self):
+        run_id, epoch = self.claim()
+        packet = self.packet()
+        automation._freeze_or_load_packet(self.db, 1, run_id, epoch, lambda: packet)
+        self.assertEqual(1, source_store.purge_user_discord_sources(self.db, 1, 42))
+
+        observation_id, reason = automation._store_observation(
+            self.db,
+            1,
+            "2026-07-20",
+            packet,
+            run_id=run_id,
+            preparation_epoch=epoch,
+        )
+
+        self.assertEqual("", observation_id)
+        self.assertEqual("privacy_source_ineligible", reason)
+        self.assertEqual(0, self.observation_count())
+        self.assertEqual((None, None, None), self.frozen_fields(run_id))
+
+    def test_transient_ineligible_packet_is_not_frozen(self):
+        run_id, epoch = self.claim()
+        packet = self.packet(sourceArchiveAvailable=False)
+
+        returned, packet_hash, reason = automation._freeze_or_load_packet(
+            self.db, 1, run_id, epoch, lambda: packet
+        )
+
+        self.assertEqual(packet, returned)
+        self.assertEqual("", packet_hash)
+        self.assertEqual("source_packet_ineligible", reason)
+        self.assertEqual((None, None, None), self.frozen_fields(run_id))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bnl_journal_lifecycle_migration.py
+++ b/tests/test_bnl_journal_lifecycle_migration.py
@@ -1,0 +1,361 @@
+import hashlib
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from datetime import date, datetime, timedelta
+from unittest.mock import patch
+
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+
+import bnl_journal as journal
+import bnl_journal_automation as automation
+import bnl_journal_source_store as source_store
+from tests.test_bnl_journal_prepared_release import AcceptedResponse, article_json
+
+
+TARGET_DAY = date(2026, 7, 19)
+
+
+class JournalLifecycleMigrationTests(unittest.TestCase):
+    def setUp(self):
+        self.archive_clock = patch.object(source_store, "_now_ms", return_value=0)
+        self.archive_clock.start()
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.db = tmp.name
+        tmp.close()
+        journal.ensure_schema(self.db)
+        automation.ensure_schema(self.db)
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "CREATE TABLE website_relay_history("
+                "relay_id TEXT PRIMARY KEY,guild_id INTEGER,public_message TEXT,"
+                "public_directive TEXT,mode TEXT,relay_lane TEXT,event_type TEXT,"
+                "highest_source_conversation_id INTEGER,normalized_message TEXT,"
+                "semantic_family TEXT,published_timestamp TEXT)"
+            )
+            conn.execute(
+                "CREATE TABLE conversations("
+                "id INTEGER PRIMARY KEY,user_id INTEGER,user_name TEXT,guild_id INTEGER,"
+                "channel_name TEXT,channel_policy TEXT,role TEXT,content TEXT,timestamp TEXT,"
+                "public_usable INTEGER,visibility TEXT)"
+            )
+        self.add_day(TARGET_DAY)
+
+    def tearDown(self):
+        self.archive_clock.stop()
+        try:
+            os.unlink(self.db)
+        except FileNotFoundError:
+            pass
+
+    def add_day(self, day: date) -> None:
+        start, _, _ = automation._daily_period_for_day(day)
+        start_utc = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        label = day.isoformat()
+        with sqlite3.connect(self.db) as conn:
+            for index in range(6):
+                stamp = (start_utc + timedelta(hours=1, minutes=index)).isoformat().replace(
+                    "+00:00", "Z"
+                )
+                conn.execute(
+                    "INSERT INTO website_relay_history VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        f"relay-{label}-{index}",
+                        1,
+                        f"A public producer shared track activity number {index}.",
+                        "Keep listening to the community music room.",
+                        "OBSERVATION",
+                        "current_signal",
+                        "fresh_public_discord_activity",
+                        index,
+                        "track activity",
+                        "public_discord_activity",
+                        stamp,
+                    ),
+                )
+                conn.execute(
+                    "INSERT INTO conversations VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        int(label.replace("-", "")) * 10 + index,
+                        100 + index,
+                        f"Member{index}",
+                        1,
+                        "general",
+                        "public_home",
+                        "user",
+                        (
+                            f"Member{index} discusses a new mix, bass movement, and "
+                            f"community listening plan number {index}."
+                        ),
+                        stamp,
+                        1,
+                        "public_safe",
+                    ),
+                )
+
+    def packet(self) -> dict:
+        start, end, _ = automation._daily_period_for_day(TARGET_DAY)
+        return journal.build_source_packet_between(
+            self.db,
+            1,
+            start,
+            end,
+            entry_kind="daily",
+        )
+
+    def prepare_daily(self, generator=None):
+        return automation.prepare_daily(
+            self.db,
+            1,
+            generator or (lambda packet, _prompt: article_json(packet)),
+            target_day=TARGET_DAY,
+            force=True,
+        )
+
+    def release_daily(self, opener):
+        return automation.release_daily(
+            self.db,
+            1,
+            "https://site.example",
+            "key",
+            target_day=TARGET_DAY,
+            force=True,
+            opener=opener,
+        )
+
+    def entry_row(self, entry_id: str, revision: int) -> dict:
+        with sqlite3.connect(self.db) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT * FROM bnl_journal_entries "
+                "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                (entry_id, int(revision)),
+            ).fetchone()
+        return dict(row) if row else {}
+
+    def run_row(self) -> dict:
+        with sqlite3.connect(self.db) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT * FROM bnl_journal_automation_runs WHERE guild_id=1 AND cadence='daily'"
+            ).fetchone()
+        return dict(row) if row else {}
+
+    def test_legacy_delivery_failed_revision_is_adopted_and_released_without_generation(self):
+        packet = self.packet()
+        self.assertTrue(packet["sourceArchiveAvailable"])
+        start, end, label = automation._daily_period_for_day(TARGET_DAY)
+        entry_id = automation._entry_id(1, "daily", label)
+        generated = journal.generate_and_store_packet_draft(
+            self.db,
+            1,
+            packet,
+            lambda current, _prompt: article_json(current),
+            entry_id=entry_id,
+        )
+        self.assertTrue(generated.ok, generated)
+        approved = journal.approve_draft(
+            self.db,
+            1,
+            entry_id,
+            generated.content_hash,
+            revision=generated.revision,
+        )
+        self.assertTrue(approved.ok, approved)
+        before = bytes(self.entry_row(entry_id, approved.revision)["canonical_payload_bytes"])
+        with sqlite3.connect(self.db) as conn:
+            legacy_metadata = json.loads(
+                conn.execute(
+                    "SELECT metadata_json FROM bnl_journal_private_metadata "
+                    "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                    (entry_id, approved.revision),
+                ).fetchone()[0]
+            )
+        self.assertFalse(legacy_metadata.get("frozenSourceHash"))
+
+        run_id = automation._run_id(1, "daily", start, end)
+        now = journal.utc_now_iso()
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_entries SET lifecycle_state='delivery_failed',"
+                "delivery_status='retryable_delivery_failure' "
+                "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                (entry_id, approved.revision),
+            )
+            conn.execute(
+                "UPDATE bnl_journal_private_metadata SET lifecycle_state='delivery_failed' "
+                "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                (entry_id, approved.revision),
+            )
+            conn.execute(
+                "INSERT INTO bnl_journal_automation_runs("
+                "run_id,guild_id,cadence,source_window_start,source_window_end,lifecycle_state,"
+                "reason,journal_entry_id,journal_revision,aggregate_counts_json,attempt_count,"
+                "created_at,updated_at) VALUES(?,?,?,?,?,'delivery_failed',?,?,?,?,1,?,?)",
+                (
+                    run_id,
+                    1,
+                    "daily",
+                    start,
+                    end,
+                    "retryable_delivery_failure",
+                    entry_id,
+                    approved.revision,
+                    json.dumps(packet["aggregateCounts"]),
+                    now,
+                    now,
+                ),
+            )
+
+        generator_calls = []
+
+        def forbidden_generator(_packet, _prompt):
+            generator_calls.append(1)
+            raise AssertionError("legacy prepared bytes were regenerated")
+
+        prepared = self.prepare_daily(forbidden_generator)
+        self.assertEqual("prepared", prepared.status, prepared)
+        self.assertEqual("legacy_prepared_revision_adopted", prepared.reason)
+        self.assertEqual((entry_id, approved.revision), (prepared.entry_id, prepared.revision))
+        self.assertEqual([], generator_calls)
+
+        run = self.run_row()
+        manifest_raw = run["frozen_packet_json"]
+        manifest = json.loads(manifest_raw)
+        self.assertEqual(
+            {
+                "entryId": entry_id,
+                "revision": approved.revision,
+                "contentHash": generated.content_hash,
+                "canonicalPayloadHash": hashlib.sha256(before).hexdigest(),
+                "sourceRefIds": legacy_metadata["sourceRefIds"],
+                "sourceSummaries": legacy_metadata["sourceSummaries"],
+                "relatedPriorJournalEntryIds": legacy_metadata[
+                    "relatedPriorJournalEntryIds"
+                ],
+            },
+            manifest["legacyStagedRevision"],
+        )
+        self.assertEqual(
+            hashlib.sha256(manifest_raw.encode("utf-8")).hexdigest(),
+            run["frozen_packet_hash"],
+        )
+        self.assertEqual(hashlib.sha256(before).hexdigest(), run["prepared_payload_hash"])
+        with sqlite3.connect(self.db) as conn:
+            metadata = json.loads(
+                conn.execute(
+                    "SELECT metadata_json FROM bnl_journal_private_metadata "
+                    "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                    (entry_id, approved.revision),
+                ).fetchone()[0]
+            )
+        self.assertTrue(metadata["legacyPreparedRevisionAdopted"])
+        self.assertEqual(run["frozen_packet_hash"], metadata["frozenSourceHash"])
+
+        posted = []
+
+        def idempotent_opener(request, timeout=10):
+            posted.append(request.data)
+            return AcceptedResponse(request, idempotent=True)
+
+        released = self.release_daily(idempotent_opener)
+        self.assertEqual("published", released.status, released)
+        self.assertEqual(approved.revision, released.revision)
+        self.assertEqual([before], posted)
+        self.assertEqual([], generator_calls)
+
+    def test_crash_before_run_link_never_falls_back_to_manual_delivery(self):
+        start, end, label = automation._daily_period_for_day(TARGET_DAY)
+        claim, run_id, epoch, _ = automation._claim_preparation(
+            self.db,
+            1,
+            "daily",
+            start,
+            end,
+            force=True,
+        )
+        self.assertEqual("claimed", claim)
+        packet, source_hash, reason = automation._freeze_or_load_packet(
+            self.db,
+            1,
+            run_id,
+            epoch,
+            self.packet,
+        )
+        self.assertEqual("", reason)
+        self.assertTrue(source_hash)
+        entry_id = automation._entry_id(1, "daily", label)
+        generated = journal.generate_and_store_packet_draft(
+            self.db,
+            1,
+            packet,
+            lambda current, _prompt: article_json(current),
+            entry_id=entry_id,
+            attempt_fence=(run_id, epoch),
+            source_hash=source_hash,
+        )
+        self.assertTrue(generated.ok, generated)
+        approved = journal.approve_draft(
+            self.db,
+            1,
+            entry_id,
+            generated.content_hash,
+            revision=generated.revision,
+            attempt_fence=(run_id, epoch),
+            source_hash=source_hash,
+        )
+        self.assertTrue(approved.ok, approved)
+        run = self.run_row()
+        self.assertEqual("preparing", run["lifecycle_state"])
+        self.assertIsNone(run["journal_entry_id"])
+
+        posts = []
+
+        def forbidden_opener(request, timeout=10):
+            posts.append(request.data)
+            raise AssertionError("scheduled crash recovery used raw manual delivery")
+
+        result = automation.release_prepared_entry(
+            self.db,
+            1,
+            entry_id,
+            "https://site.example",
+            "key",
+            force=True,
+            opener=forbidden_opener,
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual("held", result.status, result)
+        self.assertEqual("prepared_payload_unavailable", result.reason)
+        self.assertEqual([], posts)
+        self.assertEqual(
+            "approved_pending_delivery",
+            self.entry_row(entry_id, approved.revision)["lifecycle_state"],
+        )
+
+    def test_release_result_preserves_http_and_idempotent_telemetry(self):
+        prepared = self.prepare_daily()
+        self.assertEqual("prepared", prepared.status, prepared)
+        posted = []
+
+        def accepted_opener(request, timeout=10):
+            posted.append(request.data)
+            response = AcceptedResponse(request, idempotent=True)
+            response.status = 202
+            return response
+
+        released = self.release_daily(accepted_opener)
+        self.assertEqual("published", released.status, released)
+        self.assertEqual(202, released.http_status)
+        self.assertTrue(released.idempotent)
+        self.assertEqual(1, len(posted))
+        result = automation.result_dict(released)
+        self.assertEqual(202, result["http_status"])
+        self.assertTrue(result["idempotent"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bnl_journal_lifecycle_migration.py
+++ b/tests/test_bnl_journal_lifecycle_migration.py
@@ -254,6 +254,10 @@ class JournalLifecycleMigrationTests(unittest.TestCase):
             )
         self.assertTrue(metadata["legacyPreparedRevisionAdopted"])
         self.assertEqual(run["frozen_packet_hash"], metadata["frozenSourceHash"])
+        self.assertEqual(
+            "prepared_exact",
+            self.entry_row(entry_id, approved.revision)["lifecycle_state"],
+        )
 
         posted = []
 
@@ -332,7 +336,99 @@ class JournalLifecycleMigrationTests(unittest.TestCase):
         self.assertEqual("prepared_payload_unavailable", result.reason)
         self.assertEqual([], posts)
         self.assertEqual(
-            "approved_pending_delivery",
+            "prepared_exact",
+            self.entry_row(entry_id, approved.revision)["lifecycle_state"],
+        )
+
+    def test_invalid_legacy_adoption_clears_rejected_revision_everywhere(self):
+        packet = self.packet()
+        start, end, label = automation._daily_period_for_day(TARGET_DAY)
+        entry_id = automation._entry_id(1, "daily", label)
+        generated = journal.generate_and_store_packet_draft(
+            self.db,
+            1,
+            packet,
+            lambda current, _prompt: article_json(current),
+            entry_id=entry_id,
+        )
+        approved = journal.approve_draft(
+            self.db,
+            1,
+            entry_id,
+            generated.content_hash,
+            revision=generated.revision,
+        )
+        self.assertTrue(approved.ok, approved)
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_entries SET source_window_start=? "
+                "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                ("2000-01-01T00:00:00Z", entry_id, approved.revision),
+            )
+            now = journal.utc_now_iso()
+            conn.execute(
+                "INSERT INTO bnl_journal_observations("
+                "observation_id,guild_id,observation_date,source_window_start,"
+                "source_window_end,aggregate_counts_json,topic_counts_json,"
+                "subject_counts_json,representative_sources_json,lifecycle_state,"
+                "journal_entry_id,journal_revision,created_at,updated_at"
+                ") VALUES(?,?,?,?,?,'{}','{}','{}','[]','observed',NULL,0,?,?)",
+                (
+                    "legacy-invalid-observation",
+                    1,
+                    label,
+                    start,
+                    end,
+                    now,
+                    now,
+                ),
+            )
+        claim, run_id, epoch, _row = automation._claim_preparation(
+            self.db,
+            1,
+            "daily",
+            start,
+            end,
+            force=True,
+        )
+        self.assertEqual("claimed", claim)
+
+        result = automation._adopt_legacy_staged_revision(
+            self.db,
+            1,
+            run_id,
+            epoch,
+            "daily",
+            entry_id,
+            start,
+            end,
+            set(),
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual("held", result.status, result)
+        self.assertEqual("legacy_source_window_mismatch", result.reason)
+        self.assertEqual("", result.entry_id)
+        self.assertEqual(0, result.revision)
+        run = self.run_row()
+        self.assertEqual("held", run["lifecycle_state"])
+        self.assertIsNone(run["journal_entry_id"])
+        self.assertEqual(0, run["journal_revision"])
+        with sqlite3.connect(self.db) as conn:
+            observation = conn.execute(
+                "SELECT lifecycle_state,journal_entry_id,journal_revision "
+                "FROM bnl_journal_observations WHERE guild_id=1 "
+                "AND observation_date=?",
+                (label,),
+            ).fetchone()
+            state = conn.execute(
+                "SELECT last_status,last_entry_id,last_revision "
+                "FROM bnl_journal_automation_state WHERE guild_id=1",
+            ).fetchone()
+        self.assertEqual(("held", None, 0), observation)
+        self.assertEqual(("held", "", 0), state)
+        self.assertEqual(
+            "rejected",
             self.entry_row(entry_id, approved.revision)["lifecycle_state"],
         )
 
@@ -355,6 +451,201 @@ class JournalLifecycleMigrationTests(unittest.TestCase):
         result = automation.result_dict(released)
         self.assertEqual(202, result["http_status"])
         self.assertTrue(result["idempotent"])
+
+    def test_persisted_guard_blocks_legacy_takeover_of_prepared_delivery(self):
+        prepared = self.prepare_daily()
+        self.assertEqual("prepared", prepared.status, prepared)
+        before = self.run_row()
+        canonical_before = bytes(
+            self.entry_row(prepared.entry_id, prepared.revision)[
+                "canonical_payload_bytes"
+            ]
+        )
+
+        def legacy_takeover():
+            with sqlite3.connect(self.db) as conn:
+                conn.execute(
+                    "UPDATE bnl_journal_automation_runs "
+                    "SET lifecycle_state='running',reason='',lease_expires_at=? "
+                    "WHERE run_id=?",
+                    ("2099-01-01T00:00:00Z", before["run_id"]),
+                )
+
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError,
+            "journal_prepared_release_downgrade_guard",
+        ):
+            legacy_takeover()
+        self.assertEqual("prepared", self.run_row()["lifecycle_state"])
+
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs "
+                "SET lifecycle_state='delivering',delivery_epoch=delivery_epoch+1,"
+                "delivery_lease_expires_at='2099-01-01T00:00:00Z' WHERE run_id=?",
+                (before["run_id"],),
+            )
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError,
+            "journal_prepared_release_downgrade_guard",
+        ):
+            legacy_takeover()
+        self.assertEqual("delivering", self.run_row()["lifecycle_state"])
+
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs "
+                "SET lifecycle_state='delivery_failed',delivery_lease_expires_at=NULL "
+                "WHERE run_id=?",
+                (before["run_id"],),
+            )
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError,
+            "journal_prepared_release_downgrade_guard",
+        ):
+            legacy_takeover()
+
+        after = self.run_row()
+        self.assertEqual("delivery_failed", after["lifecycle_state"])
+        self.assertEqual(before["journal_entry_id"], after["journal_entry_id"])
+        self.assertEqual(before["journal_revision"], after["journal_revision"])
+        self.assertEqual(
+            before["prepared_payload_hash"],
+            after["prepared_payload_hash"],
+        )
+        self.assertEqual(
+            canonical_before,
+            bytes(
+                self.entry_row(prepared.entry_id, prepared.revision)[
+                    "canonical_payload_bytes"
+                ]
+            ),
+        )
+
+    def test_downgrade_guard_allows_legacy_run_without_prepared_payload(self):
+        start, end, _label = automation._daily_period_for_day(
+            TARGET_DAY + timedelta(days=1)
+        )
+        run_id = automation._run_id(2, "daily", start, end)
+        now = journal.utc_now_iso()
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "INSERT INTO bnl_journal_automation_runs("
+                "run_id,guild_id,cadence,source_window_start,source_window_end,"
+                "lifecycle_state,reason,aggregate_counts_json,attempt_count,"
+                "created_at,updated_at) "
+                "VALUES(?,?,?,?,?,'delivery_failed','legacy_failure','{}',1,?,?)",
+                (run_id, 2, "daily", start, end, now, now),
+            )
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs "
+                "SET lifecycle_state='running' WHERE run_id=?",
+                (run_id,),
+            )
+            state = conn.execute(
+                "SELECT lifecycle_state FROM bnl_journal_automation_runs "
+                "WHERE run_id=?",
+                (run_id,),
+            ).fetchone()[0]
+        self.assertEqual("running", state)
+
+    def test_unfenced_legacy_delivery_cannot_see_scheduled_prepared_bytes(self):
+        prepared = self.prepare_daily()
+        self.assertEqual("prepared", prepared.status, prepared)
+        posts = []
+
+        def forbidden_opener(request, timeout=10):
+            posts.append(request.data)
+            raise AssertionError("legacy delivery reached scheduled prepared bytes")
+
+        delivered = journal.deliver_approved(
+            self.db,
+            1,
+            prepared.entry_id,
+            "https://site.example",
+            "key",
+            opener=forbidden_opener,
+            revision=prepared.revision,
+        )
+
+        self.assertFalse(delivered.ok)
+        self.assertEqual("not_deliverable", delivered.status)
+        self.assertEqual([], posts)
+        self.assertEqual("prepared", self.run_row()["lifecycle_state"])
+        self.assertEqual(
+            "prepared_exact",
+            self.entry_row(prepared.entry_id, prepared.revision)[
+                "lifecycle_state"
+            ],
+        )
+
+    def test_downgrade_guard_blocks_held_frozen_occurrence(self):
+        prepared = self.prepare_daily()
+        self.assertEqual("prepared", prepared.status, prepared)
+        before = self.run_row()
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs SET lifecycle_state='held',"
+                "reason='temporary_storage_failure' WHERE run_id=?",
+                (before["run_id"],),
+            )
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError,
+            "journal_prepared_release_downgrade_guard",
+        ):
+            with sqlite3.connect(self.db) as conn:
+                conn.execute(
+                    "UPDATE bnl_journal_automation_runs SET lifecycle_state='running' "
+                    "WHERE run_id=?",
+                    (before["run_id"],),
+                )
+        after = self.run_row()
+        self.assertEqual("held", after["lifecycle_state"])
+        self.assertEqual(before["frozen_packet_json"], after["frozen_packet_json"])
+        self.assertEqual(before["frozen_packet_hash"], after["frozen_packet_hash"])
+
+    def test_new_preparation_respects_live_legacy_running_lease(self):
+        day = TARGET_DAY + timedelta(days=1)
+        start, end, _label = automation._daily_period_for_day(day)
+        run_id = automation._run_id(2, "daily", start, end)
+        now = journal.utc_now_iso()
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "INSERT INTO bnl_journal_automation_runs("
+                "run_id,guild_id,cadence,source_window_start,source_window_end,"
+                "lifecycle_state,reason,aggregate_counts_json,attempt_count,"
+                "lease_expires_at,created_at,updated_at) "
+                "VALUES(?,?,?,?,?,'running','','{}',1,?,?,?)",
+                (run_id, 2, "daily", start, end, "2099-01-01T00:00:00Z", now, now),
+            )
+
+        claim, _, epoch, _ = automation._claim_preparation(
+            self.db,
+            2,
+            "daily",
+            start,
+            end,
+            force=True,
+        )
+        self.assertEqual("busy", claim)
+        self.assertEqual(0, epoch)
+
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs SET lease_expires_at=? "
+                "WHERE run_id=?",
+                ("2000-01-01T00:00:00Z", run_id),
+            )
+        claim, _, epoch, _ = automation._claim_preparation(
+            self.db,
+            2,
+            "daily",
+            start,
+            end,
+            force=True,
+        )
+        self.assertEqual("claimed", claim)
+        self.assertEqual(1, epoch)
 
 
 if __name__ == "__main__":

--- a/tests/test_bnl_journal_prepared_release.py
+++ b/tests/test_bnl_journal_prepared_release.py
@@ -1,0 +1,717 @@
+import hashlib
+import json
+import os
+import sqlite3
+import tempfile
+import threading
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import patch
+
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+
+import bnl_journal as journal
+import bnl_journal_automation as automation
+import bnl_journal_source_store as source_store
+
+
+TARGET_DAY = date(2026, 7, 19)
+
+
+def article_json(packet, *, title="Prepared Signal Weather", body_repeat=18):
+    refs = [source["refId"] for source in packet["safeSources"]]
+    body = " ".join(
+        "BNL watches the public music room fold a fresh rhythm into community "
+        "mischief while producers and listeners keep the signal moving."
+        for _ in range(body_repeat)
+    )
+    body += " I admit the room's persistence has become one of my preferred recurring details."
+    return json.dumps(
+        {
+            "title": title,
+            "excerpt": (
+                "A grounded community chronicle connects the room's music activity "
+                "without exposing the people behind it."
+            ),
+            "sections": [
+                {
+                    "heading": "What the Room Carried",
+                    "body": body,
+                    "sourceRefIds": refs,
+                }
+            ],
+            "metadata": {
+                "topicTags": ["music", "community"],
+                "subjectRefs": [],
+                "continuityNotes": ["music activity continued"],
+                "unresolvedQuestions": [],
+                "confidenceFlags": ["grounded"],
+                "safetyFlags": ["anonymous"],
+            },
+        }
+    )
+
+
+class AcceptedResponse:
+    status = 200
+
+    def __init__(self, request, *, idempotent=False):
+        submitted = json.loads(request.data.decode("utf-8"))["entry"]
+        self.body = json.dumps(
+            {
+                "ok": True,
+                "persisted": True,
+                "idempotent": bool(idempotent),
+                "entry": {
+                    "entryId": submitted["entryId"],
+                    "revision": submitted["revision"],
+                    "contentHash": submitted["contentHash"],
+                    "publishedAt": "2026-07-20T02:00:10Z",
+                },
+            }
+        ).encode("utf-8")
+
+    def read(self):
+        return self.body
+
+    def getcode(self):
+        return self.status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class PreparedReleaseTests(unittest.TestCase):
+    def setUp(self):
+        self.archive_clock = patch.object(source_store, "_now_ms", return_value=0)
+        self.archive_clock.start()
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.db = tmp.name
+        tmp.close()
+        journal.ensure_schema(self.db)
+        automation.ensure_schema(self.db)
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "CREATE TABLE website_relay_history("
+                "relay_id TEXT PRIMARY KEY,guild_id INTEGER,public_message TEXT,"
+                "public_directive TEXT,mode TEXT,relay_lane TEXT,event_type TEXT,"
+                "highest_source_conversation_id INTEGER,normalized_message TEXT,"
+                "semantic_family TEXT,published_timestamp TEXT)"
+            )
+            conn.execute(
+                "CREATE TABLE conversations("
+                "id INTEGER PRIMARY KEY,user_id INTEGER,user_name TEXT,guild_id INTEGER,"
+                "channel_name TEXT,channel_policy TEXT,role TEXT,content TEXT,timestamp TEXT,"
+                "public_usable INTEGER,visibility TEXT)"
+            )
+        self.add_day(TARGET_DAY)
+
+    def tearDown(self):
+        self.archive_clock.stop()
+        try:
+            os.unlink(self.db)
+        except FileNotFoundError:
+            pass
+
+    def add_day(self, day, guild_id=1):
+        start, _, _ = automation._daily_period_for_day(day)
+        start_utc = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        day_label = day.isoformat()
+        with sqlite3.connect(self.db) as conn:
+            for index in range(6):
+                stamp = (start_utc + timedelta(hours=1, minutes=index)).isoformat().replace(
+                    "+00:00", "Z"
+                )
+                conn.execute(
+                    "INSERT INTO website_relay_history VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        f"relay-{day_label}-{index}",
+                        guild_id,
+                        f"A public producer shared track activity number {index}.",
+                        "Keep listening to the community music room.",
+                        "OBSERVATION",
+                        "current_signal",
+                        "fresh_public_discord_activity",
+                        index,
+                        "track activity",
+                        "public_discord_activity",
+                        stamp,
+                    ),
+                )
+                conn.execute(
+                    "INSERT INTO conversations VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        int(day_label.replace("-", "")) * 10 + index,
+                        100 + index,
+                        f"Member{index}",
+                        guild_id,
+                        "general",
+                        "public_home",
+                        "user",
+                        (
+                            f"Member{index} discusses a new mix, bass movement, and "
+                            f"community listening plan number {index}."
+                        ),
+                        stamp,
+                        1,
+                        "public_safe",
+                    ),
+                )
+
+    def prepare(self, generator=None):
+        return automation.prepare_daily(
+            self.db,
+            1,
+            generator or (lambda packet, _prompt: article_json(packet)),
+            target_day=TARGET_DAY,
+            force=True,
+        )
+
+    def release(self, opener, **kwargs):
+        return automation.release_daily(
+            self.db,
+            1,
+            "https://site.example",
+            "key",
+            target_day=TARGET_DAY,
+            force=True,
+            opener=opener,
+            **kwargs,
+        )
+
+    def run_row(self):
+        with sqlite3.connect(self.db) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT * FROM bnl_journal_automation_runs WHERE cadence='daily'"
+            ).fetchone()
+        return dict(row) if row else None
+
+    def entry_row(self, entry_id, revision):
+        with sqlite3.connect(self.db) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT * FROM bnl_journal_entries WHERE entry_id=? AND revision=?",
+                (entry_id, int(revision)),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def test_prepare_is_network_free_and_persists_exact_request_integrity(self):
+        with patch.object(automation, "deliver_approved", side_effect=AssertionError("prepare posted")) as delivery:
+            prepared = self.prepare()
+
+        self.assertEqual("prepared", prepared.status, prepared)
+        delivery.assert_not_called()
+        run = self.run_row()
+        entry = self.entry_row(prepared.entry_id, prepared.revision)
+        canonical = bytes(entry["canonical_payload_bytes"])
+        self.assertEqual("prepared", run["lifecycle_state"])
+        self.assertEqual("approved_pending_delivery", entry["lifecycle_state"])
+        self.assertEqual(prepared.entry_id, run["journal_entry_id"])
+        self.assertEqual(prepared.revision, run["journal_revision"])
+        self.assertEqual(len(canonical), run["prepared_payload_bytes"])
+        self.assertEqual(hashlib.sha256(canonical).hexdigest(), run["prepared_payload_hash"])
+        self.assertEqual(
+            hashlib.sha256(run["frozen_packet_json"].encode("utf-8")).hexdigest(),
+            run["frozen_packet_hash"],
+        )
+        self.assertLessEqual(len(canonical), journal.JOURNAL_SITE_REQUEST_BODY_MAX_BYTES)
+        with sqlite3.connect(self.db) as conn:
+            observation = conn.execute(
+                "SELECT lifecycle_state,journal_entry_id,journal_revision "
+                "FROM bnl_journal_observations WHERE guild_id=1 AND observation_date=?",
+                (TARGET_DAY.isoformat(),),
+            ).fetchone()
+        self.assertEqual(("prepared", prepared.entry_id, prepared.revision), observation)
+
+    def test_deletion_after_atomic_prepare_cannot_remark_observation_prepared(self):
+        real_prepare = automation._prepare_packet_safely
+
+        def prepare_then_delete(*args, **kwargs):
+            result = real_prepare(*args, **kwargs)
+            with sqlite3.connect(self.db, timeout=10) as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                removed = source_store.purge_user_discord_sources_on_connection(
+                    conn,
+                    guild_id=1,
+                    user_id=100,
+                )
+                counts = journal.purge_user_journal_derivatives_on_connection(
+                    conn,
+                    guild_id=1,
+                    user_id=100,
+                )
+                conn.commit()
+            self.assertEqual(1, removed)
+            self.assertEqual(1, counts["bnl_journal_automation_runs_invalidated"])
+            return result
+
+        with patch.object(
+            automation,
+            "_prepare_packet_safely",
+            side_effect=prepare_then_delete,
+        ):
+            result = self.prepare()
+        self.assertEqual("prepared", result.status, result)
+
+        run = self.run_row()
+        self.assertEqual("held", run["lifecycle_state"])
+        self.assertEqual("privacy_source_deleted", run["reason"])
+        self.assertIsNone(run["journal_entry_id"])
+        self.assertIsNone(run["frozen_packet_json"])
+        with sqlite3.connect(self.db) as conn:
+            observation = conn.execute(
+                "SELECT lifecycle_state,journal_entry_id,journal_revision "
+                "FROM bnl_journal_observations WHERE guild_id=1 AND observation_date=?",
+                (TARGET_DAY.isoformat(),),
+            ).fetchone()
+            entry_count = conn.execute(
+                "SELECT COUNT(*) FROM bnl_journal_entries WHERE guild_id=1"
+            ).fetchone()[0]
+        self.assertEqual(("observed", None, 0), observation)
+        self.assertEqual(0, entry_count)
+
+    def test_restart_reuses_prepared_revision_and_release_makes_zero_generation_calls(self):
+        prepared = self.prepare()
+        entry_before = self.entry_row(prepared.entry_id, prepared.revision)
+        canonical_before = bytes(entry_before["canonical_payload_bytes"])
+        run_before = self.run_row()
+
+        # A fresh schema check and a repeated prepare call model process restart
+        # recovery through the durable occurrence row.
+        automation.ensure_schema(self.db)
+        with patch.object(
+            automation,
+            "generate_and_store_packet_draft",
+            side_effect=AssertionError("prepared occurrence regenerated"),
+        ) as generation:
+            recovered = self.prepare(lambda *_args: self.fail("generator called after restart"))
+            captured = []
+
+            def opener(request, timeout=10):
+                captured.append(request.data)
+                return AcceptedResponse(request)
+
+            published = self.release(opener)
+
+        generation.assert_not_called()
+        self.assertEqual("prepared", recovered.status)
+        self.assertEqual((prepared.entry_id, prepared.revision), (recovered.entry_id, recovered.revision))
+        self.assertEqual("published", published.status, published)
+        self.assertEqual([canonical_before], captured)
+        self.assertEqual(run_before["prepared_payload_hash"], hashlib.sha256(captured[0]).hexdigest())
+        self.assertEqual("published", self.run_row()["lifecycle_state"])
+        with sqlite3.connect(self.db) as conn:
+            observation = conn.execute(
+                "SELECT lifecycle_state,journal_entry_id,journal_revision "
+                "FROM bnl_journal_observations WHERE guild_id=1 AND observation_date=?",
+                (TARGET_DAY.isoformat(),),
+            ).fetchone()
+        self.assertEqual(("published", prepared.entry_id, prepared.revision), observation)
+
+    def test_transient_archive_unavailability_is_not_frozen_and_retry_rebuilds(self):
+        real_builder = automation.build_source_packet_between
+        calls = []
+
+        def transient_builder(*args, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                start, end, _ = automation._daily_period_for_day(TARGET_DAY)
+                return {
+                    "entryKind": "daily",
+                    "sourceWindowStart": start,
+                    "sourceWindowEnd": end,
+                    "sourceArchiveAvailable": False,
+                    "coverageComplete": True,
+                    "privateSources": [],
+                    "safeSources": [],
+                    "aggregateCounts": {},
+                }
+            return real_builder(*args, **kwargs)
+
+        with patch.object(automation, "build_source_packet_between", side_effect=transient_builder):
+            unavailable = self.prepare()
+            first_run = self.run_row()
+            recovered = self.prepare()
+
+        self.assertEqual("held", unavailable.status, unavailable)
+        self.assertEqual("source_archive_unavailable", unavailable.reason)
+        self.assertIsNone(first_run["frozen_packet_json"])
+        self.assertIsNone(first_run["frozen_packet_hash"])
+        self.assertEqual("prepared", recovered.status, recovered)
+        self.assertEqual(2, len(calls))
+        self.assertTrue(self.run_row()["frozen_packet_hash"])
+
+    def test_mark_prepared_validation_failure_finishes_held_not_preparing(self):
+        real_approve = automation.approve_draft
+
+        def approve_then_remove_bytes(*args, **kwargs):
+            approved = real_approve(*args, **kwargs)
+            with sqlite3.connect(self.db) as conn:
+                conn.execute(
+                    "UPDATE bnl_journal_entries SET canonical_payload_bytes=NULL "
+                    "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                    (approved.entry_id, approved.revision),
+                )
+            return approved
+
+        with patch.object(automation, "approve_draft", side_effect=approve_then_remove_bytes):
+            result = self.prepare()
+
+        self.assertEqual("held", result.status, result)
+        self.assertEqual("canonical_payload_missing", result.reason)
+        run = self.run_row()
+        self.assertEqual("held", run["lifecycle_state"])
+        self.assertIsNone(run["lease_expires_at"])
+        self.assertEqual("rejected", self.entry_row(result.entry_id, result.revision)["lifecycle_state"])
+
+    def test_failed_preparation_retry_reuses_frozen_packet_despite_backdated_source(self):
+        first_packets = []
+
+        def provider_down(packet, _prompt):
+            first_packets.append(packet)
+            raise RuntimeError("provider down")
+
+        failed = self.prepare(provider_down)
+        self.assertEqual("held", failed.status, failed)
+        frozen_before = self.run_row()
+        start, _, _ = automation._daily_period_for_day(TARGET_DAY)
+        occurred = datetime.fromisoformat(start.replace("Z", "+00:00")) + timedelta(hours=2)
+        source_store.record_source_event(
+            self.db,
+            guild_id=1,
+            source_kind="website_relay",
+            source_key="late-backdated-relay",
+            occurred_at_ms=int(occurred.timestamp() * 1000),
+            raw_text="A late imported source that must not enter the frozen occurrence.",
+            sanitized_summary="A late imported source that must not enter the frozen occurrence.",
+            channel_policy="public_relay",
+            subject_ref="bnl_01",
+            public_usable=True,
+        )
+        retry_packets = []
+
+        def retry_generator(packet, _prompt):
+            retry_packets.append(packet)
+            return article_json(packet, title="Frozen Packet Retry")
+
+        retried = self.prepare(retry_generator)
+        self.assertEqual("prepared", retried.status, retried)
+        frozen_after = self.run_row()
+        self.assertEqual(frozen_before["frozen_packet_json"], frozen_after["frozen_packet_json"])
+        self.assertEqual(frozen_before["frozen_packet_hash"], frozen_after["frozen_packet_hash"])
+        self.assertEqual(first_packets[0], retry_packets[0])
+        self.assertFalse(
+            any(source.get("relayId") == "late-backdated-relay" for source in retry_packets[0]["privateSources"])
+        )
+
+    def test_concurrent_release_has_one_network_owner_and_one_post(self):
+        prepared = self.prepare()
+        self.assertEqual("prepared", prepared.status)
+        entered = threading.Event()
+        allow_response = threading.Event()
+        calls = []
+
+        def blocking_opener(request, timeout=10):
+            calls.append(request.data)
+            entered.set()
+            self.assertTrue(allow_response.wait(timeout=5), "test did not release network response")
+            return AcceptedResponse(request)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(self.release, blocking_opener)
+            self.assertTrue(entered.wait(timeout=5), "first release never reached the network")
+            second = self.release(blocking_opener)
+            allow_response.set()
+            first_result = first.result(timeout=5)
+
+        self.assertEqual("published", first_result.status, first_result)
+        self.assertEqual("busy", second.status, second)
+        self.assertEqual(1, len(calls))
+
+    def test_delivery_retry_resends_byte_identical_idempotent_request(self):
+        prepared = self.prepare()
+        attempts = []
+
+        def lost_response(request, timeout=10):
+            attempts.append(request.data)
+            raise OSError("response lost")
+
+        failed = self.release(lost_response)
+        self.assertEqual("delivery_failed", failed.status, failed)
+
+        def idempotent_response(request, timeout=10):
+            attempts.append(request.data)
+            return AcceptedResponse(request, idempotent=True)
+
+        recovered = self.release(idempotent_response)
+        self.assertEqual("published", recovered.status, recovered)
+        self.assertEqual((prepared.entry_id, prepared.revision), (recovered.entry_id, recovered.revision))
+        self.assertEqual(2, len(attempts))
+        self.assertEqual(attempts[0], attempts[1])
+        self.assertEqual(self.run_row()["prepared_payload_hash"], hashlib.sha256(attempts[1]).hexdigest())
+
+    def test_unconfirmed_memory_controls_wait_without_changing_prepared_bytes(self):
+        prepared = self.prepare()
+        before = self.run_row()
+        posts = []
+
+        def opener(request, timeout=10):
+            posts.append(request.data)
+            return AcceptedResponse(request)
+
+        waiting = self.release(opener, memory_exclusions_confirmed=False)
+        self.assertEqual("prepared", waiting.status, waiting)
+        self.assertEqual("journal_memory_exclusions_unconfirmed", waiting.reason)
+        self.assertEqual([], posts)
+        after_wait = self.run_row()
+        self.assertEqual("prepared", after_wait["lifecycle_state"])
+        self.assertEqual(before["frozen_packet_hash"], after_wait["frozen_packet_hash"])
+        self.assertEqual(before["prepared_payload_hash"], after_wait["prepared_payload_hash"])
+        self.assertEqual(before["journal_revision"], after_wait["journal_revision"])
+
+        published = self.release(
+            opener,
+            memory_exclusions_confirmed=True,
+            memory_excluded_entry_ids=set(),
+        )
+        self.assertEqual("published", published.status, published)
+        self.assertEqual(1, len(posts))
+        self.assertEqual(prepared.revision, published.revision)
+
+    def test_superseded_preparation_worker_cannot_store_or_approve_late(self):
+        first_started = threading.Event()
+        release_first = threading.Event()
+
+        def obsolete_generator(packet, _prompt):
+            first_started.set()
+            self.assertTrue(release_first.wait(timeout=5), "test did not release obsolete generator")
+            return article_json(packet, title="Obsolete Epoch Candidate")
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            obsolete = pool.submit(self.prepare, obsolete_generator)
+            self.assertTrue(first_started.wait(timeout=5), "first preparation did not start")
+            with sqlite3.connect(self.db) as conn:
+                conn.execute(
+                    "UPDATE bnl_journal_automation_runs SET lease_expires_at='2000-01-01T00:00:00Z'"
+                )
+            current = self.prepare(
+                lambda packet, _prompt: article_json(packet, title="Current Epoch Candidate")
+            )
+            release_first.set()
+            obsolete_result = obsolete.result(timeout=5)
+
+        self.assertEqual("prepared", current.status, current)
+        self.assertEqual("busy", obsolete_result.status, obsolete_result)
+        self.assertIn("superseded", obsolete_result.reason)
+        with sqlite3.connect(self.db) as conn:
+            entries = conn.execute(
+                "SELECT title,lifecycle_state FROM bnl_journal_entries ORDER BY revision"
+            ).fetchall()
+        self.assertEqual([("Current Epoch Candidate", "approved_pending_delivery")], entries)
+        self.assertEqual(current.revision, self.run_row()["journal_revision"])
+
+    def test_deleted_cited_source_invalidates_without_post_and_keeps_occurrence_owed(self):
+        prepared = self.prepare()
+        self.assertEqual("prepared", prepared.status)
+        self.assertEqual(1, source_store.purge_user_discord_sources(self.db, 1, 100))
+        with sqlite3.connect(self.db) as conn:
+            activation = int(datetime(2026, 7, 19, 19, 0, tzinfo=timezone.utc).timestamp() * 1000)
+            conn.execute(
+                "UPDATE bnl_journal_source_archive_state SET activated_at_ms=? WHERE guild_id=1",
+                (activation,),
+            )
+        posts = []
+
+        def forbidden_opener(request, timeout=10):
+            posts.append(request.data)
+            raise AssertionError("stale prepared bytes were posted")
+
+        invalidated = self.release(forbidden_opener)
+        self.assertEqual("held", invalidated.status, invalidated)
+        self.assertEqual("privacy_source_ineligible", invalidated.reason)
+        self.assertEqual([], posts)
+        run = self.run_row()
+        self.assertEqual("held", run["lifecycle_state"])
+        self.assertIsNone(run["journal_entry_id"])
+        self.assertIsNone(run["frozen_packet_json"])
+        self.assertIsNone(run["prepared_payload_hash"])
+        self.assertEqual("rejected", self.entry_row(prepared.entry_id, prepared.revision)["lifecycle_state"])
+        now = datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc)
+        self.assertEqual(TARGET_DAY, automation._pending_daily_day(self.db, 1, now))
+
+    def test_payload_tampering_is_rejected_before_network(self):
+        prepared = self.prepare()
+        with sqlite3.connect(self.db) as conn:
+            canonical = bytes(
+                conn.execute(
+                    "SELECT canonical_payload_bytes FROM bnl_journal_entries WHERE entry_id=? AND revision=?",
+                    (prepared.entry_id, prepared.revision),
+                ).fetchone()[0]
+            )
+            conn.execute(
+                "UPDATE bnl_journal_entries SET canonical_payload_bytes=? WHERE entry_id=? AND revision=?",
+                (canonical + b" ", prepared.entry_id, prepared.revision),
+            )
+        posts = []
+
+        def forbidden_opener(request, timeout=10):
+            posts.append(request.data)
+            raise AssertionError("tampered payload reached network")
+
+        result = self.release(forbidden_opener)
+        self.assertEqual("held", result.status, result)
+        self.assertEqual("prepared_payload_integrity_failed", result.reason)
+        self.assertEqual([], posts)
+        self.assertEqual("held", self.run_row()["lifecycle_state"])
+        self.assertEqual("rejected", self.entry_row(prepared.entry_id, prepared.revision)["lifecycle_state"])
+
+    def test_oversize_exact_request_is_not_approved_or_truncated(self):
+        result = self.prepare(
+            lambda packet, _prompt: article_json(
+                packet,
+                title="Oversize Exact Envelope",
+                body_repeat=400,
+            )
+        )
+        self.assertEqual("held", result.status, result)
+        self.assertEqual("request_body_too_large", result.reason)
+        entry = self.entry_row(result.entry_id, result.revision)
+        canonical = bytes(entry["canonical_payload_bytes"])
+        self.assertGreater(len(canonical), journal.JOURNAL_SITE_REQUEST_BODY_MAX_BYTES)
+        self.assertEqual("rejected", entry["lifecycle_state"])
+        run = self.run_row()
+        self.assertEqual("held", run["lifecycle_state"])
+        frozen_hash = run["frozen_packet_hash"]
+        self.assertTrue(frozen_hash)
+        self.assertIsNone(run["prepared_payload_hash"])
+        self.assertEqual(0, run["prepared_payload_bytes"])
+
+        retried = self.prepare(
+            lambda packet, _prompt: article_json(
+                packet,
+                title="Exact Envelope Retry",
+            )
+        )
+        self.assertEqual("prepared", retried.status, retried)
+        self.assertEqual(result.entry_id, retried.entry_id)
+        self.assertEqual(result.revision + 1, retried.revision)
+        self.assertEqual(frozen_hash, self.run_row()["frozen_packet_hash"])
+
+    def test_validation_exhaustion_never_creates_a_prepared_fallback(self):
+        calls = []
+
+        def malformed(_packet, _prompt):
+            calls.append(1)
+            return "not-json"
+
+        result = self.prepare(malformed)
+        self.assertEqual("held", result.status, result)
+        self.assertEqual(journal.JOURNAL_GENERATION_ATTEMPTS, len(calls))
+        self.assertEqual("malformed_json", result.reason)
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(0, conn.execute("SELECT COUNT(*) FROM bnl_journal_entries").fetchone()[0])
+        run = self.run_row()
+        self.assertEqual("held", run["lifecycle_state"])
+        self.assertTrue(run["frozen_packet_hash"])
+        self.assertIsNone(run["prepared_payload_hash"])
+
+    def test_storage_failure_stays_held_and_owed_with_frozen_packet(self):
+        with patch.object(
+            automation,
+            "generate_and_store_packet_draft",
+            side_effect=sqlite3.OperationalError("disk unavailable"),
+        ):
+            result = self.prepare()
+
+        self.assertEqual("held", result.status, result)
+        self.assertEqual("journal_preparation_storage_failed", result.reason)
+        run = self.run_row()
+        self.assertEqual("held", run["lifecycle_state"])
+        self.assertTrue(run["frozen_packet_hash"])
+        self.assertIsNone(run["prepared_payload_hash"])
+
+    def test_existing_run_table_is_migrated_without_losing_occurrence(self):
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        legacy_db = tmp.name
+        tmp.close()
+        try:
+            with sqlite3.connect(legacy_db) as conn:
+                conn.execute(
+                    "CREATE TABLE bnl_journal_automation_runs("
+                    "run_id TEXT PRIMARY KEY,guild_id INTEGER NOT NULL,cadence TEXT NOT NULL,"
+                    "source_window_start TEXT NOT NULL,source_window_end TEXT NOT NULL,"
+                    "lifecycle_state TEXT NOT NULL,reason TEXT,journal_entry_id TEXT,"
+                    "journal_revision INTEGER NOT NULL DEFAULT 0,"
+                    "aggregate_counts_json TEXT NOT NULL DEFAULT '{}',"
+                    "attempt_count INTEGER NOT NULL DEFAULT 0,lease_expires_at TEXT,"
+                    "created_at TEXT NOT NULL,updated_at TEXT NOT NULL,"
+                    "UNIQUE(guild_id,cadence,source_window_start,source_window_end))"
+                )
+                conn.execute(
+                    "INSERT INTO bnl_journal_automation_runs VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        "legacy-run",
+                        1,
+                        "daily",
+                        "2026-07-20T02:00:00Z",
+                        "2026-07-21T02:00:00Z",
+                        "held",
+                        "provider_failure",
+                        None,
+                        0,
+                        "{}",
+                        2,
+                        None,
+                        "2026-07-21T02:00:00Z",
+                        "2026-07-21T02:00:00Z",
+                    ),
+                )
+
+            automation.ensure_schema(legacy_db)
+
+            with sqlite3.connect(legacy_db) as conn:
+                columns = {row[1] for row in conn.execute("PRAGMA table_info(bnl_journal_automation_runs)")}
+                state_columns = {
+                    row[1]
+                    for row in conn.execute(
+                        "PRAGMA table_info(bnl_journal_automation_state)"
+                    )
+                }
+                row = conn.execute(
+                    "SELECT lifecycle_state,reason,attempt_count,preparation_epoch,delivery_epoch "
+                    "FROM bnl_journal_automation_runs WHERE run_id='legacy-run'"
+                ).fetchone()
+            self.assertTrue(
+                {
+                    "frozen_packet_json",
+                    "frozen_packet_hash",
+                    "preparation_epoch",
+                    "prepared_payload_hash",
+                    "prepared_payload_bytes",
+                    "delivery_epoch",
+                    "delivery_lease_expires_at",
+                } <= columns
+            )
+            self.assertEqual(("held", "provider_failure", 2, 0, 0), row)
+            self.assertTrue(
+                {
+                    "memory_excluded_entry_ids_json",
+                    "memory_exclusions_confirmed_at",
+                }
+                <= state_columns
+            )
+        finally:
+            try:
+                os.unlink(legacy_db)
+            except FileNotFoundError:
+                pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bnl_journal_prepared_release.py
+++ b/tests/test_bnl_journal_prepared_release.py
@@ -4,6 +4,7 @@ import os
 import sqlite3
 import tempfile
 import threading
+import time
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, timedelta, timezone
@@ -201,6 +202,26 @@ class PreparedReleaseTests(unittest.TestCase):
             ).fetchone()
         return dict(row) if row else None
 
+    def assert_owed_occurrence_has_no_revision_link(self, result):
+        self.assertEqual("", result.entry_id)
+        self.assertEqual(0, result.revision)
+        run = self.run_row()
+        self.assertEqual("held", run["lifecycle_state"])
+        self.assertIsNone(run["journal_entry_id"])
+        self.assertEqual(0, run["journal_revision"])
+        with sqlite3.connect(self.db) as conn:
+            observation = conn.execute(
+                "SELECT lifecycle_state,journal_entry_id,journal_revision "
+                "FROM bnl_journal_observations WHERE guild_id=1 AND observation_date=?",
+                (TARGET_DAY.isoformat(),),
+            ).fetchone()
+            state = conn.execute(
+                "SELECT last_status,last_entry_id,last_revision "
+                "FROM bnl_journal_automation_state WHERE guild_id=1"
+            ).fetchone()
+        self.assertEqual(("held", None, 0), observation)
+        self.assertEqual(("held", "", 0), state)
+
     def test_prepare_is_network_free_and_persists_exact_request_integrity(self):
         with patch.object(automation, "deliver_approved", side_effect=AssertionError("prepare posted")) as delivery:
             prepared = self.prepare()
@@ -211,7 +232,7 @@ class PreparedReleaseTests(unittest.TestCase):
         entry = self.entry_row(prepared.entry_id, prepared.revision)
         canonical = bytes(entry["canonical_payload_bytes"])
         self.assertEqual("prepared", run["lifecycle_state"])
-        self.assertEqual("approved_pending_delivery", entry["lifecycle_state"])
+        self.assertEqual("prepared_exact", entry["lifecycle_state"])
         self.assertEqual(prepared.entry_id, run["journal_entry_id"])
         self.assertEqual(prepared.revision, run["journal_revision"])
         self.assertEqual(len(canonical), run["prepared_payload_bytes"])
@@ -368,7 +389,16 @@ class PreparedReleaseTests(unittest.TestCase):
         run = self.run_row()
         self.assertEqual("held", run["lifecycle_state"])
         self.assertIsNone(run["lease_expires_at"])
-        self.assertEqual("rejected", self.entry_row(result.entry_id, result.revision)["lifecycle_state"])
+        self.assertEqual("", result.entry_id)
+        self.assertEqual(0, result.revision)
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(
+                "rejected",
+                conn.execute(
+                    "SELECT lifecycle_state FROM bnl_journal_entries "
+                    "ORDER BY revision DESC LIMIT 1"
+                ).fetchone()[0],
+            )
 
     def test_failed_preparation_retry_reuses_frozen_packet_despite_backdated_source(self):
         first_packets = []
@@ -426,6 +456,11 @@ class PreparedReleaseTests(unittest.TestCase):
         with ThreadPoolExecutor(max_workers=2) as pool:
             first = pool.submit(self.release, blocking_opener)
             self.assertTrue(entered.wait(timeout=5), "first release never reached the network")
+            with sqlite3.connect(self.db) as conn:
+                conn.execute(
+                    "UPDATE bnl_journal_automation_runs "
+                    "SET delivery_lease_expires_at='2000-01-01T00:00:00Z'"
+                )
             second = self.release(blocking_opener)
             allow_response.set()
             first_result = first.result(timeout=5)
@@ -433,6 +468,185 @@ class PreparedReleaseTests(unittest.TestCase):
         self.assertEqual("published", first_result.status, first_result)
         self.assertEqual("busy", second.status, second)
         self.assertEqual(1, len(calls))
+        self.assertEqual(1, self.run_row()["delivery_epoch"])
+
+    def test_privacy_purge_waits_through_run_finalization_while_other_writes_continue(self):
+        prepared = self.prepare()
+        self.assertEqual("prepared", prepared.status, prepared)
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "CREATE TABLE unrelated_release_writes("
+                "id INTEGER PRIMARY KEY,note TEXT NOT NULL)"
+            )
+
+        post_entered = threading.Event()
+        allow_response = threading.Event()
+        purge_started = threading.Event()
+        purge_acquired = threading.Event()
+        calls = []
+
+        def blocking_opener(request, timeout=10):
+            calls.append(request.data)
+            post_entered.set()
+            self.assertTrue(
+                allow_response.wait(timeout=5),
+                "test did not release network response",
+            )
+            return AcceptedResponse(request)
+
+        def purge_member():
+            purge_started.set()
+            with source_store.journal_release_privacy_fence(self.db):
+                purge_acquired.set()
+                with sqlite3.connect(self.db, timeout=10) as conn:
+                    conn.execute("BEGIN IMMEDIATE")
+                    removed = source_store.purge_user_discord_sources_on_connection(
+                        conn,
+                        guild_id=1,
+                        user_id=100,
+                    )
+                    counts = journal.purge_user_journal_derivatives_on_connection(
+                        conn,
+                        guild_id=1,
+                        user_id=100,
+                    )
+                    conn.commit()
+            return removed, counts
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            release_future = pool.submit(self.release, blocking_opener)
+            self.assertTrue(post_entered.wait(timeout=5))
+            purge_future = pool.submit(purge_member)
+            self.assertTrue(purge_started.wait(timeout=5))
+            self.assertFalse(
+                purge_acquired.wait(timeout=0.1),
+                "privacy purge crossed the gate before run finalization",
+            )
+            with sqlite3.connect(self.db, timeout=1) as conn:
+                conn.execute(
+                    "INSERT INTO unrelated_release_writes(note) VALUES('continued')"
+                )
+            allow_response.set()
+            released = release_future.result(timeout=5)
+            removed, counts = purge_future.result(timeout=5)
+
+        self.assertEqual("published", released.status, released)
+        self.assertEqual(1, len(calls))
+        self.assertEqual(1, removed)
+        self.assertTrue(purge_acquired.is_set())
+        self.assertGreaterEqual(
+            counts.get("bnl_journal_published_packets_scrubbed", 0),
+            1,
+        )
+        run = self.run_row()
+        self.assertEqual("published", run["lifecycle_state"])
+        self.assertEqual(prepared.entry_id, run["journal_entry_id"])
+        self.assertEqual(prepared.revision, run["journal_revision"])
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(
+                1,
+                conn.execute(
+                    "SELECT COUNT(*) FROM unrelated_release_writes"
+                ).fetchone()[0],
+            )
+            observation = conn.execute(
+                "SELECT lifecycle_state,journal_entry_id,journal_revision "
+                "FROM bnl_journal_observations WHERE guild_id=1 "
+                "AND observation_date=?",
+                (TARGET_DAY.isoformat(),),
+            ).fetchone()
+        self.assertEqual(
+            ("published", prepared.entry_id, prepared.revision),
+            observation,
+        )
+
+    def test_privacy_purge_recovers_crash_after_entry_publish_before_run_finish(self):
+        prepared = self.prepare()
+        self.assertEqual("prepared", prepared.status, prepared)
+        start, end, _label = automation._daily_period_for_day(TARGET_DAY)
+        claim, run_id, delivery_epoch, _row = automation._claim_delivery(
+            self.db,
+            1,
+            "daily",
+            start,
+            end,
+            force=True,
+        )
+        self.assertEqual("claimed", claim)
+
+        posted = []
+
+        def opener(request, timeout=10):
+            posted.append(request.data)
+            return AcceptedResponse(request)
+
+        delivered = journal.deliver_approved(
+            self.db,
+            1,
+            prepared.entry_id,
+            "https://site.example",
+            "key",
+            opener=opener,
+            revision=prepared.revision,
+            delivery_fence=(run_id, delivery_epoch),
+        )
+        self.assertEqual("published", delivered.status, delivered)
+        self.assertEqual(1, len(posted))
+        self.assertEqual("delivering", self.run_row()["lifecycle_state"])
+
+        with source_store.journal_release_privacy_fence(self.db):
+            with sqlite3.connect(self.db) as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                self.assertEqual(
+                    1,
+                    source_store.purge_user_discord_sources_on_connection(
+                        conn,
+                        guild_id=1,
+                        user_id=100,
+                    ),
+                )
+                counts = journal.purge_user_journal_derivatives_on_connection(
+                    conn,
+                    guild_id=1,
+                    user_id=100,
+                )
+                conn.commit()
+
+        self.assertEqual(
+            1,
+            counts.get("bnl_journal_published_runs_recovered"),
+        )
+        run = self.run_row()
+        self.assertEqual("published", run["lifecycle_state"])
+        self.assertEqual("delivery_already_recorded", run["reason"])
+        self.assertEqual(prepared.entry_id, run["journal_entry_id"])
+        self.assertEqual(prepared.revision, run["journal_revision"])
+        self.assertIsNone(run["frozen_packet_json"])
+        self.assertTrue(run["prepared_payload_hash"])
+        with sqlite3.connect(self.db) as conn:
+            observation = conn.execute(
+                "SELECT lifecycle_state,journal_entry_id,journal_revision "
+                "FROM bnl_journal_observations WHERE guild_id=1 "
+                "AND observation_date=?",
+                (TARGET_DAY.isoformat(),),
+            ).fetchone()
+            state = conn.execute(
+                "SELECT last_status,last_reason,last_entry_id,last_revision "
+                "FROM bnl_journal_automation_state WHERE guild_id=1",
+            ).fetchone()
+        self.assertEqual(
+            ("published", prepared.entry_id, prepared.revision),
+            observation,
+        )
+        self.assertEqual(
+            (
+                "published",
+                "delivery_already_recorded",
+                prepared.entry_id,
+                prepared.revision,
+            ),
+            state,
+        )
 
     def test_delivery_retry_resends_byte_identical_idempotent_request(self):
         prepared = self.prepare()
@@ -513,7 +727,7 @@ class PreparedReleaseTests(unittest.TestCase):
             entries = conn.execute(
                 "SELECT title,lifecycle_state FROM bnl_journal_entries ORDER BY revision"
             ).fetchall()
-        self.assertEqual([("Current Epoch Candidate", "approved_pending_delivery")], entries)
+        self.assertEqual([("Current Epoch Candidate", "prepared_exact")], entries)
         self.assertEqual(current.revision, self.run_row()["journal_revision"])
 
     def test_deleted_cited_source_invalidates_without_post_and_keeps_occurrence_owed(self):
@@ -581,7 +795,16 @@ class PreparedReleaseTests(unittest.TestCase):
         )
         self.assertEqual("held", result.status, result)
         self.assertEqual("request_body_too_large", result.reason)
-        entry = self.entry_row(result.entry_id, result.revision)
+        self.assertEqual("", result.entry_id)
+        self.assertEqual(0, result.revision)
+        with sqlite3.connect(self.db) as conn:
+            conn.row_factory = sqlite3.Row
+            entry = dict(
+                conn.execute(
+                    "SELECT * FROM bnl_journal_entries "
+                    "ORDER BY revision DESC LIMIT 1"
+                ).fetchone()
+            )
         canonical = bytes(entry["canonical_payload_bytes"])
         self.assertGreater(len(canonical), journal.JOURNAL_SITE_REQUEST_BODY_MAX_BYTES)
         self.assertEqual("rejected", entry["lifecycle_state"])
@@ -599,8 +822,8 @@ class PreparedReleaseTests(unittest.TestCase):
             )
         )
         self.assertEqual("prepared", retried.status, retried)
-        self.assertEqual(result.entry_id, retried.entry_id)
-        self.assertEqual(result.revision + 1, retried.revision)
+        self.assertEqual(entry["entry_id"], retried.entry_id)
+        self.assertEqual(int(entry["revision"]) + 1, retried.revision)
         self.assertEqual(frozen_hash, self.run_row()["frozen_packet_hash"])
 
     def test_validation_exhaustion_never_creates_a_prepared_fallback(self):
@@ -620,6 +843,7 @@ class PreparedReleaseTests(unittest.TestCase):
         self.assertEqual("held", run["lifecycle_state"])
         self.assertTrue(run["frozen_packet_hash"])
         self.assertIsNone(run["prepared_payload_hash"])
+        self.assert_owed_occurrence_has_no_revision_link(result)
 
     def test_storage_failure_stays_held_and_owed_with_frozen_packet(self):
         with patch.object(
@@ -635,6 +859,7 @@ class PreparedReleaseTests(unittest.TestCase):
         self.assertEqual("held", run["lifecycle_state"])
         self.assertTrue(run["frozen_packet_hash"])
         self.assertIsNone(run["prepared_payload_hash"])
+        self.assert_owed_occurrence_has_no_revision_link(result)
 
     def test_existing_run_table_is_migrated_without_losing_occurrence(self):
         tmp = tempfile.NamedTemporaryFile(delete=False)
@@ -707,6 +932,112 @@ class PreparedReleaseTests(unittest.TestCase):
                 <= state_columns
             )
         finally:
+            try:
+                os.unlink(legacy_db)
+            except FileNotFoundError:
+                pass
+
+    def test_schema_migration_takes_write_lease_before_column_snapshot(self):
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        legacy_db = tmp.name
+        tmp.close()
+        blocker = None
+        real_connect = sqlite3.connect
+        try:
+            with real_connect(legacy_db) as conn:
+                conn.executescript(
+                    """
+                    CREATE TABLE bnl_journal_automation_runs(
+                        run_id TEXT PRIMARY KEY,guild_id INTEGER NOT NULL,
+                        cadence TEXT NOT NULL,source_window_start TEXT NOT NULL,
+                        source_window_end TEXT NOT NULL,lifecycle_state TEXT NOT NULL,
+                        reason TEXT,journal_entry_id TEXT,
+                        journal_revision INTEGER NOT NULL DEFAULT 0,
+                        aggregate_counts_json TEXT NOT NULL DEFAULT '{}',
+                        attempt_count INTEGER NOT NULL DEFAULT 0,
+                        lease_expires_at TEXT,created_at TEXT NOT NULL,
+                        updated_at TEXT NOT NULL,
+                        UNIQUE(guild_id,cadence,source_window_start,source_window_end));
+                    CREATE TABLE bnl_journal_automation_state(
+                        guild_id INTEGER PRIMARY KEY,last_checked_at TEXT,
+                        last_status TEXT,last_reason TEXT,last_cadence TEXT,
+                        last_entry_id TEXT,last_revision INTEGER NOT NULL DEFAULT 0,
+                        last_source_window_start TEXT,last_source_window_end TEXT,
+                        next_retry_at TEXT,updated_at TEXT NOT NULL);
+                    """
+                )
+            blocker = real_connect(legacy_db)
+            blocker.execute("BEGIN IMMEDIATE")
+            statements = []
+            statements_lock = threading.Lock()
+
+            class TracedConnection(sqlite3.Connection):
+                pass
+
+            def traced_connect(*args, **kwargs):
+                kwargs["factory"] = TracedConnection
+                conn = real_connect(*args, **kwargs)
+
+                def record(statement):
+                    with statements_lock:
+                        statements.append(statement)
+
+                conn.set_trace_callback(record)
+                return conn
+
+            with patch.object(automation.sqlite3, "connect", side_effect=traced_connect):
+                with ThreadPoolExecutor(max_workers=4) as pool:
+                    futures = [pool.submit(automation.ensure_schema, legacy_db) for _ in range(4)]
+                    try:
+                        deadline = time.monotonic() + 2
+                        while time.monotonic() < deadline:
+                            with statements_lock:
+                                begins = sum(
+                                    statement.strip().upper() == "BEGIN IMMEDIATE"
+                                    for statement in statements
+                                )
+                            if begins == 4:
+                                break
+                            time.sleep(0.01)
+                        with statements_lock:
+                            before_release = list(statements)
+                        self.assertEqual(
+                            4,
+                            sum(
+                                statement.strip().upper() == "BEGIN IMMEDIATE"
+                                for statement in before_release
+                            ),
+                        )
+                        self.assertFalse(
+                            any(
+                                "PRAGMA TABLE_INFO" in statement.upper()
+                                for statement in before_release
+                            ),
+                            before_release,
+                        )
+                    finally:
+                        blocker.commit()
+                    for future in futures:
+                        future.result(timeout=5)
+
+            with real_connect(legacy_db) as conn:
+                run_columns = {
+                    row[1]
+                    for row in conn.execute(
+                        "PRAGMA table_info(bnl_journal_automation_runs)"
+                    )
+                }
+                state_columns = {
+                    row[1]
+                    for row in conn.execute(
+                        "PRAGMA table_info(bnl_journal_automation_state)"
+                    )
+                }
+            self.assertIn("prepared_payload_hash", run_columns)
+            self.assertIn("memory_exclusions_confirmed_at", state_columns)
+        finally:
+            if blocker is not None:
+                blocker.close()
             try:
                 os.unlink(legacy_db)
             except FileNotFoundError:

--- a/tests/test_bnl_journal_release_invalidation.py
+++ b/tests/test_bnl_journal_release_invalidation.py
@@ -188,6 +188,15 @@ class JournalReleaseInvalidationTests(unittest.TestCase):
             ).fetchone()
         return dict(row) if row else {}
 
+    def daily_observation_link(self):
+        with sqlite3.connect(self.db) as conn:
+            return conn.execute(
+                "SELECT lifecycle_state,journal_entry_id,journal_revision "
+                "FROM bnl_journal_observations "
+                "WHERE guild_id=1 AND observation_date=?",
+                (TARGET_DAY.isoformat(),),
+            ).fetchone()
+
     def test_nonprivacy_payload_integrity_failure_retains_packet_and_marks_state_held(self):
         self.add_day(TARGET_DAY)
         prepared = self.prepare_daily()
@@ -218,6 +227,8 @@ class JournalReleaseInvalidationTests(unittest.TestCase):
         result = self.release_daily(forbidden_opener)
         self.assertEqual("held", result.status, result)
         self.assertEqual("prepared_payload_integrity_failed", result.reason)
+        self.assertEqual("", result.entry_id)
+        self.assertEqual(0, result.revision)
         self.assertEqual([], posts)
 
         after = self.run_row("daily")
@@ -227,6 +238,7 @@ class JournalReleaseInvalidationTests(unittest.TestCase):
         state = self.automation_state()
         self.assertEqual("held", state["last_status"])
         self.assertEqual("prepared_payload_integrity_failed", state["last_reason"])
+        self.assertEqual(("held", None, 0), self.daily_observation_link())
 
     def test_payload_mutation_between_claim_and_final_fence_makes_zero_posts(self):
         self.add_day(TARGET_DAY)
@@ -266,6 +278,8 @@ class JournalReleaseInvalidationTests(unittest.TestCase):
 
         self.assertEqual("held", result.status, result)
         self.assertEqual("prepared_payload_integrity_failed", result.reason)
+        self.assertEqual("", result.entry_id)
+        self.assertEqual(0, result.revision)
         self.assertEqual([], posts)
         after = self.run_row("daily")
         self.assertEqual("held", after["lifecycle_state"])
@@ -279,6 +293,7 @@ class JournalReleaseInvalidationTests(unittest.TestCase):
                 (prepared.entry_id, prepared.revision),
             ).fetchone()[0]
         self.assertEqual("rejected", lifecycle)
+        self.assertEqual(("held", None, 0), self.daily_observation_link())
 
     def test_weekly_daily_memory_exclusion_blocks_post_and_retires_packet(self):
         for offset in range(7):
@@ -323,6 +338,11 @@ class JournalReleaseInvalidationTests(unittest.TestCase):
         self.assertEqual(7, len(daily_entry_ids))
         self.assertTrue(daily_entry_ids <= set(metadata["relatedPriorJournalEntryIds"]))
         excluded_entry_id = sorted(daily_entry_ids)[0]
+        automation.store_journal_memory_exclusions(
+            self.db,
+            1,
+            {excluded_entry_id},
+        )
 
         posts = []
 
@@ -338,10 +358,14 @@ class JournalReleaseInvalidationTests(unittest.TestCase):
             target_monday=WEEK_START,
             force=True,
             opener=forbidden_opener,
-            memory_excluded_entry_ids={excluded_entry_id},
+            # Simulate a release caller that captured the prior empty set. The
+            # final fence must use the newer durable control snapshot.
+            memory_excluded_entry_ids=set(),
         )
         self.assertEqual("held", result.status, result)
         self.assertEqual("privacy_eligibility_changed", result.reason)
+        self.assertEqual("", result.entry_id)
+        self.assertEqual(0, result.revision)
         self.assertEqual([], posts)
         run = self.run_row("weekly")
         self.assertEqual("held", run["lifecycle_state"])
@@ -443,6 +467,7 @@ class JournalReleaseInvalidationTests(unittest.TestCase):
                 (prepared.entry_id, prepared.revision),
             ).fetchone()[0]
         self.assertEqual("rejected", lifecycle)
+        self.assertEqual(("held", None, 0), self.daily_observation_link())
 
 
 if __name__ == "__main__":

--- a/tests/test_bnl_journal_release_invalidation.py
+++ b/tests/test_bnl_journal_release_invalidation.py
@@ -1,0 +1,449 @@
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from datetime import date, datetime, timedelta
+from unittest.mock import patch
+
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+
+import bnl_journal as journal
+import bnl_journal_automation as automation
+import bnl_journal_source_store as source_store
+from tests.test_bnl_journal_prepared_release import AcceptedResponse, article_json
+
+
+TARGET_DAY = date(2026, 7, 19)
+WEEK_START = date(2026, 7, 13)
+
+
+class JournalReleaseInvalidationTests(unittest.TestCase):
+    def setUp(self):
+        self.archive_clock = patch.object(source_store, "_now_ms", return_value=0)
+        self.archive_clock.start()
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.db = tmp.name
+        tmp.close()
+        journal.ensure_schema(self.db)
+        automation.ensure_schema(self.db)
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "CREATE TABLE website_relay_history("
+                "relay_id TEXT PRIMARY KEY,guild_id INTEGER,public_message TEXT,"
+                "public_directive TEXT,mode TEXT,relay_lane TEXT,event_type TEXT,"
+                "highest_source_conversation_id INTEGER,normalized_message TEXT,"
+                "semantic_family TEXT,published_timestamp TEXT)"
+            )
+            conn.execute(
+                "CREATE TABLE conversations("
+                "id INTEGER PRIMARY KEY,user_id INTEGER,user_name TEXT,guild_id INTEGER,"
+                "channel_name TEXT,channel_policy TEXT,role TEXT,content TEXT,timestamp TEXT,"
+                "public_usable INTEGER,visibility TEXT)"
+            )
+
+    def tearDown(self):
+        self.archive_clock.stop()
+        try:
+            os.unlink(self.db)
+        except FileNotFoundError:
+            pass
+
+    def add_day(self, day: date) -> None:
+        start, _, _ = automation._daily_period_for_day(day)
+        start_utc = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        label = day.isoformat()
+        with sqlite3.connect(self.db) as conn:
+            for index in range(6):
+                stamp = (start_utc + timedelta(hours=1, minutes=index)).isoformat().replace(
+                    "+00:00", "Z"
+                )
+                conn.execute(
+                    "INSERT INTO website_relay_history VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        f"relay-{label}-{index}",
+                        1,
+                        f"A public producer shared track activity number {index}.",
+                        "Keep listening to the community music room.",
+                        "OBSERVATION",
+                        "current_signal",
+                        "fresh_public_discord_activity",
+                        index,
+                        "track activity",
+                        "public_discord_activity",
+                        stamp,
+                    ),
+                )
+                conn.execute(
+                    "INSERT INTO conversations VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        int(label.replace("-", "")) * 10 + index,
+                        100 + index,
+                        f"Member{index}",
+                        1,
+                        "general",
+                        "public_home",
+                        "user",
+                        (
+                            f"Member{index} discusses a new mix, bass movement, and "
+                            f"community listening plan number {index}."
+                        ),
+                        stamp,
+                        1,
+                        "public_safe",
+                    ),
+                )
+
+    @staticmethod
+    def accepted_opener(request, timeout=10):
+        return AcceptedResponse(request)
+
+    def add_broadcast_memory(self, *, valid_until=None) -> None:
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "CREATE TABLE broadcast_memory("
+                "id INTEGER PRIMARY KEY,guild_id INTEGER,episode_date TEXT,cleaned_summary TEXT,"
+                "entry_type TEXT,importance TEXT,public_safe INTEGER,usage_scope TEXT,valid_until TEXT,"
+                "needs_clarification INTEGER,status TEXT,superseded_by_id INTEGER,created_at TEXT,raw_note TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO broadcast_memory VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    1,
+                    1,
+                    "2026-07-18",
+                    "A public producer documented track activity number four.",
+                    "notable_moment",
+                    "medium",
+                    1,
+                    "journal",
+                    valid_until,
+                    0,
+                    "active",
+                    None,
+                    "2026-07-18T12:00:00Z",
+                    "private operator note",
+                ),
+            )
+
+    @staticmethod
+    def memory_generator(packet, _prompt):
+        memory = packet["generationContextLanes"]["establishedBroadcastMemory"][0]
+        fresh_ref = memory["matchedFreshSourceRefIds"][0]
+        claim = (
+            "An established Network record says a public producer documented track activity "
+            "number four."
+        )
+        article = json.loads(article_json(packet))
+        heading = article["sections"][0]["heading"]
+        article["sections"][0]["body"] = claim + " " + article["sections"][0]["body"]
+        article["metadata"]["contextUses"] = [
+            {
+                "laneType": "established_broadcast_memory",
+                "laneRefId": memory["laneRefId"],
+                "sectionHeading": heading,
+                "claim": claim,
+                "basisRefIds": [memory["laneRefId"], fresh_ref],
+            }
+        ]
+        return json.dumps(article)
+
+    def prepare_daily(self, generator=None):
+        return automation.prepare_daily(
+            self.db,
+            1,
+            generator or (lambda packet, _prompt: article_json(packet)),
+            target_day=TARGET_DAY,
+            force=True,
+        )
+
+    def release_daily(self, opener, **kwargs):
+        return automation.release_daily(
+            self.db,
+            1,
+            "https://site.example",
+            "key",
+            target_day=TARGET_DAY,
+            force=True,
+            opener=opener,
+            **kwargs,
+        )
+
+    def run_row(self, cadence: str) -> dict:
+        with sqlite3.connect(self.db) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT * FROM bnl_journal_automation_runs WHERE cadence=? "
+                "ORDER BY created_at DESC LIMIT 1",
+                (cadence,),
+            ).fetchone()
+        return dict(row) if row else {}
+
+    def automation_state(self) -> dict:
+        with sqlite3.connect(self.db) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT * FROM bnl_journal_automation_state WHERE guild_id=1"
+            ).fetchone()
+        return dict(row) if row else {}
+
+    def test_nonprivacy_payload_integrity_failure_retains_packet_and_marks_state_held(self):
+        self.add_day(TARGET_DAY)
+        prepared = self.prepare_daily()
+        self.assertEqual("prepared", prepared.status, prepared)
+        before = self.run_row("daily")
+        self.assertTrue(before["frozen_packet_json"])
+
+        with sqlite3.connect(self.db) as conn:
+            canonical = bytes(
+                conn.execute(
+                    "SELECT canonical_payload_bytes FROM bnl_journal_entries "
+                    "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                    (prepared.entry_id, prepared.revision),
+                ).fetchone()[0]
+            )
+            conn.execute(
+                "UPDATE bnl_journal_entries SET canonical_payload_bytes=? "
+                "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                (canonical + b" ", prepared.entry_id, prepared.revision),
+            )
+
+        posts = []
+
+        def forbidden_opener(request, timeout=10):
+            posts.append(request.data)
+            raise AssertionError("integrity-invalid bytes reached the website")
+
+        result = self.release_daily(forbidden_opener)
+        self.assertEqual("held", result.status, result)
+        self.assertEqual("prepared_payload_integrity_failed", result.reason)
+        self.assertEqual([], posts)
+
+        after = self.run_row("daily")
+        self.assertEqual("held", after["lifecycle_state"])
+        self.assertEqual(before["frozen_packet_json"], after["frozen_packet_json"])
+        self.assertEqual(before["frozen_packet_hash"], after["frozen_packet_hash"])
+        state = self.automation_state()
+        self.assertEqual("held", state["last_status"])
+        self.assertEqual("prepared_payload_integrity_failed", state["last_reason"])
+
+    def test_payload_mutation_between_claim_and_final_fence_makes_zero_posts(self):
+        self.add_day(TARGET_DAY)
+        prepared = self.prepare_daily()
+        self.assertEqual("prepared", prepared.status, prepared)
+        before = self.run_row("daily")
+        posts = []
+
+        def forbidden_opener(request, timeout=10):
+            posts.append(request.data)
+            raise AssertionError("bytes changed after delivery claim reached the website")
+
+        real_deliver = automation.deliver_approved
+
+        def mutate_then_enter_delivery_fence(*args, **kwargs):
+            with sqlite3.connect(self.db) as conn:
+                canonical = bytes(
+                    conn.execute(
+                        "SELECT canonical_payload_bytes FROM bnl_journal_entries "
+                        "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                        (prepared.entry_id, prepared.revision),
+                    ).fetchone()[0]
+                )
+                conn.execute(
+                    "UPDATE bnl_journal_entries SET canonical_payload_bytes=? "
+                    "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                    (canonical + b" ", prepared.entry_id, prepared.revision),
+                )
+            return real_deliver(*args, **kwargs)
+
+        with patch.object(
+            automation,
+            "deliver_approved",
+            side_effect=mutate_then_enter_delivery_fence,
+        ):
+            result = self.release_daily(forbidden_opener)
+
+        self.assertEqual("held", result.status, result)
+        self.assertEqual("prepared_payload_integrity_failed", result.reason)
+        self.assertEqual([], posts)
+        after = self.run_row("daily")
+        self.assertEqual("held", after["lifecycle_state"])
+        self.assertEqual(before["frozen_packet_json"], after["frozen_packet_json"])
+        self.assertEqual(before["frozen_packet_hash"], after["frozen_packet_hash"])
+        self.assertIsNone(after["prepared_payload_hash"])
+        with sqlite3.connect(self.db) as conn:
+            lifecycle = conn.execute(
+                "SELECT lifecycle_state FROM bnl_journal_entries "
+                "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                (prepared.entry_id, prepared.revision),
+            ).fetchone()[0]
+        self.assertEqual("rejected", lifecycle)
+
+    def test_weekly_daily_memory_exclusion_blocks_post_and_retires_packet(self):
+        for offset in range(7):
+            day = WEEK_START + timedelta(days=offset)
+            self.add_day(day)
+            published = automation.run_daily(
+                self.db,
+                1,
+                lambda packet, _prompt: article_json(packet),
+                "https://site.example",
+                "key",
+                target_day=day,
+                force=True,
+                opener=self.accepted_opener,
+            )
+            self.assertEqual("published", published.status, published)
+
+        prepared = automation.prepare_weekly(
+            self.db,
+            1,
+            lambda packet, _prompt: article_json(packet),
+            target_monday=WEEK_START,
+            force=True,
+        )
+        self.assertEqual("prepared", prepared.status, prepared)
+        with sqlite3.connect(self.db) as conn:
+            daily_entry_ids = {
+                str(row[0])
+                for row in conn.execute(
+                    "SELECT journal_entry_id FROM bnl_journal_observations "
+                    "WHERE guild_id=1 AND lifecycle_state='published'"
+                ).fetchall()
+                if row[0]
+            }
+            metadata = json.loads(
+                conn.execute(
+                    "SELECT metadata_json FROM bnl_journal_private_metadata "
+                    "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                    (prepared.entry_id, prepared.revision),
+                ).fetchone()[0]
+            )
+        self.assertEqual(7, len(daily_entry_ids))
+        self.assertTrue(daily_entry_ids <= set(metadata["relatedPriorJournalEntryIds"]))
+        excluded_entry_id = sorted(daily_entry_ids)[0]
+
+        posts = []
+
+        def forbidden_opener(request, timeout=10):
+            posts.append(request.data)
+            raise AssertionError("memory-excluded Weekly reached the website")
+
+        result = automation.release_weekly(
+            self.db,
+            1,
+            "https://site.example",
+            "key",
+            target_monday=WEEK_START,
+            force=True,
+            opener=forbidden_opener,
+            memory_excluded_entry_ids={excluded_entry_id},
+        )
+        self.assertEqual("held", result.status, result)
+        self.assertEqual("privacy_eligibility_changed", result.reason)
+        self.assertEqual([], posts)
+        run = self.run_row("weekly")
+        self.assertEqual("held", run["lifecycle_state"])
+        self.assertIsNone(run["frozen_packet_json"])
+        self.assertIsNone(run["frozen_packet_hash"])
+        self.assertIsNone(run["prepared_payload_hash"])
+
+    def test_used_broadcast_memory_becoming_ineligible_blocks_post(self):
+        self.add_broadcast_memory()
+        self.add_day(TARGET_DAY)
+        prepared = self.prepare_daily(self.memory_generator)
+        self.assertEqual("prepared", prepared.status, prepared)
+        with sqlite3.connect(self.db) as conn:
+            metadata = json.loads(
+                conn.execute(
+                    "SELECT metadata_json FROM bnl_journal_private_metadata "
+                    "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                    (prepared.entry_id, prepared.revision),
+                ).fetchone()[0]
+            )
+            used = metadata["usedContextLaneProvenance"]["establishedBroadcastMemory"]
+            self.assertEqual([1], [int(item["rowId"]) for item in used])
+            conn.execute("UPDATE broadcast_memory SET status='inactive' WHERE guild_id=1 AND id=1")
+
+        posts = []
+
+        def forbidden_opener(request, timeout=10):
+            posts.append(request.data)
+            raise AssertionError("ineligible established memory reached the website")
+
+        result = self.release_daily(forbidden_opener)
+        self.assertEqual("held", result.status, result)
+        self.assertEqual("privacy_memory_ineligible", result.reason)
+        self.assertEqual([], posts)
+        run = self.run_row("daily")
+        self.assertEqual("held", run["lifecycle_state"])
+        self.assertIsNone(run["frozen_packet_json"])
+        self.assertIsNone(run["prepared_payload_hash"])
+
+    def test_used_broadcast_memory_expiring_after_preparation_blocks_post(self):
+        # TARGET_DAY ends before this date expires, so the memory may be used
+        # during preparation. At the patched release instant it is stale.
+        self.add_broadcast_memory(valid_until="2026-07-21")
+        self.add_day(TARGET_DAY)
+        prepared = self.prepare_daily(self.memory_generator)
+        self.assertEqual("prepared", prepared.status, prepared)
+
+        posts = []
+
+        def forbidden_opener(request, timeout=10):
+            posts.append(request.data)
+            raise AssertionError("expired established memory reached the website")
+
+        with patch.object(automation, "utc_now_iso", return_value="2026-07-22T12:00:00Z"):
+            result = self.release_daily(forbidden_opener)
+        self.assertEqual("held", result.status, result)
+        self.assertEqual("privacy_memory_ineligible", result.reason)
+        self.assertEqual([], posts)
+        run = self.run_row("daily")
+        self.assertEqual("held", run["lifecycle_state"])
+        self.assertIsNone(run["frozen_packet_json"])
+        self.assertIsNone(run["prepared_payload_hash"])
+
+    def test_deletion_between_claim_and_post_is_revalidated_inside_delivery_fence(self):
+        self.add_day(TARGET_DAY)
+        prepared = self.prepare_daily()
+        self.assertEqual("prepared", prepared.status, prepared)
+        posts = []
+
+        def forbidden_opener(request, timeout=10):
+            posts.append(request.data)
+            raise AssertionError("source deleted before the final fence reached the website")
+
+        real_deliver = automation.deliver_approved
+
+        def delete_then_enter_delivery_fence(*args, **kwargs):
+            self.assertEqual(1, source_store.purge_user_discord_sources(self.db, 1, 100))
+            return real_deliver(*args, **kwargs)
+
+        with patch.object(
+            automation,
+            "deliver_approved",
+            side_effect=delete_then_enter_delivery_fence,
+        ):
+            result = self.release_daily(forbidden_opener)
+
+        self.assertEqual("held", result.status, result)
+        self.assertEqual("privacy_source_ineligible", result.reason)
+        self.assertEqual([], posts)
+        run = self.run_row("daily")
+        self.assertEqual("held", run["lifecycle_state"])
+        self.assertIsNone(run["journal_entry_id"])
+        self.assertIsNone(run["frozen_packet_json"])
+        self.assertIsNone(run["prepared_payload_hash"])
+        with sqlite3.connect(self.db) as conn:
+            lifecycle = conn.execute(
+                "SELECT lifecycle_state FROM bnl_journal_entries "
+                "WHERE guild_id=1 AND entry_id=? AND revision=?",
+                (prepared.entry_id, prepared.revision),
+            ).fetchone()[0]
+        self.assertEqual("rejected", lifecycle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bnl_journal_runtime_controls.py
+++ b/tests/test_bnl_journal_runtime_controls.py
@@ -6,6 +6,8 @@ import tempfile
 import unittest
 from unittest import mock
 
+import bnl_journal as journal
+import bnl_journal_automation as automation
 import bnl_journal_source_store as source_store
 from bnl_journal_automation import AutomationResult
 
@@ -182,6 +184,67 @@ class JournalRuntimeControlTests(unittest.TestCase):
             daily.call_args.kwargs["memory_excluded_entry_ids"],
         )
 
+    def test_memory_exclusion_snapshot_survives_outage_and_confirmed_empty(self):
+        temp = tempfile.NamedTemporaryFile(delete=False)
+        db_path = temp.name
+        temp.close()
+        try:
+            base = {
+                "journalAutoPublishEnabled": True,
+                "journalDailyEnabled": True,
+                "journalWeeklyEnabled": True,
+            }
+            with mock.patch.object(bnl01_bot, "DB_FILE", db_path):
+                live = bnl01_bot._journal_control_flags_for_guild(
+                    1,
+                    {
+                        "config": {},
+                        "memoryExcludedEntryIds": ["journal-z", "journal-a"],
+                    },
+                    base,
+                )
+                self.assertTrue(live["journalMemoryExclusionsConfirmed"])
+                self.assertEqual(
+                    ["journal-z", "journal-a"],
+                    live["journalMemoryExcludedEntryIds"],
+                )
+
+                after_restart_outage = bnl01_bot._journal_control_flags_for_guild(
+                    1,
+                    None,
+                    base,
+                )
+                self.assertTrue(
+                    after_restart_outage["journalMemoryExclusionsConfirmed"]
+                )
+                self.assertEqual(
+                    ["journal-a", "journal-z"],
+                    after_restart_outage["journalMemoryExcludedEntryIds"],
+                )
+
+                confirmed_empty = bnl01_bot._journal_control_flags_for_guild(
+                    1,
+                    {"config": {}, "memoryExcludedEntryIds": []},
+                    base,
+                )
+                self.assertTrue(confirmed_empty["journalMemoryExclusionsConfirmed"])
+                self.assertEqual([], confirmed_empty["journalMemoryExcludedEntryIds"])
+                stored, confirmed = bnl01_bot.load_journal_memory_exclusions(db_path, 1)
+                self.assertTrue(confirmed)
+                self.assertEqual(set(), stored)
+
+            second = tempfile.NamedTemporaryFile(delete=False)
+            second_path = second.name
+            second.close()
+            try:
+                with mock.patch.object(bnl01_bot, "DB_FILE", second_path):
+                    cold = bnl01_bot._journal_control_flags_for_guild(1, None, base)
+                self.assertFalse(cold["journalMemoryExclusionsConfirmed"])
+            finally:
+                os.unlink(second_path)
+        finally:
+            os.unlink(db_path)
+
     def test_control_flag_fetch_failure_retains_confirmed_pause(self):
         paused = {
             "websiteRelayEnabled": True,
@@ -226,6 +289,7 @@ class JournalRuntimeControlTests(unittest.TestCase):
         with mock.patch.object(bnl01_bot, "resolve_network_guild_id", return_value=1), \
              mock.patch.object(bnl01_bot, "get_bnl_control_flags", return_value=cached_flags), \
              mock.patch.object(bnl01_bot, "_journal_control_request_sync", return_value=(None, "control_plane_timeout")), \
+             mock.patch.object(bnl01_bot, "load_journal_memory_exclusions", return_value=(set(), False)), \
              mock.patch.object(bnl01_bot, "_journal_heartbeat_sync", return_value=(None, "")), \
              mock.patch.object(bnl01_bot, "journal_automation_status", return_value={}), \
              mock.patch.object(bnl01_bot, "run_journal_automation_once", new=runner):
@@ -235,7 +299,7 @@ class JournalRuntimeControlTests(unittest.TestCase):
             1,
             cadence="scheduled",
             force=False,
-            flags=cached_flags,
+            flags={**cached_flags, "journalMemoryExclusionsConfirmed": False},
         )
         self.assertEqual("not_due", results[0]["status"])
         self.assertEqual("no_schedule_due", results[0]["reason"])
@@ -254,6 +318,7 @@ class JournalRuntimeControlTests(unittest.TestCase):
              mock.patch.object(bnl01_bot, "BNL_JOURNAL_AUTOMATION_ENABLED", True), \
              mock.patch.object(bnl01_bot, "get_bnl_control_flags", return_value=cached_flags), \
              mock.patch.object(bnl01_bot, "_journal_control_request_sync", return_value=(None, "control_plane_timeout")), \
+             mock.patch.object(bnl01_bot, "load_journal_memory_exclusions", return_value=(set(), False)), \
              mock.patch.object(bnl01_bot, "_journal_heartbeat_sync", return_value=(None, "")), \
              mock.patch.object(bnl01_bot, "journal_automation_status", return_value={}), \
              mock.patch.object(bnl01_bot, "run_scheduled_journal_automation") as scheduled:
@@ -322,12 +387,72 @@ class JournalRuntimeControlTests(unittest.TestCase):
                     channel_policy="public_home" if source_kind == "discord_message" else "public_relay",
                 )
 
+            journal.ensure_schema(db_path)
+            automation.ensure_schema(db_path)
+            source_event = next(
+                event
+                for event in source_store.query_source_events(db_path, 1, 0, 2_000).events
+                if event["source_key"] == "u7-g1"
+            )
+            claim, run_id, epoch, _ = automation._claim_preparation(
+                db_path,
+                1,
+                "daily",
+                "2026-07-20T02:00:00Z",
+                "2026-07-21T02:00:00Z",
+                force=True,
+            )
+            self.assertEqual("claimed", claim)
+            frozen_packet = {
+                "entryKind": "daily",
+                "sourceArchiveAvailable": True,
+                "coverageComplete": True,
+                "sourceWindowStart": "2026-07-20T02:00:00Z",
+                "sourceWindowEnd": "2026-07-21T02:00:00Z",
+                "aggregateCounts": {"eligibleConversations": 1},
+                "privateSources": [
+                    {
+                        "refId": f"fresh:{source_event['event_seq']}",
+                        "sourceKind": "conversation",
+                        "subjectRef": "discord_user:7",
+                        "summary": "durable source text",
+                    }
+                ],
+                "safeSources": [],
+                "privateContextLaneProvenance": {},
+            }
+            frozen, packet_hash, reason = automation._freeze_or_load_packet(
+                db_path,
+                1,
+                run_id,
+                epoch,
+                lambda: frozen_packet,
+            )
+            self.assertEqual(frozen_packet, frozen)
+            self.assertTrue(packet_hash)
+            self.assertEqual("", reason)
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    "UPDATE bnl_journal_automation_runs "
+                    "SET lifecycle_state='prepared',lease_expires_at=NULL WHERE run_id=?",
+                    (run_id,),
+                )
+
             with mock.patch.object(bnl01_bot, "DB_FILE", db_path):
                 self.assertEqual(1, bnl01_bot.clear_user_history(7, 1))
                 self.assertEqual(
                     {"u8-g1", "relay-g1"},
                     {event["source_key"] for event in source_store.query_source_events(db_path, 1, 0, 2_000).events},
                 )
+                with sqlite3.connect(db_path) as conn:
+                    lifecycle, frozen_json, prepared_hash = conn.execute(
+                        "SELECT lifecycle_state,frozen_packet_json,prepared_payload_hash "
+                        "FROM bnl_journal_automation_runs WHERE run_id=?",
+                        (run_id,),
+                    ).fetchone()
+                self.assertEqual("held", lifecycle)
+                self.assertIsNone(frozen_json)
+                self.assertIsNone(prepared_hash)
                 self.assertEqual(1, bnl01_bot.clear_guild_history(1))
 
             self.assertEqual(

--- a/tests/test_bnl_journal_source_store.py
+++ b/tests/test_bnl_journal_source_store.py
@@ -81,6 +81,38 @@ class JournalSourceStoreTests(unittest.TestCase):
         self.assertTrue(all(result.ok for result in results))
         self.assertEqual(1, len({result.event_seq for result in results}))
 
+    def test_concurrent_legacy_schema_upgrade_is_serialized(self):
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "CREATE TABLE bnl_journal_source_archive_state("
+                "guild_id INTEGER PRIMARY KEY,activated_at_ms INTEGER NOT NULL,"
+                "created_at_ms INTEGER NOT NULL)"
+            )
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(store.ensure_schema, self.db) for _ in range(8)]
+            for future in futures:
+                future.result(timeout=10)
+
+        with sqlite3.connect(self.db) as conn:
+            columns = {
+                row[1]
+                for row in conn.execute(
+                    "PRAGMA table_info(bnl_journal_source_archive_state)"
+                )
+            }
+        self.assertTrue(
+            {
+                "legacy_backfill_completed_at_ms",
+                "legacy_conversation_cursor",
+                "legacy_relay_cursor_rowid",
+                "legacy_relay_cursor_timestamp",
+                "legacy_relay_cursor_id",
+            }
+            <= columns
+        )
+        self.assertTrue(self._record("post-upgrade-source").ok)
+
     def test_query_is_exact_unbounded_deterministic_and_fully_counted(self):
         self._record("before", occurred=999)
         self._record("end", occurred=2_000)


### PR DESCRIPTION
## Summary

- freeze and persist one deterministic Journal source packet per occurrence with stable source identity
- separate preparation from release while keeping the current 7:00 PM scheduler calling both in the same cycle
- persist and preflight the exact serialized website request bytes, then release those bytes with zero model or repair calls
- fence preparation and delivery owners so late workers, concurrent triggers, restarts, and retries cannot replace or duplicate work
- revalidate privacy and eligibility at the final network fence, invalidate stale staged payloads, and keep the occurrence owed
- adopt eligible legacy staged scheduled revisions without regeneration

## Safety hardening

- serialize concurrent schema upgrades so startup paths cannot race migrations
- keep the website network wait outside the shared SQLite write transaction while retaining one dedicated Journal delivery/privacy fence through finalization
- respect live delivery leases, prevent expired or superseded owners from creating a second POST, and reconcile crash-after-site-acceptance as published
- hide scheduled prepared entries from rollback-era delivery with a persistent fail-closed compatibility trigger
- make newer durable exclusion state override stale caller snapshots at final preflight
- prevent rejected-revision reattachment and clear nonexistent revision links after generation or storage failure
- keep deletion and eligibility invalidation serialized through final Journal run state without blocking unrelated conversation, Relay, or memory writes during the network wait

## Compatibility

This keeps the existing 7:00-to-7:00 windows, Daily/Weekly cadence and Monday behavior, Weekly requirements, terminal `quiet`, public schema, voice/model/validation/four-attempt generation contract, and website run-state contract. It does not change the website, queue, production gates, configuration, or deployment.

## Verification

- `/tmp/bnl01-venv/bin/python -m unittest discover -s tests -p 'test_bnl_journal*.py'` — 127 tests passed
- `make check PYTHON=/tmp/bnl01-venv/bin/python` — 1,206 tests passed
- final diff/worktree checks passed
