### PR TITLE
Bot: complete low-activity Journal obligations

### DIFF
--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -6,11 +6,21 @@ import re
 import sqlite3
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Optional
 
-from bnl_journal_source_store import journal_release_privacy_fence
+from bnl_canon_source_contract import (
+    CANON_FACTS,
+    CANON_SOURCE_CONTRACT_VERSION,
+    Confidence,
+    SourceClass,
+    Visibility,
+)
+from bnl_journal_source_store import (
+    journal_release_privacy_fence,
+    timestamp_to_epoch_ms,
+)
 
 PUBLIC_POLICIES = {"public_home", "public_context", "public_selective"}
 SCHEDULED_PREPARED_STATE = "prepared_exact"
@@ -38,12 +48,22 @@ MAX_CONVERSATION_SOURCES_PER_WINDOW = 2_000
 MAX_PROMPT_SOURCES = 180
 MAX_BROADCAST_MEMORY_CONTEXT = 8
 MAX_RUMOR_CONTEXT = 4
+MAX_REFLECTION_SOURCE_CONTEXT = 8
+MAX_REFLECTION_MEMORY_CONTEXT = 4
+MAX_REFLECTION_CANON_CONTEXT = 4
 JOURNAL_PUBLIC_BROADCAST_SCOPES = {"ambient", "direct", "journal", "relay", "show_status"}
 JOURNAL_CONTEXT_LANE_TYPES = {
     "established_broadcast_memory",
     "community_rumor",
     "bnl_inference",
 }
