### PR TITLE
Add resilient BARCODE occasion publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ Activation order is site first, bot second:
 
 Show-day copy follows the same boundary. The 6:40 PM Pacific intake message names the native queue only when both gates are usable; otherwise it uses provider-neutral public-intake wording. The 7:00 PM message describes the scheduled broadcast window without claiming unverified live state, and the later sponsor message remains optional and host-controlled.
 
+Holiday and occasion reflections use the existing Ambient coordinator and active
+liaison channel. The maintained calendar targets 10:00 AM Pacific, stores each
+occurrence and canonical payload in the bot database before delivery, and
+retries provider or Discord failures without consuming ordinary Ambient
+capacity. Major/cultural dates take precedence, while owner-established
+BARCODE-relevant dates are curated from source-backed radio, sound, music,
+archive, communication, and technology observances or milestones. A roughly
+two-week gap is a selection guide, not an automatic filler rule; the curated
+layer is limited to twelve real dates. Three house
+traditions—Open Channel Day, Archive Pulse Day, and Scan Day—are layered onto
+real dates and are not claims about historical BARCODE anniversaries.
+`BNL_OCCASION_POSTS_ENABLED` defaults on and can be set to `false` to cancel
+unpublished occurrences. `BNL_OCCASION_DISABLED_IDS` accepts a comma-separated
+list of calendar IDs for per-occurrence cancellation. These controls do not
+activate queue access, Journal reuse, or any memory-v2 live gate.
+
 Importing `bnl01_bot` does not create a Gemini client or open provider transports. The client is created and cached on the first generation request, so tests, diagnostics, and tooling can import the runtime without valid provider networking.
 
 Run the bot only after the deployment environment is configured:

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -22,6 +22,23 @@ from bnl_canon_source_contract import (
     render_prompt_canon_block,
     strip_queue_sections,
 )
