### PR TITLE
Repair current-choice grounding recovery

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -8396,11 +8396,29 @@ def build_contextual_followthrough_correction_prompt(prompt: str) -> str:
     )
 
 
-def build_current_payload_grounding_correction_prompt(prompt: str) -> str:
+def build_current_payload_grounding_correction_prompt(
+    prompt: str,
+    current_payload_anchors=(),
+) -> str:
+    resolved = tuple(
+        dict.fromkeys(
+            str(anchor or "").strip()
+            for anchor in current_payload_anchors or ()
+            if str(anchor or "").strip()
+        )
+    )
+    resolved_line = (
+        "\nResolved current alternatives: "
+        + " | ".join(f"“{anchor}”" for anchor in resolved)
+        + "."
+        if resolved
+        else ""
+    )
     return (
         (prompt or "")
         + "\n\nCURRENT-PAYLOAD CORRECTION REQUIRED: The previous draft did not answer the named alternatives in the current exchange. "
-        + "Answer the current choice, comparison, or selection directly and explicitly name at least one of its current alternatives. "
+        + resolved_line
+        + "\nAnswer the current choice, comparison, or selection directly. In the first sentence, explicitly name at least one resolved current alternative; if choosing both or neither, name both. "
         + "Messages labeled as current payload fragments belong to this request even when another member supplied one of them. "
         + "Do not substitute names or options from an older completed exchange unless the current request explicitly resumes or combines that thread."
     )
@@ -26753,7 +26771,10 @@ async def apply_guarded_response_regeneration(
             )
             return "", diagnostics
         regenerated = await regenerate(
-            build_current_payload_grounding_correction_prompt(prompt)
+            build_current_payload_grounding_correction_prompt(
+                prompt,
+                current_payload_anchors,
+            )
         )
         diagnostics["current_payload_grounding_regenerated"] = True
         regenerated = (regenerated or "").strip()
@@ -26762,6 +26783,14 @@ async def apply_guarded_response_regeneration(
             regenerated_grounding.status
         )
         if retry_has_guard_failure(regenerated):
