### PR TITLE
Bot: owner-lock Journal and official broadcast-memory controls

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -5370,6 +5370,15 @@ def is_owner_operator(user: discord.abc.User) -> bool:
     return bool(BNL_OWNER_USER_ID) and bool(user) and user.id == BNL_OWNER_USER_ID
 
 
+def configured_owner_control_denial_reason(user: discord.abc.User) -> str:
+    """Fail closed for controls reserved to the configured BARCODE owner."""
+    if not BNL_OWNER_USER_ID:
+        return "owner_user_id_not_configured"
+    if not is_owner_operator(user):
+        return "configured_owner_required"
+    return ""
+
+
 def has_mod_role(member: discord.Member) -> bool:
     if not member or not BNL_MOD_ROLE_ID:
         return False
@@ -5992,6 +6001,24 @@ def _parse_journal_command(text: str) -> tuple[bool, dict, str]:
     return True, opts, ""
 
 
+JOURNAL_OPERATOR_READ_ONLY_ACTIONS = frozenset({"preview", "status"})
+
+
+def journal_command_permission_denial(
+    action: str,
+    user: discord.abc.User,
+    member: discord.Member | None,
+    guild: discord.Guild,
+) -> str:
+    """Keep Journal mutations owner-only while retaining operator read access."""
+    normalized_action = str(action or "").strip().lower()
+    if normalized_action not in JOURNAL_OPERATOR_READ_ONLY_ACTIONS:
+        return configured_owner_control_denial_reason(user)
+    if not can_send_dossier_recommendation(user, member, guild):
+        return "operator_permission_required"
+    return ""
+
+
 def _parse_journal_hours(value, default: int = 72) -> int:
     try:
         hours = int(str(value or default).strip())