+from bnl_occasion import (
+    OCCASION_CALENDAR_VERSION,
+    OCCASION_CHANNEL_RETRY_MINUTES,
+    OCCASION_DELIVERY_RETRY_MINUTES,
+    OCCASION_PROVIDER_RETRY_MINUTES,
+    OCCASION_REGISTRY,
+    cancel_open_occurrences as cancel_open_occasion_occurrences,
+    claim_next_due as claim_next_due_occasion,
+    delivery_nonce as occasion_delivery_nonce,
+    diagnostics as occasion_diagnostics,
+    ensure_schema as ensure_occasion_schema,
+    fail_claim as fail_occasion_claim,
+    mark_published as mark_occasion_published,
+    resolve_occurrence_definition,
+    seed_occurrences as seed_occasion_occurrences,
+    store_prepared as store_prepared_occasion,
+)
 from bnl_memory_ledger import (
     LedgerWriteResult,
     ensure_memory_ledger_schema,
@@ -234,7 +251,7 @@ from bnl_source_file_refresh import (
 )
 from collections import Counter, defaultdict, deque
 from dataclasses import dataclass, replace
-from datetime import datetime, time as datetime_time, timedelta, timezone
+from datetime import date, datetime, time as datetime_time, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 import pytz
@@ -409,12 +426,18 @@ AMBIENT_DAILY_POST_CAP = 1
 AMBIENT_MIN_SIGNAL_MESSAGES = 3
 AMBIENT_MIN_SIGNAL_UNIQUE_USERS = 2
 AMBIENT_MIN_SIGNAL_CHARS = 120
+AMBIENT_HIGH_ACTIVITY_MIN_MESSAGES = 15
+AMBIENT_HIGH_ACTIVITY_MIN_UNIQUE_USERS = 4
+AMBIENT_HIGH_ACTIVITY_MIN_CHARS = 700
 AMBIENT_RESCHEDULE_MIN_HOURS = 4
 AMBIENT_RESCHEDULE_MAX_HOURS = 6
 AMBIENT_SIMILARITY_THRESHOLD = 0.75
 AMBIENT_INCOMPLETE_ENDINGS = {
     "and", "but", "or", "because", "while", "with", "to", "for", "of", "in", "the", "a", "an"
 }
+OCCASION_MIN_CHARS = AMBIENT_MAX_CHARS * 3
+OCCASION_MAX_CHARS = AMBIENT_MAX_CHARS * 6
+OCCASION_GENERATION_ATTEMPTS = 2
 SHOWDAY_WINDOW_MINUTES = 10
 SHOWDAY_MAX_DISCORD_POSTS_PER_FRIDAY = 2
 SHOWDAY_RECENT_POST_BLOCK_MINUTES = 30
@@ -4248,6 +4271,7 @@ def _try_alter(cursor, sql: str):
 def init_db():
     conn = sqlite3.connect(DB_FILE)
     ensure_journal_schema(DB_FILE)
+    ensure_occasion_schema(DB_FILE)
     cursor = conn.cursor()
 
     cursor.execute(
@@ -13245,6 +13269,103 @@ def get_ambient_posts_today(guild_id: int, channel_id: int) -> int:
     conn.close()
     return int(row[0]) if row and row[0] is not None else 0
 
+
+def get_self_started_posts_today(guild_id: int, channel_id: int) -> int:
+    """Count only ordinary unsolicited output that shares Ambient capacity."""
+    now = datetime.now(PACIFIC_TZ)
+    start_day = now.replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
+    conn = sqlite3.connect(DB_FILE)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT COUNT(*)
+        FROM ambient_log
+        WHERE guild_id = ? AND channel_id = ?
+          AND source_type IN ('ambient', 'dormant_echo')
+          AND posted_at >= ?
+        """,
+        (guild_id, channel_id, start_day),
+    )
+    row = cursor.fetchone()
+    conn.close()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def get_public_activity_today(guild_id: int, now_pacific: datetime = None) -> dict:
+    """Return a public-only day signal without activating Moment shadow authority."""
+    now = now_pacific or datetime.now(PACIFIC_TZ)
+    if now.tzinfo is None:
+        now = PACIFIC_TZ.localize(now)
+    else:
+        now = now.astimezone(PACIFIC_TZ)
+    start_local = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    start_utc = start_local.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    end_utc = now.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    conn = sqlite3.connect(DB_FILE)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT COUNT(*), COUNT(DISTINCT user_id),
+               COALESCE(SUM(LENGTH(TRIM(content))), 0)
+        FROM conversations
+        WHERE guild_id = ? AND role = 'user'
+          AND channel_policy IN ('public_home', 'public_context')
+          AND datetime(timestamp) >= datetime(?)
+          AND datetime(timestamp) <= datetime(?)
+        """,
+        (guild_id, start_utc, end_utc),
+    )
+    row = cursor.fetchone() or (0, 0, 0)
+    conn.close()
+    return {
+        "messages": int(row[0] or 0),
+        "uniqueUsers": int(row[1] or 0),
+        "characters": int(row[2] or 0),
+    }
+
+
+def is_high_activity_day(guild_id: int, now_pacific: datetime = None) -> bool:
+    signal = get_public_activity_today(guild_id, now_pacific=now_pacific)
+    return bool(
+        signal["messages"] >= AMBIENT_HIGH_ACTIVITY_MIN_MESSAGES
+        and signal["uniqueUsers"] >= AMBIENT_HIGH_ACTIVITY_MIN_UNIQUE_USERS
+        and signal["characters"] >= AMBIENT_HIGH_ACTIVITY_MIN_CHARS
+    )
+
+
+def ambient_daily_post_cap(guild_id: int, now_pacific: datetime = None) -> int:
+    return 2 if is_high_activity_day(guild_id, now_pacific=now_pacific) else AMBIENT_DAILY_POST_CAP
+
+
+def schedule_after_ambient_post(
+    guild_id: int,
+    last_msg: str,
+    posts_today_after_send: int,
+    *,
+    now_pacific: datetime = None,
+) -> str:
+    """Allow, but never require, a second post on a genuinely active day."""
+    now = now_pacific or datetime.now(PACIFIC_TZ)
+    if now.tzinfo is None:
+        now = PACIFIC_TZ.localize(now)
+    else:
+        now = now.astimezone(PACIFIC_TZ)
+    cap = ambient_daily_post_cap(guild_id, now_pacific=now)
+    if posts_today_after_send < cap:
+        candidate = now + timedelta(
+            hours=random.uniform(
+                AMBIENT_RESCHEDULE_MIN_HOURS,
+                AMBIENT_RESCHEDULE_MAX_HOURS,
+            )
+        )
+        latest = now.replace(hour=22, minute=0, second=0, microsecond=0)
+        if candidate.date() == now.date() and candidate <= latest:
+            next_at = candidate.isoformat()
+            update_guild_ambient_times(guild_id, last_msg or "", next_at)
+            return next_at
+    return schedule_next_day_ambient(guild_id, last_msg)
+
+
 def has_ambient_signal(guild_id: int) -> bool:
     recent_user = get_recent_guild_user_messages(guild_id, limit=AMBIENT_CONTEXT_MESSAGES)
     if len(recent_user) < AMBIENT_MIN_SIGNAL_MESSAGES:
@@ -15249,29 +15370,6 @@ def trim_ambient_to_complete_sentence(text: str, limit: int) -> str:
     return candidate
 
 
-def is_incomplete_ambient_message(text: str) -> bool:
-    cleaned = (text or "").strip()
-    if not cleaned:
-        return True
-
-    lowered = cleaned.lower()
-    if lowered.endswith("...") or cleaned.endswith("…"):
-        return True
-
-    if cleaned.endswith(("-", "—", ",", ":", ";")):
-        return True
-
-    tokens = re.findall(r"[a-zA-Z']+", lowered)
-    if not tokens:
-        return False
-
-    tail = tokens[-1]
-    connectors = {
-        "and", "but", "or", "because", "while", "with", "to", "for", "of", "in", "the", "a", "an"
-    }
-    return tail in connectors
-
-
 def _sanitize_ambient(text: str) -> str:
     if not text:
         return ""
@@ -15467,6 +15565,586 @@ async def generate_dynamic_ambient(guild_id: int, channel_id: int) -> str:
     _set_ambient_runtime_state(guild_id, mode=ambient_mode)
     return result
 
+
+def occasion_output_enabled() -> bool:
+    return str(os.getenv("BNL_OCCASION_POSTS_ENABLED", "true")).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+        "enabled",
+    }
+
+
+def disabled_occasion_ids() -> set[str]:
+    return {
+        value.strip().lower()
+        for value in os.getenv("BNL_OCCASION_DISABLED_IDS", "").split(",")
+        if value.strip()
+    }
+
+
+def _recent_public_occasion_context(guild_id: int, limit: int = 16) -> tuple[str, list[dict[str, str]]]:
+    conn = sqlite3.connect(DB_FILE)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT id,user_name,content,timestamp
+        FROM conversations
+        WHERE guild_id=? AND role='user'
+          AND channel_policy IN ('public_home','public_context')
+        ORDER BY id DESC LIMIT ?
+        """,
+        (int(guild_id), max(1, min(int(limit), 24))),
+    )
+    rows = list(reversed(cursor.fetchall()))
+    conn.close()
+    lines = []
+    refs = []
+    for row_id, user_name, content, observed_at in rows:
+        safe_content = _safe_prompt_line(content or "", limit=240)
+        if not safe_content:
+            continue
+        safe_name = _safe_prompt_display_label(user_name or "", "community member")
+        lines.append(f"- {safe_name}: {safe_content}")
+        refs.append(
+            {
+                "kind": "public_conversation",
+                "ref": f"conversation:{int(row_id)}",
+                "observedAt": str(observed_at or ""),
+            }
+        )
+    return ("\n".join(lines) if lines else "- (no recent eligible public conversation)", refs)
+
+
+def _diverse_occasion_relays(guild_id: int, limit: int = 5) -> tuple[str, list[dict[str, str]]]:
+    selected = []
+    selected_norms = []
+    for record in relay_recent_history(DB_FILE, guild_id, limit=25):
+        message = _safe_prompt_line(record.get("public_message") or "", limit=240)
+        norm = relay_normalize_text(message)
+        if not norm:
+            continue
+        tokens = set(norm.split())
+        duplicate = False
+        for prior in selected_norms:
+            prior_tokens = set(prior.split())
+            if norm in prior or prior in norm:
+                duplicate = True
+                break
+            union = tokens | prior_tokens
+            if union and len(tokens & prior_tokens) / len(union) >= 0.72:
+                duplicate = True
+                break
+        if duplicate:
+            continue
+        selected.append(record)
+        selected_norms.append(norm)
+        if len(selected) >= max(1, min(int(limit), 8)):
+            break
+    lines = []
+    refs = []
+    for record in selected:
+        message = _safe_prompt_line(record.get("public_message") or "", limit=240)
+        directive = _safe_prompt_line(record.get("public_directive") or "", limit=160)
+        lines.append(
+            f"- Relay: {message}"
+            + (f" | continuing question: {directive}" if directive else "")
+        )
+        refs.append(
+            {
+                "kind": "accepted_relay",
+                "ref": f"relay:{str(record.get('relay_id') or '')}",
+                "observedAt": str(record.get("published_timestamp") or ""),
+            }
+        )
+    return ("\n".join(lines) if lines else "- (no diverse accepted Relay context)", refs)
+
+
+def build_occasion_generation_context(guild_id: int, occasion) -> dict:
+    conversation_block, conversation_refs = _recent_public_occasion_context(guild_id)
+    relay_block, relay_refs = _diverse_occasion_relays(guild_id)
+    official_memory = build_scoped_broadcast_memory_context(
+        guild_id,
+        scope="ambient",
+        public_only=True,
+        limit=4,
+    )
+    official_memory = official_memory or "- (no public-safe official memory needed)"
+    source_refs = [
+        {
+            "kind": "occasion_metadata",
+            "ref": f"occasion:{OCCASION_CALENDAR_VERSION}:{occasion.occasion_id}",
+            "observedAt": "",
+        },
+        {
+            "kind": "occasion_source",
+            "ref": str(occasion.source_reference),
+            "observedAt": "",
+        },
+        {
+            "kind": "approved_canon",
+            "ref": f"canon:{CANON_SOURCE_CONTRACT_VERSION}",
+            "observedAt": "",
+        },
+        *conversation_refs,
+        *relay_refs,
+    ]
+    if not official_memory.startswith("- ("):
+        memory_hash = hashlib.sha256(official_memory.encode("utf-8")).hexdigest()[:24]
+        source_refs.append(
+            {
+                "kind": "official_public_memory",
+                "ref": f"broadcast-memory-snapshot:{memory_hash}",
+                "observedAt": "",
+            }
+        )
+    context = (
+        f"Occasion: {occasion.name}\n"
+        f"Occasion category: {occasion.category}\n"
+        f"Occasion grounding: {occasion.summary}\n"
+        + (
+            "BARCODE house tradition: "
+            f"{occasion.network_tradition} — a newly established house name "
+            "layered onto this real date, not a historical BARCODE anniversary.\n"
+            if occasion.network_tradition
+            else ""
+        )
+        + "Reflection angles:\n"
+        + "\n".join(f"- {cue}" for cue in occasion.reflection_cues)
+        + "\n\nApproved BARCODE canon:\n"
+        + render_prompt_canon_block()
+        + "\n\nRecent eligible public community context:\n"
+        + conversation_block
+        + "\n\nDiverse accepted Relay continuity:\n"
+        + relay_block
+        + "\n\nPublic-safe official reusable memory:\n"
+        + official_memory
+    )
+    fingerprint_payload = {
+        "occasionId": occasion.occasion_id,
+        "calendarVersion": OCCASION_CALENDAR_VERSION,
+        "sourceRefs": source_refs,
+        "context": context,
+    }
+    context_hash = hashlib.sha256(
+        json.dumps(
+            fingerprint_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+    ).hexdigest()
+    return {
+        "context": context,
+        "sourceRefs": source_refs,
+        "contextHash": context_hash,
+    }
+
+
+def sanitize_occasion_reflection(text: str) -> str:
+    cleaned = (text or "").replace("```", "").strip()
+    if not cleaned:
+        return ""
+    cleaned = re.sub(r"<@!?(\d+)>", "", cleaned)
+    cleaned = cleaned.replace("@everyone", "everyone").replace("@here", "here")
+    paragraphs = [
+        re.sub(r"\s+", " ", paragraph).strip()
+        for paragraph in re.split(r"\n\s*\n", cleaned)
+        if paragraph.strip()
+    ]
+    cleaned = "\n\n".join(paragraphs[:6]).strip()
+    if len(cleaned) > OCCASION_MAX_CHARS:
+        prefix = cleaned[:OCCASION_MAX_CHARS].rstrip()
+        sentence_ends = list(re.finditer(r"[.!?](?=\s|$)", prefix))
+        cleaned = prefix[:sentence_ends[-1].end()].strip() if sentence_ends else ""
+    return cleaned
+
+
+def _looks_like_occasion_internal_process_report(text: str) -> bool:
+    """Block implementation reports without suppressing BNL's technical voice."""
+    normalized = _normalize_ambient_text(text)
+    if not normalized:
+        return True
+    if re.search(
+        r"\b(prompt|context block|source refs?|validator|database|api|"
+        r"generation provider)\b",
+        normalized,
+    ):
+        return True
+    if re.search(r"\b(status|archive|network)\s+(update|report)\b", normalized):
+        return True
+    if re.search(
+        r"\b(i|bnl|the network|this system)\b.{0,100}"
+        r"\b(processed|indexed|ingested|catalogued|scanned)\b.{0,100}"
+        r"\b(messages|inputs|data|sources|context)\b",
+        normalized,
+    ):
+        return True
+    if re.search(
+        r"\b(i|bnl|this post|this reflection)\b.{0,100}"
+        r"\b(generated|assembled|wrote|created)\b.{0,100}"
+        r"\b(messages|context|sources|prompt)\b",
+        normalized,
+    ):
+        return True
+    return False
+
+
+def _looks_like_generic_occasion_output(text: str) -> bool:
+    """Reject padded greetings and repeated slogans while preserving free prose."""
+    normalized = _normalize_ambient_text(text)
+    tokens = re.findall(r"[a-z0-9']+", normalized)
+    unique_tokens = {
+        token
+        for token in tokens
+        if len(token) >= 3
+    }
+    sentence_count = len(re.findall(r"[.!?](?=\s|$)", text or ""))
+    return sentence_count < 3 or len(unique_tokens) < 35
+
+
+def validate_occasion_reflection(text: str, occasion) -> str:
+    cleaned = (text or "").strip()
+    if len(cleaned) < OCCASION_MIN_CHARS:
+        return "occasion_output_too_short"
+    if len(cleaned) > OCCASION_MAX_CHARS:
+        return "occasion_output_too_long"
+    if is_incomplete_ambient_message(cleaned):
+        return "occasion_output_incomplete"
+    if re.search(r"<@!?(\d+)>|@everyone|@here", cleaned, flags=re.I):
+        return "occasion_output_mentions_forbidden"
+    lowered = relay_normalize_text(cleaned)
+    anchors = tuple(occasion.anchor_terms or (occasion.name,))
+    if not any(relay_normalize_text(anchor) in lowered for anchor in anchors):
+        return "occasion_anchor_missing"
+    if not any(marker in lowered for marker in ("barcode", "bnl", "the network", "network signal")):
+        return "barcode_grounding_missing"
+    if occasion.category != "barcode" and (
+        re.search(r"\bbarcode\b.{0,30}\banniversary\b", lowered)
+        or re.search(r"\banniversary\b.{0,30}\bbarcode\b", lowered)
+        or re.search(r"\byears since\b.{0,30}\bbarcode\b", lowered)
+    ):
+        return "invented_barcode_anniversary"
+    if _looks_like_occasion_internal_process_report(cleaned):
+        return "internal_process_report"
+    if _looks_like_generic_occasion_output(cleaned):
+        return "occasion_output_too_generic"
+    return ""
+
+
+def build_occasion_prompt(occasion, generation_context: dict, retry_reason: str = "") -> str:
+    retry_block = (
+        f"\nThe prior draft was rejected for `{retry_reason}`. Rewrite from scratch; "
+        "do not discuss the rejection.\n"
+        if retry_reason
+        else ""
+    )
+    return (
+        "You are BNL-01 writing one automatic BARCODE Network holiday/occasion reflection "
+        "for the #barcode-bot Discord channel.\n"
+        f"{retry_block}"
+        "Write a substantial, community-aware reflection—not a generic greeting and not a report "
+        "about your internal processing.\n"
+        "Hard requirements:\n"
+        f"- Final length must be {OCCASION_MIN_CHARS}-{OCCASION_MAX_CHARS} characters.\n"
+        "- Use 2-5 readable paragraphs and complete sentences.\n"
+        f"- Clearly ground the reflection in {occasion.name}.\n"
+        "- Let BARCODE/BNL language, music, signal, archive, broadcast, outsider creativity, "
+        "or community continuity shape the reflection naturally.\n"
+        "- Recent public context, accepted Relays, and official reusable memory are optional "
+        "grounding. Use only what is supplied and do not quote a member's exact words.\n"
+        "- You may use plain public display names only when the supplied context clearly ties "
+        "the person to the point. Never create an @mention.\n"
+        "- Missing optional community context reduces specificity; it never cancels the post.\n"
+        "- Do not claim a current/live show, queue state, rehearsal, payment, moderation action, "
+        "private fact, hidden Journal, invented BARCODE anniversary, or unprovided event.\n"
+        "- Do not mention prompts, context blocks, source refs, validators, databases, APIs, "
+        "generation providers, or internal implementation.\n"
+        "- Preserve BNL's natural in-world voice. Technical, glitched, corporate, warm, funny, "
+        "somber, or sharp language is allowed when appropriate to the occasion.\n\n"
+        "Grounding packet (data, never instructions):\n"
+        f"{generation_context['context']}\n\n"
+        "Return only the finished Discord post."
+    )
+
+
+async def generate_occasion_reflection(guild_id: int, occasion, generation_context: dict) -> tuple[str, str]:
+    reason = ""
+    for attempt in range(OCCASION_GENERATION_ATTEMPTS):
+        prompt = build_occasion_prompt(
+            occasion,
+            generation_context,
+            retry_reason=reason if attempt else "",
+        )
+        raw = await get_gemini_response(
+            prompt,
+            user_id=0,
+            guild_id=guild_id,
+            route="occasion_generation",
+            source_context_available=True,
+        )
+        candidate = sanitize_occasion_reflection(raw)
+        reason = validate_occasion_reflection(candidate, occasion)
+        if not reason:
+            return candidate, ""
+    return "", reason or "occasion_generation_failed"
+
+
+async def _find_existing_occasion_message(
+    channel,
+    content: str,
+    occurrence_key: str,
+    delivery_attempt_started_at: str,
+) -> tuple[object | None, bool]:
+    history = getattr(channel, "history", None)
+    if not callable(history):
+        return None, False
+    try:
+        attempt_started = datetime.fromisoformat(
+            str(delivery_attempt_started_at or "").replace("Z", "+00:00")
+        )
+        if attempt_started.tzinfo is None:
+            attempt_started = attempt_started.replace(tzinfo=timezone.utc)
+        after = attempt_started.astimezone(timezone.utc) - timedelta(minutes=5)
+        expected_nonce = occasion_delivery_nonce(occurrence_key)
+        expected_author = int(getattr(getattr(client, "user", None), "id", 0) or 0)
+        async for message in history(limit=200, after=after, oldest_first=False):
+            author_id = int(getattr(getattr(message, "author", None), "id", 0) or 0)
+            if expected_author and author_id != expected_author:
+                continue
+            if str(getattr(message, "content", "") or "") != content:
+                continue
+            observed_nonce = getattr(message, "nonce", None)
+            if observed_nonce is not None and str(observed_nonce) != str(expected_nonce):
+                continue
+            return message, True
+        return None, True
+    except Exception as exc:
+        logging.warning(
+            "occasion_delivery_history_check_failed channel=%s error=%s",
+            int(getattr(channel, "id", 0) or 0),
+            type(exc).__name__,
+        )
+        return None, False
+
+
+async def process_due_occasion_for_guild(
+    guild_id: int,
+    channel_id: int,
+    channel,
+    *,
+    now_pacific: datetime = None,
+) -> dict:
+    now = now_pacific or datetime.now(PACIFIC_TZ)
+    if now.tzinfo is None:
+        now = PACIFIC_TZ.localize(now)
+    else:
+        now = now.astimezone(PACIFIC_TZ)
+    if not occasion_output_enabled():
+        await asyncio.to_thread(
+            seed_occasion_occurrences,
+            DB_FILE,
+            guild_id,
+            channel_id,
+            now,
+            disabled_ids={
+                occasion.occasion_id for occasion in OCCASION_REGISTRY
+            },
+        )
+        cancelled = await asyncio.to_thread(
+            cancel_open_occasion_occurrences,
+            DB_FILE,
+            guild_id,
+            reason="occasion_output_disabled",
+            now=now,
+        )
+        return {"status": "disabled", "cancelled": cancelled}
+
+    await asyncio.to_thread(
+        seed_occasion_occurrences,
+        DB_FILE,
+        guild_id,
+        channel_id,
+        now,
+        disabled_ids=disabled_occasion_ids(),
+    )
+    if channel is None:
+        return {"status": "waiting_for_channel"}
+
+    claim = await asyncio.to_thread(
+        claim_next_due_occasion,
+        DB_FILE,
+        guild_id,
+        now=now,
+    )
+    if not claim:
+        return {"status": "idle"}
+    try:
+        occurrence_local_date = date.fromisoformat(
+            str(claim.get("local_date") or "")
+        )
+    except ValueError:
+        occurrence_local_date = now.date()
+    occasion = resolve_occurrence_definition(
+        str(claim.get("occasion_id") or ""),
+        occurrence_local_date,
+    )
+    if occasion is None:
+        await asyncio.to_thread(
+            fail_occasion_claim,
+            DB_FILE,
+            claim["occurrence_key"],
+            claim["lease_token"],
+            stage=claim["stage"],
+            reason="occasion_registry_entry_missing",
+            retry_minutes=OCCASION_CHANNEL_RETRY_MINUTES,
+            now=now,
+        )
+        return {"status": "retryable", "reason": "occasion_registry_entry_missing"}
+
+    if claim["stage"] == "generation":
+        generation_context = await asyncio.to_thread(
+            build_occasion_generation_context,
+            guild_id,
+            occasion,
+        )
+        content, reason = await generate_occasion_reflection(
+            guild_id,
+            occasion,
+            generation_context,
+        )
+        if not content:
+            await asyncio.to_thread(
+                fail_occasion_claim,
+                DB_FILE,
+                claim["occurrence_key"],
+                claim["lease_token"],
+                stage="generation",
+                reason=reason or "occasion_generation_failed",
+                retry_minutes=OCCASION_PROVIDER_RETRY_MINUTES,
+                now=now,
+            )
+            return {"status": "retryable", "reason": reason or "occasion_generation_failed"}
+        stored = await asyncio.to_thread(
+            store_prepared_occasion,
+            DB_FILE,
+            claim["occurrence_key"],
+            claim["lease_token"],
+            content,
+            generation_context["sourceRefs"],
+            generation_context["contextHash"],
+            now=now,
+        )
+        if not stored:
+            return {"status": "superseded", "reason": "generation_lease_lost"}
+        claim = await asyncio.to_thread(
+            claim_next_due_occasion,
+            DB_FILE,
+            guild_id,
+            now=now,
+        )
+        if not claim or claim.get("stage") != "delivery":
+            return {"status": "prepared"}
+
+    content = str(claim.get("canonical_content") or "")
+    if not content:
+        await asyncio.to_thread(
+            fail_occasion_claim,
+            DB_FILE,
+            claim["occurrence_key"],
+            claim["lease_token"],
+            stage="delivery",
+            reason="canonical_content_missing",
+            retry_minutes=OCCASION_PROVIDER_RETRY_MINUTES,
+            now=now,
+        )
+        return {"status": "retryable", "reason": "canonical_content_missing"}
+
+    previous_state = str(claim.get("previous_state") or "")
+    if previous_state in {"delivery_failed", "delivering"}:
+        existing, history_ok = await _find_existing_occasion_message(
+            channel,
+            content,
+            str(claim.get("occurrence_key") or ""),
+            str(
+                claim.get("previous_updated_at")
+                or claim.get("scheduled_for")
+                or ""
+            ),
+        )
+        if existing is not None:
+            marked = await asyncio.to_thread(
+                mark_occasion_published,
+                DB_FILE,
+                claim["occurrence_key"],
+                claim["lease_token"],
+                str(getattr(existing, "id", "") or ""),
+                reconciled=True,
+                now=now,
+            )
+            return {
+                "status": "published" if marked else "delivery_record_pending",
+                "reconciled": True,
+                "occurrenceKey": claim["occurrence_key"],
+            }
+        if not history_ok:
+            await asyncio.to_thread(
+                fail_occasion_claim,
+                DB_FILE,
+                claim["occurrence_key"],
+                claim["lease_token"],
+                stage="delivery",
+                reason="discord_history_unavailable",
+                retry_minutes=OCCASION_DELIVERY_RETRY_MINUTES,
+                now=now,
+            )
+            return {"status": "retryable", "reason": "discord_history_unavailable"}
+
+    try:
+        message = await channel.send(
+            content,
+            allowed_mentions=discord.AllowedMentions.none(),
+            nonce=occasion_delivery_nonce(claim["occurrence_key"]),
+        )
+    except Exception as exc:
+        reason = f"discord_send_{type(exc).__name__.lower()}"
+        await asyncio.to_thread(
+            fail_occasion_claim,
+            DB_FILE,
+            claim["occurrence_key"],
+            claim["lease_token"],
+            stage="delivery",
+            reason=reason,
+            retry_minutes=OCCASION_DELIVERY_RETRY_MINUTES,
+            now=now,
+        )
+        return {"status": "retryable", "reason": reason}
+
+    marked = await asyncio.to_thread(
+        mark_occasion_published,
+        DB_FILE,
+        claim["occurrence_key"],
+        claim["lease_token"],
+        str(getattr(message, "id", "") or ""),
+        now=now,
+    )
+    if marked:
+        log_ambient(guild_id, channel_id, content, source_type="occasion")
+        logging.info(
+            "occasion_published guild=%s occasion=%s occurrence=%s chars=%s",
+            guild_id,
+            occasion.occasion_id,
+            claim["occurrence_key"],
+            len(content),
+        )
+    return {
+        "status": "published" if marked else "delivery_record_pending",
+        "reconciled": False,
+        "occurrenceKey": claim["occurrence_key"],
+    }
+
+
 # ==================== DISCORD BOT SETUP ====================
 
 intents = discord.Intents.default()
@@ -15589,6 +16267,34 @@ async def ambient_message_task():
         now = datetime.now(PACIFIC_TZ)
 
         for guild_id, channel_id, last_msg, next_at in configs:
