### PR TITLE
Bot: add Relay diversity and Google Drive backup durability

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,50 @@ unpublished occurrences. `BNL_OCCASION_DISABLED_IDS` accepts a comma-separated
 list of calendar IDs for per-occurrence cancellation. These controls do not
 activate queue access, Journal reuse, or any memory-v2 live gate.
 
+## Relay accepted-history durability
+
+Accepted public Relays are retained indefinitely in the existing
+`website_relay_history` SQLite table. The operational recent-25 view remains
+bounded, and the website's public recent-20 projection is unchanged.
+
+`bnl_relay_backup.py` exports a full Relay-only snapshot for a named month. The
+compressed artifact contains only accepted Relay rows plus the minimal Relay
+cursor state; it does not copy the production database, attempts, pending
+drafts, conversations, heartbeats, provider traces, Journals, or other private
+tables.
+
+```bash
+python -m bnl_relay_backup export \
+  --db bnl01_conversations.db \
+  --month 2026-07 \
+  --output-dir backups/relay
+
+python -m bnl_relay_backup verify \
+  --archive backups/relay/<archive>.json.gz \
+  --checksum backups/relay/<archive>.json.gz.sha256
+
+python -m bnl_relay_backup upload \
+  --archive backups/relay/<archive>.json.gz \
+  --checksum backups/relay/<archive>.json.gz.sha256 \
+  --remote "gdrive:BNL-01 Backups/Relay Archive"
+
+python -m bnl_relay_backup round-trip \
+  --archive backups/relay/<archive>.json.gz \
+  --checksum backups/relay/<archive>.json.gz.sha256 \
+  --remote "gdrive:BNL-01 Backups/Relay Archive" \
+  --production-db /home/ubuntu/bnl01/bnl01_conversations.db
+```
+
+Transport uses the operator's external `rclone` configuration and never reads
+or writes OAuth credentials itself. Round-trip proof downloads the artifact,
+verifies its checksum, restores it twice into a temporary isolated database,
+and confirms the production database was untouched.
+
+No timer, service, or cron entry is installed by this repository. The
+`scheduled-run` command fails closed unless
+`BNL_RELAY_BACKUP_SCHEDULE_ENABLED=true`; keep it false until Google Drive
+authentication and an end-to-end owner-approved proof are complete.
+
 Importing `bnl01_bot` does not create a Gemini client or open provider transports. The client is created and cached on the first generation request, so tests, diagnostics, and tooling can import the runtime without valid provider networking.
 
 Run the bot only after the deployment environment is configured:

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -266,6 +266,7 @@ from google import genai
 from bnl_website_relay_state import (
     RelaySourceDecision,
     WebsiteRelayDecision,
+    accepted_publication_count as relay_accepted_publication_count,
     begin_attempt as relay_begin_attempt,
     complete_attempt as relay_complete_attempt,
     get_attempt as relay_get_attempt,
@@ -2818,19 +2819,10 @@ _recent_relay_topics: dict[int, list[str]] = {}
 _recent_weak_context_modes: dict[int, list[str]] = {}
 _last_relay_lane_by_guild: dict[int, str] = {}
 _recent_relay_lanes_by_guild = defaultdict(lambda: deque(maxlen=8))
+_recent_relay_sources_by_guild = defaultdict(lambda: deque(maxlen=8))
 _last_relay_metadata_by_guild: dict[int, dict] = {}
 _website_relay_generation_tasks_by_guild: dict[int, asyncio.Task] = {}
 _website_relay_transaction_locks_by_guild: dict[int, asyncio.Lock] = {}
-RELAY_ANGLE_ROTATION = [
-    "whisper",
-    "wonder",
-    "overheard transmission",
-    "field note",
-    "archive murmur",
-    "cross-band drift",
-    "corridor note",
-    "receiver note",
-]
 RELAY_TOPIC_KEYWORDS = {
     "submission_corridor": ("submit", "submission", "track", "send", "payload", "intake"),
     "host_signal": ("host", "6 bit", "6bit", "voice", "carrier"),
@@ -2840,6 +2832,22 @@ RELAY_TOPIC_KEYWORDS = {
     "signal_drift": ("drift", "interference", "cross-band", "phase", "offset"),
     "timing_tension": ("friday", "tonight", "show", "countdown", "window"),
     "outer_channel_movement": ("outer channel", "corridor", "aperture", "access"),
+}
+QUIET_RELAY_SOURCE_CLASSES = (
+    "conversation_continuity",
+    "broadcast_memory",
+    "canon",
+)
+RELAY_SOURCE_CLASS_ALIASES = {
+    "recent_public_continuity": "conversation_continuity",
+    "scoped_broadcast_memory": "broadcast_memory",
+    "public_safe_memory": "broadcast_memory",
+    "approved_canon": "canon",
+}
+QUIET_RELAY_LANES_BY_SOURCE = {
+    "conversation_continuity": ("residual_echo", "question_formation", "network_posture"),
+    "broadcast_memory": ("residual_echo", "question_formation", "network_posture"),
+    "canon": ("question_formation", "network_posture"),
 }
 force_pull_runner = None
 _force_pull_state_by_guild: dict[int, dict] = {}
@@ -3480,6 +3488,23 @@ def _relay_topic_from_text(text: str) -> str:
     return "general_surface"
 
 
+def _relay_source_class_from_event_type(event_type: str) -> str:
+    normalized = (event_type or "").strip().lower()
+    if normalized == "fresh_public_discord_activity":
+        return "fresh_discord"
+    normalized = RELAY_SOURCE_CLASS_ALIASES.get(normalized, normalized)
+    if normalized in QUIET_RELAY_SOURCE_CLASSES:
+        return normalized
+    return normalized or "unknown"
+
+
+def _remember_relay_source(guild_id: int, source_class: str):
+    normalized = _relay_source_class_from_event_type(source_class)
+    if normalized == "unknown":
+        return
+    _recent_relay_sources_by_guild[guild_id].append(normalized)
+
+
 def _remember_relay_topic(guild_id: int, message: str, max_items: int = 8):
     topic = _relay_topic_from_text(message)
     pool = _recent_relay_topics.setdefault(guild_id, [])
@@ -3494,6 +3519,38 @@ def _recent_relay_topic_summary(guild_id: int, max_items: int = 5) -> str:
         return "no stored topic history"
     trimmed = topics[-max_items:]
     return ", ".join(trimmed)
+
+
+def _rotation_rank(recent: list[str], value: str, base_index: int) -> tuple[int, int, int, int]:
+    recent_window = recent[-8:]
+    immediate_repeat = 1 if recent_window and recent_window[-1] == value else 0
+    recent_count = recent_window.count(value)
+    last_index = max((idx for idx, item in enumerate(recent_window) if item == value), default=-1)
+    return immediate_repeat, recent_count, last_index, base_index
+
+
+def _prioritize_relay_subject_items(guild_id: int, items: list, text_getter) -> list:
+    recent_topics = list(_recent_relay_topics.get(guild_id, []))[-8:]
+    ranked = []
+    for idx, item in enumerate(items):
+        topic = _relay_topic_from_text(text_getter(item))
+        ranked.append((_rotation_rank(recent_topics, topic, idx), item))
+    ranked.sort(key=lambda pair: pair[0])
+    return [item for _rank, item in ranked]
+
+
+def _relay_diversity_prompt_block(guild_id: int) -> str:
+    subjects = list(_recent_relay_topics.get(guild_id, []))[-6:]
+    sources = list(_recent_relay_sources_by_guild.get(guild_id, []))[-6:]
+    lanes = list(_recent_relay_lanes_by_guild.get(guild_id, []))[-6:]
+    return (
+        "Recent accepted Relay diversity context, oldest to newest:\n"
+        f"- subject families: {', '.join(subjects) if subjects else 'none'}\n"
+        f"- source classes: {', '.join(sources) if sources else 'none'}\n"
+        f"- relay angles: {', '.join(lanes) if lanes else 'none'}\n"
+        "When the approved evidence supports more than one truthful choice, prefer a subject and framing that are less represented above. "
+        "Never invent, distort, or abandon the approved source merely to be different.\n"
+    )
 
 
 def _remember_relay_message(guild_id: int, message: str, max_items: int = 8):
@@ -3602,14 +3659,25 @@ async def _fetch_fresh_public_relay_rows(guild_id: int) -> tuple[list[tuple], in
 
 def _hydrate_recent_relay_memory(guild_id: int) -> None:
     history = relay_recent_history(DB_FILE, guild_id, limit=25)
-    if history:
-        _recent_relay_messages[guild_id] = [h.get("normalized_message", "") for h in reversed(history) if h.get("normalized_message")]
-        _recent_relay_lanes_by_guild[guild_id].clear()
-        newest_lanes = history[:8]
-        for h in reversed(newest_lanes):
-            lane = h.get("relay_lane")
-            if lane:
-                _recent_relay_lanes_by_guild[guild_id].append(lane)
+    chronological = list(reversed(history[:8]))
+    _recent_relay_messages[guild_id] = []
+    _recent_relay_topics[guild_id] = []
+    _recent_relay_lanes_by_guild[guild_id].clear()
+    _recent_relay_sources_by_guild[guild_id].clear()
+    _last_relay_lane_by_guild.pop(guild_id, None)
+    for record in chronological:
+        message = record.get("public_message") or ""
+        normalized = record.get("normalized_message") or _normalize_for_repeat(message)
+        if normalized:
+            _recent_relay_messages[guild_id].append(normalized)
+        if message:
+            _remember_relay_topic(guild_id, message)
+        lane = (record.get("relay_lane") or "").strip()
+        if lane:
+            _recent_relay_lanes_by_guild[guild_id].append(lane)
+            if lane in RELAY_LANES:
+                _last_relay_lane_by_guild[guild_id] = lane
+        _remember_relay_source(guild_id, record.get("event_type") or "")
 
 
 def _strict_relay_output_line(line: str, *, limit: int, min_chars: int = 0) -> str:
@@ -3709,6 +3777,7 @@ def _select_relay_safe_continuity_source(guild_id: int, cursor_value: int, highe
         fragments.append(f"[public_continuity_theme_{len(fragments)+1}] {text}")
     if not fragments:
         return None
+    fragments = _prioritize_relay_subject_items(guild_id, fragments, lambda item: item)
     counts = {"conversation_continuity": len(fragments), "broadcast_memory": 0, "canon": 0, "reflection": 0}
     return RelaySourceDecision(
         "conversation_continuity",
@@ -3716,7 +3785,12 @@ def _select_relay_safe_continuity_source(guild_id: int, cursor_value: int, highe
         counts,
         source_cursor=cursor_value,
         highest_eligible_conversation_id=highest,
-        metadata={"source_message_count": len(fragments), "eligible_policies": sorted(policies), "freshness_hours": RELAY_CONTINUITY_FRESHNESS_HOURS},
+        metadata={
+            "source_message_count": len(fragments),
+            "eligible_policies": sorted(policies),
+            "freshness_hours": RELAY_CONTINUITY_FRESHNESS_HOURS,
+            "candidate_subject_families": [_relay_topic_from_text(item) for item in fragments[:6]],
+        },
     )
 
 
@@ -3779,24 +3853,81 @@ def _approved_relay_broadcast_memory(guild_id: int, *, limit: int = 8) -> list[d
 
 def _select_approved_quiet_relay_source(guild_id: int, cursor_value: int, highest: int, *, allow_continuity: bool = True) -> RelaySourceDecision:
     """Choose one approved non-fresh source for quiet website relay attempts."""
+    _hydrate_recent_relay_memory(guild_id)
+    available: list[RelaySourceDecision] = []
     continuity = _select_relay_safe_continuity_source(guild_id, cursor_value, highest) if allow_continuity else None
     if continuity:
-        return continuity
+        available.append(continuity)
     memories = _approved_relay_broadcast_memory(guild_id, limit=8)
     if memories:
+        memories = _prioritize_relay_subject_items(
+            guild_id,
+            memories,
+            lambda item: str(item.get("cleaned_summary") or ""),
+        )
         lines = [f"[approved_broadcast_memory_{idx}] {item['cleaned_summary']}" for idx, item in enumerate(memories[:6], start=1)]
         counts = {"conversation_continuity": 0, "broadcast_memory": len(lines), "canon": 0, "reflection": 0}
-        return RelaySourceDecision("broadcast_memory", "\n".join(lines), counts, source_cursor=cursor_value, highest_eligible_conversation_id=highest, metadata={"source_message_count": len(lines)})
-    history = relay_recent_history(DB_FILE, guild_id, limit=25)
-    accepted_canon_count = sum(1 for h in history if str(h.get("event_type") or "") == "canon")
+        available.append(
+            RelaySourceDecision(
+                "broadcast_memory",
+                "\n".join(lines),
+                counts,
+                source_cursor=cursor_value,
+                highest_eligible_conversation_id=highest,
+                metadata={
+                    "source_message_count": len(lines),
+                    "candidate_subject_families": [
+                        _relay_topic_from_text(item.get("cleaned_summary") or "")
+                        for item in memories[:6]
+                    ],
+                },
+            )
+        )
+    accepted_canon_count = relay_accepted_publication_count(
+        DB_FILE,
+        guild_id,
+        ("canon", "approved_canon"),
+    )
     anchor_index = accepted_canon_count % len(CANON_RELAY_ANCHORS)
     anchor = CANON_RELAY_ANCHORS[anchor_index]
     canon = f"[approved_barcode_canon:{anchor_index}] {anchor}"
     counts = {"conversation_continuity": 0, "broadcast_memory": 0, "canon": 1, "reflection": 0}
-    return RelaySourceDecision("canon", canon, counts, source_cursor=cursor_value, highest_eligible_conversation_id=highest, metadata={"canon_anchor_index": anchor_index})
+    available.append(
+        RelaySourceDecision(
+            "canon",
+            canon,
+            counts,
+            source_cursor=cursor_value,
+            highest_eligible_conversation_id=highest,
+            metadata={
+                "canon_anchor_index": anchor_index,
+                "candidate_subject_families": [_relay_topic_from_text(anchor)],
+            },
+        )
+    )
+    recent_sources = list(_recent_relay_sources_by_guild.get(guild_id, []))
+    ranked = sorted(
+        enumerate(available),
+        key=lambda pair: _rotation_rank(recent_sources, pair[1].source_class, pair[0]),
+    )
+    selected = ranked[0][1]
+    selected.metadata["available_source_classes"] = [item.source_class for item in available]
+    selected.metadata["recent_source_classes"] = recent_sources[-6:]
+    return selected
 
 
-def _build_source_decision_prompt(decision: RelaySourceDecision, mode: str) -> str:
+def _select_quiet_relay_lane(guild_id: int, source_class: str) -> str:
+    candidates = list(QUIET_RELAY_LANES_BY_SOURCE.get(source_class, ("question_formation", "network_posture")))
+    recent_lanes = list(_recent_relay_lanes_by_guild.get(guild_id, []))
+    ranked = sorted(
+        enumerate(candidates),
+        key=lambda pair: _rotation_rank(recent_lanes, pair[1], pair[0]),
+    )
+    return ranked[0][1] if ranked else "network_posture"
+
+
+def _build_source_decision_prompt(decision: RelaySourceDecision, mode: str, guild_id: int, relay_lane: str) -> str:
+    has_public_residue = decision.source_class in {"conversation_continuity", "broadcast_memory"}
     return (
         f"Write a BNL website relay from the selected approved source class: {decision.source_class}.\n"
         "Return exactly two lines: public relay message, then current directive.\n"
@@ -3804,7 +3935,11 @@ def _build_source_decision_prompt(decision: RelaySourceDecision, mode: str) -> s
         "Line 2 must be a real inquiry, follow-up, recognition target, or invitation grounded in the source.\n"
         "Forbidden: queue/read-model state, now-playing, up-next, payment, availability, queue counts, #bnl-testing, private/admin/mod/research content, prior relay output, Field Logs, runtime inference, generic waiting/monitoring/standby/quiet-signal/bridge-active copy, usernames, channel names, direct quotes, urgency, or pressure.\n"
         "Do not claim tonight, currently, live, imminent, available, on-air, or other current show state unless the approved source explicitly says so.\n"
-        f"Mode: {mode}.\nApproved source context:\n{decision.context}\n"
+        f"Mode: {mode}.\n"
+        f"{_build_relay_lane_prompt(relay_lane, has_public_residue)}"
+        f"{_relay_diversity_prompt_block(guild_id)}"
+        "The diversity context is avoidance guidance only, not factual source material. Do not quote it or treat it as current activity.\n"
+        f"Approved source context:\n{decision.context}\n"
     )
 
 
@@ -3814,7 +3949,8 @@ async def _generate_quiet_website_relay(guild_id: int, *, source_cursor: int, hi
         logging.info("website_relay_no_publish guild=%s reason=%s", guild_id, quiet_source.skip_reason)
         return WebsiteRelayDecision(False, skipReason=quiet_source.skip_reason, sourceCursor=source_cursor, metadata={"reason": quiet_source.skip_reason, "source_class": quiet_source.source_class})
     mode = "OBSERVATION"
-    prompt = _build_source_decision_prompt(quiet_source, mode)
+    relay_lane = _select_quiet_relay_lane(guild_id, quiet_source.source_class)
+    prompt = _build_source_decision_prompt(quiet_source, mode, guild_id, relay_lane)
     try:
         generated = await get_gemini_response(prompt, user_id=0, guild_id=guild_id, route="website_relay_event") or ""
     except Exception as exc:
@@ -3833,11 +3969,24 @@ async def _generate_quiet_website_relay(guild_id: int, *, source_cursor: int, hi
     directive_reason = relay_stock_directive_reason(directive)
     if directive_reason:
         return WebsiteRelayDecision(False, skipReason=directive_reason, sourceCursor=source_cursor, metadata={"reason": directive_reason, "source_class": quiet_source.source_class, "aggregate_source_counts": quiet_source.aggregate_counts})
+    lane_ok, lane_reason = _validate_relay_lane_adherence(relay_message, relay_lane, False, guild_id)
+    if not lane_ok:
+        return WebsiteRelayDecision(
+            False,
+            skipReason="lane_validation_failure",
+            sourceCursor=source_cursor,
+            relayLane=relay_lane,
+            metadata={
+                "reason": lane_reason,
+                "source_class": quiet_source.source_class,
+                "aggregate_source_counts": quiet_source.aggregate_counts,
+            },
+        )
     dup_reason = relay_reject_reason_for_candidate(DB_FILE, guild_id, relay_message, directive)
     if dup_reason:
         return WebsiteRelayDecision(False, skipReason=dup_reason, sourceCursor=source_cursor, metadata={"reason": dup_reason, "source_class": quiet_source.source_class, "aggregate_source_counts": quiet_source.aggregate_counts})
-    meta = {**quiet_source.metadata, "reason": reason, "source_class": quiet_source.source_class, "aggregate_source_counts": quiet_source.aggregate_counts, "relay_lane": "network_posture", "highest_eligible_conversation_id": quiet_source.highest_eligible_conversation_id}
-    return WebsiteRelayDecision(True, eventType=quiet_source.source_class, sourceConversationIds=quiet_source.source_conversation_ids, sourceCursor=source_cursor, message=relay_message, directive=directive, mode=mode, relayLane="network_posture", metadata=meta)
+    meta = {**quiet_source.metadata, "reason": reason, "source_class": quiet_source.source_class, "aggregate_source_counts": quiet_source.aggregate_counts, "relay_lane": relay_lane, "highest_eligible_conversation_id": quiet_source.highest_eligible_conversation_id}
+    return WebsiteRelayDecision(True, eventType=quiet_source.source_class, sourceConversationIds=quiet_source.source_conversation_ids, sourceCursor=source_cursor, message=relay_message, directive=directive, mode=mode, relayLane=relay_lane, metadata=meta)
 
 
 async def generate_dynamic_website_relay(guild_id: int, *, allow_quiet_sources: bool = False) -> WebsiteRelayDecision:
@@ -3885,7 +4034,10 @@ async def generate_dynamic_website_relay(guild_id: int, *, allow_quiet_sources: 
         "Forbidden sources: queue state, read-model state, now-playing, up-next, queue counts, payment state, availability, and inferred site/runtime conditions.\n"
         "Radio, releases, dossiers, Transmissions, music, events, and other BARCODE subjects may be mentioned only when the supplied Discord context explicitly supports them. Do not infer live operational state.\n"
         "Do not include usernames, direct quotations, waiting, standby, monitoring, listening-window, quiet-signal, bridge-active, generic online language, private/sensitive solicitations, urgency, or pressure.\n"
-        f"Mode: {mode}.\nFresh public context:\n{relay_context}\n"
+        f"Mode: {mode}.\n"
+        f"{_relay_diversity_prompt_block(guild_id)}"
+        "The diversity context is avoidance guidance only, not factual source material. Do not quote it or treat it as current activity.\n"
+        f"Fresh public context:\n{relay_context}\n"
     )
     try:
         generated = await get_gemini_response(prompt, user_id=0, guild_id=guild_id, route="website_relay_event") or ""
@@ -3976,6 +4128,7 @@ async def _execute_website_relay_transaction(guild_id: int, *, force: bool = Fal
                 _remember_relay_message(guild_id, pending_decision.message)
                 _remember_relay_topic(guild_id, pending_decision.message)
                 _remember_relay_lane(guild_id, pending_decision.relayLane)
+                _remember_relay_source(guild_id, pending_decision.eventType)
                 return pending_decision
 
         decision = await _generate_website_relay_guarded(guild_id, allow_quiet_sources=True)
@@ -4036,6 +4189,7 @@ async def _execute_website_relay_transaction(guild_id: int, *, force: bool = Fal
         _remember_relay_message(guild_id, decision.message)
         _remember_relay_topic(guild_id, decision.message)
         _remember_relay_lane(guild_id, decision.relayLane)
+        _remember_relay_source(guild_id, decision.eventType)
         return decision
 
 def resolve_network_guild_id(requested_guild_id: int) -> int:

--- a/bnl_relay_backup.py
+++ b/bnl_relay_backup.py
@@ -1,0 +1,1118 @@
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import io
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Mapping, Optional, Sequence
+
+
+SNAPSHOT_FORMAT = "bnl01.accepted-website-relay-snapshot"
+SNAPSHOT_FORMAT_VERSION = 1
+SCHEDULE_ENABLED_ENV = "BNL_RELAY_BACKUP_SCHEDULE_ENABLED"
+DEFAULT_RCLONE_BIN = "rclone"
+DEFAULT_TRANSPORT_TIMEOUT_SECONDS = 300
+SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
+MAX_COMPRESSED_BYTES = 64 * 1024 * 1024
+MAX_DECOMPRESSED_BYTES = 256 * 1024 * 1024
+
+HISTORY_COLUMNS = (
+    "relay_id",
+    "guild_id",
+    "public_message",
+    "public_directive",
+    "mode",
+    "relay_lane",
+    "event_type",
+    "highest_source_conversation_id",
+    "normalized_message",
+    "semantic_family",
+    "published_timestamp",
+)
+STATE_COLUMNS = (
+    "guild_id",
+    "last_published_conversation_cursor",
+    "last_publication_timestamp",
+)
+SNAPSHOT_KEYS = {
+    "format",
+    "format_version",
+    "snapshot_month",
+    "source_max_published_at",
+    "history_columns",
+    "state_columns",
+    "history_count",
+    "state_count",
+    "history",
+    "state",
+    "content_sha256",
+}
+ALLOWED_RESTORE_TABLES = {"website_relay_history", "website_relay_state"}
+MONTH_PATTERN = re.compile(r"^\d{4}-(0[1-9]|1[0-2])$")
+CHECKSUM_PATTERN = re.compile(r"^([0-9a-f]{64})  ([^/\r\n]+)\n?$")
+
+
+class RelayBackupError(RuntimeError):
+    pass
+
+
+class RelayBackupValidationError(RelayBackupError):
+    pass
+
+
+class RelayBackupConflictError(RelayBackupError):
+    pass
+
+
+class RelayBackupTransportError(RelayBackupError):
+    pass
+
+
+@dataclass(frozen=True)
+class ArchiveArtifact:
+    archive_path: Path
+    checksum_path: Path
+    snapshot_month: str
+    content_sha256: str
+    archive_sha256: str
+    history_count: int
+    state_count: int
+
+
+@dataclass(frozen=True)
+class RelaySnapshot:
+    payload: dict
+    archive_path: Path
+    checksum_path: Path
+
+    @property
+    def snapshot_month(self) -> str:
+        return str(self.payload["snapshot_month"])
+
+    @property
+    def content_sha256(self) -> str:
+        return str(self.payload["content_sha256"])
+
+    @property
+    def history_count(self) -> int:
+        return int(self.payload["history_count"])
+
+    @property
+    def state_count(self) -> int:
+        return int(self.payload["state_count"])
+
+
+@dataclass(frozen=True)
+class RestoreReport:
+    target_db_path: Path
+    history_inserted: int
+    history_existing: int
+    state_inserted: int
+    state_existing: int
+    history_count: int
+    state_count: int
+
+
+@dataclass(frozen=True)
+class TransportReport:
+    operation: str
+    transferred: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RoundTripReport:
+    downloaded_archive_sha256: str
+    downloaded_content_sha256: str
+    downloaded_history_count: int
+    downloaded_state_count: int
+    first_restore: RestoreReport
+    second_restore: RestoreReport
+    production_db_untouched: bool
+
+
+def _validate_snapshot_month(snapshot_month: str) -> str:
+    value = (snapshot_month or "").strip()
+    if not MONTH_PATTERN.fullmatch(value):
+        raise RelayBackupValidationError("snapshot_month_must_be_yyyy_mm")
+    return value
+
+
+def _canonical_json_bytes(payload: Mapping) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _logical_content_sha256(payload: Mapping) -> str:
+    digest_payload = dict(payload)
+    digest_payload.pop("content_sha256", None)
+    return hashlib.sha256(_canonical_json_bytes(digest_payload)).hexdigest()
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _gzip_bytes(payload: bytes) -> bytes:
+    output = io.BytesIO()
+    with gzip.GzipFile(
+        filename="",
+        mode="wb",
+        fileobj=output,
+        compresslevel=9,
+        mtime=0,
+    ) as compressed:
+        compressed.write(payload)
+    return output.getvalue()
+
+
+def _read_gzip_bounded(path: Path) -> bytes:
+    if not path.is_file():
+        raise RelayBackupValidationError("archive_missing")
+    if path.stat().st_size > MAX_COMPRESSED_BYTES:
+        raise RelayBackupValidationError("archive_too_large")
+    try:
+        with gzip.open(path, "rb") as compressed:
+            payload = compressed.read(MAX_DECOMPRESSED_BYTES + 1)
+    except (OSError, EOFError) as exc:
+        raise RelayBackupValidationError("archive_gzip_invalid") from exc
+    if len(payload) > MAX_DECOMPRESSED_BYTES:
+        raise RelayBackupValidationError("archive_decompressed_too_large")
+    return payload
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        if path.read_bytes() == data:
+            os.chmod(path, 0o600)
+            return
+        raise RelayBackupConflictError(f"artifact_path_conflict:{path.name}")
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(str(temporary_path), str(path))
+        os.chmod(path, 0o600)
+    except Exception:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        try:
+            temporary_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _read_source_snapshot(db_path: Path) -> tuple[list[dict], list[dict]]:
+    source = db_path.expanduser().resolve()
+    if not source.is_file():
+        raise RelayBackupValidationError("source_database_missing")
+    uri = source.as_uri() + "?mode=ro"
+    try:
+        with sqlite3.connect(uri, uri=True) as connection:
+            connection.row_factory = sqlite3.Row
+            connection.execute("PRAGMA query_only=ON")
+            connection.execute("BEGIN")
+            tables = {
+                str(row[0])
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            if not ALLOWED_RESTORE_TABLES.issubset(tables):
+                raise RelayBackupValidationError("relay_tables_missing")
+            history_columns = tuple(
+                str(row[1])
+                for row in connection.execute(
+                    "PRAGMA table_info(website_relay_history)"
+                ).fetchall()
+            )
+            state_columns = tuple(
+                str(row[1])
+                for row in connection.execute(
+                    "PRAGMA table_info(website_relay_state)"
+                ).fetchall()
+            )
+            if history_columns != HISTORY_COLUMNS:
+                raise RelayBackupValidationError("relay_history_schema_mismatch")
+            if state_columns != STATE_COLUMNS:
+                raise RelayBackupValidationError("relay_state_schema_mismatch")
+            history_rows = [
+                dict(row)
+                for row in connection.execute(
+                    f"""
+                    SELECT {", ".join(HISTORY_COLUMNS)}
+                    FROM website_relay_history
+                    ORDER BY guild_id, published_timestamp, relay_id
+                    """
+                ).fetchall()
+            ]
+            state_rows = [
+                dict(row)
+                for row in connection.execute(
+                    f"""
+                    SELECT {", ".join(STATE_COLUMNS)}
+                    FROM website_relay_state
+                    ORDER BY guild_id
+                    """
+                ).fetchall()
+            ]
+            connection.commit()
+    except sqlite3.Error as exc:
+        raise RelayBackupValidationError("source_database_unreadable") from exc
+    return history_rows, state_rows
+
+
+def _build_snapshot_payload(
+    history_rows: Sequence[Mapping],
+    state_rows: Sequence[Mapping],
+    snapshot_month: str,
+) -> dict:
+    history = [dict(row) for row in history_rows]
+    state = [dict(row) for row in state_rows]
+    payload = {
+        "format": SNAPSHOT_FORMAT,
+        "format_version": SNAPSHOT_FORMAT_VERSION,
+        "snapshot_month": _validate_snapshot_month(snapshot_month),
+        "source_max_published_at": max(
+            (str(row["published_timestamp"]) for row in history),
+            default="",
+        ),
+        "history_columns": list(HISTORY_COLUMNS),
+        "state_columns": list(STATE_COLUMNS),
+        "history_count": len(history),
+        "state_count": len(state),
+        "history": history,
+        "state": state,
+    }
+    payload["content_sha256"] = _logical_content_sha256(payload)
+    return payload
+
+
+def export_monthly_snapshot(
+    db_path: os.PathLike,
+    output_dir: os.PathLike,
+    snapshot_month: str,
+) -> ArchiveArtifact:
+    month = _validate_snapshot_month(snapshot_month)
+    history_rows, state_rows = _read_source_snapshot(Path(db_path))
+    payload = _build_snapshot_payload(history_rows, state_rows, month)
+    json_bytes = _canonical_json_bytes(payload)
+    compressed_bytes = _gzip_bytes(json_bytes)
+    archive_sha256 = _sha256_bytes(compressed_bytes)
+    content_sha256 = str(payload["content_sha256"])
+    archive_name = (
+        f"bnl01-relay-history-{month}-{content_sha256[:12]}.json.gz"
+    )
+    archive_path = Path(output_dir).expanduser().resolve() / archive_name
+    checksum_path = archive_path.with_name(archive_path.name + ".sha256")
+    checksum_bytes = f"{archive_sha256}  {archive_path.name}\n".encode("ascii")
+    _atomic_write(archive_path, compressed_bytes)
+    try:
+        _atomic_write(checksum_path, checksum_bytes)
+    except Exception:
+        if not checksum_path.exists():
+            try:
+                archive_path.unlink()
+            except OSError:
+                pass
+        raise
+    return ArchiveArtifact(
+        archive_path=archive_path,
+        checksum_path=checksum_path,
+        snapshot_month=month,
+        content_sha256=content_sha256,
+        archive_sha256=archive_sha256,
+        history_count=len(history_rows),
+        state_count=len(state_rows),
+    )
+
+
+def _validate_history_row(row: object) -> dict:
+    if not isinstance(row, dict) or set(row) != set(HISTORY_COLUMNS):
+        raise RelayBackupValidationError("archive_history_row_schema_invalid")
+    if not isinstance(row["relay_id"], str) or not row["relay_id"]:
+        raise RelayBackupValidationError("archive_relay_id_invalid")
+    if not isinstance(row["guild_id"], int):
+        raise RelayBackupValidationError("archive_history_guild_id_invalid")
+    if not isinstance(row["highest_source_conversation_id"], int):
+        raise RelayBackupValidationError("archive_history_cursor_invalid")
+    for key in (
+        "public_message",
+        "public_directive",
+        "mode",
+        "relay_lane",
+        "event_type",
+        "normalized_message",
+        "semantic_family",
+        "published_timestamp",
+    ):
+        if not isinstance(row[key], str):
+            raise RelayBackupValidationError(f"archive_history_{key}_invalid")
+    return {column: row[column] for column in HISTORY_COLUMNS}
+
+
+def _validate_state_row(row: object) -> dict:
+    if not isinstance(row, dict) or set(row) != set(STATE_COLUMNS):
+        raise RelayBackupValidationError("archive_state_row_schema_invalid")
+    if not isinstance(row["guild_id"], int):
+        raise RelayBackupValidationError("archive_state_guild_id_invalid")
+    if not isinstance(row["last_published_conversation_cursor"], int):
+        raise RelayBackupValidationError("archive_state_cursor_invalid")
+    timestamp = row["last_publication_timestamp"]
+    if timestamp is not None and not isinstance(timestamp, str):
+        raise RelayBackupValidationError("archive_state_timestamp_invalid")
+    return {column: row[column] for column in STATE_COLUMNS}
+
+
+def _validate_snapshot_payload(payload: object) -> dict:
+    if not isinstance(payload, dict) or set(payload) != SNAPSHOT_KEYS:
+        raise RelayBackupValidationError("archive_top_level_schema_invalid")
+    if payload.get("format") != SNAPSHOT_FORMAT:
+        raise RelayBackupValidationError("archive_format_invalid")
+    if payload.get("format_version") != SNAPSHOT_FORMAT_VERSION:
+        raise RelayBackupValidationError("archive_format_version_invalid")
+    _validate_snapshot_month(str(payload.get("snapshot_month") or ""))
+    if payload.get("history_columns") != list(HISTORY_COLUMNS):
+        raise RelayBackupValidationError("archive_history_columns_invalid")
+    if payload.get("state_columns") != list(STATE_COLUMNS):
+        raise RelayBackupValidationError("archive_state_columns_invalid")
+    history_raw = payload.get("history")
+    state_raw = payload.get("state")
+    if not isinstance(history_raw, list) or not isinstance(state_raw, list):
+        raise RelayBackupValidationError("archive_rows_invalid")
+    history = [_validate_history_row(row) for row in history_raw]
+    state = [_validate_state_row(row) for row in state_raw]
+    if payload.get("history_count") != len(history):
+        raise RelayBackupValidationError("archive_history_count_mismatch")
+    if payload.get("state_count") != len(state):
+        raise RelayBackupValidationError("archive_state_count_mismatch")
+    relay_ids = [row["relay_id"] for row in history]
+    if len(relay_ids) != len(set(relay_ids)):
+        raise RelayBackupValidationError("archive_duplicate_relay_id")
+    guild_ids = [row["guild_id"] for row in state]
+    if len(guild_ids) != len(set(guild_ids)):
+        raise RelayBackupValidationError("archive_duplicate_state_guild")
+    expected_max = max(
+        (str(row["published_timestamp"]) for row in history),
+        default="",
+    )
+    if payload.get("source_max_published_at") != expected_max:
+        raise RelayBackupValidationError("archive_max_timestamp_mismatch")
+    expected_content_sha256 = _logical_content_sha256(payload)
+    if payload.get("content_sha256") != expected_content_sha256:
+        raise RelayBackupValidationError("archive_content_checksum_mismatch")
+    normalized = dict(payload)
+    normalized["history"] = history
+    normalized["state"] = state
+    return normalized
+
+
+def verify_archive(
+    archive_path: os.PathLike,
+    checksum_path: os.PathLike,
+) -> RelaySnapshot:
+    archive = Path(archive_path).expanduser().resolve()
+    checksum = Path(checksum_path).expanduser().resolve()
+    if not checksum.is_file():
+        raise RelayBackupValidationError("checksum_missing")
+    try:
+        checksum_text = checksum.read_text(encoding="ascii")
+    except (OSError, UnicodeError) as exc:
+        raise RelayBackupValidationError("checksum_unreadable") from exc
+    match = CHECKSUM_PATTERN.fullmatch(checksum_text)
+    if not match or match.group(2) != archive.name:
+        raise RelayBackupValidationError("checksum_format_invalid")
+    expected_archive_sha256 = match.group(1)
+    actual_archive_sha256 = _sha256_file(archive)
+    if actual_archive_sha256 != expected_archive_sha256:
+        raise RelayBackupValidationError("archive_checksum_mismatch")
+    json_bytes = _read_gzip_bounded(archive)
+    try:
+        decoded = json.loads(json_bytes.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise RelayBackupValidationError("archive_json_invalid") from exc
+    payload = _validate_snapshot_payload(decoded)
+    return RelaySnapshot(
+        payload=payload,
+        archive_path=archive,
+        checksum_path=checksum,
+    )
+
+
+def _paths_refer_to_same_file(left: Path, right: Path) -> bool:
+    if left.resolve(strict=False) == right.resolve(strict=False):
+        return True
+    if left.exists() and right.exists():
+        try:
+            return os.path.samefile(str(left), str(right))
+        except OSError:
+            return False
+    return False
+
+
+def _validated_production_db_path(path: os.PathLike) -> Path:
+    production = Path(path).expanduser()
+    try:
+        resolved = production.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise RelayBackupValidationError(
+            "production_database_missing_or_unresolvable"
+        ) from exc
+    if not resolved.is_file():
+        raise RelayBackupValidationError("production_database_not_a_file")
+    return production
+
+
+def _production_family_paths(production: Path) -> tuple[Path, ...]:
+    bases = (production, production.resolve(strict=True))
+    candidates = []
+    seen = set()
+    for base in bases:
+        for candidate in (
+            base,
+            *(Path(f"{base}{suffix}") for suffix in SQLITE_SIDECAR_SUFFIXES),
+        ):
+            identity = str(candidate.resolve(strict=False))
+            if identity in seen:
+                continue
+            seen.add(identity)
+            candidates.append(candidate)
+    return tuple(candidates)
+
+
+def _restore_target_kind(
+    target: Path,
+    production: Path,
+) -> Optional[str]:
+    if _paths_refer_to_same_file(target, production):
+        return "production_database"
+    for related_path in _production_family_paths(production):
+        if related_path == production:
+            continue
+        if _paths_refer_to_same_file(target, related_path):
+            return "production_database_sidecar"
+    return None
+
+
+def _create_restore_schema(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS website_relay_state (
+            guild_id INTEGER PRIMARY KEY,
+            last_published_conversation_cursor INTEGER NOT NULL DEFAULT 0,
+            last_publication_timestamp TEXT
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS website_relay_history (
+            relay_id TEXT PRIMARY KEY,
+            guild_id INTEGER NOT NULL,
+            public_message TEXT NOT NULL,
+            public_directive TEXT NOT NULL,
+            mode TEXT NOT NULL,
+            relay_lane TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            highest_source_conversation_id INTEGER NOT NULL,
+            normalized_message TEXT NOT NULL,
+            semantic_family TEXT NOT NULL,
+            published_timestamp TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_website_relay_history_guild_time
+        ON website_relay_history(guild_id, published_timestamp DESC)
+        """
+    )
+
+
+def _validate_restore_target_schema(connection: sqlite3.Connection) -> None:
+    tables = {
+        str(row[0])
+        for row in connection.execute(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type='table' AND name NOT LIKE 'sqlite_%'
+            """
+        ).fetchall()
+    }
+    if not tables.issubset(ALLOWED_RESTORE_TABLES):
+        raise RelayBackupValidationError("restore_target_contains_unapproved_tables")
+    _create_restore_schema(connection)
+    history_columns = tuple(
+        str(row[1])
+        for row in connection.execute(
+            "PRAGMA table_info(website_relay_history)"
+        ).fetchall()
+    )
+    state_columns = tuple(
+        str(row[1])
+        for row in connection.execute(
+            "PRAGMA table_info(website_relay_state)"
+        ).fetchall()
+    )
+    if history_columns != HISTORY_COLUMNS or state_columns != STATE_COLUMNS:
+        raise RelayBackupValidationError("restore_target_schema_mismatch")
+
+
+def _row_dict(row: sqlite3.Row, columns: Sequence[str]) -> dict:
+    return {column: row[column] for column in columns}
+
+
+def _target_rows(connection: sqlite3.Connection) -> tuple[list[dict], list[dict]]:
+    connection.row_factory = sqlite3.Row
+    history = [
+        _row_dict(row, HISTORY_COLUMNS)
+        for row in connection.execute(
+            f"""
+            SELECT {", ".join(HISTORY_COLUMNS)}
+            FROM website_relay_history
+            ORDER BY guild_id, published_timestamp, relay_id
+            """
+        ).fetchall()
+    ]
+    state = [
+        _row_dict(row, STATE_COLUMNS)
+        for row in connection.execute(
+            f"""
+            SELECT {", ".join(STATE_COLUMNS)}
+            FROM website_relay_state
+            ORDER BY guild_id
+            """
+        ).fetchall()
+    ]
+    return history, state
+
+
+def restore_to_isolated_db(
+    snapshot: RelaySnapshot,
+    target_db_path: os.PathLike,
+    production_db_path: os.PathLike,
+) -> RestoreReport:
+    target = Path(target_db_path).expanduser()
+    production = _validated_production_db_path(production_db_path)
+    if target.is_symlink():
+        raise RelayBackupValidationError("restore_target_symlink_rejected")
+    target_kind = _restore_target_kind(target, production)
+    if target_kind is not None:
+        raise RelayBackupValidationError(f"restore_target_is_{target_kind}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    created_target = False
+    if not target.exists():
+        descriptor = os.open(
+            str(target),
+            os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+            0o600,
+        )
+        os.close(descriptor)
+        created_target = True
+    elif target.is_dir():
+        raise RelayBackupValidationError("restore_target_is_directory")
+    try:
+        with sqlite3.connect(str(target)) as connection:
+            connection.row_factory = sqlite3.Row
+            _validate_restore_target_schema(connection)
+            connection.commit()
+            connection.execute("BEGIN IMMEDIATE")
+            history_inserted = 0
+            history_existing = 0
+            state_inserted = 0
+            state_existing = 0
+            for archived in snapshot.payload["history"]:
+                existing = connection.execute(
+                    f"""
+                    SELECT {", ".join(HISTORY_COLUMNS)}
+                    FROM website_relay_history
+                    WHERE relay_id=?
+                    """,
+                    (archived["relay_id"],),
+                ).fetchone()
+                if existing is not None:
+                    if _row_dict(existing, HISTORY_COLUMNS) != archived:
+                        raise RelayBackupConflictError(
+                            f"restore_relay_id_conflict:{archived['relay_id']}"
+                        )
+                    history_existing += 1
+                    continue
+                connection.execute(
+                    f"""
+                    INSERT INTO website_relay_history({", ".join(HISTORY_COLUMNS)})
+                    VALUES({", ".join("?" for _column in HISTORY_COLUMNS)})
+                    """,
+                    tuple(archived[column] for column in HISTORY_COLUMNS),
+                )
+                history_inserted += 1
+            for archived in snapshot.payload["state"]:
+                existing = connection.execute(
+                    f"""
+                    SELECT {", ".join(STATE_COLUMNS)}
+                    FROM website_relay_state
+                    WHERE guild_id=?
+                    """,
+                    (archived["guild_id"],),
+                ).fetchone()
+                if existing is not None:
+                    if _row_dict(existing, STATE_COLUMNS) != archived:
+                        raise RelayBackupConflictError(
+                            f"restore_state_conflict:{archived['guild_id']}"
+                        )
+                    state_existing += 1
+                    continue
+                connection.execute(
+                    f"""
+                    INSERT INTO website_relay_state({", ".join(STATE_COLUMNS)})
+                    VALUES({", ".join("?" for _column in STATE_COLUMNS)})
+                    """,
+                    tuple(archived[column] for column in STATE_COLUMNS),
+                )
+                state_inserted += 1
+            restored_history, restored_state = _target_rows(connection)
+            if restored_history != snapshot.payload["history"]:
+                raise RelayBackupConflictError("restore_history_not_isolated_exact")
+            if restored_state != snapshot.payload["state"]:
+                raise RelayBackupConflictError("restore_state_not_isolated_exact")
+            integrity = connection.execute("PRAGMA integrity_check").fetchone()
+            if not integrity or str(integrity[0]).lower() != "ok":
+                raise RelayBackupValidationError("restore_integrity_check_failed")
+            connection.commit()
+    except Exception:
+        if created_target:
+            try:
+                target.unlink()
+            except OSError:
+                pass
+        raise
+    os.chmod(target, 0o600)
+    return RestoreReport(
+        target_db_path=target.resolve(),
+        history_inserted=history_inserted,
+        history_existing=history_existing,
+        state_inserted=state_inserted,
+        state_existing=state_existing,
+        history_count=snapshot.history_count,
+        state_count=snapshot.state_count,
+    )
+
+
+def _remote_path(remote_root: str, file_name: str) -> str:
+    root = (remote_root or "").strip().rstrip("/")
+    if not root or ":" not in root:
+        raise RelayBackupValidationError("rclone_remote_root_invalid")
+    if Path(file_name).name != file_name:
+        raise RelayBackupValidationError("rclone_file_name_invalid")
+    return f"{root}/{file_name}"
+
+
+def _run_rclone(
+    arguments: Sequence[str],
+    *,
+    runner: Callable = subprocess.run,
+    rclone_bin: str = DEFAULT_RCLONE_BIN,
+    timeout_seconds: int = DEFAULT_TRANSPORT_TIMEOUT_SECONDS,
+) -> None:
+    command = [rclone_bin, *arguments]
+    try:
+        completed = runner(
+            command,
+            shell=False,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except FileNotFoundError as exc:
+        raise RelayBackupTransportError("rclone_not_installed") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RelayBackupTransportError("rclone_timeout") from exc
+    except OSError as exc:
+        raise RelayBackupTransportError("rclone_start_failed") from exc
+    return_code = int(getattr(completed, "returncode", 1))
+    if return_code != 0:
+        raise RelayBackupTransportError(
+            f"rclone_failed:{arguments[0]}:exit_{return_code}"
+        )
+
+
+def upload_archive(
+    artifact: ArchiveArtifact,
+    remote_root: str,
+    *,
+    runner: Callable = subprocess.run,
+    rclone_bin: str = DEFAULT_RCLONE_BIN,
+    timeout_seconds: int = DEFAULT_TRANSPORT_TIMEOUT_SECONDS,
+) -> TransportReport:
+    for local_path in (artifact.archive_path, artifact.checksum_path):
+        if not local_path.is_file():
+            raise RelayBackupValidationError(
+                f"upload_artifact_missing:{local_path.name}"
+            )
+        _run_rclone(
+            (
+                "copyto",
+                str(local_path),
+                _remote_path(remote_root, local_path.name),
+            ),
+            runner=runner,
+            rclone_bin=rclone_bin,
+            timeout_seconds=timeout_seconds,
+        )
+    return TransportReport(
+        operation="upload",
+        transferred=(artifact.archive_path.name, artifact.checksum_path.name),
+    )
+
+
+def download_archive(
+    remote_root: str,
+    archive_name: str,
+    checksum_name: str,
+    destination_dir: os.PathLike,
+    *,
+    runner: Callable = subprocess.run,
+    rclone_bin: str = DEFAULT_RCLONE_BIN,
+    timeout_seconds: int = DEFAULT_TRANSPORT_TIMEOUT_SECONDS,
+) -> ArchiveArtifact:
+    if Path(archive_name).name != archive_name:
+        raise RelayBackupValidationError("download_archive_name_invalid")
+    if Path(checksum_name).name != checksum_name:
+        raise RelayBackupValidationError("download_checksum_name_invalid")
+    destination = Path(destination_dir).expanduser().resolve()
+    destination.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        prefix=".relay-download-",
+        dir=str(destination),
+    ) as temporary_dir:
+        temporary = Path(temporary_dir)
+        temporary_archive = temporary / archive_name
+        temporary_checksum = temporary / checksum_name
+        for remote_name, local_path in (
+            (archive_name, temporary_archive),
+            (checksum_name, temporary_checksum),
+        ):
+            _run_rclone(
+                (
+                    "copyto",
+                    _remote_path(remote_root, remote_name),
+                    str(local_path),
+                ),
+                runner=runner,
+                rclone_bin=rclone_bin,
+                timeout_seconds=timeout_seconds,
+            )
+        snapshot = verify_archive(temporary_archive, temporary_checksum)
+        final_archive = destination / archive_name
+        final_checksum = destination / checksum_name
+        if final_archive.exists() or final_checksum.exists():
+            raise RelayBackupConflictError("download_destination_exists")
+        os.replace(str(temporary_archive), str(final_archive))
+        os.replace(str(temporary_checksum), str(final_checksum))
+        os.chmod(final_archive, 0o600)
+        os.chmod(final_checksum, 0o600)
+    return ArchiveArtifact(
+        archive_path=final_archive,
+        checksum_path=final_checksum,
+        snapshot_month=snapshot.snapshot_month,
+        content_sha256=snapshot.content_sha256,
+        archive_sha256=_sha256_file(final_archive),
+        history_count=snapshot.history_count,
+        state_count=snapshot.state_count,
+    )
+
+
+def _file_fingerprint(path: Path) -> Optional[tuple[int, str]]:
+    if not path.is_file():
+        return None
+    return path.stat().st_size, _sha256_file(path)
+
+
+def _database_family_fingerprint(
+    production: Path,
+) -> tuple[tuple[str, Optional[tuple[int, str]]], ...]:
+    return tuple(
+        (
+            str(path.resolve(strict=False)),
+            _file_fingerprint(path),
+        )
+        for path in _production_family_paths(production)
+    )
+
+
+def prove_remote_round_trip(
+    artifact: ArchiveArtifact,
+    remote_root: str,
+    production_db_path: os.PathLike,
+    *,
+    runner: Callable = subprocess.run,
+    rclone_bin: str = DEFAULT_RCLONE_BIN,
+    timeout_seconds: int = DEFAULT_TRANSPORT_TIMEOUT_SECONDS,
+) -> RoundTripReport:
+    production = _validated_production_db_path(production_db_path)
+    production_before = _database_family_fingerprint(production)
+    with tempfile.TemporaryDirectory(prefix="bnl-relay-round-trip-") as work_dir:
+        downloaded = download_archive(
+            remote_root,
+            artifact.archive_path.name,
+            artifact.checksum_path.name,
+            Path(work_dir) / "downloaded",
+            runner=runner,
+            rclone_bin=rclone_bin,
+            timeout_seconds=timeout_seconds,
+        )
+        snapshot = verify_archive(
+            downloaded.archive_path,
+            downloaded.checksum_path,
+        )
+        target = Path(work_dir) / "isolated-relay-restore.db"
+        first = restore_to_isolated_db(snapshot, target, production)
+        second = restore_to_isolated_db(snapshot, target, production)
+        if second.history_inserted != 0 or second.state_inserted != 0:
+            raise RelayBackupConflictError("round_trip_restore_not_idempotent")
+    production_after = _database_family_fingerprint(production)
+    untouched = production_before == production_after
+    if not untouched:
+        raise RelayBackupConflictError("production_database_changed")
+    return RoundTripReport(
+        downloaded_archive_sha256=downloaded.archive_sha256,
+        downloaded_content_sha256=downloaded.content_sha256,
+        downloaded_history_count=downloaded.history_count,
+        downloaded_state_count=downloaded.state_count,
+        first_restore=first,
+        second_restore=second,
+        production_db_untouched=True,
+    )
+
+
+def scheduled_backup_enabled(
+    environ: Optional[Mapping[str, str]] = None,
+) -> bool:
+    source = os.environ if environ is None else environ
+    return str(source.get(SCHEDULE_ENABLED_ENV, "")).strip().lower() == "true"
+
+
+def _artifact_from_verified_snapshot(snapshot: RelaySnapshot) -> ArchiveArtifact:
+    return ArchiveArtifact(
+        archive_path=snapshot.archive_path,
+        checksum_path=snapshot.checksum_path,
+        snapshot_month=snapshot.snapshot_month,
+        content_sha256=snapshot.content_sha256,
+        archive_sha256=_sha256_file(snapshot.archive_path),
+        history_count=snapshot.history_count,
+        state_count=snapshot.state_count,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Export and prove Relay-only accepted-history backups.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    export_parser = subparsers.add_parser("export")
+    export_parser.add_argument("--db", required=True)
+    export_parser.add_argument("--month", required=True)
+    export_parser.add_argument("--output-dir", required=True)
+
+    verify_parser = subparsers.add_parser("verify")
+    verify_parser.add_argument("--archive", required=True)
+    verify_parser.add_argument("--checksum", required=True)
+
+    upload_parser = subparsers.add_parser("upload")
+    upload_parser.add_argument("--archive", required=True)
+    upload_parser.add_argument("--checksum", required=True)
+    upload_parser.add_argument("--remote", required=True)
+    upload_parser.add_argument("--rclone-bin", default=DEFAULT_RCLONE_BIN)
+
+    restore_parser = subparsers.add_parser("restore")
+    restore_parser.add_argument("--archive", required=True)
+    restore_parser.add_argument("--checksum", required=True)
+    restore_parser.add_argument("--target-db", required=True)
+    restore_parser.add_argument("--production-db", required=True)
+
+    round_trip_parser = subparsers.add_parser("round-trip")
+    round_trip_parser.add_argument("--archive", required=True)
+    round_trip_parser.add_argument("--checksum", required=True)
+    round_trip_parser.add_argument("--remote", required=True)
+    round_trip_parser.add_argument("--production-db", required=True)
+    round_trip_parser.add_argument("--rclone-bin", default=DEFAULT_RCLONE_BIN)
+
+    scheduled_parser = subparsers.add_parser("scheduled-run")
+    scheduled_parser.add_argument("--db", required=True)
+    scheduled_parser.add_argument("--output-dir", required=True)
+    scheduled_parser.add_argument("--remote", required=True)
+    scheduled_parser.add_argument("--rclone-bin", default=DEFAULT_RCLONE_BIN)
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "scheduled-run":
+            if not scheduled_backup_enabled():
+                raise RelayBackupValidationError(
+                    "scheduled_backup_disabled_fail_closed"
+                )
+            month = datetime.now(timezone.utc).strftime("%Y-%m")
+            artifact = export_monthly_snapshot(
+                args.db,
+                args.output_dir,
+                month,
+            )
+            upload_archive(
+                artifact,
+                args.remote,
+                rclone_bin=args.rclone_bin,
+            )
+            print(
+                json.dumps(
+                    {
+                        "status": "uploaded",
+                        "archive": artifact.archive_path.name,
+                        "history_count": artifact.history_count,
+                        "state_count": artifact.state_count,
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
+        if args.command == "export":
+            artifact = export_monthly_snapshot(
+                args.db,
+                args.output_dir,
+                args.month,
+            )
+            print(
+                json.dumps(
+                    {
+                        "status": "exported",
+                        "archive": str(artifact.archive_path),
+                        "checksum": str(artifact.checksum_path),
+                        "history_count": artifact.history_count,
+                        "state_count": artifact.state_count,
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
+        snapshot = verify_archive(args.archive, args.checksum)
+        if args.command == "verify":
+            print(
+                json.dumps(
+                    {
+                        "status": "verified",
+                        "snapshot_month": snapshot.snapshot_month,
+                        "history_count": snapshot.history_count,
+                        "state_count": snapshot.state_count,
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
+        artifact = _artifact_from_verified_snapshot(snapshot)
+        if args.command == "upload":
+            upload_archive(
+                artifact,
+                args.remote,
+                rclone_bin=args.rclone_bin,
+            )
+            print(
+                json.dumps(
+                    {
+                        "status": "uploaded",
+                        "archive": artifact.archive_path.name,
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
+        if args.command == "restore":
+            report = restore_to_isolated_db(
+                snapshot,
+                args.target_db,
+                args.production_db,
+            )
+            print(
+                json.dumps(
+                    {
+                        "status": "restored",
+                        "target_db": str(report.target_db_path),
+                        "history_inserted": report.history_inserted,
+                        "history_existing": report.history_existing,
+                        "state_inserted": report.state_inserted,
+                        "state_existing": report.state_existing,
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
+        report = prove_remote_round_trip(
+            artifact,
+            args.remote,
+            args.production_db,
+            rclone_bin=args.rclone_bin,
+        )
+        print(
+            json.dumps(
+                {
+                    "status": "round_trip_verified",
+                    "history_count": report.first_restore.history_count,
+                    "state_count": report.first_restore.state_count,
+                    "second_restore_inserted": (
+                        report.second_restore.history_inserted
+                        + report.second_restore.state_inserted
+                    ),
+                    "production_db_untouched": (
+                        report.production_db_untouched
+                    ),
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except RelayBackupError as exc:
+        print(f"relay_backup_error:{exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bnl_website_relay_state.py
+++ b/bnl_website_relay_state.py
@@ -203,10 +203,28 @@ def recent_history(db_path: str, guild_id: int, limit: int = MAX_HISTORY) -> lis
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(
-            "SELECT * FROM website_relay_history WHERE guild_id=? ORDER BY published_timestamp DESC LIMIT ?",
+            "SELECT * FROM website_relay_history WHERE guild_id=? ORDER BY published_timestamp DESC, relay_id DESC LIMIT ?",
             (guild_id, bounded_limit),
         ).fetchall()
     return [dict(r) for r in rows]
+
+
+def accepted_publication_count(db_path: str, guild_id: int, event_types: tuple[str, ...] = ()) -> int:
+    """Count accepted public Relay rows without applying the operational 25-row view."""
+    ensure_schema(db_path)
+    params: list[Any] = [guild_id]
+    where = "guild_id=?"
+    normalized_types = tuple(item.strip() for item in event_types if item and item.strip())
+    if normalized_types:
+        placeholders = ",".join("?" for _item in normalized_types)
+        where += f" AND event_type IN ({placeholders})"
+        params.extend(normalized_types)
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM website_relay_history WHERE {where}",
+            params,
+        ).fetchone()
+    return int((row or [0])[0] or 0)
 
 
 def reject_reason_for_candidate(db_path: str, guild_id: int, message: str, directive: str = "", *, threshold: float = 0.92) -> str:
@@ -278,31 +296,135 @@ def clear_pending_v2_publication(db_path: str, guild_id: int, relay_id: str = ""
             conn.execute("DELETE FROM website_relay_pending_v2 WHERE guild_id=?", (guild_id,))
 
 
+def _later_publication_timestamp(current: str | None, candidate: str) -> str:
+    if not current:
+        return candidate
+    current_epoch = timestamp_to_epoch_ms(current)
+    candidate_epoch = timestamp_to_epoch_ms(candidate)
+    if current_epoch is not None and candidate_epoch is not None:
+        return candidate if candidate_epoch > current_epoch else current
+    if candidate_epoch is not None:
+        return candidate
+    if current_epoch is not None:
+        return current
+    return max(current, candidate)
+
+
+def _advance_publication_state(
+    conn: sqlite3.Connection,
+    guild_id: int,
+    source_cursor: int,
+    published_timestamp: str,
+) -> None:
+    existing = conn.execute(
+        """
+        SELECT last_published_conversation_cursor, last_publication_timestamp
+        FROM website_relay_state
+        WHERE guild_id=?
+        """,
+        (guild_id,),
+    ).fetchone()
+    if existing is None:
+        conn.execute(
+            """
+            INSERT INTO website_relay_state(
+                guild_id,
+                last_published_conversation_cursor,
+                last_publication_timestamp
+            ) VALUES(?,?,?)
+            """,
+            (guild_id, int(source_cursor or 0), published_timestamp),
+        )
+        return
+    next_cursor = max(int(existing[0] or 0), int(source_cursor or 0))
+    next_timestamp = _later_publication_timestamp(
+        existing[1],
+        published_timestamp,
+    )
+    conn.execute(
+        """
+        UPDATE website_relay_state
+        SET last_published_conversation_cursor=?,
+            last_publication_timestamp=?
+        WHERE guild_id=?
+        """,
+        (next_cursor, next_timestamp, guild_id),
+    )
+
+
 def record_publication(db_path: str, guild_id: int, *, message: str, directive: str, mode: str, relay_lane: str, event_type: str, source_cursor: int, published_timestamp: str | None = None, relay_id: str | None = None) -> str:
     ensure_schema(db_path)
     ts = published_timestamp or utc_now_iso()
     norm = normalize_text(message)
     fam = semantic_family(message)
     relay_id = relay_id or hashlib.sha256(f"{guild_id}|{source_cursor}|{norm}|{ts}".encode()).hexdigest()[:24]
+    inserted = False
     with sqlite3.connect(db_path) as conn:
-        existing = conn.execute("SELECT public_message, public_directive FROM website_relay_history WHERE relay_id=?", (relay_id,)).fetchone()
-        if existing:
-            if existing[0] != message or existing[1] != directive:
-                raise ValueError("local_relay_id_conflict")
-            conn.execute("INSERT OR REPLACE INTO website_relay_state(guild_id,last_published_conversation_cursor,last_publication_timestamp) VALUES(?,?,?)", (guild_id, int(source_cursor or 0), ts))
-            conn.execute("""
-            UPDATE website_relay_history
-            SET guild_id=?, mode=?, relay_lane=?, event_type=?, highest_source_conversation_id=?, normalized_message=?, semantic_family=?, published_timestamp=?
+        conn.row_factory = sqlite3.Row
+        existing = conn.execute(
+            """
+            SELECT guild_id, public_message, public_directive, mode, relay_lane,
+                   event_type, highest_source_conversation_id,
+                   published_timestamp
+            FROM website_relay_history
             WHERE relay_id=?
-            """, (guild_id, mode, relay_lane, event_type, int(source_cursor or 0), norm, fam, ts, relay_id))
+            """,
+            (relay_id,),
+        ).fetchone()
+        if existing:
+            if (
+                int(existing["guild_id"]) != int(guild_id)
+                or existing["public_message"] != message
+                or existing["public_directive"] != directive
+            ):
+                raise ValueError("local_relay_id_conflict")
+            accepted_timestamp = str(existing["published_timestamp"])
+            accepted_cursor = int(
+                existing["highest_source_conversation_id"] or 0
+            )
+            if existing["relay_lane"] == "hydrated":
+                accepted_cursor = max(
+                    accepted_cursor,
+                    int(source_cursor or 0),
+                )
+                conn.execute(
+                    """
+                    UPDATE website_relay_history
+                    SET mode=?, relay_lane=?, event_type=?,
+                        highest_source_conversation_id=?,
+                        normalized_message=?, semantic_family=?
+                    WHERE relay_id=?
+                    """,
+                    (
+                        mode,
+                        relay_lane,
+                        event_type,
+                        accepted_cursor,
+                        norm,
+                        fam,
+                        relay_id,
+                    ),
+                )
+            _advance_publication_state(
+                conn,
+                guild_id,
+                accepted_cursor,
+                accepted_timestamp,
+            )
         else:
-            conn.execute("INSERT OR REPLACE INTO website_relay_state(guild_id,last_published_conversation_cursor,last_publication_timestamp) VALUES(?,?,?)", (guild_id, int(source_cursor or 0), ts))
             conn.execute("""
             INSERT INTO website_relay_history(relay_id,guild_id,public_message,public_directive,mode,relay_lane,event_type,highest_source_conversation_id,normalized_message,semantic_family,published_timestamp)
             VALUES(?,?,?,?,?,?,?,?,?,?,?)
             """, (relay_id, guild_id, message, directive, mode, relay_lane, event_type, int(source_cursor or 0), norm, fam, ts))
+            _advance_publication_state(
+                conn,
+                guild_id,
+                int(source_cursor or 0),
+                ts,
+            )
+            inserted = True
     occurred_at_ms = timestamp_to_epoch_ms(ts)
-    if occurred_at_ms is not None:
+    if inserted and occurred_at_ms is not None:
         try:
             record_source_event(
                 db_path,

--- a/tests/test_relay_backup.py
+++ b/tests/test_relay_backup.py
@@ -1,0 +1,473 @@
+import gzip
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import bnl_relay_backup as backup
+import bnl_website_relay_state as state
+
+
+class RelayBackupTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.source_db = self.root / "bnl01_conversations.db"
+        state.ensure_schema(str(self.source_db))
+        for index in range(30):
+            message = (
+                "Accepted public Relay %02d preserves a distinct archive subject."
+                % index
+            )
+            directive = (
+                "Follow accepted public subject %02d for a confirmed next detail."
+                % index
+            )
+            if index == 7:
+                message = (
+                    "Accepted public Relay 07 keeps Unicode exact: 6 Bit ⚡\n"
+                    "A second public line remains intact."
+                )
+                directive = "Preserve the exact Unicode and newline payload."
+            state.record_publication(
+                str(self.source_db),
+                42,
+                message=message,
+                directive=directive,
+                mode="OBSERVATION",
+                relay_lane=(
+                    "current_signal" if index % 2 == 0 else "question_formation"
+                ),
+                event_type=(
+                    "fresh_public_discord_activity"
+                    if index % 3
+                    else "canon"
+                ),
+                source_cursor=index,
+                published_timestamp=f"2026-07-15T00:00:{index:02d}Z",
+                relay_id=f"relay-{index:02d}",
+            )
+        self._seed_excluded_private_data()
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def _seed_excluded_private_data(self):
+        state.begin_attempt(
+            str(self.source_db),
+            "attempt-secret",
+            42,
+            "scheduled",
+            source_class="provider-trace-secret",
+        )
+        state.complete_attempt(
+            str(self.source_db),
+            "attempt-secret",
+            source_class="provider-trace-secret",
+            outcome="rejected",
+            reason="PRIVATE-ATTEMPT-SENTINEL",
+        )
+        state.save_pending_v2_publication(
+            str(self.source_db),
+            42,
+            relay_id="pending-secret",
+            message="PRIVATE-PENDING-SENTINEL",
+            current_directive="PRIVATE-PENDING-DIRECTIVE",
+            source_class="canon",
+            trigger="scheduled",
+            source_cursor=99,
+            source_conversation_fingerprint="PRIVATE-FINGERPRINT",
+            canonical_json='{"secret":"PRIVATE-CANONICAL-SENTINEL"}',
+        )
+        with sqlite3.connect(self.source_db) as connection:
+            connection.execute(
+                "CREATE TABLE conversations(content TEXT NOT NULL)"
+            )
+            connection.execute(
+                "INSERT INTO conversations VALUES('PRIVATE-CONVERSATION-SENTINEL')"
+            )
+            connection.execute(
+                "CREATE TABLE website_presence_heartbeats(payload TEXT NOT NULL)"
+            )
+            connection.execute(
+                "INSERT INTO website_presence_heartbeats VALUES('PRIVATE-HEARTBEAT-SENTINEL')"
+            )
+            connection.execute(
+                "CREATE TABLE provider_traces(trace TEXT NOT NULL)"
+            )
+            connection.execute(
+                "INSERT INTO provider_traces VALUES('PRIVATE-PROVIDER-TRACE-SENTINEL')"
+            )
+
+    def _export(self, directory_name="exports"):
+        return backup.export_monthly_snapshot(
+            self.source_db,
+            self.root / directory_name,
+            "2026-07",
+        )
+
+    def _source_fingerprint(self):
+        data = self.source_db.read_bytes()
+        return len(data), hashlib.sha256(data).hexdigest()
+
+    def test_full_archive_is_deterministic_and_strictly_allowlisted(self):
+        recent = state.recent_history(str(self.source_db), 42, 50)
+        self.assertEqual(len(recent), 25)
+        with sqlite3.connect(self.source_db) as connection:
+            count = connection.execute(
+                "SELECT COUNT(*) FROM website_relay_history"
+            ).fetchone()[0]
+            oldest = connection.execute(
+                """
+                SELECT relay_id, published_timestamp
+                FROM website_relay_history
+                ORDER BY published_timestamp, relay_id
+                LIMIT 1
+                """
+            ).fetchone()
+        self.assertEqual(count, 30)
+        self.assertEqual(oldest, ("relay-00", "2026-07-15T00:00:00Z"))
+
+        first = self._export("first")
+        second = self._export("second")
+        self.assertEqual(
+            first.archive_path.read_bytes(),
+            second.archive_path.read_bytes(),
+        )
+        self.assertEqual(
+            first.checksum_path.read_bytes(),
+            second.checksum_path.read_bytes(),
+        )
+        self.assertEqual(first.history_count, 30)
+        self.assertEqual(first.state_count, 1)
+
+        snapshot = backup.verify_archive(
+            first.archive_path,
+            first.checksum_path,
+        )
+        self.assertEqual(snapshot.history_count, 30)
+        self.assertEqual(
+            [row["relay_id"] for row in snapshot.payload["history"]],
+            [f"relay-{index:02d}" for index in range(30)],
+        )
+        unicode_row = next(
+            row
+            for row in snapshot.payload["history"]
+            if row["relay_id"] == "relay-07"
+        )
+        self.assertIn("6 Bit ⚡\nA second public line", unicode_row["public_message"])
+        self.assertEqual(
+            unicode_row["published_timestamp"],
+            "2026-07-15T00:00:07Z",
+        )
+        self.assertEqual(
+            snapshot.payload["state"],
+            [
+                {
+                    "guild_id": 42,
+                    "last_published_conversation_cursor": 29,
+                    "last_publication_timestamp": "2026-07-15T00:00:29Z",
+                }
+            ],
+        )
+
+        decompressed = gzip.decompress(first.archive_path.read_bytes())
+        for sentinel in (
+            b"PRIVATE-ATTEMPT-SENTINEL",
+            b"PRIVATE-PENDING-SENTINEL",
+            b"PRIVATE-CANONICAL-SENTINEL",
+            b"PRIVATE-CONVERSATION-SENTINEL",
+            b"PRIVATE-HEARTBEAT-SENTINEL",
+            b"PRIVATE-PROVIDER-TRACE-SENTINEL",
+        ):
+            self.assertNotIn(sentinel, decompressed)
+        payload = json.loads(decompressed.decode("utf-8"))
+        self.assertEqual(set(payload), backup.SNAPSHOT_KEYS)
+        self.assertEqual(payload["history_columns"], list(backup.HISTORY_COLUMNS))
+        self.assertEqual(payload["state_columns"], list(backup.STATE_COLUMNS))
+
+    def test_restore_is_exact_idempotent_and_never_mutates_production(self):
+        artifact = self._export()
+        snapshot = backup.verify_archive(
+            artifact.archive_path,
+            artifact.checksum_path,
+        )
+        target = self.root / "isolated.db"
+        before = self._source_fingerprint()
+        first = backup.restore_to_isolated_db(
+            snapshot,
+            target,
+            self.source_db,
+        )
+        second = backup.restore_to_isolated_db(
+            snapshot,
+            target,
+            self.source_db,
+        )
+        after = self._source_fingerprint()
+
+        self.assertEqual(before, after)
+        self.assertEqual(first.history_inserted, 30)
+        self.assertEqual(first.state_inserted, 1)
+        self.assertEqual(second.history_inserted, 0)
+        self.assertEqual(second.history_existing, 30)
+        self.assertEqual(second.state_inserted, 0)
+        self.assertEqual(second.state_existing, 1)
+        with sqlite3.connect(target) as connection:
+            tables = {
+                row[0]
+                for row in connection.execute(
+                    """
+                    SELECT name FROM sqlite_master
+                    WHERE type='table' AND name NOT LIKE 'sqlite_%'
+                    """
+                ).fetchall()
+            }
+            restored = connection.execute(
+                """
+                SELECT public_message, published_timestamp
+                FROM website_relay_history
+                WHERE relay_id='relay-07'
+                """
+            ).fetchone()
+            cursor = connection.execute(
+                """
+                SELECT last_published_conversation_cursor,
+                       last_publication_timestamp
+                FROM website_relay_state
+                WHERE guild_id=42
+                """
+            ).fetchone()
+            integrity = connection.execute("PRAGMA integrity_check").fetchone()
+        self.assertEqual(tables, backup.ALLOWED_RESTORE_TABLES)
+        self.assertIn("6 Bit ⚡\nA second public line", restored[0])
+        self.assertEqual(restored[1], "2026-07-15T00:00:07Z")
+        self.assertEqual(cursor, (29, "2026-07-15T00:00:29Z"))
+        self.assertEqual(integrity, ("ok",))
+
+    def test_corruption_is_rejected_before_restore_target_creation(self):
+        artifact = self._export()
+        original = bytearray(artifact.archive_path.read_bytes())
+        original[-1] ^= 0x01
+        artifact.archive_path.write_bytes(bytes(original))
+        target = self.root / "must-not-exist.db"
+        result = backup.main(
+            [
+                "restore",
+                "--archive",
+                str(artifact.archive_path),
+                "--checksum",
+                str(artifact.checksum_path),
+                "--target-db",
+                str(target),
+                "--production-db",
+                str(self.source_db),
+            ]
+        )
+        self.assertEqual(result, 1)
+        self.assertFalse(target.exists())
+
+    def test_restore_conflict_rolls_back_earlier_inserts(self):
+        artifact = self._export()
+        snapshot = backup.verify_archive(
+            artifact.archive_path,
+            artifact.checksum_path,
+        )
+        target = self.root / "conflict.db"
+        with sqlite3.connect(target) as connection:
+            backup._create_restore_schema(connection)
+            conflict = dict(snapshot.payload["history"][1])
+            conflict["public_message"] = "conflicting text"
+            connection.execute(
+                f"""
+                INSERT INTO website_relay_history({", ".join(backup.HISTORY_COLUMNS)})
+                VALUES({", ".join("?" for _ in backup.HISTORY_COLUMNS)})
+                """,
+                tuple(conflict[column] for column in backup.HISTORY_COLUMNS),
+            )
+        with self.assertRaises(backup.RelayBackupConflictError):
+            backup.restore_to_isolated_db(
+                snapshot,
+                target,
+                self.source_db,
+            )
+        with sqlite3.connect(target) as connection:
+            rows = connection.execute(
+                "SELECT relay_id, public_message FROM website_relay_history"
+            ).fetchall()
+        self.assertEqual(rows, [("relay-01", "conflicting text")])
+
+    def test_production_alias_symlink_and_hardlink_targets_are_rejected(self):
+        artifact = self._export()
+        snapshot = backup.verify_archive(
+            artifact.archive_path,
+            artifact.checksum_path,
+        )
+        before = self._source_fingerprint()
+        with self.assertRaises(backup.RelayBackupValidationError):
+            backup.restore_to_isolated_db(
+                snapshot,
+                self.source_db,
+                self.source_db,
+            )
+
+        symlink_target = self.root / "production-symlink.db"
+        symlink_target.symlink_to(self.source_db)
+        with self.assertRaises(backup.RelayBackupValidationError):
+            backup.restore_to_isolated_db(
+                snapshot,
+                symlink_target,
+                self.source_db,
+            )
+
+        hardlink_target = self.root / "production-hardlink.db"
+        os.link(self.source_db, hardlink_target)
+        with self.assertRaises(backup.RelayBackupValidationError):
+            backup.restore_to_isolated_db(
+                snapshot,
+                hardlink_target,
+                self.source_db,
+            )
+        self.assertEqual(before, self._source_fingerprint())
+
+    def test_missing_production_reference_and_sidecars_are_rejected(self):
+        artifact = self._export()
+        snapshot = backup.verify_archive(
+            artifact.archive_path,
+            artifact.checksum_path,
+        )
+        missing_production = self.root / "mistyped-production.db"
+        target = self.root / "must-not-be-created.db"
+        with self.assertRaisesRegex(
+            backup.RelayBackupValidationError,
+            "production_database_missing_or_unresolvable",
+        ):
+            backup.restore_to_isolated_db(
+                snapshot,
+                target,
+                missing_production,
+            )
+        self.assertFalse(target.exists())
+
+        before = self._source_fingerprint()
+        for suffix in backup.SQLITE_SIDECAR_SUFFIXES:
+            sidecar_target = Path(f"{self.source_db}{suffix}")
+            with self.subTest(suffix=suffix):
+                with self.assertRaisesRegex(
+                    backup.RelayBackupValidationError,
+                    "restore_target_is_production_database_sidecar",
+                ):
+                    backup.restore_to_isolated_db(
+                        snapshot,
+                        sidecar_target,
+                        self.source_db,
+                    )
+                self.assertFalse(sidecar_target.exists())
+        self.assertEqual(before, self._source_fingerprint())
+
+    def test_rclone_upload_download_and_isolated_round_trip(self):
+        artifact = self._export()
+        remote_root = "gdrive:BNL-01 Backups/Relay Archive"
+        remote_dir = self.root / "fake-google-drive"
+        remote_dir.mkdir()
+        calls = []
+
+        def fake_runner(command, **kwargs):
+            calls.append((list(command), dict(kwargs)))
+            self.assertFalse(kwargs["shell"])
+            self.assertEqual(command[1], "copyto")
+            source = command[2]
+            destination = command[3]
+            if source.startswith(remote_root + "/"):
+                remote_name = source[len(remote_root) + 1 :]
+                shutil.copyfile(remote_dir / remote_name, destination)
+            else:
+                remote_name = destination[len(remote_root) + 1 :]
+                shutil.copyfile(source, remote_dir / remote_name)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        upload = backup.upload_archive(
+            artifact,
+            remote_root,
+            runner=fake_runner,
+        )
+        self.assertEqual(upload.operation, "upload")
+        self.assertTrue((remote_dir / artifact.archive_path.name).is_file())
+        self.assertTrue((remote_dir / artifact.checksum_path.name).is_file())
+
+        before = self._source_fingerprint()
+        proof = backup.prove_remote_round_trip(
+            artifact,
+            remote_root,
+            self.source_db,
+            runner=fake_runner,
+        )
+        self.assertEqual(before, self._source_fingerprint())
+        self.assertTrue(proof.production_db_untouched)
+        self.assertEqual(proof.first_restore.history_inserted, 30)
+        self.assertEqual(proof.second_restore.history_inserted, 0)
+        self.assertEqual(proof.second_restore.state_inserted, 0)
+        self.assertEqual(len(calls), 4)
+        for command, kwargs in calls:
+            self.assertEqual(command[0], "rclone")
+            self.assertFalse(kwargs["shell"])
+            self.assertTrue(
+                any("BNL-01 Backups/Relay Archive" in arg for arg in command)
+            )
+
+    def test_rclone_failure_is_observable_and_non_destructive(self):
+        artifact = self._export()
+        before = self._source_fingerprint()
+
+        def failed_runner(command, **kwargs):
+            return SimpleNamespace(returncode=9, stdout="", stderr="provider trace")
+
+        with self.assertRaises(backup.RelayBackupTransportError):
+            backup.upload_archive(
+                artifact,
+                "gdrive:BNL-01 Backups/Relay Archive",
+                runner=failed_runner,
+            )
+        self.assertTrue(artifact.archive_path.is_file())
+        self.assertTrue(artifact.checksum_path.is_file())
+        self.assertEqual(before, self._source_fingerprint())
+
+    def test_scheduled_run_defaults_off_before_database_or_rclone_work(self):
+        missing_db = self.root / "missing.db"
+        with mock.patch.dict(
+            os.environ,
+            {backup.SCHEDULE_ENABLED_ENV: ""},
+            clear=False,
+        ), mock.patch.object(
+            backup,
+            "export_monthly_snapshot",
+            side_effect=AssertionError("database opened"),
+        ) as export_mock, mock.patch.object(
+            backup,
+            "upload_archive",
+            side_effect=AssertionError("rclone invoked"),
+        ) as upload_mock:
+            result = backup.main(
+                [
+                    "scheduled-run",
+                    "--db",
+                    str(missing_db),
+                    "--output-dir",
+                    str(self.root / "scheduled"),
+                    "--remote",
+                    "gdrive:BNL-01 Backups/Relay Archive",
+                ]
+            )
+        self.assertEqual(result, 1)
+        export_mock.assert_not_called()
+        upload_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_website_relay_event_driven.py
+++ b/tests/test_website_relay_event_driven.py
@@ -23,6 +23,10 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
         bnl01_bot.BNL_WEBSITE_CONTRACT_VERSION = "1"
         bnl01_bot.DB_FILE = self.db
         bnl01_bot._recent_relay_messages.clear()
+        bnl01_bot._recent_relay_topics.clear()
+        bnl01_bot._recent_relay_lanes_by_guild.clear()
+        bnl01_bot._recent_relay_sources_by_guild.clear()
+        bnl01_bot._last_relay_lane_by_guild.clear()
         bnl01_bot._website_relay_transaction_locks_by_guild.clear()
         bnl01_bot._website_relay_generation_tasks_by_guild.clear()
         with sqlite3.connect(self.db) as conn:
@@ -44,6 +48,11 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
     def tearDown(self):
         bnl01_bot.DB_FILE = self.old_db
         bnl01_bot.BNL_WEBSITE_CONTRACT_VERSION = self.old_contract_version
+        bnl01_bot._recent_relay_messages.clear()
+        bnl01_bot._recent_relay_topics.clear()
+        bnl01_bot._recent_relay_lanes_by_guild.clear()
+        bnl01_bot._recent_relay_sources_by_guild.clear()
+        bnl01_bot._last_relay_lane_by_guild.clear()
         try:
             os.unlink(self.db)
         except OSError:
@@ -122,13 +131,162 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
         state.record_publication(self.db, 42, message="Public Discord is comparing show questions with track submission context.", directive="Review those fresh public questions.", mode="OBSERVATION", relay_lane="current_signal", event_type="fresh_public_discord_activity", source_cursor=5)
         self.assertIn(state.reject_reason_for_candidate(self.db, 42, "Public Discord is comparing show questions with track submission context!", "Review those fresh public questions."), {"exact_duplicate", "near_duplicate"})
 
-    def test_history_retains_25_and_no_raw_names(self):
+    def test_permanent_history_retains_all_rows_while_recent_view_stays_25(self):
         for i in range(30):
-            state.record_publication(self.db, 42, message=f"Public Discord raised distinct track question {i} with enough detail.", directive=f"Review public context item {i}.", mode="OBSERVATION", relay_lane="current_signal", event_type="fresh_public_discord_activity", source_cursor=i)
+            state.record_publication(
+                self.db,
+                42,
+                message=f"Public Discord raised distinct track question {i} with enough detail.",
+                directive=f"Review public context item {i}.",
+                mode="OBSERVATION",
+                relay_lane="current_signal",
+                event_type="fresh_public_discord_activity",
+                source_cursor=i,
+                published_timestamp=f"2026-07-15T00:00:{i:02d}Z",
+                relay_id=f"relay-{i:02d}",
+            )
         hist = state.recent_history(self.db, 42, 50)
         self.assertEqual(len(hist), 25)
+        with sqlite3.connect(self.db) as conn:
+            permanent_count = conn.execute(
+                "SELECT COUNT(*) FROM website_relay_history WHERE guild_id=42"
+            ).fetchone()[0]
+            oldest = conn.execute(
+                """
+                SELECT public_message
+                FROM website_relay_history
+                WHERE guild_id=42
+                ORDER BY published_timestamp, relay_id
+                LIMIT 1
+                """
+            ).fetchone()[0]
+        self.assertEqual(permanent_count, 30)
+        self.assertEqual(state.accepted_publication_count(self.db, 42), 30)
+        self.assertIn("question 0", oldest)
         joined = "\n".join(str(h) for h in hist)
         self.assertNotIn("tester", joined)
+
+    def test_same_id_retry_cannot_rewrite_accepted_row_or_cross_guilds(self):
+        relay_id = "relay-immutable-01"
+        accepted_timestamp = "2026-07-01T00:00:00Z"
+        state.record_publication(
+            self.db,
+            42,
+            message="One accepted public Relay keeps its original text.",
+            directive="Keep the accepted directive exactly as published.",
+            mode="OBSERVATION",
+            relay_lane="current_signal",
+            event_type="fresh_public_discord_activity",
+            source_cursor=7,
+            published_timestamp=accepted_timestamp,
+            relay_id=relay_id,
+        )
+        state.record_publication(
+            self.db,
+            42,
+            message="One accepted public Relay keeps its original text.",
+            directive="Keep the accepted directive exactly as published.",
+            mode="DIFFERENT_RETRY_MODE",
+            relay_lane="network_posture",
+            event_type="canon",
+            source_cursor=99,
+            published_timestamp="2026-07-31T00:00:00Z",
+            relay_id=relay_id,
+        )
+        with sqlite3.connect(self.db) as connection:
+            row = connection.execute(
+                """
+                SELECT guild_id, public_message, public_directive, mode,
+                       relay_lane, event_type,
+                       highest_source_conversation_id, published_timestamp
+                FROM website_relay_history
+                WHERE relay_id=?
+                """,
+                (relay_id,),
+            ).fetchone()
+            count = connection.execute(
+                "SELECT COUNT(*) FROM website_relay_history WHERE relay_id=?",
+                (relay_id,),
+            ).fetchone()[0]
+            publication_state = connection.execute(
+                """
+                SELECT last_published_conversation_cursor,
+                       last_publication_timestamp
+                FROM website_relay_state
+                WHERE guild_id=42
+                """
+            ).fetchone()
+        self.assertEqual(count, 1)
+        self.assertEqual(
+            row,
+            (
+                42,
+                "One accepted public Relay keeps its original text.",
+                "Keep the accepted directive exactly as published.",
+                "OBSERVATION",
+                "current_signal",
+                "fresh_public_discord_activity",
+                7,
+                accepted_timestamp,
+            ),
+        )
+        self.assertEqual(publication_state, (7, accepted_timestamp))
+
+        with self.assertRaisesRegex(ValueError, "local_relay_id_conflict"):
+            state.record_publication(
+                self.db,
+                99,
+                message="One accepted public Relay keeps its original text.",
+                directive="Keep the accepted directive exactly as published.",
+                mode="OBSERVATION",
+                relay_lane="current_signal",
+                event_type="fresh_public_discord_activity",
+                source_cursor=7,
+                published_timestamp=accepted_timestamp,
+                relay_id=relay_id,
+            )
+        self.assertIsNone(state.get_cursor(self.db, 99))
+
+    def test_hydrated_placeholder_enrichment_keeps_acceptance_time(self):
+        relay_id = "relay-hydrated-01"
+        accepted_timestamp = "2026-07-01T00:00:00Z"
+        state.hydrate_publication(
+            self.db,
+            42,
+            relay_id=relay_id,
+            message="Hydrated accepted Relay text stays immutable.",
+            directive="Keep its accepted directive and time.",
+            source_class="approved_canon",
+            trigger="scheduled",
+            published_timestamp=accepted_timestamp,
+        )
+        state.record_publication(
+            self.db,
+            42,
+            message="Hydrated accepted Relay text stays immutable.",
+            directive="Keep its accepted directive and time.",
+            mode="OBSERVATION",
+            relay_lane="network_posture",
+            event_type="canon",
+            source_cursor=12,
+            published_timestamp="2026-07-31T00:00:00Z",
+            relay_id=relay_id,
+        )
+        with sqlite3.connect(self.db) as connection:
+            row = connection.execute(
+                """
+                SELECT relay_lane, event_type,
+                       highest_source_conversation_id, published_timestamp
+                FROM website_relay_history
+                WHERE relay_id=?
+                """,
+                (relay_id,),
+            ).fetchone()
+        self.assertEqual(
+            row,
+            ("network_posture", "canon", 12, accepted_timestamp),
+        )
+        self.assertEqual(state.get_cursor(self.db, 42), 12)
 
     def test_read_model_helpers_not_called_by_generation(self):
         state.bootstrap_cursor(self.db, 42, 0)
@@ -168,7 +326,10 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
              mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=fake_gemini):
             decision = self.generate()
         self.assertTrue(decision.publish)
+        self.assertEqual(decision.eventType, "fresh_public_discord_activity")
         self.assertIn("BARCODE Radio", prompts[0])
+        self.assertIn("Recent accepted Relay diversity context", prompts[0])
+        self.assertIn("avoidance guidance only", prompts[0])
 
     def test_concurrent_transactions_publish_once_and_advance_once(self):
         state.bootstrap_cursor(self.db, 42, 0)
@@ -268,6 +429,102 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
         bnl01_bot._recent_relay_lanes_by_guild[42].clear()
         bnl01_bot._hydrate_recent_relay_memory(42)
         self.assertEqual(list(bnl01_bot._recent_relay_lanes_by_guild[42]), lanes[2:10])
+
+    def test_restart_hydration_restores_subject_source_angle_and_last_lane(self):
+        accepted = [
+            (
+                "relay-a",
+                "A public archive discussion identified one old release question.",
+                "conversation_continuity",
+                "residual_echo",
+            ),
+            (
+                "relay-b",
+                "A public track discussion compared two submission approaches.",
+                "broadcast_memory",
+                "question_formation",
+            ),
+            (
+                "relay-c",
+                "The crowd discussion asked how names should appear in a recap.",
+                "fresh_public_discord_activity",
+                "current_signal",
+            ),
+        ]
+        for index, (relay_id, message, event_type, lane) in enumerate(accepted):
+            state.record_publication(
+                self.db,
+                42,
+                message=message,
+                directive=f"Follow accepted subject {index} for a confirmed detail.",
+                mode="OBSERVATION",
+                relay_lane=lane,
+                event_type=event_type,
+                source_cursor=index,
+                published_timestamp=f"2026-07-15T00:00:0{index}Z",
+                relay_id=relay_id,
+            )
+        bnl01_bot._recent_relay_messages.clear()
+        bnl01_bot._recent_relay_topics.clear()
+        bnl01_bot._recent_relay_lanes_by_guild.clear()
+        bnl01_bot._recent_relay_sources_by_guild.clear()
+        bnl01_bot._last_relay_lane_by_guild.clear()
+
+        bnl01_bot._hydrate_recent_relay_memory(42)
+
+        self.assertEqual(
+            bnl01_bot._recent_relay_topics[42],
+            ["archive_pressure", "submission_corridor", "crowd_behavior"],
+        )
+        self.assertEqual(
+            list(bnl01_bot._recent_relay_sources_by_guild[42]),
+            ["conversation_continuity", "broadcast_memory", "fresh_discord"],
+        )
+        self.assertEqual(
+            list(bnl01_bot._recent_relay_lanes_by_guild[42]),
+            ["residual_echo", "question_formation", "current_signal"],
+        )
+        self.assertEqual(
+            bnl01_bot._last_relay_lane_by_guild[42],
+            "current_signal",
+        )
+
+    def test_restart_hydration_clears_stale_state_when_archive_is_empty(self):
+        bnl01_bot._recent_relay_messages[42] = ["stale"]
+        bnl01_bot._recent_relay_topics[42] = ["stale_topic"]
+        bnl01_bot._recent_relay_lanes_by_guild[42].append("network_posture")
+        bnl01_bot._recent_relay_sources_by_guild[42].append("canon")
+        bnl01_bot._last_relay_lane_by_guild[42] = "network_posture"
+
+        bnl01_bot._hydrate_recent_relay_memory(42)
+
+        self.assertEqual(bnl01_bot._recent_relay_messages[42], [])
+        self.assertEqual(bnl01_bot._recent_relay_topics[42], [])
+        self.assertEqual(list(bnl01_bot._recent_relay_lanes_by_guild[42]), [])
+        self.assertEqual(list(bnl01_bot._recent_relay_sources_by_guild[42]), [])
+        self.assertNotIn(42, bnl01_bot._last_relay_lane_by_guild)
+
+    def test_diversity_prompt_uses_only_grounded_accepted_history(self):
+        for index in range(30):
+            state.record_publication(
+                self.db,
+                42,
+                message=f"Accepted public archive subject {index} remains distinct.",
+                directive=f"Follow archive subject {index} for one confirmed detail.",
+                mode="OBSERVATION",
+                relay_lane="current_signal",
+                event_type="fresh_public_discord_activity",
+                source_cursor=index,
+                published_timestamp=f"2026-07-15T00:00:{index:02d}Z",
+                relay_id=f"angle-{index:02d}",
+            )
+        bnl01_bot._hydrate_recent_relay_memory(42)
+        block = bnl01_bot._relay_diversity_prompt_block(42)
+        self.assertIn("subject families: archive_pressure", block)
+        self.assertIn("source classes: fresh_discord", block)
+        self.assertIn("relay angles: current_signal", block)
+        self.assertNotIn("next presentation angle:", block)
+        self.assertEqual(len(state.recent_history(self.db, 42, 50)), 25)
 
     def test_silence_for_failure_modes_and_stock_directive(self):
         state.bootstrap_cursor(self.db, 42, 0)
@@ -506,6 +763,115 @@ class WebsiteRelayRecoveryTests(unittest.TestCase):
                 """,
                 (summary, entry_type, public_safe, usage_scope, valid_until, status, superseded_by_id),
             )
+
+    def test_quiet_source_rotation_uses_accepted_history_across_restart(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        self.add_row(
+            "A recent public archive discussion asks how release questions should be grouped."
+        )
+        self.add_broadcast_memory(
+            "Approved public relay memory compares two track-submission approaches."
+        )
+
+        first = bnl01_bot._select_approved_quiet_relay_source(42, 0, 1)
+        self.assertEqual(first.source_class, "conversation_continuity")
+        state.record_publication(
+            self.db,
+            42,
+            message="A recent public archive question remains available as continuity.",
+            directive="Follow the archive question for one confirmed grouping detail.",
+            mode="OBSERVATION",
+            relay_lane="residual_echo",
+            event_type=first.source_class,
+            source_cursor=0,
+            published_timestamp="2026-07-15T00:00:01Z",
+            relay_id="rotation-1",
+        )
+
+        state.begin_attempt(
+            self.db,
+            "rejected-not-accepted",
+            42,
+            "scheduled",
+            source_class="canon",
+        )
+        state.complete_attempt(
+            self.db,
+            "rejected-not-accepted",
+            source_class="canon",
+            outcome="rejected",
+            reason="candidate_rejected",
+        )
+        state.save_pending_v2_publication(
+            self.db,
+            42,
+            relay_id="pending-not-accepted",
+            message="Pending draft must not affect diversity.",
+            current_directive="Pending directive must not affect diversity.",
+            source_class="canon",
+            trigger="scheduled",
+            source_cursor=0,
+            source_conversation_fingerprint="pending",
+            canonical_json="{}",
+        )
+
+        bnl01_bot._recent_relay_sources_by_guild.clear()
+        second = bnl01_bot._select_approved_quiet_relay_source(42, 0, 1)
+        self.assertEqual(second.source_class, "broadcast_memory")
+        state.record_publication(
+            self.db,
+            42,
+            message="Approved memory preserves a different track-submission subject.",
+            directive="Follow the approved memory for one confirmed comparison detail.",
+            mode="OBSERVATION",
+            relay_lane="question_formation",
+            event_type=second.source_class,
+            source_cursor=0,
+            published_timestamp="2026-07-15T00:00:02Z",
+            relay_id="rotation-2",
+        )
+
+        bnl01_bot._recent_relay_sources_by_guild.clear()
+        third = bnl01_bot._select_approved_quiet_relay_source(42, 0, 1)
+        self.assertEqual(third.source_class, "canon")
+        state.record_publication(
+            self.db,
+            42,
+            message="BARCODE canon preserves a third grounded archive angle.",
+            directive="Ask which confirmed canon detail belongs in the public index.",
+            mode="OBSERVATION",
+            relay_lane="network_posture",
+            event_type=third.source_class,
+            source_cursor=0,
+            published_timestamp="2026-07-15T00:00:03Z",
+            relay_id="rotation-3",
+        )
+
+        bnl01_bot._recent_relay_sources_by_guild.clear()
+        wrapped = bnl01_bot._select_approved_quiet_relay_source(42, 0, 1)
+        self.assertEqual(wrapped.source_class, "conversation_continuity")
+        self.assertEqual(state.accepted_publication_count(self.db, 42), 3)
+
+    def test_quiet_angle_rotation_survives_restart(self):
+        first_lane = bnl01_bot._select_quiet_relay_lane(42, "canon")
+        self.assertEqual(first_lane, "question_formation")
+        state.record_publication(
+            self.db,
+            42,
+            message="BARCODE canon frames one confirmed public archive question.",
+            directive="Ask which confirmed archive detail should be indexed next.",
+            mode="OBSERVATION",
+            relay_lane=first_lane,
+            event_type="canon",
+            source_cursor=0,
+            published_timestamp="2026-07-15T00:00:01Z",
+            relay_id="angle-restart",
+        )
+        bnl01_bot._recent_relay_lanes_by_guild.clear()
+        bnl01_bot._last_relay_lane_by_guild.clear()
+        bnl01_bot._hydrate_recent_relay_memory(42)
+        second_lane = bnl01_bot._select_quiet_relay_lane(42, "canon")
+        self.assertEqual(second_lane, "network_posture")
 
     def test_bootstrap_transaction_publishes_quiet_without_replaying_history(self):
         self.add_row("Old historical Discord row from ArchivistName should not be replayed as fresh current content.", user="ArchivistName")


### PR DESCRIPTION
## Summary

- Preserve the existing permanent accepted Relay archive while keeping the operational recent-25 projection unchanged.
- Make accepted stable IDs, public text/directives, and publication times immutable across idempotent retries; reject cross-guild stable-ID collisions.
- Rehydrate accepted subject/source/lane history across restart and use that grounded evidence to reduce repeated subjects, source classes, and Relay lanes.
- Add deterministic cumulative monthly accepted-history exports as compressed JSON plus SHA-256 checksum.
- Add rclone upload/download transport and strict verification with exact, transactional, idempotent restore into an isolated Relay-only SQLite database.
- Keep transport failures non-destructive and keep scheduled execution fail-closed behind `BNL_RELAY_BACKUP_SCHEDULE_ENABLED=true`.

## Verification

- `python -m py_compile bnl_relay_backup.py bnl_website_relay_state.py bnl01_bot.py tests/test_relay_backup.py tests/test_website_relay_event_driven.py`
- Focused Relay/contract/backup suite: 82 tests passed.
- `make check PYTHON=/workspace/scratch/a7e989174770/BNL01-Bot/venv/bin/python`: passed.

## Protected boundaries

- No website repository changes.
- No queue, Journal, Ambient, occasion, Dormant Echo, reaction, conversation, Candidate Intake, dossier, taxonomy, Memory/Governance/Relationship, or production-gate changes.
- No credential, OAuth token, rclone configuration, database, test archive, or backup secret is committed.
- No timer/service is installed and the monthly production job remains disabled.
- No production restore path exists: restore requires an explicit existing production DB reference, rejects the DB and its SQLite sidecars/aliases, and writes only to an isolated Relay-only target.

## Runtime proof still required

Google Drive authentication, a real rclone upload/download, checksum verification, and temporary isolated restore remain intentionally unproven until the owner configures rclone for the Ubuntu service user. Scheduling must remain disabled until that end-to-end proof and explicit deployment/configuration approval.