### PR TITLE
Bot: shorten Journal recovery backoffs

### DIFF
--- a/bnl_journal_automation.py
+++ b/bnl_journal_automation.py
@@ -41,7 +41,8 @@ MIN_DAILY_SOURCE_COUNT = 5
 MIN_WEEKLY_ACTIVE_DAYS = 1
 LEASE_MINUTES = 30
 DELIVERY_LEASE_MINUTES = 2
-RETRY_MINUTES = 60
+PREPARATION_RETRY_MINUTES = 30
+DELIVERY_RETRY_MINUTES = 15
 TERMINAL_RUN_STATES = {"published", "quiet", "incomplete", "superseded"}
 DELIVERY_PREFLIGHT_INVALIDATION_REASONS = frozenset({
     "prepared_revision_missing",
@@ -1040,7 +1041,9 @@ def _claim_preparation(
             if current["lifecycle_state"] in {"held", "delivery_failed", "deferred"} and not force:
                 updated_at = str(current.get("updated_at") or "")
                 if updated_at:
-                    retry_at = _parse_utc(updated_at) + timedelta(minutes=RETRY_MINUTES)
+                    retry_at = _parse_utc(updated_at) + timedelta(
+                        minutes=PREPARATION_RETRY_MINUTES
+                    )
                     if retry_at > now:
                         current["retry_at"] = _utc_iso(retry_at)
                         conn.commit()
@@ -1098,7 +1101,10 @@ def _finish_preparation(
 ) -> AutomationResult:
     retry_at = ""
     if result.status in {"held", "delivery_failed", "deferred"}:
-        retry_at = _utc_iso(datetime.now(timezone.utc) + timedelta(minutes=RETRY_MINUTES))
+        retry_at = _utc_iso(
+            datetime.now(timezone.utc)
+            + timedelta(minutes=PREPARATION_RETRY_MINUTES)
+        )
     with sqlite3.connect(db_path) as conn:
         conn.execute("BEGIN IMMEDIATE")
         row = conn.execute(
@@ -2318,7 +2324,10 @@ def _invalidate_prepared_in_transaction(
             conn,
             guild_id,
             result,
-            next_retry_at=_utc_iso(datetime.now(timezone.utc) + timedelta(minutes=RETRY_MINUTES)),
+            next_retry_at=_utc_iso(
+                datetime.now(timezone.utc)
+                + timedelta(minutes=PREPARATION_RETRY_MINUTES)
+            ),
         )
 
 
@@ -2375,8 +2384,16 @@ def _claim_delivery(
             return "complete", run_id, int(current.get("delivery_epoch") or 0), current
         if current["lifecycle_state"] == "delivery_failed" and not force:
             updated_at = str(current.get("updated_at") or "")
-            if updated_at and _parse_utc(updated_at) + timedelta(minutes=RETRY_MINUTES) > now_dt:
-                current["retry_at"] = _utc_iso(_parse_utc(updated_at) + timedelta(minutes=RETRY_MINUTES))
+            if (
+                updated_at
+                and _parse_utc(updated_at)
+                + timedelta(minutes=DELIVERY_RETRY_MINUTES)
+                > now_dt
+            ):
+                current["retry_at"] = _utc_iso(
+                    _parse_utc(updated_at)
+                    + timedelta(minutes=DELIVERY_RETRY_MINUTES)
+                )
                 conn.commit()
                 return "backoff", run_id, int(current.get("delivery_epoch") or 0), current
         delivery_lease = str(current.get("delivery_lease_expires_at") or "")
@@ -2529,7 +2546,10 @@ def _finish_delivery(
 ) -> AutomationResult:
     retry_at = ""
     if result.status in {"held", "delivery_failed", "deferred"}:
-        retry_at = _utc_iso(datetime.now(timezone.utc) + timedelta(minutes=RETRY_MINUTES))
+        retry_at = _utc_iso(
+            datetime.now(timezone.utc)
+            + timedelta(minutes=DELIVERY_RETRY_MINUTES)
+        )
     with sqlite3.connect(db_path) as conn:
         conn.execute("BEGIN IMMEDIATE")
         row = conn.execute(

--- a/tests/test_bnl_journal_prepared_release.py
+++ b/tests/test_bnl_journal_prepared_release.py
@@ -670,6 +670,148 @@ class PreparedReleaseTests(unittest.TestCase):
         self.assertEqual(attempts[0], attempts[1])
         self.assertEqual(self.run_row()["prepared_payload_hash"], hashlib.sha256(attempts[1]).hexdigest())
 
+    def test_preparation_retry_waits_thirty_minutes_without_lowering_quality_path(self):
+        first_attempt = []
+
+        def timed_out(packet, prompt):
+            first_attempt.append((packet, prompt))
+            raise RuntimeError("journal_preparation_timeout")
+
+        first = self.prepare(timed_out)
+        self.assertEqual("held", first.status, first)
+        self.assertEqual(1, len(first_attempt))
+
+        with sqlite3.connect(self.db) as conn:
+            state = conn.execute(
+                "SELECT last_checked_at,next_retry_at "
+                "FROM bnl_journal_automation_state WHERE guild_id=1"
+            ).fetchone()
+        self.assertIsNotNone(state)
+        retry_delay = automation._parse_utc(state[1]) - automation._parse_utc(state[0])
+        self.assertGreaterEqual(retry_delay, timedelta(minutes=29, seconds=58))
+        self.assertLessEqual(retry_delay, timedelta(minutes=30))
+
+        generation_calls = []
+
+        def full_quality_generator(packet, prompt):
+            generation_calls.append((packet, prompt))
+            return article_json(packet)
+
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs SET updated_at=? "
+                "WHERE cadence='daily'",
+                (
+                    automation._utc_iso(
+                        datetime.now(timezone.utc) - timedelta(minutes=29)
+                    ),
+                ),
+            )
+        waiting = automation.prepare_daily(
+            self.db,
+            1,
+            full_quality_generator,
+            target_day=TARGET_DAY,
+            force=False,
+        )
+        self.assertEqual("backoff", waiting.status, waiting)
+        self.assertEqual([], generation_calls)
+
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs SET updated_at=? "
+                "WHERE cadence='daily'",
+                (
+                    automation._utc_iso(
+                        datetime.now(timezone.utc) - timedelta(minutes=31)
+                    ),
+                ),
+            )
+        recovered = automation.prepare_daily(
+            self.db,
+            1,
+            full_quality_generator,
+            target_day=TARGET_DAY,
+            force=False,
+        )
+        self.assertEqual("prepared", recovered.status, recovered)
+        self.assertEqual(1, len(generation_calls))
+        self.assertEqual(first_attempt[0], generation_calls[0])
+
+    def test_delivery_retry_waits_fifteen_minutes_and_never_regenerates(self):
+        prepared = self.prepare()
+        attempts = []
+
+        def lost_response(request, timeout=10):
+            attempts.append(request.data)
+            raise OSError("response lost")
+
+        failed = self.release(lost_response)
+        self.assertEqual("delivery_failed", failed.status, failed)
+
+        with sqlite3.connect(self.db) as conn:
+            state = conn.execute(
+                "SELECT last_checked_at,next_retry_at "
+                "FROM bnl_journal_automation_state WHERE guild_id=1"
+            ).fetchone()
+        self.assertIsNotNone(state)
+        retry_delay = automation._parse_utc(state[1]) - automation._parse_utc(state[0])
+        self.assertGreaterEqual(retry_delay, timedelta(minutes=14, seconds=58))
+        self.assertLessEqual(retry_delay, timedelta(minutes=15))
+
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs SET updated_at=? "
+                "WHERE cadence='daily'",
+                (
+                    automation._utc_iso(
+                        datetime.now(timezone.utc) - timedelta(minutes=14)
+                    ),
+                ),
+            )
+        waiting = automation.release_daily(
+            self.db,
+            1,
+            "https://site.example",
+            "key",
+            target_day=TARGET_DAY,
+            force=False,
+            opener=lambda *_args, **_kwargs: self.fail(
+                "delivery retried before its fifteen-minute backoff"
+            ),
+        )
+        self.assertEqual("backoff", waiting.status, waiting)
+        self.assertEqual(1, len(attempts))
+
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs SET updated_at=? "
+                "WHERE cadence='daily'",
+                (
+                    automation._utc_iso(
+                        datetime.now(timezone.utc) - timedelta(minutes=16)
+                    ),
+                ),
+            )
+
+        def idempotent_response(request, timeout=10):
+            attempts.append(request.data)
+            return AcceptedResponse(request, idempotent=True)
+
+        recovered = automation.release_daily(
+            self.db,
+            1,
+            "https://site.example",
+            "key",
+            target_day=TARGET_DAY,
+            force=False,
+            opener=idempotent_response,
+        )
+        self.assertEqual("published", recovered.status, recovered)
+        self.assertEqual((prepared.entry_id, prepared.revision), (recovered.entry_id, recovered.revision))
+        self.assertEqual(2, len(attempts))
+        self.assertEqual(attempts[0], attempts[1])
+
     def test_unconfirmed_memory_controls_wait_without_changing_prepared_bytes(self):
         prepared = self.prepare()
         before = self.run_row()


### PR DESCRIPTION
## What changed

- Split the previous shared 60-minute Journal retry delay into phase-specific backoffs.
- Retry full-quality Journal preparation after 30 minutes.
- Retry delivery of an already-frozen website payload after 15 minutes.
- Keep manual force behavior, live-lease protection, generation quality controls, and byte-identical delivery intact.

## Why

Preparation failures and website-delivery failures were using the same one-hour policy even though they have different costs and risks. Preparation may require another full model run, while delivery only resends the exact saved Journal bytes. This gives each phase the shortest conservative recovery window without rushing generation or relaxing validation.

## Impact

- A missed preparation becomes eligible for a normal-quality retry in 30 minutes instead of 60.
- A failed website POST becomes eligible for an idempotent resend in 15 minutes instead of 60.
- Journal prompts, evidence, model settings, four-attempt limit, 25-minute preparation budget, validators, 6:30 preparation, and 7:00 release are unchanged.

## Validation

- 147 focused Journal tests passed.
- 1,226 repository tests passed.
- New regressions prove preparation is blocked at 29 minutes and eligible after 30.
- New regressions prove delivery is blocked at 14 minutes, eligible after 15, resends identical frozen bytes, and does not regenerate.