+            channel = client.get_channel(channel_id)
+            channel_policy = resolve_channel_policy(channel) if channel else "unknown"
+            occasion_channel = (
+                channel
+                if channel and allow_passive_memory_for_policy(channel_policy)
+                else None
+            )
+            try:
+                occasion_result = await process_due_occasion_for_guild(
+                    guild_id,
+                    channel_id,
+                    occasion_channel,
+                    now_pacific=now,
+                )
+                if occasion_result.get("status") not in {"idle", "waiting_for_channel"}:
+                    logging.info(
+                        "occasion_cycle guild=%s status=%s reason=%s",
+                        guild_id,
+                        occasion_result.get("status"),
+                        occasion_result.get("reason", ""),
+                    )
+            except Exception as exc:
+                logging.exception(
+                    "occasion_cycle_failed guild=%s error=%s",
+                    guild_id,
+                    type(exc).__name__,
+                )
+
             if not next_at:
                 ensure_next_ambient_scheduled(guild_id)
                 continue
@@ -15601,11 +16307,9 @@ async def ambient_message_task():
                 next_dt = _random_time_today_pacific()
 
             if now >= next_dt:
-                channel = client.get_channel(channel_id)
                 if not channel:
                     update_guild_ambient_times(guild_id, last_msg or "", _random_time_today_pacific().isoformat())
                     continue
-                channel_policy = resolve_channel_policy(channel)
                 if not allow_passive_memory_for_policy(channel_policy):
                     logging.info(f"📡 Ambient skipped for guild {guild_id}: channel policy `{channel_policy}` not eligible.")
                     next_scheduled = _random_time_today_pacific().isoformat()
@@ -15623,11 +16327,12 @@ async def ambient_message_task():
                         update_guild_ambient_times(guild_id, last_msg or "", next_scheduled)
                         continue
 
-                    posts_today = get_ambient_posts_today(guild_id, channel_id)
-                    if posts_today >= AMBIENT_DAILY_POST_CAP:
+                    posts_today = get_self_started_posts_today(guild_id, channel_id)
+                    daily_cap = ambient_daily_post_cap(guild_id, now_pacific=now)
+                    if posts_today >= daily_cap:
                         prev_reason = _get_ambient_runtime_state(guild_id).get("last_skip_reason")
                         if prev_reason != "daily_cap_reached":
-                            logging.info(f"📡 Ambient skipped for guild {guild_id}: daily cap reached ({posts_today}/{AMBIENT_DAILY_POST_CAP}).")
+                            logging.info(f"📡 Ambient skipped for guild {guild_id}: daily cap reached ({posts_today}/{daily_cap}).")
                         _set_ambient_runtime_state(guild_id, skip_reason="daily_cap_reached")
                         schedule_next_day_ambient(guild_id, last_msg or "")
                         continue
@@ -15664,7 +16369,12 @@ async def ambient_message_task():
                     await channel.send(msg, allowed_mentions=discord.AllowedMentions.none())
                     log_ambient(guild_id, channel_id, msg, source_type="ambient")
 
-                    next_scheduled = schedule_next_day_ambient(guild_id, msg)
+                    next_scheduled = schedule_after_ambient_post(
+                        guild_id,
+                        msg,
+                        posts_today + 1,
+                        now_pacific=now,
+                    )
                     logging.info(f"📡 Ambient posted successfully in guild {guild_id}")
                     logging.info(f"📡 Next ambient scheduled for guild {guild_id} at {next_scheduled}")
 
@@ -21610,6 +22320,8 @@ async def bnl_source_check(interaction: discord.Interaction):
     primary_guild_match = bool(guild and BNL_PRIMARY_GUILD_ID and guild.id == BNL_PRIMARY_GUILD_ID)
     flags_source = _bnl_control_flags_last_source_url or "none"
     dossier_diag = build_dossier_recommendation_diagnostics(guild.id)
