### PR TITLE
Bot: restore balanced reaction selection

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -885,13 +885,12 @@ BNL_REACTIONS_BROADCAST = ["📻", "🎚️", "🎛️", "🔊", "🎤", "📡",
 BNL_REACTIONS_GLITCH = ["🧿", "🫨", "⚠️", "❓", "🌀", "☢️", "📛", "📟"]
 BNL_REACTIONS_TECH = ["🧠", "⚙️", "💻", "🛰️", "🗜️", "📈", "🔧", "💾", "🗄️"]
 BNL_REACTIONS_VIBE = ["🫡", "👀", "🔥", "💯", "😵‍💫", "🧪", "🕶️", "🫶", "🖤"]
-BNL_CUSTOM_REACTION_CHANCE = 0.35
 BNL_CUSTOM_REACTION_NAMES = {
-    "base": ("barcode", "bnl", "bnl01", "sixbit", "galaknoise"),
-    "broadcast": ("djfloppydisc", "floppydisc", "sixbit", "galaknoise"),
-    "glitch": ("nulltv", "null_tv"),
-    "tech": ("macmodem", "mac_modem", "cacheback", "cache_back"),
-    "vibe": ("barcode", "bnl", "bnl01", "sixbit", "galaknoise"),
+    "base": ("barcode", "bnl", "bnl01", "sixbit", "6bit", "galaknoise"),
+    "broadcast": ("djfloppydisc", "floppydisc", "sixbit", "6bit", "galaknoise"),
+    "glitch": ("nulltv", "null_tv", "willythewarg"),
+    "tech": ("macmodem", "mac_modem", "macmod3m", "cacheback", "cache_back"),
+    "vibe": ("barcode", "bnl", "bnl01", "sixbit", "6bit", "galaknoise"),
 }
 
 PROTECTED_SYSTEM_CHANNELS = {"welcome", "episode-tracker"}
@@ -19103,6 +19102,7 @@ _last_reaction_by_channel = {}
 
 
 def _reaction_context_groups(content: str) -> list[str]:
+    content = (content or "").lower()
     groups = ["base"]
     if any(k in content for k in ("radio", "broadcast", "mix", "track", "song", "music", "tiktok", "show", "listen", "audio", "dj")):
         groups.append("broadcast")
@@ -19110,13 +19110,27 @@ def _reaction_context_groups(content: str) -> list[str]:
         groups.append("glitch")
     if any(k in content for k in ("code", "deploy", "server", "bot", "update", "memory", "database", "api", "archive", "backup")):
         groups.append("tech")
-    if any(k in content for k in ("lol", "lmao", "damn", "crazy", "fire", "wild", "w", "love", "community")):
+    if (
+        any(k in content for k in ("lol", "lmao", "damn", "crazy", "fire", "wild", "love", "community"))
+        or re.search(r"(?<![a-z0-9])w(?![a-z0-9])", content)
+    ):
         groups.append("vibe")
     return groups
 
 
 def _normalized_custom_emoji_name(name: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", (name or "").strip().lower())
+
+
+def _custom_emoji_name_matches(name: str, allowed_names: set[str]) -> bool:
+    normalized_name = _normalized_custom_emoji_name(name)
+    if not normalized_name:
+        return False
+    return any(
+        normalized_name == allowed_name
+        or (len(allowed_name) >= 3 and allowed_name in normalized_name)
+        for allowed_name in allowed_names
+    )
 
 
 def _available_custom_reactions(message: discord.Message, groups: list[str]) -> list:
@@ -19132,7 +19146,7 @@ def _available_custom_reactions(message: discord.Message, groups: list[str]) -> 
     }
     available = []
     for emoji in guild_emojis:
-        if _normalized_custom_emoji_name(getattr(emoji, "name", "")) not in allowed_names:
+        if not _custom_emoji_name_matches(getattr(emoji, "name", ""), allowed_names):
             continue
         if not getattr(emoji, "available", True):
             continue
@@ -19167,15 +19181,11 @@ def choose_contextual_reaction(message: discord.Message, *, allow_custom: bool =
 
     last = _last_reaction_by_channel.get(message.channel.id)
     if allow_custom:
-        custom_options = [
+        merged.extend(
             emoji
             for emoji in _available_custom_reactions(message, groups)
             if str(emoji) != last
-        ]
-        if custom_options and random.random() < BNL_CUSTOM_REACTION_CHANCE:
-            choice = random.choice(custom_options)
-            _last_reaction_by_channel[message.channel.id] = str(choice)
-            return choice
+        )
 
     options = [e for e in merged if str(e) != last] or merged
     choice = random.choice(options)

--- a/tests/test_reactions_and_typing.py
+++ b/tests/test_reactions_and_typing.py
@@ -38,6 +38,14 @@ class FakeReactionMessage:
 
 
 class ContextualReactionTests(unittest.IsolatedAsyncioTestCase):
+    ORIGINAL_REACTIONS = {
+        "👁️", "📡", "⚙️", "🧠", "🛰️", "🔍", "💾", "📊", "🖥️", "📼", "🧬", "📶",
+        "📻", "🎚️", "🎛️", "🔊", "🎤",
+        "🧿", "🫨", "⚠️", "❓", "🌀", "☢️", "📛",
+        "💻", "🗜️", "📈", "🔧",
+        "🫡", "👀", "🔥", "💯", "😵‍💫", "🧪", "🕶️",
+    }
+
     def setUp(self):
         bnl01_bot._last_reaction_by_channel.clear()
 
@@ -47,10 +55,19 @@ class ContextualReactionTests(unittest.IsolatedAsyncioTestCase):
     def test_reaction_probability_is_slightly_reduced(self):
         self.assertEqual(bnl01_bot.REACTION_CHANCE, 0.22)
 
+    def test_every_original_unicode_reaction_remains_reachable(self):
+        current = {
+            *bnl01_bot.BNL_REACTIONS_BASE,
+            *bnl01_bot.BNL_REACTIONS_BROADCAST,
+            *bnl01_bot.BNL_REACTIONS_GLITCH,
+            *bnl01_bot.BNL_REACTIONS_TECH,
+            *bnl01_bot.BNL_REACTIONS_VIBE,
+        }
+        self.assertTrue(self.ORIGINAL_REACTIONS.issubset(current))
+
     def test_contextual_unicode_pool_includes_expanded_broadcast_reactions(self):
         message = FakeReactionMessage("listen to this new track")
         with (
-            mock.patch.object(bnl01_bot.random, "random", return_value=1.0),
             mock.patch.object(bnl01_bot.random, "choice", return_value="🎧") as choose,
         ):
             reaction = bnl01_bot.choose_contextual_reaction(message)
@@ -58,8 +75,18 @@ class ContextualReactionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(reaction, "🎧")
         self.assertIn("🎧", choose.call_args.args[0])
 
-    def test_only_available_usable_allowlisted_custom_emoji_can_be_selected(self):
-        allowed = FakeCustomEmoji("DJ_FloppyDisc", 1)
+    def test_standalone_w_triggers_vibe_without_matching_every_letter_w(self):
+        self.assertEqual(
+            bnl01_bot._reaction_context_groups("we should wait for the next window"),
+            ["base"],
+        )
+        self.assertEqual(
+            bnl01_bot._reaction_context_groups("that track is a W"),
+            ["base", "broadcast", "vibe"],
+        )
+
+    def test_available_usable_custom_emoji_joins_contextual_pool_as_normal_candidate(self):
+        allowed = FakeCustomEmoji("DJ_FloppyDisc_hype", 1)
         not_allowlisted = FakeCustomEmoji("party_blob", 2)
         unavailable = FakeCustomEmoji("barcode", 3, available=False)
         unusable = FakeCustomEmoji("sixbit", 4, usable=False)
@@ -69,21 +96,37 @@ class ContextualReactionTests(unittest.IsolatedAsyncioTestCase):
         )
 
         with (
-            mock.patch.object(bnl01_bot.random, "random", return_value=0.0),
-            mock.patch.object(bnl01_bot.random, "choice", side_effect=lambda options: options[0]),
+            mock.patch.object(bnl01_bot.random, "choice", return_value=allowed) as choose,
         ):
             reaction = bnl01_bot.choose_contextual_reaction(message)
 
         self.assertIs(reaction, allowed)
+        options = choose.call_args.args[0]
+        self.assertIn(allowed, options)
+        self.assertIn("📻", options)
+        self.assertNotIn(not_allowlisted, options)
+
+    def test_numeric_six_bit_custom_emoji_name_is_recognized(self):
+        six_bit = FakeCustomEmoji("6Bit_signal", 5)
+        message = FakeReactionMessage("signal received", (six_bit,))
+
+        with mock.patch.object(bnl01_bot.random, "choice", return_value=six_bit) as choose:
+            reaction = bnl01_bot.choose_contextual_reaction(message)
+
+        self.assertIs(reaction, six_bit)
+        self.assertIn(six_bit, choose.call_args.args[0])
 
     async def test_failed_custom_reaction_falls_back_to_unicode(self):
-        allowed = FakeCustomEmoji("barcode", 5)
+        allowed = FakeCustomEmoji("barcode", 6)
         message = FakeReactionMessage("signal received", (allowed,))
         message.fail_custom = True
 
         with (
-            mock.patch.object(bnl01_bot.random, "random", return_value=0.0),
-            mock.patch.object(bnl01_bot.random, "choice", side_effect=lambda options: options[0]),
+            mock.patch.object(
+                bnl01_bot.random,
+                "choice",
+                side_effect=lambda options: allowed if allowed in options else options[0],
+            ),
         ):
             added = await bnl01_bot.add_contextual_reaction(message)
 
@@ -99,7 +142,6 @@ class ContextualReactionTests(unittest.IsolatedAsyncioTestCase):
 
         message.add_reaction = reject
         with (
-            mock.patch.object(bnl01_bot.random, "random", return_value=1.0),
             mock.patch.object(bnl01_bot.random, "choice", side_effect=lambda options: options[0]),
         ):
             added = await bnl01_bot.add_contextual_reaction(message)


### PR DESCRIPTION
## What changed

- Restores one contextual candidate pool: approved usable custom emojis now participate alongside the existing Unicode reactions instead of passing through a separate custom-first probability branch.
- Fixes the short `W` cue so it matches only a standalone “W,” rather than every ordinary message containing the letter `w`.
- Keeps every pre-#365 Unicode reaction and every useful themed addition reachable.
- Keeps the reduced overall reaction rate at 22%, one-reaction behavior, last-reaction avoidance, and nonfatal Unicode fallback.
- Broadens approved custom-emoji matching to tolerate common server naming variants and suffixes, including numeric `6Bit` and canonical BARCODE persona forms.

## Root cause

PR #365 changed selection shape and used exact normalized custom-emoji names. The vibe matcher also treated `"w"` as a raw substring, so ordinary sentences were routinely classified as vibe messages, over-serving 🕶️ and 🫶. Exact custom-name equality could silently exclude valid server emoji variants.

## User impact

Reactions should be less repetitive and more contextually distributed. Custom BARCODE emoji can surface as ordinary candidates without displacing the original reaction personality.

## Validation

- Focused reaction plus typing suite: **46/46 passed**
- Complete bot suite: **1,526/1,526 passed**
- Python compilation: passed
- Diff/whitespace check: passed
- Remote file blobs match the validated local files exactly

## Boundaries

The intended typing implementation from #365 is untouched. No conversation, memory, Moment, Governance, Relationship, Active Engagement, Ambient/occasion, Journal, Relay, dossier, website, queue/overlay, production-gate, deployment, configuration, or secrets behavior is changed.