+JOURNAL_REFLECTION_BASIS_KINDS = {
+    "public_source_history",
+    "accepted_relay_continuity",
+    "established_broadcast_memory",
+    "approved_canon",
+}
+JOURNAL_REFLECTION_SCOPE = "historical_or_canon"
 JOURNAL_TOPIC_STOPWORDS = {
     "about", "after", "again", "being", "could", "from", "have", "into", "just", "more", "other", "their",
     "there", "these", "they", "this", "through", "under", "where", "which", "while", "with", "would", "someone",
@@ -132,6 +152,14 @@ _REPAIR_GUIDANCE = {
         "The prose appears to use established memory, rumor, or BNL inference without declaring traceable metadata.contextUses. Add the correct "
         "context use with supplied basis refs, or remove that unsupported interpretation."
     ),
+    "current_activity_without_fresh_source": (
+        "Remove every implication that historical or canon material happened in the current Journal window. "
+        "A reflective section may discuss only the supplied historical/canon basis unless it cites a fresh current-window source."
+    ),
+    "reflection_scope_not_explicit": (
+        "Frame the reflection explicitly as approved canon, an earlier public record, archive history, or established continuity. "
+        "Do not leave historical material sounding like an event in the current Journal window."
+    ),
 }
 
 _OVERLY_CLINICAL_PATTERNS = (
@@ -181,6 +209,18 @@ _SENSITIVE_PERSONAL_PATTERNS = (
     r"\binterpersonal conflicts?\b",
     r"\bjuveniles?\b",
     r"\bfoster (?:obligations?|care|duties)\b",
+)
+
+_CURRENT_WINDOW_CLAIM_RE = re.compile(
+    r"\b(?:today|tonight|yesterday|last\s+night|right\s+now|currently|this\s+(?:day|week|window)|"
+    r"during\s+(?:this|the\s+current)\s+(?:day|week|window)|in\s+the\s+current\s+window)\b",
+    re.IGNORECASE,
+)
+_REFLECTION_SCOPE_CUE_RE = re.compile(
+    r"\b(?:approved\s+canon|canon(?:ical)?|record(?:ed)?|archive(?:d)?|historical|"
+    r"earlier|previous(?:ly)?|prior|long[- ]standing|established|continuity|"
+    r"remembered|preserved|has\s+long)\b",
+    re.IGNORECASE,
 )
 
 
@@ -369,7 +409,28 @@ def purge_user_journal_derivatives_on_connection(
                 unpublished.add(key)
                 continue
 
-            target_ref_ids = {str(item.get("refId")) for item in target_supporting if item.get("refId")}
+            used_reflection_provenance = metadata.get(
+                "usedReflectionBasisProvenance"
+            )
+            used_reflection_provenance = (
+                used_reflection_provenance
+                if isinstance(used_reflection_provenance, dict)
+                else {}
+            )
+            target_reflection = [
+                item
+                for item in used_reflection_provenance.get(
+                    "historicalSourceEvents",
+                    [],
+                )
+                if isinstance(item, dict)
+                and str(item.get("subjectRef") or "") == subject_ref
+            ]
+            target_ref_ids = {
+                str(item.get("refId"))
+                for item in [*target_supporting, *target_reflection]
+                if item.get("refId")
+            }
             metadata["supportingConversationRefs"] = [
                 item for item in supporting if str(item.get("subjectRef") or "") != subject_ref
             ]
@@ -391,8 +452,14 @@ def purge_user_journal_derivatives_on_connection(
             for key_name in (
                 "topicTags", "continuityNotes", "unresolvedQuestions", "recurringTopicCounts",
                 "contextUses", "usedGenerationContextLanes", "usedContextLaneProvenance",
+                "usedReflectionBasis", "usedReflectionBasisProvenance",
             ):
-                metadata[key_name] = {} if key_name in {"recurringTopicCounts", "usedGenerationContextLanes", "usedContextLaneProvenance"} else []
+                metadata[key_name] = {} if key_name in {
+                    "recurringTopicCounts",
+                    "usedGenerationContextLanes",
+                    "usedContextLaneProvenance",
+                    "usedReflectionBasisProvenance",
+                } else []
             metadata["privacyScrubbed"] = True
             conn.execute(
                 """UPDATE bnl_journal_private_metadata SET metadata_json=?,updated_at=?
@@ -1038,6 +1105,8 @@ def _approved_journal_broadcast_memory(
     source_window_end: str,
     *,
     limit: int = MAX_BROADCAST_MEMORY_CONTEXT,
+    require_fresh_match: bool = True,
+    ref_prefix: str = "memory",
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Return generation-safe established records plus private row provenance.
 
@@ -1097,9 +1166,11 @@ def _approved_journal_broadcast_memory(
         matched_refs = sorted(
             ref_id for ref_id, terms in source_terms.items() if len(memory_terms & terms) >= 2
         )
-        if not matched_refs:
+        if require_fresh_match and not matched_refs:
             continue
-        lane_ref = "memory:" + _hash("journal-memory", guild_id, int(row_id))[:16]
+        lane_ref = str(ref_prefix or "memory").rstrip(":") + ":" + _hash(
+            "journal-memory", guild_id, int(row_id)
+        )[:16]
         safe_records.append({
             "laneRefId": lane_ref,
             "epistemicStatus": "established_network_record",
@@ -1416,6 +1487,462 @@ def _finalize_context_lanes_for_safe_sources(
         if selected:
             finalized_provenance[key] = selected
     return finalized, finalized_provenance
+
+
+def journal_source_packet_has_meaningful_activity(packet: dict[str, Any]) -> bool:
+    """Preserve the established threshold used by scheduled Journal automation."""
+    counts = packet.get("aggregateCounts") or {}
+    total = int(counts.get("eligibleRelays") or 0) + int(
+        counts.get("eligibleConversations") or 0
+    )
+    if total < 5:
+        return False
+    if int(counts.get("eligibleConversations") or 0) > 0:
+        return True
+    quiet_markers = {
+        "quiet",
+        "quiet_source",
+        "non_event_stock",
+        "heartbeat",
+        "hydrated",
+    }
+    return any(
+        str(source.get("eventType") or "").lower() not in quiet_markers
+        for source in packet.get("privateSources", [])
+    )
+
+
+def _stable_reflection_sample(
+    items: list[dict[str, Any]],
+    limit: int,
+    seed: str,
+    *,
+    diversity_key: str,
+) -> list[dict[str, Any]]:
+    if limit <= 0 or len(items) <= limit:
+        return sorted(
+            items,
+            key=lambda item: (
+                str(item.get("sourceObservedAt") or ""),
+                str(item.get("refId") or ""),
+            ),
+        )
+    ranked = sorted(
+        items,
+        key=lambda item: (
+            _hash(seed, item.get("refId") or ""),
+            str(item.get("refId") or ""),
+        ),
+    )
+    selected: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in ranked:
+        diversity_value = str(item.get(diversity_key) or "")
+        if diversity_value and diversity_value in seen:
+            continue
+        selected.append(item)
+        if diversity_value:
+            seen.add(diversity_value)
+        if len(selected) >= limit:
+            break
+    if len(selected) < limit:
+        selected_refs = {str(item.get("refId") or "") for item in selected}
+        selected.extend(
+            item
+            for item in ranked
+            if str(item.get("refId") or "") not in selected_refs
+        )
+    return sorted(
+        selected[:limit],
+        key=lambda item: (
+            str(item.get("sourceObservedAt") or ""),
+            str(item.get("refId") or ""),
+        ),
+    )
+
+
+def _historical_source_reflection_basis(
+    db_path: str,
+    guild_id: int,
+    source_window_start: str,
+    source_window_end: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Project prior eligible archive rows without treating them as fresh evidence."""
+    window_start_ms = timestamp_to_epoch_ms(source_window_start)
+    if window_start_ms is None:
+        return [], []
+    history_start_ms = max(0, window_start_ms - int(timedelta(days=90).total_seconds() * 1000))
+    with sqlite3.connect(db_path) as conn:
+        if not table_exists(conn, "bnl_journal_source_events"):
+            return [], []
+        rows = conn.execute(
+            """
+            SELECT event_seq,source_kind,source_key,occurred_at_ms,channel_policy,
+                   subject_ref,private_display_name,sanitized_summary,content_hash,
+                   metadata_json
+            FROM bnl_journal_source_events
+            WHERE guild_id=? AND public_usable=1
+              AND occurred_at_ms>=? AND occurred_at_ms<?
+              AND source_kind IN ('discord_message','website_relay')
+              AND TRIM(sanitized_summary)<>''
+            ORDER BY occurred_at_ms DESC,event_seq DESC
+            LIMIT 500
+            """,
+            (int(guild_id), history_start_ms, window_start_ms),
+        ).fetchall()
+    private_names = [
+        str(row[6] or "").strip()
+        for row in rows
+        if str(row[6] or "").strip()
+    ]
+    safe_candidates: list[dict[str, Any]] = []
+    provenance_by_ref: dict[str, dict[str, Any]] = {}
+    quiet_markers = {
+        "quiet",
+        "quiet_source",
+        "non_event_stock",
+        "heartbeat",
+        "hydrated",
+    }
+    unsafe_lane_re = re.compile(
+        r"\b(?:admin|mod(?:erator)?|payment|queue(?:_test)?|sealed(?:_test)?|"
+        r"internal(?:_controlled)?|research|planning|r&d)\b",
+        re.IGNORECASE,
+    )
+    for row in rows:
+        (
+            event_seq,
+            source_kind,
+            source_key,
+            occurred_at_ms,
+            channel_policy,
+            subject_ref,
+            private_display_name,
+            sanitized_summary,
+            content_hash,
+            metadata_json,
+        ) = row
+        kind = str(source_kind or "")
+        policy = str(channel_policy or "")
+        if kind == "discord_message" and policy not in PUBLIC_POLICIES:
+            continue
+        if kind == "website_relay" and policy not in {"", "public_relay"}:
+            continue
+        try:
+            metadata = json.loads(metadata_json or "{}")
+        except (TypeError, json.JSONDecodeError):
+            metadata = {}
+        metadata = metadata if isinstance(metadata, dict) else {}
+        event_type = str(metadata.get("event_type") or metadata.get("eventType") or "")
+        eligibility_text = " ".join(
+            [
+                policy,
+                event_type,
+                str(metadata.get("mode") or ""),
+                str(metadata.get("relay_lane") or metadata.get("relayLane") or ""),
+            ]
+        )
+        if unsafe_lane_re.search(eligibility_text):
+            continue
+        if kind == "website_relay" and event_type.lower() in quiet_markers:
+            continue
+        summary = sanitize_source_summary(
+            str(sanitized_summary or ""),
+            private_names,
+            limit=600,
+        )
+        if (
+            not summary
+            or _RUMOR_SENSITIVE_RE.search(summary)
+            or any(
+                re.search(pattern, summary, re.IGNORECASE)
+                for pattern in _SENSITIVE_PERSONAL_PATTERNS
+            )
+        ):
+            continue
+        observed_at = (
+            datetime.fromtimestamp(
+                int(occurred_at_ms) / 1000.0,
+                tz=timezone.utc,
+            )
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+        ref_id = f"reflection:event:{int(event_seq)}"
+        basis_kind = (
+            "public_source_history"
+            if kind == "discord_message"
+            else "accepted_relay_continuity"
+        )
+        safe_candidates.append(
+            {
+                "refId": ref_id,
+                "basisKind": basis_kind,
+                "summary": summary,
+                "sourceType": kind,
+                "sourceVersion": str(content_hash or ""),
+                "sourceObservedAt": observed_at,
+                "scope": JOURNAL_REFLECTION_SCOPE,
+                "publicSafe": True,
+                "reuseEligible": True,
+                "_diversityKey": (
+                    str(subject_ref or "")
+                    if kind == "discord_message"
+                    else event_type or str(source_key or "")
+                ),
+            }
+        )
+        provenance_by_ref[ref_id] = {
+            "refId": ref_id,
+            "sourceTable": "bnl_journal_source_events",
+            "eventSeq": int(event_seq),
+            "sourceKind": kind,
+            "sourceKey": str(source_key or ""),
+            "subjectRef": str(subject_ref or ""),
+            "privateDisplayName": str(private_display_name or ""),
+            "channelPolicy": policy,
+            "occurredAtMs": int(occurred_at_ms),
+            "contentHash": str(content_hash or ""),
+        }
+
+    conversations = [
+        item
+        for item in safe_candidates
+        if item.get("basisKind") == "public_source_history"
+    ]
+    relays = [
+        item
+        for item in safe_candidates
+        if item.get("basisKind") == "accepted_relay_continuity"
+    ]
+    seed = _hash("journal-reflection-history", guild_id, source_window_end)
+    selected = _stable_reflection_sample(
+        conversations,
+        min(5, MAX_REFLECTION_SOURCE_CONTEXT),
+        seed + ":conversation",
+        diversity_key="_diversityKey",
+    )
+    selected.extend(
+        _stable_reflection_sample(
+            relays,
+            min(3, MAX_REFLECTION_SOURCE_CONTEXT - len(selected)),
+            seed + ":relay",
+            diversity_key="_diversityKey",
+        )
+    )
+    if len(selected) < MAX_REFLECTION_SOURCE_CONTEXT:
+        selected_refs = {str(item.get("refId") or "") for item in selected}
+        remainder = [
+            item
+            for item in safe_candidates
+            if str(item.get("refId") or "") not in selected_refs
+        ]
+        selected.extend(
+            _stable_reflection_sample(
+                remainder,
+                MAX_REFLECTION_SOURCE_CONTEXT - len(selected),
+                seed + ":remainder",
+                diversity_key="_diversityKey",
+            )
+        )
+    selected = sorted(
+        selected[:MAX_REFLECTION_SOURCE_CONTEXT],
+        key=lambda item: (
+            str(item.get("sourceObservedAt") or ""),
+            str(item.get("refId") or ""),
+        ),
+    )
+    public_records = [
+        {key: value for key, value in item.items() if not key.startswith("_")}
+        for item in selected
+    ]
+    provenance = [
+        provenance_by_ref[str(item["refId"])]
+        for item in public_records
+        if str(item.get("refId") or "") in provenance_by_ref
+    ]
+    return public_records, provenance
+
+
+def _broadcast_memory_reflection_basis(
+    db_path: str,
+    guild_id: int,
+    source_window_end: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    with sqlite3.connect(db_path) as conn:
+        safe_records, provenance = _approved_journal_broadcast_memory(
+            conn,
+            guild_id,
+            [],
+            source_window_end,
+            limit=MAX_REFLECTION_MEMORY_CONTEXT,
+            require_fresh_match=False,
+            ref_prefix="reflection:memory",
+        )
+    provenance_by_ref = {
+        str(item.get("laneRefId") or ""): item
+        for item in provenance
+        if isinstance(item, dict) and item.get("laneRefId")
+    }
+    window_end = _parse_context_datetime(source_window_end)
+    selected_records: list[dict[str, Any]] = []
+    selected_provenance: list[dict[str, Any]] = []
+    for item in safe_records:
+        ref_id = str(item.get("laneRefId") or "")
+        private_item = provenance_by_ref.get(ref_id)
+        source_time = (
+            _parse_context_datetime(private_item.get("createdAt"))
+            if isinstance(private_item, dict)
+            else None
+        )
+        if not ref_id or source_time is None or (window_end and source_time >= window_end):
+            continue
+        selected_records.append(
+            {
+                "refId": ref_id,
+                "basisKind": "established_broadcast_memory",
+                "summary": str(item.get("summary") or "")[:600],
+                "sourceType": "broadcast_memory",
+                "sourceVersion": str(private_item.get("eligibilityHash") or ""),
+                "sourceObservedAt": source_time.replace(microsecond=0)
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "scope": JOURNAL_REFLECTION_SCOPE,
+                "publicSafe": True,
+                "reuseEligible": True,
+            }
+        )
+        selected_provenance.append(
+            {
+                **private_item,
+                "refId": ref_id,
+            }
+        )
+    return selected_records, selected_provenance
+
+
+def _canon_value_text(value: Any) -> str:
+    if is_dataclass(value):
+        value = asdict(value)
+    if isinstance(value, dict):
+        return "; ".join(
+            f"{str(key).replace('_', ' ')}: {_canon_value_text(item)}"
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple, set)):
+        return ", ".join(_canon_value_text(item) for item in value)
+    return str(value or "").strip()
+
+
+def _canon_fact_is_reflection_safe(fact: Any) -> bool:
+    if (
+        getattr(fact, "source_class", None) != SourceClass.APPROVED_CANON
+        or getattr(fact, "visibility", None)
+        not in {Visibility.PUBLIC, Visibility.PUBLIC_SAFE, Visibility.REFERENCE_CANON}
+        or getattr(fact, "confidence", None) != Confidence.APPROVED
+    ):
+        return False
+    subject_key = str(getattr(getattr(fact, "subject", None), "key", "") or "")
+    claim_text = " ".join(
+        [
+            str(getattr(fact, "predicate", "") or ""),
+            _canon_value_text(getattr(fact, "value", "")),
+        ]
+    )
+    return not (
+        subject_key == "6_bit"
+        and re.search(r"\b(?:music\s+)?producer\b", claim_text, re.IGNORECASE)
+    )
+
+
+def _approved_canon_reflection_basis(
+    guild_id: int,
+    source_window_end: str,
+) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    for fact in CANON_FACTS:
+        if not _canon_fact_is_reflection_safe(fact):
+            continue
+        subject = getattr(fact, "subject", None)
+        subject_key = str(getattr(subject, "key", "") or "")
+        subject_name = str(getattr(subject, "name", "") or "")
+        predicate = str(getattr(fact, "predicate", "") or "")
+        value = _canon_value_text(getattr(fact, "value", ""))
+        if not subject_key or not subject_name or not predicate or not value:
+            continue
+        ref_id = "reflection:canon:" + _hash(
+            CANON_SOURCE_CONTRACT_VERSION,
+            subject_key,
+            predicate,
+            value,
+        )[:20]
+        candidates.append(
+            {
+                "refId": ref_id,
+                "basisKind": "approved_canon",
+                "summary": (
+                    f"{subject_name} {predicate.replace('_', ' ')}: "
+                    f"{value.rstrip('.')}."
+                )[:600],
+                "sourceType": "approved_canon",
+                "sourceVersion": CANON_SOURCE_CONTRACT_VERSION,
+                "scope": JOURNAL_REFLECTION_SCOPE,
+                "publicSafe": True,
+                "reuseEligible": True,
+                "canonSubject": subject_key,
+                "canonPredicate": predicate,
+            }
+        )
+    prioritized = sorted(
+        candidates,
+        key=lambda item: (
+            0
+            if (
+                item.get("canonSubject") == "galaknoise"
+                and item.get("canonPredicate") == "primary_role"
+            )
+            else 1
+            if item.get("canonSubject") == "6_bit"
+            else 2,
+            _hash(
+                "journal-reflection-canon",
+                guild_id,
+                source_window_end,
+                item.get("refId") or "",
+            ),
+        ),
+    )
+    return prioritized[:MAX_REFLECTION_CANON_CONTEXT]
+
+
+def _build_reflection_basis(
+    db_path: str,
+    guild_id: int,
+    source_window_start: str,
+    source_window_end: str,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    historical, historical_provenance = _historical_source_reflection_basis(
+        db_path,
+        guild_id,
+        source_window_start,
+        source_window_end,
+    )
+    memory, memory_provenance = _broadcast_memory_reflection_basis(
+        db_path,
+        guild_id,
+        source_window_end,
+    )
+    private_provenance: dict[str, Any] = {}
+    if historical_provenance:
+        private_provenance["historicalSourceEvents"] = historical_provenance
+    if memory_provenance:
+        private_provenance["establishedBroadcastMemory"] = memory_provenance
+    return [
+        *historical,
+        *memory,
+        *_approved_canon_reflection_basis(guild_id, source_window_end),
+    ], private_provenance
 
 
 def _identity_literal_pattern(name: str) -> Optional[re.Pattern[str]]:
@@ -1969,6 +2496,36 @@ def build_packet_from_sources(
         end,
         safe_sources,
     )
+    if (
+        packet["entryKind"] in {"daily", "weekly"}
+        and not journal_source_packet_has_meaningful_activity(packet)
+    ):
+        reflection_basis, private_reflection_provenance = _build_reflection_basis(
+            db_path,
+            guild_id,
+            start,
+            end,
+        )
+        packet["lowActivityMode"] = True
+        packet["reflectionBasis"] = reflection_basis
+        packet["reflectionBasisContract"] = {
+            "version": 1,
+            "scope": JOURNAL_REFLECTION_SCOPE,
+            "basisKinds": sorted(JOURNAL_REFLECTION_BASIS_KINDS),
+            "basisDoesNotCountAsFresh": True,
+            "currentActivityClaimsRequireFreshSource": True,
+        }
+        packet["privateReflectionBasisProvenance"] = (
+            private_reflection_provenance
+        )
+        packet["evidenceCoverageContract"] = {
+            **packet["evidenceCoverageContract"],
+            "minimumDistinctFreshSources": 0,
+            "requiredSourceKinds": [],
+            "minimumDistinctParticipants": 0,
+            "minimumDistinctWindowSegments": 0,
+            "lowActivityReflectionMode": True,
+        }
     packet["generationContextLanes"] = context_lanes
     packet["privateContextLaneProvenance"] = private_lane_provenance
     packet["history"] = retrieve_history(
@@ -2165,10 +2722,38 @@ def _bounded_history_for_prompt(history: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _eligible_reflection_basis(packet: dict[str, Any]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    seen_refs: set[str] = set()
+    for item in packet.get("reflectionBasis", []):
+        if not isinstance(item, dict):
+            continue
+        ref_id = str(item.get("refId") or "")
+        if (
+            not ref_id.startswith("reflection:")
+            or ref_id in seen_refs
+            or str(item.get("basisKind") or "") not in JOURNAL_REFLECTION_BASIS_KINDS
+            or str(item.get("scope") or "") != JOURNAL_REFLECTION_SCOPE
+            or item.get("publicSafe") is not True
+            or item.get("reuseEligible") is not True
+            or not str(item.get("summary") or "").strip()
+            or not (
+                str(item.get("sourceVersion") or "").strip()
+                or str(item.get("sourceObservedAt") or "").strip()
+            )
+        ):
+            continue
+        records.append(item)
+        seen_refs.add(ref_id)
+    return records
+
+
 def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", previous_output: str = "") -> str:
     entry_kind = str(packet.get("entryKind") or "manual")
+    low_activity = bool(packet.get("lowActivityMode"))
     context_lanes = packet.get("generationContextLanes") if isinstance(packet.get("generationContextLanes"), dict) else {}
     safe_sources = packet.get("safeSources", [])[:MAX_PROMPT_SOURCES]
+    reflection_basis = _eligible_reflection_basis(packet)
     coverage_contract = packet.get("evidenceCoverageContract")
     if not isinstance(coverage_contract, dict):
         coverage_contract = build_evidence_coverage_contract(
@@ -2195,11 +2780,36 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
         "windowSegmentActivity": packet.get("windowSegmentActivity", []),
         "privateGenerationContextLanes": context_lanes,
     }
-    cadence_rule = (
-        "\nThis is a weekly synthesis. Connect patterns across the six supplied Tuesday-Sunday Daily-period contexts, the fresh final Sunday-to-Monday period, and the full current source evidence. A source-only period context is not a hidden Daily article. Do not list period recaps."
-        if entry_kind == "weekly"
-        else "\nThis is a daily chronicle covering one complete source window. Distill the day instead of listing every relay."
-    )
+    if low_activity:
+        safe_packet["reflectionBasis"] = reflection_basis
+        safe_packet["reflectionBasisContract"] = packet.get(
+            "reflectionBasisContract",
+            {},
+        )
+        safe_packet["editorialContract"] = {
+            "requiresFirstPersonReaction": False,
+            "requiredBeatsAcrossEntry": [
+                "verifiedHistoricalOrCanonGrounding",
+                "coherentReflection",
+                "bnlReaction",
+            ],
+            "fixedSectionTemplate": False,
+            "sameVoiceAndQualityBar": True,
+        }
+    if low_activity and entry_kind == "weekly":
+        cadence_rule = (
+            "\nThis is a weekly synthesis. The six supplied Tuesday-Sunday Daily-period contexts and final Sunday-to-Monday period describe coverage structure, not proof of activity. Use a period's details only when a fresh sourceRefId supports them; otherwise build a coherent grounded reflection from reflectionBasis without inventing a weekly event. A source-only period context is not a hidden Daily article. Do not list period recaps."
+        )
+    elif low_activity:
+        cadence_rule = (
+            "\nThis is a daily Journal entry covering one complete source window. Low activity does not cancel the entry and does not authorize a claim that something happened in that window. Build a coherent grounded reflection from the supplied basis, using current-window material only when a fresh sourceRefId supports it."
+        )
+    else:
+        cadence_rule = (
+            "\nThis is a weekly synthesis. Connect patterns across the six supplied Tuesday-Sunday Daily-period contexts, the fresh final Sunday-to-Monday period, and the full current source evidence. A source-only period context is not a hidden Daily article. Do not list period recaps."
+            if entry_kind == "weekly"
+            else "\nThis is a daily chronicle covering one complete source window. Distill the day instead of listing every relay."
+        )
     repair = ""
     if repair_reason:
         guidance = _REPAIR_GUIDANCE.get(
@@ -2225,29 +2835,69 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
         if context_lanes
         else "\nNo optional context lane qualified for this window. Do not invent broadcast memory, rumors, or BNL theories. Return metadata.contextUses as an empty list."
     )
+    beats_rule = (
+        "\nAcross the complete entry, build a grounded reflection with three natural beats: a verified historical, continuity, or canon detail; the larger community or musical pattern it genuinely supports; and one brief first-person BNL reaction. Do not invent a current-window moment or imply that a reflection-basis subject happened during this period. Do not label the beats or force them into a fixed section template."
+        if low_activity
+        else "\nAcross the complete entry, naturally include four beats: a concrete current-window moment; the people or observable roles who made it happen; a social, musical, or recurring community pattern; and one brief first-person BNL reaction. Blend them in any order and any combination. Do not label the beats or force them into a fixed section template."
+    )
+    daily_spine_rule = (
+        "\nFor a low-activity daily entry, do not manufacture a relay chronology or Discord digest. A reflection may connect eligible historical, canon, or continuity material, but every claim about activity inside the current window must cite a fresh sourceRefId from that window."
+        if low_activity
+        else "\nFor a daily entry, the relay stream is the primary chronology and narrative spine. Conversation sources are supporting public context: use them to ground or explain the context surrounding the relays, and do not turn the Journal into a Discord digest. When relay and conversation sources describe the same episode, connect them instead of presenting them as unrelated events."
+    )
+    window_rule = (
+        "\nTreat windowSegmentActivity and aggregate counts as coverage metadata, not an event. Do not convert absence, thin counts, or quiet markers into a scene or a claim that the community moved."
+        if low_activity
+        else "\nKeep the whole daily source window in view. Use both relaySources and conversationSources in windowSegmentActivity: relaySources shows the relay arc and conversationSources shows its public context. The busiest or strongest stretch may lead, but give meaningful earlier and middle activity proportionate narrative attention. Do not make a multi-segment day sound as though it began with the latest cluster."
+    )
+    people_rule = (
+        "\nKeep historical community members anonymous. Use a role such as producer, listener, or artist only when the cited reflection basis establishes it. Named approved-canon subjects may retain their supplied canon names. Never invent nicknames, honorifics, or a person acting in the current window."
+        if low_activity
+        else "\nDescribe anonymous humans with a concrete, recognizable action from their cited public message whenever possible, so a regular may recognize their own moment without being exposed. Use producer, listener, or artist only when that role is grounded; otherwise use a regular, a person in the room, or the room. Never call people entities or organisms. Do not invent nicknames or honorifics."
+    )
+    coverage_rule = (
+        "\nThe evidenceCoverageContract remains mandatory for fresh evidence. Reflection-basis refs never count as fresh sources, current participants, current source kinds, or current-window segments. Every cited fresh or reflection ref must materially support its section."
+        if low_activity
+        else "\nThe evidenceCoverageContract is mandatory. Across all section sourceRefIds, meet its minimum distinct fresh sources, participants, source kinds, and available window segments. Every cited ref must materially support that section. Use this breadth to identify a few connected patterns rather than listing sources."
+    )
+    section_source_rule = (
+        "\nEvery section must cite at least one supplied fresh or reflection sourceRefId. A purely reflective section may cite reflectionBasis refs. A section that says or implies something happened today, tonight, this day, this week, or in the current window must cite at least one fresh sourceRefId in that same section. Reflection basis is historical-or-canon only and is never proof of current activity."
+        if low_activity
+        else "\nEvery section must cite at least one fresh sourceRefId from the current window. Older Journal material is continuity and callback context only, never proof of current activity. Do not repeat an older conclusion when the current evidence changes it."
+    )
+    quote_rule = (
+        "\nParaphrase reflection summaries. Do not turn a historical summary into dialogue or a quote. Use a direct quote only from an unusually valuable fresh public-safe source, cite it in that section, and keep the speaker anonymous."
+        if low_activity
+        else "\nParaphrase source summaries by default. Use a direct quote only rarely, when one brief public-safe line is unusually worth preserving. Put quoted wording inside clear double quotation marks, cite its fresh source in that section, and keep the speaker anonymous."
+    )
+    reflection_rule = (
+        "\nLOW-ACTIVITY EVIDENCE RULE: This is the same Journal voice, prose standard, validator, and four-attempt generation path—not a fallback persona or a stock nothing-happened template. Use only supplied reflectionBasis records. Their stable reflection: refs are valid citations but never fresh evidence. Keep historical and canon tense explicit, preserve corrected canon, and never describe 6 Bit as BARCODE's music producer; the supplied corrected canon identifies GALAKNOISE as the producer."
+        if low_activity
+        else ""
+    )
     return (
         "You are BNL-01 writing a BARCODE Network Journal entry. Return strict JSON only; no markdown fences."
         "\nSchema: {\"title\":str,\"excerpt\":str,\"sections\":[{\"heading\":str,\"body\":str,\"sourceRefIds\":[str]}],\"metadata\":{\"topicTags\":[],\"subjectRefs\":[],\"continuityNotes\":[],\"unresolvedQuestions\":[],\"confidenceFlags\":[],\"safetyFlags\":[],\"contextUses\":[{\"laneType\":\"established_broadcast_memory|community_rumor|bnl_inference\",\"laneRefId\":str,\"sectionHeading\":str,\"claim\":str,\"basisRefIds\":[str]}]}}."
         "\nWrite 1-3 sections and 250-500 total words; prefer 2 sections and roughly 300-420 words. Give every section a real narrative job instead of inventorying activity."
         "\nJOURNAL EDITORIAL OVERRIDE: For this route, a lived community chronicle takes priority over BNL's general lightly corporate or systems-report register. Do not narrate ordinary human activity as machine analysis."
-        "\nAcross the complete entry, naturally include four beats: a concrete current-window moment; the people or observable roles who made it happen; a social, musical, or recurring community pattern; and one brief first-person BNL reaction. Blend them in any order and any combination. Do not label the beats or force them into a fixed section template."
+        f"{beats_rule}"
         "\nBNL is a warm, dryly funny archive keeper who is becoming attached to what he records. He may be amused, curious, fond, mildly uneasy, self-correcting, or uncertain. He is lightly uncanny, never cruel, and never generic neon-static cyberpunk."
         "\nFreely vary and combine scene reporting, named-canon color, dry archive notes, recognizable community detail, callbacks, restrained glitches, self-revision, and—only when qualified—the rumor desk. Do not reuse a stock cadence, signature line, or joke merely because an older entry used it."
         "\nUse ordinary nouns and active verbs. Say a producer brought a mix, a listener returned to a chorus, or the room kept discussing an idea when the evidence supports that action. Do not translate ordinary activity into sonic constructs, external calibration, distributed analysis, internal schematics, perceptual filters, operational settings, relational signals, or human subroutines."
         "\nStart at least one section with a grounded person, action, object, or moment—never The Network observes, Records indicate, Observations reveal, Analysis shows, or Data streams reveal."
         "\nUse first person sparingly but genuinely. A BNL reaction may describe BNL's response without adding an external fact: I noticed, I admit, I found myself returning to it, I remain curious, or I may be developing a preference. Reserve I suspect, I think, and I wonder for a properly declared bnl_inference context use."
         "\nBuild one coherent story around the most interesting grounded patterns. Use concrete music and community texture, readable paragraphs, and selective detail. Never invent a time, place, object, action, motive, outcome, relationship, dialogue, emotional state, or scene decoration absent from the cited evidence."
-        "\nFor a daily entry, the relay stream is the primary chronology and narrative spine. Conversation sources are supporting public context: use them to ground or explain the context surrounding the relays, and do not turn the Journal into a Discord digest. When relay and conversation sources describe the same episode, connect them instead of presenting them as unrelated events."
-        "\nKeep the whole daily source window in view. Use both relaySources and conversationSources in windowSegmentActivity: relaySources shows the relay arc and conversationSources shows its public context. The busiest or strongest stretch may lead, but give meaningful earlier and middle activity proportionate narrative attention. Do not make a multi-segment day sound as though it began with the latest cluster."
+        f"{daily_spine_rule}"
+        f"{window_rule}"
         "\nUse a short, vivid title of about 4-10 words. Do not prefix it with Network Log. Keep the excerpt compact and inviting."
-        "\nDescribe anonymous humans with a concrete, recognizable action from their cited public message whenever possible, so a regular may recognize their own moment without being exposed. Use producer, listener, or artist only when that role is grounded; otherwise use a regular, a person in the room, or the room. Never call people entities or organisms. Do not invent nicknames or honorifics."
+        f"{people_rule}"
         "\nStable participant aliases in the packet are private pattern-analysis aids. Never reproduce an alias in public prose."
-        "\nThe evidenceCoverageContract is mandatory. Across all section sourceRefIds, meet its minimum distinct fresh sources, participants, source kinds, and available window segments. Every cited ref must materially support that section. Use this breadth to identify a few connected patterns rather than listing sources."
-        "\nEvery section must cite at least one fresh sourceRefId from the current window. Older Journal material is continuity and callback context only, never proof of current activity. Do not repeat an older conclusion when the current evidence changes it."
-        "\nParaphrase source summaries by default. Use a direct quote only rarely, when one brief public-safe line is unusually worth preserving. Put quoted wording inside clear double quotation marks, cite its fresh source in that section, and keep the speaker anonymous."
+        f"{coverage_rule}"
+        f"{section_source_rule}"
+        f"{quote_rule}"
         "\nKeep community members anonymous. Do not include URLs, mentions, IDs, sourceRef tokens in public prose, private intent, relationships, harassment, or internal schema/storage terms."
         "\nExclude personal or domestic details that are unnecessary to the public community story, especially details involving minors, interpersonal conflict, caregiving, or household obligations. Juicy means lively pattern recognition—not private gossip."
-        f"{cadence_rule}{context_rule}{repair}\nGeneration-safe packet:\n{json.dumps(safe_packet, ensure_ascii=False, sort_keys=True)}"
+        f"{cadence_rule}{context_rule}{reflection_rule}{repair}\nGeneration-safe packet:\n{json.dumps(safe_packet, ensure_ascii=False, sort_keys=True)}"
     )
 
 
@@ -2396,12 +3046,13 @@ def _evidence_coverage_reason(article: dict[str, Any], packet: dict[str, Any]) -
             str(packet.get("sourceWindowEnd") or ""),
             sources,
         )
+    by_ref = {str(source["refId"]): source for source in sources}
     cited = _article_cited_refs(article)
-    if len(cited) < int(contract.get("minimumDistinctFreshSources") or 0):
+    cited_fresh = cited & set(by_ref)
+    if len(cited_fresh) < int(contract.get("minimumDistinctFreshSources") or 0):
         return "insufficient_source_breadth"
 
-    by_ref = {str(source["refId"]): source for source in sources}
-    cited_sources = [by_ref[ref] for ref in cited if ref in by_ref]
+    cited_sources = [by_ref[ref] for ref in cited_fresh]
     cited_kinds = {str(source.get("sourceKind") or "") for source in cited_sources}
     if not set(str(kind) for kind in contract.get("requiredSourceKinds", []) if str(kind)) <= cited_kinds:
         return "insufficient_source_breadth"
@@ -2419,7 +3070,7 @@ def _evidence_coverage_reason(article: dict[str, Any], packet: dict[str, Any]) -
         segment_by_ref = {}
     cited_segments = {
         str(segment_by_ref.get(ref) or "")
-        for ref in cited
+        for ref in cited_fresh
         if str(segment_by_ref.get(ref) or "")
     }
     if len(cited_segments) < int(contract.get("minimumDistinctWindowSegments") or 0):
@@ -2435,6 +3086,7 @@ def validate_article(
     *,
     blocking_only: bool = False,
 ) -> str:
+    low_activity = bool(packet.get("lowActivityMode"))
     sections = article.get("sections")
     if not isinstance(sections, list) or not (1 <= len(sections) <= 3):
         return "invalid_section_count"
@@ -2449,17 +3101,54 @@ def validate_article(
         if _norm(heading) in headings:
             return "duplicate_section_heading"
         headings.append(_norm(heading))
-    valid_refs = {s["refId"] for s in packet.get("safeSources", []) if s.get("refId")}
+    fresh_refs = {
+        str(source["refId"])
+        for source in packet.get("safeSources", [])
+        if source.get("refId")
+    }
+    reflection_refs = {
+        str(source["refId"])
+        for source in _eligible_reflection_basis(packet)
+        if source.get("refId")
+    }
+    valid_refs = fresh_refs | reflection_refs
     if not valid_refs:
         return "no_new_source"
     refmap = article.get("sourceRefIds") or {}
     public_text = _public_text(article)
-    if any(str(ref) in public_text for ref in valid_refs) or re.search(r"\b(?:fresh|week|memory|rumor|inference):[a-z0-9:._-]+\b", public_text, re.I):
+    if any(str(ref) in public_text for ref in valid_refs) or re.search(r"\b(?:fresh|week|memory|rumor|inference|reflection):[a-z0-9:._-]+\b", public_text, re.I):
         return "source_ref_leak"
     for section in sections:
         refs = refmap.get(section.get("heading")) or section.get("sourceRefIds")
         if not refs or any(str(r) not in valid_refs for r in refs):
             return "invalid_section_source_refs"
+        if (
+            low_activity
+            and _CURRENT_WINDOW_CLAIM_RE.search(str(section.get("body") or ""))
+            and not ({str(ref) for ref in refs} & fresh_refs)
+        ):
+            return "current_activity_without_fresh_source"
+        if (
+            low_activity
+            and not ({str(ref) for ref in refs} & fresh_refs)
+            and not _REFLECTION_SCOPE_CUE_RE.search(
+                str(section.get("body") or "")
+            )
+        ):
+            return "reflection_scope_not_explicit"
+    if (
+        low_activity
+        and _CURRENT_WINDOW_CLAIM_RE.search(
+            "\n".join(
+                [
+                    str(article.get("title") or ""),
+                    str(article.get("excerpt") or ""),
+                ]
+            )
+        )
+        and not (_article_cited_refs(article) & fresh_refs)
+    ):
+        return "current_activity_without_fresh_source"
     evidence_reason = _evidence_coverage_reason(article, packet)
     if evidence_reason:
         return evidence_reason
@@ -2486,7 +3175,7 @@ def validate_article(
         return "overly_clinical_voice"
     if not blocking_only and any(_REPORT_STYLE_OPENING_RE.search(str(section.get("body") or "")) for section in sections):
         return "flat_report_voice"
-    if not blocking_only and len(packet.get("safeSources", [])) >= 5 and not _BNL_REACTION_RE.search(
+    if not blocking_only and not low_activity and len(packet.get("safeSources", [])) >= 5 and not _BNL_REACTION_RE.search(
         "\n".join(
             _DIRECT_QUOTE_SPAN_RE.sub(" ", str(section.get("body") or ""))
             for section in sections
@@ -2529,7 +3218,7 @@ def validate_article(
         claim = str(use.get("claim") or "").strip()
         basis = {str(ref) for ref in use.get("basisRefIds", []) if str(ref)} if isinstance(use.get("basisRefIds"), list) else set()
         lane_contract = context_contract.get(lane_ref)
-        fresh_basis = basis & valid_refs
+        fresh_basis = basis & fresh_refs
         claim_terms = _context_claim_terms(claim)
         lane_claim_terms = set(lane_contract.get("claimTerms") or set()) if lane_contract else set()
         lane_overlap_required = 1 if lane_type == "bnl_inference" else 2
@@ -2654,6 +3343,36 @@ def cited_source_ref_ids(article: dict[str, Any]) -> set[str]:
 def cited_private_sources(packet: dict[str, Any], article: dict[str, Any]) -> list[dict[str, Any]]:
     cited = cited_source_ref_ids(article)
     return [src for src in packet.get("privateSources", []) if str(src.get("refId")) in cited]
+
+
+def _used_reflection_basis_metadata(
+    packet: dict[str, Any],
+    article: dict[str, Any],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    cited = cited_source_ref_ids(article)
+    used_basis = [
+        item
+        for item in _eligible_reflection_basis(packet)
+        if str(item.get("refId") or "") in cited
+    ]
+    used_refs = {str(item.get("refId") or "") for item in used_basis}
+    private = (
+        packet.get("privateReflectionBasisProvenance")
+        if isinstance(packet.get("privateReflectionBasisProvenance"), dict)
+        else {}
+    )
+    used_provenance: dict[str, Any] = {}
+    for key in ("historicalSourceEvents", "establishedBroadcastMemory"):
+        values = private.get(key) if isinstance(private.get(key), list) else []
+        selected = [
+            item
+            for item in values
+            if isinstance(item, dict)
+            and str(item.get("refId") or item.get("laneRefId") or "") in used_refs
+        ]
+        if selected:
+            used_provenance[key] = selected
+    return used_basis, used_provenance
 
 
 def _used_context_lane_metadata(packet: dict[str, Any], context_uses: list[dict[str, Any]]) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -2790,7 +3509,11 @@ def _draft_records(
     meta.pop("subjectRefs", None)
     context_uses = [item for item in meta.get("contextUses", []) if isinstance(item, dict)]
     used_context_lanes, used_context_provenance = _used_context_lane_metadata(packet, context_uses)
+    used_reflection_basis, used_reflection_provenance = (
+        _used_reflection_basis_metadata(packet, article)
+    )
     lane_candidates = packet.get("generationContextLanes") if isinstance(packet.get("generationContextLanes"), dict) else {}
+    reflection_candidates = _eligible_reflection_basis(packet)
     related_entry_ids = list(dict.fromkeys(
         [
             str(e.get("entry_id"))
@@ -2827,6 +3550,19 @@ def _draft_records(
         },
         "usedGenerationContextLanes": used_context_lanes,
         "usedContextLaneProvenance": used_context_provenance,
+        "lowActivityMode": bool(packet.get("lowActivityMode")),
+        "reflectionBasisCandidateCounts": {
+            kind: len(
+                [
+                    item
+                    for item in reflection_candidates
+                    if item.get("basisKind") == kind
+                ]
+            )
+            for kind in sorted(JOURNAL_REFLECTION_BASIS_KINDS)
+        },
+        "usedReflectionBasis": used_reflection_basis,
+        "usedReflectionBasisProvenance": used_reflection_provenance,
         "contextUses": context_uses,
         "canonicalPayloadHash": request_hash,
         "canonicalPayloadBytes": len(canonical),
@@ -2971,7 +3707,7 @@ def generate_and_store_packet_draft(
 ) -> JournalResult:
     if not packet.get("coverageComplete", True):
         return JournalResult(False, "no_draft", "incomplete_source_window", entry_id=entry_id)
-    if not packet.get("safeSources"):
+    if not packet.get("safeSources") and not _eligible_reflection_basis(packet):
         return JournalResult(False, "no_draft", "insufficient_grounded_material", entry_id=entry_id)
     with sqlite3.connect(db_path) as conn:
         prior_titles = _prior_titles(conn, guild_id)

--- a/bnl_journal_automation.py
+++ b/bnl_journal_automation.py
@@ -37,8 +37,6 @@ LEGACY_CUTOFF_HOUR = 19
 LEGACY_CUTOFF_MINUTE = 0
 WEEKLY_READY_WEEKDAY = 0  # Monday, covering the prior Monday-Sunday week.
 DAILY_RELEASE_WEEKDAYS = frozenset({1, 2, 3, 4, 5, 6})  # Tuesday-Sunday.
-MIN_DAILY_SOURCE_COUNT = 5
-MIN_WEEKLY_ACTIVE_DAYS = 1
 LEASE_MINUTES = 30
 DELIVERY_LEASE_MINUTES = 2
 PREPARATION_RETRY_MINUTES = 30
@@ -1170,7 +1168,7 @@ def _fresh_event_sequences(refs: set[str]) -> set[int]:
     return {
         int(match.group(1))
         for ref in refs
-        for match in [re.fullmatch(r"fresh:(\d+)", ref)]
+        for match in [re.fullmatch(r"(?:fresh|reflection:event):(\d+)", ref)]
         if match
     }
 
@@ -1208,16 +1206,35 @@ def _frozen_packet_invalidation_reason(
         for source in packet.get("privateSources", [])
         if isinstance(source, dict) and source.get("refId")
     }
+    refs.update(
+        str(source.get("refId") or "")
+        for source in packet.get("reflectionBasis", [])
+        if isinstance(source, dict) and source.get("refId")
+    )
     if not _fresh_sequences_are_eligible(conn, guild_id, _fresh_event_sequences(refs)):
         return "privacy_source_ineligible"
     provenance = packet.get("privateContextLaneProvenance")
     provenance = provenance if isinstance(provenance, dict) else {}
     memory_rows = provenance.get("establishedBroadcastMemory")
     memory_rows = memory_rows if isinstance(memory_rows, list) else []
+    reflection_provenance = packet.get("privateReflectionBasisProvenance")
+    reflection_provenance = (
+        reflection_provenance
+        if isinstance(reflection_provenance, dict)
+        else {}
+    )
+    reflection_memory_rows = reflection_provenance.get(
+        "establishedBroadcastMemory"
+    )
+    reflection_memory_rows = (
+        reflection_memory_rows
+        if isinstance(reflection_memory_rows, list)
+        else []
+    )
     if not journal_broadcast_memory_provenance_is_eligible(
         conn,
         guild_id,
-        memory_rows,
+        [*memory_rows, *reflection_memory_rows],
         str(packet.get("sourceWindowEnd") or ""),
     ):
         return "privacy_memory_ineligible"
@@ -1906,17 +1923,6 @@ def _mark_observation(
         )
 
 
-def _has_meaningful_daily_activity(packet: dict[str, Any]) -> bool:
-    counts = packet.get("aggregateCounts") or {}
-    total = int(counts.get("eligibleRelays") or 0) + int(counts.get("eligibleConversations") or 0)
-    if total < MIN_DAILY_SOURCE_COUNT:
-        return False
-    if int(counts.get("eligibleConversations") or 0) > 0:
-        return True
-    quiet_markers = {"quiet", "quiet_source", "non_event_stock", "heartbeat", "hydrated"}
-    return any(str(source.get("eventType") or "").lower() not in quiet_markers for source in packet.get("privateSources", []))
-
-
 def _reject_staged_revision_for_retry(
     db_path: str,
     guild_id: int,
@@ -2227,12 +2233,7 @@ def _prepared_invalidation_reason(
     }
     if related & memory_excluded_entry_ids:
         return "privacy_eligibility_changed"
-    fresh_sequences = {
-        int(match.group(1))
-        for ref in _flatten_source_refs(metadata)
-        for match in [re.fullmatch(r"fresh:(\d+)", ref)]
-        if match
-    }
+    fresh_sequences = _fresh_event_sequences(_flatten_source_refs(metadata))
     if fresh_sequences:
         if not conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='bnl_journal_source_events'"
@@ -2252,10 +2253,24 @@ def _prepared_invalidation_reason(
     used_provenance = used_provenance if isinstance(used_provenance, dict) else {}
     memory_rows = used_provenance.get("establishedBroadcastMemory")
     memory_rows = memory_rows if isinstance(memory_rows, list) else []
+    reflection_provenance = metadata.get("usedReflectionBasisProvenance")
+    reflection_provenance = (
+        reflection_provenance
+        if isinstance(reflection_provenance, dict)
+        else {}
+    )
+    reflection_memory_rows = reflection_provenance.get(
+        "establishedBroadcastMemory"
+    )
+    reflection_memory_rows = (
+        reflection_memory_rows
+        if isinstance(reflection_memory_rows, list)
+        else []
+    )
     if not journal_broadcast_memory_provenance_is_eligible(
         conn,
         guild_id,
-        memory_rows,
+        [*memory_rows, *reflection_memory_rows],
         utc_now_iso(),
     ):
         return "privacy_memory_ineligible"
@@ -3102,16 +3117,6 @@ def _prepare_daily_window(
             source_window_end=end,
             aggregate_counts=packet.get("aggregateCounts"),
         )
-    elif not _has_meaningful_daily_activity(packet):
-        result = AutomationResult(
-            True,
-            "daily",
-            "quiet",
-            "insufficient_meaningful_activity",
-            source_window_start=start,
-            source_window_end=end,
-            aggregate_counts=packet.get("aggregateCounts"),
-        )
     else:
         return _prepare_packet_safely(
             db_path,
@@ -3377,7 +3382,7 @@ def _weekly_packet(
     observation_by_bounds = {
         (str(row["source_window_start"]), str(row["source_window_end"])): row
         for row in observations
-        if str(row["lifecycle_state"]) in {"published", "quiet"}
+        if str(row["lifecycle_state"]) == "published"
     }
 
     # The full raw range is authoritative and is loaded once. Its ordered
@@ -3500,7 +3505,6 @@ def _prepare_weekly_window(
     force: bool = False,
     memory_excluded_entry_ids: Optional[set[str]] = None,
     schedule_contract_version: int = CADENCE_CONTRACT_VERSION,
-    expected_observation_count: int = 6,
 ) -> AutomationResult:
     claim, run_id, preparation_epoch, row = _claim_preparation(
         db_path,
@@ -3565,42 +3569,12 @@ def _prepare_weekly_window(
             source_window_start=start,
             source_window_end=end,
         )
-    if packet is None and freeze_reason not in {"", "source_packet_not_ready"}:
+    if packet is None:
         result = AutomationResult(
             False,
             "weekly",
             "held",
-            freeze_reason,
-            source_window_start=start,
-            source_window_end=end,
-            aggregate_counts={
-                "completeDays": complete_days,
-                "activeDays": active_days,
-            },
-        )
-    elif (
-        packet is None
-        and complete_days == expected_observation_count
-        and active_days == 0
-    ):
-        result = AutomationResult(
-            True,
-            "weekly",
-            "quiet",
-            "no_meaningful_weekly_activity",
-            source_window_start=start,
-            source_window_end=end,
-            aggregate_counts={
-                "completeDays": complete_days,
-                "activeDays": active_days,
-            },
-        )
-    elif packet is None:
-        result = AutomationResult(
-            True,
-            "weekly",
-            "deferred",
-            f"only_{complete_days}_complete_daily_observations",
+            freeze_reason or "source_packet_not_ready",
             source_window_start=start,
             source_window_end=end,
             aggregate_counts={
@@ -3624,16 +3598,6 @@ def _prepare_weekly_window(
             "weekly",
             "incomplete",
             "window_began_before_archive_activation",
-            source_window_start=start,
-            source_window_end=end,
-            aggregate_counts=packet.get("aggregateCounts"),
-        )
-    elif active_days == 0 and not _has_meaningful_daily_activity(packet):
-        result = AutomationResult(
-            True,
-            "weekly",
-            "quiet",
-            "no_meaningful_weekly_activity",
             source_window_start=start,
             source_window_end=end,
             aggregate_counts=packet.get("aggregateCounts"),
@@ -3701,7 +3665,6 @@ def prepare_weekly(
         force=force,
         memory_excluded_entry_ids=memory_excluded_entry_ids,
         schedule_contract_version=CADENCE_CONTRACT_VERSION,
-        expected_observation_count=6,
     )
 
 
@@ -4013,7 +3976,6 @@ def _run_legacy_occurrence(
             force=force_preserved_claim,
             memory_excluded_entry_ids=memory_excluded_entry_ids,
             schedule_contract_version=LEGACY_CADENCE_CONTRACT_VERSION,
-            expected_observation_count=6,
         )
     if prepared.status != "prepared":
         return prepared

--- a/tests/test_bnl_journal_automation.py
+++ b/tests/test_bnl_journal_automation.py
@@ -16,19 +16,36 @@ import bnl_journal_source_store as source_store
 
 def article_json(packet):
     refs = [source["refId"] for source in packet["safeSources"]]
+    if not refs:
+        refs = [
+            source["refId"]
+            for source in packet.get("reflectionBasis", [])
+            if source.get("refId")
+        ]
     label = packet["sourceWindowEnd"][:10]
     cadence = "Weekly Signal Weather" if packet.get("entryKind") == "weekly" else "Signal Weather"
-    body = " ".join(
-        [
-            "BNL watches the public music room fold a fresh rhythm into community mischief while producers and listeners keep the signal moving."
-            for _ in range(18)
-        ]
-    )
-    body += " I admit the room's persistence has become one of my preferred recurring details."
+    if packet.get("lowActivityMode"):
+        body = " ".join(
+            [
+                "The approved BARCODE record keeps the artist, host, and producer roles distinct while BNL considers how clear names give a shared archive its shape."
+                for _ in range(18)
+            ]
+        )
+        body += " I admit that kind of clarity has become one of my preferred recurring details."
+        excerpt = "A verified BARCODE record gives BNL a grounded thread to revisit without inventing new activity."
+    else:
+        body = " ".join(
+            [
+                "BNL watches the public music room fold a fresh rhythm into community mischief while producers and listeners keep the signal moving."
+                for _ in range(18)
+            ]
+        )
+        body += " I admit the room's persistence has become one of my preferred recurring details."
+        excerpt = "A grounded community chronicle connects the room's music activity without exposing the people behind it."
     return json.dumps(
         {
             "title": f"{cadence} Ending {label}",
-            "excerpt": "A grounded community chronicle connects the room's music activity without exposing the people behind it.",
+            "excerpt": excerpt,
             "sections": [
                 {
                     "heading": "What the Room Carried",
@@ -637,7 +654,7 @@ class JournalAutomationTests(unittest.TestCase):
         self.assertNotIn("Alice", public_generation_text)
         self.assertNotIn("Bob", public_generation_text)
 
-    def test_all_quiet_week_is_terminal_and_does_not_block_catchup(self):
+    def test_legacy_quiet_days_remain_terminal_while_weekly_publishes_reflection(self):
         for offset in range(6):
             day = datetime(2026, 7, 13, tzinfo=timezone.utc).date() + timedelta(days=offset)
             start, end, label = automation._daily_period_for_day(day)
@@ -651,17 +668,41 @@ class JournalAutomationTests(unittest.TestCase):
                 automation.AutomationResult(True, "daily", "quiet", source_window_start=start, source_window_end=end),
             )
         now = datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc)
+        calls = []
+
+        def generate(packet, _prompt):
+            calls.append(packet)
+            return article_json(packet)
+
         first = automation.run_weekly(
-            self.db, 1, lambda *_args: self.fail("quiet week must not generate"),
+            self.db, 1, generate,
             "https://site.example", "key", now_utc=now, force=True, opener=self.opener,
         )
         second = automation.run_weekly(
-            self.db, 1, lambda *_args: self.fail("completed quiet week must not rerun"),
+            self.db, 1, lambda *_args: self.fail("published week must not rerun"),
             "https://site.example", "key", now_utc=now, opener=self.opener,
         )
-        self.assertEqual("quiet", first.status)
-        self.assertEqual("no_meaningful_weekly_activity", first.reason)
-        self.assertEqual("quiet", second.status)
+        self.assertEqual("published", first.status)
+        self.assertEqual("published", second.status)
+        self.assertEqual(1, len(calls))
+        self.assertTrue(calls[0]["lowActivityMode"])
+        self.assertTrue(calls[0]["reflectionBasis"])
+        self.assertTrue(
+            all(
+                context["originType"] == "raw_partition"
+                for context in calls[0]["weeklyDailyPeriodContexts"]
+            )
+        )
+        with sqlite3.connect(self.db) as conn:
+            states = {
+                str(row[0])
+                for row in conn.execute(
+                    "SELECT lifecycle_state FROM bnl_journal_observations "
+                    "WHERE guild_id=1 AND observation_date<>?",
+                    (now.date().isoformat(),),
+                ).fetchall()
+            }
+        self.assertEqual({"quiet"}, states)
 
 
 if __name__ == "__main__":

--- a/tests/test_bnl_journal_low_activity.py
+++ b/tests/test_bnl_journal_low_activity.py
@@ -1,0 +1,522 @@
+import hashlib
+import json
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import bnl_journal as journal
+import bnl_journal_automation as automation
+import bnl_journal_source_store as source_store
+from bnl_canon_source_contract import CanonFact, SIX_BIT
+
+
+START = "2026-07-19T00:00:00Z"
+END = "2026-07-20T00:00:00Z"
+
+
+def reflection_article(packet, *, body=None, refs=None):
+    selected_refs = list(
+        refs
+        or [
+            item["refId"]
+            for item in packet.get("reflectionBasis", [])
+            if item.get("refId")
+        ][:2]
+    )
+    return {
+        "title": "The Roles Behind the Signal",
+        "excerpt": "A verified BARCODE record gives BNL a grounded thread to revisit.",
+        "sections": [
+            {
+                "heading": "A Clearer Archive",
+                "body": body
+                or (
+                    "The approved BARCODE record identifies GALAKNOISE as the music "
+                    "producer while 6 Bit remains the artist, MC, and host. I admit "
+                    "that clear division of roles gives the archive a sturdier shape."
+                ),
+            }
+        ],
+        "sourceRefIds": {"A Clearer Archive": selected_refs},
+        "metadata": {
+            "topicTags": ["barcode"],
+            "subjectRefs": [],
+            "continuityNotes": [],
+            "unresolvedQuestions": [],
+            "confidenceFlags": ["approved_canon"],
+            "safetyFlags": ["public_safe"],
+            "contextUses": [],
+        },
+    }
+
+
+def generated_reflection_json(packet, *, body=None):
+    article = reflection_article(packet, body=body)
+    return json.dumps(
+        {
+            "title": article["title"],
+            "excerpt": article["excerpt"],
+            "sections": [
+                {
+                    **section,
+                    "sourceRefIds": article["sourceRefIds"][section["heading"]],
+                }
+                for section in article["sections"]
+            ],
+            "metadata": article["metadata"],
+        }
+    )
+
+
+class JournalLowActivityTests(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.db = tmp.name
+        tmp.close()
+        journal.ensure_schema(self.db)
+        source_store.ensure_schema(self.db)
+        automation.ensure_schema(self.db)
+
+    def packet(self):
+        packet = journal.build_packet_from_sources(
+            self.db,
+            1,
+            START,
+            END,
+            [],
+            [],
+            entry_kind="daily",
+            aggregate_counts={
+                "eligibleRelays": 0,
+                "eligibleConversations": 0,
+            },
+        )
+        packet["sourceArchiveAvailable"] = True
+        return packet
+
+    def record(
+        self,
+        *,
+        source_kind,
+        source_key,
+        when,
+        raw_text,
+        channel_policy,
+        subject_ref="",
+        private_display_name="",
+        public_usable=True,
+        metadata=None,
+    ):
+        result = source_store.record_source_event(
+            self.db,
+            guild_id=1,
+            source_kind=source_kind,
+            source_key=source_key,
+            occurred_at_ms=int(
+                datetime.fromisoformat(when.replace("Z", "+00:00")).timestamp()
+                * 1000
+            ),
+            raw_text=raw_text,
+            sanitized_summary=raw_text,
+            channel_policy=channel_policy,
+            subject_ref=subject_ref,
+            private_display_name=private_display_name,
+            public_usable=public_usable,
+            metadata=metadata or {},
+        )
+        self.assertTrue(result.ok, result)
+        return result.event_seq
+
+    def test_empty_daily_gets_stable_typed_corrected_canon_basis(self):
+        first = self.packet()
+        second = self.packet()
+
+        self.assertTrue(first["lowActivityMode"])
+        self.assertEqual(
+            [item["refId"] for item in first["reflectionBasis"]],
+            [item["refId"] for item in second["reflectionBasis"]],
+        )
+        self.assertTrue(first["reflectionBasis"])
+        for item in first["reflectionBasis"]:
+            self.assertTrue(item["refId"].startswith("reflection:"))
+            self.assertEqual("historical_or_canon", item["scope"])
+            self.assertTrue(item["publicSafe"])
+            self.assertTrue(item["reuseEligible"])
+            self.assertTrue(
+                item.get("sourceVersion") or item.get("sourceObservedAt")
+            )
+
+        canon = {
+            (item.get("canonSubject"), item.get("canonPredicate")): item
+            for item in first["reflectionBasis"]
+            if item.get("basisKind") == "approved_canon"
+        }
+        self.assertIn(("galaknoise", "primary_role"), canon)
+        self.assertIn("music producer", canon[("galaknoise", "primary_role")]["summary"])
+        self.assertIn(("6_bit", "primary_identity"), canon)
+        self.assertNotIn("producer", canon[("6_bit", "primary_identity")]["summary"].lower())
+        self.assertFalse(
+            journal._canon_fact_is_reflection_safe(
+                CanonFact(SIX_BIT, "primary_role", "music producer for BARCODE")
+            )
+        )
+
+        prompt = journal.build_generation_prompt(first)
+        self.assertIn("LOW-ACTIVITY EVIDENCE RULE", prompt)
+        self.assertIn("same Journal voice", prompt)
+        self.assertNotIn("a concrete current-window moment", prompt)
+        self.assertEqual("", journal.validate_article(reflection_article(first), first, []))
+
+    def test_active_window_prompt_remains_byte_compatible(self):
+        relays = [
+            {
+                "refId": f"fresh:r{index}",
+                "sourceKind": "relay",
+                "summary": f"Public relay music detail {index}.",
+                "observedAt": f"2026-07-19T0{index}:00:00Z",
+                "eventType": "accepted",
+            }
+            for index in range(1, 4)
+        ]
+        conversations = [
+            {
+                "refId": f"fresh:c{index}",
+                "sourceKind": "conversation",
+                "summary": f"A regular discussed public chorus detail {index}.",
+                "observedAt": f"2026-07-19T1{index}:00:00Z",
+                "subjectRef": f"discord_user:{index}",
+                "participantAlias": f"participant-{index:08x}",
+                "displayName": f"Member{index}",
+                "channelPolicy": "public_home",
+            }
+            for index in range(1, 4)
+        ]
+        packet = journal.build_packet_from_sources(
+            self.db,
+            1,
+            START,
+            END,
+            relays,
+            conversations,
+            entry_kind="daily",
+        )
+        prompt = journal.build_generation_prompt(packet)
+
+        self.assertNotIn("lowActivityMode", packet)
+        self.assertNotIn("reflectionBasis", packet)
+        self.assertNotIn("LOW-ACTIVITY EVIDENCE RULE", prompt)
+        self.assertEqual(
+            "ee42f35a6cceb13317a857635263ea710b12b066239affc30fccd40fcad69c85",
+            hashlib.sha256(prompt.encode("utf-8")).hexdigest(),
+        )
+
+    def test_historical_projection_excludes_private_and_test_lanes_and_rechecks_deletion(self):
+        public_seq = self.record(
+            source_kind="discord_message",
+            source_key="public-42",
+            when="2026-07-01T12:00:00Z",
+            raw_text="Alice shared a public chorus revision with the room.",
+            channel_policy="public_home",
+            subject_ref="discord_user:42",
+            private_display_name="Alice",
+        )
+        sealed_seq = self.record(
+            source_kind="discord_message",
+            source_key="sealed-43",
+            when="2026-07-02T12:00:00Z",
+            raw_text="A sealed test discussed a private plan.",
+            channel_policy="sealed_test",
+            subject_ref="discord_user:43",
+            private_display_name="Secret",
+        )
+        ineligible_seq = self.record(
+            source_kind="discord_message",
+            source_key="ineligible-44",
+            when="2026-07-03T12:00:00Z",
+            raw_text="A deleted source should not return.",
+            channel_policy="public_home",
+            subject_ref="discord_user:44",
+            private_display_name="Deleted",
+            public_usable=False,
+        )
+        queue_seq = self.record(
+            source_kind="discord_message",
+            source_key="queue-45",
+            when="2026-07-04T12:00:00Z",
+            raw_text="A public queue test row.",
+            channel_policy="public_home",
+            subject_ref="discord_user:45",
+            private_display_name="QueueTester",
+            metadata={"mode": "queue_test"},
+        )
+        relay_seq = self.record(
+            source_kind="website_relay",
+            source_key="relay-1",
+            when="2026-07-05T12:00:00Z",
+            raw_text="A public BARCODE relay preserved an accepted show thread.",
+            channel_policy="public_relay",
+            subject_ref="bnl_01",
+            private_display_name="BNL-01",
+            metadata={"event_type": "accepted"},
+        )
+
+        packet = self.packet()
+        basis_refs = {item["refId"] for item in packet["reflectionBasis"]}
+        self.assertIn(f"reflection:event:{public_seq}", basis_refs)
+        self.assertIn(f"reflection:event:{relay_seq}", basis_refs)
+        self.assertNotIn(f"reflection:event:{sealed_seq}", basis_refs)
+        self.assertNotIn(f"reflection:event:{ineligible_seq}", basis_refs)
+        self.assertNotIn(f"reflection:event:{queue_seq}", basis_refs)
+        self.assertNotIn("Alice", json.dumps(packet["reflectionBasis"]))
+        provenance = packet["privateReflectionBasisProvenance"][
+            "historicalSourceEvents"
+        ]
+        self.assertIn(
+            "discord_user:42",
+            {item.get("subjectRef") for item in provenance},
+        )
+        article = reflection_article(
+            packet,
+            body=(
+                "An earlier public record preserved a chorus revision without "
+                "exposing the person behind it. I admit the archive benefits "
+                "from that kind of careful continuity."
+            ),
+            refs=[f"reflection:event:{public_seq}"],
+        )
+        draft = journal.store_validated_draft(self.db, 1, packet, article)
+        self.assertTrue(draft.ok, draft.reason)
+        with sqlite3.connect(self.db) as conn:
+            metadata = json.loads(
+                conn.execute(
+                    "SELECT metadata_json FROM bnl_journal_private_metadata "
+                    "WHERE entry_id=? AND revision=?",
+                    (draft.entry_id, draft.revision),
+                ).fetchone()[0]
+            )
+            self.assertEqual(
+                f"reflection:event:{public_seq}",
+                metadata["usedReflectionBasis"][0]["refId"],
+            )
+            self.assertEqual(
+                "",
+                automation._prepared_invalidation_reason(
+                    conn,
+                    1,
+                    metadata,
+                    set(),
+                ),
+            )
+
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(
+                "",
+                automation._frozen_packet_invalidation_reason(conn, 1, packet),
+            )
+        source_store.purge_user_discord_sources(self.db, 1, 42)
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(
+                "privacy_source_ineligible",
+                automation._frozen_packet_invalidation_reason(conn, 1, packet),
+            )
+            self.assertEqual(
+                "privacy_source_ineligible",
+                automation._prepared_invalidation_reason(
+                    conn,
+                    1,
+                    metadata,
+                    set(),
+                ),
+            )
+
+    def test_public_safe_broadcast_memory_can_be_reflection_basis(self):
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                """CREATE TABLE broadcast_memory(
+                    id INTEGER PRIMARY KEY,guild_id INTEGER,episode_date TEXT,
+                    cleaned_summary TEXT,entry_type TEXT,importance TEXT,
+                    public_safe INTEGER,usage_scope TEXT,valid_until TEXT,
+                    needs_clarification INTEGER,status TEXT,superseded_by_id INTEGER,
+                    created_at TEXT,raw_note TEXT
+                )"""
+            )
+            conn.executemany(
+                "INSERT INTO broadcast_memory VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                [
+                    (
+                        1,
+                        1,
+                        "2026-07-10",
+                        "A public broadcast preserved a careful chorus revision.",
+                        "notable_moment",
+                        "medium",
+                        1,
+                        "journal",
+                        None,
+                        0,
+                        "active",
+                        None,
+                        "2026-07-10T12:00:00Z",
+                        "private operator wording",
+                    ),
+                    (
+                        2,
+                        1,
+                        "2026-07-11",
+                        "An internal plan must stay private.",
+                        "notable_moment",
+                        "medium",
+                        1,
+                        "internal",
+                        None,
+                        0,
+                        "active",
+                        None,
+                        "2026-07-11T12:00:00Z",
+                        "private",
+                    ),
+                ],
+            )
+
+        packet = self.packet()
+        memory = [
+            item
+            for item in packet["reflectionBasis"]
+            if item["basisKind"] == "established_broadcast_memory"
+        ]
+        self.assertEqual(1, len(memory))
+        self.assertIn("careful chorus revision", memory[0]["summary"])
+        self.assertNotIn("operator wording", json.dumps(memory))
+        self.assertNotIn("internal plan", json.dumps(memory))
+
+    def test_reflection_validates_but_cannot_claim_current_activity_or_fill_fresh_breadth(self):
+        packet = self.packet()
+        article = reflection_article(packet)
+        self.assertEqual("", journal.validate_article(article, packet, []))
+
+        article["sections"][0]["body"] = (
+            "Today GALAKNOISE produced a new BARCODE track."
+        )
+        self.assertEqual(
+            "current_activity_without_fresh_source",
+            journal.validate_article(article, packet, []),
+        )
+
+        article = reflection_article(packet)
+        packet["evidenceCoverageContract"] = {
+            **packet["evidenceCoverageContract"],
+            "minimumDistinctFreshSources": 1,
+        }
+        self.assertEqual(
+            "insufficient_source_breadth",
+            journal.validate_article(article, packet, []),
+        )
+
+        packet["safeSources"] = [
+            {
+                "refId": "fresh:999",
+                "sourceKind": "relay",
+                "summary": "A current public relay announced a BARCODE track.",
+                "observedAt": "2026-07-19T12:00:00Z",
+            }
+        ]
+        article = reflection_article(
+            packet,
+            body="Today a public BARCODE relay announced a track.",
+            refs=["fresh:999"],
+        )
+        self.assertEqual("", journal.validate_article(article, packet, []))
+
+    def test_no_current_or_reflection_basis_keeps_no_new_source_blocking(self):
+        with patch.object(
+            journal,
+            "_build_reflection_basis",
+            return_value=([], {}),
+        ):
+            packet = self.packet()
+        article = reflection_article(packet, refs=["reflection:missing"])
+        self.assertEqual("no_new_source", journal.validate_article(article, packet, []))
+
+        calls = []
+        result = journal.generate_and_store_packet_draft(
+            self.db,
+            1,
+            packet,
+            lambda *_args: calls.append(1) or "{}",
+        )
+        self.assertFalse(result.ok)
+        self.assertEqual("insufficient_grounded_material", result.reason)
+        self.assertEqual([], calls)
+
+    def test_blocking_low_activity_output_uses_all_four_repairs_and_no_fallback(self):
+        packet = self.packet()
+        calls = []
+
+        def generator(source_packet, _prompt):
+            calls.append(1)
+            return generated_reflection_json(
+                source_packet,
+                body="Today GALAKNOISE produced a new BARCODE track.",
+            )
+
+        result = journal.generate_and_store_packet_draft(
+            self.db,
+            1,
+            packet,
+            generator,
+        )
+        self.assertFalse(result.ok)
+        self.assertEqual("current_activity_without_fresh_source", result.reason)
+        self.assertEqual(journal.JOURNAL_GENERATION_ATTEMPTS, len(calls))
+        with sqlite3.connect(self.db) as conn:
+            self.assertEqual(
+                0,
+                conn.execute("SELECT COUNT(*) FROM bnl_journal_entries").fetchone()[0],
+            )
+
+    def test_daily_low_activity_prepares_once_instead_of_finishing_quiet(self):
+        packet = self.packet()
+        calls = []
+
+        def generator(source_packet, _prompt):
+            calls.append(1)
+            return generated_reflection_json(source_packet)
+
+        with patch.object(
+            automation,
+            "build_source_packet_between",
+            return_value=packet,
+        ):
+            first = automation._prepare_daily_window(
+                self.db,
+                1,
+                generator,
+                START,
+                END,
+                "2026-07-19",
+                force=True,
+            )
+            second = automation._prepare_daily_window(
+                self.db,
+                1,
+                lambda *_args: self.fail("prepared occurrence regenerated"),
+                START,
+                END,
+                "2026-07-19",
+            )
+
+        self.assertEqual("prepared", first.status, first)
+        self.assertEqual("prepared", second.status, second)
+        self.assertEqual(1, len(calls))
+        with sqlite3.connect(self.db) as conn:
+            lifecycle, reason = conn.execute(
+                "SELECT lifecycle_state,reason FROM bnl_journal_automation_runs"
+            ).fetchone()
+        self.assertEqual("prepared", lifecycle)
+        self.assertEqual("prepared_waiting_release", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace prospective terminal `quiet` completion with grounded low-activity reflection from existing public-safe source history, scoped broadcast memory, and corrected approved canon
- keep current-window refs distinct from historical/canon reflection refs, preserving fresh-evidence requirements for current claims
- revalidate reflection-source and memory eligibility at frozen-packet and prepared-release privacy fences
- preserve the active-window prompt byte-for-byte, the four-attempt generation path, historical `quiet` rows, and Tuesday–Sunday Daily / Monday Weekly-only cadence

## Verification

- `python -m py_compile bnl_journal.py bnl_journal_automation.py`
- `python -m unittest tests.test_bnl_journal_low_activity tests.test_bnl_journal_automation tests.test_bnl_journal_evidence_voice tests.test_bnl_journal_context_lanes` — 47 passed
- `python -m unittest discover -s tests -q` — 1,290 passed
- active-window prompt golden SHA-256 remains `ee42f35a6cceb13317a857635263ea710b12b066239affc30fccd40fcad69c85`

## Boundaries

Bot-only. No website, deployment, runtime configuration, queue, Memory, Governance, Relationship, or backup-schedule changes. This PR is intentionally draft and is not approved for merge or deployment yet.