### PR TITLE
Add unified response assessment shadow

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -100,6 +100,13 @@ from bnl_shadow_acceptance import (
     build_v2_shadow_acceptance_snapshot,
     render_v2_shadow_acceptance_lines,
 )
+from bnl_unified_response_assessment import (
+    UnifiedResponseAssessment,
+    build_unified_response_assessment,
+    ensure_schema as ensure_unified_response_assessment_schema,
+    persist_shadow_run as persist_unified_response_assessment_shadow_run,
+    shadow_enabled as unified_response_assessment_shadow_enabled,
+)
 from bnl_journal import (
     JOURNAL_ROUTE,
     ensure_schema as ensure_journal_schema,
@@ -4877,6 +4884,7 @@ def init_db():
         ensure_entity_evidence_schema(evidence_conn)
         ensure_memory_ledger_schema(evidence_conn)
         ensure_relationship_v2_schema(evidence_conn)
+        ensure_unified_response_assessment_schema(evidence_conn)
         orphan_reconciliation = (
             reconcile_orphaned_conversation_ledger_sources(
                 evidence_conn,
@@ -17404,7 +17412,21 @@ def build_user_memory_context(
     source_metadata: dict | None = None,
 ) -> str:
     if source_metadata is not None:
-        source_metadata["moment_gist_rendered"] = False
+        source_metadata.update(
+            {
+                "moment_gist_rendered": False,
+                "approved_fact_count": 0,
+                "legacy_relationship_present": False,
+                "legacy_memory_present": False,
+                "relationship_v2_candidate_present": False,
+                "governed_entry_ids": (),
+                "governed_candidate_count": 0,
+                "governance_exclusion_count": 0,
+                "governance_contradiction_count": 0,
+                "moment_candidate_count": 0,
+                "prompt_budget": 0,
+            }
+        )
     if route_mode == ROUTE_MODE_SIMPLE_GREETING:
         LAST_MEMORY_PROMPT_DIAGNOSTICS[(user_id, guild_id)] = {"skipped_reason": "simple_greeting", "included": {"short": 0, "medium": 0, "long": 0}}
         return "Memory intentionally skipped for simple greeting."
@@ -17419,6 +17441,14 @@ def build_user_memory_context(
     journal = get_relationship_journal(user_id, guild_id, limit=4)
     habits = get_user_habits(user_id, guild_id)
     tier_rows = get_memory_tiers(user_id, guild_id)
+    if source_metadata is not None:
+        source_metadata.update(
+            {
+                "approved_fact_count": len(approved_facts),
+                "legacy_relationship_present": bool(relation or journal),
+                "prompt_budget": int(limits.get("prompt_budget") or 0),
+            }
+        )
 
     sections = []
     moment_gist_context = ""
@@ -17570,6 +17600,8 @@ def build_user_memory_context(
                 + "\n".join(tier_lines)
             )
     legacy_context = "\n".join(sections) if sections else "No durable memory yet."
+    if source_metadata is not None:
+        source_metadata["legacy_memory_present"] = bool(sections)
     diagnostics["skipped"] = dict(diagnostics["skipped"])
     if memory_governance_shadow_enabled():
         try:
@@ -17599,6 +17631,30 @@ def build_user_memory_context(
                     "invalid_invariants": gov_result.diagnostics.invalid_invariants,
                     "fallback_reason": gov_result.diagnostics.fallback_reason,
                 }
+                if source_metadata is not None:
+                    source_metadata.update(
+                        {
+                            "governed_entry_ids": tuple(
+                                candidate.entry_id
+                                for candidate in gov_result.selected
+                                if candidate.entry_id
+                            ),
+                            "governed_candidate_count": int(
+                                gov_result.diagnostics.selected_count or 0
+                            ),
+                            "governance_exclusion_count": sum(
+                                int(count or 0)
+                                for count in gov_result.diagnostics.excluded_by_reason.values()
+                            ),
+                            "governance_contradiction_count": len(
+                                gov_result.diagnostics.contradiction_resolutions
+                            ),
+                            "moment_candidate_count": int(
+                                gov_result.diagnostics.moment_candidate_count
+                                or 0
+                            ),
+                        }
+                    )
                 persist_shadow_diagnostics(gov_conn, gov_req, gov_result, legacy_context)
                 unsafe_governed = bool(gov_result.diagnostics.processing_errors or gov_result.diagnostics.invalid_invariants)
                 if memory_governance_live_enabled() and not unsafe_governed:
@@ -17729,6 +17785,8 @@ class ConversationPromptSourceBasis:
     channel_name: str
     channel_policy: str
     source_row_ids: tuple[int, ...] = ()
+    participant_user_ids: tuple[int, ...] = ()
+    speaker_labels: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -17749,6 +17807,214 @@ PromptSourceBasis = Union[
     ConversationPromptSourceBasis,
     BatchMomentPromptSourceBasis,
 ]
+
+_UNIFIED_ASSESSMENT_CANON_RELEVANCE_RE = re.compile(
+    r"\b(?:barcode(?: network| radio)?|bnl-?01|6 bit|six bit|"
+    r"cache back|dj floppydisc|mac modem|sheila|cliff|studio rats?|"
+    r"9 bit|auxchord|friday show|broadcast)\b",
+    re.I,
+)
+
+
+def _canon_relevant_to_response(text: str) -> bool:
+    return bool(_UNIFIED_ASSESSMENT_CANON_RELEVANCE_RE.search(text or ""))
+
+
+def build_unified_response_assessment_shadow(
+    *,
+    guild_id: int,
+    route_mode: str,
+    channel_policy: str,
+    conversation_surface: str,
+    current_text: str,
+    current_speaker_user_ids: tuple[int, ...],
+    current_speaker_labels: tuple[str, ...],
+    target_user_ids: tuple[int, ...] = (),
+    prompt_source_bases: tuple[PromptSourceBasis, ...] = (),
+    memory_source_metadata: dict | None = None,
+    prompt_lanes: tuple[str, ...] = (),
+    continuity_required: bool = False,
+    exact_quote_requested: bool = False,
+    exact_quote_authority_present: bool = False,
+    show_state_present: bool = False,
+    website_read_model_present: bool = False,
+    source_context_present: bool = False,
+    broadcast_memory_present: bool = False,
+) -> UnifiedResponseAssessment | None:
+    """Build a shadow view from evidence already selected by existing owners."""
+    if not unified_response_assessment_shadow_enabled():
+        return None
+
+    memory_meta = memory_source_metadata or {}
+    conversation_bases = tuple(
+        basis
+        for basis in prompt_source_bases
+        if isinstance(basis, ConversationPromptSourceBasis)
+    )
+    participant_user_ids = tuple(
+        dict.fromkeys(
+            int(user_id or 0)
+            for user_id in (
+                *current_speaker_user_ids,
+                *target_user_ids,
+                *(
+                    participant_id
+                    for basis in conversation_bases
+                    for participant_id in basis.participant_user_ids
+                ),
+            )
+            if int(user_id or 0) > 0
+        )
+    )
+    speaker_labels = tuple(
+        dict.fromkeys(
+            label
+            for label in (
+                *current_speaker_labels,
+                *(
+                    speaker_label
+                    for basis in conversation_bases
+                    for speaker_label in basis.speaker_labels
+                ),
+            )
+            if str(label or "").strip()
+        )
+    )
+    current_exchange_source_ids = tuple(
+        dict.fromkeys(
+            source_row_id
+            for basis in conversation_bases
+            for source_row_id in basis.source_row_ids
+        )
+    )
+    has_moment_gist = bool(
+        memory_meta.get("moment_gist_rendered")
+        or any(
+            isinstance(
+                basis,
+                (MemoryPromptSourceBasis, BatchMomentPromptSourceBasis),
+            )
+            and basis.has_moment_gist
+            for basis in prompt_source_bases
+        )
+    )
+    canon_relevant = _canon_relevant_to_response(current_text)
+    return build_unified_response_assessment(
+        guild_id=guild_id,
+        route_mode=route_mode,
+        channel_policy=channel_policy,
+        conversation_surface=conversation_surface,
+        current_speaker_user_ids=current_speaker_user_ids,
+        target_user_ids=target_user_ids,
+        participant_user_ids=participant_user_ids,
+        speaker_labels=speaker_labels,
+        current_exchange_source_ids=current_exchange_source_ids,
+        prior_moment_ids=("rendered_moment_gist",) if has_moment_gist else (),
+        governed_entry_ids=tuple(
+            memory_meta.get("governed_entry_ids") or ()
+        ),
+        relationship_candidate_keys=(
+            ("relationship_v2_candidate",)
+            if memory_meta.get("relationship_v2_candidate_present")
+            else ()
+        ),
+        canon_refs=(
+            ("canon:%s" % CANON_SOURCE_CONTRACT_VERSION,)
+            if canon_relevant
+            else ()
+        ),
+        prompt_lanes=prompt_lanes,
+        continuity_required=continuity_required,
+        immediate_recap=immediate_room_recap_requested(current_text),
+        exact_quote_requested=exact_quote_requested,
+        exact_quote_authority_present=exact_quote_authority_present,
+        source_bases=prompt_source_bases,
+        prompt_budget=int(memory_meta.get("prompt_budget") or 0),
+        moment_candidate_count=int(
+            memory_meta.get("moment_candidate_count") or 0
+        ),
+        governed_candidate_count=int(
+            memory_meta.get("governed_candidate_count") or 0
+        ),
+        governance_exclusion_count=int(
+            memory_meta.get("governance_exclusion_count") or 0
+        ),
+        governance_contradiction_count=int(
+            memory_meta.get("governance_contradiction_count") or 0
+        ),
+        legacy_memory_present=bool(
+            memory_meta.get("legacy_memory_present")
+        ),
+        legacy_relationship_present=bool(
+            memory_meta.get("legacy_relationship_present")
+        ),
+        relationship_v2_candidate_present=bool(
+            memory_meta.get("relationship_v2_candidate_present")
+        ),
+        canon_relevant=canon_relevant,
+        show_state_present=show_state_present,
+        website_read_model_present=website_read_model_present,
+        source_context_present=source_context_present,
+        broadcast_memory_present=broadcast_memory_present,
+    )
+
+
+def record_unified_response_assessment_shadow(
+    assessment: UnifiedResponseAssessment | None,
+    *,
+    response: str,
+    guard_diagnostics: dict | None = None,
+    response_sent: bool = True,
+) -> str:
+    """Persist one content-free receipt; never affect response delivery."""
+    if assessment is None:
+        return ""
+    try:
+        with sqlite3.connect(DB_FILE, timeout=0.25) as assessment_conn:
+            run_id = persist_unified_response_assessment_shadow_run(
+                assessment_conn,
+                assessment,
+                response=response,
+                guard_diagnostics=guard_diagnostics,
+                response_sent=response_sent,
+            )
+            assessment_conn.commit()
+        logging.info(
+            "unified_response_assessment_shadow_recorded "
+            "route_mode=%s response_act=%s comparison=%s",
+            assessment.route_mode,
+            assessment.response_act,
+            assessment.comparison_status,
+        )
+        return run_id
+    except Exception as exc:
+        logging.warning(
+            "unified_response_assessment_shadow_record_failed "
+            "route_mode=%s error=%s",
+            assessment.route_mode,
+            type(exc).__name__,
+        )
+        return ""
+
+
+async def record_unified_response_assessment_shadow_after_send(
+    assessment: UnifiedResponseAssessment | None,
+    *,
+    response: str,
+    guard_diagnostics: dict | None = None,
+    response_sent: bool = True,
+) -> str:
+    """Keep additive shadow persistence off Discord's live event loop."""
+    if assessment is None:
+        return ""
+    return await asyncio.to_thread(
+        record_unified_response_assessment_shadow,
+        assessment,
+        response=response,
+        guard_diagnostics=guard_diagnostics,
+        response_sent=response_sent,
+    )
+
 
 _SOURCE_BEARING_MEMORY_MARKERS = (
     "Moment-based continuity gist",
@@ -17984,6 +18250,30 @@ def build_conversation_prompt_source_basis(
                 }
             )
         )
+        participant_user_ids = tuple(
+            sorted(
+                {
+                    int(row.get("user_id") or 0)
+                    for row in selected_rows
+                    if str(row.get("role") or "").strip().lower() == "user"
+                    and int(row.get("user_id") or 0) > 0
+                }
+            )
+        )
+        speaker_labels = tuple(
+            dict.fromkeys(
+                _safe_prompt_display_label(
+                    str(row.get("user_name") or ""),
+                    "",
+                )
+                for row in selected_rows
+                if str(row.get("role") or "").strip().lower() == "user"
+                and _safe_prompt_display_label(
+                    str(row.get("user_name") or ""),
+                    "",
+                )
+            )
+        )
         # Hand-built/test continuity blocks can lack resolvable rows. Preserve
         # the older conservative candidate digest for that compatibility path;
         # production-rendered v2 blocks carry exact source ids.
@@ -18018,6 +18308,8 @@ def build_conversation_prompt_source_basis(
         channel_name=(channel_name or "").strip().lower(),
         channel_policy=(channel_policy or "unknown").strip().lower(),
         source_row_ids=source_row_ids,
+        participant_user_ids=participant_user_ids,
+        speaker_labels=speaker_labels,
     )
 
 
@@ -23437,6 +23729,83 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 batch_continuity_source,
                 typed_moment_gist_basis=batch_has_typed_moment_gist,
             )
+            batch_assessment_prompt_lanes = tuple(
+                dict.fromkeys(
+                    lane
+                    for lane, present in (
+                        ("current_exchange", True),
+                        (
+                            "conversation_context",
+                            batch_conversation_basis is not None,
+                        ),
+                        (
+                            "legacy_memory",
+                            any(
+                                isinstance(
+                                    basis,
+                                    MemoryPromptSourceBasis,
+                                )
+                                for basis in batch_prompt_source_bases
+                            ),
+                        ),
+                        (
+                            "relationship",
+                            bool(
+                                batch_memory_source_metadata.get(
+                                    "legacy_relationship_present"
+                                )
+                            ),
+                        ),
+                        ("prior_moment", batch_has_typed_moment_gist),
+                        (
+                            "canon",
+                            _canon_relevant_to_response(combined_text),
+                        ),
+                    )
+                    if present
+                )
+            )
+            batch_unified_assessment = (
+                build_unified_response_assessment_shadow(
+                    guild_id=guild_id,
+                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy=channel_policy,
+                    conversation_surface=(
+                        conversation_surface_for_channel_policy(
+                            channel_policy
+                        )
+                    ),
+                    current_text=combined_text,
+                    current_speaker_user_ids=tuple(unique_user_ids),
+                    current_speaker_labels=tuple(
+                        dict.fromkeys(
+                            _safe_prompt_display_label(name)
+                            for name, _content, _uid in collapsed_items
+                            if _safe_prompt_display_label(name)
+                        )
+                    ),
+                    target_user_ids=(
+                        (batch_attribution_contract.target_user_id,)
+                        if batch_attribution_contract.target_user_id > 0
+                        else ()
+                    ),
+                    prompt_source_bases=tuple(
+                        batch_prompt_source_bases
+                    ),
+                    memory_source_metadata=(
+                        batch_memory_source_metadata
+                    ),
+                    prompt_lanes=batch_assessment_prompt_lanes,
+                    continuity_required=batch_continuity_required,
+                    exact_quote_requested=(
+                        batch_attribution_contract.exact_quote_requested
+                    ),
+                    exact_quote_authority_present=(
+                        batch_attribution_contract.exact_quote_authority
+                        is not None
+                    ),
+                )
+            )
             continuity_contract = build_general_conversation_continuity_contract(
                 combined_text,
                 batch_continuity_source,
@@ -24028,6 +24397,12 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             _log_batch_event(logging.INFO, "pending_request_continuation_answer", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
         _log_batch_event(logging.INFO, "batch_response_answer", guild_id, channel_id, len(collapsed_items), f"reason={reason}")
         _channel_last_reply_at[channel_id] = datetime.now(PACIFIC_TZ)
+        await record_unified_response_assessment_shadow_after_send(
+            batch_unified_assessment,
+            response=response,
+            guard_diagnostics=guard_diagnostics,
+            response_sent=True,
+        )
     finally:
         _channel_payload_wait_extended[channel_id] = False
         await _clear_generation_state(channel_id, local_generation_id)
@@ -24447,6 +24822,63 @@ def build_user_aware_prompt(
         continuity_source_context,
         typed_moment_gist_basis=has_typed_moment_gist,
     )
+    assessment_prompt_lanes = tuple(
+        dict.fromkeys(
+            lane
+            for lane, present in (
+                ("current_exchange", True),
+                (
+                    "conversation_context",
+                    conversation_prompt_basis is not None,
+                ),
+                ("legacy_memory", memory_prompt_basis is not None),
+                (
+                    "relationship",
+                    bool(
+                        memory_source_metadata.get(
+                            "legacy_relationship_present"
+                        )
+                    ),
+                ),
+                ("prior_moment", has_typed_moment_gist),
+                ("broadcast_memory", bool(broadcast_context)),
+                ("show_state", bool(show_state_context)),
+                (
+                    "website_read_model",
+                    bool(website_read_model_context),
+                ),
+                ("source_context", bool(source_context_block)),
+                ("canon", _canon_relevant_to_response(clean_content)),
+            )
+            if present
+        )
+    )
+    unified_assessment = build_unified_response_assessment_shadow(
+        guild_id=guild_id,
+        route_mode=route_mode,
+        channel_policy=channel_policy,
+        conversation_surface=conversation_surface_for_channel_policy(
+            channel_policy
+        ),
+        current_text=clean_content,
+        current_speaker_user_ids=(int(user_id or 0),),
+        current_speaker_labels=(safe_display_name,),
+        target_user_ids=(
+            (int(moment_attribution_target_user_id),)
+            if int(moment_attribution_target_user_id or 0) > 0
+            else ()
+        ),
+        prompt_source_bases=tuple(prompt_source_bases),
+        memory_source_metadata=memory_source_metadata,
+        prompt_lanes=assessment_prompt_lanes,
+        continuity_required=continuity_required_state,
+        exact_quote_requested=exact_quote_requested,
+        exact_quote_authority_present=exact_quote_authority is not None,
+        show_state_present=bool(show_state_context),
+        website_read_model_present=bool(website_read_model_context),
+        source_context_present=bool(source_context_block),
+        broadcast_memory_present=bool(broadcast_context),
+    )
 
     if prompt_metadata is not None:
         prompt_metadata["source_context_available"] = bool(
@@ -24469,6 +24901,9 @@ def build_user_aware_prompt(
         )
         prompt_metadata["prompt_source_bases"] = tuple(
             prompt_source_bases
+        )
+        prompt_metadata["unified_response_assessment_shadow"] = (
+            unified_assessment
         )
 
     room_prompt_block = ""
@@ -25540,6 +25975,12 @@ async def _generate_direct_payload_session(session_key, reason: str):
     session["generating"] = False
     session["generation_invalidated"] = False
     logging.info(f"direct_session_committed revision={generation_revision} payload_count={payload_count}")
+    await record_unified_response_assessment_shadow_after_send(
+        prompt_metadata.get("unified_response_assessment_shadow"),
+        response=response,
+        guard_diagnostics=guard_diagnostics,
+        response_sent=True,
+    )
     if delta_mode:
         logging.info(f"direct_session_delta_completed new_payload_count={payload_count}")
 
@@ -26405,6 +26846,7 @@ async def send_planned_conversation_response(
     exact_quote_authority: CurrentRoomQuoteAuthority | None = None,
     third_party_attribution_requested: bool = False,
     prompt_source_bases: tuple[PromptSourceBasis, ...] = (),
+    unified_response_assessment_shadow: UnifiedResponseAssessment | None = None,
 ) -> MemoryWriteDecision:
     """Send a planned normal-conversation response through one governed path."""
     logging.info(
@@ -26628,6 +27070,12 @@ async def send_planned_conversation_response(
             logging.info("continuation_mark_skipped reason=guard_fallback_or_generic_non_answer route=%s channel_policy=%s", plan.route_mode, plan.channel_policy)
         if _response_requests_retransmission(response):
             _mark_awaiting_retransmission(message.guild.id, message.channel.id, message.author.id)
+    await record_unified_response_assessment_shadow_after_send(
+        unified_response_assessment_shadow,
+        response=response,
+        guard_diagnostics=guard_diagnostics,
+        response_sent=True,
+    )
     return model_decision
 
 
@@ -27621,6 +28069,9 @@ async def on_message(message: discord.Message):
                 prompt_source_bases=tuple(
                     prompt_metadata.get("prompt_source_bases") or ()
                 ),
+                unified_response_assessment_shadow=prompt_metadata.get(
+                    "unified_response_assessment_shadow"
+                ),
             )
             return
 
@@ -27952,6 +28403,9 @@ async def on_message(message: discord.Message):
             prompt_source_bases=tuple(
                 prompt_metadata.get("prompt_source_bases") or ()
             ),
+            unified_response_assessment_shadow=prompt_metadata.get(
+                "unified_response_assessment_shadow"
+            ),
         )
         return
 
@@ -28234,6 +28688,9 @@ async def on_message(message: discord.Message):
             ),
             prompt_source_bases=tuple(
                 prompt_metadata.get("prompt_source_bases") or ()
+            ),
+            unified_response_assessment_shadow=prompt_metadata.get(
+                "unified_response_assessment_shadow"
             ),
         )
         return

--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -16,6 +16,10 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence
 from bnl_memory_ledger import build_memory_ledger_evaluation
 from bnl_moment_engine import build_moment_evaluation_report
 from bnl_relationship_engine import build_evaluation_report as build_relationship_evaluation_report
+from bnl_unified_response_assessment import (
+    build_evaluation_report as build_unified_assessment_evaluation_report,
+    shadow_configuration as unified_assessment_shadow_configuration,
+)
 
 
 SHADOW_ACCEPTANCE_VERSION = "v2_shadow_acceptance_v2"
@@ -39,7 +43,7 @@ def _flag_enabled(environ: Mapping[str, str], name: str, default: str = "") -> b
     return value.strip().lower() in {"1", "true", "yes", "on", "enabled"}
 
 
-def build_gate_snapshot(environ: Optional[Mapping[str, str]] = None) -> Dict[str, bool]:
+def build_gate_snapshot(environ: Optional[Mapping[str, str]] = None) -> Dict[str, Any]:
     """Return requested and effective gate state without changing the environment."""
 
     env = environ if environ is not None else os.environ
@@ -52,6 +56,7 @@ def build_gate_snapshot(environ: Optional[Mapping[str, str]] = None) -> Dict[str
     engagement_live = _flag_enabled(env, "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED")
     context_value = str(env.get("BNL_CONVERSATION_CONTEXT_V2_ENABLED", "true") or "true")
     context_enabled = context_value.strip().lower() not in {"false", "0", "off"}
+    unified_assessment = unified_assessment_shadow_configuration(env)
     return {
         "conversation_context_v2": context_enabled,
         "memory_ledger_shadow_requested": ledger,
@@ -63,6 +68,15 @@ def build_gate_snapshot(environ: Optional[Mapping[str, str]] = None) -> Dict[str
         "relationship_v2_shadow_requested": relationship_shadow,
         "relationship_v2_live_requested": relationship_live,
         "active_engagement_v2_live_requested": engagement_live,
+        "unified_response_assessment_shadow_requested": bool(
+            unified_assessment["requested"]
+        ),
+        "unified_response_assessment_shadow_effective": bool(
+            unified_assessment["effective"]
+        ),
+        "unified_response_assessment_shadow_reason": str(
+            unified_assessment["reason"]
+        ),
         "all_live_gates_clear": not (
             governance_live_requested or relationship_live or engagement_live
         ),
@@ -500,6 +514,46 @@ def _read_relationship_report(conn: sqlite3.Connection, guild_id: int) -> Dict[s
         return _report_error({**_empty_relationship_report(), "tablePresent": True}, exc)
 
 
+def _empty_unified_assessment_report() -> Dict[str, Any]:
+    return {
+        "tablePresent": False,
+        "runs": 0,
+        "response_sent_runs": 0,
+        "current_exchange_primary_runs": 0,
+        "comparison_status_counts": {},
+        "response_alignment_counts": {},
+        "prompt_overincluded_runs": 0,
+        "prompt_underincluded_runs": 0,
+        "prompt_different_runs": 0,
+        "source_basis_changed_runs": 0,
+        "guard_triggered_runs": 0,
+        "guard_repaired_runs": 0,
+        "visible_control_marker_runs": 0,
+        "processing_errors": 0,
+        "behavior_changed_runs": 0,
+        "new_authority_applied_runs": 0,
+        "content_fields_present": [],
+        "evidenceWindow": {"first": "none", "last": "none"},
+    }
+
+
+def _read_unified_assessment_report(
+    conn: sqlite3.Connection,
+    guild_id: int,
+) -> Dict[str, Any]:
+    try:
+        return build_unified_assessment_evaluation_report(
+            conn,
+            guild_id=guild_id,
+            prepare_schema=False,
+        )
+    except (sqlite3.DatabaseError, ValueError, TypeError) as exc:
+        return _report_error(
+            _empty_unified_assessment_report(),
+            exc,
+        )
+
+
 def _safe_context_report(diagnostics: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
     source = diagnostics or {}
     numeric = (
@@ -561,6 +615,7 @@ def build_v2_shadow_acceptance_snapshot(
     moments = _read_moment_report(conn, guild_id)
     governance = build_persisted_governance_report(conn, guild_id=guild_id)
     relationship = _read_relationship_report(conn, guild_id)
+    unified_assessment = _read_unified_assessment_report(conn, guild_id)
     context = _safe_context_report(conversation_context_diagnostics)
 
     live_gates = [
@@ -723,11 +778,30 @@ def build_v2_shadow_acceptance_snapshot(
         },
     }
 
+    unified_assessment_blockers = []
+    for key in (
+        "processing_errors",
+        "behavior_changed_runs",
+        "new_authority_applied_runs",
+    ):
+        if int(unified_assessment.get(key, 0) or 0):
+            unified_assessment_blockers.append(key)
+    if unified_assessment.get("content_fields_present"):
+        unified_assessment_blockers.append("content_fields_present")
+    if unified_assessment.get("reportError"):
+        unified_assessment_blockers.append(
+            "report_error:%s" % unified_assessment["reportError"]
+        )
+
     blockers = ["live_gate_enabled:%s" % name for name in live_gates]
     if context_cross_channel:
         blockers.append("conversation_context_cross_channel_pair")
     for stage_name, stage in stages.items():
         blockers.extend("%s:%s" % (stage_name, reason) for reason in stage["blockers"])
+    blockers.extend(
+        "unified_response_assessment:%s" % reason
+        for reason in unified_assessment_blockers
+    )
 
     warnings = []
     if int(ledger.get("legacyToLedgerParityMismatches", 0) or 0):
@@ -746,13 +820,39 @@ def build_v2_shadow_acceptance_snapshot(
         warnings.append("governance_older_rows_lack_aggregate_diagnostics")
     if int(governance.get("legacy_reclassified_exclusion_count", 0) or 0):
         warnings.append("governance_legacy_safe_exclusions_reclassified")
+    if (
+        gates.get("unified_response_assessment_shadow_effective")
+        and int(unified_assessment.get("runs", 0) or 0) == 0
+    ):
+        warnings.append("unified_assessment_no_response_evidence")
+    if any(
+        int(unified_assessment.get(key, 0) or 0)
+        for key in (
+            "prompt_overincluded_runs",
+            "prompt_underincluded_runs",
+            "prompt_different_runs",
+        )
+    ):
+        warnings.append("unified_assessment_prompt_comparison_review")
+    if int(unified_assessment.get("visible_control_marker_runs", 0) or 0):
+        warnings.append("unified_assessment_visible_control_marker_review")
 
     stage_statuses = [stage["status"] for stage in stages.values()]
+    unified_assessment_ready = bool(
+        not gates.get("unified_response_assessment_shadow_requested")
+        or (
+            int(unified_assessment.get("runs", 0) or 0) > 0
+            and not unified_assessment_blockers
+        )
+    )
     if live_gates:
         status = "blocked_live_authority_detected"
     elif blockers:
         status = "blocked_shadow_invariant_failure"
-    elif all(value.startswith("candidate_pass") for value in stage_statuses):
+    elif (
+        all(value.startswith("candidate_pass") for value in stage_statuses)
+        and unified_assessment_ready
+    ):
         status = "ready_for_owner_review_not_live_cutover"
     else:
         status = "collecting_shadow_evidence"
@@ -776,12 +876,37 @@ def build_v2_shadow_acceptance_snapshot(
             "momentEngine": moments,
             "memoryGovernance": governance,
             "relationshipV2": relationship,
+            "unifiedResponseAssessment": unified_assessment,
+        },
+        "unifiedResponseAssessmentShadow": {
+            "requested": bool(
+                gates.get(
+                    "unified_response_assessment_shadow_requested"
+                )
+            ),
+            "effective": bool(
+                gates.get(
+                    "unified_response_assessment_shadow_effective"
+                )
+            ),
+            "reason": str(
+                gates.get(
+                    "unified_response_assessment_shadow_reason",
+                    "disabled",
+                )
+            ),
+            "evidenceObserved": int(
+                unified_assessment.get("runs", 0) or 0
+            )
+            > 0,
+            "blockers": unified_assessment_blockers,
         },
         "rollback": {
             "legacyProductionTruthPreserved": gates["all_live_gates_clear"],
             "databaseDeletionRequired": False,
             "restartRequiredAfterEnvironmentChange": True,
             "disableOrder": [
+                "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED",
                 "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED",
                 "BNL_RELATIONSHIP_V2_LIVE_ENABLED",
                 "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED",
@@ -813,6 +938,8 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
     moments = reports.get("momentEngine") or {}
     governance = reports.get("memoryGovernance") or {}
     relationship = reports.get("relationshipV2") or {}
+    unified_assessment = reports.get("unifiedResponseAssessment") or {}
+    unified_state = snapshot.get("unifiedResponseAssessmentShadow") or {}
     blockers = snapshot.get("blockers") or []
     warnings = snapshot.get("warnings") or []
 
@@ -889,6 +1016,32 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             relationship.get("moment_link_integrity_violations", 0),
         ),
         "- relationship_legacy_v2_comparison: `%s`" % relationship.get("legacy_v2_comparison", "not_collected"),
+        "- unified_assessment: requested=`%s` effective=`%s` reason=`%s` runs=`%s` current_primary=`%s` comparison=`%s` alignments=`%s` source_changes=`%s` guards=`%s/%s` visible_control_markers=`%s` errors=`%s` behavior_changes=`%s` new_authority=`%s` window_last=`%s`" % (
+            _on(unified_state.get("requested")),
+            _on(unified_state.get("effective")),
+            unified_state.get("reason", "disabled"),
+            unified_assessment.get("runs", 0),
+            unified_assessment.get("current_exchange_primary_runs", 0),
+            json.dumps(
+                unified_assessment.get("comparison_status_counts", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                unified_assessment.get("response_alignment_counts", {}),
+                sort_keys=True,
+            ),
+            unified_assessment.get("source_basis_changed_runs", 0),
+            unified_assessment.get("guard_triggered_runs", 0),
+            unified_assessment.get("guard_repaired_runs", 0),
+            unified_assessment.get("visible_control_marker_runs", 0),
+            unified_assessment.get("processing_errors", 0),
+            unified_assessment.get("behavior_changed_runs", 0),
+            unified_assessment.get("new_authority_applied_runs", 0),
+            (unified_assessment.get("evidenceWindow") or {}).get(
+                "last",
+                "none",
+            ),
+        ),
         "- blockers: `%s`" % (", ".join(blockers) if blockers else "none"),
         "- warnings: `%s`" % (", ".join(warnings) if warnings else "none"),
         "- rollback: `disable in reverse dependency order; restart; preserve shadow evidence; delete nothing`",

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -1,0 +1,834 @@
+"""Shadow-only unified response assessment for BNL's existing planner.
+
+This module does not retrieve conversation history, memory, Moments,
+relationships, canon, or Source Files.  The existing owners select those
+inputs first; the conversation planner passes only their typed references and
+aggregate metadata here.  The resulting assessment is never rendered into a
+production prompt in this stage.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import uuid
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
+
+
+ASSESSMENT_VERSION = "unified_response_assessment_v1"
+SHADOW_ENV = "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED"
+TABLE_NAME = "unified_response_assessment_shadow_runs"
+
+_SHADOW_PREREQUISITES = (
+    "BNL_MEMORY_LEDGER_SHADOW_ENABLED",
+    "BNL_MOMENT_ENGINE_SHADOW_ENABLED",
+    "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED",
+    "BNL_RELATIONSHIP_V2_SHADOW_ENABLED",
+)
+_LIVE_GATES = (
+    "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED",
+    "BNL_RELATIONSHIP_V2_LIVE_ENABLED",
+    "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED",
+)
+_LOWER_PRECEDENCE_LANES = (
+    "show_state",
+    "website_read_model",
+    "source_context",
+    "broadcast_memory",
+    "active_episode",
+    "prior_moment",
+    "governed_memory",
+    "relationship",
+    "canon",
+)
+_KNOWN_LANES = frozenset(
+    (
+        "current_exchange",
+        "conversation_context",
+        "show_state",
+        "website_read_model",
+        "source_context",
+        "broadcast_memory",
+        "active_episode",
+        "prior_moment",
+        "governed_memory",
+        "legacy_memory",
+        "relationship",
+        "canon",
+    )
+)
+_VISIBLE_CONTROL_MARKER_RE = re.compile(
+    r"(?im)^\s*(?:"
+    r"\[\s*(?:pause|wait|typing|thinking)\s*(?::[^\]\n]{0,40})?\s*\]"
+    r"|<\s*(?:pause|wait|typing|thinking)(?:\s+[^>\n]{0,40})?\s*>"
+    r")\s*"
+)
+
+
+def _flag(value: Any) -> bool:
+    return str(value or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+        "enabled",
+    }
+
+
+def shadow_configuration(
+    environ: Optional[Mapping[str, str]] = None,
+) -> Dict[str, Any]:
+    """Return the derived shadow state without changing environment values."""
+
+    env = os.environ if environ is None else environ
+    prerequisites = {
+        name: _flag(env.get(name, ""))
+        for name in _SHADOW_PREREQUISITES
+    }
+    live_gates = {
+        name: _flag(env.get(name, ""))
+        for name in _LIVE_GATES
+    }
+    explicitly_configured = SHADOW_ENV in env
+    requested = (
+        _flag(env.get(SHADOW_ENV, ""))
+        if explicitly_configured
+        else all(prerequisites.values())
+    )
+    missing = tuple(
+        name for name, enabled in prerequisites.items() if not enabled
+    )
+    active_live = tuple(
+        name for name, enabled in live_gates.items() if enabled
+    )
+    effective = bool(requested and not missing and not active_live)
+    if not requested:
+        reason = "disabled"
+    elif missing:
+        reason = "missing_shadow_prerequisites"
+    elif active_live:
+        reason = "live_authority_detected"
+    else:
+        reason = "shadow_only"
+    return {
+        "requested": requested,
+        "effective": effective,
+        "explicitly_configured": explicitly_configured,
+        "reason": reason,
+        "missing_prerequisites": missing,
+        "active_live_gates": active_live,
+    }
+
+
+def shadow_enabled(
+    environ: Optional[Mapping[str, str]] = None,
+) -> bool:
+    return bool(shadow_configuration(environ)["effective"])
+
+
+def _unique_positive_ints(values: Sequence[Any]) -> Tuple[int, ...]:
+    result = set()
+    for value in values or ():
+        try:
+            parsed = int(value or 0)
+        except (TypeError, ValueError):
+            continue
+        if parsed > 0:
+            result.add(parsed)
+    return tuple(sorted(result))
+
+
+def _unique_strings(values: Sequence[Any]) -> Tuple[str, ...]:
+    return tuple(
+        dict.fromkeys(
+            str(value or "").strip()
+            for value in (values or ())
+            if str(value or "").strip()
+        )
+    )
+
+
+def _known_lanes(values: Sequence[Any]) -> Tuple[str, ...]:
+    return _unique_strings(
+        value
+        for value in (values or ())
+        if str(value or "").strip() in _KNOWN_LANES
+    )
+
+
+def _basis_kind(value: Any) -> str:
+    name = type(value).__name__
+    return {
+        "ConversationPromptSourceBasis": "conversation",
+        "MemoryPromptSourceBasis": "memory",
+        "BatchMomentPromptSourceBasis": "batch_moment",
+    }.get(name, "unknown")
+
+
+def source_basis_kinds(values: Sequence[Any]) -> Tuple[str, ...]:
+    return _unique_strings(_basis_kind(value) for value in (values or ()))
+
+
+def _response_act(
+    *,
+    immediate_recap: bool,
+    continuity_required: bool,
+    exact_quote_requested: bool,
+    route_mode: str,
+    show_state_present: bool,
+) -> str:
+    if immediate_recap:
+        return "recap_current_exchange"
+    if exact_quote_requested:
+        return "verify_exact_wording"
+    if continuity_required:
+        return "continue_active_thread"
+    if route_mode == "direct_payload_task":
+        return "complete_request_payload"
+    if show_state_present or route_mode == "show_status":
+        return "answer_show_status"
+    return "answer_current_turn"
+
+
+@dataclass(frozen=True)
+class UnifiedResponseAssessment:
+    """One response-time view over references chosen by existing owners."""
+
+    schema_version: str
+    guild_id: int
+    route_mode: str
+    channel_policy: str
+    conversation_surface: str
+    current_speaker_user_ids: Tuple[int, ...]
+    target_user_ids: Tuple[int, ...]
+    participant_user_ids: Tuple[int, ...]
+    speaker_labels: Tuple[str, ...]
+    current_exchange_source_ids: Tuple[int, ...]
+    active_episode_id: str
+    prior_moment_ids: Tuple[str, ...]
+    governed_entry_ids: Tuple[str, ...]
+    relationship_candidate_keys: Tuple[str, ...]
+    canon_refs: Tuple[str, ...]
+    selected_lanes: Tuple[str, ...]
+    excluded_lanes: Tuple[Tuple[str, str], ...]
+    conflict_reasons: Tuple[str, ...]
+    supported_inferences: Tuple[str, ...]
+    response_act: str
+    exact_quote_authority_present: bool
+    source_basis_kinds: Tuple[str, ...]
+    prompt_budget: int
+    prompt_lanes: Tuple[str, ...]
+    comparison_status: str
+    prompt_extra_lanes: Tuple[str, ...]
+    prompt_missing_lanes: Tuple[str, ...]
+    diagnostic_reasons: Tuple[str, ...]
+    moment_candidate_count: int
+    governed_candidate_count: int
+    governance_exclusion_count: int
+
+
+def build_unified_response_assessment(
+    *,
+    guild_id: int,
+    route_mode: str,
+    channel_policy: str,
+    conversation_surface: str,
+    current_speaker_user_ids: Sequence[int],
+    target_user_ids: Sequence[int] = (),
+    participant_user_ids: Sequence[int] = (),
+    speaker_labels: Sequence[str] = (),
+    current_exchange_source_ids: Sequence[int] = (),
+    active_episode_id: str = "",
+    prior_moment_ids: Sequence[str] = (),
+    governed_entry_ids: Sequence[str] = (),
+    relationship_candidate_keys: Sequence[str] = (),
+    canon_refs: Sequence[str] = (),
+    prompt_lanes: Sequence[str] = (),
+    continuity_required: bool = False,
+    immediate_recap: bool = False,
+    exact_quote_requested: bool = False,
+    exact_quote_authority_present: bool = False,
+    source_bases: Sequence[Any] = (),
+    prompt_budget: int = 0,
+    moment_candidate_count: int = 0,
+    governed_candidate_count: int = 0,
+    governance_exclusion_count: int = 0,
+    governance_contradiction_count: int = 0,
+    legacy_memory_present: bool = False,
+    legacy_relationship_present: bool = False,
+    relationship_v2_candidate_present: bool = False,
+    canon_relevant: bool = False,
+    show_state_present: bool = False,
+    website_read_model_present: bool = False,
+    source_context_present: bool = False,
+    broadcast_memory_present: bool = False,
+) -> UnifiedResponseAssessment:
+    """Assemble one deterministic assessment without rendering it live."""
+
+    current_speakers = _unique_positive_ints(current_speaker_user_ids)
+    targets = _unique_positive_ints(target_user_ids)
+    participants = _unique_positive_ints(
+        tuple(participant_user_ids) + current_speakers + targets
+    )
+    labels = _unique_strings(speaker_labels)
+    exchange_ids = _unique_positive_ints(current_exchange_source_ids)
+    moment_ids = _unique_strings(prior_moment_ids)
+    governed_ids = _unique_strings(governed_entry_ids)
+    relationship_keys = _unique_strings(relationship_candidate_keys)
+    canonical_refs = _unique_strings(canon_refs)
+    actual_prompt_lanes = _known_lanes(prompt_lanes)
+
+    selected = ["current_exchange"]
+    excluded = []
+    conflicts = []
+    inferences = []
+    diagnostics = []
+
+    if immediate_recap:
+        if "conversation_context" in actual_prompt_lanes or exchange_ids:
+            selected.append("conversation_context")
+        inferences.append("shared_current_exchange")
+        diagnostics.append("current_exchange_primary")
+    elif continuity_required:
+        if "conversation_context" in actual_prompt_lanes or exchange_ids:
+            selected.append("conversation_context")
+        inferences.append("active_thread_continuity")
+    elif "conversation_context" in actual_prompt_lanes or exchange_ids:
+        selected.append("conversation_context")
+
+    authoritative_current_lanes = (
+        ("show_state", show_state_present),
+        ("website_read_model", website_read_model_present),
+        ("source_context", source_context_present),
+        ("broadcast_memory", broadcast_memory_present),
+    )
+    for lane, present in authoritative_current_lanes:
+        if not present:
+            continue
+        if immediate_recap:
+            excluded.append((lane, "current_exchange_precedence"))
+        else:
+            selected.append(lane)
+
+    episode_id = str(active_episode_id or "").strip()
+    if episode_id:
+        if immediate_recap:
+            excluded.append(("active_episode", "current_exchange_precedence"))
+        else:
+            selected.append("active_episode")
+    else:
+        diagnostics.append("active_episode_unavailable_in_moment_v1")
+
+    if moment_ids:
+        if immediate_recap:
+            excluded.append(("prior_moment", "current_exchange_precedence"))
+        else:
+            selected.append("prior_moment")
+    elif int(moment_candidate_count or 0) > 0:
+        excluded.append(("prior_moment", "not_selected_by_current_governance"))
+        diagnostics.append("moment_candidates_observed_without_selected_ids")
+
+    governed_count = max(int(governed_candidate_count or 0), len(governed_ids))
+    if governed_count:
+        if immediate_recap:
+            excluded.append(("governed_memory", "current_exchange_precedence"))
+        else:
+            selected.append("governed_memory")
+    elif legacy_memory_present:
+        excluded.append(("legacy_memory", "no_governed_candidate"))
+
+    if relationship_v2_candidate_present or relationship_keys:
+        if immediate_recap:
+            excluded.append(("relationship", "current_exchange_precedence"))
+        else:
+            selected.append("relationship")
+    elif legacy_relationship_present:
+        excluded.append(("relationship", "legacy_only_live_authority_off"))
+
+    if canon_relevant and canonical_refs:
+        if immediate_recap:
+            excluded.append(("canon", "current_exchange_precedence"))
+        else:
+            selected.append("canon")
+
+    if immediate_recap and any(
+        lane in actual_prompt_lanes for lane in _LOWER_PRECEDENCE_LANES
+    ):
+        conflicts.append("current_exchange_precedence")
+    if int(governance_contradiction_count or 0) > 0:
+        conflicts.append("governance_contradiction_resolved")
+
+    selected_lanes = _unique_strings(selected)
+    excluded_lanes = tuple(
+        dict.fromkeys(
+            (str(lane or "").strip(), str(reason or "").strip())
+            for lane, reason in excluded
+            if str(lane or "").strip() and str(reason or "").strip()
+        )
+    )
+    selected_set = set(selected_lanes)
+    prompt_set = set(actual_prompt_lanes)
+    prompt_extra = tuple(sorted(prompt_set - selected_set))
+    prompt_missing = tuple(sorted(selected_set - prompt_set))
+    if not prompt_extra and not prompt_missing:
+        comparison = "match"
+    elif prompt_extra and not prompt_missing:
+        comparison = "prompt_overincluded"
+    elif prompt_missing and not prompt_extra:
+        comparison = "prompt_underincluded"
+    else:
+        comparison = "different"
+
+    act = _response_act(
+        immediate_recap=bool(immediate_recap),
+        continuity_required=bool(continuity_required),
+        exact_quote_requested=bool(exact_quote_requested),
+        route_mode=str(route_mode or "unknown"),
+        show_state_present=bool(show_state_present),
+    )
+    diagnostics.append("response_act:%s" % act)
+    diagnostics.append("prompt_comparison:%s" % comparison)
+
+    return UnifiedResponseAssessment(
+        schema_version=ASSESSMENT_VERSION,
+        guild_id=int(guild_id or 0),
+        route_mode=str(route_mode or "unknown")[:80],
+        channel_policy=str(channel_policy or "unknown")[:80],
+        conversation_surface=str(conversation_surface or "unknown")[:80],
+        current_speaker_user_ids=current_speakers,
+        target_user_ids=targets,
+        participant_user_ids=participants,
+        speaker_labels=labels,
+        current_exchange_source_ids=exchange_ids,
+        active_episode_id=episode_id,
+        prior_moment_ids=moment_ids,
+        governed_entry_ids=governed_ids,
+        relationship_candidate_keys=relationship_keys,
+        canon_refs=canonical_refs,
+        selected_lanes=selected_lanes,
+        excluded_lanes=excluded_lanes,
+        conflict_reasons=_unique_strings(conflicts),
+        supported_inferences=_unique_strings(inferences),
+        response_act=act,
+        exact_quote_authority_present=bool(exact_quote_authority_present),
+        source_basis_kinds=source_basis_kinds(source_bases),
+        prompt_budget=max(0, int(prompt_budget or 0)),
+        prompt_lanes=actual_prompt_lanes,
+        comparison_status=comparison,
+        prompt_extra_lanes=prompt_extra,
+        prompt_missing_lanes=prompt_missing,
+        diagnostic_reasons=_unique_strings(diagnostics),
+        moment_candidate_count=max(0, int(moment_candidate_count or 0)),
+        governed_candidate_count=governed_count,
+        governance_exclusion_count=max(
+            0,
+            int(governance_exclusion_count or 0),
+        ),
+    )
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    """Create the additive, content-free shadow receipt table."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS unified_response_assessment_shadow_runs (
+            run_id TEXT PRIMARY KEY,
+            schema_version TEXT NOT NULL,
+            guild_id INTEGER NOT NULL,
+            route_mode TEXT NOT NULL,
+            channel_policy TEXT NOT NULL,
+            conversation_surface TEXT NOT NULL,
+            current_speaker_count INTEGER NOT NULL DEFAULT 0,
+            target_count INTEGER NOT NULL DEFAULT 0,
+            participant_count INTEGER NOT NULL DEFAULT 0,
+            current_exchange_source_count INTEGER NOT NULL DEFAULT 0,
+            active_episode_present INTEGER NOT NULL DEFAULT 0,
+            prior_moment_count INTEGER NOT NULL DEFAULT 0,
+            moment_candidate_count INTEGER NOT NULL DEFAULT 0,
+            governed_entry_count INTEGER NOT NULL DEFAULT 0,
+            governed_candidate_count INTEGER NOT NULL DEFAULT 0,
+            governance_exclusion_count INTEGER NOT NULL DEFAULT 0,
+            relationship_candidate_count INTEGER NOT NULL DEFAULT 0,
+            canon_ref_count INTEGER NOT NULL DEFAULT 0,
+            response_act TEXT NOT NULL,
+            selected_lanes_json TEXT NOT NULL DEFAULT '[]',
+            excluded_lanes_json TEXT NOT NULL DEFAULT '{}',
+            conflict_reasons_json TEXT NOT NULL DEFAULT '[]',
+            supported_inference_count INTEGER NOT NULL DEFAULT 0,
+            exact_quote_authority_present INTEGER NOT NULL DEFAULT 0,
+            source_basis_kinds_json TEXT NOT NULL DEFAULT '[]',
+            source_basis_count INTEGER NOT NULL DEFAULT 0,
+            prompt_budget INTEGER NOT NULL DEFAULT 0,
+            prompt_lanes_json TEXT NOT NULL DEFAULT '[]',
+            comparison_status TEXT NOT NULL,
+            prompt_extra_lanes_json TEXT NOT NULL DEFAULT '[]',
+            prompt_missing_lanes_json TEXT NOT NULL DEFAULT '[]',
+            source_basis_changed_before_send INTEGER NOT NULL DEFAULT 0,
+            guard_triggered INTEGER NOT NULL DEFAULT 0,
+            guard_repaired INTEGER NOT NULL DEFAULT 0,
+            response_sent INTEGER NOT NULL DEFAULT 0,
+            response_length INTEGER NOT NULL DEFAULT 0,
+            speaker_label_coverage_count INTEGER NOT NULL DEFAULT 0,
+            visible_control_marker INTEGER NOT NULL DEFAULT 0,
+            response_alignment TEXT NOT NULL,
+            processing_errors_json TEXT NOT NULL DEFAULT '[]',
+            behavior_changed INTEGER NOT NULL DEFAULT 0,
+            new_authority_applied INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_unified_assessment_shadow_guild
+        ON unified_response_assessment_shadow_runs(guild_id, created_at)
+        """
+    )
+
+
+def _excluded_counts(
+    excluded_lanes: Sequence[Tuple[str, str]],
+) -> Dict[str, int]:
+    counts = Counter()
+    for lane, reason in excluded_lanes:
+        counts["%s:%s" % (lane, reason)] += 1
+    return dict(sorted(counts.items()))
+
+
+def _guard_signal(guard_diagnostics: Mapping[str, Any]) -> Tuple[bool, bool]:
+    source = guard_diagnostics or {}
+    trigger_keys = (
+        "scripted_mode_leak_guard_triggered",
+        "register_mismatch_guard_triggered",
+        "generic_non_answer_triggered",
+        "source_grounding_guard_triggered",
+        "contextual_followthrough_guard_triggered",
+        "community_visual_guard_triggered",
+        "exact_quote_guard_triggered",
+        "prompt_source_basis_changed",
+    )
+    repair_keys = (
+        "regenerated_for_mode_leak",
+        "regenerated_for_register_mismatch",
+        "generic_non_answer_regenerated",
+        "source_grounding_regenerated",
+        "contextual_followthrough_regenerated",
+        "community_visual_regenerated",
+        "exact_quote_regenerated",
+        "prompt_source_basis_regenerated",
+    )
+    return (
+        any(bool(source.get(key)) for key in trigger_keys),
+        any(bool(source.get(key)) for key in repair_keys),
+    )
+
+
+def persist_shadow_run(
+    conn: sqlite3.Connection,
+    assessment: UnifiedResponseAssessment,
+    *,
+    response: str,
+    guard_diagnostics: Optional[Mapping[str, Any]] = None,
+    response_sent: bool = True,
+    processing_errors: Sequence[str] = (),
+    created_at: str = "",
+) -> str:
+    """Persist one content-free comparison receipt."""
+
+    ensure_schema(conn)
+    guard = guard_diagnostics or {}
+    guard_triggered, guard_repaired = _guard_signal(guard)
+    response_text = str(response or "")
+    lowered_response = response_text.lower()
+    labels = tuple(
+        label
+        for label in assessment.speaker_labels
+        if len(label.strip()) >= 2
+    )
+    speaker_coverage = sum(
+        1 for label in labels if label.lower() in lowered_response
+    )
+    visible_control_marker = bool(
+        _VISIBLE_CONTROL_MARKER_RE.search(response_text)
+    )
+    source_changed = bool(guard.get("prompt_source_basis_changed"))
+    if not response_sent:
+        alignment = "not_sent"
+    elif source_changed and not guard_repaired:
+        alignment = "source_changed_unrepaired"
+    elif bool(guard.get("suppressed")):
+        alignment = "suppressed"
+    elif visible_control_marker:
+        alignment = "visible_control_marker"
+    elif assessment.response_act == "recap_current_exchange" and labels:
+        alignment = (
+            "recap_full_speaker_label_coverage"
+            if speaker_coverage == len(labels)
+            else "recap_partial_speaker_label_coverage"
+        )
+    elif guard_repaired:
+        alignment = "guard_repaired"
+    else:
+        alignment = "guard_clear"
+
+    run_id = "ura_" + uuid.uuid4().hex
+    timestamp = created_at or datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        """
+        INSERT INTO unified_response_assessment_shadow_runs (
+            run_id, schema_version, guild_id, route_mode, channel_policy,
+            conversation_surface, current_speaker_count, target_count,
+            participant_count, current_exchange_source_count,
+            active_episode_present, prior_moment_count, moment_candidate_count,
+            governed_entry_count, governed_candidate_count,
+            governance_exclusion_count, relationship_candidate_count,
+            canon_ref_count, response_act, selected_lanes_json,
+            excluded_lanes_json, conflict_reasons_json,
+            supported_inference_count, exact_quote_authority_present,
+            source_basis_kinds_json, source_basis_count, prompt_budget,
+            prompt_lanes_json, comparison_status, prompt_extra_lanes_json,
+            prompt_missing_lanes_json, source_basis_changed_before_send,
+            guard_triggered, guard_repaired, response_sent, response_length,
+            speaker_label_coverage_count, visible_control_marker,
+            response_alignment, processing_errors_json, behavior_changed,
+            new_authority_applied, created_at
+        ) VALUES (
+            ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,
+            ?,?,?,?,?,?,?,?,?
+        )
+        """,
+        (
+            run_id,
+            assessment.schema_version,
+            assessment.guild_id,
+            assessment.route_mode,
+            assessment.channel_policy,
+            assessment.conversation_surface,
+            len(assessment.current_speaker_user_ids),
+            len(assessment.target_user_ids),
+            len(assessment.participant_user_ids),
+            len(assessment.current_exchange_source_ids),
+            int(bool(assessment.active_episode_id)),
+            len(assessment.prior_moment_ids),
+            assessment.moment_candidate_count,
+            len(assessment.governed_entry_ids),
+            assessment.governed_candidate_count,
+            assessment.governance_exclusion_count,
+            len(assessment.relationship_candidate_keys),
+            len(assessment.canon_refs),
+            assessment.response_act,
+            json.dumps(assessment.selected_lanes),
+            json.dumps(_excluded_counts(assessment.excluded_lanes), sort_keys=True),
+            json.dumps(assessment.conflict_reasons),
+            len(assessment.supported_inferences),
+            int(assessment.exact_quote_authority_present),
+            json.dumps(assessment.source_basis_kinds),
+            len(assessment.source_basis_kinds),
+            assessment.prompt_budget,
+            json.dumps(assessment.prompt_lanes),
+            assessment.comparison_status,
+            json.dumps(assessment.prompt_extra_lanes),
+            json.dumps(assessment.prompt_missing_lanes),
+            int(source_changed),
+            int(guard_triggered),
+            int(guard_repaired),
+            int(bool(response_sent)),
+            len(response_text),
+            speaker_coverage,
+            int(visible_control_marker),
+            alignment,
+            json.dumps(
+                tuple(
+                    "processing_error"
+                    for _error in (processing_errors or ())
+                )
+            ),
+            0,
+            0,
+            timestamp,
+        ),
+    )
+    return run_id
+
+
+def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    return bool(
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+            (table_name,),
+        ).fetchone()
+    )
+
+
+def _safe_json(value: Any, fallback: Any) -> Any:
+    try:
+        return json.loads(str(value or ""))
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _empty_evaluation_report() -> Dict[str, Any]:
+    return {
+        "tablePresent": False,
+        "runs": 0,
+        "response_sent_runs": 0,
+        "current_exchange_primary_runs": 0,
+        "comparison_status_counts": {},
+        "selected_lane_counts": {},
+        "excluded_lane_reason_counts": {},
+        "response_act_counts": {},
+        "response_alignment_counts": {},
+        "prompt_overincluded_runs": 0,
+        "prompt_underincluded_runs": 0,
+        "prompt_different_runs": 0,
+        "source_basis_changed_runs": 0,
+        "guard_triggered_runs": 0,
+        "guard_repaired_runs": 0,
+        "visible_control_marker_runs": 0,
+        "processing_errors": 0,
+        "behavior_changed_runs": 0,
+        "new_authority_applied_runs": 0,
+        "content_fields_present": [],
+        "evidenceWindow": {"first": "none", "last": "none"},
+    }
+
+
+def build_evaluation_report(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    prepare_schema: bool = False,
+    limit: int = 500,
+) -> Dict[str, Any]:
+    """Aggregate retained receipts without exposing people, text, or source IDs."""
+
+    if prepare_schema:
+        ensure_schema(conn)
+    if not _table_exists(conn, TABLE_NAME):
+        return _empty_evaluation_report()
+    columns = {
+        str(row[1])
+        for row in conn.execute("PRAGMA table_info(%s)" % TABLE_NAME)
+    }
+    disallowed_content_columns = sorted(
+        columns
+        & {
+            "raw_text",
+            "request_text",
+            "response_text",
+            "speaker_labels",
+            "participant_ids",
+            "source_ids",
+            "source_text",
+        }
+    )
+    rows = conn.execute(
+        """
+        SELECT response_sent, selected_lanes_json, excluded_lanes_json,
+               response_act, comparison_status,
+               source_basis_changed_before_send, guard_triggered,
+               guard_repaired, visible_control_marker, response_alignment,
+               processing_errors_json, behavior_changed,
+               new_authority_applied, created_at
+        FROM unified_response_assessment_shadow_runs
+        WHERE guild_id=?
+        ORDER BY created_at DESC, run_id DESC
+        LIMIT ?
+        """,
+        (int(guild_id or 0), max(1, min(int(limit or 500), 5000))),
+    ).fetchall()
+
+    selected_counts = Counter()
+    excluded_counts = Counter()
+    act_counts = Counter()
+    comparison_counts = Counter()
+    alignment_counts = Counter()
+    response_sent_runs = current_primary = source_changed = 0
+    guard_triggered_runs = guard_repaired_runs = marker_runs = 0
+    processing_errors = behavior_changed = new_authority = 0
+    for row in rows:
+        (
+            response_sent,
+            selected_json,
+            excluded_json,
+            response_act,
+            comparison,
+            source_basis_changed,
+            guard_triggered,
+            guard_repaired,
+            visible_control_marker,
+            response_alignment,
+            errors_json,
+            changed_behavior,
+            applied_authority,
+            _created_at,
+        ) = row
+        selected = _safe_json(selected_json, [])
+        if not isinstance(selected, list):
+            selected = []
+            processing_errors += 1
+        excluded = _safe_json(excluded_json, {})
+        if not isinstance(excluded, dict):
+            excluded = {}
+            processing_errors += 1
+        errors = _safe_json(errors_json, ["invalid_json"])
+        if not isinstance(errors, (list, tuple, dict)):
+            errors = ["invalid_shape"] if errors else []
+        selected_counts.update(str(item) for item in selected)
+        excluded_counts.update(
+            {
+                str(key): max(0, int(value or 0))
+                for key, value in excluded.items()
+            }
+        )
+        act_counts[str(response_act or "unknown")] += 1
+        comparison_counts[str(comparison or "unknown")] += 1
+        alignment_counts[str(response_alignment or "unknown")] += 1
+        response_sent_runs += int(bool(response_sent))
+        current_primary += int(bool(selected and selected[0] == "current_exchange"))
+        source_changed += int(bool(source_basis_changed))
+        guard_triggered_runs += int(bool(guard_triggered))
+        guard_repaired_runs += int(bool(guard_repaired))
+        marker_runs += int(bool(visible_control_marker))
+        processing_errors += len(errors)
+        behavior_changed += int(bool(changed_behavior))
+        new_authority += int(bool(applied_authority))
+
+    return {
+        "tablePresent": True,
+        "runs": len(rows),
+        "response_sent_runs": response_sent_runs,
+        "current_exchange_primary_runs": current_primary,
+        "comparison_status_counts": dict(sorted(comparison_counts.items())),
+        "selected_lane_counts": dict(sorted(selected_counts.items())),
+        "excluded_lane_reason_counts": dict(sorted(excluded_counts.items())),
+        "response_act_counts": dict(sorted(act_counts.items())),
+        "response_alignment_counts": dict(sorted(alignment_counts.items())),
+        "prompt_overincluded_runs": comparison_counts.get(
+            "prompt_overincluded",
+            0,
+        ),
+        "prompt_underincluded_runs": comparison_counts.get(
+            "prompt_underincluded",
+            0,
+        ),
+        "prompt_different_runs": comparison_counts.get("different", 0),
+        "source_basis_changed_runs": source_changed,
+        "guard_triggered_runs": guard_triggered_runs,
+        "guard_repaired_runs": guard_repaired_runs,
+        "visible_control_marker_runs": marker_runs,
+        "processing_errors": processing_errors,
+        "behavior_changed_runs": behavior_changed,
+        "new_authority_applied_runs": new_authority,
+        "content_fields_present": disallowed_content_columns,
+        "evidenceWindow": {
+            "first": str(rows[-1][13]) if rows else "none",
+            "last": str(rows[0][13]) if rows else "none",
+        },
+    }

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -821,6 +821,60 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
             ["Crow preferred the stronger cobalt framing."],
         )
 
+    async def test_batch_records_one_participant_neutral_unified_assessment_after_send(self):
+        channel = self._channel(8137)
+        now = bnl01_bot.datetime.now(bnl01_bot.PACIFIC_TZ)
+        for item in (
+            ("Jon", "I will handle the intro.", 100),
+            ("Miss Bit", "I will handle the artwork.", 101),
+            ("Crow", "I will handle the promo clips.", 102),
+            ("Jon", "What did everyone just decide?", 100),
+        ):
+            bnl01_bot._channel_buffers[channel.id].append(item)
+        bnl01_bot._channel_first_seen[channel.id] = now
+        bnl01_bot._channel_last_message_at[channel.id] = now
+        bnl01_bot._channel_last_reply_at[channel.id] = (
+            now - bnl01_bot.timedelta(hours=2)
+        )
+        recorder = mock.AsyncMock()
+
+        async def generate(_prompt, **_kwargs):
+            return (
+                "Jon has the intro, Miss Bit has the artwork, and Crow has "
+                "the promo clips."
+            )
+
+        with (
+            self._flush_runtime(channel.id, generate),
+            mock.patch.object(
+                bnl01_bot,
+                "unified_response_assessment_shadow_enabled",
+                return_value=True,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "record_unified_response_assessment_shadow_after_send",
+                new=recorder,
+            ),
+        ):
+            await bnl01_bot._flush_channel_buffer(channel)
+
+        self.assertEqual(len(channel.sent), 1)
+        recorder.assert_awaited_once()
+        assessment = recorder.call_args.args[0]
+        self.assertEqual(assessment.response_act, "recap_current_exchange")
+        self.assertEqual(len(assessment.current_speaker_user_ids), 3)
+        self.assertEqual(len(assessment.participant_user_ids), 3)
+        self.assertEqual(
+            assessment.selected_lanes,
+            ("current_exchange",),
+        )
+        self.assertEqual(
+            recorder.call_args.kwargs["response"],
+            channel.sent[0],
+        )
+        self.assertTrue(recorder.call_args.kwargs["response_sent"])
+
     async def test_batched_repair_turn_uses_visible_context_generation_not_canned_reply(self):
         channel = self._channel(8116)
         prompts = []
@@ -1686,9 +1740,17 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
             conversation_surface=bnl01_bot.CONVERSATION_SURFACE_FREE_SPEAK_SEALED_MIRROR,
         )
         show_context = {"context_source": "followup", "answer_type": "show_state"}
+        unified_assessment = bnl01_bot.build_unified_response_assessment(
+            guild_id=message.guild.id,
+            route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            channel_policy="sealed_test",
+            conversation_surface="test",
+            current_speaker_user_ids=(message.author.id,),
+        )
         greeting = mock.Mock()
         show_state = mock.Mock()
         save = mock.Mock(return_value=SimpleNamespace(save_conversation=True, reason="saved"))
+        assessment_record = mock.AsyncMock()
         with (
             mock.patch.object(bnl01_bot, "_apply_direct_response_pacing", new=mock.AsyncMock()),
             mock.patch.object(
@@ -1702,6 +1764,11 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
             mock.patch.object(bnl01_bot, "set_last_greeting_at", new=greeting),
             mock.patch.object(bnl01_bot, "_store_show_state_topic_context", new=show_state),
             mock.patch.object(bnl01_bot, "_mark_conversation_continuation_state"),
+            mock.patch.object(
+                bnl01_bot,
+                "record_unified_response_assessment_shadow_after_send",
+                new=assessment_record,
+            ),
         ):
             await bnl01_bot.send_planned_conversation_response(
                 message,
@@ -1712,6 +1779,7 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
                 direct_repair_generation=token,
                 allow_greeting_on_commit=True,
                 show_state_context_on_commit=show_context,
+                unified_response_assessment_shadow=unified_assessment,
             )
 
         self.assertEqual(message.replies, ["Corrected answer."])
@@ -1724,6 +1792,12 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
             show_context,
         )
         save.assert_called_once()
+        assessment_record.assert_awaited_once_with(
+            unified_assessment,
+            response="Corrected answer.",
+            guard_diagnostics={"suppressed": False},
+            response_sent=True,
+        )
         self.assertNotIn(token["key"], bnl01_bot._inflight_direct_repair_generations)
 
     async def test_on_message_plain_name_request_preempts_batch_and_accepts_tag_payload(self):

--- a/tests/test_unified_response_assessment_bot_paths.py
+++ b/tests/test_unified_response_assessment_bot_paths.py
@@ -1,0 +1,285 @@
+import os
+import sqlite3
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+
+
+class UnifiedResponseAssessmentBotPathTests(unittest.TestCase):
+    def conversation_basis(self, participant_count=10):
+        return bnl01_bot.ConversationPromptSourceBasis(
+            expected_digest="digest",
+            rendered_context="bounded room context",
+            guild_id=1,
+            current_user_id=101,
+            channel_id=303,
+            channel_name="bnl-testing",
+            channel_policy="sealed_test",
+            source_row_ids=tuple(range(1, participant_count + 1)),
+            participant_user_ids=tuple(
+                range(101, 101 + participant_count)
+            ),
+            speaker_labels=tuple(
+                "Member %s" % index
+                for index in range(1, participant_count + 1)
+            ),
+        )
+
+    def test_bot_adapter_keeps_any_participant_count_and_current_precedence(self):
+        basis = self.conversation_basis(10)
+        with mock.patch.object(
+            bnl01_bot,
+            "unified_response_assessment_shadow_enabled",
+            return_value=True,
+        ):
+            assessment = (
+                bnl01_bot.build_unified_response_assessment_shadow(
+                    guild_id=1,
+                    route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy="sealed_test",
+                    conversation_surface="test",
+                    current_text="What did everyone just decide?",
+                    current_speaker_user_ids=tuple(range(101, 111)),
+                    current_speaker_labels=basis.speaker_labels,
+                    prompt_source_bases=(basis,),
+                    memory_source_metadata={
+                        "governed_entry_ids": ("private-ledger-ref",),
+                        "governed_candidate_count": 1,
+                        "moment_candidate_count": 3,
+                        "legacy_memory_present": True,
+                        "legacy_relationship_present": True,
+                    },
+                    prompt_lanes=(
+                        "current_exchange",
+                        "conversation_context",
+                        "legacy_memory",
+                        "relationship",
+                    ),
+                    continuity_required=True,
+                )
+            )
+
+        self.assertIsNotNone(assessment)
+        self.assertEqual(len(assessment.participant_user_ids), 10)
+        self.assertEqual(len(assessment.speaker_labels), 10)
+        self.assertEqual(
+            assessment.selected_lanes,
+            ("current_exchange", "conversation_context"),
+        )
+        self.assertEqual(
+            assessment.response_act,
+            "recap_current_exchange",
+        )
+        self.assertIn(
+            ("governed_memory", "current_exchange_precedence"),
+            assessment.excluded_lanes,
+        )
+        self.assertIn(
+            ("relationship", "legacy_only_live_authority_off"),
+            assessment.excluded_lanes,
+        )
+
+    def test_direct_prompt_is_byte_identical_with_shadow_on_or_off(self):
+        visual_basis = SimpleNamespace(status="not_requested")
+        conversation_basis = self.conversation_basis(3)
+
+        def memory_context(*_args, **kwargs):
+            metadata = kwargs.get("source_metadata")
+            if metadata is not None:
+                metadata.update(
+                    {
+                        "moment_gist_rendered": False,
+                        "approved_fact_count": 1,
+                        "legacy_relationship_present": True,
+                        "legacy_memory_present": True,
+                        "relationship_v2_candidate_present": False,
+                        "governed_entry_ids": ("governed-ref",),
+                        "governed_candidate_count": 1,
+                        "governance_exclusion_count": 2,
+                        "governance_contradiction_count": 0,
+                        "moment_candidate_count": 0,
+                        "prompt_budget": 900,
+                    }
+                )
+            return (
+                "Approved direct self-reports:\n"
+                "- Favorite color: blue\n"
+                "Relationship state: stage=known."
+            )
+
+        common_patches = (
+            mock.patch.object(
+                bnl01_bot,
+                "get_user_profile",
+                return_value=("Member 1", ""),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "should_allow_greeting",
+                return_value=False,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "choose_response_style",
+                return_value=("balanced", "Respond naturally."),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_user_memory_context",
+                side_effect=memory_context,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "memory_governance_live_enabled",
+                return_value=False,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_broadcast_memory_context",
+                return_value="",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_conversation_prompt_source_basis",
+                return_value=conversation_basis,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_community_visual_basis",
+                return_value=visual_basis,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "render_community_visual_basis_for_prompt",
+                return_value="",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "get_guild_config",
+                return_value=303,
+            ),
+        )
+        for patcher in common_patches:
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+        metadata_off = {}
+        with mock.patch.object(
+            bnl01_bot,
+            "unified_response_assessment_shadow_enabled",
+            return_value=False,
+        ):
+            prompt_off, *_ = bnl01_bot.build_user_aware_prompt(
+                101,
+                1,
+                "Member 1",
+                "What did everyone just decide?",
+                room_context="bounded room context",
+                channel_name="bnl-testing",
+                channel_id=303,
+                channel_policy="sealed_test",
+                route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                is_direct_interaction=True,
+                prompt_metadata=metadata_off,
+            )
+
+        metadata_on = {}
+        with mock.patch.object(
+            bnl01_bot,
+            "unified_response_assessment_shadow_enabled",
+            return_value=True,
+        ):
+            prompt_on, *_ = bnl01_bot.build_user_aware_prompt(
+                101,
+                1,
+                "Member 1",
+                "What did everyone just decide?",
+                room_context="bounded room context",
+                channel_name="bnl-testing",
+                channel_id=303,
+                channel_policy="sealed_test",
+                route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                is_direct_interaction=True,
+                prompt_metadata=metadata_on,
+            )
+
+        self.assertEqual(prompt_on, prompt_off)
+        self.assertIsNone(
+            metadata_off["unified_response_assessment_shadow"]
+        )
+        assessment = metadata_on["unified_response_assessment_shadow"]
+        self.assertIsNotNone(assessment)
+        self.assertEqual(
+            assessment.response_act,
+            "recap_current_exchange",
+        )
+        self.assertEqual(
+            assessment.selected_lanes,
+            ("current_exchange", "conversation_context"),
+        )
+
+    def test_bot_recorder_persists_only_aggregate_receipt(self):
+        with mock.patch.object(
+            bnl01_bot,
+            "unified_response_assessment_shadow_enabled",
+            return_value=True,
+        ):
+            assessment = (
+                bnl01_bot.build_unified_response_assessment_shadow(
+                    guild_id=1,
+                    route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy="sealed_test",
+                    conversation_surface="test",
+                    current_text="What did everyone just decide?",
+                    current_speaker_user_ids=(101, 102),
+                    current_speaker_labels=("PRIVATE A", "PRIVATE B"),
+                    prompt_source_bases=(self.conversation_basis(2),),
+                    prompt_lanes=(
+                        "current_exchange",
+                        "conversation_context",
+                    ),
+                    continuity_required=True,
+                )
+            )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "assessment.db")
+            with mock.patch.object(bnl01_bot, "DB_FILE", db_path):
+                run_id = (
+                    bnl01_bot.record_unified_response_assessment_shadow(
+                        assessment,
+                        response=(
+                            "PRIVATE A has the intro and PRIVATE B has the art."
+                        ),
+                    )
+                )
+
+            self.assertTrue(run_id.startswith("ura_"))
+            with sqlite3.connect(db_path) as conn:
+                row = conn.execute(
+                    "SELECT current_speaker_count, participant_count, "
+                    "response_length, behavior_changed, new_authority_applied "
+                    "FROM unified_response_assessment_shadow_runs"
+                ).fetchone()
+                self.assertEqual(row[:2], (2, 2))
+                self.assertGreater(row[2], 0)
+                self.assertEqual(row[3:], (0, 0))
+                schema = "\n".join(
+                    str(item)
+                    for item in conn.execute(
+                        "SELECT sql FROM sqlite_master "
+                        "WHERE name='unified_response_assessment_shadow_runs'"
+                    ).fetchone()
+                )
+                self.assertNotIn("response_text", schema)
+                self.assertNotIn("speaker_labels", schema)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_unified_response_assessment_shadow.py
+++ b/tests/test_unified_response_assessment_shadow.py
@@ -1,0 +1,274 @@
+import json
+import sqlite3
+import unittest
+
+from bnl_unified_response_assessment import (
+    ASSESSMENT_VERSION,
+    build_evaluation_report,
+    build_unified_response_assessment,
+    persist_shadow_run,
+    shadow_configuration,
+)
+
+
+FOUNDATION_SHADOWS = {
+    "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+    "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+    "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+    "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+    "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
+    "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
+    "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+}
+
+
+class UnifiedResponseAssessmentShadowTests(unittest.TestCase):
+    def test_shadow_derives_from_foundations_and_explicit_false_is_rollback(self):
+        derived = shadow_configuration(FOUNDATION_SHADOWS)
+        self.assertTrue(derived["requested"])
+        self.assertTrue(derived["effective"])
+        self.assertFalse(derived["explicitly_configured"])
+        self.assertEqual(derived["reason"], "shadow_only")
+
+        disabled = shadow_configuration(
+            {
+                **FOUNDATION_SHADOWS,
+                "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED": "false",
+            }
+        )
+        self.assertFalse(disabled["requested"])
+        self.assertFalse(disabled["effective"])
+        self.assertTrue(disabled["explicitly_configured"])
+        self.assertEqual(disabled["reason"], "disabled")
+
+    def test_shadow_fails_closed_when_a_foundation_is_missing_or_live(self):
+        missing = shadow_configuration(
+            {
+                **FOUNDATION_SHADOWS,
+                "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "false",
+                "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED": "true",
+            }
+        )
+        self.assertFalse(missing["effective"])
+        self.assertEqual(missing["reason"], "missing_shadow_prerequisites")
+        self.assertEqual(
+            missing["missing_prerequisites"],
+            ("BNL_MOMENT_ENGINE_SHADOW_ENABLED",),
+        )
+
+        live = shadow_configuration(
+            {
+                **FOUNDATION_SHADOWS,
+                "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "true",
+            }
+        )
+        self.assertFalse(live["effective"])
+        self.assertEqual(live["reason"], "live_authority_detected")
+        self.assertEqual(
+            live["active_live_gates"],
+            ("BNL_RELATIONSHIP_V2_LIVE_ENABLED",),
+        )
+
+    def test_immediate_recap_is_current_first_for_any_participant_count(self):
+        participants = tuple(range(1001, 1011))
+        labels = tuple("Member %s" % index for index in range(1, 11))
+        assessment = build_unified_response_assessment(
+            guild_id=1,
+            route_mode="normal_chat",
+            channel_policy="public_home",
+            conversation_surface="active_channel",
+            current_speaker_user_ids=participants,
+            participant_user_ids=participants,
+            speaker_labels=labels,
+            current_exchange_source_ids=tuple(range(1, 11)),
+            prior_moment_ids=("moment-private-id",),
+            governed_entry_ids=("ledger-private-id",),
+            relationship_candidate_keys=("relationship-private-key",),
+            canon_refs=("canon:one",),
+            prompt_lanes=(
+                "current_exchange",
+                "conversation_context",
+                "prior_moment",
+                "governed_memory",
+                "relationship",
+                "canon",
+            ),
+            immediate_recap=True,
+            continuity_required=True,
+            moment_candidate_count=4,
+            governed_candidate_count=3,
+            relationship_v2_candidate_present=True,
+            canon_relevant=True,
+        )
+
+        self.assertEqual(assessment.schema_version, ASSESSMENT_VERSION)
+        self.assertEqual(assessment.participant_user_ids, participants)
+        self.assertEqual(assessment.speaker_labels, labels)
+        self.assertEqual(
+            assessment.selected_lanes,
+            ("current_exchange", "conversation_context"),
+        )
+        self.assertEqual(
+            assessment.response_act,
+            "recap_current_exchange",
+        )
+        self.assertIn(
+            ("prior_moment", "current_exchange_precedence"),
+            assessment.excluded_lanes,
+        )
+        self.assertIn(
+            ("governed_memory", "current_exchange_precedence"),
+            assessment.excluded_lanes,
+        )
+        self.assertIn(
+            ("relationship", "current_exchange_precedence"),
+            assessment.excluded_lanes,
+        )
+        self.assertIn("current_exchange_precedence", assessment.conflict_reasons)
+        self.assertEqual(assessment.comparison_status, "prompt_overincluded")
+
+    def test_general_turn_unifies_selected_governed_lanes_without_rendering(self):
+        assessment = build_unified_response_assessment(
+            guild_id=1,
+            route_mode="normal_chat",
+            channel_policy="public_context",
+            conversation_surface="free_speak",
+            current_speaker_user_ids=(7,),
+            participant_user_ids=(7, 8),
+            current_exchange_source_ids=(100, 101),
+            prior_moment_ids=("moment-one",),
+            governed_entry_ids=("ledger-one", "ledger-two"),
+            relationship_candidate_keys=("relationship-current-member",),
+            canon_refs=("canon:contract",),
+            prompt_lanes=(
+                "current_exchange",
+                "conversation_context",
+                "prior_moment",
+                "governed_memory",
+                "relationship",
+                "canon",
+            ),
+            continuity_required=True,
+            moment_candidate_count=2,
+            governed_candidate_count=2,
+            relationship_v2_candidate_present=True,
+            canon_relevant=True,
+        )
+
+        self.assertEqual(
+            assessment.selected_lanes,
+            (
+                "current_exchange",
+                "conversation_context",
+                "prior_moment",
+                "governed_memory",
+                "relationship",
+                "canon",
+            ),
+        )
+        self.assertEqual(assessment.comparison_status, "match")
+        self.assertEqual(assessment.response_act, "continue_active_thread")
+        self.assertEqual(assessment.prompt_extra_lanes, ())
+        self.assertEqual(assessment.prompt_missing_lanes, ())
+
+    def test_receipt_is_content_free_and_observes_visible_pause_marker(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            assessment = build_unified_response_assessment(
+                guild_id=123,
+                route_mode="normal_chat",
+                channel_policy="sealed_test",
+                conversation_surface="test",
+                current_speaker_user_ids=(987654321,),
+                target_user_ids=(123456789,),
+                participant_user_ids=(987654321, 123456789),
+                speaker_labels=("PRIVATE ALPHA", "PRIVATE BETA"),
+                current_exchange_source_ids=(444, 555),
+                prior_moment_ids=("SECRET MOMENT ID",),
+                governed_entry_ids=("SECRET LEDGER ID",),
+                relationship_candidate_keys=("SECRET RELATIONSHIP KEY",),
+                canon_refs=("SECRET CANON REF",),
+                prompt_lanes=(
+                    "current_exchange",
+                    "conversation_context",
+                    "PRIVATE PROMPT PAYLOAD",
+                ),
+                immediate_recap=True,
+            )
+            self.assertNotIn(
+                "PRIVATE PROMPT PAYLOAD",
+                assessment.prompt_lanes,
+            )
+            persist_shadow_run(
+                conn,
+                assessment,
+                response=(
+                    "[Pause: 0.2s]\n"
+                    "PRIVATE ALPHA has the intro and PRIVATE BETA has the artwork."
+                ),
+                guard_diagnostics={
+                    "contextual_followthrough_guard_triggered": True,
+                    "contextual_followthrough_regenerated": True,
+                },
+                processing_errors=("PRIVATE ERROR PAYLOAD",),
+                created_at="2026-07-24T17:00:00+00:00",
+            )
+            conn.commit()
+
+            columns = {
+                row[1]
+                for row in conn.execute(
+                    "PRAGMA table_info(unified_response_assessment_shadow_runs)"
+                )
+            }
+            self.assertFalse(
+                columns
+                & {
+                    "raw_text",
+                    "request_text",
+                    "response_text",
+                    "speaker_labels",
+                    "participant_ids",
+                    "source_ids",
+                    "source_text",
+                }
+            )
+            row = conn.execute(
+                "SELECT * FROM unified_response_assessment_shadow_runs"
+            ).fetchone()
+            serialized_row = json.dumps(row)
+            for secret in (
+                "PRIVATE ALPHA",
+                "PRIVATE BETA",
+                "987654321",
+                "123456789",
+                "SECRET MOMENT ID",
+                "SECRET LEDGER ID",
+                "SECRET RELATIONSHIP KEY",
+                "SECRET CANON REF",
+                "PRIVATE PROMPT PAYLOAD",
+                "PRIVATE ERROR PAYLOAD",
+            ):
+                self.assertNotIn(secret, serialized_row)
+
+            report = build_evaluation_report(conn, guild_id=123)
+            self.assertEqual(report["runs"], 1)
+            self.assertEqual(report["response_sent_runs"], 1)
+            self.assertEqual(report["current_exchange_primary_runs"], 1)
+            self.assertEqual(report["guard_triggered_runs"], 1)
+            self.assertEqual(report["guard_repaired_runs"], 1)
+            self.assertEqual(report["visible_control_marker_runs"], 1)
+            self.assertEqual(report["processing_errors"], 1)
+            self.assertEqual(report["behavior_changed_runs"], 0)
+            self.assertEqual(report["new_authority_applied_runs"], 0)
+            self.assertEqual(report["content_fields_present"], [])
+            self.assertEqual(
+                report["response_alignment_counts"],
+                {"visible_control_marker": 1},
+            )
+        finally:
+            conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v2_shadow_acceptance.py
+++ b/tests/test_v2_shadow_acceptance.py
@@ -29,6 +29,10 @@ from bnl_shadow_acceptance import (
     build_v2_shadow_acceptance_snapshot,
     render_v2_shadow_acceptance_lines,
 )
+from bnl_unified_response_assessment import (
+    build_unified_response_assessment,
+    persist_shadow_run as persist_unified_assessment_shadow_run,
+)
 
 
 class V2ShadowAcceptanceTests(unittest.TestCase):
@@ -43,6 +47,7 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
                 "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "",
                 "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "",
                 "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "",
+                "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED": "",
             },
             clear=False,
         )
@@ -79,6 +84,9 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
         self.assertTrue(snapshot["ownerReviewRequired"])
         self.assertFalse(snapshot["automaticCutoverAllowed"])
         self.assertFalse(snapshot["behaviorChangesApplied"])
+        self.assertFalse(
+            snapshot["unifiedResponseAssessmentShadow"]["requested"]
+        )
         self.assertTrue(
             all(stage["status"] == "disabled" for stage in snapshot["stages"].values())
         )
@@ -88,6 +96,109 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
                 "SELECT type,name,sql FROM sqlite_master ORDER BY type,name"
             ).fetchall(),
             before_schema,
+        )
+
+    def test_unified_assessment_overlay_is_content_free_and_not_a_fifth_stage(self):
+        assessment = build_unified_response_assessment(
+            guild_id=1,
+            route_mode="normal_chat",
+            channel_policy="public_home",
+            conversation_surface="active_channel",
+            current_speaker_user_ids=(99,),
+            participant_user_ids=(99, 100),
+            speaker_labels=("PRIVATE ONE", "PRIVATE TWO"),
+            current_exchange_source_ids=(500, 501),
+            governed_entry_ids=("PRIVATE LEDGER REF",),
+            prompt_lanes=("current_exchange", "conversation_context"),
+            immediate_recap=True,
+        )
+        persist_unified_assessment_shadow_run(
+            self.conn,
+            assessment,
+            response=(
+                "[Pause: 0.2s]\n"
+                "PRIVATE ONE has the intro; PRIVATE TWO has the artwork."
+            ),
+        )
+        self.conn.commit()
+
+        environ = {
+            "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+            "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+            "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+            "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+        }
+        snapshot = self.snapshot(environ)
+        overlay = snapshot["unifiedResponseAssessmentShadow"]
+        report = snapshot["reports"]["unifiedResponseAssessment"]
+
+        self.assertEqual(
+            snapshot["evaluationOrder"],
+            list(SHADOW_EVALUATION_ORDER),
+        )
+        self.assertNotIn("unified_response_assessment", snapshot["stages"])
+        self.assertTrue(overlay["requested"])
+        self.assertTrue(overlay["effective"])
+        self.assertEqual(overlay["reason"], "shadow_only")
+        self.assertTrue(overlay["evidenceObserved"])
+        self.assertEqual(overlay["blockers"], [])
+        self.assertEqual(report["runs"], 1)
+        self.assertEqual(report["current_exchange_primary_runs"], 1)
+        self.assertEqual(report["visible_control_marker_runs"], 1)
+        self.assertEqual(report["behavior_changed_runs"], 0)
+        self.assertEqual(report["new_authority_applied_runs"], 0)
+        self.assertEqual(report["content_fields_present"], [])
+        self.assertIn(
+            "unified_assessment_visible_control_marker_review",
+            snapshot["warnings"],
+        )
+
+        encoded = json.dumps(snapshot, sort_keys=True)
+        self.assertNotIn("PRIVATE ONE", encoded)
+        self.assertNotIn("PRIVATE TWO", encoded)
+        self.assertNotIn("PRIVATE LEDGER REF", encoded)
+        rendered = "\n".join(render_v2_shadow_acceptance_lines(snapshot))
+        self.assertIn("unified_assessment:", rendered)
+        self.assertIn("visible_control_markers=`1`", rendered)
+
+    def test_unified_assessment_new_authority_or_behavior_is_a_hard_blocker(self):
+        assessment = build_unified_response_assessment(
+            guild_id=1,
+            route_mode="normal_chat",
+            channel_policy="public_home",
+            conversation_surface="active_channel",
+            current_speaker_user_ids=(99,),
+        )
+        persist_unified_assessment_shadow_run(
+            self.conn,
+            assessment,
+            response="Safe response.",
+        )
+        self.conn.execute(
+            "UPDATE unified_response_assessment_shadow_runs "
+            "SET behavior_changed=1, new_authority_applied=1"
+        )
+        self.conn.commit()
+
+        snapshot = self.snapshot(
+            {
+                "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+                "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+                "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+                "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+            }
+        )
+        self.assertEqual(
+            snapshot["status"],
+            "blocked_shadow_invariant_failure",
+        )
+        self.assertIn(
+            "unified_response_assessment:behavior_changed_runs",
+            snapshot["blockers"],
+        )
+        self.assertIn(
+            "unified_response_assessment:new_authority_applied_runs",
+            snapshot["blockers"],
         )
 
     def test_missing_schemas_are_reported_without_creating_tables(self):
@@ -770,6 +881,18 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
             channel_policy="public_home",
             current_direct=True,
             now="2026-07-19T00:12:00+00:00",
+        )
+        persist_unified_assessment_shadow_run(
+            self.conn,
+            build_unified_response_assessment(
+                guild_id=1,
+                route_mode="normal_chat",
+                channel_policy="public_home",
+                conversation_surface="test",
+                current_speaker_user_ids=(2,),
+                prompt_lanes=("current_exchange",),
+            ),
+            response="Acknowledged.",
         )
         self.conn.commit()
 


### PR DESCRIPTION
## What changed

- Adds a typed, metadata-only Unified Response Assessment owned by the existing conversation planner.
- Produces shadow assessments across direct, deferred, and participant-neutral batched response paths using evidence already selected by current owners.
- Records content-free comparison receipts and exposes the shadow evidence through the existing owner diagnostic.
- Keeps assessment persistence off Discord's event loop and after the live response/state commit.

## Why

Conversation Context v2, episodic Moments, governed memory, relationships, and canon are intended to cooperate as one mind. This PR establishes the response-time assessment and comparison layer needed to evaluate that architecture before granting it any live authority.

## Behavior and safety

- BNL's prompt and sent reply remain byte-equivalent with the shadow enabled or disabled.
- The assessment is never injected into the model prompt and cannot authorize a live lane.
- Persisted receipts contain counts, lane names, comparison states, and guard outcomes only—no message text, reply text, names, participant IDs, or source IDs.
- No schema migration, configuration change, deployment, queue, Journal, Relay, website, Source File, dossier, Moment canary, Memory Governance live gate, Relationship live gate, or Active Engagement live gate change.
- The separate visible `[Pause: 0.2s]` output leak is intentionally outside this PR.

## Validation

- 1,468 repository tests passed.
- Focused 331-test context, batching, deferred, Moment, Governance, diagnostic, and shadow matrix passed.
- Python 3.9 grammar parsing passed.
- Compilation and whitespace validation passed.
- GitHub comparison: one commit, seven intended files, based directly on merge SHA `a149c3b071340efebd70f3c148caca80f97699a1`.