### PR TITLE
Resolve selected conversation referents in shadow assessment

### DIFF
--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 from bnl_conversation_context_v2 import assess_payload_grounding
 
 
-ASSESSMENT_VERSION = "unified_response_assessment_v3"
+ASSESSMENT_VERSION = "unified_response_assessment_v4"
 SHADOW_ENV = "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED"
 TABLE_NAME = "unified_response_assessment_shadow_runs"
 
@@ -136,6 +136,25 @@ _UNRESOLVED_REFERENT_RE = re.compile(
     r"\b(?:that|this|it|those|these|they|them|there|the\s+former|"
     r"the\s+latter|the\s+first|the\s+second)\b",
     re.I,
+)
+_REFERENT_CONTEXT_FILLERS = frozenset(
+    {
+        "got",
+        "hello",
+        "hey",
+        "hi",
+        "lmao",
+        "lol",
+        "no",
+        "ok",
+        "okay",
+        "right",
+        "sure",
+        "thank",
+        "thanks",
+        "understood",
+        "yes",
+    }
 )
 _QUOTED_OPTION_RE = re.compile(r"[\"“](?P<value>[^\"”\n]{1,80})[\"”]")
 _BETWEEN_OPTION_RE = re.compile(
@@ -658,6 +677,39 @@ def _option_referents(
     return tuple(result)
 
 
+def _usable_referent_context_present(
+    objective: str,
+    evidence_items: Sequence[ConversationEvidenceItem],
+) -> bool:
+    """Recognize a referent supplied by the planner's selected evidence."""
+
+    objective_text = str(objective or "").strip()
+    objective_normalized = _semantic_normalize(objective_text)
+    for item in reversed(tuple(evidence_items or ())):
+        item_text = str(item.text or "").strip()
+        if not item_text:
+            continue
+        if _semantic_normalize(item_text) == objective_normalized:
+            continue
+
+        residual = item_text
+        if objective_text and objective_text in residual:
+            residual = residual.replace(objective_text, " ", 1)
+        residual_terms = set(_semantic_terms(residual))
+        residual_terms.difference_update(_semantic_terms(item.speaker_label))
+        residual_terms.difference_update(_REFERENT_CONTEXT_FILLERS)
+        if (
+            len(residual_terms) >= 2
+            or item.option_anchors
+            or item.criterion_positive_terms
+            or item.criterion_negative_terms
+            or "decision" in item.semantic_roles
+            or "correction" in item.semantic_roles
+        ):
+            return True
+    return False
+
+
 def _ambiguity_reasons(
     *,
     objective: str,
@@ -665,6 +717,7 @@ def _ambiguity_reasons(
     criteria: Sequence[AttributedCriterion],
     current_options: Sequence[str],
     thread_focus_mode: str,
+    evidence_items: Sequence[ConversationEvidenceItem],
 ) -> Tuple[str, ...]:
     reasons = []
     if thread_focus_mode in {
@@ -680,6 +733,10 @@ def _ambiguity_reasons(
         _UNRESOLVED_REFERENT_RE.search(objective or "")
         and not criteria
         and not current_options
+        and not _usable_referent_context_present(
+            objective,
+            evidence_items,
+        )
     ):
         reasons.append("current_referent_unresolved")
     return _unique_strings(reasons)
@@ -836,6 +893,7 @@ def build_unified_response_assessment(
         criteria=criteria,
         current_options=current_options,
         thread_focus_mode=resolved_thread_focus,
+        evidence_items=evidence_items,
     )
     option_referents = _option_referents(
         current_options,

--- a/tests/test_unified_response_assessment_shadow.py
+++ b/tests/test_unified_response_assessment_shadow.py
@@ -310,6 +310,119 @@ class UnifiedResponseAssessmentShadowTests(unittest.TestCase):
         self.assertEqual(coherence.status, "passed")
         self.assertEqual(coherence.clarification_status, "appropriate")
 
+    def test_pronoun_followup_uses_selected_conversation_referent(self):
+        request = "How does it work?"
+        assessment = build_unified_response_assessment(
+            guild_id=1,
+            route_mode="normal_chat",
+            channel_policy="sealed_test",
+            conversation_surface="test",
+            current_speaker_user_ids=(101,),
+            participant_user_ids=(101, 202),
+            speaker_labels=("Jon", "Miss Bit"),
+            current_exchange_source_ids=(40,),
+            prompt_lanes=("current_exchange", "conversation_context"),
+            current_text=request,
+            conversation_evidence_items=(
+                build_conversation_evidence_item(
+                    text=(
+                        "The grounding fallback retries one draft before "
+                        "suppressing a stale answer."
+                    ),
+                    source_id=40,
+                    speaker_user_id=202,
+                    speaker_label="Miss Bit",
+                ),
+                build_conversation_evidence_item(
+                    text=request,
+                    speaker_user_id=101,
+                    speaker_label="Jon",
+                    current_turn=True,
+                ),
+            ),
+        )
+
+        self.assertEqual(assessment.ambiguity_reasons, ())
+        self.assertEqual(assessment.response_act, "answer_current_turn")
+        self.assertEqual(
+            assessment.expected_answer_shape,
+            "direct_answer_then_support",
+        )
+        coherence = assess_response_coherence(
+            assessment,
+            (
+                "The grounding fallback retries one draft, then suppresses "
+                "the answer only if that retry is still stale."
+            ),
+        )
+        self.assertNotEqual(coherence.status, "failed")
+        self.assertNotIn(
+            "ambiguity_answered_without_clarification",
+            coherence.reason_codes,
+        )
+
+    def test_pronoun_without_usable_context_still_requires_clarification(self):
+        request = "How does it work?"
+        assessment = build_unified_response_assessment(
+            guild_id=1,
+            route_mode="normal_chat",
+            channel_policy="sealed_test",
+            conversation_surface="test",
+            current_speaker_user_ids=(101,),
+            current_text=request,
+            conversation_evidence_items=(
+                build_conversation_evidence_item(
+                    text="Okay.",
+                    source_id=50,
+                    speaker_user_id=202,
+                    speaker_label="Miss Bit",
+                ),
+                build_conversation_evidence_item(
+                    text=request,
+                    speaker_user_id=101,
+                    speaker_label="Jon",
+                    current_turn=True,
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            assessment.ambiguity_reasons,
+            ("current_referent_unresolved",),
+        )
+        self.assertEqual(
+            assessment.response_act,
+            "ask_clarifying_question",
+        )
+
+    def test_pronoun_can_resolve_inside_fragmented_current_turn(self):
+        request = "How does it work?"
+        assessment = build_unified_response_assessment(
+            guild_id=1,
+            route_mode="normal_chat",
+            channel_policy="sealed_test",
+            conversation_surface="test",
+            current_speaker_user_ids=(101,),
+            current_text=request,
+            conversation_evidence_items=(
+                build_conversation_evidence_item(
+                    text="The retry guard now has a bounded fallback.",
+                    speaker_user_id=101,
+                    speaker_label="Jon",
+                    current_turn=True,
+                ),
+                build_conversation_evidence_item(
+                    text=request,
+                    speaker_user_id=101,
+                    speaker_label="Jon",
+                    current_turn=True,
+                ),
+            ),
+        )
+
+        self.assertEqual(assessment.ambiguity_reasons, ())
+        self.assertEqual(assessment.response_act, "answer_current_turn")
+
     def test_decisions_corrections_and_open_loops_keep_source_lineage(self):
         evidence = (
             build_conversation_evidence_item(


### PR DESCRIPTION
## Summary

Corrects the existing Unified Response Assessment after the post-merge review of #375.

- Treats substantive conversation evidence already selected by the planner as usable context for ordinary follow-up referents such as `it`, `they`, and `there`.
- Preserves clarification when no usable referent evidence exists.
- Handles referents supplied by an earlier stored contribution or by another fragment in the current turn.
- Advances the shadow assessment algorithm version so corrected receipts are distinguishable.

## Root cause

#375 marked any current objective containing a pronoun-like referent as ambiguous whenever it had no extracted criterion or named option. It did not consider the typed, speaker-attributed conversation evidence already supplied to the assessment. A normal follow-up such as `How does it work?` could therefore be forced into `ask_clarifying_question`, and a valid direct answer could become a false hard coherence failure.

## Validation

- 47 focused Unified Assessment, bot-path, and V2-acceptance tests passed.
- All 1,496 repository tests passed.
- Python compilation passed.
- Python 3.9 grammar validation passed for both changed files.
- Whitespace validation passed.
- Exact two-file tree verified against the tested local commit.

## Boundaries

- Shadow-only; no production prompt or reply behavior changes.
- No schema or durable-store change.
- No Moment lifecycle, Governance, Relationship, Active Engagement, queue, Journal, Relay, website, configuration, source authority, or live-gate change.
- The next planned dependency remains episodic Moment lifecycle v2 after this correction is merged and deployed.