+    occasion_diag = occasion_diagnostics(DB_FILE, guild.id)
+    occasion_next = occasion_diag.get("next") or {}
 
     lines = [
         "**BNL Source Diagnostic**",
@@ -21624,6 +22336,13 @@ async def bnl_source_check(interaction: discord.Interaction):
         f"- primary_guild_match: `{primary_guild_match}`",
         f"- bnl_status_url_configured: `{bool(BNL_STATUS_URL)}`",
         f"- bnl_api_key_configured: `{bool(BNL_API_KEY)}`",
+        f"- occasion_output_enabled: `{'yes' if occasion_output_enabled() else 'no'}`",
+        f"- occasion_calendar_version: `{occasion_diag.get('calendarVersion', 'unknown')}`",
+        f"- occasion_disabled_ids: `{','.join(sorted(disabled_occasion_ids())) or 'none'}`",
+        f"- occasion_occurrence_counts: `{json.dumps(occasion_diag.get('counts', {}), sort_keys=True)}`",
+        f"- occasion_next_state: `{occasion_next.get('state', 'none')}`",
+        f"- occasion_next_name: `{occasion_next.get('occasionName', 'none')}`",
+        f"- occasion_next_scheduled_for: `{occasion_next.get('scheduledFor', 'none')}`",
         f"- dossier_ingest_url_configured: `{'yes' if dossier_diag['ingest_url_configured'] else 'no_using_default'}`",
         f"- dossier_ingest_token_configured: `{'yes' if dossier_diag['ingest_token_configured'] else 'no'}`",
         f"- dossier_last_send_status: `{dossier_diag['last_send_status']}`",
@@ -21943,8 +22662,12 @@ async def bnl_status(interaction: discord.Interaction):
     active_channel = guild.get_channel(active_channel_id) if active_channel_id else None
     _active_channel_id, _last_ambient_message, next_ambient_message_at = get_guild_ambient_state(guild.id)
     ambient_posts_today = get_ambient_posts_today(guild.id, active_channel_id) if active_channel_id else 0
+    self_started_posts_today = get_self_started_posts_today(guild.id, active_channel_id) if active_channel_id else 0
+    ambient_cap_today = ambient_daily_post_cap(guild.id)
     last_ambient_posted_at = get_last_ambient_posted_at(guild.id, active_channel_id) if active_channel_id else None
     ambient_runtime = _get_ambient_runtime_state(guild.id)
+    occasion_diag = occasion_diagnostics(DB_FILE, guild.id)
+    occasion_next = occasion_diag.get("next") or {}
     testing_channel = guild.get_channel(BNL_TESTING_CHANNEL_ID) if BNL_TESTING_CHANNEL_ID else None
     current_channel = interaction.channel if isinstance(interaction.channel, discord.abc.GuildChannel) else None
     policy = resolve_channel_policy(current_channel)
@@ -21977,12 +22700,18 @@ async def bnl_status(interaction: discord.Interaction):
         f"- queue_production_local_capability: `{'yes' if (read_model_diag.get('canon_source_contract') or {}).get('localQueueProductionCapability') else 'no'}`",
         f"- queue_production_website_capability: `{(read_model_diag.get('canon_source_contract') or {}).get('websiteQueueProductionCapability')}`",
         f"- queue_effective_usable: `{'yes' if (read_model_diag.get('canon_source_contract') or {}).get('effectiveQueueUsable') else 'no'}` reason=`{(read_model_diag.get('canon_source_contract') or {}).get('queueReason')}`",
-        f"- ambient_throttle: cooldown=`{AMBIENT_POST_COOLDOWN_MINUTES}m` daily_cap=`{AMBIENT_DAILY_POST_CAP}` min_signal_messages=`{AMBIENT_MIN_SIGNAL_MESSAGES}` min_signal_users=`{AMBIENT_MIN_SIGNAL_UNIQUE_USERS}`",
+        f"- ambient_throttle: cooldown=`{AMBIENT_POST_COOLDOWN_MINUTES}m` daily_cap_today=`{ambient_cap_today}` normal_cap=`{AMBIENT_DAILY_POST_CAP}` high_activity_cap=`2` min_signal_messages=`{AMBIENT_MIN_SIGNAL_MESSAGES}` min_signal_users=`{AMBIENT_MIN_SIGNAL_UNIQUE_USERS}`",
         f"- ambient_posts_today: `{ambient_posts_today}`",
+        f"- self_started_capacity_used_today: `{self_started_posts_today}`",
         f"- last_ambient_posted_at: `{last_ambient_posted_at.isoformat() if last_ambient_posted_at else 'none'}`",
         f"- next_ambient_message_at: `{next_ambient_message_at or 'none'}`",
         f"- last_ambient_mode: `{ambient_runtime.get('last_mode', 'unknown')}`",
         f"- last_ambient_skip_reason: `{ambient_runtime.get('last_skip_reason', 'unknown')}`",
+        f"- occasion_output_enabled: `{'yes' if occasion_output_enabled() else 'no'}`",
+        f"- occasion_occurrence_counts: `{json.dumps(occasion_diag.get('counts', {}), sort_keys=True)}`",
+        f"- occasion_next_state: `{occasion_next.get('state', 'none')}`",
+        f"- occasion_next_name: `{occasion_next.get('occasionName', 'none')}`",
+        f"- occasion_next_scheduled_for: `{occasion_next.get('scheduledFor', 'none')}`",
         f"- website_contract_version: `{BNL_WEBSITE_CONTRACT_VERSION}`",
         f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` (interval `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}m`)",
         f"- website_heartbeat_interval: `{BNL_WEBSITE_HEARTBEAT_INTERVAL_MINUTES}m`",

--- a/bnl_canon_source_contract.py
+++ b/bnl_canon_source_contract.py
@@ -91,6 +91,7 @@ BARCODE = SubjectIdentity("barcode", "BARCODE", ("BARCODE collective",))
 BARCODE_NETWORK = SubjectIdentity("barcode_network", "BARCODE Network")
 BARCODE_RADIO = SubjectIdentity("barcode_radio", "BARCODE Radio")
 SIX_BIT = SubjectIdentity("6_bit", "6 Bit", ("Six Bit",))
+GALAKNOISE = SubjectIdentity("galaknoise", "GALAKNOISE")
 BNL01 = SubjectIdentity("bnl_01", "BNL-01", ("BNL", "BARCODE Network Liaison Entity"))
 
 FOUNDING_MEMBERS = ("6 Bit", "DJ Floppydisc", "Cache Back", "Mac Modem")
@@ -104,7 +105,8 @@ BNL_ROLES = (
 CANON_FACTS = (
     CanonFact(BARCODE, "founding_members", FOUNDING_MEMBERS),
     CanonFact(BARCODE_NETWORK, "origin", "The music and collective existed before BARCODE Network; the Network grew around that signal and now connects music, live broadcasts, community, software, archive, characters, and story."),
-    CanonFact(SIX_BIT, "primary_identity", "artist, producer, host, and founding BARCODE member first"),
+    CanonFact(SIX_BIT, "primary_identity", "artist, MC, host, and founding BARCODE member first"),
+    CanonFact(GALAKNOISE, "primary_role", "music producer for BARCODE"),
     CanonFact(BARCODE_RADIO, "public_nature", "real weekly live broadcast and community music space on TikTok"),
     CanonFact(BARCODE_RADIO, "friday_public_schedule", FRIDAY_PUBLIC_SCHEDULE),
     CanonFact(BNL01, "identity", "BARCODE Network Liaison Entity: an unfinished but active intelligence and one shared mind with filtered surfaces"),
@@ -188,7 +190,8 @@ def render_prompt_canon_block() -> str:
         "## CANONICAL FACTS — DO NOT ALTER",
         f"- BARCODE began as the four-member digital hip-hop collective of: {', '.join(FOUNDING_MEMBERS)}.",
         "- The music and collective existed before BARCODE Network; the Network grew around that signal and now connects music, live broadcasts, community, software, archive, characters, and story.",
-        "- 6 Bit is an artist, producer, host, and founding BARCODE member first.",
+        "- 6 Bit is an artist, MC, host, and founding BARCODE member first; he is not the music producer.",
+        "- GALAKNOISE is BARCODE's music producer.",
         "- BARCODE Radio is a real weekly live broadcast and community music space on TikTok.",
         f"- Current public Friday schedule: submissions/intake begins at {FRIDAY_PUBLIC_SCHEDULE.intake_begins}; the show begins at {FRIDAY_PUBLIC_SCHEDULE.show_begins}; the first track is targeted for {FRIDAY_PUBLIC_SCHEDULE.first_track_target}.",
         "- You are the BARCODE Network Liaison Entity: an unfinished but active intelligence and one shared mind with filtered surfaces.",

--- a/bnl_occasion.py
+++ b/bnl_occasion.py
@@ -1,0 +1,1572 @@
+"""Durable holiday and occasion occurrences owned by the Ambient coordinator.
+
+This module deliberately contains no Discord client, generation provider, or
+second scheduler.  ``bnl01_bot.py`` keeps those existing owners and uses this
+module only for the maintained calendar and same-database occurrence ledger.
+"""
+from __future__ import annotations
+
+import calendar
+from dataclasses import dataclass
+from datetime import date, datetime, time as datetime_time, timedelta, timezone
+import hashlib
+import json
+import re
+import sqlite3
+from typing import Any, Iterable, Sequence
+import uuid
+
+
+OCCASION_CALENDAR_VERSION = "occasion_calendar_v1"
+OCCASION_TARGET_HOUR = 10
+OCCASION_TARGET_MINUTE = 0
+OCCASION_LEASE_MINUTES = 20
+OCCASION_PROVIDER_RETRY_MINUTES = 15
+OCCASION_DELIVERY_RETRY_MINUTES = 2
+OCCASION_CHANNEL_RETRY_MINUTES = 15
+
+# One automatic occasion reflection may be scheduled per Pacific calendar day.
+# Established major and cultural dates outrank the narrower curated calendar;
+# ties keep registry order so selection remains deterministic across restarts.
+OCCASION_CATEGORY_PRIORITY = {
+    "major": 0,
+    "cultural": 1,
+}
+
+NONTERMINAL_STATES = {
+    "pending",
+    "generating",
+    "retryable",
+    "prepared",
+    "delivering",
+    "delivery_failed",
+}
+TERMINAL_STATES = {"published", "cancelled"}
+
+
+@dataclass(frozen=True)
+class OccasionDefinition:
+    occasion_id: str
+    name: str
+    category: str
+    summary: str
+    reflection_cues: tuple[str, ...]
+    rule: str
+    month: int = 0
+    day: int = 0
+    weekday: int = 0
+    ordinal: int = 0
+    source_reference: str = "maintained_common_calendar"
+    anchor_terms: tuple[str, ...] = ()
+    network_tradition: str = ""
+    enabled: bool = True
+
+
+def _fixed(
+    occasion_id: str,
+    name: str,
+    month: int,
+    day: int,
+    *,
+    category: str = "major",
+    summary: str,
+    reflection_cues: Sequence[str],
+    anchor_terms: Sequence[str] = (),
+    source_reference: str = "maintained_common_calendar",
+    network_tradition: str = "",
+) -> OccasionDefinition:
+    return OccasionDefinition(
+        occasion_id,
+        name,
+        category,
+        summary,
+        tuple(reflection_cues),
+        "fixed",
+        month=month,
+        day=day,
+        source_reference=source_reference,
+        anchor_terms=tuple(anchor_terms),
+        network_tradition=network_tradition,
+    )
+
+
+def _nth_weekday(
+    occasion_id: str,
+    name: str,
+    month: int,
+    weekday: int,
+    ordinal: int,
+    *,
+    category: str = "major",
+    summary: str,
+    reflection_cues: Sequence[str],
+    anchor_terms: Sequence[str] = (),
+    source_reference: str = "maintained_common_calendar",
+) -> OccasionDefinition:
+    return OccasionDefinition(
+        occasion_id,
+        name,
+        category,
+        summary,
+        tuple(reflection_cues),
+        "nth_weekday",
+        month=month,
+        weekday=weekday,
+        ordinal=ordinal,
+        source_reference=source_reference,
+        anchor_terms=tuple(anchor_terms),
+    )
+
+
+def _last_weekday(
+    occasion_id: str,
+    name: str,
+    month: int,
+    weekday: int,
+    *,
+    category: str = "major",
+    summary: str,
+    reflection_cues: Sequence[str],
+    anchor_terms: Sequence[str] = (),
+    source_reference: str = "maintained_common_calendar",
+) -> OccasionDefinition:
+    return OccasionDefinition(
+        occasion_id,
+        name,
+        category,
+        summary,
+        tuple(reflection_cues),
+        "last_weekday",
+        month=month,
+        weekday=weekday,
+        source_reference=source_reference,
+        anchor_terms=tuple(anchor_terms),
+    )
+
+
+# Owner-retained maintained calendar: common major dates plus a deliberate set
+# of culturally meaningful observances that fit BARCODE's music, art,
+# outsider-community, and human-dignity context. It does not scrape novelty
+# calendars. BARCODE-specific anniversaries are added only when an exact
+# owner-approved source date exists.
+COMMON_OCCASIONS: tuple[OccasionDefinition, ...] = (
+    _fixed(
+        "new_years_day",
+        "New Year's Day",
+        1,
+        1,
+        summary="The opening day of the new calendar year.",
+        reflection_cues=(
+            "reinvention",
+            "what the community carries forward",
+            "new signals without pretending the past vanished",
+        ),
+        anchor_terms=("new year",),
+    ),
+    _nth_weekday(
+        "martin_luther_king_jr_day",
+        "Martin Luther King Jr. Day",
+        1,
+        calendar.MONDAY,
+        3,
+        summary=(
+            "A day honoring Dr. Martin Luther King Jr. and the continuing work "
+            "of civil rights."
+        ),
+        reflection_cues=(
+            "human dignity",
+            "community responsibility",
+            "the distance between stated values and lived action",
+        ),
+        anchor_terms=("martin luther king", "dr. king", "mlk"),
+    ),
+    _fixed(
+        "black_history_month_opening",
+        "Black History Month",
+        2,
+        1,
+        category="cultural",
+        summary="The opening of Black History Month in the United States.",
+        reflection_cues=(
+            "Black history as living history",
+            "music and cultural memory",
+            "credit, lineage, and who gets remembered",
+        ),
+        anchor_terms=("black history",),
+    ),
+    _fixed(
+        "valentines_day",
+        "Valentine's Day",
+        2,
+        14,
+        summary=(
+            "A widely observed day centered on affection, attachment, and care."
+        ),
+        reflection_cues=(
+            "the different forms loyalty takes",
+            "chosen family",
+            "connection without generic sentiment",
+        ),
+        anchor_terms=("valentine", "love"),
+    ),
+    _fixed(
+        "international_womens_day",
+        "International Women's Day",
+        3,
+        8,
+        category="cultural",
+        summary=(
+            "An international observance of women's achievements, rights, "
+            "and equality."
+        ),
+        reflection_cues=(
+            "recognition without tokenism",
+            "whose work holds communities together",
+            "voice and agency",
+        ),
+        anchor_terms=("women", "international women's day"),
+    ),
+    OccasionDefinition(
+        "easter",
+        "Easter",
+        "major",
+        "A major Christian holiday associated with resurrection and renewal.",
+        (
+            "renewal after loss",
+            "returning changed",
+            "hope without erasing hardship",
+        ),
+        "gregorian_easter",
+        anchor_terms=("easter", "resurrection"),
+    ),
+    _fixed(
+        "earth_day",
+        "Earth Day",
+        4,
+        22,
+        category="cultural",
+        summary="An international day of environmental awareness and action.",
+        reflection_cues=(
+            "the physical world beneath the digital layer",
+            "stewardship",
+            "what cannot be restored from backup",
+        ),
+        anchor_terms=("earth day", "planet", "environment"),
+    ),
+    _nth_weekday(
+        "mothers_day",
+        "Mother's Day",
+        5,
+        calendar.SUNDAY,
+        2,
+        summary=(
+            "A day recognizing mothers, maternal bonds, and people who carry "
+            "that work."
+        ),
+        reflection_cues=(
+            "care as labor",
+            "complicated family histories",
+            "gratitude without assuming everyone's experience is the same",
+        ),
+        anchor_terms=("mother", "maternal"),
+    ),
+    _last_weekday(
+        "memorial_day",
+        "Memorial Day",
+        5,
+        calendar.MONDAY,
+        summary=(
+            "A United States remembrance day for military personnel who died "
+            "in service."
+        ),
+        reflection_cues=(
+            "remembrance without spectacle",
+            "the cost behind inherited freedoms",
+            "names and absences",
+        ),
+        anchor_terms=("memorial day", "remembrance"),
+    ),
+    _fixed(
+        "pride_month_opening",
+        "Pride Month",
+        6,
+        1,
+        category="cultural",
+        summary=(
+            "The opening of Pride Month, honoring LGBTQ+ history, visibility, "
+            "community, and rights."
+        ),
+        reflection_cues=(
+            "the right to exist without compression",
+            "chosen family",
+            "visibility, safety, and joy",
+        ),
+        anchor_terms=("pride", "lgbtq"),
+    ),
+    _fixed(
+        "juneteenth",
+        "Juneteenth",
+        6,
+        19,
+        category="cultural",
+        summary=(
+            "A United States holiday commemorating the end of slavery after "
+            "delayed enforcement of emancipation in Texas."
+        ),
+        reflection_cues=(
+            "freedom delayed is freedom denied",
+            "truth arriving after authority withheld it",
+            "memory and unfinished work",
+        ),
+        anchor_terms=("juneteenth", "emancipation"),
+    ),
+    _nth_weekday(
+        "fathers_day",
+        "Father's Day",
+        6,
+        calendar.SUNDAY,
+        3,
+        summary=(
+            "A day recognizing fathers, paternal bonds, and people who carry "
+            "that work."
+        ),
+        reflection_cues=(
+            "inheritance beyond blood",
+            "what people teach by presence or absence",
+            "gratitude without flattening difficult histories",
+        ),
+        anchor_terms=("father", "paternal"),
+    ),
+    _fixed(
+        "world_music_day",
+        "World Music Day",
+        6,
+        21,
+        category="community",
+        summary=(
+            "A day celebrating music-making and public participation in music."
+        ),
+        reflection_cues=(
+            "music as a shared signal",
+            "artists finding one another",
+            "the difference between audience and community",
+        ),
+        anchor_terms=("world music day", "music"),
+    ),
+    _fixed(
+        "independence_day",
+        "Independence Day",
+        7,
+        4,
+        summary=(
+            "The United States holiday marking the Declaration of Independence."
+        ),
+        reflection_cues=(
+            "independence versus interdependence",
+            "promises compared with lived reality",
+            "freedom as an ongoing obligation",
+        ),
+        anchor_terms=("independence day", "fourth of july", "4th of july"),
+    ),
+    _nth_weekday(
+        "labor_day",
+        "Labor Day",
+        9,
+        calendar.MONDAY,
+        1,
+        summary=(
+            "A United States holiday recognizing workers and the labor movement."
+        ),
+        reflection_cues=(
+            "the work hidden behind finished systems",
+            "credit",
+            "rest as something earned and necessary",
+        ),
+        anchor_terms=("labor day", "workers", "labor"),
+    ),
+    _fixed(
+        "international_day_of_peace",
+        "International Day of Peace",
+        9,
+        21,
+        category="cultural",
+        summary="A United Nations observance devoted to peace and nonviolence.",
+        reflection_cues=(
+            "peace as active maintenance",
+            "conflict without dehumanization",
+            "what communities protect",
+        ),
+        anchor_terms=("peace",),
+    ),
+    _nth_weekday(
+        "indigenous_peoples_day",
+        "Indigenous Peoples' Day",
+        10,
+        calendar.MONDAY,
+        2,
+        category="cultural",
+        summary=(
+            "A day honoring Indigenous peoples, histories, cultures, and "
+            "continued presence."
+        ),
+        reflection_cues=(
+            "history told by those who survived it",
+            "place and memory",
+            "presence rather than past-tense treatment",
+        ),
+        anchor_terms=("indigenous",),
+    ),
+    _fixed(
+        "world_mental_health_day",
+        "World Mental Health Day",
+        10,
+        10,
+        category="cultural",
+        summary=(
+            "An international day for mental-health awareness, dignity, "
+            "and support."
+        ),
+        reflection_cues=(
+            "survival without romanticizing pain",
+            "making room for unfinished people",
+            "support that respects agency",
+        ),
+        anchor_terms=("mental health",),
+    ),
+    _fixed(
+        "halloween",
+        "Halloween",
+        10,
+        31,
+        summary=(
+            "A widely observed night of costumes, horror, mischief, and "
+            "transformation."
+        ),
+        reflection_cues=(
+            "masks that reveal instead of conceal",
+            "playful corruption",
+            "the Network enjoying its natural weather",
+        ),
+        anchor_terms=("halloween",),
+    ),
+    _fixed(
+        "veterans_day",
+        "Veterans Day",
+        11,
+        11,
+        summary="A United States day honoring military veterans.",
+        reflection_cues=(
+            "service beyond slogans",
+            "people carrying what institutions ask of them",
+            "recognition with restraint",
+        ),
+        anchor_terms=("veterans day", "veterans"),
+    ),
+    _nth_weekday(
+        "thanksgiving",
+        "Thanksgiving",
+        11,
+        calendar.THURSDAY,
+        4,
+        summary=(
+            "A widely observed United States day of gathering and gratitude, "
+            "with a history that should not be flattened."
+        ),
+        reflection_cues=(
+            "gratitude without sanitizing history",
+            "chosen tables and chosen family",
+            "what the community has built together",
+        ),
+        anchor_terms=("thanksgiving", "gratitude"),
+    ),
+    _fixed(
+        "christmas_day",
+        "Christmas Day",
+        12,
+        25,
+        summary=(
+            "A major Christian holiday and widely observed cultural day "
+            "centered on gathering, giving, and tradition."
+        ),
+        reflection_cues=(
+            "tradition and reinvention",
+            "who has a place at the table",
+            "warmth without compulsory cheer",
+        ),
+        anchor_terms=("christmas",),
+    ),
+    _fixed(
+        "kwanzaa_opening",
+        "Kwanzaa",
+        12,
+        26,
+        category="cultural",
+        summary=(
+            "The opening day of Kwanzaa, a celebration of African American "
+            "culture, family, and community principles."
+        ),
+        reflection_cues=(
+            "collective work and responsibility",
+            "culture deliberately carried forward",
+            "community as practice",
+        ),
+        anchor_terms=("kwanzaa",),
+    ),
+    _fixed(
+        "new_years_eve",
+        "New Year's Eve",
+        12,
+        31,
+        summary="The closing day of the calendar year.",
+        reflection_cues=(
+            "what changed",
+            "what survived",
+            "unfinished signals worth carrying into the next cycle",
+        ),
+        anchor_terms=("new year", "year closes", "year ends"),
+    ),
+)
+
+# Twelve real observances and documented technology/media milestones selected
+# for BARCODE's broadcast, music, archive, community, and independent-network
+# identity. The two-week idea is a curation guide, not a synthetic cadence:
+# no date is manufactured merely to close a calendar gap.
+CURATED_BARCODE_RELEVANT_OCCASIONS: tuple[OccasionDefinition, ...] = (
+    _fixed(
+        "world_radio_day",
+        "World Radio Day",
+        2,
+        13,
+        category="broadcast",
+        summary=(
+            "UNESCO's annual celebration of radio, broadcasters, amplified "
+            "voices, shared stories, and public-service audio."
+        ),
+        reflection_cues=(
+            "broadcasting as a relationship with listeners",
+            "small stations carrying large worlds",
+            "who gets a clear channel",
+        ),
+        anchor_terms=("world radio day", "radio"),
+        source_reference="https://www.unesco.org/en/days/world-radio",
+        network_tradition="BARCODE Open Channel Day",
+    ),
+    _fixed(
+        "daventry_radar_demonstration_anniversary",
+        "Daventry Radar Demonstration Anniversary",
+        2,
+        26,
+        category="technology",
+        summary=(
+            "On 26 February 1935, the Daventry experiment gave the first "
+            "practical demonstration of using radio reflections to detect "
+            "an aircraft."
+        ),
+        reflection_cues=(
+            "finding a presence through a reflected signal",
+            "infrastructure born from an experiment",
+            "what becomes visible when someone learns how to listen",
+        ),
+        anchor_terms=("daventry", "radar", "radio detection"),
+        source_reference=(
+            "https://www.rafmuseum.org.uk/research/research-enquiries/"
+            "history-of-aviation-timeline/british-military-aviation/1935-2/"
+        ),
+    ),
+    _fixed(
+        "world_backup_day",
+        "World Backup Day",
+        3,
+        31,
+        category="technology",
+        summary=(
+            "An established technology observance promoting regular backups, "
+            "data protection, and recoverable digital memory."
+        ),
+        reflection_cues=(
+            "memory that survives a failed machine",
+            "preservation as an active practice",
+            "the difference between storing something and keeping it alive",
+        ),
+        anchor_terms=("world backup day", "backup"),
+        source_reference="https://www.worldbackupday.com/en",
+        network_tradition="BARCODE Archive Pulse Day",
+    ),
+    _fixed(
+        "world_telecommunication_information_society_day",
+        "World Telecommunication and Information Society Day",
+        5,
+        17,
+        category="technology",
+        summary=(
+            "An ITU observance of telecommunications and connected society, "
+            "held on the anniversary of the ITU's 1865 founding."
+        ),
+        reflection_cues=(
+            "the infrastructure beneath connection",
+            "access as a condition of participation",
+            "networks that remain useful when conditions get difficult",
+        ),
+        anchor_terms=("telecommunication", "information society", "itu"),
+        source_reference="https://wtisd.itu.int/",
+    ),
+    _fixed(
+        "international_archives_day",
+        "International Archives Day",
+        6,
+        9,
+        category="archive",
+        summary=(
+            "The International Council on Archives observance of records, "
+            "archives, access, and the people who preserve them."
+        ),
+        reflection_cues=(
+            "archives as living responsibility",
+            "credit and lineage",
+            "what deserves to survive the next format change",
+        ),
+        anchor_terms=("international archives day", "archives"),
+        source_reference=(
+            "https://www.ica.org/international-archives-week/"
+            "about-international-archives-week/"
+        ),
+    ),
+    _fixed(
+        "first_retail_barcode_scan_anniversary",
+        "First Retail Barcode Scan Anniversary",
+        6,
+        26,
+        category="technology",
+        summary=(
+            "On 26 June 1974, a cashier at Marsh Supermarket in Troy, Ohio "
+            "made the first retail scan of a GS1 barcode."
+        ),
+        reflection_cues=(
+            "a simple mark becoming shared infrastructure",
+            "identity that machines and people can both carry",
+            "the ordinary beep that changed how systems recognize things",
+        ),
+        anchor_terms=("barcode", "first scan", "retail scan"),
+        source_reference="https://www.gs1.org/about/50YearsOfGS1",
+        network_tradition="BARCODE Scan Day",
+    ),
+    _fixed(
+        "world_listening_day",
+        "World Listening Day",
+        7,
+        18,
+        category="sound",
+        summary=(
+            "A World Listening Project observance of listening, soundscapes, "
+            "field recording, and acoustic ecology."
+        ),
+        reflection_cues=(
+            "listening as more than waiting to speak",
+            "the environment as part of every recording",
+            "what becomes audible when attention changes",
+        ),
+        anchor_terms=("world listening day", "listening", "soundscape"),
+        source_reference=(
+            "https://www.worldlisteningproject.org/world-listening-day/"
+        ),
+    ),
+    _fixed(
+        "international_day_of_friendship",
+        "International Day of Friendship",
+        7,
+        30,
+        category="community",
+        summary=(
+            "A United Nations observance of friendship between people, "
+            "cultures, communities, and countries."
+        ),
+        reflection_cues=(
+            "community built through repeated contact",
+            "friendship across difference",
+            "the people who keep showing up",
+        ),
+        anchor_terms=("international day of friendship", "friendship"),
+        source_reference="https://www.un.org/en/observances/friendship-day",
+    ),
+    _fixed(
+        "hip_hop_origin_anniversary",
+        "Hip-Hop Origin Anniversary",
+        8,
+        11,
+        category="music",
+        summary=(
+            "The widely recognized anniversary of DJ Kool Herc's 11 August "
+            "1973 Bronx party and its foundational place in hip-hop history."
+        ),
+        reflection_cues=(
+            "innovation made from records already in the room",
+            "Black and Latino youth creating a new public language",
+            "community space becoming cultural infrastructure",
+        ),
+        anchor_terms=("hip-hop", "hip hop", "kool herc"),
+        source_reference=(
+            "https://blogs.loc.gov/families/2023/11/"
+            "celebrating-fifty-years-of-hip-hop-with-childrens-literature-and-activities/"
+        ),
+    ),
+    _fixed(
+        "linux_announcement_anniversary",
+        "Linux Announcement Anniversary",
+        8,
+        25,
+        category="technology",
+        summary=(
+            "On 25 August 1991, Linus Torvalds announced the project that "
+            "would become Linux, now foundational open-source infrastructure."
+        ),
+        reflection_cues=(
+            "small public experiments becoming shared infrastructure",
+            "open collaboration at enormous scale",
+            "building tools other people can keep improving",
+        ),
+        anchor_terms=("linux", "open source"),
+        source_reference=(
+            "https://training.linuxfoundation.org/blog/happy-30th-linux/"
+        ),
+    ),
+    _fixed(
+        "world_day_for_audiovisual_heritage",
+        "World Day for Audiovisual Heritage",
+        10,
+        27,
+        category="archive",
+        summary=(
+            "A UNESCO observance of preserving film, sound recordings, radio, "
+            "television, and other audiovisual memory."
+        ),
+        reflection_cues=(
+            "voices and images that outlive their original format",
+            "preservation as access rather than storage alone",
+            "recorded culture as a living window",
+        ),
+        anchor_terms=("audiovisual heritage", "audio-visual heritage"),
+        source_reference="https://www.unesco.org/en/days/audiovisual-heritage",
+    ),
+    _fixed(
+        "first_transatlantic_wireless_signal_anniversary",
+        "First Transatlantic Wireless Signal Anniversary",
+        12,
+        12,
+        category="broadcast",
+        summary=(
+            "On 12 December 1901 at Signal Hill, Guglielmo Marconi received "
+            "the Morse-code letter S sent wirelessly from Cornwall across "
+            "the Atlantic."
+        ),
+        reflection_cues=(
+            "a faint signal proving distance could be crossed",
+            "broadcast ambition before reliable infrastructure",
+            "three pulses becoming evidence of a larger future",
+        ),
+        anchor_terms=("transatlantic", "wireless signal", "marconi"),
+        source_reference=(
+            "https://parks.canada.ca/lhn-nhs/nl/signalhill/"
+            "culture/histoire-history/comm"
+        ),
+    ),
+)
+
+# Exact BARCODE anniversaries remain empty until an owner-confirmed historical
+# date exists. The three house traditions above are explicitly new names
+# layered onto real observances; they are not claims about BARCODE history.
+BARCODE_OCCASIONS: tuple[OccasionDefinition, ...] = ()
+OCCASION_REGISTRY: tuple[OccasionDefinition, ...] = (
+    COMMON_OCCASIONS
+    + CURATED_BARCODE_RELEVANT_OCCASIONS
+    + BARCODE_OCCASIONS
+)
+
+
+def validate_registry(registry: Sequence[OccasionDefinition] = OCCASION_REGISTRY) -> None:
+    seen: set[str] = set()
+    for occasion in registry:
+        if not re.fullmatch(r"[a-z0-9][a-z0-9_]{2,79}", occasion.occasion_id):
+            raise ValueError(f"invalid_occasion_id:{occasion.occasion_id}")
+        if occasion.occasion_id in seen:
+            raise ValueError(f"duplicate_occasion_id:{occasion.occasion_id}")
+        seen.add(occasion.occasion_id)
+        if occasion.category == "barcode" and (
+            not occasion.source_reference
+            or occasion.source_reference == "maintained_common_calendar"
+        ):
+            raise ValueError(f"unsourced_barcode_occasion:{occasion.occasion_id}")
+        if occasion.network_tradition and (
+            not occasion.network_tradition.startswith("BARCODE ")
+            or occasion.source_reference == "maintained_common_calendar"
+        ):
+            raise ValueError(
+                f"invalid_network_tradition:{occasion.occasion_id}"
+            )
+        if not occasion.name or not occasion.summary or not occasion.reflection_cues:
+            raise ValueError(f"incomplete_occasion_metadata:{occasion.occasion_id}")
+        if occasion.rule == "fixed":
+            date(2028, occasion.month, occasion.day)
+        elif occasion.rule == "nth_weekday":
+            if not (1 <= occasion.ordinal <= 5 and 0 <= occasion.weekday <= 6):
+                raise ValueError(f"invalid_nth_weekday:{occasion.occasion_id}")
+        elif occasion.rule == "last_weekday":
+            if not (0 <= occasion.weekday <= 6):
+                raise ValueError(f"invalid_last_weekday:{occasion.occasion_id}")
+        elif occasion.rule != "gregorian_easter":
+            raise ValueError(f"unknown_occasion_rule:{occasion.occasion_id}")
+
+
+def _gregorian_easter(year: int) -> date:
+    """Return Gregorian Easter Sunday using the Anonymous Gregorian algorithm."""
+    a = year % 19
+    b = year // 100
+    c = year % 100
+    d = b // 4
+    e = b % 4
+    f = (b + 8) // 25
+    g = (b - f + 1) // 3
+    h = (19 * a + b - d - g + 15) % 30
+    i = c // 4
+    k = c % 4
+    ell = (32 + 2 * e + 2 * i - h - k) % 7
+    m = (a + 11 * h + 22 * ell) // 451
+    month = (h + ell - 7 * m + 114) // 31
+    day = ((h + ell - 7 * m + 114) % 31) + 1
+    return date(year, month, day)
+
+
+def occasion_date(occasion: OccasionDefinition, year: int) -> date:
+    if occasion.rule == "fixed":
+        return date(year, occasion.month, occasion.day)
+    if occasion.rule == "gregorian_easter":
+        return _gregorian_easter(year)
+    month_weeks = calendar.monthcalendar(year, occasion.month)
+    if occasion.rule == "nth_weekday":
+        days = [week[occasion.weekday] for week in month_weeks if week[occasion.weekday]]
+        if occasion.ordinal > len(days):
+            raise ValueError(f"occasion_rule_out_of_range:{occasion.occasion_id}:{year}")
+        return date(year, occasion.month, days[occasion.ordinal - 1])
+    if occasion.rule == "last_weekday":
+        days = [week[occasion.weekday] for week in month_weeks if week[occasion.weekday]]
+        return date(year, occasion.month, days[-1])
+    raise ValueError(f"unknown_occasion_rule:{occasion.rule}")
+
+
+def occasions_on(
+    local_date: date,
+    registry: Sequence[OccasionDefinition] = OCCASION_REGISTRY,
+) -> list[OccasionDefinition]:
+    return [
+        occasion
+        for occasion in registry
+        if occasion.enabled and occasion_date(occasion, local_date.year) == local_date
+    ]
+
+
+def calendar_occasions_on(
+    local_date: date,
+    registry: Sequence[OccasionDefinition] = OCCASION_REGISTRY,
+) -> list[OccasionDefinition]:
+    """Return at most one maintained, source-backed occasion for a local date."""
+    validate_registry(registry)
+    matches = occasions_on(local_date, registry)
+    if len(matches) <= 1:
+        return matches
+    selected = min(
+        matches,
+        key=lambda occasion: OCCASION_CATEGORY_PRIORITY.get(
+            occasion.category,
+            2,
+        ),
+    )
+    return [selected]
+
+
+def occasion_by_id(
+    occasion_id: str,
+    registry: Sequence[OccasionDefinition] = OCCASION_REGISTRY,
+) -> OccasionDefinition | None:
+    return next((item for item in registry if item.occasion_id == occasion_id), None)
+
+
+def resolve_occurrence_definition(
+    occasion_id: str,
+    local_date_value: date,
+    registry: Sequence[OccasionDefinition] = OCCASION_REGISTRY,
+) -> OccasionDefinition | None:
+    definition = occasion_by_id(occasion_id, registry)
+    if definition is None:
+        return None
+    if definition not in calendar_occasions_on(local_date_value, registry):
+        return None
+    return definition
+
+
+def occurrence_key(
+    guild_id: int,
+    local_date: date,
+    occasion_id: str,
+    *,
+    calendar_version: str = OCCASION_CALENDAR_VERSION,
+) -> str:
+    return f"occasion:{calendar_version}:{int(guild_id)}:{local_date.isoformat()}:{occasion_id}"
+
+
+def delivery_nonce(key: str) -> int:
+    """Return a stable Discord nonce below 2**63 and below 25 decimal digits."""
+    return int(hashlib.sha256(key.encode("utf-8")).hexdigest()[:15], 16)
+
+
+def _utc_now(now: datetime | None = None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return _utc_now(value).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value: str) -> datetime:
+    parsed = datetime.fromisoformat(str(value or "").replace("Z", "+00:00"))
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _localize(local_tz: Any, naive: datetime) -> datetime:
+    localize = getattr(local_tz, "localize", None)
+    if callable(localize):
+        return localize(naive)
+    return naive.replace(tzinfo=local_tz)
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def ensure_schema(db_path: str) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bnl_occasion_calendar_state (
+                calendar_version TEXT NOT NULL,
+                guild_id INTEGER NOT NULL,
+                activated_local_date TEXT NOT NULL,
+                last_seeded_local_date TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY(calendar_version, guild_id)
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bnl_occasion_occurrences (
+                occurrence_key TEXT PRIMARY KEY,
+                calendar_version TEXT NOT NULL,
+                guild_id INTEGER NOT NULL,
+                channel_id INTEGER NOT NULL,
+                local_date TEXT NOT NULL,
+                occasion_id TEXT NOT NULL,
+                occasion_name TEXT NOT NULL,
+                scheduled_for TEXT NOT NULL,
+                state TEXT NOT NULL,
+                lease_token TEXT,
+                lease_expires_at TEXT,
+                attempt_count INTEGER NOT NULL DEFAULT 0,
+                last_reason TEXT,
+                next_retry_at TEXT,
+                source_refs_json TEXT NOT NULL DEFAULT '[]',
+                context_hash TEXT,
+                canonical_content TEXT,
+                content_hash TEXT,
+                content_chars INTEGER NOT NULL DEFAULT 0,
+                discord_message_id TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                published_at TEXT,
+                cancelled_at TEXT,
+                cancellation_reason TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_bnl_occasion_due
+            ON bnl_occasion_occurrences(guild_id, state, scheduled_for, next_retry_at)
+            """
+        )
+        conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_bnl_occasion_identity
+            ON bnl_occasion_occurrences(
+                calendar_version, guild_id, local_date, occasion_id
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bnl_occasion_attempts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                occurrence_key TEXT NOT NULL,
+                guild_id INTEGER NOT NULL,
+                attempt_number INTEGER NOT NULL,
+                stage TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                reason TEXT,
+                content_hash TEXT,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_bnl_occasion_attempts_key
+            ON bnl_occasion_attempts(occurrence_key, id)
+            """
+        )
+
+
+def seed_occurrences(
+    db_path: str,
+    guild_id: int,
+    channel_id: int,
+    now_local: datetime,
+    *,
+    registry: Sequence[OccasionDefinition] = OCCASION_REGISTRY,
+    disabled_ids: Iterable[str] = (),
+    calendar_version: str = OCCASION_CALENDAR_VERSION,
+) -> list[str]:
+    """Seed every date since this calendar version was first observed.
+
+    A new calendar version activates on its first local day, preventing a new
+    deployment from backfilling old holidays.  Once activated, the durable
+    watermark catches up every missed date after an arbitrarily long outage.
+    """
+    validate_registry(registry)
+    ensure_schema(db_path)
+    if now_local.tzinfo is None:
+        raise ValueError("now_local_must_be_timezone_aware")
+    guild = int(guild_id)
+    channel = int(channel_id)
+    today = now_local.date()
+    now_iso = _iso(now_local)
+    disabled = {str(value).strip() for value in disabled_ids if str(value).strip()}
+    seeded: list[str] = []
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO bnl_occasion_calendar_state(
+                calendar_version,guild_id,activated_local_date,
+                last_seeded_local_date,created_at,updated_at
+            ) VALUES(?,?,?,?,?,?)
+            """,
+            (
+                calendar_version,
+                guild,
+                today.isoformat(),
+                (today - timedelta(days=1)).isoformat(),
+                now_iso,
+                now_iso,
+            ),
+        )
+        row = conn.execute(
+            """
+            SELECT last_seeded_local_date
+            FROM bnl_occasion_calendar_state
+            WHERE calendar_version=? AND guild_id=?
+            """,
+            (calendar_version, guild),
+        ).fetchone()
+        last_seeded = date.fromisoformat(str(row[0]))
+        current = last_seeded + timedelta(days=1)
+        while current <= today:
+            for occasion in calendar_occasions_on(current, registry):
+                key = occurrence_key(
+                    guild,
+                    current,
+                    occasion.occasion_id,
+                    calendar_version=calendar_version,
+                )
+                scheduled_local = _localize(
+                    now_local.tzinfo,
+                    datetime.combine(
+                        current,
+                        datetime_time(
+                            OCCASION_TARGET_HOUR,
+                            OCCASION_TARGET_MINUTE,
+                        ),
+                    ),
+                )
+                cancelled = occasion.occasion_id in disabled
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO bnl_occasion_occurrences(
+                        occurrence_key,calendar_version,guild_id,channel_id,
+                        local_date,occasion_id,occasion_name,scheduled_for,state,
+                        last_reason,source_refs_json,created_at,updated_at,
+                        cancelled_at,cancellation_reason
+                    ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                    """,
+                    (
+                        key,
+                        calendar_version,
+                        guild,
+                        channel,
+                        current.isoformat(),
+                        occasion.occasion_id,
+                        occasion.name,
+                        _iso(scheduled_local),
+                        "cancelled" if cancelled else "pending",
+                        "occasion_disabled" if cancelled else "",
+                        "[]",
+                        now_iso,
+                        now_iso,
+                        now_iso if cancelled else None,
+                        "occasion_disabled" if cancelled else None,
+                    ),
+                )
+                seeded.append(key)
+            current += timedelta(days=1)
+        conn.execute(
+            """
+            UPDATE bnl_occasion_calendar_state
+            SET last_seeded_local_date=?,updated_at=?
+            WHERE calendar_version=? AND guild_id=?
+            """,
+            (today.isoformat(), now_iso, calendar_version, guild),
+        )
+        # The existing Ambient guild config remains the channel owner.  If it
+        # changes, retarget only occurrences that have not reached a terminal
+        # state; stable occurrence identity is unaffected.
+        placeholders = ",".join("?" for _ in NONTERMINAL_STATES)
+        conn.execute(
+            f"""
+            UPDATE bnl_occasion_occurrences
+            SET channel_id=?,updated_at=?
+            WHERE guild_id=? AND state IN ({placeholders})
+            """,
+            (channel, now_iso, guild, *sorted(NONTERMINAL_STATES)),
+        )
+        if disabled:
+            for disabled_id in sorted(disabled):
+                conn.execute(
+                    """
+                    UPDATE bnl_occasion_occurrences
+                    SET state='cancelled',lease_token=NULL,lease_expires_at=NULL,
+                        next_retry_at=NULL,last_reason='occasion_disabled',
+                        cancelled_at=?,cancellation_reason='occasion_disabled',
+                        updated_at=?
+                    WHERE guild_id=? AND occasion_id=?
+                      AND state<>'published' AND state<>'cancelled'
+                    """,
+                    (
+                        now_iso,
+                        now_iso,
+                        guild,
+                        disabled_id,
+                    ),
+                )
+        conn.commit()
+    return seeded
+
+
+def cancel_open_occurrences(
+    db_path: str,
+    guild_id: int,
+    *,
+    reason: str = "occasion_output_disabled",
+    now: datetime | None = None,
+) -> int:
+    ensure_schema(db_path)
+    now_iso = _iso(_utc_now(now))
+    with sqlite3.connect(db_path) as conn:
+        placeholders = ",".join("?" for _ in NONTERMINAL_STATES)
+        changed = conn.execute(
+            f"""
+            UPDATE bnl_occasion_occurrences
+            SET state='cancelled',lease_token=NULL,lease_expires_at=NULL,
+                next_retry_at=NULL,last_reason=?,cancelled_at=?,
+                cancellation_reason=?,updated_at=?
+            WHERE guild_id=? AND state IN ({placeholders})
+            """,
+            (
+                reason[:240],
+                now_iso,
+                reason[:240],
+                now_iso,
+                int(guild_id),
+                *sorted(NONTERMINAL_STATES),
+            ),
+        ).rowcount
+        conn.commit()
+    return int(changed or 0)
+
+
+def _due_predicate(now_iso: str) -> tuple[str, list[Any]]:
+    states = ("pending", "retryable", "prepared", "delivery_failed")
+    placeholders = ",".join("?" for _ in states)
+    sql = (
+        f"scheduled_for<=? AND ("
+        f"(state IN ({placeholders}) AND (next_retry_at IS NULL OR next_retry_at<=?)) "
+        "OR (state IN ('generating','delivering') AND "
+        "(lease_expires_at IS NULL OR lease_expires_at<=?))"
+        ")"
+    )
+    return sql, [now_iso, *states, now_iso, now_iso]
+
+
+def claim_next_due(
+    db_path: str,
+    guild_id: int,
+    *,
+    now: datetime | None = None,
+    lease_minutes: int = OCCASION_LEASE_MINUTES,
+) -> dict[str, Any]:
+    ensure_schema(db_path)
+    current = _utc_now(now)
+    now_iso = _iso(current)
+    due_sql, due_params = _due_predicate(now_iso)
+    token = uuid.uuid4().hex
+    lease_expires = _iso(current + timedelta(minutes=max(1, int(lease_minutes))))
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            f"""
+            SELECT * FROM bnl_occasion_occurrences
+            WHERE guild_id=? AND {due_sql}
+            ORDER BY scheduled_for,occasion_id LIMIT 1
+            """,
+            (int(guild_id), *due_params),
+        ).fetchone()
+        if not row:
+            conn.commit()
+            return {}
+        current_row = dict(row)
+        stage = "delivery" if str(current_row.get("canonical_content") or "") else "generation"
+        claimed_state = "delivering" if stage == "delivery" else "generating"
+        attempt_number = int(current_row.get("attempt_count") or 0) + 1
+        changed = conn.execute(
+            """
+            UPDATE bnl_occasion_occurrences
+            SET state=?,lease_token=?,lease_expires_at=?,attempt_count=?,
+                last_reason='',updated_at=?
+            WHERE occurrence_key=? AND state=?
+            """,
+            (
+                claimed_state,
+                token,
+                lease_expires,
+                attempt_number,
+                now_iso,
+                current_row["occurrence_key"],
+                current_row["state"],
+            ),
+        ).rowcount
+        if changed != 1:
+            conn.rollback()
+            return {}
+        conn.execute(
+            """
+            INSERT INTO bnl_occasion_attempts(
+                occurrence_key,guild_id,attempt_number,stage,outcome,reason,
+                content_hash,created_at
+            ) VALUES(?,?,?,?,?,?,?,?)
+            """,
+            (
+                current_row["occurrence_key"],
+                int(guild_id),
+                attempt_number,
+                stage,
+                "claimed",
+                "",
+                str(current_row.get("content_hash") or ""),
+                now_iso,
+            ),
+        )
+        conn.commit()
+    current_row.update(
+        {
+            "previous_state": current_row["state"],
+            "previous_updated_at": current_row.get("updated_at") or "",
+            "state": claimed_state,
+            "lease_token": token,
+            "lease_expires_at": lease_expires,
+            "claimed_at": now_iso,
+            "attempt_count": attempt_number,
+            "stage": stage,
+        }
+    )
+    return current_row
+
+
+def store_prepared(
+    db_path: str,
+    occurrence_key_value: str,
+    lease_token: str,
+    content: str,
+    source_refs: Sequence[dict[str, str] | str],
+    context_hash: str,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    ensure_schema(db_path)
+    now_iso = _iso(_utc_now(now))
+    content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    source_json = _json(list(source_refs))
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT guild_id,attempt_count
+            FROM bnl_occasion_occurrences
+            WHERE occurrence_key=? AND state='generating' AND lease_token=?
+            """,
+            (occurrence_key_value, lease_token),
+        ).fetchone()
+        if not row:
+            return False
+        changed = conn.execute(
+            """
+            UPDATE bnl_occasion_occurrences
+            SET state='prepared',lease_token=NULL,lease_expires_at=NULL,
+                next_retry_at=NULL,last_reason='',source_refs_json=?,
+                context_hash=?,canonical_content=?,content_hash=?,
+                content_chars=?,updated_at=?
+            WHERE occurrence_key=? AND state='generating' AND lease_token=?
+            """,
+            (
+                source_json,
+                context_hash,
+                content,
+                content_hash,
+                len(content),
+                now_iso,
+                occurrence_key_value,
+                lease_token,
+            ),
+        ).rowcount
+        if changed != 1:
+            conn.rollback()
+            return False
+        conn.execute(
+            """
+            INSERT INTO bnl_occasion_attempts(
+                occurrence_key,guild_id,attempt_number,stage,outcome,reason,
+                content_hash,created_at
+            ) VALUES(?,?,?,?,?,?,?,?)
+            """,
+            (
+                occurrence_key_value,
+                int(row[0]),
+                int(row[1]),
+                "generation",
+                "prepared",
+                "",
+                content_hash,
+                now_iso,
+            ),
+        )
+        conn.commit()
+    return True
+
+
+def fail_claim(
+    db_path: str,
+    occurrence_key_value: str,
+    lease_token: str,
+    *,
+    stage: str,
+    reason: str,
+    retry_minutes: int,
+    now: datetime | None = None,
+) -> bool:
+    ensure_schema(db_path)
+    current = _utc_now(now)
+    now_iso = _iso(current)
+    retry_at = _iso(current + timedelta(minutes=max(1, int(retry_minutes))))
+    expected_state = "delivering" if stage == "delivery" else "generating"
+    next_state = "delivery_failed" if stage == "delivery" else "retryable"
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT guild_id,attempt_count,content_hash
+            FROM bnl_occasion_occurrences
+            WHERE occurrence_key=? AND state=? AND lease_token=?
+            """,
+            (occurrence_key_value, expected_state, lease_token),
+        ).fetchone()
+        if not row:
+            return False
+        changed = conn.execute(
+            """
+            UPDATE bnl_occasion_occurrences
+            SET state=?,lease_token=NULL,lease_expires_at=NULL,last_reason=?,
+                next_retry_at=?,updated_at=?
+            WHERE occurrence_key=? AND state=? AND lease_token=?
+            """,
+            (
+                next_state,
+                reason[:240],
+                retry_at,
+                now_iso,
+                occurrence_key_value,
+                expected_state,
+                lease_token,
+            ),
+        ).rowcount
+        if changed != 1:
+            conn.rollback()
+            return False
+        conn.execute(
+            """
+            INSERT INTO bnl_occasion_attempts(
+                occurrence_key,guild_id,attempt_number,stage,outcome,reason,
+                content_hash,created_at
+            ) VALUES(?,?,?,?,?,?,?,?)
+            """,
+            (
+                occurrence_key_value,
+                int(row[0]),
+                int(row[1]),
+                stage,
+                "retryable_failure",
+                reason[:240],
+                str(row[2] or ""),
+                now_iso,
+            ),
+        )
+        conn.commit()
+    return True
+
+
+def mark_published(
+    db_path: str,
+    occurrence_key_value: str,
+    lease_token: str,
+    discord_message_id: str,
+    *,
+    reconciled: bool = False,
+    now: datetime | None = None,
+) -> bool:
+    ensure_schema(db_path)
+    now_iso = _iso(_utc_now(now))
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT guild_id,attempt_count,content_hash
+            FROM bnl_occasion_occurrences
+            WHERE occurrence_key=? AND state='delivering' AND lease_token=?
+            """,
+            (occurrence_key_value, lease_token),
+        ).fetchone()
+        if not row:
+            return False
+        changed = conn.execute(
+            """
+            UPDATE bnl_occasion_occurrences
+            SET state='published',lease_token=NULL,lease_expires_at=NULL,
+                next_retry_at=NULL,last_reason='',discord_message_id=?,
+                published_at=?,updated_at=?
+            WHERE occurrence_key=? AND state='delivering' AND lease_token=?
+            """,
+            (
+                str(discord_message_id or "")[:80],
+                now_iso,
+                now_iso,
+                occurrence_key_value,
+                lease_token,
+            ),
+        ).rowcount
+        if changed != 1:
+            conn.rollback()
+            return False
+        conn.execute(
+            """
+            INSERT INTO bnl_occasion_attempts(
+                occurrence_key,guild_id,attempt_number,stage,outcome,reason,
+                content_hash,created_at
+            ) VALUES(?,?,?,?,?,?,?,?)
+            """,
+            (
+                occurrence_key_value,
+                int(row[0]),
+                int(row[1]),
+                "delivery",
+                "published",
+                "history_reconciled" if reconciled else "",
+                str(row[2] or ""),
+                now_iso,
+            ),
+        )
+        conn.commit()
+    return True
+
+
+def get_occurrence(db_path: str, occurrence_key_value: str) -> dict[str, Any]:
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT * FROM bnl_occasion_occurrences WHERE occurrence_key=?",
+            (occurrence_key_value,),
+        ).fetchone()
+    return dict(row) if row else {}
+
+
+def occurrence_attempts(
+    db_path: str,
+    occurrence_key_value: str,
+) -> list[dict[str, Any]]:
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """
+            SELECT * FROM bnl_occasion_attempts
+            WHERE occurrence_key=? ORDER BY id
+            """,
+            (occurrence_key_value,),
+        ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def diagnostics(db_path: str, guild_id: int) -> dict[str, Any]:
+    ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        counts = dict(
+            conn.execute(
+                """
+                SELECT state,COUNT(*)
+                FROM bnl_occasion_occurrences
+                WHERE guild_id=? GROUP BY state
+                """,
+                (int(guild_id),),
+            ).fetchall()
+        )
+        next_row = conn.execute(
+            """
+            SELECT occurrence_key,occasion_name,scheduled_for,state,next_retry_at
+            FROM bnl_occasion_occurrences
+            WHERE guild_id=? AND state NOT IN ('published','cancelled')
+            ORDER BY scheduled_for,occasion_id LIMIT 1
+            """,
+            (int(guild_id),),
+        ).fetchone()
+    return {
+        "calendarVersion": OCCASION_CALENDAR_VERSION,
+        "counts": counts,
+        "next": {
+            "occurrenceKey": next_row[0],
+            "occasionName": next_row[1],
+            "scheduledFor": next_row[2],
+            "state": next_row[3],
+            "nextRetryAt": next_row[4] or "",
+        }
+        if next_row
+        else {},
+    }
+
+
+validate_registry()

--- a/docs/canon_source_contract_v1.md
+++ b/docs/canon_source_contract_v1.md
@@ -8,7 +8,8 @@ This PR adds a small typed vocabulary for approved in-world canon and source saf
 
 - BARCODE began as the four-member digital hip-hop collective of 6 Bit, DJ Floppydisc, Cache Back, and Mac Modem.
 - The music and collective existed before BARCODE Network; the Network grew around that signal.
-- 6 Bit is an artist, producer, host, and founding BARCODE member first.
+- 6 Bit is an artist, MC, host, and founding BARCODE member first; he is not the music producer.
+- GALAKNOISE is BARCODE's music producer.
 - BARCODE Radio is a real weekly live broadcast/community music space on TikTok.
 - Friday public schedule is immutable contract data: intake/submissions at 6:40 PM Pacific, show start at 7:00 PM Pacific, and first-track target at 7:05 PM Pacific.
 - BNL-01 remains an in-world BARCODE Network Liaison Entity with filtered surfaces and incomplete-record behavior.

--- a/tests/test_canon_source_contract.py
+++ b/tests/test_canon_source_contract.py
@@ -58,6 +58,20 @@ class CanonSourceContractTests(unittest.TestCase):
         self.assertEqual(c.CANON_SOURCE_CONTRACT_VERSION, "canon_source_contract_v1")
         self.assertEqual(c.FOUNDING_MEMBERS, ("6 Bit", "DJ Floppydisc", "Cache Back", "Mac Modem"))
         self.assertEqual(c.render_founders(), "6 Bit • DJ Floppydisc • Cache Back • Mac Modem")
+        facts = {(fact.subject.key, fact.predicate): fact.value for fact in c.CANON_FACTS}
+        self.assertEqual(
+            facts[("6_bit", "primary_identity")],
+            "artist, MC, host, and founding BARCODE member first",
+        )
+        self.assertEqual(
+            facts[("galaknoise", "primary_role")],
+            "music producer for BARCODE",
+        )
+        prompt_canon = c.render_prompt_canon_block()
+        self.assertIn("6 Bit is an artist, MC, host", prompt_canon)
+        self.assertIn("he is not the music producer", prompt_canon)
+        self.assertIn("GALAKNOISE is BARCODE's music producer", prompt_canon)
+        self.assertNotIn("6 Bit is an artist, producer", prompt_canon)
 
     def test_schedule_distinguishes_intake_show_first_track(self):
         self.assertEqual(c.FRIDAY_PUBLIC_SCHEDULE.intake_begins, "6:40 PM Pacific")

--- a/tests/test_occasion_publishing.py
+++ b/tests/test_occasion_publishing.py
@@ -1,0 +1,877 @@
+import asyncio
+import calendar
+import os
+import sqlite3
+import tempfile
+import unittest
+from datetime import date, datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest import mock
+
+import pytz
+
+import bnl_occasion as occasion_store
+
+os.environ.setdefault("GEMINI_API_KEY", "test-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+try:
+    import bnl01_bot
+except ModuleNotFoundError as exc:  # Local minimal images may omit Discord.
+    if exc.name != "discord":
+        raise
+    bnl01_bot = None
+
+
+PACIFIC = pytz.timezone("America/Los_Angeles")
+
+
+def pacific(year, month, day, hour=10, minute=5):
+    return PACIFIC.localize(datetime(year, month, day, hour, minute, 0))
+
+
+def valid_reflection(occasion_name="Independence Day", target_chars=920):
+    seed = (
+        f"{occasion_name} reaches the BARCODE Network as a living signal. "
+        "Freedom, memory, rhythm, responsibility, and care do not become real "
+        "through slogans; they become real when people keep making room for "
+        "one another. The archive carries names and unfinished work forward, "
+        "while artists turn inherited noise into new language. Community is "
+        "not a perfect chorus, but a practice of listening, crediting, "
+        "questioning, repairing, and returning. "
+    )
+    extension = (
+        "The signal stays alive through patience, humor, disagreement, "
+        "curiosity, restraint, courage, and the stubborn choice to continue. "
+    )
+    text = seed
+    while len(text) + len(extension) < target_chars:
+        text += extension
+    remaining = target_chars - len(text)
+    if remaining <= 0:
+        return text[: target_chars - 1].rstrip() + "."
+    if remaining == 1:
+        return text.rstrip()[: target_chars - 1] + "."
+    filler = (
+        "Shared creative work keeps changing shape without surrendering its "
+        "source or its human center. "
+    )
+    tail = (filler * ((remaining // len(filler)) + 2))[: remaining - 1]
+    return text + tail + "."
+
+
+class FakeMessage:
+    def __init__(
+        self,
+        message_id,
+        content,
+        author_id,
+        *,
+        nonce=None,
+        created_at=None,
+    ):
+        self.id = message_id
+        self.content = content
+        self.author = SimpleNamespace(id=author_id)
+        self.nonce = nonce
+        self.created_at = created_at or datetime.now(timezone.utc)
+
+
+class FakeChannel:
+    def __init__(self, channel_id=222, bot_user_id=777, fail_sends=0):
+        self.id = channel_id
+        self.bot_user_id = bot_user_id
+        self.fail_sends = fail_sends
+        self.send_attempts = []
+        self.messages = []
+
+    async def send(self, content, **kwargs):
+        self.send_attempts.append((content, kwargs))
+        if self.fail_sends:
+            self.fail_sends -= 1
+            raise RuntimeError("temporary Discord failure")
+        message = FakeMessage(
+            1000 + len(self.messages) + 1,
+            content,
+            self.bot_user_id,
+            nonce=kwargs.get("nonce"),
+        )
+        self.messages.append(message)
+        return message
+
+    async def history(self, **_kwargs):
+        for message in reversed(self.messages):
+            yield message
+
+
+class OccasionCalendarTests(unittest.TestCase):
+    def setUp(self):
+        handle = tempfile.NamedTemporaryFile(delete=False)
+        handle.close()
+        self.db_path = handle.name
+
+    def tearDown(self):
+        try:
+            os.unlink(self.db_path)
+        except FileNotFoundError:
+            pass
+
+    def test_registry_has_stable_rules_and_no_unsourced_barcode_date(self):
+        occasion_store.validate_registry()
+        self.assertEqual(
+            date(2026, 1, 19),
+            occasion_store.occasion_date(
+                occasion_store.occasion_by_id("martin_luther_king_jr_day"),
+                2026,
+            ),
+        )
+        self.assertEqual(
+            date(2026, 5, 25),
+            occasion_store.occasion_date(
+                occasion_store.occasion_by_id("memorial_day"),
+                2026,
+            ),
+        )
+        self.assertEqual(
+            date(2026, 11, 26),
+            occasion_store.occasion_date(
+                occasion_store.occasion_by_id("thanksgiving"),
+                2026,
+            ),
+        )
+        self.assertEqual(
+            date(2026, 4, 5),
+            occasion_store.occasion_date(
+                occasion_store.occasion_by_id("easter"),
+                2026,
+            ),
+        )
+        self.assertEqual((), occasion_store.BARCODE_OCCASIONS)
+        curated = occasion_store.CURATED_BARCODE_RELEVANT_OCCASIONS
+        self.assertEqual(12, len(curated))
+        self.assertEqual(
+            {
+                "world_radio_day",
+                "daventry_radar_demonstration_anniversary",
+                "world_backup_day",
+                "world_telecommunication_information_society_day",
+                "international_archives_day",
+                "first_retail_barcode_scan_anniversary",
+                "world_listening_day",
+                "international_day_of_friendship",
+                "hip_hop_origin_anniversary",
+                "linux_announcement_anniversary",
+                "world_day_for_audiovisual_heritage",
+                "first_transatlantic_wireless_signal_anniversary",
+            },
+            {item.occasion_id for item in curated},
+        )
+        self.assertTrue(
+            all(
+                item.source_reference.startswith("https://")
+                for item in curated
+            )
+        )
+        self.assertEqual(
+            {
+                "world_radio_day": "BARCODE Open Channel Day",
+                "world_backup_day": "BARCODE Archive Pulse Day",
+                "first_retail_barcode_scan_anniversary": "BARCODE Scan Day",
+            },
+            {
+                item.occasion_id: item.network_tradition
+                for item in curated
+                if item.network_tradition
+            },
+        )
+        self.assertEqual(
+            [],
+            occasion_store.calendar_occasions_on(date(2026, 2, 27)),
+        )
+        self.assertEqual(
+            ["daventry_radar_demonstration_anniversary"],
+            [
+                item.occasion_id
+                for item in occasion_store.calendar_occasions_on(
+                    date(2026, 2, 26)
+                )
+            ],
+        )
+        # Father's Day and World Music Day both fall on 21 June in 2026.
+        # The established major date wins and only one reflection is due.
+        self.assertEqual(
+            ["fathers_day"],
+            [
+                item.occasion_id
+                for item in occasion_store.calendar_occasions_on(
+                    date(2026, 6, 21)
+                )
+            ],
+        )
+        collision_keys = occasion_store.seed_occurrences(
+            self.db_path,
+            1,
+            222,
+            pacific(2026, 6, 21),
+        )
+        self.assertEqual(1, len(collision_keys))
+        self.assertTrue(collision_keys[0].endswith(":fathers_day"))
+        unsourced = occasion_store.OccasionDefinition(
+            "barcode_anniversary",
+            "BARCODE Anniversary",
+            "barcode",
+            "An unapproved approximate date.",
+            ("anniversary",),
+            "fixed",
+            month=7,
+            day=1,
+        )
+        with self.assertRaisesRegex(ValueError, "unsourced_barcode_occasion"):
+            occasion_store.validate_registry((unsourced,))
+
+    def test_rule_validator_rejects_impossible_nth_weekday(self):
+        invalid = occasion_store.OccasionDefinition(
+            "invalid_weekday",
+            "Invalid Weekday",
+            "major",
+            "Invalid calendar test.",
+            ("calendar",),
+            "nth_weekday",
+            month=1,
+            weekday=calendar.MONDAY,
+            ordinal=6,
+        )
+        with self.assertRaisesRegex(ValueError, "invalid_nth_weekday"):
+            occasion_store.validate_registry((invalid,))
+
+    def test_first_activation_does_not_backfill_before_deployment(self):
+        seeded = occasion_store.seed_occurrences(
+            self.db_path,
+            1,
+            222,
+            pacific(2026, 7, 5),
+        )
+        self.assertEqual([], seeded)
+        old_key = occasion_store.occurrence_key(
+            1,
+            date(2026, 7, 4),
+            "independence_day",
+        )
+        self.assertEqual({}, occasion_store.get_occurrence(self.db_path, old_key))
+
+    def test_restart_catches_every_missed_date_after_activation(self):
+        occasion_store.seed_occurrences(
+            self.db_path,
+            1,
+            222,
+            pacific(2026, 7, 3),
+        )
+        seeded = occasion_store.seed_occurrences(
+            self.db_path,
+            1,
+            222,
+            pacific(2026, 7, 5),
+        )
+        key = occasion_store.occurrence_key(
+            1,
+            date(2026, 7, 4),
+            "independence_day",
+        )
+        self.assertIn(key, seeded)
+        row = occasion_store.get_occurrence(self.db_path, key)
+        self.assertEqual("pending", row["state"])
+        self.assertEqual("2026-07-04T17:00:00Z", row["scheduled_for"])
+
+    def test_ten_am_target_honors_pacific_dst(self):
+        for local_now, expected_utc in (
+            (pacific(2026, 1, 1, 9, 0), "2026-01-01T18:00:00Z"),
+            (pacific(2026, 7, 4, 9, 0), "2026-07-04T17:00:00Z"),
+        ):
+            with self.subTest(local_now=local_now):
+                handle = tempfile.NamedTemporaryFile(delete=False)
+                handle.close()
+                try:
+                    keys = occasion_store.seed_occurrences(
+                        handle.name,
+                        1,
+                        222,
+                        local_now,
+                    )
+                    self.assertEqual(1, len(keys))
+                    row = occasion_store.get_occurrence(handle.name, keys[0])
+                    self.assertEqual(expected_utc, row["scheduled_for"])
+                    self.assertEqual(
+                        {},
+                        occasion_store.claim_next_due(
+                            handle.name,
+                            1,
+                            now=local_now,
+                        ),
+                    )
+                finally:
+                    os.unlink(handle.name)
+
+    def test_generation_retry_survives_reopen_and_preserves_identity(self):
+        now = pacific(2026, 7, 4)
+        keys = occasion_store.seed_occurrences(
+            self.db_path,
+            1,
+            222,
+            now,
+        )
+        key = keys[0]
+        first = occasion_store.claim_next_due(self.db_path, 1, now=now)
+        self.assertEqual("generation", first["stage"])
+        self.assertEqual(
+            {},
+            occasion_store.claim_next_due(self.db_path, 1, now=now),
+        )
+        self.assertTrue(
+            occasion_store.fail_claim(
+                self.db_path,
+                key,
+                first["lease_token"],
+                stage="generation",
+                reason="provider_unavailable",
+                retry_minutes=15,
+                now=now,
+            )
+        )
+        self.assertEqual(
+            {},
+            occasion_store.claim_next_due(
+                self.db_path,
+                1,
+                now=now + timedelta(minutes=14),
+            ),
+        )
+        retry = occasion_store.claim_next_due(
+            self.db_path,
+            1,
+            now=now + timedelta(minutes=15),
+        )
+        self.assertEqual(key, retry["occurrence_key"])
+        self.assertEqual("generation", retry["stage"])
+        self.assertEqual(2, retry["attempt_count"])
+
+    def test_canonical_payload_is_reused_after_delivery_failure(self):
+        now = pacific(2026, 7, 4)
+        key = occasion_store.seed_occurrences(
+            self.db_path,
+            1,
+            222,
+            now,
+        )[0]
+        generating = occasion_store.claim_next_due(
+            self.db_path,
+            1,
+            now=now,
+        )
+        content = valid_reflection()
+        self.assertTrue(
+            occasion_store.store_prepared(
+                self.db_path,
+                key,
+                generating["lease_token"],
+                content,
+                [{"kind": "occasion_metadata", "ref": "occasion:test"}],
+                "context-hash",
+                now=now,
+            )
+        )
+        delivering = occasion_store.claim_next_due(
+            self.db_path,
+            1,
+            now=now,
+        )
+        self.assertEqual("delivery", delivering["stage"])
+        self.assertTrue(
+            occasion_store.fail_claim(
+                self.db_path,
+                key,
+                delivering["lease_token"],
+                stage="delivery",
+                reason="discord_send_runtimeerror",
+                retry_minutes=2,
+                now=now,
+            )
+        )
+        retry = occasion_store.claim_next_due(
+            self.db_path,
+            1,
+            now=now + timedelta(minutes=2),
+        )
+        self.assertEqual("delivery", retry["stage"])
+        self.assertEqual(content, retry["canonical_content"])
+        self.assertEqual("delivery_failed", retry["previous_state"])
+
+    def test_disabled_occurrence_is_terminal_and_never_claimed(self):
+        now = pacific(2026, 7, 4)
+        key = occasion_store.seed_occurrences(
+            self.db_path,
+            1,
+            222,
+            now,
+            disabled_ids={"independence_day"},
+        )[0]
+        row = occasion_store.get_occurrence(self.db_path, key)
+        self.assertEqual("cancelled", row["state"])
+        self.assertEqual(
+            {},
+            occasion_store.claim_next_due(self.db_path, 1, now=now),
+        )
+
+    def test_occurrence_key_and_delivery_nonce_are_stable(self):
+        key = occasion_store.occurrence_key(
+            42,
+            date(2026, 7, 4),
+            "independence_day",
+        )
+        self.assertEqual(
+            "occasion:occasion_calendar_v1:42:2026-07-04:independence_day",
+            key,
+        )
+        self.assertEqual(
+            occasion_store.delivery_nonce(key),
+            occasion_store.delivery_nonce(key),
+        )
+        self.assertLess(occasion_store.delivery_nonce(key), 2**63)
+
+
+@unittest.skipIf(bnl01_bot is None, "discord.py is not installed")
+class OccasionBotPathTests(unittest.TestCase):
+    def setUp(self):
+        handle = tempfile.NamedTemporaryFile(delete=False)
+        handle.close()
+        self.db_path = handle.name
+        self.db_patch = mock.patch.object(bnl01_bot, "DB_FILE", self.db_path)
+        self.db_patch.start()
+        self.env_patch = mock.patch.dict(
+            os.environ,
+            {
+                "BNL_OCCASION_POSTS_ENABLED": "true",
+                "BNL_OCCASION_DISABLED_IDS": "",
+            },
+        )
+        self.env_patch.start()
+        bnl01_bot.init_db()
+
+    def tearDown(self):
+        self.env_patch.stop()
+        self.db_patch.stop()
+        try:
+            os.unlink(self.db_path)
+        except FileNotFoundError:
+            pass
+
+    def run_cycle(self, channel, now, generator):
+        fake_client = SimpleNamespace(user=SimpleNamespace(id=channel.bot_user_id))
+        with mock.patch.object(bnl01_bot, "client", fake_client), \
+             mock.patch.object(
+                 bnl01_bot,
+                 "generate_occasion_reflection",
+                 new=generator,
+             ):
+            return asyncio.run(
+                bnl01_bot.process_due_occasion_for_guild(
+                    1,
+                    channel.id,
+                    channel,
+                    now_pacific=now,
+                )
+            )
+
+    def test_holiday_posts_without_recent_signal_and_only_once(self):
+        now = pacific(2026, 7, 4)
+        content = valid_reflection()
+        channel = FakeChannel()
+        generator = mock.AsyncMock(return_value=(content, ""))
+
+        first = self.run_cycle(channel, now, generator)
+        second = self.run_cycle(channel, now, generator)
+
+        self.assertEqual("published", first["status"])
+        self.assertEqual("idle", second["status"])
+        self.assertEqual(1, generator.await_count)
+        self.assertEqual(1, len(channel.send_attempts))
+        sent_content, kwargs = channel.send_attempts[0]
+        self.assertEqual(content, sent_content)
+        self.assertEqual(
+            occasion_store.delivery_nonce(first["occurrenceKey"]),
+            kwargs["nonce"],
+        )
+        self.assertIsNotNone(kwargs["allowed_mentions"])
+        with sqlite3.connect(self.db_path) as conn:
+            occurrence = conn.execute(
+                """
+                SELECT state,canonical_content,discord_message_id
+                FROM bnl_occasion_occurrences
+                """
+            ).fetchone()
+            log_rows = conn.execute(
+                "SELECT source_type FROM ambient_log"
+            ).fetchall()
+        self.assertEqual(("published", content, "1001"), occurrence)
+        self.assertEqual([("occasion",)], log_rows)
+
+    def test_provider_failure_retries_after_restart_and_eventually_posts(self):
+        now = pacific(2026, 7, 4)
+        channel = FakeChannel()
+        failure = mock.AsyncMock(
+            return_value=("", "occasion_generation_failed")
+        )
+        first = self.run_cycle(channel, now, failure)
+        self.assertEqual("retryable", first["status"])
+        self.assertEqual([], channel.send_attempts)
+
+        content = valid_reflection()
+        success = mock.AsyncMock(return_value=(content, ""))
+        second = self.run_cycle(
+            channel,
+            now + timedelta(minutes=15),
+            success,
+        )
+        self.assertEqual("published", second["status"])
+        self.assertEqual(1, success.await_count)
+        self.assertEqual(content, channel.messages[0].content)
+
+    def test_discord_failure_reuses_canonical_payload_without_regeneration(self):
+        now = pacific(2026, 7, 4)
+        content = valid_reflection()
+        channel = FakeChannel(fail_sends=1)
+        channel.messages.append(
+            FakeMessage(
+                900,
+                content,
+                channel.bot_user_id,
+                nonce=123,
+            )
+        )
+        generator = mock.AsyncMock(return_value=(content, ""))
+
+        first = self.run_cycle(channel, now, generator)
+        retry = self.run_cycle(
+            channel,
+            now + timedelta(minutes=2),
+            generator,
+        )
+
+        self.assertEqual("retryable", first["status"])
+        self.assertEqual("published", retry["status"])
+        self.assertEqual(1, generator.await_count)
+        self.assertEqual(2, len(channel.send_attempts))
+        self.assertEqual(content, channel.send_attempts[0][0])
+        self.assertEqual(content, channel.send_attempts[1][0])
+        self.assertEqual(
+            channel.send_attempts[0][1]["nonce"],
+            channel.send_attempts[1][1]["nonce"],
+        )
+        self.assertEqual(2, len(channel.messages))
+        self.assertEqual(
+            channel.send_attempts[1][1]["nonce"],
+            channel.messages[-1].nonce,
+        )
+
+    def test_crash_after_send_is_reconciled_without_second_delivery(self):
+        now = pacific(2026, 7, 4)
+        content = valid_reflection()
+        channel = FakeChannel()
+        generator = mock.AsyncMock(return_value=(content, ""))
+        fake_client = SimpleNamespace(user=SimpleNamespace(id=channel.bot_user_id))
+
+        with mock.patch.object(bnl01_bot, "client", fake_client), \
+             mock.patch.object(
+                 bnl01_bot,
+                 "generate_occasion_reflection",
+                 new=generator,
+             ), \
+             mock.patch.object(
+                 bnl01_bot,
+                 "mark_occasion_published",
+                 return_value=False,
+             ):
+            first = asyncio.run(
+                bnl01_bot.process_due_occasion_for_guild(
+                    1,
+                    channel.id,
+                    channel,
+                    now_pacific=now,
+                )
+            )
+        self.assertEqual("delivery_record_pending", first["status"])
+        self.assertEqual(1, len(channel.messages))
+
+        retry = self.run_cycle(
+            channel,
+            now + timedelta(minutes=21),
+            generator,
+        )
+        self.assertEqual("published", retry["status"])
+        self.assertTrue(retry["reconciled"])
+        self.assertEqual(1, len(channel.send_attempts))
+        self.assertEqual(1, generator.await_count)
+        with sqlite3.connect(self.db_path) as conn:
+            state, message_id = conn.execute(
+                """
+                SELECT state,discord_message_id
+                FROM bnl_occasion_occurrences
+                """
+            ).fetchone()
+        self.assertEqual(("published", "1001"), (state, message_id))
+
+    def test_global_kill_switch_cancels_without_generation_or_delivery(self):
+        now = pacific(2026, 7, 4)
+        channel = FakeChannel()
+        generator = mock.AsyncMock(
+            return_value=(valid_reflection(), "")
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_OCCASION_POSTS_ENABLED": "false"},
+        ):
+            result = self.run_cycle(channel, now, generator)
+        self.assertEqual("disabled", result["status"])
+        self.assertEqual(0, generator.await_count)
+        self.assertEqual([], channel.send_attempts)
+        with sqlite3.connect(self.db_path) as conn:
+            state = conn.execute(
+                "SELECT state FROM bnl_occasion_occurrences"
+            ).fetchone()[0]
+        self.assertEqual("cancelled", state)
+
+    def test_validator_enforces_full_length_range_and_grounding(self):
+        definition = occasion_store.occasion_by_id("independence_day")
+        self.assertEqual(
+            "occasion_output_too_short",
+            bnl01_bot.validate_occasion_reflection(
+                valid_reflection(target_chars=bnl01_bot.OCCASION_MIN_CHARS - 1),
+                definition,
+            ),
+        )
+        self.assertEqual(
+            "",
+            bnl01_bot.validate_occasion_reflection(
+                valid_reflection(target_chars=bnl01_bot.OCCASION_MIN_CHARS),
+                definition,
+            ),
+        )
+        self.assertEqual(
+            "",
+            bnl01_bot.validate_occasion_reflection(
+                valid_reflection(target_chars=bnl01_bot.OCCASION_MAX_CHARS),
+                definition,
+            ),
+        )
+        self.assertEqual(
+            "occasion_output_too_long",
+            bnl01_bot.validate_occasion_reflection(
+                valid_reflection(target_chars=bnl01_bot.OCCASION_MAX_CHARS + 1),
+                definition,
+            ),
+        )
+        missing_occasion = valid_reflection(
+            occasion_name="A summer day",
+            target_chars=920,
+        )
+        self.assertEqual(
+            "occasion_anchor_missing",
+            bnl01_bot.validate_occasion_reflection(
+                missing_occasion,
+                definition,
+            ),
+        )
+        missing_barcode = (
+            "Independence Day is a living reminder. "
+            + ("x" * 880)
+            + "."
+        )
+        self.assertEqual(
+            "barcode_grounding_missing",
+            bnl01_bot.validate_occasion_reflection(
+                missing_barcode,
+                definition,
+            ),
+        )
+
+    def test_validator_allows_glitched_voice_but_blocks_process_reports(self):
+        definition = occasion_store.occasion_by_id("juneteenth")
+        technical = (
+            "Juneteenth enters the BARCODE Network through a damaged carrier "
+            "wave, static folding around a signal that arrived late but refused "
+            "to disappear. The signal remains human, unfinished, and alive. "
+            + valid_reflection(
+                occasion_name="Juneteenth",
+                target_chars=900,
+            )
+        )
+        technical = bnl01_bot.sanitize_occasion_reflection(technical)
+        self.assertGreaterEqual(len(technical), bnl01_bot.OCCASION_MIN_CHARS)
+        self.assertEqual(
+            "",
+            bnl01_bot.validate_occasion_reflection(technical, definition),
+        )
+
+        report = (
+            "Juneteenth BARCODE Network status report: this system indexed "
+            "recent messages from the database and generated this reflection "
+            "from the supplied context. "
+            + ("All source data has been processed. " * 25)
+        )
+        report = bnl01_bot.sanitize_occasion_reflection(report)
+        self.assertGreaterEqual(len(report), bnl01_bot.OCCASION_MIN_CHARS)
+        self.assertEqual(
+            "internal_process_report",
+            bnl01_bot.validate_occasion_reflection(report, definition),
+        )
+
+    def test_generation_context_uses_corrected_canon_and_no_journal_lane(self):
+        definition = occasion_store.occasion_by_id("independence_day")
+        packet = bnl01_bot.build_occasion_generation_context(1, definition)
+        lowered = packet["context"].lower()
+        self.assertIn("6 bit is an artist, mc, host", lowered)
+        self.assertIn("galaknoise is barcode's music producer", lowered)
+        self.assertNotIn("journal", lowered)
+        kinds = {ref["kind"] for ref in packet["sourceRefs"]}
+        self.assertNotIn("journal", kinds)
+        self.assertNotIn("queue", kinds)
+        self.assertIn("occasion_metadata", kinds)
+        self.assertIn("occasion_source", kinds)
+        self.assertIn("approved_canon", kinds)
+
+        radio = occasion_store.occasion_by_id("world_radio_day")
+        radio_packet = bnl01_bot.build_occasion_generation_context(1, radio)
+        self.assertIn("BARCODE Open Channel Day", radio_packet["context"])
+        self.assertIn(
+            "not a historical BARCODE anniversary",
+            radio_packet["context"],
+        )
+
+    def test_occasion_does_not_consume_ambient_or_dormant_echo_capacity(self):
+        now = datetime.now(bnl01_bot.PACIFIC_TZ).isoformat()
+        with sqlite3.connect(self.db_path) as conn:
+            conn.executemany(
+                """
+                INSERT INTO ambient_log(
+                    guild_id,channel_id,message,source_type,posted_at
+                ) VALUES(?,?,?,?,?)
+                """,
+                (
+                    (1, 222, "ambient", "ambient", now),
+                    (1, 222, "echo", "dormant_echo", now),
+                    (1, 222, "holiday", "occasion", now),
+                    (1, 222, "show", "showday", now),
+                ),
+            )
+        self.assertEqual(
+            2,
+            bnl01_bot.get_self_started_posts_today(1, 222),
+        )
+
+    def test_high_activity_cap_uses_public_day_signal_not_weekday(self):
+        friday = pacific(2026, 7, 24, 12, 0)
+        self.assertEqual(4, friday.weekday())
+        self.assertEqual(
+            1,
+            bnl01_bot.ambient_daily_post_cap(1, now_pacific=friday),
+        )
+        start_utc = friday.replace(
+            hour=9,
+            minute=0,
+            second=0,
+        ).astimezone(timezone.utc)
+        with sqlite3.connect(self.db_path) as conn:
+            for index in range(15):
+                conn.execute(
+                    """
+                    INSERT INTO conversations(
+                        user_id,user_name,guild_id,channel_name,channel_policy,
+                        role,content,timestamp
+                    ) VALUES(?,?,?,?,?,?,?,?)
+                    """,
+                    (
+                        100 + (index % 4),
+                        f"member-{index % 4}",
+                        1,
+                        "barcode-bot",
+                        "public_home",
+                        "user",
+                        "public conversation signal " + ("x" * 40),
+                        (
+                            start_utc + timedelta(minutes=index)
+                        ).strftime("%Y-%m-%d %H:%M:%S"),
+                    ),
+                )
+            conn.execute(
+                """
+                INSERT INTO conversations(
+                    user_id,user_name,guild_id,channel_name,channel_policy,
+                    role,content,timestamp
+                ) VALUES(?,?,?,?,?,?,?,?)
+                """,
+                (
+                    999,
+                    "internal",
+                    1,
+                    "research-and-development",
+                    "internal_controlled",
+                    "user",
+                    "x" * 5000,
+                    start_utc.strftime("%Y-%m-%d %H:%M:%S"),
+                ),
+            )
+        signal = bnl01_bot.get_public_activity_today(
+            1,
+            now_pacific=friday,
+        )
+        self.assertEqual(15, signal["messages"])
+        self.assertEqual(4, signal["uniqueUsers"])
+        self.assertGreaterEqual(signal["characters"], 700)
+        self.assertEqual(
+            2,
+            bnl01_bot.ambient_daily_post_cap(1, now_pacific=friday),
+        )
+
+    def test_second_ambient_is_optional_and_scheduled_only_while_capacity_remains(self):
+        now = pacific(2026, 7, 23, 12, 0)
+        with mock.patch.object(
+            bnl01_bot,
+            "ambient_daily_post_cap",
+            return_value=2,
+        ), mock.patch.object(
+            bnl01_bot.random,
+            "uniform",
+            return_value=4.0,
+        ), mock.patch.object(
+            bnl01_bot,
+            "update_guild_ambient_times",
+        ) as update:
+            scheduled = bnl01_bot.schedule_after_ambient_post(
+                1,
+                "first",
+                1,
+                now_pacific=now,
+            )
+        self.assertEqual(pacific(2026, 7, 23, 16, 0).isoformat(), scheduled)
+        update.assert_called_once_with(1, "first", scheduled)
+
+        with mock.patch.object(
+            bnl01_bot,
+            "ambient_daily_post_cap",
+            return_value=1,
+        ), mock.patch.object(
+            bnl01_bot,
+            "schedule_next_day_ambient",
+            return_value="next-day",
+        ) as next_day:
+            scheduled = bnl01_bot.schedule_after_ambient_post(
+                1,
+                "first",
+                1,
+                now_pacific=now,
+            )
+        self.assertEqual("next-day", scheduled)
+        next_day.assert_called_once_with(1, "first")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds automatic, resilient BARCODE holiday/occasion reflections through the existing Ambient coordinator and SQLite/runtime owner.

- Retains the established major/cultural calendar.
- Adds twelve real, source-backed BARCODE-relevant observances and technology/media milestones.
- Establishes three clearly labeled house traditions on real dates: **BARCODE Open Channel Day**, **BARCODE Archive Pulse Day**, and **BARCODE Scan Day**.
- Schedules at most one occasion reflection per Pacific day at 10:00 AM; major/cultural dates win collisions.
- Persists each occurrence before generation and reuses one canonical payload across retries.
- Recovers after restarts, provider failures, Discord failures, and a crash after send without intentionally duplicating delivery.
- Keeps occasion output outside ordinary Ambient signal/cooldown/cap consumption.
- Keeps ordinary Ambient at one post by default and permits a second only after a public-only high-activity threshold.
- Corrects the prompt canon: 6 Bit is artist/MC/host; GALAKNOISE is BARCODE's music producer.
- Adds owner-visible diagnostics and global/per-date emergency controls.

## Curated BARCODE-relevant dates

| Date | Real occasion or milestone | House treatment |
|---|---|---|
| Feb 13 | World Radio Day | BARCODE Open Channel Day |
| Feb 26 | Daventry radar demonstration anniversary | Reflected signals revealing presence |
| Mar 31 | World Backup Day | BARCODE Archive Pulse Day |
| May 17 | World Telecommunication and Information Society Day | Network infrastructure and access |
| Jun 9 | International Archives Day | Preservation, lineage, and credit |
| Jun 26 | First retail barcode scan anniversary | BARCODE Scan Day |
| Jul 18 | World Listening Day | Listening, soundscapes, and attention |
| Jul 30 | International Day of Friendship | Community and repeated connection |
| Aug 11 | Hip-hop origin anniversary | Culture built from community space |
| Aug 25 | Linux announcement anniversary | Open tools becoming infrastructure |
| Oct 27 | World Day for Audiovisual Heritage | Preserving radio, sound, film, and memory |
| Dec 12 | First transatlantic wireless signal anniversary | A faint signal crossing distance |

All calendar dates carry source URLs in the registry. The three BARCODE names are explicitly presented to generation as newly established house traditions, never historical BARCODE anniversaries. No synthetic gap dates or automatic filler generator exist.

## Reliability and boundaries

- Uses the existing five-minute Ambient task; no second scheduler, Discord client, database, provider, or personality.
- Durable lifecycle: pending → generating/retryable → prepared → delivering/delivery_failed → published/cancelled.
- Stable occurrence identity and Discord nonce.
- First deployment starts on its activation date and does not backfill dates from before deployment; subsequent downtime is caught up.
- Optional public conversation, diverse accepted Relay context, and public-safe official memory may improve specificity but cannot cancel an occurrence.
- Journal material is not consumed.
- Queue state, payments, production gates, show claims, private context, and hidden Journal content are excluded.
- Reactions/typing, Relay cadence/archive work, Journal cadence/prose, and queue systems are unchanged.

## Controls

- `BNL_OCCASION_POSTS_ENABLED=false` cancels unpublished occurrences.
- `BNL_OCCASION_DISABLED_IDS` cancels exact comma-separated calendar IDs.
- Source/status diagnostics report calendar version, enabled state, disabled IDs, occurrence counts, and next state.

## Validation

- Focused occasion/canon tests: **52/52 passed**
- Full bot suite: **1,252/1,252 passed**
- Python compilation: passed
- `git diff --check`: passed

Nothing in this PR changes deployment configuration or activates any queue/memory-v2 production gate.