+            logging.warning(
+                "current_payload_grounding_regeneration_result "
+                "status=%s outcome=suppressed route_mode=%s "
+                "channel_policy=%s",
+                regenerated_grounding.status,
+                route_mode,
+                channel_policy,
+            )
             diagnostics.update(
                 {
                     "suppressed": True,
@@ -26772,6 +26801,13 @@ async def apply_guarded_response_regeneration(
                 }
             )
             return "", diagnostics
+        logging.info(
+            "current_payload_grounding_regeneration_result "
+            "status=%s outcome=repaired route_mode=%s channel_policy=%s",
+            regenerated_grounding.status,
+            route_mode,
+            channel_policy,
+        )
         response = regenerated
     # No provider await may occur after this source-of-truth recheck. If a
     # deletion, clear, or correction changed the supporting rows during any

--- a/bnl_conversation_context_v2.py
+++ b/bnl_conversation_context_v2.py
@@ -83,7 +83,7 @@ _TITLE_CHOICE_RE = re.compile(
     r"(?:\s+[A-Z][A-Za-z0-9'’\-]*){0,4})"
 )
 _BETWEEN_TITLE_CHOICE_RE = re.compile(
-    r"\bbetween\s+"
+    r"(?i:\bbetween)\s+"
     r"(?P<first>[A-Z][A-Za-z0-9'’\-]*(?:\s+[A-Z][A-Za-z0-9'’\-]*){0,3})"
     r"\s+and\s+"
     r"(?P<second>[A-Z][A-Za-z0-9'’\-]*(?:\s+[A-Z][A-Za-z0-9'’\-]*){0,3})"
@@ -344,6 +344,51 @@ def _extract_named_anchors(text: str) -> tuple[str, ...]:
     )[:8]
 
 
+def _current_choice_reference_present(
+    response: str,
+    *,
+    option_count: int,
+) -> bool:
+    """Recognize unambiguous references to alternatives in the current turn.
+
+    A natural answer does not always repeat an option verbatim.  With an
+    explicit bounded choice in the current turn, "the latter" or "the second
+    option" is still grounded.  Keep this deliberately narrower than general
+    pronoun resolution so an unrelated "that one" cannot satisfy the guard.
+    """
+    if option_count < 2:
+        return False
+    normalized = normalize_text(response)
+    if not normalized:
+        return False
+    reference_patterns = [
+        r"\b(?:the\s+)?first\s+(?:one|option|choice|title|name|label|version|idea|concept)\b",
+        r"\b(?:option|choice|title|name|label|version|idea|concept)\s+(?:one|1)\b",
+        r"\b(?:the\s+)?1st\s+(?:one|option|choice|title|name|label|version|idea|concept)\b",
+        r"\b(?:the\s+)?second\s+(?:one|option|choice|title|name|label|version|idea|concept)\b",
+        r"\b(?:option|choice|title|name|label|version|idea|concept)\s+(?:two|2)\b",
+        r"\b(?:the\s+)?2nd\s+(?:one|option|choice|title|name|label|version|idea|concept)\b",
+    ]
+    if option_count == 2:
+        reference_patterns.extend(
+            (
+                r"\b(?:the\s+)?former(?:\s+(?:one|option|choice|title|name))?\b",
+                r"\b(?:the\s+)?latter(?:\s+(?:one|option|choice|title|name))?\b",
+                r"\b(?:both|neither|either)\s+(?:one|option|choice|title|name)s?\b",
+                r"^(?:both|neither|either)\b",
+            )
+        )
+    if option_count >= 3:
+        reference_patterns.extend(
+            (
+                r"\b(?:the\s+)?third\s+(?:one|option|choice|title|name|label|version|idea|concept)\b",
+                r"\b(?:option|choice|title|name|label|version|idea|concept)\s+(?:three|3)\b",
+                r"\b(?:the\s+)?3rd\s+(?:one|option|choice|title|name|label|version|idea|concept)\b",
+            )
+        )
+    return any(re.search(pattern, normalized) for pattern in reference_patterns)
+
+
 def extract_explicit_choice_anchors(text: str) -> tuple[str, ...]:
     """Extract alternatives only when the text actually requests a choice."""
     anchors = _extract_named_anchors(text)
@@ -501,6 +546,11 @@ def assess_payload_grounding(
         status = "grounded_current_payload"
     elif prior_hits:
         status = "stale_thread_substitution"
+    elif _current_choice_reference_present(
+        response,
+        option_count=len(current),
+    ):
+        status = "grounded_current_payload_reference"
     else:
         status = "current_payload_unanswered"
     return PayloadGroundingAssessment(

--- a/tests/test_conversation_context_v2.py
+++ b/tests/test_conversation_context_v2.py
@@ -58,6 +58,35 @@ class ConversationContextV2Tests(unittest.TestCase):
         self.assertEqual(result.status, "current_payload_unanswered")
         self.assertEqual(result.current_anchor_hit_count, 0)
 
+    def test_payload_grounding_accepts_unambiguous_current_choice_reference(self):
+        for response in (
+            "The latter fits better because it sounds like a place.",
+            "The second option fits better because it sounds like a place.",
+            "Neither option fits the room yet.",
+        ):
+            with self.subTest(response=response):
+                result = assess_payload_grounding(
+                    response,
+                    current_payload_anchors=(
+                        "circuit saint",
+                        "null chapel",
+                    ),
+                )
+                self.assertEqual(
+                    result.status,
+                    "grounded_current_payload_reference",
+                )
+                self.assertFalse(result.failed)
+
+    def test_current_choice_reference_does_not_override_named_stale_option(self):
+        result = assess_payload_grounding(
+            "Ghost Signal is still stronger than the second option.",
+            current_payload_anchors=("dead channel", "open circuit"),
+            prior_thread_anchors=("ghost signal", "neon static"),
+        )
+        self.assertEqual(result.status, "stale_thread_substitution")
+        self.assertTrue(result.failed)
+
     def test_named_choice_helpers_keep_current_and_prior_payloads_distinct(self):
         current = (
             'Compare “Dead Channel” with “Open Circuit”; '

--- a/tests/test_unified_response_assessment_bot_paths.py
+++ b/tests/test_unified_response_assessment_bot_paths.py
@@ -383,6 +383,88 @@ class CurrentPayloadGroundingGuardTests(unittest.IsolatedAsyncioTestCase):
             "CURRENT-PAYLOAD CORRECTION REQUIRED",
             provider.await_args.args[1],
         )
+        retry_prompt = provider.await_args.args[1].lower()
+        self.assertIn("resolved current alternatives", retry_prompt)
+        self.assertIn("dead channel", retry_prompt)
+        self.assertIn("open circuit", retry_prompt)
+
+    async def test_shared_guard_accepts_referential_current_choice_answer(self):
+        provider = mock.AsyncMock()
+        current_text = (
+            "Between Circuit Saint and Null Chapel, which fits the hidden "
+            "room better?"
+        )
+        with mock.patch.object(
+            bnl01_bot,
+            "get_gemini_response_with_optional_typing",
+            provider,
+        ):
+            response, diagnostics = (
+                await bnl01_bot.apply_guarded_response_regeneration(
+                    (
+                        "The latter fits better because it reads as a place "
+                        "instead of a person."
+                    ),
+                    prompt="Current user request: " + current_text,
+                    user_id=101,
+                    guild_id=1,
+                    route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy="sealed_test",
+                    current_user_text=current_text,
+                )
+            )
+
+        self.assertIn("The latter fits better", response)
+        self.assertEqual(
+            diagnostics["current_payload_grounding_status"],
+            "grounded_current_payload_reference",
+        )
+        self.assertFalse(
+            diagnostics["current_payload_grounding_guard_triggered"]
+        )
+        self.assertFalse(diagnostics["suppressed"])
+        provider.assert_not_awaited()
+
+    async def test_shared_guard_accepts_referential_grounding_retry(self):
+        provider = mock.AsyncMock(
+            return_value=(
+                "The second option fits better because it sounds like a place."
+            )
+        )
+        current_text = (
+            "Between Circuit Saint and Null Chapel, which fits the hidden "
+            "room better?"
+        )
+        with mock.patch.object(
+            bnl01_bot,
+            "get_gemini_response_with_optional_typing",
+            provider,
+        ):
+            response, diagnostics = (
+                await bnl01_bot.apply_guarded_response_regeneration(
+                    "Ghost Signal is still the stronger archive name.",
+                    prompt="Current user request: " + current_text,
+                    user_id=101,
+                    guild_id=1,
+                    route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy="sealed_test",
+                    current_user_text=current_text,
+                )
+            )
+
+        self.assertIn("The second option fits better", response)
+        self.assertTrue(
+            diagnostics["current_payload_grounding_guard_triggered"]
+        )
+        self.assertTrue(
+            diagnostics["current_payload_grounding_regenerated"]
+        )
+        self.assertEqual(
+            diagnostics["current_payload_grounding_status"],
+            "grounded_current_payload_reference",
+        )
+        self.assertFalse(diagnostics["suppressed"])
+        provider.assert_awaited_once()
 
     async def test_shared_guard_suppresses_second_unanswered_choice(self):
         provider = mock.AsyncMock(

--- a/tests/test_unified_response_assessment_shadow.py
+++ b/tests/test_unified_response_assessment_shadow.py
@@ -358,6 +358,57 @@ class UnifiedResponseAssessmentShadowTests(unittest.TestCase):
         finally:
             conn.close()
 
+    def test_receipt_accepts_unambiguous_current_choice_reference(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            assessment = build_unified_response_assessment(
+                guild_id=321,
+                route_mode="normal_chat",
+                channel_policy="sealed_test",
+                conversation_surface="test",
+                current_speaker_user_ids=(1,),
+                prompt_lanes=("current_exchange",),
+                current_exchange_source_ids=(10,),
+                current_payload_anchors=(
+                    "circuit saint",
+                    "null chapel",
+                ),
+                thread_focus_mode="new_thread",
+            )
+            persist_shadow_run(
+                conn,
+                assessment,
+                response=(
+                    "The latter fits better because it sounds like a place."
+                ),
+            )
+            conn.commit()
+
+            row = conn.execute(
+                "SELECT payload_grounding_status, response_alignment, "
+                "current_payload_anchor_count, "
+                "current_payload_anchor_hit_count "
+                "FROM unified_response_assessment_shadow_runs"
+            ).fetchone()
+            self.assertEqual(
+                row,
+                (
+                    "grounded_current_payload_reference",
+                    "guard_clear",
+                    2,
+                    0,
+                ),
+            )
+            report = build_evaluation_report(conn, guild_id=321)
+            self.assertEqual(report["payload_grounding_applicable_runs"], 1)
+            self.assertEqual(report["payload_grounding_failure_runs"], 0)
+            self.assertEqual(
+                report["payload_grounding_status_counts"],
+                {"grounded_current_payload_reference": 1},
+            )
+        finally:
+            conn.close()
+
     def test_existing_v1_receipt_table_is_migrated_additively(self):
         conn = sqlite3.connect(":memory:")
         try:


### PR DESCRIPTION
## What changed

- Accept unambiguous current-choice references such as “the former,” “the latter,” and “the second option” in the existing payload-grounding guard.
- Pass the resolved current alternatives into the single grounding retry so regeneration can answer the actual question.
- Keep stale named alternatives blocked.
- Record content-free retry outcomes for diagnosis without storing message or option text.
- Add regressions for natural current-choice references, stale substitutions, strengthened retry input, shadow receipts, and V2 blocker behavior.

## Why

PR #373 correctly selected the new conversation thread and recovered its two current alternatives, but its final guard required the response to repeat an alternative’s exact wording. A grounded answer such as “the latter fits better” was rejected. The retry also lacked the resolved alternatives, so it could fail the same check and leave BNL silent.

## Impact

BNL can answer naturally while remaining grounded in the current question. The stale-thread protection remains in place; this fixes the false rejection and silent fallback observed in sealed production testing.

## Validation

- 109 focused conversation-grounding and assessment tests passed.
- All 1,485 repository tests passed.
- Python 3.9 grammar, compilation, and whitespace checks passed.
- Exact five-file tree verified against local tested commit `bd03f10817315730fa4246b461d0f5b142dd4382`.

## Boundaries

No schema, database, configuration, prompt-authority, queue, website, Journal, Relay, Moment, or V2 live-gate changes.