### PR TITLE
Bot: prepare Journals at 6:30 and release at 7:00

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -95,6 +95,8 @@ from bnl_journal_source_store import (
 from bnl_journal_automation import (
     automation_status as journal_automation_status,
     load_journal_memory_exclusions,
+    prepare_scheduled as prepare_scheduled_journal_automation,
+    release_scheduled as release_scheduled_journal_automation,
     release_prepared_entry as release_prepared_journal_entry,
     result_dict as journal_automation_result_dict,
     run_daily as run_daily_journal_automation,
@@ -132,6 +134,7 @@ import urllib.parse
 import calendar
 import time
 import threading
+import concurrent.futures
 
 from bnl_dossier_candidate_discovery import (
     DEFAULT_DISCOVERY_LANES,
@@ -343,10 +346,19 @@ BNL_COMMUNITY_SCOUTING_MIN_SIGNALS = community_min_signals()
 
 DAILY_TOKEN_LIMIT = 1_350_000
 PACIFIC_TZ = pytz.timezone("US/Pacific")
+JOURNAL_PREPARATION_SCHEDULE_TIME = datetime_time(
+    hour=18,
+    minute=30,
+    tzinfo=ZoneInfo("America/Los_Angeles"),
+)
 JOURNAL_DAILY_SCHEDULE_TIME = datetime_time(
     hour=19,
     minute=0,
     tzinfo=ZoneInfo("America/Los_Angeles"),
+)
+JOURNAL_PREPARATION_MAX_SECONDS = max(
+    60,
+    int(os.getenv("BNL_JOURNAL_PREPARATION_MAX_SECONDS", "1500") or 1500),
 )
 DB_FILE = "bnl01_conversations.db"
 
@@ -6008,6 +6020,53 @@ def _generate_journal_json_sync(_packet: dict, prompt: str) -> str:
     return text or ""
 
 
+def _journal_preparation_budget_seconds(now_pacific: datetime | None = None) -> float:
+    now = now_pacific or datetime.now(PACIFIC_TZ)
+    if now.tzinfo is None:
+        now = PACIFIC_TZ.localize(now)
+    else:
+        now = now.astimezone(PACIFIC_TZ)
+    if (18, 30) <= (now.hour, now.minute) < (19, 0):
+        release_at = PACIFIC_TZ.localize(
+            datetime.combine(now.date(), datetime_time(19, 0))
+        )
+        return max(
+            1.0,
+            min(
+                float(JOURNAL_PREPARATION_MAX_SECONDS),
+                (release_at - now).total_seconds() - 5.0,
+            ),
+        )
+    return float(JOURNAL_PREPARATION_MAX_SECONDS)
+
+
+def _bounded_journal_preparation_generator(
+    *,
+    now_pacific: datetime | None = None,
+):
+    """Bound the complete four-attempt preparation lane before release time."""
+    deadline = time.monotonic() + _journal_preparation_budget_seconds(now_pacific)
+
+    def generate(packet: dict, prompt: str) -> str:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise RuntimeError("journal_preparation_timeout")
+        executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="journal-provider",
+        )
+        future = executor.submit(_generate_journal_json_sync, packet, prompt)
+        try:
+            return future.result(timeout=remaining)
+        except concurrent.futures.TimeoutError as exc:
+            future.cancel()
+            raise RuntimeError("journal_preparation_timeout") from exc
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
+
+    return generate
+
+
 def _journal_control_url() -> str:
     explicit = os.getenv("BNL_JOURNAL_CONTROL_URL", "").strip()
     if explicit:
@@ -6159,7 +6218,7 @@ def _journal_site_run_state(status: str) -> str:
         return normalized
     if normalized in {"paused"}:
         return "disabled"
-    if normalized in {"quiet", "deferred", "not_due"}:
+    if normalized in {"quiet", "deferred", "not_due", "not_applicable", "superseded"}:
         return "skipped"
     return "failed"
 
@@ -6242,16 +6301,25 @@ async def run_journal_automation_once(
     guild_id: int,
     *,
     cadence: str = "scheduled",
+    phase: str = "recover",
     force: bool = False,
     flags: dict | None = None,
 ) -> list[dict]:
     """Serialize generation/delivery per guild and enforce every automation control flag."""
     guild_id = resolve_network_guild_id(int(guild_id))
     cadence = str(cadence or "scheduled").lower()
+    phase = str(phase or "recover").lower()
+    if phase not in {"prepare", "release", "recover"}:
+        phase = "recover"
     lock = _journal_automation_lock(guild_id)
     async with lock:
         runtime = _journal_automation_runtime_by_guild.setdefault(guild_id, {})
-        runtime.update({"lastStartedAt": _utc_now_iso(), "lastError": "", "lastCadence": cadence})
+        runtime.update({
+            "lastStartedAt": _utc_now_iso(),
+            "lastError": "",
+            "lastCadence": cadence,
+            "lastPhase": phase,
+        })
         if not BNL_JOURNAL_AUTOMATION_ENABLED:
             results = [_journal_control_result(cadence, "paused", "local_automation_disabled")]
         else:
@@ -6300,15 +6368,33 @@ async def run_journal_automation_once(
                 )
                 results = [journal_automation_result_dict(result)]
             else:
-                scheduled = await asyncio.to_thread(
-                    run_scheduled_journal_automation,
-                    DB_FILE,
-                    guild_id,
-                    _generate_journal_json_sync,
-                    _journal_website_base_url(),
-                    BNL_API_KEY,
-                    effective_flags,
-                )
+                if phase == "release":
+                    scheduled = await asyncio.to_thread(
+                        release_scheduled_journal_automation,
+                        DB_FILE,
+                        guild_id,
+                        _journal_website_base_url(),
+                        BNL_API_KEY,
+                        effective_flags,
+                    )
+                elif phase == "prepare":
+                    scheduled = await asyncio.to_thread(
+                        prepare_scheduled_journal_automation,
+                        DB_FILE,
+                        guild_id,
+                        _bounded_journal_preparation_generator(),
+                        effective_flags,
+                    )
+                else:
+                    scheduled = await asyncio.to_thread(
+                        run_scheduled_journal_automation,
+                        DB_FILE,
+                        guild_id,
+                        _bounded_journal_preparation_generator(),
+                        _journal_website_base_url(),
+                        BNL_API_KEY,
+                        effective_flags,
+                    )
                 results = [journal_automation_result_dict(item) for item in scheduled]
         runtime.update({
             "lastCompletedAt": _utc_now_iso(),
@@ -6316,15 +6402,20 @@ async def run_journal_automation_once(
             "lastDetail": "; ".join(str(item.get("reason") or item.get("status") or "") for item in results)[:240],
         })
         logging.info(
-            "journal_automation_cycle guild=%s cadence=%s results=%s",
+            "journal_automation_cycle guild=%s cadence=%s phase=%s results=%s",
             guild_id,
             cadence,
+            phase,
             ",".join(f"{item.get('cadence')}:{item.get('status')}" for item in results),
         )
         return results
 
 
-async def run_journal_automation_control_cycle(guild_id: int) -> list[dict]:
+async def run_journal_automation_control_cycle(
+    guild_id: int,
+    *,
+    phase: str = "recover",
+) -> list[dict]:
     """Poll admin controls, claim at most one Run Now request, then run/report safely."""
     guild_id = resolve_network_guild_id(int(guild_id))
     base_flags = await asyncio.to_thread(get_bnl_control_flags)
@@ -6345,6 +6436,7 @@ async def run_journal_automation_control_cycle(guild_id: int) -> list[dict]:
         results = await run_journal_automation_once(
             guild_id,
             cadence="scheduled",
+            phase=phase,
             force=False,
             flags=flags,
         )
@@ -6364,7 +6456,7 @@ async def run_journal_automation_control_cycle(guild_id: int) -> list[dict]:
         await asyncio.to_thread(_journal_heartbeat_sync, runtime, flags)
         return results
     claimed = None
-    if control is not None:
+    if control is not None and phase == "recover":
         claimed, claim_error = await asyncio.to_thread(_journal_control_claim_sync, control)
         control_error = claim_error or control_error
     request_id = str((claimed or {}).get("requestId") or "")[:120]
@@ -6384,6 +6476,7 @@ async def run_journal_automation_control_cycle(guild_id: int) -> list[dict]:
     results = await run_journal_automation_once(
         guild_id,
         cadence=cadence if cadence in {"daily", "weekly"} else "scheduled",
+        phase="recover" if claimed else phase,
         force=bool(claimed),
         flags=flags,
     )
@@ -15342,7 +15435,11 @@ tree = app_commands.CommandTree(client)
 _ambient_post_locks = {}
 
 
-async def _run_journal_automation_for_managed_guilds(trigger: str) -> None:
+async def _run_journal_automation_for_managed_guilds(
+    trigger: str,
+    *,
+    phase: str = "recover",
+) -> None:
     """Run the idempotent Journal scheduler for each configured Discord guild."""
     for guild in iter_managed_guilds():
         guild_id = int(getattr(guild, "id", 0) or 0)
@@ -15350,11 +15447,12 @@ async def _run_journal_automation_for_managed_guilds(trigger: str) -> None:
             continue
         try:
             logging.info(
-                "journal_automation_trigger guild=%s trigger=%s",
+                "journal_automation_trigger guild=%s trigger=%s phase=%s",
                 guild_id,
                 trigger,
+                phase,
             )
-            await run_journal_automation_control_cycle(guild_id)
+            await run_journal_automation_control_cycle(guild_id, phase=phase)
         except Exception as exc:
             runtime = _journal_automation_runtime_by_guild.setdefault(guild_id, {})
             runtime.update({"lastCompletedAt": _utc_now_iso(), "lastError": type(exc).__name__})
@@ -15405,13 +15503,28 @@ async def source_file_refresh_worker_task():
     except Exception as exc:
         logging.warning("source_refresh_worker_cycle processed=0 skipped=0 failed=1 error=%s", exc)
 
-    await _run_journal_automation_for_managed_guilds("interval_catch_up")
+    await _run_journal_automation_for_managed_guilds(
+        "interval_catch_up",
+        phase="recover",
+    )
+
+
+@tasks.loop(time=JOURNAL_PREPARATION_SCHEDULE_TIME)
+async def journal_preparation_schedule_task():
+    """Close evidence and start the scheduled Journal at 6:30 PM Pacific."""
+    await _run_journal_automation_for_managed_guilds(
+        "preparation_630pm_pacific",
+        phase="prepare",
+    )
 
 
 @tasks.loop(time=JOURNAL_DAILY_SCHEDULE_TIME)
 async def journal_daily_schedule_task():
-    """Start the daily Journal cycle at exactly 7:00 PM Pacific."""
-    await _run_journal_automation_for_managed_guilds("daily_7pm_pacific")
+    """Release the already-prepared scheduled Journal at 7:00 PM Pacific."""
+    await _run_journal_automation_for_managed_guilds(
+        "release_7pm_pacific",
+        phase="release",
+    )
 
 # ==================== AMBIENT MESSAGE TASK ====================
 
@@ -18105,6 +18218,9 @@ async def on_ready():
 
     if not source_file_refresh_worker_task.is_running():
         source_file_refresh_worker_task.start()
+
+    if not journal_preparation_schedule_task.is_running():
+        journal_preparation_schedule_task.start()
 
     if not journal_daily_schedule_task.is_running():
         journal_daily_schedule_task.start()

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -1806,6 +1806,83 @@ def _sample_source_kinds(
     return sorted(chosen, key=_source_sort_key)
 
 
+def _source_period_partitions(
+    period_bounds: list[dict[str, Any]],
+    relays: list[dict[str, Any]],
+    conversations: list[dict[str, Any]],
+    *,
+    eligible_ref_ids: Optional[set[str]] = None,
+) -> list[dict[str, Any]]:
+    """Describe ordered source-only periods from one already-loaded raw range.
+
+    Weekly cadence assembly uses these bounded, non-prose contexts so it can
+    account for each aligned period without re-querying the source archive or
+    manufacturing a hidden Daily article.
+    """
+    partitions: list[dict[str, Any]] = []
+    for spec in period_bounds:
+        start = str(spec.get("sourceWindowStart") or "")
+        end = str(spec.get("sourceWindowEnd") or "")
+        try:
+            start_dt = _parse_context_datetime(start)
+            end_dt = _parse_context_datetime(end)
+        except (TypeError, ValueError):
+            start_dt = None
+            end_dt = None
+        if start_dt is None or end_dt is None or end_dt <= start_dt:
+            raise ValueError("invalid_source_period_partition")
+
+        def in_period(source: dict[str, Any]) -> bool:
+            observed = _parse_context_datetime(source.get("observedAt"))
+            return observed is not None and start_dt <= observed < end_dt
+
+        period_relays = [source for source in relays if in_period(source)]
+        period_conversations = [source for source in conversations if in_period(source)]
+        ordered = sorted(period_relays + period_conversations, key=_source_sort_key)
+        eligible_ordered = [
+            source
+            for source in ordered
+            if eligible_ref_ids is None
+            or str(source.get("refId") or "") in eligible_ref_ids
+        ]
+        representative_refs = [
+            str(source.get("refId") or "")
+            for source in _evenly_sample(
+                eligible_ordered,
+                min(12, len(eligible_ordered)),
+            )
+            if str(source.get("refId") or "")
+        ]
+        safe_topics = [
+            _source_for_prompt(source)
+            for source in ordered
+            if str(source.get("summary") or "").strip()
+        ]
+        partitions.append(
+            {
+                "periodId": str(spec.get("periodId") or ""),
+                "periodKind": str(spec.get("periodKind") or "daily_period"),
+                "releaseDay": str(spec.get("releaseDay") or ""),
+                "sourceWindowStart": start,
+                "sourceWindowEnd": end,
+                "aggregateCounts": {
+                    "eligibleRelays": len(period_relays),
+                    "eligibleConversations": len(period_conversations),
+                    "participants": len(
+                        {
+                            source.get("subjectRef")
+                            for source in period_conversations
+                            if source.get("subjectRef")
+                        }
+                    ),
+                },
+                "topicTags": list(journal_topic_counts(safe_topics, limit=12)),
+                "sourceRefIds": representative_refs,
+            }
+        )
+    return partitions
+
+
 def build_packet_from_sources(
     db_path: str,
     guild_id: int,
@@ -1912,6 +1989,7 @@ def build_source_packet_between(
     entry_kind: str = "daily",
     observation_context: Optional[list[dict[str, Any]]] = None,
     excluded_history_entry_ids: Optional[set[str]] = None,
+    source_period_bounds: Optional[list[dict[str, Any]]] = None,
 ) -> dict[str, Any]:
     try:
         from bnl_journal_source_store import backfill_legacy_sources, query_source_events, timestamp_to_epoch_ms
@@ -1983,6 +2061,17 @@ def build_source_packet_between(
                 else True
             ),
         )
+        if source_period_bounds:
+            packet["sourcePeriodPartitions"] = _source_period_partitions(
+                source_period_bounds,
+                relays,
+                conversations,
+                eligible_ref_ids={
+                    str(source.get("refId") or "")
+                    for source in packet.get("safeSources", [])
+                    if str(source.get("refId") or "")
+                },
+            )
         packet["sourceArchiveAvailable"] = True
         return packet
     except (ImportError, sqlite3.Error, ValueError):
@@ -2011,6 +2100,17 @@ def build_source_packet_between(
         excluded_history_entry_ids=excluded_history_entry_ids,
         coverage_complete=relay_count <= MAX_RELAY_SOURCES_PER_WINDOW and conversation_count <= MAX_CONVERSATION_SOURCES_PER_WINDOW,
     )
+    if source_period_bounds:
+        packet["sourcePeriodPartitions"] = _source_period_partitions(
+            source_period_bounds,
+            relays,
+            conversations,
+            eligible_ref_ids={
+                str(source.get("refId") or "")
+                for source in packet.get("safeSources", [])
+                if str(source.get("refId") or "")
+            },
+        )
     packet["sourceArchiveAvailable"] = False
     return packet
 
@@ -2090,12 +2190,13 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
         },
         "history": _bounded_history_for_prompt(packet.get("history", {})),
         "aggregateCounts": packet.get("aggregateCounts", {}),
-        "dailyObservations": packet.get("observationContext", [])[:7],
+        "dailyObservations": packet.get("weeklyDailyPeriodContexts", packet.get("observationContext", []))[:6],
+        "weeklyFinalPeriod": packet.get("weeklyFinalPeriodContext"),
         "windowSegmentActivity": packet.get("windowSegmentActivity", []),
         "privateGenerationContextLanes": context_lanes,
     }
     cadence_rule = (
-        "\nThis is a weekly synthesis. Connect patterns across the supplied daily observations and current source evidence; do not merely list seven daily recaps."
+        "\nThis is a weekly synthesis. Connect patterns across the six supplied Tuesday-Sunday Daily-period contexts, the fresh final Sunday-to-Monday period, and the full current source evidence. A source-only period context is not a hidden Daily article. Do not list period recaps."
         if entry_kind == "weekly"
         else "\nThis is a daily chronicle covering one complete source window. Distill the day instead of listing every relay."
     )
@@ -2769,7 +2870,13 @@ def _generate_article_with_repairs(
         except Exception as exc:
             if retained_publishable is not None:
                 return retained_publishable, "", True
-            reason = "quota_unavailable" if "quota" in str(exc).lower() else "provider_failure"
+            lowered = str(exc).lower()
+            if "quota" in lowered:
+                reason = "quota_unavailable"
+            elif "journal_preparation_timeout" in lowered:
+                reason = "journal_preparation_timeout"
+            else:
+                reason = "provider_failure"
             return None, reason, False
         previous_output = raw
         try:

--- a/bnl_journal_automation.py
+++ b/bnl_journal_automation.py
@@ -7,7 +7,7 @@ import re
 import sqlite3
 from dataclasses import asdict, dataclass
 from datetime import date, datetime, time as datetime_time, timedelta, timezone
-from typing import Any, Callable, Optional
+from typing import AbstractSet, Any, Callable, Optional
 
 import pytz
 
@@ -27,16 +27,22 @@ from bnl_journal import (
 from bnl_journal_source_store import journal_release_privacy_fence
 
 PACIFIC = pytz.timezone("US/Pacific")
-DAILY_READY_HOUR = 19
-DAILY_READY_MINUTE = 0
+CADENCE_CONTRACT_VERSION = 2
+LEGACY_CADENCE_CONTRACT_VERSION = 1
+EVIDENCE_CUTOFF_HOUR = 18
+EVIDENCE_CUTOFF_MINUTE = 30
+PUBLIC_RELEASE_HOUR = 19
+PUBLIC_RELEASE_MINUTE = 0
+LEGACY_CUTOFF_HOUR = 19
+LEGACY_CUTOFF_MINUTE = 0
 WEEKLY_READY_WEEKDAY = 0  # Monday, covering the prior Monday-Sunday week.
-WEEKLY_READY_HOUR = 19
+DAILY_RELEASE_WEEKDAYS = frozenset({1, 2, 3, 4, 5, 6})  # Tuesday-Sunday.
 MIN_DAILY_SOURCE_COUNT = 5
 MIN_WEEKLY_ACTIVE_DAYS = 1
 LEASE_MINUTES = 30
 DELIVERY_LEASE_MINUTES = 2
 RETRY_MINUTES = 60
-TERMINAL_RUN_STATES = {"published", "quiet", "incomplete"}
+TERMINAL_RUN_STATES = {"published", "quiet", "incomplete", "superseded"}
 DELIVERY_PREFLIGHT_INVALIDATION_REASONS = frozenset({
     "prepared_revision_missing",
     "prepared_payload_integrity_failed",
@@ -79,7 +85,13 @@ def _utc_iso(value: datetime) -> str:
 
 def _pacific_journal_cutoff(day: date) -> datetime:
     return PACIFIC.localize(
-        datetime.combine(day, datetime_time(DAILY_READY_HOUR, DAILY_READY_MINUTE))
+        datetime.combine(day, datetime_time(EVIDENCE_CUTOFF_HOUR, EVIDENCE_CUTOFF_MINUTE))
+    )
+
+
+def _legacy_pacific_journal_cutoff(day: date) -> datetime:
+    return PACIFIC.localize(
+        datetime.combine(day, datetime_time(LEGACY_CUTOFF_HOUR, LEGACY_CUTOFF_MINUTE))
     )
 
 
@@ -92,7 +104,7 @@ def _daily_period_for_day(day: date) -> tuple[str, str, str]:
 def daily_period(now_utc: Optional[datetime] = None) -> tuple[str, str, str]:
     now = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
     start_day = now.date() - timedelta(days=1)
-    if (now.hour, now.minute) < (DAILY_READY_HOUR, DAILY_READY_MINUTE):
+    if (now.hour, now.minute) < (EVIDENCE_CUTOFF_HOUR, EVIDENCE_CUTOFF_MINUTE):
         start_day -= timedelta(days=1)
     return _daily_period_for_day(start_day)
 
@@ -106,40 +118,95 @@ def _weekly_period_for_monday(monday: date) -> tuple[str, str, str]:
 def weekly_period(now_utc: Optional[datetime] = None) -> tuple[str, str, str]:
     now = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
     monday = now.date() - timedelta(days=now.weekday())
-    if now.weekday() == WEEKLY_READY_WEEKDAY and now.hour < WEEKLY_READY_HOUR:
+    if (
+        now.weekday() == WEEKLY_READY_WEEKDAY
+        and (now.hour, now.minute) < (EVIDENCE_CUTOFF_HOUR, EVIDENCE_CUTOFF_MINUTE)
+    ):
         monday -= timedelta(days=7)
     return _weekly_period_for_monday(monday - timedelta(days=7))
 
 
+def daily_preparation_due(now_utc: Optional[datetime] = None) -> bool:
+    local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
+    return (
+        local.weekday() in DAILY_RELEASE_WEEKDAYS
+        and (local.hour, local.minute) >= (EVIDENCE_CUTOFF_HOUR, EVIDENCE_CUTOFF_MINUTE)
+    )
+
+
 def daily_due(now_utc: Optional[datetime] = None) -> bool:
     local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
-    return (local.hour, local.minute) >= (DAILY_READY_HOUR, DAILY_READY_MINUTE)
+    return (
+        local.weekday() in DAILY_RELEASE_WEEKDAYS
+        and (local.hour, local.minute) >= (PUBLIC_RELEASE_HOUR, PUBLIC_RELEASE_MINUTE)
+    )
+
+
+def weekly_preparation_due(now_utc: Optional[datetime] = None) -> bool:
+    local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
+    return (
+        local.weekday() == WEEKLY_READY_WEEKDAY
+        and (local.hour, local.minute) >= (EVIDENCE_CUTOFF_HOUR, EVIDENCE_CUTOFF_MINUTE)
+    )
 
 
 def weekly_due(now_utc: Optional[datetime] = None) -> bool:
     local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
-    return local.weekday() == WEEKLY_READY_WEEKDAY and local.hour >= WEEKLY_READY_HOUR
+    return (
+        local.weekday() == WEEKLY_READY_WEEKDAY
+        and (local.hour, local.minute) >= (PUBLIC_RELEASE_HOUR, PUBLIC_RELEASE_MINUTE)
+    )
+
+
+def _next_local_time(
+    local: datetime,
+    weekdays: AbstractSet[int],
+    hour: int,
+    minute: int,
+) -> datetime:
+    for offset in range(9):
+        candidate_day = local.date() + timedelta(days=offset)
+        if candidate_day.weekday() not in weekdays:
+            continue
+        candidate = PACIFIC.localize(
+            datetime.combine(candidate_day, datetime_time(hour, minute))
+        )
+        if candidate > local:
+            return candidate
+    raise RuntimeError("journal_schedule_resolution_failed")
 
 
 def next_schedule_times(now_utc: Optional[datetime] = None) -> tuple[str, str]:
     local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
-    daily_day = local.date()
-    daily_local = PACIFIC.localize(
-        datetime.combine(daily_day, datetime_time(DAILY_READY_HOUR, DAILY_READY_MINUTE))
+    daily_local = _next_local_time(
+        local,
+        DAILY_RELEASE_WEEKDAYS,
+        PUBLIC_RELEASE_HOUR,
+        PUBLIC_RELEASE_MINUTE,
     )
-    if daily_local <= local:
-        daily_local = PACIFIC.localize(
-            datetime.combine(daily_day + timedelta(days=1), datetime_time(DAILY_READY_HOUR, DAILY_READY_MINUTE))
-        )
-    days_until_monday = (WEEKLY_READY_WEEKDAY - local.weekday()) % 7
-    weekly_day = local.date() + timedelta(days=days_until_monday)
-    weekly_local = PACIFIC.localize(
-        datetime.combine(weekly_day, datetime_time(WEEKLY_READY_HOUR, 0))
+    weekly_local = _next_local_time(
+        local,
+        {WEEKLY_READY_WEEKDAY},
+        PUBLIC_RELEASE_HOUR,
+        PUBLIC_RELEASE_MINUTE,
     )
-    if weekly_local <= local:
-        weekly_local = PACIFIC.localize(
-            datetime.combine(weekly_day + timedelta(days=7), datetime_time(WEEKLY_READY_HOUR, 0))
-        )
+    return _utc_iso(daily_local), _utc_iso(weekly_local)
+
+
+def next_preparation_times(now_utc: Optional[datetime] = None) -> tuple[str, str]:
+    local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
+    daily_local = _next_local_time(
+        local,
+        DAILY_RELEASE_WEEKDAYS,
+        EVIDENCE_CUTOFF_HOUR,
+        EVIDENCE_CUTOFF_MINUTE,
+    )
+    weekly_local = _next_local_time(
+        local,
+        {WEEKLY_READY_WEEKDAY},
+        EVIDENCE_CUTOFF_HOUR,
+        EVIDENCE_CUTOFF_MINUTE,
+    )
     return _utc_iso(daily_local), _utc_iso(weekly_local)
 
 
@@ -187,6 +254,7 @@ def ensure_schema(db_path: str) -> None:
             prepared_at TEXT,
             delivery_epoch INTEGER NOT NULL DEFAULT 0,
             delivery_lease_expires_at TEXT,
+            schedule_contract_version INTEGER NOT NULL DEFAULT 1,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             UNIQUE(guild_id,cadence,source_window_start,source_window_end))""")
@@ -201,6 +269,7 @@ def ensure_schema(db_path: str) -> None:
             "prepared_at": "TEXT",
             "delivery_epoch": "INTEGER NOT NULL DEFAULT 0",
             "delivery_lease_expires_at": "TEXT",
+            "schedule_contract_version": "INTEGER NOT NULL DEFAULT 1",
         }
         for column, declaration in run_migrations.items():
             if column not in run_columns:
@@ -235,6 +304,15 @@ def ensure_schema(db_path: str) -> None:
             next_retry_at TEXT,
             memory_excluded_entry_ids_json TEXT NOT NULL DEFAULT '[]',
             memory_exclusions_confirmed_at TEXT,
+            cadence_contract_version INTEGER NOT NULL DEFAULT 1,
+            cadence_activated_at TEXT,
+            legacy_daily_boundary TEXT,
+            legacy_weekly_boundary TEXT,
+            daily_transition_start TEXT,
+            daily_transition_end TEXT,
+            weekly_transition_start TEXT,
+            weekly_transition_end TEXT,
+            cadence_activation_detail_json TEXT NOT NULL DEFAULT '{}',
             updated_at TEXT NOT NULL)""")
         state_columns = {
             str(row[1]) for row in conn.execute("PRAGMA table_info(bnl_journal_automation_state)")
@@ -242,12 +320,51 @@ def ensure_schema(db_path: str) -> None:
         state_migrations = {
             "memory_excluded_entry_ids_json": "TEXT NOT NULL DEFAULT '[]'",
             "memory_exclusions_confirmed_at": "TEXT",
+            "cadence_contract_version": "INTEGER NOT NULL DEFAULT 1",
+            "cadence_activated_at": "TEXT",
+            "legacy_daily_boundary": "TEXT",
+            "legacy_weekly_boundary": "TEXT",
+            "daily_transition_start": "TEXT",
+            "daily_transition_end": "TEXT",
+            "weekly_transition_start": "TEXT",
+            "weekly_transition_end": "TEXT",
+            "cadence_activation_detail_json": "TEXT NOT NULL DEFAULT '{}'",
         }
         for column, declaration in state_migrations.items():
             if column not in state_columns:
                 conn.execute(
                     f"ALTER TABLE bnl_journal_automation_state ADD COLUMN {column} {declaration}"
                 )
+        # Persist a fail-closed rollback boundary. A pre-cadence binary does
+        # not know the activation marker and would otherwise begin creating
+        # fresh 7 PM occurrences (including a Monday Daily) after rollback.
+        # Existing preserved version-1 obligations remain recoverable, but no
+        # new version-1 identity may appear after activation and a migration-
+        # superseded Monday Daily can never be revived.
+        conn.execute(
+            """CREATE TRIGGER IF NOT EXISTS
+                   trg_bnl_journal_runs_guard_cadence_v2_insert
+               BEFORE INSERT ON bnl_journal_automation_runs
+               WHEN COALESCE(NEW.schedule_contract_version,1) < 2
+                AND EXISTS(
+                    SELECT 1 FROM bnl_journal_automation_state s
+                    WHERE s.guild_id=NEW.guild_id
+                      AND COALESCE(s.cadence_contract_version,1) >= 2
+                )
+               BEGIN
+                   SELECT RAISE(ABORT,'journal_cadence_v2_downgrade_guard');
+               END"""
+        )
+        conn.execute(
+            """CREATE TRIGGER IF NOT EXISTS
+                   trg_bnl_journal_runs_guard_cadence_superseded
+               BEFORE UPDATE ON bnl_journal_automation_runs
+               WHEN OLD.lifecycle_state='superseded'
+                AND NEW.lifecycle_state<>'superseded'
+               BEGIN
+                   SELECT RAISE(ABORT,'journal_cadence_superseded_guard');
+               END"""
+        )
         if conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='bnl_journal_entries'"
         ).fetchone():
@@ -279,6 +396,499 @@ def ensure_schema(db_path: str) -> None:
                     "AND r.prepared_payload_hash IS NOT NULL"
                     ")"
                 )
+
+
+def _legacy_daily_period_for_day(day: date) -> tuple[str, str, str]:
+    start_local = _legacy_pacific_journal_cutoff(day)
+    end_local = _legacy_pacific_journal_cutoff(day + timedelta(days=1))
+    return _utc_iso(start_local), _utc_iso(end_local), day.isoformat()
+
+
+def _legacy_weekly_period_for_monday(monday: date) -> tuple[str, str, str]:
+    start_local = _legacy_pacific_journal_cutoff(monday)
+    end_local = _legacy_pacific_journal_cutoff(monday + timedelta(days=7))
+    return _utc_iso(start_local), _utc_iso(end_local), monday.isoformat()
+
+
+def _archive_activation_day_on_connection(
+    conn: sqlite3.Connection,
+    guild_id: int,
+    cutoff: Callable[[date], datetime],
+) -> Optional[date]:
+    table = conn.execute(
+        "SELECT 1 FROM sqlite_master "
+        "WHERE type='table' AND name='bnl_journal_source_archive_state'"
+    ).fetchone()
+    if not table:
+        return None
+    row = conn.execute(
+        "SELECT activated_at_ms FROM bnl_journal_source_archive_state WHERE guild_id=?",
+        (int(guild_id),),
+    ).fetchone()
+    if not row:
+        return None
+    activated = datetime.fromtimestamp(
+        int(row[0]) / 1000.0,
+        tz=timezone.utc,
+    ).astimezone(PACIFIC)
+    same_day_cutoff = cutoff(activated.date())
+    return activated.date() if activated <= same_day_cutoff else activated.date() + timedelta(days=1)
+
+
+def _legacy_latest_daily_day(now_utc: datetime) -> date:
+    local = now_utc.astimezone(PACIFIC)
+    latest = local.date() - timedelta(days=1)
+    if (local.hour, local.minute) < (LEGACY_CUTOFF_HOUR, LEGACY_CUTOFF_MINUTE):
+        latest -= timedelta(days=1)
+    return latest
+
+
+def _legacy_latest_week_monday(now_utc: datetime) -> date:
+    local = now_utc.astimezone(PACIFIC)
+    current_monday = local.date() - timedelta(days=local.weekday())
+    if (
+        local.weekday() == WEEKLY_READY_WEEKDAY
+        and (local.hour, local.minute) < (LEGACY_CUTOFF_HOUR, LEGACY_CUTOFF_MINUTE)
+    ):
+        current_monday -= timedelta(days=7)
+    return current_monday - timedelta(days=7)
+
+
+def _window_end_weekday(end: str) -> int:
+    return _parse_utc(end).astimezone(PACIFIC).weekday()
+
+
+def _insert_migration_legacy_run(
+    conn: sqlite3.Connection,
+    guild_id: int,
+    cadence: str,
+    start: str,
+    end: str,
+    lifecycle_state: str,
+    reason: str,
+) -> str:
+    run_id = _run_id(guild_id, cadence, start, end)
+    now = utc_now_iso()
+    conn.execute(
+        """INSERT OR IGNORE INTO bnl_journal_automation_runs(
+            run_id,guild_id,cadence,source_window_start,source_window_end,
+            lifecycle_state,reason,aggregate_counts_json,attempt_count,
+            schedule_contract_version,created_at,updated_at
+        ) VALUES(?,?,?,?,?,?,?,'{}',0,?,?,?)""",
+        (
+            run_id,
+            int(guild_id),
+            cadence,
+            start,
+            end,
+            lifecycle_state,
+            reason,
+            LEGACY_CADENCE_CONTRACT_VERSION,
+            now,
+            now,
+        ),
+    )
+    return run_id
+
+
+def _next_cutoff_after(
+    threshold: datetime,
+    weekdays: AbstractSet[int],
+) -> datetime:
+    local = threshold.astimezone(PACIFIC)
+    for offset in range(9):
+        candidate_day = local.date() + timedelta(days=offset)
+        if candidate_day.weekday() not in weekdays:
+            continue
+        candidate = _pacific_journal_cutoff(candidate_day)
+        if candidate > local:
+            return candidate
+    raise RuntimeError("journal_cadence_cutoff_resolution_failed")
+
+
+def ensure_cadence_activation(
+    db_path: str,
+    guild_id: int,
+    *,
+    now_utc: Optional[datetime] = None,
+) -> dict[str, Any]:
+    # Once activated, this is a read-only fast path. In particular, normal
+    # release must not wait on the migration fence while another delivery owns
+    # the network boundary.
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        state = conn.execute(
+            "SELECT * FROM bnl_journal_automation_state WHERE guild_id=?",
+            (int(guild_id),),
+        ).fetchone()
+    if state and int(state["cadence_contract_version"] or 1) >= CADENCE_CONTRACT_VERSION:
+        return dict(state)
+
+    # Cadence activation can terminally supersede an unpublished old Monday
+    # Daily. Order that mutation against the same cross-process fence used by
+    # the final POST so activation cannot race a delivery already at the
+    # network boundary.
+    with journal_release_privacy_fence(db_path, blocking=True) as acquired:
+        if not acquired:
+            raise sqlite3.OperationalError("journal_cadence_activation_fence_unavailable")
+        return _ensure_cadence_activation_under_fence(
+            db_path,
+            guild_id,
+            now_utc=now_utc,
+        )
+
+
+def _ensure_cadence_activation_under_fence(
+    db_path: str,
+    guild_id: int,
+    *,
+    now_utc: Optional[datetime] = None,
+) -> dict[str, Any]:
+    """Activate the 6:30/7:00 cadence once without reinterpreting old rows."""
+    ensure_schema(db_path)
+    now = (now_utc or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    with sqlite3.connect(db_path, timeout=30) as conn:
+        conn.row_factory = sqlite3.Row
+        conn.execute("BEGIN IMMEDIATE")
+        state = conn.execute(
+            "SELECT * FROM bnl_journal_automation_state WHERE guild_id=?",
+            (int(guild_id),),
+        ).fetchone()
+        if state and int(state["cadence_contract_version"] or 1) >= CADENCE_CONTRACT_VERSION:
+            conn.commit()
+            return dict(state)
+
+        old_rows = [
+            dict(row)
+            for row in conn.execute(
+                "SELECT * FROM bnl_journal_automation_runs "
+                "WHERE guild_id=? AND COALESCE(schedule_contract_version,1)=1",
+                (int(guild_id),),
+            ).fetchall()
+        ]
+        daily_rows = {
+            (str(row["source_window_start"]), str(row["source_window_end"])): row
+            for row in old_rows
+            if str(row.get("cadence") or "") == "daily"
+        }
+        weekly_rows = {
+            (str(row["source_window_start"]), str(row["source_window_end"])): row
+            for row in old_rows
+            if str(row.get("cadence") or "") == "weekly"
+        }
+        classified_run_ids: list[str] = []
+        preserved_run_ids: list[str] = []
+
+        first_daily = _archive_activation_day_on_connection(
+            conn,
+            guild_id,
+            _legacy_pacific_journal_cutoff,
+        )
+        if first_daily is not None:
+            current = _legacy_latest_daily_day(now)
+            while current >= first_daily:
+                start, end, _ = _legacy_daily_period_for_day(current)
+                row = daily_rows.get((start, end))
+                if row is None:
+                    preserved_run_ids.append(
+                        _insert_migration_legacy_run(
+                            conn,
+                            guild_id,
+                            "daily",
+                            start,
+                            end,
+                            "held",
+                            "cadence_migration_preserved_owed_legacy_window",
+                        )
+                    )
+                    break
+                if str(row.get("lifecycle_state") or "") not in TERMINAL_RUN_STATES:
+                    break
+                current -= timedelta(days=1)
+
+        first_week_day = _archive_activation_day_on_connection(
+            conn,
+            guild_id,
+            _legacy_pacific_journal_cutoff,
+        )
+        if first_week_day is not None:
+            first_monday = first_week_day + timedelta(days=(7 - first_week_day.weekday()) % 7)
+            latest_monday = _legacy_latest_week_monday(now)
+            # The predecessor scheduler selected the earliest incomplete
+            # Weekly, unlike Daily's newest-first rule. Preserve that one
+            # finite deterministic obligation exactly.
+            current = first_monday
+            while current <= latest_monday:
+                start, end, _ = _legacy_weekly_period_for_monday(current)
+                row = weekly_rows.get((start, end))
+                if row is None:
+                    preserved_run_ids.append(
+                        _insert_migration_legacy_run(
+                            conn,
+                            guild_id,
+                            "weekly",
+                            start,
+                            end,
+                            "held",
+                            "cadence_migration_preserved_owed_legacy_window",
+                        )
+                    )
+                    break
+                if str(row.get("lifecycle_state") or "") not in TERMINAL_RUN_STATES:
+                    break
+                current += timedelta(days=7)
+
+        # Reload after inserting explicit historical classifications.
+        old_rows = [
+            dict(row)
+            for row in conn.execute(
+                "SELECT * FROM bnl_journal_automation_runs "
+                "WHERE guild_id=? AND COALESCE(schedule_contract_version,1)=1",
+                (int(guild_id),),
+            ).fetchall()
+        ]
+        superseded_run_ids: list[str] = []
+        now_iso = utc_now_iso()
+        for row in old_rows:
+            if (
+                str(row.get("cadence") or "") != "daily"
+                or _window_end_weekday(str(row.get("source_window_end") or ""))
+                != WEEKLY_READY_WEEKDAY
+                or str(row.get("lifecycle_state") or "") == "published"
+            ):
+                continue
+            run_id = str(row.get("run_id") or "")
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs "
+                "SET lifecycle_state='superseded',"
+                "reason='cadence_migration_monday_weekly_only',"
+                "lease_expires_at=NULL,delivery_lease_expires_at=NULL,updated_at=? "
+                "WHERE run_id=?",
+                (now_iso, run_id),
+            )
+            entry_id = str(row.get("journal_entry_id") or "")
+            revision = int(row.get("journal_revision") or 0)
+            if entry_id and revision > 0:
+                if conn.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='table' AND name='bnl_journal_entries'"
+                ).fetchone():
+                    conn.execute(
+                        "UPDATE bnl_journal_entries "
+                        "SET lifecycle_state='rejected',"
+                        "review_reason='cadence_migration_monday_weekly_only',updated_at=? "
+                        "WHERE guild_id=? AND entry_id=? AND revision=? "
+                        "AND lifecycle_state<>'published'",
+                        (now_iso, int(guild_id), entry_id, revision),
+                    )
+                if conn.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='table' AND name='bnl_journal_private_metadata'"
+                ).fetchone():
+                    conn.execute(
+                        "UPDATE bnl_journal_private_metadata "
+                        "SET lifecycle_state='rejected',updated_at=? "
+                        "WHERE guild_id=? AND entry_id=? AND revision=? "
+                        "AND lifecycle_state<>'published'",
+                        (now_iso, int(guild_id), entry_id, revision),
+                    )
+            superseded_run_ids.append(run_id)
+
+        if superseded_run_ids:
+            latest_superseded = max(
+                (
+                    row
+                    for row in old_rows
+                    if str(row.get("run_id") or "") in set(superseded_run_ids)
+                ),
+                key=lambda row: str(row.get("source_window_end") or ""),
+            )
+            try:
+                superseded_counts = json.loads(
+                    str(latest_superseded.get("aggregate_counts_json") or "{}")
+                )
+            except (TypeError, json.JSONDecodeError):
+                superseded_counts = {}
+            _update_state(
+                conn,
+                int(guild_id),
+                AutomationResult(
+                    False,
+                    "daily",
+                    "superseded",
+                    "cadence_migration_monday_weekly_only",
+                    str(latest_superseded.get("journal_entry_id") or ""),
+                    int(latest_superseded.get("journal_revision") or 0),
+                    str(latest_superseded.get("source_window_start") or ""),
+                    str(latest_superseded.get("source_window_end") or ""),
+                    superseded_counts,
+                ),
+            )
+
+        active_legacy = [
+            row
+            for row in old_rows
+            if str(row.get("run_id") or "") not in set(superseded_run_ids)
+            and str(row.get("lifecycle_state") or "") != "superseded"
+        ]
+        legacy_daily_boundary = max(
+            (
+                str(row.get("source_window_end") or "")
+                for row in active_legacy
+                if str(row.get("cadence") or "") == "daily"
+            ),
+            default="",
+        )
+        legacy_weekly_boundary = max(
+            (
+                str(row.get("source_window_end") or "")
+                for row in active_legacy
+                if str(row.get("cadence") or "") == "weekly"
+            ),
+            default="",
+        )
+
+        daily_threshold = max(
+            [value for value in (now, _parse_utc(legacy_daily_boundary) if legacy_daily_boundary else None) if value is not None]
+        )
+        daily_transition_end_local = _next_cutoff_after(
+            daily_threshold,
+            DAILY_RELEASE_WEEKDAYS,
+        )
+        daily_normal_start_local = _pacific_journal_cutoff(
+            daily_transition_end_local.date() - timedelta(days=1)
+        )
+        daily_transition_start_local = daily_normal_start_local
+        if legacy_daily_boundary:
+            legacy_daily_local = _parse_utc(legacy_daily_boundary).astimezone(PACIFIC)
+            if daily_normal_start_local < legacy_daily_local < daily_transition_end_local:
+                daily_transition_start_local = legacy_daily_local
+
+        weekly_threshold = max(
+            [value for value in (now, _parse_utc(legacy_weekly_boundary) if legacy_weekly_boundary else None) if value is not None]
+        )
+        weekly_transition_end_local = _next_cutoff_after(
+            weekly_threshold,
+            {WEEKLY_READY_WEEKDAY},
+        )
+        weekly_normal_start_local = _pacific_journal_cutoff(
+            weekly_transition_end_local.date() - timedelta(days=7)
+        )
+        weekly_transition_start_local = weekly_normal_start_local
+        if legacy_weekly_boundary:
+            legacy_weekly_local = _parse_utc(legacy_weekly_boundary).astimezone(PACIFIC)
+            if weekly_normal_start_local < legacy_weekly_local < weekly_transition_end_local:
+                weekly_transition_start_local = legacy_weekly_local
+
+        classified_legacy_ranges: list[dict[str, str]] = []
+        if legacy_daily_boundary:
+            legacy_daily_local = _parse_utc(legacy_daily_boundary).astimezone(PACIFIC)
+            if legacy_daily_local < daily_normal_start_local:
+                classified_legacy_ranges.append(
+                    {
+                        "cadence": "daily",
+                        "sourceWindowStart": _utc_iso(legacy_daily_local),
+                        "sourceWindowEnd": _utc_iso(daily_normal_start_local),
+                        "reason": "cadence_migration_monday_weekly_only_range",
+                    }
+                )
+        if legacy_weekly_boundary:
+            legacy_weekly_local = _parse_utc(legacy_weekly_boundary).astimezone(PACIFIC)
+            if legacy_weekly_local < weekly_normal_start_local:
+                classified_legacy_ranges.append(
+                    {
+                        "cadence": "weekly",
+                        "sourceWindowStart": _utc_iso(legacy_weekly_local),
+                        "sourceWindowEnd": _utc_iso(weekly_normal_start_local),
+                        "reason": (
+                            "cadence_migration_unbounded_prospective_backlog_"
+                            "not_materialized"
+                        ),
+                    }
+                )
+
+        detail = {
+            "classifiedLegacyRunIds": sorted(set(classified_run_ids)),
+            "classifiedLegacyRanges": classified_legacy_ranges,
+            "preservedLegacyRunIds": sorted(set(preserved_run_ids)),
+            "supersededMondayDailyRunIds": sorted(set(superseded_run_ids)),
+        }
+        activation_values = (
+            int(guild_id),
+            CADENCE_CONTRACT_VERSION,
+            _utc_iso(now),
+            legacy_daily_boundary or None,
+            legacy_weekly_boundary or None,
+            _utc_iso(daily_transition_start_local),
+            _utc_iso(daily_transition_end_local),
+            _utc_iso(weekly_transition_start_local),
+            _utc_iso(weekly_transition_end_local),
+            _json(detail),
+            now_iso,
+        )
+        conn.execute(
+            """INSERT INTO bnl_journal_automation_state(
+                guild_id,cadence_contract_version,cadence_activated_at,
+                legacy_daily_boundary,legacy_weekly_boundary,
+                daily_transition_start,daily_transition_end,
+                weekly_transition_start,weekly_transition_end,
+                cadence_activation_detail_json,updated_at
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?)
+            ON CONFLICT(guild_id) DO UPDATE SET
+                cadence_contract_version=excluded.cadence_contract_version,
+                cadence_activated_at=excluded.cadence_activated_at,
+                legacy_daily_boundary=excluded.legacy_daily_boundary,
+                legacy_weekly_boundary=excluded.legacy_weekly_boundary,
+                daily_transition_start=excluded.daily_transition_start,
+                daily_transition_end=excluded.daily_transition_end,
+                weekly_transition_start=excluded.weekly_transition_start,
+                weekly_transition_end=excluded.weekly_transition_end,
+                cadence_activation_detail_json=excluded.cadence_activation_detail_json,
+                updated_at=excluded.updated_at""",
+            activation_values,
+        )
+        conn.commit()
+    return {
+        "guild_id": int(guild_id),
+        "cadence_contract_version": CADENCE_CONTRACT_VERSION,
+        "cadence_activated_at": _utc_iso(now),
+        "legacy_daily_boundary": legacy_daily_boundary,
+        "legacy_weekly_boundary": legacy_weekly_boundary,
+        "daily_transition_start": _utc_iso(daily_transition_start_local),
+        "daily_transition_end": _utc_iso(daily_transition_end_local),
+        "weekly_transition_start": _utc_iso(weekly_transition_start_local),
+        "weekly_transition_end": _utc_iso(weekly_transition_end_local),
+        "cadence_activation_detail_json": _json(detail),
+    }
+
+
+def _daily_period_for_target(
+    db_path: str,
+    guild_id: int,
+    target_day: date,
+    *,
+    now_utc: Optional[datetime] = None,
+) -> tuple[str, str, str]:
+    state = ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
+    start, end, label = _daily_period_for_day(target_day)
+    if end == str(state.get("daily_transition_end") or ""):
+        start = str(state.get("daily_transition_start") or start)
+    return start, end, label
+
+
+def _weekly_period_for_target(
+    db_path: str,
+    guild_id: int,
+    target_monday: date,
+    *,
+    now_utc: Optional[datetime] = None,
+) -> tuple[str, str, str]:
+    state = ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
+    start, end, label = _weekly_period_for_monday(target_monday)
+    if end == str(state.get("weekly_transition_end") or ""):
+        start = str(state.get("weekly_transition_start") or start)
+    return start, end, label
 
 
 def _load_journal_memory_exclusions_on_connection(
@@ -403,6 +1013,7 @@ def _claim_preparation(
     end: str,
     *,
     force: bool = False,
+    schedule_contract_version: int = CADENCE_CONTRACT_VERSION,
 ) -> tuple[str, str, int, dict[str, Any]]:
     ensure_schema(db_path)
     run_id = _run_id(guild_id, cadence, start, end)
@@ -447,16 +1058,33 @@ def _claim_preparation(
             epoch = int(current.get("preparation_epoch") or 0) + 1
             conn.execute("""UPDATE bnl_journal_automation_runs
                 SET lifecycle_state='preparing',reason='',attempt_count=attempt_count+1,
-                    preparation_epoch=?,lease_expires_at=?,delivery_lease_expires_at=NULL,updated_at=?
-                WHERE run_id=?""", (epoch, lease, utc_now_iso(), run_id))
+                    preparation_epoch=?,lease_expires_at=?,delivery_lease_expires_at=NULL,
+                    schedule_contract_version=?,updated_at=?
+                WHERE run_id=?""", (
+                    epoch,
+                    lease,
+                    int(schedule_contract_version),
+                    utc_now_iso(),
+                    run_id,
+                ))
         else:
             now_iso = utc_now_iso()
             epoch = 1
             conn.execute("""INSERT INTO bnl_journal_automation_runs(
                 run_id,guild_id,cadence,source_window_start,source_window_end,lifecycle_state,reason,
-                aggregate_counts_json,attempt_count,lease_expires_at,preparation_epoch,created_at,updated_at
-            ) VALUES(?,?,?,?,?,'preparing','', '{}',1,?,?,?,?)""", (
-                run_id, guild_id, cadence, start, end, lease, epoch, now_iso, now_iso,
+                aggregate_counts_json,attempt_count,lease_expires_at,preparation_epoch,
+                schedule_contract_version,created_at,updated_at
+            ) VALUES(?,?,?,?,?,'preparing','', '{}',1,?,?,?,?,?)""", (
+                run_id,
+                guild_id,
+                cadence,
+                start,
+                end,
+                lease,
+                epoch,
+                int(schedule_contract_version),
+                now_iso,
+                now_iso,
             ))
         conn.commit()
     return "claimed", run_id, epoch, {}
@@ -1742,7 +2370,7 @@ def _claim_delivery(
             conn.rollback()
             return "not_prepared", run_id, 0, {}
         current = dict(run)
-        if current["lifecycle_state"] == "published":
+        if current["lifecycle_state"] in TERMINAL_RUN_STATES:
             conn.commit()
             return "complete", run_id, int(current.get("delivery_epoch") or 0), current
         if current["lifecycle_state"] == "delivery_failed" and not force:
@@ -2293,21 +2921,60 @@ def release_prepared_entry(
     )
 
 
-def prepare_daily(
+def _window_is_closed(end: str, now_utc: Optional[datetime]) -> bool:
+    now = (now_utc or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    return now >= _parse_utc(end)
+
+
+def _window_release_is_due(end: str, now_utc: Optional[datetime]) -> bool:
+    now = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
+    end_local = _parse_utc(end).astimezone(PACIFIC)
+    release_local = PACIFIC.localize(
+        datetime.combine(
+            end_local.date(),
+            datetime_time(PUBLIC_RELEASE_HOUR, PUBLIC_RELEASE_MINUTE),
+        )
+    )
+    return now >= release_local
+
+
+def _daily_window_is_scheduled(end: str) -> bool:
+    return _window_end_weekday(end) in DAILY_RELEASE_WEEKDAYS
+
+
+def _v2_window_is_activated(
+    state: dict[str, Any],
+    cadence: str,
+    end: str,
+) -> bool:
+    transition_end = str(state.get(f"{cadence}_transition_end") or "")
+    return bool(
+        transition_end
+        and _parse_utc(end) >= _parse_utc(transition_end)
+    )
+
+
+def _prepare_daily_window(
     db_path: str,
     guild_id: int,
     generator: Callable[[dict[str, Any], str], str],
+    start: str,
+    end: str,
+    label: str,
     *,
-    now_utc: Optional[datetime] = None,
-    target_day: Optional[date] = None,
     force: bool = False,
     memory_excluded_entry_ids: Optional[set[str]] = None,
+    schedule_contract_version: int = CADENCE_CONTRACT_VERSION,
 ) -> AutomationResult:
-    ensure_schema(db_path)
-    start, end, label = _daily_period_for_day(target_day) if target_day else daily_period(now_utc)
-    if not force and target_day is None and not daily_due(now_utc):
-        return AutomationResult(False, "daily", "not_due", "before_daily_publish_time", source_window_start=start, source_window_end=end)
-    claim, run_id, preparation_epoch, row = _claim_preparation(db_path, guild_id, "daily", start, end, force=force)
+    claim, run_id, preparation_epoch, row = _claim_preparation(
+        db_path,
+        guild_id,
+        "daily",
+        start,
+        end,
+        force=force,
+        schedule_contract_version=schedule_contract_version,
+    )
     if claim != "claimed":
         return _result_from_existing("daily", row, claim=claim)
     legacy = _adopt_legacy_staged_revision(
@@ -2339,12 +3006,26 @@ def prepare_daily(
     )
     if packet is None:
         if freeze_reason.startswith("preparation_epoch_"):
-            return AutomationResult(False, "daily", "busy", freeze_reason, source_window_start=start, source_window_end=end)
+            return AutomationResult(
+                False,
+                "daily",
+                "busy",
+                freeze_reason,
+                source_window_start=start,
+                source_window_end=end,
+            )
         return _finish_preparation(
             db_path,
             run_id,
             preparation_epoch,
-            AutomationResult(False, "daily", "held", freeze_reason or "source_packet_freeze_failed", source_window_start=start, source_window_end=end),
+            AutomationResult(
+                False,
+                "daily",
+                "held",
+                freeze_reason or "source_packet_freeze_failed",
+                source_window_start=start,
+                source_window_end=end,
+            ),
         )
     if source_hash:
         observation_id, observation_reason = _store_observation(
@@ -2380,15 +3061,39 @@ def prepare_daily(
                 ),
             )
     if not packet.get("sourceArchiveAvailable", False):
-        result = AutomationResult(False, "daily", "held", "source_archive_unavailable", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
+        result = AutomationResult(
+            False,
+            "daily",
+            "held",
+            "source_archive_unavailable",
+            source_window_start=start,
+            source_window_end=end,
+            aggregate_counts=packet.get("aggregateCounts"),
+        )
     elif not packet.get("coverageComplete", True):
         # Time cannot make a pre-archive window complete. Record it explicitly
         # and move on instead of blocking every later catch-up day forever.
-        result = AutomationResult(False, "daily", "incomplete", "window_began_before_archive_activation", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
+        result = AutomationResult(
+            False,
+            "daily",
+            "incomplete",
+            "window_began_before_archive_activation",
+            source_window_start=start,
+            source_window_end=end,
+            aggregate_counts=packet.get("aggregateCounts"),
+        )
     elif not _has_meaningful_daily_activity(packet):
-        result = AutomationResult(True, "daily", "quiet", "insufficient_meaningful_activity", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
+        result = AutomationResult(
+            True,
+            "daily",
+            "quiet",
+            "insufficient_meaningful_activity",
+            source_window_start=start,
+            source_window_end=end,
+            aggregate_counts=packet.get("aggregateCounts"),
+        )
     else:
-        result = _prepare_packet_safely(
+        return _prepare_packet_safely(
             db_path,
             guild_id,
             "daily",
@@ -2399,9 +3104,60 @@ def prepare_daily(
             source_hash,
             generator,
         )
-        return result
-    finished = _finish_preparation(db_path, run_id, preparation_epoch, result)
-    return finished
+    return _finish_preparation(db_path, run_id, preparation_epoch, result)
+
+
+def prepare_daily(
+    db_path: str,
+    guild_id: int,
+    generator: Callable[[dict[str, Any], str], str],
+    *,
+    now_utc: Optional[datetime] = None,
+    target_day: Optional[date] = None,
+    force: bool = False,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
+) -> AutomationResult:
+    ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
+    if target_day is None:
+        _start, _end, label = daily_period(now_utc)
+        resolved_day = date.fromisoformat(label)
+    else:
+        resolved_day = target_day
+    start, end, label = _daily_period_for_target(
+        db_path,
+        guild_id,
+        resolved_day,
+        now_utc=now_utc,
+    )
+    if not _daily_window_is_scheduled(end):
+        return AutomationResult(
+            False,
+            "daily",
+            "not_applicable",
+            "monday_weekly_only",
+            source_window_start=start,
+            source_window_end=end,
+        )
+    if not _window_is_closed(end, now_utc):
+        return AutomationResult(
+            False,
+            "daily",
+            "not_due",
+            "before_daily_preparation_time",
+            source_window_start=start,
+            source_window_end=end,
+        )
+    return _prepare_daily_window(
+        db_path,
+        guild_id,
+        generator,
+        start,
+        end,
+        label,
+        force=force,
+        memory_excluded_entry_ids=memory_excluded_entry_ids,
+        schedule_contract_version=CADENCE_CONTRACT_VERSION,
+    )
 
 
 def release_daily(
@@ -2417,9 +3173,36 @@ def release_daily(
     memory_excluded_entry_ids: Optional[set[str]] = None,
     memory_exclusions_confirmed: bool = True,
 ) -> AutomationResult:
-    start, end, label = _daily_period_for_day(target_day) if target_day else daily_period(now_utc)
-    if not force and target_day is None and not daily_due(now_utc):
-        return AutomationResult(False, "daily", "not_due", "before_daily_publish_time", source_window_start=start, source_window_end=end)
+    ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
+    if target_day is None:
+        _start, _end, label = daily_period(now_utc)
+        resolved_day = date.fromisoformat(label)
+    else:
+        resolved_day = target_day
+    start, end, label = _daily_period_for_target(
+        db_path,
+        guild_id,
+        resolved_day,
+        now_utc=now_utc,
+    )
+    if not _daily_window_is_scheduled(end):
+        return AutomationResult(
+            False,
+            "daily",
+            "not_applicable",
+            "monday_weekly_only",
+            source_window_start=start,
+            source_window_end=end,
+        )
+    if not _window_release_is_due(end, now_utc):
+        return AutomationResult(
+            True,
+            "daily",
+            "prepared",
+            "prepared_waiting_release",
+            source_window_start=start,
+            source_window_end=end,
+        )
     result = release_occurrence(
         db_path,
         guild_id,
@@ -2461,6 +3244,8 @@ def run_daily(
     )
     if prepared.status != "prepared":
         return prepared
+    if not _window_release_is_due(prepared.source_window_end, now_utc):
+        return prepared
     return release_daily(
         db_path,
         guild_id,
@@ -2475,6 +3260,70 @@ def run_daily(
     )
 
 
+def _weekly_source_period_bounds(
+    start: str,
+    end: str,
+    *,
+    cutoff_hour: int = EVIDENCE_CUTOFF_HOUR,
+    cutoff_minute: int = EVIDENCE_CUTOFF_MINUTE,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    start_local = _parse_utc(start).astimezone(PACIFIC)
+    end_local = _parse_utc(end).astimezone(PACIFIC)
+    if (
+        end_local.weekday() != WEEKLY_READY_WEEKDAY
+        or (end_local.hour, end_local.minute)
+        != (cutoff_hour, cutoff_minute)
+        or start_local >= end_local
+    ):
+        raise ValueError("invalid_weekly_cadence_window")
+
+    def cutoff(day: date) -> datetime:
+        return PACIFIC.localize(
+            datetime.combine(day, datetime_time(cutoff_hour, cutoff_minute))
+        )
+
+    daily_periods: list[dict[str, Any]] = []
+    current_start = start_local
+    for days_before_end in range(6, 0, -1):
+        release_day = end_local.date() - timedelta(days=days_before_end)
+        period_end = cutoff(release_day)
+        if period_end <= current_start:
+            raise ValueError("invalid_weekly_transition_component")
+        period_start_iso = _utc_iso(current_start)
+        period_end_iso = _utc_iso(period_end)
+        daily_periods.append(
+            {
+                "periodId": "jperiod_"
+                + hashlib.sha256(
+                    f"daily|{period_start_iso}|{period_end_iso}".encode("utf-8")
+                ).hexdigest()[:20],
+                "periodKind": "daily_period",
+                "releaseDay": release_day.isoformat(),
+                "sourceWindowStart": period_start_iso,
+                "sourceWindowEnd": period_end_iso,
+            }
+        )
+        current_start = period_end
+
+    final_period = {
+        "periodId": "jperiod_"
+        + hashlib.sha256(
+            f"weekly_final|{_utc_iso(current_start)}|{_utc_iso(end_local)}".encode(
+                "utf-8"
+            )
+        ).hexdigest()[:20],
+        "periodKind": "weekly_final_period",
+        "releaseDay": end_local.date().isoformat(),
+        "sourceWindowStart": _utc_iso(current_start),
+        "sourceWindowEnd": _utc_iso(end_local),
+    }
+    if _parse_utc(final_period["sourceWindowEnd"]) <= _parse_utc(
+        final_period["sourceWindowStart"]
+    ):
+        raise ValueError("invalid_weekly_final_period")
+    return daily_periods, final_period
+
+
 def _weekly_packet(
     db_path: str,
     guild_id: int,
@@ -2482,9 +3331,19 @@ def _weekly_packet(
     end: str,
     *,
     memory_excluded_entry_ids: Optional[set[str]] = None,
+    schedule_contract_version: int = CADENCE_CONTRACT_VERSION,
 ) -> tuple[Optional[dict[str, Any]], int, int]:
     ensure_schema(db_path)
     excluded = {str(entry_id) for entry_id in (memory_excluded_entry_ids or set()) if str(entry_id)}
+    if int(schedule_contract_version) == LEGACY_CADENCE_CONTRACT_VERSION:
+        daily_bounds, final_bound = _weekly_source_period_bounds(
+            start,
+            end,
+            cutoff_hour=LEGACY_CUTOFF_HOUR,
+            cutoff_minute=LEGACY_CUTOFF_MINUTE,
+        )
+    else:
+        daily_bounds, final_bound = _weekly_source_period_bounds(start, end)
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
         observations = conn.execute("""SELECT * FROM bnl_journal_observations
@@ -2495,55 +3354,134 @@ def _weekly_packet(
             for row in conn.execute("""SELECT entry_id,title,excerpt FROM bnl_journal_entries
                 WHERE guild_id=? AND lifecycle_state='published' AND source_window_start>=? AND source_window_end<=?""", (guild_id, start, end)).fetchall()
         }
-    complete = [row for row in observations if row["lifecycle_state"] in {"published", "quiet"}]
-    active = [row for row in complete if row["lifecycle_state"] == "published"]
-    # A weekly synthesis is only grounded once all seven daily windows have
-    # reached a durable terminal state. Held/incomplete days are excluded.
-    if len(complete) < 7 or len(active) < MIN_WEEKLY_ACTIVE_DAYS:
-        return None, len(complete), len(active)
-    observation_context: list[dict[str, Any]] = []
-    for row in complete:
-        counts = json.loads(row["aggregate_counts_json"] or "{}")
-        topics = json.loads(row["topic_counts_json"] or "{}")
-        daily_entry_id = str(row["journal_entry_id"] or "")
-        entry = daily_entries.get(daily_entry_id, {}) if daily_entry_id not in excluded else {}
-        observation_context.append({
-            "date": row["observation_date"], "state": row["lifecycle_state"], "counts": counts,
-            "topicCounts": topics, "dailyEntryId": "" if daily_entry_id in excluded else daily_entry_id,
-            "dailyTitle": entry.get("title", ""), "dailyExcerpt": entry.get("excerpt", ""),
-        })
-    # Re-read the durable full-week archive and sample it exactly once. Reusing
-    # already-sampled daily representatives caused busy weeks to be compressed
-    # twice and discarded the private display-name set needed for the normal
-    # cross-participant sanitization pass.
+    observation_by_bounds = {
+        (str(row["source_window_start"]), str(row["source_window_end"])): row
+        for row in observations
+        if str(row["lifecycle_state"]) in {"published", "quiet"}
+    }
+
+    # The full raw range is authoritative and is loaded once. Its ordered
+    # partitions let Weekly proceed when Daily automation was disabled or an
+    # exact Daily observation is absent, without creating a hidden seventh
+    # Daily or re-sampling the Sunday-to-Monday tail.
     packet = build_source_packet_between(
         db_path,
         guild_id,
         start,
         end,
         entry_kind="weekly",
-        observation_context=observation_context,
         excluded_history_entry_ids=excluded,
+        source_period_bounds=daily_bounds + [final_bound],
     )
-    packet.setdefault("aggregateCounts", {})["daysObserved"] = len(complete)
-    packet["aggregateCounts"]["activeDays"] = len(active)
-    return packet, len(complete), len(active)
+    partitions = {
+        str(item.get("periodId") or ""): item
+        for item in packet.pop("sourcePeriodPartitions", [])
+        if isinstance(item, dict)
+    }
+    daily_contexts: list[dict[str, Any]] = []
+    complete_days = 0
+    active_days = 0
+    for bound in daily_bounds:
+        partition = dict(partitions.get(str(bound["periodId"]), {}))
+        row = observation_by_bounds.get(
+            (str(bound["sourceWindowStart"]), str(bound["sourceWindowEnd"]))
+        )
+        if row is not None:
+            complete_days += 1
+            active_days += 1 if str(row["lifecycle_state"]) == "published" else 0
+        daily_entry_id = str(row["journal_entry_id"] or "") if row is not None else ""
+        entry = (
+            daily_entries.get(daily_entry_id, {})
+            if daily_entry_id and daily_entry_id not in excluded
+            else {}
+        )
+        context = {
+            **bound,
+            "originType": "daily_observation" if row is not None else "raw_partition",
+            "state": str(row["lifecycle_state"]) if row is not None else "source_only",
+            "counts": (
+                json.loads(row["aggregate_counts_json"] or "{}")
+                if row is not None
+                else partition.get("aggregateCounts", {})
+            ),
+            "topicCounts": (
+                json.loads(row["topic_counts_json"] or "{}")
+                if row is not None
+                else {
+                    str(topic): 1
+                    for topic in partition.get("topicTags", [])
+                    if str(topic)
+                }
+            ),
+            "sourceRefIds": list(partition.get("sourceRefIds", [])),
+            "dailyEntryId": (
+                daily_entry_id if daily_entry_id and daily_entry_id not in excluded else ""
+            ),
+            "dailyTitle": str(entry.get("title") or ""),
+            "dailyExcerpt": str(entry.get("excerpt") or ""),
+        }
+        daily_contexts.append(context)
+
+    final_partition = dict(partitions.get(str(final_bound["periodId"]), {}))
+    final_context = {
+        **final_bound,
+        "originType": "raw_partition",
+        "state": "source_only",
+        "counts": final_partition.get("aggregateCounts", {}),
+        "topicCounts": {
+            str(topic): 1
+            for topic in final_partition.get("topicTags", [])
+            if str(topic)
+        },
+        "sourceRefIds": list(final_partition.get("sourceRefIds", [])),
+    }
+    packet["observationContext"] = daily_contexts
+    packet["weeklyDailyPeriodContexts"] = daily_contexts
+    packet["weeklyFinalPeriodContext"] = final_context
+    packet["cadenceContractVersion"] = int(schedule_contract_version)
+    aggregate = packet.setdefault("aggregateCounts", {})
+    aggregate["daysObserved"] = complete_days
+    aggregate["activeDays"] = active_days
+    aggregate["dailyPeriodContexts"] = len(daily_contexts)
+    aggregate["finalPeriodSources"] = int(
+        final_context["counts"].get("eligibleRelays") or 0
+    ) + int(final_context["counts"].get("eligibleConversations") or 0)
+    return packet, complete_days, active_days
 
 
-def prepare_weekly(
+def _legacy_weekly_packet(
+    db_path: str,
+    guild_id: int,
+    start: str,
+    end: str,
+    *,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
+) -> tuple[Optional[dict[str, Any]], int, int]:
+    """Rebuild one preserved 7 PM Weekly without manufacturing a Monday Daily."""
+    return _weekly_packet(
+        db_path,
+        guild_id,
+        start,
+        end,
+        memory_excluded_entry_ids=memory_excluded_entry_ids,
+        schedule_contract_version=LEGACY_CADENCE_CONTRACT_VERSION,
+    )
+
+
+def _prepare_weekly_window(
     db_path: str,
     guild_id: int,
     generator: Callable[[dict[str, Any], str], str],
+    start: str,
+    end: str,
+    label: str,
+    packet_builder: Callable[[], tuple[Optional[dict[str, Any]], int, int]],
     *,
-    now_utc: Optional[datetime] = None,
-    target_monday: Optional[date] = None,
     force: bool = False,
     memory_excluded_entry_ids: Optional[set[str]] = None,
+    schedule_contract_version: int = CADENCE_CONTRACT_VERSION,
+    expected_observation_count: int = 6,
 ) -> AutomationResult:
-    ensure_schema(db_path)
-    start, end, label = _weekly_period_for_monday(target_monday) if target_monday else weekly_period(now_utc)
-    if not force and target_monday is None and not weekly_due(now_utc):
-        return AutomationResult(False, "weekly", "not_due", "before_weekly_publish_time", source_window_start=start, source_window_end=end)
     claim, run_id, preparation_epoch, row = _claim_preparation(
         db_path,
         guild_id,
@@ -2551,6 +3489,7 @@ def prepare_weekly(
         start,
         end,
         force=force,
+        schedule_contract_version=schedule_contract_version,
     )
     if claim != "claimed":
         return _result_from_existing("weekly", row, claim=claim)
@@ -2571,13 +3510,7 @@ def prepare_weekly(
     readiness: dict[str, int] = {}
 
     def build_weekly_packet() -> Optional[dict[str, Any]]:
-        packet, complete_days, active_days = _weekly_packet(
-            db_path,
-            guild_id,
-            start,
-            end,
-            memory_excluded_entry_ids=memory_excluded_entry_ids,
-        )
+        packet, complete_days, active_days = packet_builder()
         readiness["completeDays"] = complete_days
         readiness["activeDays"] = active_days
         return packet
@@ -2591,8 +3524,14 @@ def prepare_weekly(
     )
     if packet is not None:
         aggregate = packet.get("aggregateCounts") or {}
-        complete_days = int(aggregate.get("daysObserved") or readiness.get("completeDays") or 0)
-        active_days = int(aggregate.get("activeDays") or readiness.get("activeDays") or 0)
+        complete_days = int(
+            aggregate.get("daysObserved")
+            or readiness.get("completeDays")
+            or 0
+        )
+        active_days = int(
+            aggregate.get("activeDays") or readiness.get("activeDays") or 0
+        )
     else:
         complete_days = int(readiness.get("completeDays") or 0)
         active_days = int(readiness.get("activeDays") or 0)
@@ -2614,16 +3553,71 @@ def prepare_weekly(
             freeze_reason,
             source_window_start=start,
             source_window_end=end,
-            aggregate_counts={"completeDays": complete_days, "activeDays": active_days},
+            aggregate_counts={
+                "completeDays": complete_days,
+                "activeDays": active_days,
+            },
         )
-    elif packet is None and complete_days == 7 and active_days == 0:
-        result = AutomationResult(True, "weekly", "quiet", "no_meaningful_weekly_activity", source_window_start=start, source_window_end=end, aggregate_counts={"completeDays": complete_days, "activeDays": active_days})
+    elif (
+        packet is None
+        and complete_days == expected_observation_count
+        and active_days == 0
+    ):
+        result = AutomationResult(
+            True,
+            "weekly",
+            "quiet",
+            "no_meaningful_weekly_activity",
+            source_window_start=start,
+            source_window_end=end,
+            aggregate_counts={
+                "completeDays": complete_days,
+                "activeDays": active_days,
+            },
+        )
     elif packet is None:
-        result = AutomationResult(True, "weekly", "deferred", f"only_{complete_days}_complete_daily_observations", source_window_start=start, source_window_end=end, aggregate_counts={"completeDays": complete_days, "activeDays": active_days})
+        result = AutomationResult(
+            True,
+            "weekly",
+            "deferred",
+            f"only_{complete_days}_complete_daily_observations",
+            source_window_start=start,
+            source_window_end=end,
+            aggregate_counts={
+                "completeDays": complete_days,
+                "activeDays": active_days,
+            },
+        )
     elif not packet.get("sourceArchiveAvailable", False):
-        result = AutomationResult(False, "weekly", "held", "source_archive_unavailable", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
+        result = AutomationResult(
+            False,
+            "weekly",
+            "held",
+            "source_archive_unavailable",
+            source_window_start=start,
+            source_window_end=end,
+            aggregate_counts=packet.get("aggregateCounts"),
+        )
     elif not packet.get("coverageComplete", True):
-        result = AutomationResult(False, "weekly", "incomplete", "window_began_before_archive_activation", source_window_start=start, source_window_end=end, aggregate_counts=packet.get("aggregateCounts"))
+        result = AutomationResult(
+            False,
+            "weekly",
+            "incomplete",
+            "window_began_before_archive_activation",
+            source_window_start=start,
+            source_window_end=end,
+            aggregate_counts=packet.get("aggregateCounts"),
+        )
+    elif active_days == 0 and not _has_meaningful_daily_activity(packet):
+        result = AutomationResult(
+            True,
+            "weekly",
+            "quiet",
+            "no_meaningful_weekly_activity",
+            source_window_start=start,
+            source_window_end=end,
+            aggregate_counts=packet.get("aggregateCounts"),
+        )
     else:
         return _prepare_packet_safely(
             db_path,
@@ -2639,6 +3633,58 @@ def prepare_weekly(
     return _finish_preparation(db_path, run_id, preparation_epoch, result)
 
 
+def prepare_weekly(
+    db_path: str,
+    guild_id: int,
+    generator: Callable[[dict[str, Any], str], str],
+    *,
+    now_utc: Optional[datetime] = None,
+    target_monday: Optional[date] = None,
+    force: bool = False,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
+) -> AutomationResult:
+    ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
+    if target_monday is None:
+        _start, _end, label = weekly_period(now_utc)
+        resolved_monday = date.fromisoformat(label)
+    else:
+        resolved_monday = target_monday
+    start, end, label = _weekly_period_for_target(
+        db_path,
+        guild_id,
+        resolved_monday,
+        now_utc=now_utc,
+    )
+    if not _window_is_closed(end, now_utc):
+        return AutomationResult(
+            False,
+            "weekly",
+            "not_due",
+            "before_weekly_preparation_time",
+            source_window_start=start,
+            source_window_end=end,
+        )
+    return _prepare_weekly_window(
+        db_path,
+        guild_id,
+        generator,
+        start,
+        end,
+        label,
+        lambda: _weekly_packet(
+            db_path,
+            guild_id,
+            start,
+            end,
+            memory_excluded_entry_ids=memory_excluded_entry_ids,
+        ),
+        force=force,
+        memory_excluded_entry_ids=memory_excluded_entry_ids,
+        schedule_contract_version=CADENCE_CONTRACT_VERSION,
+        expected_observation_count=6,
+    )
+
+
 def release_weekly(
     db_path: str,
     guild_id: int,
@@ -2652,9 +3698,27 @@ def release_weekly(
     memory_excluded_entry_ids: Optional[set[str]] = None,
     memory_exclusions_confirmed: bool = True,
 ) -> AutomationResult:
-    start, end, _label = _weekly_period_for_monday(target_monday) if target_monday else weekly_period(now_utc)
-    if not force and target_monday is None and not weekly_due(now_utc):
-        return AutomationResult(False, "weekly", "not_due", "before_weekly_publish_time", source_window_start=start, source_window_end=end)
+    ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
+    if target_monday is None:
+        _start, _end, label = weekly_period(now_utc)
+        resolved_monday = date.fromisoformat(label)
+    else:
+        resolved_monday = target_monday
+    start, end, _label = _weekly_period_for_target(
+        db_path,
+        guild_id,
+        resolved_monday,
+        now_utc=now_utc,
+    )
+    if not _window_release_is_due(end, now_utc):
+        return AutomationResult(
+            True,
+            "weekly",
+            "prepared",
+            "prepared_waiting_release",
+            source_window_start=start,
+            source_window_end=end,
+        )
     return release_occurrence(
         db_path,
         guild_id,
@@ -2695,6 +3759,8 @@ def run_weekly(
     )
     if prepared.status != "prepared":
         return prepared
+    if not _window_release_is_due(prepared.source_window_end, now_utc):
+        return prepared
     return release_weekly(
         db_path,
         guild_id,
@@ -2722,7 +3788,7 @@ def _archive_activation_day(db_path: str, guild_id: int) -> Optional[date]:
         return None
     activated = datetime.fromtimestamp(int(row[0]) / 1000.0, tz=timezone.utc).astimezone(PACIFIC)
     same_day_cutoff = _pacific_journal_cutoff(activated.date())
-    # The first fully covered window starts at the first 7 PM cutoff at or
+    # The first fully covered window starts at the first 6:30 PM cutoff at or
     # after activation. An activation later that evening must wait until the
     # following day's cutoff.
     if activated <= same_day_cutoff:
@@ -2733,67 +3799,428 @@ def _archive_activation_day(db_path: str, guild_id: int) -> Optional[date]:
 def _latest_daily_day(now_utc: Optional[datetime]) -> date:
     local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
     latest = local.date() - timedelta(days=1)
-    if (local.hour, local.minute) < (DAILY_READY_HOUR, DAILY_READY_MINUTE):
+    if (local.hour, local.minute) < (EVIDENCE_CUTOFF_HOUR, EVIDENCE_CUTOFF_MINUTE):
         latest -= timedelta(days=1)
     return latest
 
 
 def _pending_daily_day(db_path: str, guild_id: int, now_utc: Optional[datetime]) -> Optional[date]:
-    first = _archive_activation_day(db_path, guild_id)
-    latest = _latest_daily_day(now_utc)
-    if first is None or first > latest:
+    state = ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
+    transition_end = str(state.get("daily_transition_end") or "")
+    if not transition_end:
         return None
+    first = _parse_utc(transition_end).astimezone(PACIFIC).date() - timedelta(days=1)
+    latest = _latest_daily_day(now_utc)
     with sqlite3.connect(db_path) as conn:
         rows = {
             (str(row[0]), str(row[1]), str(row[2])): str(row[3])
             for row in conn.execute(
-                "SELECT cadence,source_window_start,source_window_end,lifecycle_state FROM bnl_journal_automation_runs WHERE guild_id=? AND cadence='daily'",
-                (guild_id,),
+                "SELECT cadence,source_window_start,source_window_end,lifecycle_state "
+                "FROM bnl_journal_automation_runs "
+                "WHERE guild_id=? AND cadence='daily' "
+                "AND COALESCE(schedule_contract_version,1)=?",
+                (guild_id, CADENCE_CONTRACT_VERSION),
             ).fetchall()
         }
-    # Always give the newly closed 7-to-7 window first priority. Once that
+    # Always give the newly closed 6:30-to-6:30 window first priority. Once that
     # window is terminal, the interval worker walks backward through any
     # older backlog without letting an old held run starve today's Journal.
-    current = latest
-    while current >= first:
-        start, end, _ = _daily_period_for_day(current)
-        if rows.get(("daily", start, end)) not in TERMINAL_RUN_STATES:
-            return current
-        current -= timedelta(days=1)
+    if first <= latest:
+        current = latest
+        while current >= first:
+            start, end, _ = _daily_period_for_target(
+                db_path,
+                guild_id,
+                current,
+                now_utc=now_utc,
+            )
+            if not _daily_window_is_scheduled(end):
+                current -= timedelta(days=1)
+                continue
+            if rows.get(("daily", start, end)) not in TERMINAL_RUN_STATES:
+                return current
+            current -= timedelta(days=1)
+    existing_pending = [
+        (
+            _parse_utc(end),
+            _parse_utc(start).astimezone(PACIFIC).date(),
+        )
+        for (_cadence, start, end), lifecycle in rows.items()
+        if lifecycle not in TERMINAL_RUN_STATES
+        and _daily_window_is_scheduled(end)
+        and _window_is_closed(end, now_utc)
+    ]
+    if existing_pending:
+        return max(existing_pending, key=lambda item: item[0])[1]
     return None
 
 
 def _latest_week_monday(now_utc: Optional[datetime]) -> date:
     local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
     current_monday = local.date() - timedelta(days=local.weekday())
-    if local.weekday() == WEEKLY_READY_WEEKDAY and local.hour < WEEKLY_READY_HOUR:
+    if (
+        local.weekday() == WEEKLY_READY_WEEKDAY
+        and (local.hour, local.minute) < (EVIDENCE_CUTOFF_HOUR, EVIDENCE_CUTOFF_MINUTE)
+    ):
         current_monday -= timedelta(days=7)
     return current_monday - timedelta(days=7)
 
 
 def _pending_week_monday(db_path: str, guild_id: int, now_utc: Optional[datetime]) -> Optional[date]:
-    first_day = _archive_activation_day(db_path, guild_id)
-    if first_day is None:
+    state = ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
+    transition_end = str(state.get("weekly_transition_end") or "")
+    if not transition_end:
         return None
-    first_monday = first_day + timedelta(days=(7 - first_day.weekday()) % 7)
+    first_monday = _parse_utc(transition_end).astimezone(PACIFIC).date() - timedelta(days=7)
     latest = _latest_week_monday(now_utc)
-    if first_monday > latest:
-        return None
     with sqlite3.connect(db_path) as conn:
         rows = {
             (str(row[0]), str(row[1])): str(row[2])
             for row in conn.execute(
-                "SELECT source_window_start,source_window_end,lifecycle_state FROM bnl_journal_automation_runs WHERE guild_id=? AND cadence='weekly'",
-                (guild_id,),
+                "SELECT source_window_start,source_window_end,lifecycle_state "
+                "FROM bnl_journal_automation_runs "
+                "WHERE guild_id=? AND cadence='weekly' "
+                "AND COALESCE(schedule_contract_version,1)=?",
+                (guild_id, CADENCE_CONTRACT_VERSION),
             ).fetchall()
         }
-    current = first_monday
-    while current <= latest:
-        start, end, _ = _weekly_period_for_monday(current)
-        if rows.get((start, end)) not in TERMINAL_RUN_STATES:
-            return current
-        current += timedelta(days=7)
+    if first_monday <= latest:
+        current = latest
+        while current >= first_monday:
+            start, end, _ = _weekly_period_for_target(
+                db_path,
+                guild_id,
+                current,
+                now_utc=now_utc,
+            )
+            if rows.get((start, end)) not in TERMINAL_RUN_STATES:
+                return current
+            current -= timedelta(days=7)
+    existing_pending = [
+        (
+            _parse_utc(end),
+            _parse_utc(start).astimezone(PACIFIC).date(),
+        )
+        for (start, end), lifecycle in rows.items()
+        if lifecycle not in TERMINAL_RUN_STATES and _window_is_closed(end, now_utc)
+    ]
+    if existing_pending:
+        return max(existing_pending, key=lambda item: item[0])[1]
     return None
+
+
+def _pending_legacy_run(
+    db_path: str,
+    guild_id: int,
+    now_utc: Optional[datetime],
+) -> Optional[dict[str, Any]]:
+    """Return one preserved old-schedule obligation without reinterpreting it."""
+    ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = [
+            dict(row)
+            for row in conn.execute(
+                "SELECT * FROM bnl_journal_automation_runs "
+                "WHERE guild_id=? AND COALESCE(schedule_contract_version,1)=? "
+                "ORDER BY source_window_end DESC,created_at DESC",
+                (int(guild_id), LEGACY_CADENCE_CONTRACT_VERSION),
+            ).fetchall()
+        ]
+    for row in rows:
+        if str(row.get("lifecycle_state") or "") in TERMINAL_RUN_STATES:
+            continue
+        cadence = str(row.get("cadence") or "")
+        end = str(row.get("source_window_end") or "")
+        if cadence not in {"daily", "weekly"} or not end:
+            continue
+        if cadence == "daily" and not _daily_window_is_scheduled(end):
+            # Activation should already have made this terminal. Fail closed if
+            # a partially upgraded database is observed.
+            continue
+        if _window_is_closed(end, now_utc):
+            return row
+    return None
+
+
+def _run_legacy_occurrence(
+    db_path: str,
+    guild_id: int,
+    row: dict[str, Any],
+    generator: Callable[[dict[str, Any], str], str],
+    base_url: str,
+    api_key: str,
+    *,
+    opener=None,
+    memory_excluded_entry_ids: Optional[set[str]] = None,
+    memory_exclusions_confirmed: bool = True,
+) -> AutomationResult:
+    cadence = str(row.get("cadence") or "")
+    start = str(row.get("source_window_start") or "")
+    end = str(row.get("source_window_end") or "")
+    label = _parse_utc(start).astimezone(PACIFIC).date().isoformat()
+    force_preserved_claim = (
+        str(row.get("reason") or "")
+        == "cadence_migration_preserved_owed_legacy_window"
+    )
+    if cadence == "daily":
+        prepared = _prepare_daily_window(
+            db_path,
+            guild_id,
+            generator,
+            start,
+            end,
+            label,
+            force=force_preserved_claim,
+            memory_excluded_entry_ids=memory_excluded_entry_ids,
+            schedule_contract_version=LEGACY_CADENCE_CONTRACT_VERSION,
+        )
+    else:
+        prepared = _prepare_weekly_window(
+            db_path,
+            guild_id,
+            generator,
+            start,
+            end,
+            label,
+            lambda: _legacy_weekly_packet(
+                db_path,
+                guild_id,
+                start,
+                end,
+                memory_excluded_entry_ids=memory_excluded_entry_ids,
+            ),
+            force=force_preserved_claim,
+            memory_excluded_entry_ids=memory_excluded_entry_ids,
+            schedule_contract_version=LEGACY_CADENCE_CONTRACT_VERSION,
+            expected_observation_count=6,
+        )
+    if prepared.status != "prepared":
+        return prepared
+    return release_occurrence(
+        db_path,
+        guild_id,
+        cadence,
+        start,
+        end,
+        base_url,
+        api_key,
+        opener=opener,
+        memory_excluded_entry_ids=memory_excluded_entry_ids,
+        memory_exclusions_confirmed=memory_exclusions_confirmed,
+    )
+
+
+def _scheduled_controls(
+    flags: Optional[dict[str, Any]],
+) -> tuple[dict[str, Any], set[str], bool]:
+    controls = flags or {}
+    memory_excluded_entry_ids = {
+        str(entry_id)
+        for entry_id in controls.get("journalMemoryExcludedEntryIds", [])
+        if str(entry_id)
+    }
+    memory_exclusions_confirmed = bool(
+        controls.get("journalMemoryExclusionsConfirmed", True)
+    )
+    return controls, memory_excluded_entry_ids, memory_exclusions_confirmed
+
+
+def _prepare_scheduler_storage(
+    db_path: str,
+    guild_id: int,
+    now_utc: Optional[datetime],
+) -> Optional[AutomationResult]:
+    try:
+        from bnl_journal_source_store import backfill_legacy_sources
+
+        backfill_legacy_sources(db_path, guild_id)
+        ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
+    except (ImportError, sqlite3.Error, ValueError):
+        return AutomationResult(False, "all", "held", "source_archive_unavailable")
+    return None
+
+
+def prepare_scheduled(
+    db_path: str,
+    guild_id: int,
+    generator: Callable[[dict[str, Any], str], str],
+    flags: Optional[dict[str, Any]] = None,
+    *,
+    now_utc: Optional[datetime] = None,
+) -> list[AutomationResult]:
+    controls, memory_excluded_entry_ids, _confirmed = _scheduled_controls(flags)
+    if not bool(controls.get("journalAutoPublishEnabled", True)):
+        return [AutomationResult(False, "all", "paused", "auto_publish_paused")]
+    storage_error = _prepare_scheduler_storage(db_path, guild_id, now_utc)
+    if storage_error is not None:
+        return [storage_error]
+    local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
+    if (
+        local.weekday() == WEEKLY_READY_WEEKDAY
+        and weekly_preparation_due(now_utc)
+        and bool(controls.get("journalWeeklyEnabled", True))
+    ):
+        target_monday = _latest_week_monday(now_utc)
+        state = ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
+        _start, end, _label = _weekly_period_for_target(
+            db_path,
+            guild_id,
+            target_monday,
+            now_utc=now_utc,
+        )
+        if not _v2_window_is_activated(state, "weekly", end):
+            return [
+                AutomationResult(
+                    False,
+                    "weekly",
+                    "not_due",
+                    "cadence_transition_not_ready",
+                    source_window_start=_start,
+                    source_window_end=end,
+                )
+            ]
+        return [
+            prepare_weekly(
+                db_path,
+                guild_id,
+                generator,
+                now_utc=now_utc,
+                target_monday=target_monday,
+                memory_excluded_entry_ids=memory_excluded_entry_ids,
+            )
+        ]
+    if (
+        local.weekday() in DAILY_RELEASE_WEEKDAYS
+        and daily_preparation_due(now_utc)
+        and bool(controls.get("journalDailyEnabled", True))
+    ):
+        target_day = _latest_daily_day(now_utc)
+        state = ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
+        _start, end, _label = _daily_period_for_target(
+            db_path,
+            guild_id,
+            target_day,
+            now_utc=now_utc,
+        )
+        if not _v2_window_is_activated(state, "daily", end):
+            return [
+                AutomationResult(
+                    False,
+                    "daily",
+                    "not_due",
+                    "cadence_transition_not_ready",
+                    source_window_start=_start,
+                    source_window_end=end,
+                )
+            ]
+        return [
+            prepare_daily(
+                db_path,
+                guild_id,
+                generator,
+                now_utc=now_utc,
+                target_day=target_day,
+                memory_excluded_entry_ids=memory_excluded_entry_ids,
+            )
+        ]
+    return [AutomationResult(False, "all", "not_due", "no_preparation_due")]
+
+
+def release_scheduled(
+    db_path: str,
+    guild_id: int,
+    base_url: str,
+    api_key: str,
+    flags: Optional[dict[str, Any]] = None,
+    *,
+    now_utc: Optional[datetime] = None,
+    opener=None,
+) -> list[AutomationResult]:
+    controls, memory_excluded_entry_ids, memory_exclusions_confirmed = (
+        _scheduled_controls(flags)
+    )
+    if not bool(controls.get("journalAutoPublishEnabled", True)):
+        return [AutomationResult(False, "all", "paused", "auto_publish_paused")]
+    storage_error = _prepare_scheduler_storage(db_path, guild_id, now_utc)
+    if storage_error is not None:
+        return [storage_error]
+    local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
+    if (
+        local.weekday() == WEEKLY_READY_WEEKDAY
+        and weekly_due(now_utc)
+        and bool(controls.get("journalWeeklyEnabled", True))
+    ):
+        target_monday = _latest_week_monday(now_utc)
+        state = ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
+        _start, end, _label = _weekly_period_for_target(
+            db_path,
+            guild_id,
+            target_monday,
+            now_utc=now_utc,
+        )
+        if not _v2_window_is_activated(state, "weekly", end):
+            return [
+                AutomationResult(
+                    False,
+                    "weekly",
+                    "not_due",
+                    "cadence_transition_not_ready",
+                    source_window_start=_start,
+                    source_window_end=end,
+                )
+            ]
+        return [
+            release_weekly(
+                db_path,
+                guild_id,
+                base_url,
+                api_key,
+                now_utc=now_utc,
+                target_monday=target_monday,
+                opener=opener,
+                memory_excluded_entry_ids=memory_excluded_entry_ids,
+                memory_exclusions_confirmed=memory_exclusions_confirmed,
+            )
+        ]
+    if (
+        local.weekday() in DAILY_RELEASE_WEEKDAYS
+        and daily_due(now_utc)
+        and bool(controls.get("journalDailyEnabled", True))
+    ):
+        target_day = _latest_daily_day(now_utc)
+        state = ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
+        _start, end, _label = _daily_period_for_target(
+            db_path,
+            guild_id,
+            target_day,
+            now_utc=now_utc,
+        )
+        if not _v2_window_is_activated(state, "daily", end):
+            return [
+                AutomationResult(
+                    False,
+                    "daily",
+                    "not_due",
+                    "cadence_transition_not_ready",
+                    source_window_start=_start,
+                    source_window_end=end,
+                )
+            ]
+        return [
+            release_daily(
+                db_path,
+                guild_id,
+                base_url,
+                api_key,
+                now_utc=now_utc,
+                target_day=target_day,
+                opener=opener,
+                memory_excluded_entry_ids=memory_excluded_entry_ids,
+                memory_exclusions_confirmed=memory_exclusions_confirmed,
+            )
+        ]
+    return [AutomationResult(False, "all", "not_due", "no_release_due")]
 
 
 def run_scheduled(
@@ -2807,55 +4234,195 @@ def run_scheduled(
     now_utc: Optional[datetime] = None,
     opener=None,
 ) -> list[AutomationResult]:
-    controls = flags or {}
-    memory_excluded_entry_ids = {
-        str(entry_id)
-        for entry_id in controls.get("journalMemoryExcludedEntryIds", [])
-        if str(entry_id)
-    }
-    memory_exclusions_confirmed = bool(
-        controls.get("journalMemoryExclusionsConfirmed", True)
+    """Recover the newest owed occurrence without changing exact-time phases."""
+    controls, memory_excluded_entry_ids, memory_exclusions_confirmed = (
+        _scheduled_controls(flags)
     )
     if not bool(controls.get("journalAutoPublishEnabled", True)):
         return [AutomationResult(False, "all", "paused", "auto_publish_paused")]
-    try:
-        from bnl_journal_source_store import backfill_legacy_sources
+    storage_error = _prepare_scheduler_storage(db_path, guild_id, now_utc)
+    if storage_error is not None:
+        return [storage_error]
+    local = (now_utc or datetime.now(timezone.utc)).astimezone(PACIFIC)
+    # Do not let backlog generation occupy the dedicated close-to-release lane.
+    if (local.hour, local.minute) >= (
+        EVIDENCE_CUTOFF_HOUR,
+        EVIDENCE_CUTOFF_MINUTE,
+    ) and (local.hour, local.minute) < (
+        PUBLIC_RELEASE_HOUR,
+        PUBLIC_RELEASE_MINUTE,
+    ):
+        return prepare_scheduled(
+            db_path,
+            guild_id,
+            generator,
+            controls,
+            now_utc=now_utc,
+        )
 
-        backfill_legacy_sources(db_path, guild_id)
-    except (ImportError, sqlite3.Error, ValueError):
-        return [AutomationResult(False, "all", "held", "source_archive_unavailable")]
-    results: list[AutomationResult] = []
+    candidates: list[tuple[str, date]] = []
     if bool(controls.get("journalDailyEnabled", True)):
         target_day = _pending_daily_day(db_path, guild_id, now_utc)
         if target_day is not None:
-            results.append(run_daily(db_path, guild_id, generator, base_url, api_key, now_utc=now_utc, target_day=target_day, opener=opener, memory_excluded_entry_ids=memory_excluded_entry_ids, memory_exclusions_confirmed=memory_exclusions_confirmed))
+            _start, end, _label = _daily_period_for_target(
+                db_path,
+                guild_id,
+                target_day,
+                now_utc=now_utc,
+            )
+            candidates.append(("daily", target_day))
     if bool(controls.get("journalWeeklyEnabled", True)):
         target_monday = _pending_week_monday(db_path, guild_id, now_utc)
         if target_monday is not None:
-            results.append(run_weekly(db_path, guild_id, generator, base_url, api_key, now_utc=now_utc, target_monday=target_monday, opener=opener, memory_excluded_entry_ids=memory_excluded_entry_ids, memory_exclusions_confirmed=memory_exclusions_confirmed))
-    return results or [AutomationResult(False, "all", "not_due", "no_schedule_due")]
+            _start, end, _label = _weekly_period_for_target(
+                db_path,
+                guild_id,
+                target_monday,
+                now_utc=now_utc,
+            )
+            candidates.append(("weekly", target_monday))
+    legacy = _pending_legacy_run(db_path, guild_id, now_utc)
+    if legacy is not None:
+        legacy_cadence = str(legacy.get("cadence") or "")
+        if (
+            legacy_cadence == "daily"
+            and not bool(controls.get("journalDailyEnabled", True))
+        ) or (
+            legacy_cadence == "weekly"
+            and not bool(controls.get("journalWeeklyEnabled", True))
+        ):
+            legacy = None
+
+    def candidate_end(item: tuple[str, date]) -> datetime:
+        cadence, target = item
+        if cadence == "daily":
+            _start, end, _label = _daily_period_for_target(
+                db_path,
+                guild_id,
+                target,
+                now_utc=now_utc,
+            )
+        else:
+            _start, end, _label = _weekly_period_for_target(
+                db_path,
+                guild_id,
+                target,
+                now_utc=now_utc,
+            )
+        return _parse_utc(end)
+
+    if legacy is not None and (
+        not candidates
+        or _parse_utc(str(legacy.get("source_window_end") or ""))
+        > max(candidate_end(item) for item in candidates)
+    ):
+        return [
+            _run_legacy_occurrence(
+                db_path,
+                guild_id,
+                legacy,
+                generator,
+                base_url,
+                api_key,
+                opener=opener,
+                memory_excluded_entry_ids=memory_excluded_entry_ids,
+                memory_exclusions_confirmed=memory_exclusions_confirmed,
+            )
+        ]
+    if not candidates:
+        return [AutomationResult(False, "all", "not_due", "no_schedule_due")]
+
+    cadence, target = max(candidates, key=candidate_end)
+    if cadence == "daily":
+        prepared = prepare_daily(
+            db_path,
+            guild_id,
+            generator,
+            now_utc=now_utc,
+            target_day=target,
+            memory_excluded_entry_ids=memory_excluded_entry_ids,
+        )
+        if prepared.status == "prepared" and _window_release_is_due(
+            prepared.source_window_end,
+            now_utc,
+        ):
+            return [
+                release_daily(
+                    db_path,
+                    guild_id,
+                    base_url,
+                    api_key,
+                    now_utc=now_utc,
+                    target_day=target,
+                    opener=opener,
+                    memory_excluded_entry_ids=memory_excluded_entry_ids,
+                    memory_exclusions_confirmed=memory_exclusions_confirmed,
+                )
+            ]
+        return [prepared]
+    prepared = prepare_weekly(
+        db_path,
+        guild_id,
+        generator,
+        now_utc=now_utc,
+        target_monday=target,
+        memory_excluded_entry_ids=memory_excluded_entry_ids,
+    )
+    if prepared.status == "prepared" and _window_release_is_due(
+        prepared.source_window_end,
+        now_utc,
+    ):
+        return [
+            release_weekly(
+                db_path,
+                guild_id,
+                base_url,
+                api_key,
+                now_utc=now_utc,
+                target_monday=target,
+                opener=opener,
+                memory_excluded_entry_ids=memory_excluded_entry_ids,
+                memory_exclusions_confirmed=memory_exclusions_confirmed,
+            )
+        ]
+    return [prepared]
 
 
 def automation_status(db_path: str, guild_id: int) -> dict[str, Any]:
-    ensure_schema(db_path)
+    now = datetime.now(timezone.utc)
+    ensure_cadence_activation(db_path, guild_id, now_utc=now)
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
         state = conn.execute("SELECT * FROM bnl_journal_automation_state WHERE guild_id=?", (guild_id,)).fetchone()
         runs = conn.execute("""SELECT cadence,lifecycle_state,reason,journal_entry_id,journal_revision,
             source_window_start,source_window_end,aggregate_counts_json,updated_at
             FROM bnl_journal_automation_runs WHERE guild_id=? ORDER BY updated_at DESC LIMIT 10""", (guild_id,)).fetchall()
-    now = datetime.now(timezone.utc)
-    daily_start, daily_end, _ = daily_period(now)
-    weekly_start, weekly_end, _ = weekly_period(now)
+    _daily_start, _daily_end, daily_label = daily_period(now)
+    daily_start, daily_end, _ = _daily_period_for_target(
+        db_path,
+        guild_id,
+        date.fromisoformat(daily_label),
+        now_utc=now,
+    )
+    _weekly_start, _weekly_end, weekly_label = weekly_period(now)
+    weekly_start, weekly_end, _ = _weekly_period_for_target(
+        db_path,
+        guild_id,
+        date.fromisoformat(weekly_label),
+        now_utc=now,
+    )
     next_daily_at, next_weekly_at = next_schedule_times(now)
+    next_daily_prepare_at, next_weekly_prepare_at = next_preparation_times(now)
     return {
-        "contractVersion": 1,
+        "contractVersion": 2,
         "guildId": guild_id,
         "schedulerState": "ready",
         "dailyWindow": {"start": daily_start, "end": daily_end},
         "weeklyWindow": {"start": weekly_start, "end": weekly_end},
         "nextDailyAt": next_daily_at,
         "nextWeeklyAt": next_weekly_at,
+        "nextDailyPreparationAt": next_daily_prepare_at,
+        "nextWeeklyPreparationAt": next_weekly_prepare_at,
         "lastState": dict(state) if state else None,
         "recentRuns": [dict(row, aggregate_counts_json=None, aggregateCounts=json.loads(row["aggregate_counts_json"] or "{}")) for row in runs],
     }

--- a/tests/test_bnl_journal_automation.py
+++ b/tests/test_bnl_journal_automation.py
@@ -153,69 +153,73 @@ class JournalAutomationTests(unittest.TestCase):
                 (activated_ms, activated_ms),
             )
 
-    def test_schedule_uses_seven_pm_pacific_and_tracks_daylight_saving(self):
-        before_daily = datetime(2026, 7, 21, 1, 59, tzinfo=timezone.utc)
-        at_daily = datetime(2026, 7, 21, 2, 0, tzinfo=timezone.utc)
-        self.assertFalse(automation.daily_due(before_daily))
-        self.assertTrue(automation.daily_due(at_daily))
+    def test_schedule_prepares_at_six_thirty_releases_at_seven_and_tracks_dst(self):
+        before_prepare = datetime(2026, 7, 22, 1, 29, 59, tzinfo=timezone.utc)
+        at_prepare = datetime(2026, 7, 22, 1, 30, tzinfo=timezone.utc)
+        before_release = datetime(2026, 7, 22, 1, 59, 59, tzinfo=timezone.utc)
+        at_release = datetime(2026, 7, 22, 2, 0, tzinfo=timezone.utc)
+        self.assertFalse(automation.daily_preparation_due(before_prepare))
+        self.assertTrue(automation.daily_preparation_due(at_prepare))
+        self.assertFalse(automation.daily_due(before_release))
+        self.assertTrue(automation.daily_due(at_release))
 
-        start, end, _ = automation._daily_period_for_day(date(2026, 7, 19))
-        self.assertEqual("2026-07-20T02:00:00Z", start)
-        self.assertEqual("2026-07-21T02:00:00Z", end)
+        start, end, _ = automation._daily_period_for_day(date(2026, 7, 20))
+        self.assertEqual("2026-07-21T01:30:00Z", start)
+        self.assertEqual("2026-07-22T01:30:00Z", end)
 
         winter_start, winter_end, _ = automation._daily_period_for_day(date(2026, 11, 9))
-        self.assertEqual("2026-11-10T03:00:00Z", winter_start)
-        self.assertEqual("2026-11-11T03:00:00Z", winter_end)
+        self.assertEqual("2026-11-10T02:30:00Z", winter_start)
+        self.assertEqual("2026-11-11T02:30:00Z", winter_end)
 
-        monday_before = datetime(2026, 7, 21, 1, 59, tzinfo=timezone.utc)
+        monday_before = datetime(2026, 7, 21, 1, 59, 59, tzinfo=timezone.utc)
         monday_at = datetime(2026, 7, 21, 2, 0, tzinfo=timezone.utc)
         self.assertFalse(automation.weekly_due(monday_before))
         self.assertTrue(automation.weekly_due(monday_at))
         next_daily, next_weekly = automation.next_schedule_times(
             datetime(2026, 7, 20, 20, 0, tzinfo=timezone.utc)
         )
-        self.assertEqual("2026-07-21T02:00:00Z", next_daily)
+        self.assertEqual("2026-07-22T02:00:00Z", next_daily)
         self.assertEqual("2026-07-21T02:00:00Z", next_weekly)
 
-    def test_forced_periods_never_include_an_unfinished_seven_pm_window(self):
+    def test_period_helpers_never_include_an_unfinished_six_thirty_window(self):
         monday_before_cutoff = datetime(2026, 7, 20, 20, 0, tzinfo=timezone.utc)
         daily_start, daily_end, _ = automation.daily_period(monday_before_cutoff)
         weekly_start, weekly_end, _ = automation.weekly_period(monday_before_cutoff)
-        self.assertEqual("2026-07-19T02:00:00Z", daily_start)
-        self.assertEqual("2026-07-20T02:00:00Z", daily_end)
-        self.assertEqual("2026-07-07T02:00:00Z", weekly_start)
-        self.assertEqual("2026-07-14T02:00:00Z", weekly_end)
+        self.assertEqual("2026-07-19T01:30:00Z", daily_start)
+        self.assertEqual("2026-07-20T01:30:00Z", daily_end)
+        self.assertEqual("2026-07-07T01:30:00Z", weekly_start)
+        self.assertEqual("2026-07-14T01:30:00Z", weekly_end)
 
         monday_after_cutoff = datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc)
         daily_start, daily_end, _ = automation.daily_period(monday_after_cutoff)
         weekly_start, weekly_end, _ = automation.weekly_period(monday_after_cutoff)
-        self.assertEqual("2026-07-20T02:00:00Z", daily_start)
-        self.assertEqual("2026-07-21T02:00:00Z", daily_end)
-        self.assertEqual("2026-07-14T02:00:00Z", weekly_start)
-        self.assertEqual("2026-07-21T02:00:00Z", weekly_end)
+        self.assertEqual("2026-07-20T01:30:00Z", daily_start)
+        self.assertEqual("2026-07-21T01:30:00Z", daily_end)
+        self.assertEqual("2026-07-14T01:30:00Z", weekly_start)
+        self.assertEqual("2026-07-21T01:30:00Z", weekly_end)
 
-    def test_archive_activation_keeps_first_fully_covered_seven_pm_window(self):
+    def test_archive_activation_keeps_first_fully_covered_six_thirty_window(self):
         self.set_archive_activation("2026-07-16T19:00:00Z")  # Noon PDT.
         self.assertEqual(
             date(2026, 7, 16),
             automation._archive_activation_day(self.db, 1),
         )
 
-        self.set_archive_activation("2026-07-17T02:00:00Z")  # 7 PM PDT.
+        self.set_archive_activation("2026-07-17T01:30:00Z")  # 6:30 PM PDT.
         self.assertEqual(
             date(2026, 7, 16),
             automation._archive_activation_day(self.db, 1),
         )
 
-        self.set_archive_activation("2026-07-17T02:00:01Z")  # Just after 7 PM PDT.
+        self.set_archive_activation("2026-07-17T01:30:01Z")  # Just after 6:30 PM PDT.
         self.assertEqual(
             date(2026, 7, 17),
             automation._archive_activation_day(self.db, 1),
         )
 
     def test_daily_auto_publishes_once_and_persists_observation(self):
-        self.add_day("2026-07-19")
-        now = datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc)
+        self.add_day("2026-07-20")
+        now = datetime(2026, 7, 22, 3, 0, tzinfo=timezone.utc)
         first = automation.run_daily(
             self.db,
             1,
@@ -246,14 +250,14 @@ class JournalAutomationTests(unittest.TestCase):
             self.assertEqual(1, conn.execute("SELECT COUNT(*) FROM bnl_journal_entries WHERE lifecycle_state='published'").fetchone()[0])
 
     def test_word_count_target_is_guidance_and_never_retries(self):
-        self.add_day("2026-07-19")
         self.add_day("2026-07-20")
+        self.add_day("2026-07-21")
         calls = []
 
         def outside_target(packet, prompt):
             calls.append(prompt)
             article = json.loads(article_json(packet))
-            if packet["sourceWindowStart"].startswith("2026-07-20"):
+            if packet["sourceWindowStart"].startswith("2026-07-21"):
                 article["sections"][0]["body"] = (
                     "A producer brought a mix into the public music room, and listeners kept the rhythm moving. "
                     "I admit the small exchange still gave the day a shape worth keeping."
@@ -276,7 +280,7 @@ class JournalAutomationTests(unittest.TestCase):
             outside_target,
             "https://site.example",
             "key",
-            target_day=date(2026, 7, 19),
+            target_day=date(2026, 7, 20),
             force=True,
             opener=self.opener,
         )
@@ -286,7 +290,7 @@ class JournalAutomationTests(unittest.TestCase):
             outside_target,
             "https://site.example",
             "key",
-            target_day=date(2026, 7, 20),
+            target_day=date(2026, 7, 21),
             force=True,
             opener=self.opener,
         )
@@ -311,7 +315,7 @@ class JournalAutomationTests(unittest.TestCase):
         self.assertGreater(word_counts[long_result.entry_id], 500)
 
     def test_editorial_polish_cannot_hold_daily_publication(self):
-        self.add_day("2026-07-19")
+        self.add_day("2026-07-20")
         calls = []
 
         def persistent_clinical_style(packet, prompt):
@@ -329,7 +333,7 @@ class JournalAutomationTests(unittest.TestCase):
             persistent_clinical_style,
             "https://site.example",
             "key",
-            target_day=date(2026, 7, 19),
+            target_day=date(2026, 7, 20),
             force=True,
             opener=self.opener,
         )
@@ -339,7 +343,7 @@ class JournalAutomationTests(unittest.TestCase):
             lambda *_args: self.fail("published daily window generated twice"),
             "https://site.example",
             "key",
-            target_day=date(2026, 7, 19),
+            target_day=date(2026, 7, 20),
             force=True,
             opener=self.opener,
         )
@@ -359,8 +363,13 @@ class JournalAutomationTests(unittest.TestCase):
 
     def test_newly_closed_day_publishes_before_an_older_held_backlog(self):
         self.add_day("2026-07-18")
-        self.add_day("2026-07-19")
-        self.set_archive_activation("2026-07-18T02:00:01Z")
+        self.add_day("2026-07-20")
+        self.set_archive_activation("2026-07-18T01:30:00Z")
+        automation.ensure_cadence_activation(
+            self.db,
+            1,
+            now_utc=datetime(2026, 7, 21, 1, 0, tzinfo=timezone.utc),
+        )
 
         def provider_down(_packet, _prompt):
             raise RuntimeError("provider down")
@@ -372,6 +381,7 @@ class JournalAutomationTests(unittest.TestCase):
             "https://site.example",
             "key",
             target_day=date(2026, 7, 18),
+            now_utc=datetime(2026, 7, 21, 1, 0, tzinfo=timezone.utc),
             force=True,
             opener=self.opener,
         )
@@ -388,14 +398,14 @@ class JournalAutomationTests(unittest.TestCase):
                 "journalDailyEnabled": True,
                 "journalWeeklyEnabled": False,
             },
-            now_utc=datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc),
+            now_utc=datetime(2026, 7, 22, 3, 0, tzinfo=timezone.utc),
             opener=self.opener,
         )
 
         self.assertEqual(1, len(results))
         self.assertEqual("published", results[0].status)
         expected_start, expected_end, _ = automation._daily_period_for_day(
-            date(2026, 7, 19)
+            date(2026, 7, 20)
         )
         self.assertEqual(expected_start, results[0].source_window_start)
         self.assertEqual(expected_end, results[0].source_window_end)
@@ -404,14 +414,14 @@ class JournalAutomationTests(unittest.TestCase):
             automation._pending_daily_day(
                 self.db,
                 1,
-                datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc),
+                datetime(2026, 7, 22, 3, 0, tzinfo=timezone.utc),
             ),
         )
 
     def test_daily_uses_complete_half_open_window_and_far_more_than_25(self):
         with sqlite3.connect(self.db) as conn:
             for index in range(90):
-                observed = datetime(2026, 7, 20, 2, 0, tzinfo=timezone.utc) + timedelta(minutes=index * 10)
+                observed = datetime(2026, 7, 20, 1, 30, tzinfo=timezone.utc) + timedelta(minutes=index * 10)
                 stamp = observed.isoformat().replace("+00:00", "Z")
                 conn.execute(
                     "INSERT INTO website_relay_history VALUES(?,?,?,?,?,?,?,?,?,?,?)",
@@ -431,13 +441,13 @@ class JournalAutomationTests(unittest.TestCase):
                 )
             conn.execute(
                 "INSERT INTO website_relay_history VALUES(?,?,?,?,?,?,?,?,?,?,?)",
-                ("boundary", 1, "Next day", "Later", "OBS", "lane", "fresh_public_discord_activity", 100, "next", "public", "2026-07-21T02:00:00Z"),
+                ("boundary", 1, "Next day", "Later", "OBS", "lane", "fresh_public_discord_activity", 100, "next", "public", "2026-07-21T01:30:00Z"),
             )
         packet = journal.build_source_packet_between(
             self.db,
             1,
-            "2026-07-20T02:00:00Z",
-            "2026-07-21T02:00:00Z",
+            "2026-07-20T01:30:00Z",
+            "2026-07-21T01:30:00Z",
             entry_kind="daily",
         )
         self.assertEqual(90, packet["aggregateCounts"]["eligibleRelays"])
@@ -445,35 +455,57 @@ class JournalAutomationTests(unittest.TestCase):
         self.assertFalse(any(source.get("relayId") == "boundary" for source in packet["privateSources"]))
 
     def test_scheduler_publishes_newest_day_then_catches_up_older_day(self):
-        for day in ("2026-07-17", "2026-07-18", "2026-07-19"):
+        for day in ("2026-07-18", "2026-07-20"):
             self.add_day(day)
         source_store.backfill_legacy_sources(self.db, 1)
-        self.set_archive_activation("2026-07-17T03:00:00Z")  # 8 PM PDT.
-        now = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+        self.set_archive_activation("2026-07-18T01:30:00Z")
+        activation_now = datetime(2026, 7, 21, 1, 0, tzinfo=timezone.utc)
+        automation.ensure_cadence_activation(
+            self.db,
+            1,
+            now_utc=activation_now,
+        )
+        now = datetime(2026, 7, 22, 3, 0, tzinfo=timezone.utc)
 
         first = automation.run_scheduled(
             self.db, 1, lambda packet, prompt: article_json(packet),
-            "https://site.example", "key", now_utc=now, opener=self.opener,
+            "https://site.example", "key",
+            {
+                "journalAutoPublishEnabled": True,
+                "journalDailyEnabled": True,
+                "journalWeeklyEnabled": False,
+            },
+            now_utc=now, opener=self.opener,
         )
         second = automation.run_scheduled(
             self.db, 1, lambda packet, prompt: article_json(packet),
-            "https://site.example", "key", now_utc=now, opener=self.opener,
+            "https://site.example", "key",
+            {
+                "journalAutoPublishEnabled": True,
+                "journalDailyEnabled": True,
+                "journalWeeklyEnabled": False,
+            },
+            now_utc=now, opener=self.opener,
         )
 
-        self.assertEqual("2026-07-19T02:00:00Z", first[0].source_window_start)
+        self.assertEqual("2026-07-21T01:30:00Z", first[0].source_window_start)
         self.assertEqual("published", first[0].status)
-        self.assertEqual("2026-07-18T02:00:00Z", second[0].source_window_start)
+        self.assertEqual("2026-07-19T02:00:00Z", second[0].source_window_start)
         self.assertEqual("published", second[0].status)
 
     def test_weekly_uses_durable_daily_observations(self):
-        for day, now_day in (
-            ("2026-07-13", 14),
-            ("2026-07-14", 15),
-            ("2026-07-15", 16),
-            ("2026-07-16", 17),
-            ("2026-07-17", 18),
-            ("2026-07-18", 19),
-            ("2026-07-19", 20),
+        automation.ensure_cadence_activation(
+            self.db,
+            1,
+            now_utc=datetime(2026, 7, 14, 1, 0, tzinfo=timezone.utc),
+        )
+        for day in (
+            "2026-07-13",
+            "2026-07-14",
+            "2026-07-15",
+            "2026-07-16",
+            "2026-07-17",
+            "2026-07-18",
         ):
             self.add_day(day)
             result = automation.run_daily(
@@ -482,7 +514,7 @@ class JournalAutomationTests(unittest.TestCase):
                 lambda packet, prompt: article_json(packet),
                 "https://site.example",
                 "key",
-                target_day=date(2026, 7, now_day - 1),
+                target_day=date.fromisoformat(day),
                 force=True,
                 opener=self.opener,
             )
@@ -491,15 +523,16 @@ class JournalAutomationTests(unittest.TestCase):
         scheduled = automation.run_scheduled(
             self.db, 1, lambda packet, prompt: article_json(packet),
             "https://site.example", "key",
-            now_utc=datetime(2026, 7, 21, 13, 0, tzinfo=timezone.utc),
+            now_utc=datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc),
             opener=self.opener,
         )
         weekly = next(item for item in scheduled if item.cadence == "weekly")
         self.assertTrue(weekly.ok, weekly)
         self.assertEqual("published", weekly.status)
         self.assertIn("journal_weekly_", weekly.entry_id)
-        self.assertEqual(7, weekly.aggregate_counts["activeDays"])
-        self.assertEqual(7, weekly.aggregate_counts["daysObserved"])
+        self.assertEqual(6, weekly.aggregate_counts["activeDays"])
+        self.assertEqual(6, weekly.aggregate_counts["daysObserved"])
+        self.assertEqual(6, weekly.aggregate_counts["dailyPeriodContexts"])
 
     def test_weekly_refuses_archive_fallback_or_incomplete_coverage(self):
         cases = (
@@ -509,7 +542,7 @@ class JournalAutomationTests(unittest.TestCase):
         # Each case uses its own occurrence. A frozen packet is now durable by
         # design and must not be replaced by a later retry of the same week.
         for index, (flags, expected_status, expected_reason) in enumerate(cases):
-            monday = date(2026, 7, 13) + timedelta(days=7 * index)
+            monday = date(2026, 7, 6) + timedelta(days=7 * index)
             start, end, _ = automation._weekly_period_for_monday(monday)
             base_packet = journal.build_packet_from_sources(
                 self.db,
@@ -525,7 +558,7 @@ class JournalAutomationTests(unittest.TestCase):
             with self.subTest(flags=flags), patch.object(
                 automation,
                 "_weekly_packet",
-                return_value=(packet, 7, 7),
+                return_value=(packet, 6, 6),
             ):
                 result = automation.run_weekly(
                     self.db,
@@ -566,35 +599,36 @@ class JournalAutomationTests(unittest.TestCase):
                 private_display_name=current_name,
                 public_usable=True,
             )
-            start, end, label = automation._daily_period_for_day(day)
-            observation_packet = journal.build_packet_from_sources(
-                self.db,
-                1,
-                start,
-                end,
-                [],
-                [],
-                entry_kind="daily",
-                aggregate_counts={"eligibleRelays": 0, "eligibleConversations": 0},
-            )
-            automation._store_observation(self.db, 1, label, observation_packet)
-            automation._mark_observation(
-                self.db,
-                1,
-                label,
-                automation.AutomationResult(
-                    True,
-                    "daily",
-                    "published",
-                    source_window_start=start,
-                    source_window_end=end,
-                ),
-            )
+            if offset < 6:
+                start, end, label = automation._daily_period_for_day(day)
+                observation_packet = journal.build_packet_from_sources(
+                    self.db,
+                    1,
+                    start,
+                    end,
+                    [],
+                    [],
+                    entry_kind="daily",
+                    aggregate_counts={"eligibleRelays": 0, "eligibleConversations": 0},
+                )
+                automation._store_observation(self.db, 1, label, observation_packet)
+                automation._mark_observation(
+                    self.db,
+                    1,
+                    label,
+                    automation.AutomationResult(
+                        True,
+                        "daily",
+                        "published",
+                        source_window_start=start,
+                        source_window_end=end,
+                    ),
+                )
 
         start, end, _ = automation._weekly_period_for_monday(monday)
         packet, complete_days, active_days = automation._weekly_packet(self.db, 1, start, end)
         self.assertIsNotNone(packet)
-        self.assertEqual((7, 7), (complete_days, active_days))
+        self.assertEqual((6, 6), (complete_days, active_days))
         self.assertTrue(packet["sourceArchiveAvailable"])
         self.assertEqual(7, packet["aggregateCounts"]["eligibleConversations"])
         self.assertEqual(7, packet["aggregateCounts"]["participants"])
@@ -604,7 +638,7 @@ class JournalAutomationTests(unittest.TestCase):
         self.assertNotIn("Bob", public_generation_text)
 
     def test_all_quiet_week_is_terminal_and_does_not_block_catchup(self):
-        for offset in range(7):
+        for offset in range(6):
             day = datetime(2026, 7, 13, tzinfo=timezone.utc).date() + timedelta(days=offset)
             start, end, label = automation._daily_period_for_day(day)
             packet = journal.build_packet_from_sources(

--- a/tests/test_bnl_journal_cadence_v2.py
+++ b/tests/test_bnl_journal_cadence_v2.py
@@ -1,0 +1,905 @@
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from datetime import date, datetime, time as datetime_time, timedelta, timezone
+from unittest.mock import patch
+
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+
+import bnl_journal as journal
+import bnl_journal_automation as automation
+import bnl_journal_source_store as source_store
+from tests.test_bnl_journal_prepared_release import AcceptedResponse, article_json
+
+
+class JournalCadenceV2Tests(unittest.TestCase):
+    def setUp(self):
+        self.archive_clock = patch.object(source_store, "_now_ms", return_value=0)
+        self.archive_clock.start()
+        temporary = tempfile.NamedTemporaryFile(delete=False)
+        self.db = temporary.name
+        temporary.close()
+        journal.ensure_schema(self.db)
+        automation.ensure_schema(self.db)
+
+    def tearDown(self):
+        self.archive_clock.stop()
+        try:
+            os.unlink(self.db)
+        except FileNotFoundError:
+            pass
+
+    @staticmethod
+    def utc(local_day: date, hour: int, minute: int, second: int = 0) -> datetime:
+        local = automation.PACIFIC.localize(
+            datetime.combine(
+                local_day,
+                datetime_time(hour, minute, second),
+            )
+        )
+        return local.astimezone(timezone.utc)
+
+    def activate(self, local_day: date, hour: int = 18, minute: int = 0) -> dict:
+        return automation.ensure_cadence_activation(
+            self.db,
+            1,
+            now_utc=self.utc(local_day, hour, minute),
+        )
+
+    def set_archive_activation(self, value: str) -> None:
+        activated = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        activated_ms = int(activated.timestamp() * 1000)
+        source_store.ensure_schema(self.db)
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                """INSERT INTO bnl_journal_source_archive_state(
+                       guild_id,activated_at_ms,created_at_ms
+                   ) VALUES(1,?,?)
+                   ON CONFLICT(guild_id) DO UPDATE SET
+                       activated_at_ms=excluded.activated_at_ms""",
+                (activated_ms, activated_ms),
+            )
+
+    def add_sources(
+        self,
+        start: str,
+        end: str,
+        *,
+        prefix: str,
+        count: int = 6,
+    ) -> None:
+        start_dt = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        end_dt = datetime.fromisoformat(end.replace("Z", "+00:00"))
+        span = (end_dt - start_dt).total_seconds()
+        for index in range(count):
+            occurred = start_dt + timedelta(
+                seconds=span * (index + 1) / (count + 1)
+            )
+            source_store.record_source_event(
+                self.db,
+                guild_id=1,
+                source_kind="discord_message",
+                source_key=f"{prefix}-{index}",
+                occurred_at_ms=int(occurred.timestamp() * 1000),
+                raw_text=(
+                    f"A public producer shared mix activity {prefix} {index} "
+                    "while listeners discussed the changing rhythm."
+                ),
+                sanitized_summary=(
+                    f"A public producer shared mix activity {prefix} {index} "
+                    "while listeners discussed the changing rhythm."
+                ),
+                channel_id=900 + index,
+                channel_policy="public_home",
+                subject_ref=f"discord_user:{1000 + index}",
+                private_display_name=f"Member{index}",
+                public_usable=True,
+            )
+
+    def add_daily_period(self, target_day: date) -> None:
+        start, end, _ = automation._daily_period_for_day(target_day)
+        self.add_sources(start, end, prefix=f"daily-{target_day.isoformat()}")
+
+    @staticmethod
+    def generator(packet, _prompt):
+        return article_json(packet)
+
+    @staticmethod
+    def opener(posts):
+        def accepted(request, timeout=10):
+            posts.append(bytes(request.data))
+            return AcceptedResponse(request)
+
+        return accepted
+
+    def test_dst_keeps_local_cutoffs_with_23_24_25_hour_days_and_167_169_hour_weeks(self):
+        durations = []
+        for target_day in (
+            date(2026, 3, 7),
+            date(2026, 7, 20),
+            date(2026, 10, 31),
+        ):
+            start, end, _ = automation._daily_period_for_day(target_day)
+            start_dt = automation._parse_utc(start)
+            end_dt = automation._parse_utc(end)
+            durations.append(int((end_dt - start_dt).total_seconds() // 3600))
+            self.assertEqual(
+                (18, 30),
+                (
+                    start_dt.astimezone(automation.PACIFIC).hour,
+                    start_dt.astimezone(automation.PACIFIC).minute,
+                ),
+            )
+            self.assertEqual(
+                (18, 30),
+                (
+                    end_dt.astimezone(automation.PACIFIC).hour,
+                    end_dt.astimezone(automation.PACIFIC).minute,
+                ),
+            )
+        self.assertEqual([23, 24, 25], durations)
+
+        spring_start, spring_end, _ = automation._weekly_period_for_monday(
+            date(2026, 3, 2)
+        )
+        fall_start, fall_end, _ = automation._weekly_period_for_monday(
+            date(2026, 10, 26)
+        )
+        self.assertEqual(
+            167,
+            int(
+                (
+                    automation._parse_utc(spring_end)
+                    - automation._parse_utc(spring_start)
+                ).total_seconds()
+                // 3600
+            ),
+        )
+        self.assertEqual(
+            169,
+            int(
+                (
+                    automation._parse_utc(fall_end)
+                    - automation._parse_utc(fall_start)
+                ).total_seconds()
+                // 3600
+            ),
+        )
+
+    def test_exact_six_thirty_boundary_belongs_only_to_new_period(self):
+        start, boundary, _ = automation._daily_period_for_day(date(2026, 7, 20))
+        _next_start, next_end, _ = automation._daily_period_for_day(
+            date(2026, 7, 21)
+        )
+        boundary_dt = automation._parse_utc(boundary)
+        for source_key, occurred in (
+            ("closing", boundary_dt - timedelta(seconds=1)),
+            ("opening", boundary_dt),
+        ):
+            source_store.record_source_event(
+                self.db,
+                guild_id=1,
+                source_kind="discord_message",
+                source_key=source_key,
+                occurred_at_ms=int(occurred.timestamp() * 1000),
+                raw_text=f"Public mix activity {source_key}.",
+                sanitized_summary=f"Public mix activity {source_key}.",
+                channel_id=1,
+                channel_policy="public_home",
+                subject_ref=f"discord_user:{source_key}",
+                private_display_name=source_key,
+                public_usable=True,
+            )
+
+        closing = journal.build_source_packet_between(
+            self.db,
+            1,
+            start,
+            boundary,
+            entry_kind="daily",
+        )
+        opening = journal.build_source_packet_between(
+            self.db,
+            1,
+            boundary,
+            next_end,
+            entry_kind="daily",
+        )
+        self.assertEqual(1, closing["aggregateCounts"]["eligibleConversations"])
+        self.assertEqual(1, opening["aggregateCounts"]["eligibleConversations"])
+        self.assertEqual(
+            boundary,
+            automation._utc_iso(automation._parse_utc(_next_start)),
+        )
+
+    def test_monday_boundary_event_is_excluded_from_closing_weekly_and_enters_tuesday_daily(self):
+        weekly_start, weekly_end, _ = automation._weekly_period_for_monday(
+            date(2026, 7, 13)
+        )
+        boundary = automation._parse_utc(weekly_end)
+        for source_key, occurred in (
+            ("weekly-tail", boundary - timedelta(seconds=1)),
+            ("next-week", boundary),
+        ):
+            source_store.record_source_event(
+                self.db,
+                guild_id=1,
+                source_kind="discord_message",
+                source_key=source_key,
+                occurred_at_ms=int(occurred.timestamp() * 1000),
+                raw_text=f"Public mix activity {source_key}.",
+                sanitized_summary=f"Public mix activity {source_key}.",
+                channel_id=1,
+                channel_policy="public_home",
+                subject_ref=f"discord_user:{source_key}",
+                private_display_name=source_key,
+                public_usable=True,
+            )
+        weekly, _complete, _active = automation._weekly_packet(
+            self.db,
+            1,
+            weekly_start,
+            weekly_end,
+        )
+        self.assertEqual(
+            1,
+            weekly["weeklyFinalPeriodContext"]["counts"][
+                "eligibleConversations"
+            ],
+        )
+        self.assertEqual(
+            1,
+            weekly["aggregateCounts"]["eligibleConversations"],
+        )
+
+        _daily_start, daily_end, _ = automation._daily_period_for_day(
+            date(2026, 7, 20)
+        )
+        daily = journal.build_source_packet_between(
+            self.db,
+            1,
+            weekly_end,
+            daily_end,
+            entry_kind="daily",
+        )
+        self.assertEqual(1, daily["aggregateCounts"]["eligibleConversations"])
+
+    def test_before_six_thirty_starts_no_occurrence_or_model_call(self):
+        self.activate(date(2026, 7, 20))
+        self.add_daily_period(date(2026, 7, 20))
+        calls = []
+        result = automation.prepare_scheduled(
+            self.db,
+            1,
+            lambda *_args: calls.append(1),
+            now_utc=self.utc(date(2026, 7, 21), 18, 29, 59),
+        )
+        self.assertEqual("not_due", result[0].status)
+        self.assertEqual([], calls)
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(
+                0,
+                conn.execute(
+                    "SELECT COUNT(*) FROM bnl_journal_automation_runs"
+                ).fetchone()[0],
+            )
+
+    def test_activation_after_cutoff_waits_for_first_transition_close(self):
+        activation_now = self.utc(date(2026, 7, 21), 18, 45)
+        state = automation.ensure_cadence_activation(
+            self.db,
+            1,
+            now_utc=activation_now,
+        )
+        self.assertEqual(
+            "2026-07-23T01:30:00Z",
+            state["daily_transition_end"],
+        )
+        calls = []
+        prepared = automation.prepare_scheduled(
+            self.db,
+            1,
+            lambda *_args: calls.append(1),
+            now_utc=activation_now,
+        )
+        released = automation.release_scheduled(
+            self.db,
+            1,
+            "https://site.example",
+            "key",
+            now_utc=self.utc(date(2026, 7, 21), 19, 0),
+            opener=lambda *_args, **_kwargs: self.fail(
+                "pre-transition window posted"
+            ),
+        )
+        self.assertEqual("cadence_transition_not_ready", prepared[0].reason)
+        self.assertEqual("cadence_transition_not_ready", released[0].reason)
+        self.assertEqual([], calls)
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(
+                0,
+                conn.execute(
+                    "SELECT COUNT(*) FROM bnl_journal_automation_runs "
+                    "WHERE schedule_contract_version=2"
+                ).fetchone()[0],
+            )
+
+    def test_owner_forced_monday_daily_creates_no_run_packet_draft_or_observation(self):
+        self.activate(date(2026, 7, 19))
+        self.add_daily_period(date(2026, 7, 19))
+        calls = []
+        result = automation.prepare_daily(
+            self.db,
+            1,
+            lambda *_args: calls.append(1),
+            now_utc=self.utc(date(2026, 7, 20), 20, 0),
+            target_day=date(2026, 7, 19),
+            force=True,
+        )
+        self.assertEqual("not_applicable", result.status)
+        self.assertEqual("monday_weekly_only", result.reason)
+        self.assertEqual([], calls)
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(
+                (0, 0, 0),
+                (
+                    conn.execute(
+                        "SELECT COUNT(*) FROM bnl_journal_automation_runs"
+                    ).fetchone()[0],
+                    conn.execute(
+                        "SELECT COUNT(*) FROM bnl_journal_entries"
+                    ).fetchone()[0],
+                    conn.execute(
+                        "SELECT COUNT(*) FROM bnl_journal_observations"
+                    ).fetchone()[0],
+                ),
+            )
+
+    def test_preparation_deadline_miss_posts_nothing_and_same_occurrence_recovers(self):
+        self.activate(date(2026, 7, 20))
+        self.add_daily_period(date(2026, 7, 20))
+        close = self.utc(date(2026, 7, 21), 18, 30)
+
+        def timed_out(_packet, _prompt):
+            raise RuntimeError("journal_preparation_timeout")
+
+        first = automation.prepare_scheduled(
+            self.db,
+            1,
+            timed_out,
+            now_utc=close,
+        )
+        self.assertEqual("held", first[0].status)
+        self.assertEqual("journal_preparation_timeout", first[0].reason)
+        with sqlite3.connect(self.db) as conn:
+            conn.row_factory = sqlite3.Row
+            before = dict(
+                conn.execute(
+                    "SELECT * FROM bnl_journal_automation_runs "
+                    "WHERE schedule_contract_version=2"
+                ).fetchone()
+            )
+            self.assertEqual(
+                0,
+                conn.execute(
+                    "SELECT COUNT(*) FROM bnl_journal_entries"
+                ).fetchone()[0],
+            )
+
+        posts = []
+        at_release = automation.release_scheduled(
+            self.db,
+            1,
+            "https://site.example",
+            "key",
+            now_utc=self.utc(date(2026, 7, 21), 19, 0),
+            opener=self.opener(posts),
+        )
+        self.assertEqual("held", at_release[0].status)
+        self.assertEqual("prepared_payload_unavailable", at_release[0].reason)
+        self.assertEqual([], posts)
+
+        recovered = automation.prepare_daily(
+            self.db,
+            1,
+            self.generator,
+            now_utc=self.utc(date(2026, 7, 21), 20, 0),
+            target_day=date(2026, 7, 20),
+            force=True,
+        )
+        self.assertEqual("prepared", recovered.status, recovered)
+        with sqlite3.connect(self.db) as conn:
+            conn.row_factory = sqlite3.Row
+            after = dict(
+                conn.execute(
+                    "SELECT * FROM bnl_journal_automation_runs "
+                    "WHERE run_id=?",
+                    (before["run_id"],),
+                ).fetchone()
+            )
+        self.assertEqual(before["run_id"], after["run_id"])
+        self.assertEqual(
+            before["frozen_packet_hash"],
+            after["frozen_packet_hash"],
+        )
+        self.assertEqual(2, after["preparation_epoch"])
+
+    def test_full_week_has_six_dailies_one_weekly_and_zero_monday_daily(self):
+        self.activate(date(2026, 7, 13))
+        for offset in range(7):
+            self.add_daily_period(date(2026, 7, 13) + timedelta(days=offset))
+
+        posts = []
+        generator_calls = []
+
+        def generate(packet, prompt):
+            generator_calls.append(
+                (packet["entryKind"], packet["sourceWindowStart"], prompt)
+            )
+            return article_json(packet)
+
+        for target_day in (
+            date(2026, 7, 13),
+            date(2026, 7, 14),
+            date(2026, 7, 15),
+            date(2026, 7, 16),
+            date(2026, 7, 17),
+            date(2026, 7, 18),
+        ):
+            release_day = target_day + timedelta(days=1)
+            posts_before_prepare = len(posts)
+            prepared = automation.prepare_scheduled(
+                self.db,
+                1,
+                generate,
+                now_utc=self.utc(release_day, 18, 30),
+            )
+            self.assertEqual("prepared", prepared[0].status, prepared[0])
+            self.assertEqual(posts_before_prepare, len(posts))
+            calls_before_release = len(generator_calls)
+            released = automation.release_scheduled(
+                self.db,
+                1,
+                "https://site.example",
+                "key",
+                now_utc=self.utc(release_day, 19, 0),
+                opener=self.opener(posts),
+            )
+            self.assertEqual("published", released[0].status, released[0])
+            self.assertEqual(calls_before_release, len(generator_calls))
+
+        weekly_prepared = automation.prepare_scheduled(
+            self.db,
+            1,
+            generate,
+            now_utc=self.utc(date(2026, 7, 20), 18, 30),
+        )
+        self.assertEqual("weekly", weekly_prepared[0].cadence)
+        self.assertEqual("prepared", weekly_prepared[0].status, weekly_prepared[0])
+        calls_before_release = len(generator_calls)
+        weekly_released = automation.release_scheduled(
+            self.db,
+            1,
+            "https://site.example",
+            "key",
+            now_utc=self.utc(date(2026, 7, 20), 19, 0),
+            opener=self.opener(posts),
+        )
+        self.assertEqual("weekly", weekly_released[0].cadence)
+        self.assertEqual("published", weekly_released[0].status)
+        self.assertEqual(calls_before_release, len(generator_calls))
+
+        with sqlite3.connect(self.db) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT * FROM bnl_journal_automation_runs "
+                "WHERE guild_id=1 AND schedule_contract_version=2"
+            ).fetchall()
+            observations = conn.execute(
+                "SELECT COUNT(*) FROM bnl_journal_observations WHERE guild_id=1"
+            ).fetchone()[0]
+        dailies = [row for row in rows if row["cadence"] == "daily"]
+        weeklies = [row for row in rows if row["cadence"] == "weekly"]
+        self.assertEqual((6, 1), (len(dailies), len(weeklies)))
+        self.assertEqual(6, observations)
+        self.assertEqual(7, len(posts))
+        attempt_counts = {}
+        for entry_kind, source_start, _prompt in generator_calls:
+            key = (entry_kind, source_start)
+            attempt_counts[key] = attempt_counts.get(key, 0) + 1
+        self.assertEqual(7, len(attempt_counts))
+        self.assertTrue(
+            all(
+                1 <= count <= journal.JOURNAL_GENERATION_ATTEMPTS
+                for count in attempt_counts.values()
+            )
+        )
+        self.assertFalse(
+            any(
+                automation._window_end_weekday(row["source_window_end"])
+                == automation.WEEKLY_READY_WEEKDAY
+                for row in dailies
+            )
+        )
+
+        weekly_packet = json.loads(weeklies[0]["frozen_packet_json"])
+        contexts = weekly_packet["weeklyDailyPeriodContexts"]
+        final_context = weekly_packet["weeklyFinalPeriodContext"]
+        self.assertEqual(6, len(contexts))
+        self.assertTrue(
+            all(item["originType"] == "daily_observation" for item in contexts)
+        )
+        self.assertEqual(
+            [1, 2, 3, 4, 5, 6],
+            [
+                automation._parse_utc(item["sourceWindowEnd"])
+                .astimezone(automation.PACIFIC)
+                .weekday()
+                for item in contexts
+            ],
+        )
+        self.assertEqual("raw_partition", final_context["originType"])
+        self.assertGreater(
+            int(final_context["counts"]["eligibleConversations"]),
+            0,
+        )
+        self.assertTrue(final_context["sourceRefIds"])
+
+    def test_weekly_still_prepares_from_one_raw_read_when_dailies_are_disabled(self):
+        self.activate(date(2026, 7, 13))
+        for offset in range(7):
+            self.add_daily_period(date(2026, 7, 13) + timedelta(days=offset))
+        flags = {
+            "journalAutoPublishEnabled": True,
+            "journalDailyEnabled": False,
+            "journalWeeklyEnabled": True,
+        }
+        with patch.object(
+            automation,
+            "build_source_packet_between",
+            wraps=journal.build_source_packet_between,
+        ) as raw_read:
+            prepared = automation.prepare_scheduled(
+                self.db,
+                1,
+                self.generator,
+                flags,
+                now_utc=self.utc(date(2026, 7, 20), 18, 30),
+            )
+        self.assertEqual("weekly", prepared[0].cadence)
+        self.assertEqual("prepared", prepared[0].status, prepared[0])
+        self.assertEqual(1, raw_read.call_count)
+        with sqlite3.connect(self.db) as conn:
+            conn.row_factory = sqlite3.Row
+            daily_count = conn.execute(
+                "SELECT COUNT(*) FROM bnl_journal_automation_runs "
+                "WHERE cadence='daily' AND schedule_contract_version=2"
+            ).fetchone()[0]
+            weekly = conn.execute(
+                "SELECT frozen_packet_json FROM bnl_journal_automation_runs "
+                "WHERE cadence='weekly' AND schedule_contract_version=2"
+            ).fetchone()
+        self.assertEqual(0, daily_count)
+        packet = json.loads(weekly["frozen_packet_json"])
+        self.assertEqual(
+            ["raw_partition"] * 6,
+            [
+                item["originType"]
+                for item in packet["weeklyDailyPeriodContexts"]
+            ],
+        )
+
+    def test_migration_preserves_one_owed_old_daily_and_is_idempotent(self):
+        # Archive ownership began at the predecessor Monday 7 PM boundary.
+        self.set_archive_activation("2026-07-21T02:00:00Z")
+        activation_now = self.utc(date(2026, 7, 22), 18, 0)
+        first = automation.ensure_cadence_activation(
+            self.db,
+            1,
+            now_utc=activation_now,
+        )
+        second = automation.ensure_cadence_activation(
+            self.db,
+            1,
+            now_utc=self.utc(date(2026, 7, 23), 12, 0),
+        )
+
+        legacy_start, legacy_end, _ = automation._legacy_daily_period_for_day(
+            date(2026, 7, 20)
+        )
+        self.assertEqual(legacy_end, first["legacy_daily_boundary"])
+        self.assertEqual("2026-07-22T02:00:00Z", first["daily_transition_start"])
+        self.assertEqual("2026-07-23T01:30:00Z", first["daily_transition_end"])
+        self.assertEqual(
+            first["cadence_activated_at"],
+            second["cadence_activated_at"],
+        )
+        with sqlite3.connect(self.db) as conn:
+            conn.row_factory = sqlite3.Row
+            legacy_rows = conn.execute(
+                "SELECT * FROM bnl_journal_automation_runs "
+                "WHERE schedule_contract_version=1"
+            ).fetchall()
+            state_count = conn.execute(
+                "SELECT COUNT(*) FROM bnl_journal_automation_state "
+                "WHERE guild_id=1 AND cadence_contract_version=2"
+            ).fetchone()[0]
+        self.assertEqual(1, len(legacy_rows))
+        self.assertEqual((legacy_start, legacy_end), (
+            legacy_rows[0]["source_window_start"],
+            legacy_rows[0]["source_window_end"],
+        ))
+        self.assertEqual("held", legacy_rows[0]["lifecycle_state"])
+        self.assertEqual(1, state_count)
+        detail = json.loads(first["cadence_activation_detail_json"])
+        self.assertEqual(
+            [legacy_rows[0]["run_id"]],
+            detail["preservedLegacyRunIds"],
+        )
+
+    def test_concurrent_activation_creates_one_marker_and_one_preserved_run(self):
+        self.set_archive_activation("2026-07-21T02:00:00Z")
+        activation_now = self.utc(date(2026, 7, 22), 18, 0)
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            states = list(
+                pool.map(
+                    lambda _index: automation.ensure_cadence_activation(
+                        self.db,
+                        1,
+                        now_utc=activation_now,
+                    ),
+                    range(8),
+                )
+            )
+        self.assertEqual(
+            1,
+            len({state["cadence_activated_at"] for state in states}),
+        )
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(
+                (1, 1),
+                (
+                    conn.execute(
+                        "SELECT COUNT(*) FROM bnl_journal_automation_state "
+                        "WHERE guild_id=1 AND cadence_contract_version=2"
+                    ).fetchone()[0],
+                    conn.execute(
+                        "SELECT COUNT(*) FROM bnl_journal_automation_runs "
+                        "WHERE schedule_contract_version=1"
+                    ).fetchone()[0],
+                ),
+            )
+
+    def test_preserved_old_daily_recovers_with_original_id_and_window(self):
+        self.set_archive_activation("2026-07-21T02:00:00Z")
+        activation_now = self.utc(date(2026, 7, 22), 18, 0)
+        state = automation.ensure_cadence_activation(
+            self.db,
+            1,
+            now_utc=activation_now,
+        )
+        with sqlite3.connect(self.db) as conn:
+            conn.row_factory = sqlite3.Row
+            legacy = dict(
+                conn.execute(
+                    "SELECT * FROM bnl_journal_automation_runs "
+                    "WHERE schedule_contract_version=1"
+                ).fetchone()
+            )
+        self.add_sources(
+            legacy["source_window_start"],
+            legacy["source_window_end"],
+            prefix="legacy-recovery",
+        )
+        posts = []
+        result = automation._run_legacy_occurrence(
+            self.db,
+            1,
+            legacy,
+            self.generator,
+            "https://site.example",
+            "key",
+            opener=self.opener(posts),
+        )
+        self.assertEqual("published", result.status, result)
+        self.assertEqual(
+            (
+                legacy["source_window_start"],
+                legacy["source_window_end"],
+            ),
+            (result.source_window_start, result.source_window_end),
+        )
+        expected_label = (
+            automation._parse_utc(legacy["source_window_start"])
+            .astimezone(automation.PACIFIC)
+            .date()
+            .isoformat()
+        )
+        self.assertEqual(
+            automation._entry_id(1, "daily", expected_label),
+            result.entry_id,
+        )
+        self.assertEqual(1, len(posts))
+        with sqlite3.connect(self.db) as conn:
+            row = conn.execute(
+                "SELECT lifecycle_state,schedule_contract_version,"
+                "source_window_start,source_window_end "
+                "FROM bnl_journal_automation_runs WHERE run_id=?",
+                (legacy["run_id"],),
+            ).fetchone()
+        self.assertEqual(
+            (
+                "published",
+                automation.LEGACY_CADENCE_CONTRACT_VERSION,
+                legacy["source_window_start"],
+                legacy["source_window_end"],
+            ),
+            row,
+        )
+        self.assertEqual(
+            "2026-07-22T02:00:00Z",
+            state["daily_transition_start"],
+        )
+
+    def test_unpublished_old_monday_daily_is_retained_but_never_posted(self):
+        start, end, _ = automation._legacy_daily_period_for_day(
+            date(2026, 7, 19)
+        )
+        run_id = automation._run_id(1, "daily", start, end)
+        now = journal.utc_now_iso()
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                """INSERT INTO bnl_journal_automation_runs(
+                       run_id,guild_id,cadence,source_window_start,
+                       source_window_end,lifecycle_state,reason,
+                       aggregate_counts_json,attempt_count,
+                       schedule_contract_version,created_at,updated_at
+                   ) VALUES(?,?,?,?,?,'held','provider_failure','{}',1,1,?,?)""",
+                (run_id, 1, "daily", start, end, now, now),
+            )
+
+        state = automation.ensure_cadence_activation(
+            self.db,
+            1,
+            now_utc=self.utc(date(2026, 7, 20), 20, 0),
+        )
+        posts = []
+        result = automation.release_occurrence(
+            self.db,
+            1,
+            "daily",
+            start,
+            end,
+            "https://site.example",
+            "key",
+            opener=self.opener(posts),
+        )
+        with sqlite3.connect(self.db) as conn:
+            row = conn.execute(
+                "SELECT lifecycle_state,reason FROM bnl_journal_automation_runs "
+                "WHERE run_id=?",
+                (run_id,),
+            ).fetchone()
+        self.assertEqual(
+            ("superseded", "cadence_migration_monday_weekly_only"),
+            row,
+        )
+        self.assertEqual("superseded", result.status)
+        self.assertEqual([], posts)
+        self.assertIn(
+            run_id,
+            json.loads(state["cadence_activation_detail_json"])[
+                "supersededMondayDailyRunIds"
+            ],
+        )
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError,
+            "journal_cadence_superseded_guard",
+        ):
+            with sqlite3.connect(self.db) as conn:
+                conn.execute(
+                    "UPDATE bnl_journal_automation_runs "
+                    "SET lifecycle_state='preparing' WHERE run_id=?",
+                    (run_id,),
+                )
+
+    def test_persisted_rollback_guard_blocks_new_old_schedule_identity(self):
+        self.activate(date(2026, 7, 20))
+        start, end, _ = automation._legacy_daily_period_for_day(
+            date(2026, 7, 20)
+        )
+        run_id = automation._run_id(1, "daily", start, end)
+        now = journal.utc_now_iso()
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError,
+            "journal_cadence_v2_downgrade_guard",
+        ):
+            with sqlite3.connect(self.db) as conn:
+                conn.execute(
+                    """INSERT INTO bnl_journal_automation_runs(
+                           run_id,guild_id,cadence,source_window_start,
+                           source_window_end,lifecycle_state,reason,
+                           aggregate_counts_json,attempt_count,
+                           schedule_contract_version,created_at,updated_at
+                       ) VALUES(?,?,?,?,?,'running','','{}',1,1,?,?)""",
+                    (run_id, 1, "daily", start, end, now, now),
+                )
+
+        v2_start, v2_end, _ = automation._daily_period_for_day(
+            date(2026, 7, 20)
+        )
+        v2_run_id = automation._run_id(1, "daily", v2_start, v2_end)
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                """INSERT INTO bnl_journal_automation_runs(
+                       run_id,guild_id,cadence,source_window_start,
+                       source_window_end,lifecycle_state,reason,
+                       aggregate_counts_json,attempt_count,
+                       schedule_contract_version,created_at,updated_at
+                   ) VALUES(?,?,?,?,?,'running','','{}',1,2,?,?)""",
+                (v2_run_id, 1, "daily", v2_start, v2_end, now, now),
+            )
+            stored_version = conn.execute(
+                "SELECT schedule_contract_version "
+                "FROM bnl_journal_automation_runs WHERE run_id=?",
+                (v2_run_id,),
+            ).fetchone()[0]
+        self.assertEqual(2, stored_version)
+
+    def test_transition_weekly_starts_at_preserved_old_boundary_then_partitions_six_plus_final(self):
+        old_start, old_end, _ = automation._legacy_weekly_period_for_monday(
+            date(2026, 7, 6)
+        )
+        run_id = automation._run_id(1, "weekly", old_start, old_end)
+        now = journal.utc_now_iso()
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                """INSERT INTO bnl_journal_automation_runs(
+                       run_id,guild_id,cadence,source_window_start,
+                       source_window_end,lifecycle_state,reason,
+                       aggregate_counts_json,attempt_count,
+                       schedule_contract_version,created_at,updated_at
+                   ) VALUES(?,?,?,?,?,'published','','{}',1,1,?,?)""",
+                (run_id, 1, "weekly", old_start, old_end, now, now),
+            )
+
+        state = automation.ensure_cadence_activation(
+            self.db,
+            1,
+            now_utc=self.utc(date(2026, 7, 14), 12, 0),
+        )
+        self.assertEqual(old_end, state["weekly_transition_start"])
+        self.assertEqual("2026-07-21T01:30:00Z", state["weekly_transition_end"])
+        contexts, final_context = automation._weekly_source_period_bounds(
+            state["weekly_transition_start"],
+            state["weekly_transition_end"],
+        )
+        self.assertEqual(6, len(contexts))
+        self.assertEqual(old_end, contexts[0]["sourceWindowStart"])
+        self.assertEqual(
+            "2026-07-15T01:30:00Z",
+            contexts[0]["sourceWindowEnd"],
+        )
+        self.assertEqual(
+            contexts[-1]["sourceWindowEnd"],
+            final_context["sourceWindowStart"],
+        )
+        self.assertEqual(
+            state["weekly_transition_end"],
+            final_context["sourceWindowEnd"],
+        )
+
+    def test_next_public_release_skips_monday_daily_but_keeps_monday_weekly(self):
+        next_daily, next_weekly = automation.next_schedule_times(
+            self.utc(date(2026, 7, 20), 12, 0)
+        )
+        self.assertEqual("2026-07-22T02:00:00Z", next_daily)
+        self.assertEqual("2026-07-21T02:00:00Z", next_weekly)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bnl_journal_lifecycle_migration.py
+++ b/tests/test_bnl_journal_lifecycle_migration.py
@@ -16,7 +16,7 @@ import bnl_journal_source_store as source_store
 from tests.test_bnl_journal_prepared_release import AcceptedResponse, article_json
 
 
-TARGET_DAY = date(2026, 7, 19)
+TARGET_DAY = date(2026, 7, 20)
 
 
 class JournalLifecycleMigrationTests(unittest.TestCase):

--- a/tests/test_bnl_journal_prepared_release.py
+++ b/tests/test_bnl_journal_prepared_release.py
@@ -18,7 +18,7 @@ import bnl_journal_automation as automation
 import bnl_journal_source_store as source_store
 
 
-TARGET_DAY = date(2026, 7, 19)
+TARGET_DAY = date(2026, 7, 20)
 
 
 def article_json(packet, *, title="Prepared Signal Weather", body_repeat=18):
@@ -756,7 +756,7 @@ class PreparedReleaseTests(unittest.TestCase):
         self.assertIsNone(run["frozen_packet_json"])
         self.assertIsNone(run["prepared_payload_hash"])
         self.assertEqual("rejected", self.entry_row(prepared.entry_id, prepared.revision)["lifecycle_state"])
-        now = datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 7, 22, 3, 0, tzinfo=timezone.utc)
         self.assertEqual(TARGET_DAY, automation._pending_daily_day(self.db, 1, now))
 
     def test_payload_tampering_is_rejected_before_network(self):

--- a/tests/test_bnl_journal_release_invalidation.py
+++ b/tests/test_bnl_journal_release_invalidation.py
@@ -15,7 +15,7 @@ import bnl_journal_source_store as source_store
 from tests.test_bnl_journal_prepared_release import AcceptedResponse, article_json
 
 
-TARGET_DAY = date(2026, 7, 19)
+TARGET_DAY = date(2026, 7, 20)
 WEEK_START = date(2026, 7, 13)
 
 
@@ -299,6 +299,8 @@ class JournalReleaseInvalidationTests(unittest.TestCase):
         for offset in range(7):
             day = WEEK_START + timedelta(days=offset)
             self.add_day(day)
+            if offset == 6:
+                continue
             published = automation.run_daily(
                 self.db,
                 1,
@@ -335,7 +337,7 @@ class JournalReleaseInvalidationTests(unittest.TestCase):
                     (prepared.entry_id, prepared.revision),
                 ).fetchone()[0]
             )
-        self.assertEqual(7, len(daily_entry_ids))
+        self.assertEqual(6, len(daily_entry_ids))
         self.assertTrue(daily_entry_ids <= set(metadata["relatedPriorJournalEntryIds"]))
         excluded_entry_id = sorted(daily_entry_ids)[0]
         automation.store_journal_memory_exclusions(
@@ -408,7 +410,7 @@ class JournalReleaseInvalidationTests(unittest.TestCase):
     def test_used_broadcast_memory_expiring_after_preparation_blocks_post(self):
         # TARGET_DAY ends before this date expires, so the memory may be used
         # during preparation. At the patched release instant it is stale.
-        self.add_broadcast_memory(valid_until="2026-07-21")
+        self.add_broadcast_memory(valid_until="2026-07-22")
         self.add_day(TARGET_DAY)
         prepared = self.prepare_daily(self.memory_generator)
         self.assertEqual("prepared", prepared.status, prepared)
@@ -419,7 +421,7 @@ class JournalReleaseInvalidationTests(unittest.TestCase):
             posts.append(request.data)
             raise AssertionError("expired established memory reached the website")
 
-        with patch.object(automation, "utc_now_iso", return_value="2026-07-22T12:00:00Z"):
+        with patch.object(automation, "utc_now_iso", return_value="2026-07-23T12:00:00Z"):
             result = self.release_daily(forbidden_opener)
         self.assertEqual("held", result.status, result)
         self.assertEqual("privacy_memory_ineligible", result.reason)

--- a/tests/test_bnl_journal_runtime_controls.py
+++ b/tests/test_bnl_journal_runtime_controls.py
@@ -4,6 +4,7 @@ import os
 import sqlite3
 import tempfile
 import unittest
+from datetime import datetime
 from unittest import mock
 
 import bnl_journal as journal
@@ -59,12 +60,102 @@ class JournalRuntimeControlTests(unittest.TestCase):
             self.assertEqual(action, options["action"])
             self.assertEqual("", error)
 
-    def test_daily_worker_is_pinned_to_seven_pm_pacific(self):
-        scheduled_times = bnl01_bot.journal_daily_schedule_task.time
-        self.assertEqual(1, len(scheduled_times))
-        scheduled = scheduled_times[0]
-        self.assertEqual((19, 0), (scheduled.hour, scheduled.minute))
-        self.assertEqual("America/Los_Angeles", getattr(scheduled.tzinfo, "key", ""))
+    def test_workers_are_pinned_to_six_thirty_and_seven_pm_pacific(self):
+        preparation_times = bnl01_bot.journal_preparation_schedule_task.time
+        release_times = bnl01_bot.journal_daily_schedule_task.time
+        self.assertEqual(1, len(preparation_times))
+        self.assertEqual(1, len(release_times))
+        preparation = preparation_times[0]
+        release = release_times[0]
+        self.assertEqual((18, 30), (preparation.hour, preparation.minute))
+        self.assertEqual((19, 0), (release.hour, release.minute))
+        self.assertEqual(
+            "America/Los_Angeles",
+            getattr(preparation.tzinfo, "key", ""),
+        )
+        self.assertEqual(
+            "America/Los_Angeles",
+            getattr(release.tzinfo, "key", ""),
+        )
+
+    def test_preparation_budget_finishes_before_release_lane(self):
+        at_close = bnl01_bot.PACIFIC_TZ.localize(
+            datetime(2026, 7, 21, 18, 30, 0)
+        )
+        near_release = bnl01_bot.PACIFIC_TZ.localize(
+            datetime(2026, 7, 21, 18, 59, 50)
+        )
+        self.assertEqual(
+            float(bnl01_bot.JOURNAL_PREPARATION_MAX_SECONDS),
+            bnl01_bot._journal_preparation_budget_seconds(at_close),
+        )
+        self.assertEqual(
+            5.0,
+            bnl01_bot._journal_preparation_budget_seconds(near_release),
+        )
+
+    def test_exact_phase_dispatch_prepares_with_generator_and_releases_without_one(self):
+        flags = {
+            "journalAutoPublishEnabled": True,
+            "journalDailyEnabled": True,
+            "journalWeeklyEnabled": True,
+        }
+        prepared_result = AutomationResult(
+            True,
+            "daily",
+            "prepared",
+            source_window_start="2026-07-21T01:30:00Z",
+            source_window_end="2026-07-22T01:30:00Z",
+        )
+        released_result = AutomationResult(
+            True,
+            "daily",
+            "published",
+            source_window_start="2026-07-21T01:30:00Z",
+            source_window_end="2026-07-22T01:30:00Z",
+        )
+        bounded_generator = object()
+        with mock.patch.object(bnl01_bot, "BNL_JOURNAL_AUTOMATION_ENABLED", True), \
+             mock.patch.object(bnl01_bot, "resolve_network_guild_id", return_value=1), \
+             mock.patch.object(bnl01_bot, "DB_FILE", "test.db"), \
+             mock.patch.object(bnl01_bot, "BNL_API_KEY", "key"), \
+             mock.patch.object(bnl01_bot, "_journal_website_base_url", return_value="https://site.example"), \
+             mock.patch.object(bnl01_bot, "_bounded_journal_preparation_generator", return_value=bounded_generator) as bounded, \
+             mock.patch.object(bnl01_bot, "prepare_scheduled_journal_automation", return_value=[prepared_result]) as prepare, \
+             mock.patch.object(bnl01_bot, "release_scheduled_journal_automation", return_value=[released_result]) as release:
+            prepared = asyncio.run(
+                bnl01_bot.run_journal_automation_once(
+                    1,
+                    cadence="scheduled",
+                    phase="prepare",
+                    flags=flags,
+                )
+            )
+            released = asyncio.run(
+                bnl01_bot.run_journal_automation_once(
+                    1,
+                    cadence="scheduled",
+                    phase="release",
+                    flags=flags,
+                )
+            )
+
+        bounded.assert_called_once_with()
+        prepare.assert_called_once_with(
+            "test.db",
+            1,
+            bounded_generator,
+            flags,
+        )
+        release.assert_called_once_with(
+            "test.db",
+            1,
+            "https://site.example",
+            "key",
+            flags,
+        )
+        self.assertEqual("prepared", prepared[0]["status"])
+        self.assertEqual("published", released[0]["status"])
 
     def test_control_get_uses_api_key_and_expected_endpoint(self):
         captured = []
@@ -298,6 +389,7 @@ class JournalRuntimeControlTests(unittest.TestCase):
         runner.assert_awaited_once_with(
             1,
             cadence="scheduled",
+            phase="recover",
             force=False,
             flags={**cached_flags, "journalMemoryExclusionsConfirmed": False},
         )


### PR DESCRIPTION
## What changed

- Close each Journal evidence window at 6:30 PM Pacific.
- Prepare and persist the full-quality Journal during the 6:30 phase.
- Release the exact saved payload at 7:00 PM with zero generation or repair calls.
- Make Tuesday through Sunday Daily occurrences and Monday Weekly-only.
- Give Weekly one authoritative raw evidence read and prevent Monday Daily artifacts through scheduled, manual, forced, and recovery paths.
- Use half-open Pacific windows that correctly span 23/24/25-hour Daily and 167/169-hour Weekly DST transitions.
- Perform a one-time cadence cutover that preserves any genuinely owed predecessor 7:00 occurrence under its original identity.
- Fail closed on incompatible rollback so the old cadence cannot silently restart or revive superseded Monday work.

## Why

The current production scheduler begins Journal generation at 7:00 PM, so a full-quality entry can only publish after 7. PR #359 made prepared Journals durable and exactly reproducible; this PR activates that architecture by drafting before the public deadline and releasing the saved result at 7:00.

## Impact

Successful Journals keep the existing prompt, model, evidence, voice, word guidance, validation, repair attempts, and terminal `quiet` behavior. The writing process starts earlier; the public release remains 7:00 PM. A genuinely failed or ineligible occurrence remains held/owed rather than publishing inferior fallback content.

This PR does not change queue behavior, Memory v2, Relationship v2, permissions, deployment configuration, or website source.

## Validation

- Focused Journal suite: 145 tests passed
- Complete repository check: 1,224 tests passed
- `git diff --check` passed
- Added deterministic coverage for a full fake-clock week, Monday suppression, one-read Weekly partitioning, cutover idempotency, predecessor occurrence preservation, exact boundary assignment, DST durations, release phase separation, rollback isolation, and migration/release serialization