@@ -6504,16 +6531,35 @@ async def maybe_handle_journal_command(message: discord.Message, clean_content: 
     if not getattr(message, "guild", None):
         await message.reply("Journal controls require a server operator context.")
         return True
+    action = str(options.get("action") or "").strip().lower()
     member = message.author if isinstance(message.author, discord.Member) else message.guild.get_member(message.author.id)
-    if not can_send_dossier_recommendation(message.author, member, message.guild):
-        await message.reply("Journal controls are operator-only.")
+    permission_denial = journal_command_permission_denial(
+        action,
+        message.author,
+        member,
+        message.guild,
+    )
+    if permission_denial:
+        logging.warning(
+            "journal_command_denied action=%s user_id=%s reason=%s",
+            action,
+            getattr(message.author, "id", 0),
+            permission_denial,
+        )
+        if permission_denial == "owner_user_id_not_configured":
+            await message.reply(
+                "Manual Journal controls are disabled because `BNL_OWNER_USER_ID` is not configured."
+            )
+        elif permission_denial == "configured_owner_required":
+            await message.reply("Manual Journal mutations are owner-only.")
+        else:
+            await message.reply("Journal read-only controls are operator-only.")
         return True
     policy = resolve_channel_policy(getattr(message, "channel", None))
     channel_name = getattr(getattr(message, "channel", None), "name", "") or ""
     if is_public_prompt_context(policy) and not is_operator_authority_context(policy, channel_name):
         await message.reply("Journal controls are restricted to approved operator channels.")
         return True
-    action = options.get("action")
     guild_id = message.guild.id
     try:
         if action == "status":
@@ -18575,6 +18621,50 @@ CONVERSATION_RETRANSMISSION_TTL_SECONDS = max(60, int(os.getenv("BNL_RETRANSMISS
 _conversation_continuation_state = {}
 
 
+async def maybe_reject_unauthorized_official_broadcast_memory(
+    message: discord.Message,
+    clean_content: str,
+) -> bool:
+    """Reject official broadcast-memory mutations unless the configured owner acts."""
+    denial_reason = configured_owner_control_denial_reason(
+        getattr(message, "author", None)
+    )
+    if not denial_reason:
+        return False
+    logging.info(
+        "broadcast_memory_intake_denied user_id=%s channel_id=%s reason=%s",
+        getattr(getattr(message, "author", None), "id", 0),
+        getattr(getattr(message, "channel", None), "id", 0),
+        denial_reason,
+    )
+    if clean_content:
+        key = (
+            getattr(getattr(message, "guild", None), "id", 0) or 0,
+            getattr(getattr(message, "channel", None), "id", 0) or 0,
+            getattr(getattr(message, "author", None), "id", 0) or 0,
+        )
+        now = datetime.now(timezone.utc)
+        last = _broadcast_memory_denial_last_at.get(key)
+        if (
+            not last
+            or (now - last).total_seconds()
+            >= BROADCAST_MEMORY_DENIAL_COOLDOWN_SECONDS
+        ):
+            _broadcast_memory_denial_last_at[key] = now
+            if denial_reason == "owner_user_id_not_configured":
+                reply = (
+                    "Not stored. Official broadcast-memory controls are disabled "
+                    "because `BNL_OWNER_USER_ID` is not configured."
+                )
+            else:
+                reply = (
+                    "Not stored. Official broadcast memory can only be created "
+                    "or corrected by the configured owner."
+                )
+            await message.reply(reply)
+    return True
+
+
 def _direct_conversation_generation_key(message: discord.Message):
     return (
         int(getattr(getattr(message, "guild", None), "id", 0) or 0),
@@ -19926,23 +20016,14 @@ async def on_message(message: discord.Message):
         return
 
     if channel_policy == "broadcast_memory":
-        member = message.author if isinstance(message.author, discord.Member) else message.guild.get_member(message.author.id)
-        allowed = is_owner_operator(message.author) or has_mod_role(member) or is_privileged_member(member, message.guild)
-        if not allowed:
-            logging.info("broadcast_memory_intake_denied user_id=%s channel_id=%s reason=permission", message.author.id, message.channel.id)
-            if clean_content:
-                key = (getattr(message.guild, "id", 0) or 0, message.channel.id, message.author.id)
-                now = datetime.now(timezone.utc)
-                last = _broadcast_memory_denial_last_at.get(key)
-                if not last or (now - last).total_seconds() >= BROADCAST_MEMORY_DENIAL_COOLDOWN_SECONDS:
-                    _broadcast_memory_denial_last_at[key] = now
-                    await message.reply("Not stored. Broadcast memory is operator-only. Ask a mod/operator to repost this as an official note, or discuss it in the public/R&D lane first.")
+        if await maybe_reject_unauthorized_official_broadcast_memory(
+            message,
+            clean_content,
+        ):
             return
         if not clean_content:
             return
         lower_clean = clean_content.lower()
-        is_owner = bool(is_owner_operator(message.author))
-        is_mod = bool(has_mod_role(member) or is_privileged_member(member, message.guild))
         explicit_target_id = _parse_broadcast_memory_target_id(clean_content)
         resolve_last_intent = bool(re.search(r"\bbnl\b.*\b(resolve|mark)\b.*\blast memory\b", lower_clean)) or ("last memory was wrong" in lower_clean and "resolve" in lower_clean)
         replace_last_match = re.search(r"\bbnl\b.*\b(correct|replace)\b.*\blast memory\b(?:\s*with)?\s*:\s*(.+)$", clean_content, flags=re.IGNORECASE)
@@ -19985,10 +20066,14 @@ async def on_message(message: discord.Message):
                         await message.reply("Multiple matches found; please specify one id/date/topic:\n" + "\n".join(lines))
                         return
                     target = candidates[0]
-            target_id, target_date, target_user_id, target_user_name, target_summary, target_type = target
-            if (not is_owner) and int(target_user_id or 0) != int(message.author.id):
-                await message.reply("Correction not applied. That entry requires owner authority.")
-                return
+            (
+                target_id,
+                target_date,
+                _target_user_id,
+                _target_user_name,
+                _target_summary,
+                target_type,
+            ) = target
             if resolve_last_intent or resolve_by_topic or resolve_by_id:
                 changed = await asyncio.to_thread(
                     _set_broadcast_memory_status,

--- a/tests/test_bnl_journal.py
+++ b/tests/test_bnl_journal.py
@@ -400,21 +400,21 @@ class BotJournalCommandTests(unittest.IsolatedAsyncioTestCase):
         old = bnl01_bot.DB_FILE; bnl01_bot.DB_FILE = self._make_db()
         try:
             msg = Mock(); msg.guild = Mock(id=1, get_member=Mock(return_value=Mock())); msg.author = Mock(id=1); msg.channel = Mock(name='research-and-development'); msg.reply = AsyncMock()
-            with patch.object(bnl01_bot, 'resolve_channel_policy', return_value='internal_controlled'), patch.object(bnl01_bot, 'can_send_dossier_recommendation', return_value=True), patch.object(bnl01_bot, 'generate_and_store_journal_draft', side_effect=RuntimeError('boom')):
+            with patch.object(bnl01_bot, 'BNL_OWNER_USER_ID', 1), patch.object(bnl01_bot, 'resolve_channel_policy', return_value='internal_controlled'), patch.object(bnl01_bot, 'can_send_dossier_recommendation', return_value=True), patch.object(bnl01_bot, 'generate_and_store_journal_draft', side_effect=RuntimeError('boom')):
                 handled = await bnl01_bot.maybe_handle_journal_command(msg, '!bnl journal create | hours=72')
             self.assertTrue(handled)
             self.assertIn('failed safely', msg.reply.await_args.args[0])
         finally:
             bnl01_bot.DB_FILE = old
 
-    async def test_operator_create_path_with_mocked_gemini_creates_draft(self):
+    async def test_owner_create_path_with_mocked_gemini_creates_draft(self):
         import bnl01_bot
         old = bnl01_bot.DB_FILE; bnl01_bot.DB_FILE = self._make_db()
         try:
             packet = j.build_source_packet(bnl01_bot.DB_FILE, 1, 24, '2026-07-18T01:00:00Z')
             response = Mock(candidates=[Mock(content=Mock(parts=[Mock(text=article_json(packet))]))], usage_metadata=Mock(total_token_count=None))
             msg = Mock(); msg.guild = Mock(id=1, get_member=Mock(return_value=Mock())); msg.author = Mock(id=1); msg.channel = Mock(name='research-and-development'); msg.reply = AsyncMock()
-            with patch.object(j, 'utc_now_iso', return_value='2026-07-18T01:00:00Z'), patch.object(bnl01_bot, 'resolve_channel_policy', return_value='internal_controlled'), patch.object(bnl01_bot, 'can_send_dossier_recommendation', return_value=True), patch.object(bnl01_bot, 'check_quota_availability', return_value=True), patch.object(bnl01_bot, '_generate_gemini_content_with_fallback', return_value=response):
+            with patch.object(j, 'utc_now_iso', return_value='2026-07-18T01:00:00Z'), patch.object(bnl01_bot, 'BNL_OWNER_USER_ID', 1), patch.object(bnl01_bot, 'resolve_channel_policy', return_value='internal_controlled'), patch.object(bnl01_bot, 'can_send_dossier_recommendation', return_value=True), patch.object(bnl01_bot, 'check_quota_availability', return_value=True), patch.object(bnl01_bot, '_generate_gemini_content_with_fallback', return_value=response):
                 handled = await bnl01_bot.maybe_handle_journal_command(msg, '!bnl journal create | hours=bad')
             self.assertTrue(handled)
             with sqlite3.connect(bnl01_bot.DB_FILE) as c:

--- a/tests/test_owner_only_controls.py
+++ b/tests/test_owner_only_controls.py
@@ -1,0 +1,405 @@
+import os
+import unittest
+from contextlib import ExitStack, contextmanager
+from types import SimpleNamespace
+from unittest import mock
+from unittest.mock import AsyncMock
+
+
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token")
+
+try:
+    import bnl01_bot
+except ModuleNotFoundError as exc:  # Minimal test images may omit Discord.
+    if exc.name != "discord":
+        raise
+    bnl01_bot = None
+
+
+MUTATING_JOURNAL_ACTIONS = (
+    "create",
+    "regenerate",
+    "reject",
+    "approve",
+    "retry",
+    "run-daily",
+    "run-weekly",
+    "rehydrate",
+)
+
+
+def permissions(**overrides):
+    values = {
+        "administrator": False,
+        "manage_guild": False,
+        "manage_messages": False,
+        "kick_members": False,
+        "ban_members": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def member(user_id, *, roles=(), **permission_overrides):
+    return SimpleNamespace(
+        id=user_id,
+        display_name=f"User{user_id}",
+        bot=False,
+        roles=list(roles),
+        guild_permissions=permissions(**permission_overrides),
+    )
+
+
+@contextmanager
+def patched_broadcast_memory_route(processed_entries=None):
+    with ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(
+                bnl01_bot,
+                "client",
+                SimpleNamespace(user=SimpleNamespace(id=4242)),
+            )
+        )
+        for name, return_value in (
+            ("_register_direct_conversation_ingress", {}),
+            ("get_guild_config", None),
+            ("resolve_channel_policy", "broadcast_memory"),
+            ("upsert_user_profile", None),
+            ("conversation_surface_for_channel_policy", "command_only"),
+            ("conversation_surface_allows_free_speak", False),
+            ("allow_passive_memory_for_policy", False),
+            ("is_direct_bnl_target", False),
+            ("resolve_discord_user_mentions_for_conversation", "Official show note."),
+            ("is_human_to_human_tag_only_turn", False),
+            (
+                "build_message_media_context",
+                {"present": False, "included": False, "count": 0},
+            ),
+            ("append_media_context_to_text", "Official show note."),
+            ("record_recent_room_event_from_message", None),
+            ("_is_previous_message_request", False),
+            ("maybe_record_live_community_presence", None),
+            ("_is_recent_direct_followup", False),
+            ("_is_recent_conversation_continuation", False),
+            ("build_current_turn_addressing_context", {}),
+            ("maybe_record_member_activity_event", None),
+            ("is_internal_channel_redirect_candidate", False),
+        ):
+            stack.enter_context(
+                mock.patch.object(bnl01_bot, name, return_value=return_value)
+            )
+        for name in (
+            "maybe_handle_provider_status_command",
+            "maybe_handle_debug_last_route_command",
+            "maybe_handle_channel_audit_command",
+            "maybe_handle_backfill_command",
+            "maybe_handle_journal_command",
+            "maybe_handle_population_scan_command",
+            "maybe_handle_source_file_refresh_command",
+            "maybe_handle_source_file_enrichment_command",
+            "maybe_handle_source_file_lookup_command",
+            "maybe_handle_entity_context_resolver_command",
+            "maybe_handle_entity_activity_summary_command",
+            "maybe_handle_dossier_recommendation_command",
+        ):
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    name,
+                    new_callable=AsyncMock,
+                    return_value=False,
+                )
+            )
+        process = stack.enter_context(
+            mock.patch.object(
+                bnl01_bot,
+                "process_broadcast_memory_notes",
+                new_callable=AsyncMock,
+                return_value=processed_entries or [],
+            )
+        )
+        add = stack.enter_context(
+            mock.patch.object(
+                bnl01_bot,
+                "add_broadcast_memory_entry",
+                return_value=1,
+            )
+        )
+        yield process, add
+
+
+@unittest.skipIf(bnl01_bot is None, "discord.py is not installed")
+class OwnerOnlyPermissionTests(unittest.TestCase):
+    def test_manual_journal_mutations_allow_only_configured_owner(self):
+        guild = SimpleNamespace(id=10, owner_id=2)
+        configured_mod_role = SimpleNamespace(id=555, name="MOD")
+        named_admin_role = SimpleNamespace(id=777, name="BARCODE_ADMIN")
+        denied_actors = (
+            ("server_owner", SimpleNamespace(id=2), member(2)),
+            (
+                "administrator",
+                SimpleNamespace(id=3),
+                member(3, administrator=True),
+            ),
+            (
+                "manage_guild",
+                SimpleNamespace(id=4),
+                member(4, manage_guild=True),
+            ),
+            (
+                "configured_mod",
+                SimpleNamespace(id=5),
+                member(5, roles=(configured_mod_role,)),
+            ),
+            (
+                "named_admin_role",
+                SimpleNamespace(id=6),
+                member(6, roles=(named_admin_role,)),
+            ),
+            ("ordinary_user", SimpleNamespace(id=7), member(7)),
+        )
+
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 999), \
+             mock.patch.object(bnl01_bot, "BNL_MOD_ROLE_ID", 555):
+            for action in MUTATING_JOURNAL_ACTIONS:
+                self.assertEqual(
+                    "",
+                    bnl01_bot.journal_command_permission_denial(
+                        action,
+                        SimpleNamespace(id=999),
+                        member(999),
+                        guild,
+                    ),
+                    action,
+                )
+                for label, user, actor_member in denied_actors:
+                    self.assertEqual(
+                        "configured_owner_required",
+                        bnl01_bot.journal_command_permission_denial(
+                            action,
+                            user,
+                            actor_member,
+                            guild,
+                        ),
+                        f"{action}:{label}",
+                    )
+
+    def test_missing_owner_id_fails_closed_for_every_mutation(self):
+        guild = SimpleNamespace(id=10, owner_id=2)
+        actor = SimpleNamespace(id=2)
+        actor_member = member(2, administrator=True)
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 0):
+            for action in MUTATING_JOURNAL_ACTIONS:
+                self.assertEqual(
+                    "owner_user_id_not_configured",
+                    bnl01_bot.journal_command_permission_denial(
+                        action,
+                        actor,
+                        actor_member,
+                        guild,
+                    ),
+                    action,
+                )
+
+    def test_preview_and_status_keep_existing_operator_access(self):
+        guild = SimpleNamespace(id=10, owner_id=2)
+        configured_mod_role = SimpleNamespace(id=555, name="MOD")
+        operator = SimpleNamespace(id=5)
+        operator_member = member(5, roles=(configured_mod_role,))
+        ordinary = SimpleNamespace(id=7)
+
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 999), \
+             mock.patch.object(bnl01_bot, "BNL_MOD_ROLE_ID", 555):
+            for action in ("preview", "status"):
+                self.assertEqual(
+                    "",
+                    bnl01_bot.journal_command_permission_denial(
+                        action,
+                        operator,
+                        operator_member,
+                        guild,
+                    ),
+                )
+                self.assertEqual(
+                    "operator_permission_required",
+                    bnl01_bot.journal_command_permission_denial(
+                        action,
+                        ordinary,
+                        member(7),
+                        guild,
+                    ),
+                )
+
+
+@unittest.skipIf(bnl01_bot is None, "discord.py is not installed")
+class OwnerOnlySurfaceTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        bnl01_bot._broadcast_memory_denial_last_at.clear()
+
+    async def test_text_journal_mutations_deny_broad_operator_before_side_effects(self):
+        actor = SimpleNamespace(id=3)
+        actor_member = member(3, administrator=True)
+        guild = SimpleNamespace(
+            id=10,
+            owner_id=2,
+            get_member=mock.Mock(return_value=actor_member),
+        )
+        message = SimpleNamespace(
+            guild=guild,
+            author=actor,
+            channel=SimpleNamespace(id=20, name="research-and-development"),
+            reply=AsyncMock(),
+        )
+        commands = (
+            "!bnl journal create | hours=72",
+            "!bnl journal regenerate entry-1 | hours=72",
+            "!bnl journal reject entry-1",
+            "!bnl journal approve entry-1 | hash=abc",
+            "!bnl journal retry entry-1",
+            "!bnl journal run-daily",
+            "!bnl journal run-weekly",
+            "!bnl journal rehydrate",
+        )
+
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 999), \
+             mock.patch.object(
+                 bnl01_bot,
+                 "can_send_dossier_recommendation",
+                 return_value=True,
+             ), \
+             mock.patch.object(
+                 bnl01_bot,
+                 "generate_and_store_journal_draft",
+             ) as create, \
+             mock.patch.object(bnl01_bot, "regenerate_journal_draft") as regenerate, \
+             mock.patch.object(bnl01_bot, "reject_journal_draft") as reject, \
+             mock.patch.object(bnl01_bot, "approve_journal_draft") as approve, \
+             mock.patch.object(
+                 bnl01_bot,
+                 "release_prepared_journal_entry",
+             ) as retry, \
+             mock.patch.object(
+                 bnl01_bot,
+                 "rehydrate_published_journal_entries",
+             ) as rehydrate, \
+             mock.patch.object(
+                 bnl01_bot,
+                 "run_journal_automation_once",
+                 new_callable=AsyncMock,
+             ) as force_run:
+            for command in commands:
+                handled = await bnl01_bot.maybe_handle_journal_command(
+                    message,
+                    command,
+                )
+                self.assertTrue(handled, command)
+
+        self.assertEqual(len(commands), message.reply.await_count)
+        for call in message.reply.await_args_list:
+            self.assertIn("owner-only", call.args[0])
+        for mutation in (
+            create,
+            regenerate,
+            reject,
+            approve,
+            retry,
+            rehydrate,
+            force_run,
+        ):
+            mutation.assert_not_called()
+
+    async def test_official_broadcast_memory_fails_closed_and_denies_non_owner(self):
+        guild = SimpleNamespace(id=10)
+        channel = SimpleNamespace(id=20)
+        non_owner_message = SimpleNamespace(
+            guild=guild,
+            channel=channel,
+            author=SimpleNamespace(id=3),
+            reply=AsyncMock(),
+        )
+        owner_message = SimpleNamespace(
+            guild=guild,
+            channel=channel,
+            author=SimpleNamespace(id=999),
+            reply=AsyncMock(),
+        )
+
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 0):
+            denied = await bnl01_bot.maybe_reject_unauthorized_official_broadcast_memory(
+                non_owner_message,
+                "Official show note.",
+            )
+        self.assertTrue(denied)
+        self.assertIn(
+            "not configured",
+            non_owner_message.reply.await_args.args[0],
+        )
+
+        bnl01_bot._broadcast_memory_denial_last_at.clear()
+        non_owner_message.reply.reset_mock()
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 999):
+            denied = await bnl01_bot.maybe_reject_unauthorized_official_broadcast_memory(
+                non_owner_message,
+                "Official show note.",
+            )
+            allowed = await bnl01_bot.maybe_reject_unauthorized_official_broadcast_memory(
+                owner_message,
+                "Official show note.",
+            )
+
+        self.assertTrue(denied)
+        self.assertIn(
+            "configured owner",
+            non_owner_message.reply.await_args.args[0],
+        )
+        self.assertFalse(allowed)
+        owner_message.reply.assert_not_awaited()
+
+    async def test_broadcast_memory_route_denies_admin_and_allows_owner_storage(self):
+        admin = member(3, administrator=True)
+        owner = member(999)
+        guild = SimpleNamespace(
+            id=10,
+            owner_id=2,
+            get_member=mock.Mock(side_effect=lambda user_id: admin if user_id == 3 else owner),
+        )
+        channel = SimpleNamespace(id=20, name="bnl-broadcast-memory")
+
+        def message_for(actor):
+            return SimpleNamespace(
+                id=100 + actor.id,
+                content="Official show note.",
+                author=actor,
+                guild=guild,
+                channel=channel,
+                reference=None,
+                attachments=[],
+                embeds=[],
+                reply=AsyncMock(),
+            )
+
+        denied_message = message_for(admin)
+        owner_message = message_for(owner)
+        processed = [{
+            "entry_type": "notable_moment",
+            "episode_date": "2026-07-23",
+            "public_safe": True,
+        }]
+
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 999), \
+             patched_broadcast_memory_route(processed) as (process, add):
+            await bnl01_bot.on_message(denied_message)
+            process.assert_not_awaited()
+            add.assert_not_called()
+            self.assertIn("configured owner", denied_message.reply.await_args.args[0])
+
+            await bnl01_bot.on_message(owner_message)
+
+        process.assert_awaited_once_with(owner_message)
+        add.assert_called_once_with(10, owner_message, processed[0])
+        self.assertIn("Logged 1 entry", owner_message.reply.await_args.args[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Reserve every mutating manual Journal action for the configured `BNL_OWNER_USER_ID`: create, regenerate, reject, approve, retry, forced Daily/Weekly execution, and rehydrate.
- Fail closed for those mutations when `BNL_OWNER_USER_ID` is missing.
- Preserve operator access to the read-only Journal `preview` and `status` actions.
- Reserve official broadcast-memory creation, correction, resolution, and supersession for the configured owner, including a fail-closed missing-owner path.
- Add Discord-route regressions covering the configured owner, server owner, administrators, `manage_guild`, configured mods, named admin roles, ordinary users, and missing configuration.

## Why

These controls change public Journal state or official broadcast truth. They should use the existing configured owner identity instead of inheriting broad mod/operator authority.

## Preserved behavior

- Scheduled Tuesday–Sunday Daily and Monday Weekly Journal automation is unchanged.
- Journal prose, evidence/privacy rules, four-attempt generation, 6:30 PM preparation, and 7:00 PM release are unchanged.
- R&D drafting and assessment, Source Files, dossier recommendations, `/myname`, normal moderation, and read-only diagnostics retain their existing permissions.
- No queue, production-gate, deployment, secret, or configuration changes are included.

## Validation

- Focused Journal/owner-control suites: 30/30 passed.
- Full bot suite: 1,232/1,232 passed.
- All source and test files compile successfully.
- Remote branch tree exactly matches the locally validated tree.