### PR TITLE
Bot: add scoped Governance recall canary

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -342,6 +342,10 @@ BNL_MOMENT_GIST_CANARY_ENABLED = (
     os.getenv("BNL_MOMENT_GIST_CANARY_ENABLED", "").strip().lower()
     in {"true", "1", "yes", "on", "enabled"}
 )
+BNL_MEMORY_GOVERNANCE_CANARY_ENABLED = (
+    os.getenv("BNL_MEMORY_GOVERNANCE_CANARY_ENABLED", "").strip().lower()
+    in {"true", "1", "yes", "on", "enabled"}
+)
 BNL_UNIFIED_MOMENT_CANARY_ENABLED = (
     os.getenv("BNL_UNIFIED_MOMENT_CANARY_ENABLED", "").strip().lower()
     in {"true", "1", "yes", "on", "enabled"}
@@ -698,6 +702,17 @@ LAST_ROUTE_DEBUG = {}
 LAST_MEMORY_LIFECYCLE_RESULT = {}
 LAST_MEMORY_PROMPT_DIAGNOSTICS = {}
 LAST_MEMORY_SKIP_REASONS = defaultdict(int)
+DEFAULT_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS = {
+    "configured_enabled": False,
+    "fully_scoped": False,
+    "enabled_for_route": False,
+    "evaluated": False,
+    "response_mode": "not_evaluated",
+    "selected_count": 0,
+    "rendered": False,
+    "fallback_reason": "not_evaluated",
+}
+LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS = {}
 LAST_CONVERSATION_CONTEXT_V2_DIAGNOSTICS = {
     "contract_version": CONVERSATION_CONTEXT_VERSION,
     "enabled": True,
@@ -794,6 +809,81 @@ def moment_gist_canary_enabled(
         in {"public_home", "public_context"}
         and memory_ledger_shadow_enabled(env)
         and moment_engine_shadow_enabled(env)
+    )
+
+
+def memory_governance_canary_configuration(
+    environ: dict[str, str] | None = None,
+) -> dict[str, int | bool]:
+    """Return safe explicit-recall canary state without exposing allowlisted IDs."""
+    env = os.environ if environ is None else environ
+    enabled = str(
+        env.get(
+            "BNL_MEMORY_GOVERNANCE_CANARY_ENABLED",
+            "true" if BNL_MEMORY_GOVERNANCE_CANARY_ENABLED else "",
+        )
+    ).strip().lower() in {"true", "1", "yes", "on", "enabled"}
+    guilds = _positive_int_allowlist(
+        env.get("BNL_MEMORY_GOVERNANCE_CANARY_GUILD_IDS", "")
+    )
+    users = _positive_int_allowlist(
+        env.get("BNL_MEMORY_GOVERNANCE_CANARY_USER_IDS", "")
+    )
+    return {
+        "configured_enabled": enabled,
+        "guild_allowlist_count": len(guilds),
+        "user_allowlist_count": len(users),
+        "fully_scoped": bool(enabled and len(guilds) == 1 and users),
+    }
+
+
+def memory_governance_canary_enabled(
+    *,
+    guild_id: int,
+    user_id: int,
+    route_mode: str,
+    channel_policy: str,
+    environ: dict[str, str] | None = None,
+) -> bool:
+    """Authorize governed output only for one explicit personal-recall route.
+
+    The existing global live switch remains independent. The canary requires
+    one configured guild, an allowlisted participant, the established public
+    explicit-recall surfaces, and both Ledger and Governance shadow inputs.
+    """
+    env = os.environ if environ is None else environ
+    configuration = memory_governance_canary_configuration(env)
+    guilds = _positive_int_allowlist(
+        env.get("BNL_MEMORY_GOVERNANCE_CANARY_GUILD_IDS", "")
+    )
+    users = _positive_int_allowlist(
+        env.get("BNL_MEMORY_GOVERNANCE_CANARY_USER_IDS", "")
+    )
+    return bool(
+        configuration["fully_scoped"]
+        and int(guild_id or 0) in guilds
+        and int(user_id or 0) in users
+        and route_mode in {ROUTE_MODE_NORMAL_CHAT, ROUTE_MODE_DIRECT_PAYLOAD}
+        and (channel_policy or "").strip().lower()
+        in {"public_home", "public_context"}
+        and memory_ledger_shadow_enabled(env)
+        and memory_governance_shadow_enabled(env)
+    )
+
+
+def memory_governance_canary_last_diagnostics(
+    user_id: int,
+    guild_id: int,
+) -> dict:
+    not_evaluated = {
+        **DEFAULT_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS,
+        **memory_governance_canary_configuration(),
+    }
+    return dict(
+        LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS.get(
+            (int(user_id or 0), int(guild_id or 0)),
+            not_evaluated,
+        )
     )
 
 
@@ -17298,9 +17388,57 @@ def apply_explicit_recall_governance(
     if not legacy_recall_response:
         return legacy_recall_response
     policy = (channel_policy or "unknown").strip().lower() or "unknown"
+    canary_configuration = memory_governance_canary_configuration()
+    canary_enabled_for_route = memory_governance_canary_enabled(
+        guild_id=guild_id,
+        user_id=user_id,
+        route_mode=route_mode,
+        channel_policy=policy,
+    )
+
+    def record_canary_diagnostics(
+        *,
+        evaluated: bool,
+        response_mode: str,
+        selected_count: int = 0,
+        rendered: bool = False,
+        fallback_reason: str = "",
+        legacy_vs_governed: dict | None = None,
+        processing_error_count: int = 0,
+        invalid_invariant_count: int = 0,
+    ) -> None:
+        LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS[
+            (int(user_id or 0), int(guild_id or 0))
+        ] = {
+            **canary_configuration,
+            "enabled_for_route": bool(canary_enabled_for_route),
+            "evaluated": bool(evaluated),
+            "response_mode": str(response_mode or "unknown")[:80],
+            "selected_count": max(0, int(selected_count or 0)),
+            "rendered": bool(rendered),
+            "fallback_reason": str(fallback_reason or "")[:120],
+            "legacy_vs_governed": dict(legacy_vs_governed or {}),
+            "processing_error_count": max(
+                0, int(processing_error_count or 0)
+            ),
+            "invalid_invariant_count": max(
+                0, int(invalid_invariant_count or 0)
+            ),
+        }
+
     if route_mode in SOURCE_INTERNAL_MODES or policy not in PUBLIC_CHAT_POLICIES:
+        record_canary_diagnostics(
+            evaluated=False,
+            response_mode="legacy_route_excluded",
+            fallback_reason="route_not_authorized",
+        )
         return legacy_recall_response
     if not memory_governance_shadow_enabled():
+        record_canary_diagnostics(
+            evaluated=False,
+            response_mode="legacy_shadow_disabled",
+            fallback_reason="governance_shadow_disabled",
+        )
         return legacy_recall_response
     try:
         limits = calculate_adaptive_memory_limits(user_id, guild_id, route_mode=route_mode, channel_policy=policy, user_text=user_text, is_owner_or_mod=is_owner_or_mod)
@@ -17321,11 +17459,59 @@ def apply_explicit_recall_governance(
         )
         with sqlite3.connect(DB_FILE) as gov_conn:
             gov_result = build_governed_context(gov_conn, gov_req, legacy_context=legacy_recall_response, include_review_moments=True)
+            unsafe_governed = bool(
+                gov_result.diagnostics.processing_errors
+                or gov_result.diagnostics.invalid_invariants
+            )
+            global_live_enabled = memory_governance_live_enabled()
+            governed_authority = bool(
+                global_live_enabled or canary_enabled_for_route
+            )
+            response_mode = (
+                "legacy_unsafe_fallback"
+                if unsafe_governed
+                else "governed"
+                if governed_authority and gov_result.rendered_context
+                else "safe_empty"
+                if governed_authority
+                else "legacy_shadow_comparison"
+            )
+            gov_result.diagnostics.route_policy.update(
+                {
+                    "conversation_surface": "discord_explicit_recall",
+                    "memory_governance_canary_enabled_for_route": bool(
+                        canary_enabled_for_route
+                    ),
+                    "global_live_enabled": bool(global_live_enabled),
+                    "response_mode": response_mode,
+                }
+            )
             persist_shadow_diagnostics(gov_conn, gov_req, gov_result, legacy_recall_response)
-        unsafe_governed = bool(gov_result.diagnostics.processing_errors or gov_result.diagnostics.invalid_invariants)
-        if memory_governance_live_enabled() and not unsafe_governed:
+        record_canary_diagnostics(
+            evaluated=True,
+            response_mode=response_mode,
+            selected_count=gov_result.diagnostics.selected_count,
+            rendered=bool(gov_result.rendered_context),
+            fallback_reason=(
+                "unsafe_governed_result" if unsafe_governed else ""
+            ),
+            legacy_vs_governed=gov_result.diagnostics.legacy_vs_governed,
+            processing_error_count=len(
+                gov_result.diagnostics.processing_errors
+            ),
+            invalid_invariant_count=len(
+                gov_result.diagnostics.invalid_invariants
+            ),
+        )
+        if governed_authority and not unsafe_governed:
             return _format_explicit_recall_governed_response(gov_result)
     except Exception as exc:
+        record_canary_diagnostics(
+            evaluated=False,
+            response_mode="legacy_exception_fallback",
+            fallback_reason=type(exc).__name__,
+            processing_error_count=1,
+        )
         logging.warning(
             "memory_governance_explicit_recall_exception event=%s route_mode=%s channel_policy=%s exception_type=%s",
             "explicit_recall_governance_exception",
@@ -18910,7 +19096,11 @@ def prompt_source_basis_failure(
 
 def purge_member_memory_caches(user_id: int, guild_id: int) -> None:
     """Remove in-process member/guild memory diagnostics after complete delete."""
-    for cache in (LAST_MEMORY_LIFECYCLE_RESULT, LAST_MEMORY_PROMPT_DIAGNOSTICS):
+    for cache in (
+        LAST_MEMORY_LIFECYCLE_RESULT,
+        LAST_MEMORY_PROMPT_DIAGNOSTICS,
+        LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS,
+    ):
         cache.pop((user_id, guild_id), None)
 
 
@@ -18929,6 +19119,15 @@ def build_memory_diagnostic_snapshot(user_id: int, guild_id: int, route_mode: st
             "memory_ledger_shadow": memory_ledger_shadow_enabled(),
             "moment_engine_shadow": moment_engine_shadow_enabled(),
             "moment_gist_canary": moment_gist_canary_configuration(),
+            "memory_governance_canary": (
+                memory_governance_canary_configuration()
+            ),
+            "memory_governance_canary_last": (
+                memory_governance_canary_last_diagnostics(
+                    user_id,
+                    guild_id,
+                )
+            ),
             "unified_moment_canary": (
                 unified_moment_canary_configuration()
             ),
@@ -30273,6 +30472,8 @@ async def bnl_memory_check(interaction: discord.Interaction):
         f"- memory_ledger_shadow_enabled: `{'yes' if memory_ledger_shadow_enabled() else 'no'}`",
         f"- moment_engine_shadow_enabled: `{'yes' if moment_engine_shadow_enabled() else 'no'}`",
         f"- moment_gist_canary_configuration: `{moment_gist_canary_configuration()}`",
+        f"- memory_governance_canary_configuration: `{memory_governance_canary_configuration()}`",
+        f"- memory_governance_canary_last: `{memory_governance_canary_last_diagnostics(interaction.user.id, guild.id)}`",
         f"- unified_moment_canary_configuration: `{unified_moment_canary_configuration()}`",
         f"- memory_governance_shadow_enabled: `{'yes' if memory_governance_shadow_enabled() else 'no'}`",
         f"- memory_governance_live_enabled: `{'yes' if memory_governance_live_enabled() else 'no'}`",

--- a/bnl_memory_governance.py
+++ b/bnl_memory_governance.py
@@ -462,6 +462,7 @@ def persist_shadow_diagnostics(conn: sqlite3.Connection, req: GovernanceRequest,
     # marker. Keeping that operation in one layer preserves any unmatched
     # remainder as a fail-closed blocker.
     aggregate_diagnostics = {
+        "route_policy": dict(result.diagnostics.route_policy),
         "selected_by_source": dict(result.diagnostics.selected_by_source),
         "invalid_invariant_counts": invalid_invariant_counts,
         "fallback_reason": str(result.diagnostics.fallback_reason or "")[:120],

--- a/tests/test_memory_governance_canary.py
+++ b/tests/test_memory_governance_canary.py
@@ -1,0 +1,540 @@
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+from bnl_memory_governance import ensure_governance_schema
+from bnl_memory_ledger import subject_key_for_user
+
+
+class MemoryGovernanceCanaryAuthorizationTests(unittest.TestCase):
+    def allowed_env(self):
+        return {
+            "BNL_MEMORY_GOVERNANCE_CANARY_ENABLED": "true",
+            "BNL_MEMORY_GOVERNANCE_CANARY_GUILD_IDS": "101",
+            "BNL_MEMORY_GOVERNANCE_CANARY_USER_IDS": "202",
+            "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+            "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+        }
+
+    def request(self, **overrides):
+        values = {
+            "guild_id": 101,
+            "user_id": 202,
+            "route_mode": bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            "channel_policy": "public_home",
+        }
+        values.update(overrides)
+        return values
+
+    def test_default_off_and_global_live_is_not_a_canary_prerequisite(self):
+        with mock.patch.object(
+            bnl01_bot,
+            "BNL_MEMORY_GOVERNANCE_CANARY_ENABLED",
+            False,
+        ):
+            self.assertFalse(
+                bnl01_bot.memory_governance_canary_enabled(
+                    **self.request(),
+                    environ={},
+                )
+            )
+
+        environ = self.allowed_env()
+        self.assertNotIn("BNL_MEMORY_GOVERNANCE_LIVE_ENABLED", environ)
+        self.assertTrue(
+            bnl01_bot.memory_governance_canary_enabled(
+                **self.request(),
+                environ=environ,
+            )
+        )
+
+    def test_one_guild_user_scope_and_shadow_prerequisites_fail_closed(self):
+        base = self.allowed_env()
+        cases = {
+            "missing_enabled": "BNL_MEMORY_GOVERNANCE_CANARY_ENABLED",
+            "missing_guilds": "BNL_MEMORY_GOVERNANCE_CANARY_GUILD_IDS",
+            "missing_users": "BNL_MEMORY_GOVERNANCE_CANARY_USER_IDS",
+            "missing_ledger_shadow": "BNL_MEMORY_LEDGER_SHADOW_ENABLED",
+            "missing_governance_shadow": (
+                "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED"
+            ),
+        }
+        for label, missing in cases.items():
+            with self.subTest(label=label):
+                environ = dict(base)
+                environ.pop(missing)
+                self.assertFalse(
+                    bnl01_bot.memory_governance_canary_enabled(
+                        **self.request(),
+                        environ=environ,
+                    )
+                )
+
+        multiple_guilds = dict(base)
+        multiple_guilds[
+            "BNL_MEMORY_GOVERNANCE_CANARY_GUILD_IDS"
+        ] = "101,102"
+        self.assertFalse(
+            bnl01_bot.memory_governance_canary_enabled(
+                **self.request(),
+                environ=multiple_guilds,
+            )
+        )
+
+        multiple_users = dict(base)
+        multiple_users[
+            "BNL_MEMORY_GOVERNANCE_CANARY_USER_IDS"
+        ] = "202,203"
+        self.assertTrue(
+            bnl01_bot.memory_governance_canary_enabled(
+                **self.request(),
+                environ=multiple_users,
+            )
+        )
+
+    def test_subject_route_and_policy_scope_fail_closed(self):
+        environ = self.allowed_env()
+        cases = {
+            "wrong_guild": {"guild_id": 999},
+            "wrong_user": {"user_id": 999},
+            "wrong_route": {
+                "route_mode": bnl01_bot.ROUTE_MODE_SIMPLE_GREETING,
+            },
+            "selective_public": {"channel_policy": "public_selective"},
+            "sealed": {"channel_policy": "sealed_test"},
+            "internal": {"channel_policy": "internal_controlled"},
+        }
+        for label, overrides in cases.items():
+            with self.subTest(label=label):
+                self.assertFalse(
+                    bnl01_bot.memory_governance_canary_enabled(
+                        **self.request(**overrides),
+                        environ=environ,
+                    )
+                )
+
+        for route_mode in (
+            bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            bnl01_bot.ROUTE_MODE_DIRECT_PAYLOAD,
+        ):
+            for channel_policy in ("public_home", "public_context"):
+                with self.subTest(
+                    route_mode=route_mode,
+                    channel_policy=channel_policy,
+                ):
+                    self.assertTrue(
+                        bnl01_bot.memory_governance_canary_enabled(
+                            **self.request(
+                                route_mode=route_mode,
+                                channel_policy=channel_policy,
+                            ),
+                            environ=environ,
+                        )
+                    )
+
+    def test_configuration_reports_counts_without_allowlisted_ids(self):
+        configuration = (
+            bnl01_bot.memory_governance_canary_configuration(
+                self.allowed_env()
+            )
+        )
+        self.assertEqual(
+            configuration,
+            {
+                "configured_enabled": True,
+                "guild_allowlist_count": 1,
+                "user_allowlist_count": 1,
+                "fully_scoped": True,
+            },
+        )
+        self.assertNotIn("101", str(configuration))
+        self.assertNotIn("202", str(configuration))
+
+
+class MemoryGovernanceCanaryIntegrationTests(unittest.TestCase):
+    CANARY_KEYS = (
+        "BNL_MEMORY_GOVERNANCE_CANARY_ENABLED",
+        "BNL_MEMORY_GOVERNANCE_CANARY_GUILD_IDS",
+        "BNL_MEMORY_GOVERNANCE_CANARY_USER_IDS",
+        "BNL_MEMORY_LEDGER_SHADOW_ENABLED",
+        "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED",
+        "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED",
+    )
+
+    def setUp(self):
+        self.old_db = bnl01_bot.DB_FILE
+        self.tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.tmp.close()
+        bnl01_bot.DB_FILE = self.tmp.name
+        self.env = mock.patch.dict(os.environ, {}, clear=False)
+        self.env.start()
+        for key in self.CANARY_KEYS:
+            os.environ.pop(key, None)
+        bnl01_bot.init_db()
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            ensure_governance_schema(conn)
+        self.old_canary_diagnostics = dict(
+            bnl01_bot.LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS
+        )
+        bnl01_bot.LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS.clear()
+
+    def tearDown(self):
+        bnl01_bot.LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS.clear()
+        bnl01_bot.LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS.update(
+            self.old_canary_diagnostics
+        )
+        self.env.stop()
+        bnl01_bot.DB_FILE = self.old_db
+        try:
+            os.unlink(self.tmp.name)
+        except OSError:
+            pass
+
+    def enable_canary(self, *, guilds="1", users="42"):
+        os.environ.update(
+            {
+                "BNL_MEMORY_GOVERNANCE_CANARY_ENABLED": "true",
+                "BNL_MEMORY_GOVERNANCE_CANARY_GUILD_IDS": guilds,
+                "BNL_MEMORY_GOVERNANCE_CANARY_USER_IDS": users,
+                "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+                "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+            }
+        )
+
+    def insert_ledger(
+        self,
+        value,
+        *,
+        entry_id,
+        predicate,
+        lifecycle="active",
+        visibility="public_safe",
+        public_usable=1,
+    ):
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            ensure_governance_schema(conn)
+            timestamp = "2026-07-20T00:00:00+00:00"
+            conn.execute(
+                """
+                INSERT INTO memory_ledger_entries (
+                    entry_id, schema_version, guild_id, subject_key,
+                    subject_display_name, entry_type, predicate_key,
+                    normalized_value, source_class, source_table,
+                    source_row_id, source_revision, source_role, visibility,
+                    confidence, public_usable, derived, projection, salience,
+                    observed_at, lifecycle_status, created_at, updated_at,
+                    route_mode, channel_policy
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    entry_id,
+                    "memory_ledger_v1",
+                    1,
+                    subject_key_for_user(42),
+                    "",
+                    "preference",
+                    predicate,
+                    value,
+                    "first_party_record",
+                    "test",
+                    entry_id,
+                    "",
+                    "member",
+                    visibility,
+                    "high",
+                    public_usable,
+                    0,
+                    0,
+                    0.9,
+                    timestamp,
+                    lifecycle,
+                    timestamp,
+                    timestamp,
+                    bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                    "public_home",
+                ),
+            )
+            conn.commit()
+
+    def govern(
+        self,
+        legacy="Archive recall:\n- favorite color: legacy blue",
+        *,
+        user_id=42,
+        guild_id=1,
+        policy="public_home",
+    ):
+        return bnl01_bot.apply_explicit_recall_governance(
+            user_id,
+            guild_id,
+            "BNL, what do you remember about me?",
+            legacy,
+            bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            policy,
+            channel_id=99,
+            channel_name="barcode-bot",
+        )
+
+    def latest_persisted_diagnostics(self):
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            row = conn.execute(
+                """
+                SELECT diagnostics_json
+                FROM memory_governance_shadow_runs
+                ORDER BY created_at DESC, run_id DESC
+                LIMIT 1
+                """
+            ).fetchone()
+        return json.loads(row[0]) if row else {}
+
+    def test_scoped_canary_serves_governed_recall_with_global_live_off(self):
+        self.enable_canary()
+        self.insert_ledger(
+            "favorite color is green",
+            entry_id="current-color",
+            predicate="favorite_color",
+        )
+
+        response = self.govern()
+
+        self.assertFalse(bnl01_bot.memory_governance_live_enabled())
+        self.assertIn("Here is what I can safely recall:", response)
+        self.assertIn("favorite color is green", response)
+        self.assertNotIn("legacy blue", response)
+        diagnostics = bnl01_bot.memory_governance_canary_last_diagnostics(
+            42,
+            1,
+        )
+        self.assertEqual(
+            diagnostics["response_mode"],
+            "governed",
+        )
+        self.assertTrue(diagnostics["enabled_for_route"])
+        persisted = self.latest_persisted_diagnostics()["route_policy"]
+        self.assertTrue(
+            persisted["memory_governance_canary_enabled_for_route"]
+        )
+        self.assertFalse(persisted["global_live_enabled"])
+        self.assertEqual(persisted["response_mode"], "governed")
+
+    def test_correction_visibility_forget_and_delete_remain_fail_closed(self):
+        self.enable_canary()
+        self.insert_ledger(
+            "old favorite color is blue",
+            entry_id="old-color",
+            predicate="favorite_color",
+            lifecycle="superseded",
+        )
+        self.insert_ledger(
+            "favorite color is green",
+            entry_id="current-color",
+            predicate="favorite_color",
+        )
+        self.insert_ledger(
+            "private operator color is ultraviolet",
+            entry_id="private-color",
+            predicate="favorite_movie",
+            visibility="private",
+            public_usable=0,
+        )
+
+        corrected = self.govern()
+        self.assertIn("favorite color is green", corrected)
+        self.assertNotIn("old favorite color", corrected)
+        self.assertNotIn("ultraviolet", corrected)
+
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            conn.execute(
+                """
+                UPDATE memory_ledger_entries
+                SET lifecycle_status='forgotten'
+                WHERE entry_id='current-color'
+                """
+            )
+            conn.commit()
+        forgotten = self.govern("legacy must not return after forget")
+        self.assertEqual(
+            forgotten,
+            "I do not have eligible durable memories available for this recall.",
+        )
+        self.assertNotIn("legacy", forgotten)
+        diagnostics = bnl01_bot.memory_governance_canary_last_diagnostics(
+            42,
+            1,
+        )
+        self.assertEqual(
+            diagnostics["response_mode"],
+            "safe_empty",
+        )
+
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            conn.execute(
+                "DELETE FROM memory_ledger_entries "
+                "WHERE entry_id='current-color'"
+            )
+            conn.commit()
+        deleted = self.govern("legacy must not return after delete")
+        self.assertEqual(
+            deleted,
+            "I do not have eligible durable memories available for this recall.",
+        )
+
+    def test_kill_switch_restores_byte_exact_legacy_and_keeps_comparison(self):
+        self.enable_canary()
+        self.insert_ledger(
+            "favorite color is green",
+            entry_id="current-color",
+            predicate="favorite_color",
+        )
+        legacy = "Archive recall:\n- favorite color: legacy blue"
+
+        self.assertNotEqual(self.govern(legacy), legacy)
+        os.environ.pop("BNL_MEMORY_GOVERNANCE_CANARY_ENABLED")
+        rolled_back = self.govern(legacy)
+
+        self.assertEqual(rolled_back, legacy)
+        diagnostics = bnl01_bot.memory_governance_canary_last_diagnostics(
+            42,
+            1,
+        )
+        self.assertFalse(diagnostics["enabled_for_route"])
+        self.assertEqual(
+            diagnostics["response_mode"],
+            "legacy_shadow_comparison",
+        )
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            self.assertEqual(
+                conn.execute(
+                    "SELECT COUNT(*) FROM memory_governance_shadow_runs"
+                ).fetchone()[0],
+                2,
+            )
+
+    def test_wrong_subject_and_unsafe_result_fall_back_to_legacy(self):
+        self.enable_canary()
+        self.insert_ledger(
+            "favorite color is green",
+            entry_id="current-color",
+            predicate="favorite_color",
+        )
+        legacy = "byte-exact legacy"
+
+        self.assertEqual(self.govern(legacy, user_id=43), legacy)
+        wrong_subject_diagnostics = (
+            bnl01_bot.memory_governance_canary_last_diagnostics(43, 1)
+        )
+        self.assertFalse(
+            wrong_subject_diagnostics["enabled_for_route"]
+        )
+
+        with mock.patch(
+            "bnl01_bot.build_governed_context",
+            side_effect=RuntimeError("synthetic private detail"),
+        ):
+            with self.assertLogs(level="WARNING") as logs:
+                self.assertEqual(self.govern(legacy), legacy)
+        diagnostics = bnl01_bot.memory_governance_canary_last_diagnostics(
+            42,
+            1,
+        )
+        self.assertEqual(
+            diagnostics["response_mode"],
+            "legacy_exception_fallback",
+        )
+        self.assertEqual(
+            diagnostics["fallback_reason"],
+            "RuntimeError",
+        )
+        self.assertNotIn(
+            "synthetic private detail",
+            str(diagnostics),
+        )
+        self.assertNotIn("synthetic private detail", "\n".join(logs.output))
+
+    def test_sealed_and_selective_routes_never_receive_canary_output(self):
+        self.enable_canary()
+        self.insert_ledger(
+            "favorite color is green",
+            entry_id="current-color",
+            predicate="favorite_color",
+        )
+        legacy = "sealed legacy response"
+
+        self.assertEqual(self.govern(legacy, policy="sealed_test"), legacy)
+        diagnostics = bnl01_bot.memory_governance_canary_last_diagnostics(
+            42,
+            1,
+        )
+        self.assertEqual(
+            diagnostics["response_mode"],
+            "legacy_route_excluded",
+        )
+        self.assertEqual(self.govern(legacy, policy="public_selective"), legacy)
+        diagnostics = bnl01_bot.memory_governance_canary_last_diagnostics(
+            42,
+            1,
+        )
+        self.assertEqual(
+            diagnostics["response_mode"],
+            "legacy_shadow_comparison",
+        )
+
+    def test_diagnostic_snapshot_exposes_safe_scope_and_last_decision(self):
+        self.enable_canary()
+        self.insert_ledger(
+            "favorite color is green",
+            entry_id="current-color",
+            predicate="favorite_color",
+        )
+        self.govern()
+
+        snapshot = bnl01_bot.build_memory_diagnostic_snapshot(
+            42,
+            1,
+            channel_policy="public_home",
+        )
+        runtime = snapshot["runtime_gates"]
+        self.assertEqual(
+            runtime["memory_governance_canary"],
+            {
+                "configured_enabled": True,
+                "guild_allowlist_count": 1,
+                "user_allowlist_count": 1,
+                "fully_scoped": True,
+            },
+        )
+        self.assertEqual(
+            runtime["memory_governance_canary_last"]["response_mode"],
+            "governed",
+        )
+        self.assertFalse(runtime["memory_governance_live"])
+        self.assertNotIn("discord_user:42", str(runtime))
+
+    def test_media_followup_precedence_and_every_recall_wrapper_are_preserved(self):
+        text = Path("bnl01_bot.py").read_text()
+        offsets = [
+            index
+            for index in range(len(text))
+            if text.startswith("try_memory_recall_response", index)
+            and text[max(0, index - 4) : index].strip().endswith("=")
+        ]
+        self.assertGreaterEqual(len(offsets), 4)
+        for index in offsets:
+            before = text[max(0, index - 500) : index]
+            after = text[index : index + 1200]
+            self.assertIn("resolve_recent_media_followup", before)
+            self.assertIn("apply_explicit_recall_governance", after)
+            self.assertIn("format_explicit_recall_for_chat", after)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Adds a separate `BNL_MEMORY_GOVERNANCE_CANARY_*` switch with one-guild and member allowlists.
- Lets only the existing Discord explicit-personal-recall wrapper serve governed candidates on `public_home` and `public_context` routes.
- Requires the existing Ledger and Memory Governance shadow layers; it does not require or enable the global Governance live switch.
- Preserves recent-media follow-up precedence and the established legacy response outside the exact canary scope.
- Records safe per-member canary diagnostics plus persisted route/response mode evidence for legacy-vs-governed review.
- Adds focused authorization, isolation, lifecycle, safe-empty, rollback, diagnostic, and failure-path coverage.

## Why

Stage 3 Moment-gist evidence is complete. This is the bounded Stage 4 rollout seam: one explicit-recall route can compare and use governed memory without making Governance globally authoritative or changing any other consumer.

## Safety and rollback

- Defaults off.
- Exactly one guild must be configured; one or more consenting members may be allowlisted.
- Sealed, internal, unknown, protected, and `public_selective` routes cannot receive canary output.
- Unsafe Governance results and exceptions fall back to the byte-exact established response.
- A safe empty governed result does not revive ineligible legacy content.
- Removing `BNL_MEMORY_GOVERNANCE_CANARY_ENABLED` and restarting restores shadow-only legacy behavior.
- `BNL_MEMORY_GOVERNANCE_LIVE_ENABLED`, Relationship v2, Active Engagement v2, queue gates, and all production configuration remain unchanged.

## Validation

- `make check PYTHON=.venv/bin/python`
- Compilation passed.
- All 1,541 tests passed.

No website, queue/rehearsal, Journal, Relay, dossier, Source File, reaction, typing, Relationship, Engagement, deployment, environment, or production-gate files changed.