### PR TITLE
Repair governed recall canary

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -60,6 +60,7 @@ from bnl_memory_ledger import (
 )
 from bnl_memory_governance import (
     GovernanceRequest,
+    assess_governance_result_safety,
     build_governed_context,
     complete_delete_member_data,
     correct_member_memory,
@@ -711,6 +712,10 @@ DEFAULT_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS = {
     "selected_count": 0,
     "rendered": False,
     "fallback_reason": "not_evaluated",
+    "processing_error_count": 0,
+    "invalid_invariant_count": 0,
+    "raw_invalid_invariant_count": 0,
+    "reclassified_invariant_count": 0,
 }
 LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS = {}
 LAST_CONVERSATION_CONTEXT_V2_DIAGNOSTICS = {
@@ -849,7 +854,7 @@ def memory_governance_canary_enabled(
 
     The existing global live switch remains independent. The canary requires
     one configured guild, an allowlisted participant, the established public
-    explicit-recall surfaces, and both Ledger and Governance shadow inputs.
+    explicit-recall surfaces, and Ledger, Moment, and Governance shadow inputs.
     """
     env = os.environ if environ is None else environ
     configuration = memory_governance_canary_configuration(env)
@@ -868,6 +873,7 @@ def memory_governance_canary_enabled(
         in {"public_home", "public_context"}
         and memory_ledger_shadow_enabled(env)
         and memory_governance_shadow_enabled(env)
+        and moment_engine_shadow_enabled(env)
     )
 
 
@@ -17363,6 +17369,13 @@ def _format_explicit_recall_governed_response(gov_result) -> str:
     lines = []
     for candidate in gov_result.selected[:5]:
         text = re.sub(r"\s+", " ", str(candidate.text or "")).strip()
+        if candidate.source_class == "moment_gist":
+            text = re.sub(
+                r"^The participant\s+",
+                "You ",
+                text,
+                count=1,
+            )
         if text:
             lines.append(f"- {text[:240]}")
     if not lines:
@@ -17406,6 +17419,8 @@ def apply_explicit_recall_governance(
         legacy_vs_governed: dict | None = None,
         processing_error_count: int = 0,
         invalid_invariant_count: int = 0,
+        raw_invalid_invariant_count: int = 0,
+        reclassified_invariant_count: int = 0,
     ) -> None:
         LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS[
             (int(user_id or 0), int(guild_id or 0))
@@ -17423,6 +17438,12 @@ def apply_explicit_recall_governance(
             ),
             "invalid_invariant_count": max(
                 0, int(invalid_invariant_count or 0)
+            ),
+            "raw_invalid_invariant_count": max(
+                0, int(raw_invalid_invariant_count or 0)
+            ),
+            "reclassified_invariant_count": max(
+                0, int(reclassified_invariant_count or 0)
             ),
         }
 
@@ -17454,16 +17475,35 @@ def apply_explicit_recall_governance(
             visibility_allowance=visibility,
             user_text=user_text or "",
             budget_chars=int(limits.get("prompt_budget") or 1200),
-            allowed_source_classes=("owner_correction", "approved_canon", "first_party_record", "runtime_observation", "public_observation", "evidence_projection", "derived_summary"),
+            allowed_source_classes=(
+                "owner_correction",
+                "approved_canon",
+                "first_party_record",
+                "runtime_observation",
+                "public_observation",
+                "moment_gist",
+                "evidence_projection",
+                "derived_summary",
+            ),
             now=datetime.now(PACIFIC_TZ).isoformat(),
         )
+        global_live_enabled = memory_governance_live_enabled()
         with sqlite3.connect(DB_FILE) as gov_conn:
-            gov_result = build_governed_context(gov_conn, gov_req, legacy_context=legacy_recall_response, include_review_moments=True)
-            unsafe_governed = bool(
-                gov_result.diagnostics.processing_errors
-                or gov_result.diagnostics.invalid_invariants
+            gov_result = build_governed_context(
+                gov_conn,
+                gov_req,
+                legacy_context=legacy_recall_response,
+                include_review_moments=True,
+                include_public_moment_gists=bool(
+                    moment_engine_shadow_enabled()
+                    and (
+                        canary_enabled_for_route
+                        or global_live_enabled
+                    )
+                ),
             )
-            global_live_enabled = memory_governance_live_enabled()
+            safety = assess_governance_result_safety(gov_result)
+            unsafe_governed = safety.unsafe
             governed_authority = bool(
                 global_live_enabled or canary_enabled_for_route
             )
@@ -17497,10 +17537,14 @@ def apply_explicit_recall_governance(
             ),
             legacy_vs_governed=gov_result.diagnostics.legacy_vs_governed,
             processing_error_count=len(
-                gov_result.diagnostics.processing_errors
+                safety.processing_errors
             ),
-            invalid_invariant_count=len(
-                gov_result.diagnostics.invalid_invariants
+            invalid_invariant_count=len(safety.blocking_invariants),
+            raw_invalid_invariant_count=(
+                safety.raw_invalid_invariant_count
+            ),
+            reclassified_invariant_count=(
+                safety.reclassified_invariant_count
             ),
         )
         if governed_authority and not unsafe_governed:
@@ -17955,7 +17999,9 @@ def build_user_memory_context(
                         }
                     )
                 persist_shadow_diagnostics(gov_conn, gov_req, gov_result, legacy_context)
-                unsafe_governed = bool(gov_result.diagnostics.processing_errors or gov_result.diagnostics.invalid_invariants)
+                unsafe_governed = assess_governance_result_safety(
+                    gov_result
+                ).unsafe
                 if memory_governance_live_enabled() and not unsafe_governed:
                     LAST_MEMORY_PROMPT_DIAGNOSTICS[(user_id, guild_id)] = diagnostics
                     governed_context = gov_result.rendered_context

--- a/bnl_memory_governance.py
+++ b/bnl_memory_governance.py
@@ -26,6 +26,7 @@ from bnl_journal_source_store import (
     purge_user_discord_sources_on_connection,
 )
 from bnl_memory_ledger import ensure_memory_ledger_schema, subject_key_for_user
+from bnl_moment_engine import select_public_participant_moment_gists
 from bnl_relationship_engine import complete_delete_relationship_v2, ensure_relationship_v2_schema, propagate_ledger_lifecycle
 
 SHADOW_ENV = "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED"
@@ -58,7 +59,7 @@ APPROVED_MEMBER_SCALAR_PREDICATES = {
     "favorite_movie",
 }
 PROJECTION_CLASSES = {"derived_summary", "evidence_projection", "source_file_projection", "dossier_projection", "entity_evidence_projection", "legacy_source_blind"}
-AUTHORITY = {"legacy_source_blind": 0, "derived_summary": 1, "evidence_projection": 2, "entity_evidence_projection": 2, "dossier_projection": 2, "source_file_projection": 2, "public_observation": 3, "runtime_observation": 4, "first_party_record": 5, "approved_canon": 6, "owner_correction": 7}
+AUTHORITY = {"legacy_source_blind": 0, "derived_summary": 1, "moment_gist": 2, "evidence_projection": 2, "entity_evidence_projection": 2, "dossier_projection": 2, "source_file_projection": 2, "public_observation": 3, "runtime_observation": 4, "first_party_record": 5, "approved_canon": 6, "owner_correction": 7}
 CONF = {"unknown": 0, "low": 1, "medium": 2, "high": 3, "approved": 4}
 IDENTITY_OWNER_ID_COLUMNS = {
     "user_id",
@@ -172,6 +173,66 @@ class GovernanceResult:
     selected: Tuple[MemoryCandidate, ...]
     exclusions: Tuple[GovernanceExclusion, ...]
     diagnostics: GovernanceDiagnostics
+
+
+@dataclass(frozen=True)
+class GovernanceSafetyAssessment:
+    processing_errors: Tuple[str, ...]
+    blocking_invariants: Tuple[str, ...]
+    raw_invalid_invariant_count: int
+    reclassified_invariant_count: int
+
+    @property
+    def unsafe(self) -> bool:
+        return bool(self.processing_errors or self.blocking_invariants)
+
+
+def _diagnostic_markers(value: Any) -> Tuple[str, ...]:
+    if not value:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    try:
+        return tuple(str(marker or "unknown") for marker in value)
+    except TypeError:
+        return (str(value),)
+
+
+def assess_governance_result_safety(
+    result: GovernanceResult,
+) -> GovernanceSafetyAssessment:
+    """Apply the acceptance reclassification before a result gains authority."""
+    errors = _diagnostic_markers(result.diagnostics.processing_errors)
+    raw_invariants = _diagnostic_markers(
+        result.diagnostics.invalid_invariants
+    )
+    safe_route_exclusions = max(
+        0,
+        int(
+            result.diagnostics.excluded_by_reason.get(
+                "invalid_route_channel_policy",
+                0,
+            )
+            or 0
+        ),
+    )
+    blocking: List[str] = []
+    reclassified = 0
+    for invariant in raw_invariants:
+        if (
+            invariant == "invalid_route_channel_policy_selected"
+            and reclassified < safe_route_exclusions
+        ):
+            reclassified += 1
+            continue
+        blocking.append(invariant)
+    return GovernanceSafetyAssessment(
+        processing_errors=errors,
+        blocking_invariants=tuple(blocking),
+        raw_invalid_invariant_count=len(raw_invariants),
+        reclassified_invariant_count=reclassified,
+    )
+
 
 def gate_enabled(name: str, environ: Optional[Dict[str, str]] = None) -> bool:
     return str((environ or os.environ).get(name, "")).strip().lower() in {"1", "true", "yes", "on", "enabled"}
@@ -320,7 +381,14 @@ def _moment_counts(conn: sqlite3.Connection, req: GovernanceRequest, diag: Gover
     except Exception as e:
         diag.processing_errors.append("moment:" + type(e).__name__)
 
-def build_governed_context(conn: sqlite3.Connection, req: GovernanceRequest, *, legacy_context: str = "", include_review_moments: bool = False) -> GovernanceResult:
+def build_governed_context(
+    conn: sqlite3.Connection,
+    req: GovernanceRequest,
+    *,
+    legacy_context: str = "",
+    include_review_moments: bool = False,
+    include_public_moment_gists: bool = False,
+) -> GovernanceResult:
     diag = GovernanceDiagnostics(route_policy={"route_mode": req.route_mode, "channel_policy": req.channel_policy, "visibility": req.visibility_allowance})
     try:
         ensure_governance_schema(conn)
@@ -402,10 +470,71 @@ def build_governed_context(conn: sqlite3.Connection, req: GovernanceRequest, *, 
             if not _relevance_ok(c, request_terms, broad):
                 exclude("topic_relevance"); continue
             cands.append(c)
-        if include_review_moments:
-            _moment_counts(conn, req, diag)
     except Exception as e:
         diag.processing_errors.append(type(e).__name__)
+    if include_review_moments or include_public_moment_gists:
+        _moment_counts(conn, req, diag)
+    if include_public_moment_gists and "moment_gist" in allowed:
+        try:
+            for moment in select_public_participant_moment_gists(
+                conn,
+                guild_id=req.guild_id,
+                participant_key=subject,
+                topic_text=req.user_text,
+                broad_recall=broad,
+                token_budget=160,
+                freshness_days=3650,
+                allowed_channel_policies=("public_home", "public_context"),
+                max_results=4,
+            ):
+                diag.candidates_by_source["moment_gist"] = (
+                    diag.candidates_by_source.get("moment_gist", 0) + 1
+                )
+                candidate = MemoryCandidate(
+                    "moment_gist",
+                    moment.frame_type or "participant_contribution",
+                    "moment:%s" % moment.moment_id,
+                    moment.canonical_ledger_entry_id or moment.moment_id,
+                    req.guild_id,
+                    subject,
+                    "shared_moment",
+                    "shared_moment",
+                    moment.contribution_gist,
+                    moment.visibility,
+                    "medium",
+                    "finalized",
+                    AUTHORITY["moment_gist"],
+                    moment.salience,
+                    moment.last_activity_at,
+                    "",
+                    "",
+                    True,
+                    True,
+                    (subject,),
+                    (),
+                    0.0,
+                    True,
+                )
+                if not _relevance_ok(
+                    candidate,
+                    request_terms,
+                    broad,
+                ):
+                    exclusions.append(
+                        GovernanceExclusion(
+                            candidate.source_ref,
+                            "topic_relevance",
+                            candidate.source_class,
+                            candidate.entry_id,
+                        )
+                    )
+                    _add(diag, "topic_relevance")
+                    continue
+                cands.append(candidate)
+        except Exception as e:
+            diag.processing_errors.append(
+                "moment_gist:" + type(e).__name__
+            )
     scored: List[MemoryCandidate] = []
     recall = _explicit_recall(req.user_text)
     participant_keys = set(req.participants)
@@ -415,7 +544,13 @@ def build_governed_context(conn: sqlite3.Connection, req: GovernanceRequest, *, 
         scored.append(replace(c, score=round(score, 4)))
     ranked = sorted(scored, key=lambda c: (-c.score, -c.authority, -CONF.get(c.confidence, 0), -_parse_time(c.observed_at), c.source_class, c.source_ref, c.entry_id))
     # Resolve contradictions by predicate: additive/open-loop-like predicates may coexist; scalar predicates keep highest ranked current value.
-    additive = {"open_loop", "commitment", "goal", "unresolved_question"}
+    additive = {
+        "open_loop",
+        "commitment",
+        "goal",
+        "unresolved_question",
+        "shared_moment",
+    }
     resolved: List[MemoryCandidate] = []
     seen_pred: Set[str] = set()
     for c in ranked:
@@ -453,18 +588,26 @@ def build_governed_context(conn: sqlite3.Connection, req: GovernanceRequest, *, 
 def persist_shadow_diagnostics(conn: sqlite3.Connection, req: GovernanceRequest, result: GovernanceResult, legacy_context: str) -> str:
     ensure_governance_schema(conn)
     now = _now(); run_id = "mgs_" + _hash("|".join([str(req.guild_id), subject_key_for_user(req.subject_user_id), now, result.diagnostics.rendered_hash]))
+    safety = assess_governance_result_safety(result)
     invalid_invariant_counts: Dict[str, int] = {}
-    for invariant in result.diagnostics.invalid_invariants:
+    for invariant in _diagnostic_markers(
+        result.diagnostics.invalid_invariants
+    ):
         key = str(invariant or "unknown")[:120]
         invalid_invariant_counts[key] = invalid_invariant_counts.get(key, 0) + 1
-    # Persist the raw aggregate counts. The acceptance reader owns the one
-    # compatibility reclassification pass for the historical route-policy
-    # marker. Keeping that operation in one layer preserves any unmatched
-    # remainder as a fail-closed blocker.
+    # Persist both the raw aggregate and the shared safety assessment. The
+    # assessor reclassifies only markers corroborated by matching safe
+    # pre-selection exclusions; unmatched remainders remain fail-closed.
     aggregate_diagnostics = {
         "route_policy": dict(result.diagnostics.route_policy),
         "selected_by_source": dict(result.diagnostics.selected_by_source),
         "invalid_invariant_counts": invalid_invariant_counts,
+        "effective_invalid_invariant_count": len(
+            safety.blocking_invariants
+        ),
+        "reclassified_invariant_count": (
+            safety.reclassified_invariant_count
+        ),
         "fallback_reason": str(result.diagnostics.fallback_reason or "")[:120],
         "visibility_exclusions": int(result.diagnostics.visibility_exclusions or 0),
         "token_budget_exclusions": int(result.diagnostics.token_budget_exclusions or 0),
@@ -497,6 +640,7 @@ def persist_shadow_diagnostics(conn: sqlite3.Connection, req: GovernanceRequest,
 def build_evaluation_report(results: List[GovernanceResult], guild_id: int) -> Dict[str, Any]:
     report: Dict[str, Any] = {"guild_id": guild_id, "runs": len(results), "selected_total": 0, "excluded_total": 0, "selected_by_source": {}, "excluded_by_reason": {}, "visibility_violations": 0, "cross_member_violations": 0, "cross_guild_violations": 0, "invalid_route_channel_policy_selections": 0, "corrected_superseded_retracted_selected": 0, "review_only_or_needs_review_selected": 0, "projection_lineage_violations": 0, "duplicate_suppression": 0, "contradiction_resolutions": 0, "budget_overruns": 0, "empty_result_frequency": 0, "processing_errors": 0, "legacy_vs_governed": [], "rollback_readiness": "ready_env_disable_live"}
     for r in results:
+        safety = assess_governance_result_safety(r)
         report["selected_total"] += len(r.selected); report["excluded_total"] += len(r.exclusions)
         for k, v in r.diagnostics.selected_by_source.items(): report["selected_by_source"][k] = report["selected_by_source"].get(k, 0) + v
         for k, v in r.diagnostics.excluded_by_reason.items(): report["excluded_by_reason"][k] = report["excluded_by_reason"].get(k, 0) + v
@@ -509,22 +653,14 @@ def build_evaluation_report(results: List[GovernanceResult], guild_id: int) -> D
         report["contradiction_resolutions"] += len(r.diagnostics.contradiction_resolutions)
         report["budget_overruns"] += r.diagnostics.token_budget_exclusions
         report["empty_result_frequency"] += 1 if not r.rendered_context else 0
-        report["processing_errors"] += len(r.diagnostics.processing_errors)
+        report["processing_errors"] += len(safety.processing_errors)
         report["legacy_vs_governed"].append(r.diagnostics.legacy_vs_governed)
-        route_policy_markers = 0
-        for inv in r.diagnostics.invalid_invariants:
+        for inv in safety.blocking_invariants:
             if inv == "cross_subject_selected": report["cross_member_violations"] += 1
             if inv == "cross_guild_selected": report["cross_guild_violations"] += 1
             if inv == "visibility_selected": report["visibility_violations"] += 1
-            if inv == "invalid_route_channel_policy_selected": route_policy_markers += 1
-        # A route-policy mismatch is rejected before candidates reach the
-        # selected set. Reclassify only the count corroborated by matching safe
-        # exclusions; any unmatched remainder still fails closed.
-        report["invalid_route_channel_policy_selections"] += max(
-            0,
-            route_policy_markers
-            - int(r.diagnostics.excluded_by_reason.get("invalid_route_channel_policy", 0) or 0),
-        )
+            if inv == "invalid_route_channel_policy_selected":
+                report["invalid_route_channel_policy_selections"] += 1
     if report["processing_errors"] or report["visibility_violations"] or report["cross_member_violations"] or report["cross_guild_violations"] or report["invalid_route_channel_policy_selections"]:
         report["rollback_readiness"] = "fallback_required_before_live"
     return report

--- a/bnl_moment_engine.py
+++ b/bnl_moment_engine.py
@@ -139,6 +139,17 @@ class MomentObservationResult:
 
 
 @dataclass(frozen=True)
+class PublicParticipantMomentGist:
+    moment_id: str
+    contribution_gist: str
+    frame_type: str
+    last_activity_at: str
+    salience: float
+    visibility: str
+    canonical_ledger_entry_id: str
+
+
+@dataclass(frozen=True)
 class EpisodeObservationResult:
     outcome: str = "skipped"
     reason_code: str = "not_attempted"
@@ -4787,6 +4798,154 @@ def _contribution_is_renderable(
         participant_key,
     )
     return gist, label
+
+
+def select_public_participant_moment_gists(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    participant_key: str,
+    topic_text: str = "",
+    broad_recall: bool = False,
+    token_budget: int = 160,
+    freshness_days: int = 3650,
+    allowed_channel_policies: tuple[str, ...] = (),
+    max_results: int = 4,
+) -> tuple[PublicParticipantMomentGist, ...]:
+    """Return source-revalidated participant gists for governed recall.
+
+    This is intentionally narrower than general Moment rendering: it accepts
+    only a typed Discord participant, public conversational policies, finalized
+    public-safe Moments, and the participant-specific contribution projection.
+    Exact-quote and third-party attribution requests remain owned by their
+    separate live-source paths.
+    """
+    ensure_moment_schema(conn)
+    if not re.fullmatch(r"discord_user:[1-9]\d*", participant_key or ""):
+        return ()
+    attribution = _parse_attribution_request(topic_text)
+    if attribution.exact_authority_requested or attribution.requested:
+        return ()
+    policies = tuple(
+        sorted(
+            {
+                _canon(policy)
+                for policy in (allowed_channel_policies or ())
+                if _canon(policy) in PUBLIC_CROSS_CHANNEL_POLICIES
+            }
+        )
+    )
+    if not policies:
+        return ()
+    relevance_text = _recall_topic_focus(topic_text)
+    family = _topic_family(relevance_text, "conversation")
+    signature = _topic_signature(relevance_text, "conversation")
+    if not broad_recall and not signature:
+        return ()
+    cutoff = (
+        datetime.now(timezone.utc) - timedelta(days=max(1, freshness_days))
+    ).isoformat()
+    placeholders = ",".join("?" for _ in policies)
+    rows = conn.execute(
+        f"""
+        SELECT moment_id,summary,topic_family,topic_signature,visibility,
+               last_activity_at,salience,channel_id,channel_policy,route_mode,
+               canonical_ledger_entry_id
+        FROM memory_moment_windows
+        WHERE guild_id=? AND channel_policy IN ({placeholders})
+          AND route_mode IN (
+              'normal_chat','direct_payload','direct_payload_task'
+          )
+          AND lifecycle_status='finalized' AND public_usable=1
+          AND last_activity_at>=?
+        ORDER BY salience DESC,last_activity_at DESC,moment_id
+        LIMIT 100
+        """,
+        (int(guild_id or 0), *policies, cutoff),
+    ).fetchall()
+    selected: list[PublicParticipantMomentGist] = []
+    seen_gists: set[str] = set()
+    used_words = 0
+    for row in rows:
+        moment_id = str(row[0] or "")
+        visibility = str(row[4] or "unknown")
+        window_signature = _load_sig(str(row[3] or "[]"))
+        if visibility not in {"public", "public_safe"}:
+            continue
+        if not broad_recall and (
+            not _coherent(
+                family,
+                signature,
+                str(row[2] or ""),
+                window_signature,
+            )
+            or not _contribution_topic_coherent(
+                signature,
+                window_signature,
+            )
+        ):
+            continue
+        if not _human_participant_present(
+            conn,
+            moment_id,
+            participant_key,
+        ):
+            continue
+        if not _moment_is_renderable(
+            conn,
+            moment_id=moment_id,
+            summary=str(row[1] or ""),
+            guild_id=int(guild_id or 0),
+            channel_id=int(row[7] or 0),
+            channel_policy=str(row[8] or ""),
+            route_mode=str(row[9] or "unknown"),
+            visibility=visibility,
+            canonical_ledger_entry_id=str(row[10] or ""),
+        ):
+            continue
+        gist, _label = _contribution_is_renderable(
+            conn,
+            moment_id=moment_id,
+            participant_key=participant_key,
+            guild_id=int(guild_id or 0),
+            channel_id=int(row[7] or 0),
+            channel_policy=str(row[8] or ""),
+            route_mode=str(row[9] or "unknown"),
+            visibility=visibility,
+        )
+        normalized_gist = re.sub(r"\s+", " ", gist).strip()
+        if not normalized_gist or normalized_gist.lower() in seen_gists:
+            continue
+        gist_words = normalized_gist.split()
+        if (
+            used_words + len(gist_words) > max(1, int(token_budget or 0))
+            or len(selected) >= max(1, int(max_results or 0))
+        ):
+            continue
+        contribution = conn.execute(
+            """
+            SELECT frame_type
+            FROM memory_moment_contributions
+            WHERE moment_id=? AND participant_key=?
+            """,
+            (moment_id, participant_key),
+        ).fetchone()
+        selected.append(
+            PublicParticipantMomentGist(
+                moment_id=moment_id,
+                contribution_gist=normalized_gist,
+                frame_type=str(contribution[0] or "") if contribution else "",
+                last_activity_at=str(row[5] or ""),
+                salience=float(row[6] or 0),
+                visibility=visibility,
+                canonical_ledger_entry_id=str(row[10] or ""),
+            )
+        )
+        seen_gists.add(normalized_gist.lower())
+        used_words += len(gist_words)
+        if len(selected) >= max(1, int(max_results or 0)):
+            break
+    return tuple(selected)
 
 
 def render_shadow_moment_context(

--- a/tests/test_memory_governance_canary.py
+++ b/tests/test_memory_governance_canary.py
@@ -3,6 +3,7 @@ import os
 import sqlite3
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
 
@@ -11,7 +12,13 @@ os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
 
 import bnl01_bot
-from bnl_memory_governance import ensure_governance_schema
+import bnl_memory_ledger as ledger
+import bnl_moment_engine as moments
+from bnl_memory_governance import (
+    GovernanceDiagnostics,
+    GovernanceResult,
+    ensure_governance_schema,
+)
 from bnl_memory_ledger import subject_key_for_user
 
 
@@ -23,6 +30,7 @@ class MemoryGovernanceCanaryAuthorizationTests(unittest.TestCase):
             "BNL_MEMORY_GOVERNANCE_CANARY_USER_IDS": "202",
             "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
             "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+            "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
         }
 
     def request(self, **overrides):
@@ -67,6 +75,7 @@ class MemoryGovernanceCanaryAuthorizationTests(unittest.TestCase):
             "missing_governance_shadow": (
                 "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED"
             ),
+            "missing_moment_shadow": "BNL_MOMENT_ENGINE_SHADOW_ENABLED",
         }
         for label, missing in cases.items():
             with self.subTest(label=label):
@@ -168,6 +177,7 @@ class MemoryGovernanceCanaryIntegrationTests(unittest.TestCase):
         "BNL_MEMORY_LEDGER_SHADOW_ENABLED",
         "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED",
         "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED",
+        "BNL_MOMENT_ENGINE_SHADOW_ENABLED",
     )
 
     def setUp(self):
@@ -207,6 +217,7 @@ class MemoryGovernanceCanaryIntegrationTests(unittest.TestCase):
                 "BNL_MEMORY_GOVERNANCE_CANARY_USER_IDS": users,
                 "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
                 "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+                "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
             }
         )
 
@@ -219,6 +230,8 @@ class MemoryGovernanceCanaryIntegrationTests(unittest.TestCase):
         lifecycle="active",
         visibility="public_safe",
         public_usable=1,
+        source_policy="public_home",
+        route_mode=None,
     ):
         with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
             ensure_governance_schema(conn)
@@ -259,8 +272,8 @@ class MemoryGovernanceCanaryIntegrationTests(unittest.TestCase):
                     lifecycle,
                     timestamp,
                     timestamp,
-                    bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
-                    "public_home",
+                    route_mode or bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                    source_policy,
                 ),
             )
             conn.commit()
@@ -272,17 +285,89 @@ class MemoryGovernanceCanaryIntegrationTests(unittest.TestCase):
         user_id=42,
         guild_id=1,
         policy="public_home",
+        user_text="BNL, what do you remember about me?",
     ):
         return bnl01_bot.apply_explicit_recall_governance(
             user_id,
             guild_id,
-            "BNL, what do you remember about me?",
+            user_text,
             legacy,
             bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
             policy,
             channel_id=99,
             channel_name="barcode-bot",
         )
+
+    def insert_public_question_moment(self):
+        messages = (
+            (
+                "user",
+                "Could dreaming affect programmed identity and anxiety?",
+            ),
+            (
+                "model",
+                "Those themes can be explored without treating them as facts.",
+            ),
+            (
+                "user",
+                "Does being alive connect to dreaming and programmed identity?",
+            ),
+            (
+                "model",
+                "That continues the same philosophical question.",
+            ),
+            (
+                "user",
+                "Could anxiety connect dreaming, being alive, and programmed identity?",
+            ),
+            (
+                "model",
+                "The thread now connects those questions directly.",
+            ),
+        )
+        moment_id = ""
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            ensure_governance_schema(conn)
+            moments.ensure_moment_schema(conn)
+            base = datetime(2026, 7, 25, 18, 0, tzinfo=timezone.utc)
+            for index, (role, content) in enumerate(messages, start=1):
+                write = ledger.shadow_conversation_row(
+                    conn,
+                    row_id=5000 + index,
+                    user_id=42,
+                    user_name="Test Member" if role == "user" else "BNL-01",
+                    guild_id=1,
+                    role=role,
+                    content=content,
+                    channel_policy="public_home",
+                    channel_id=10,
+                    channel_name="barcode-bot",
+                    route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                    observed_at=(
+                        base + timedelta(seconds=index * 10)
+                    ).isoformat(),
+                )
+                observed = moments.observe_ledger_entry(
+                    conn,
+                    write.entry_id,
+                )
+                moment_id = observed.moment_id or moment_id
+            finalized = moments.finalize_moment(conn, moment_id)
+            self.assertIn(
+                finalized.outcome,
+                {"inserted", "deduplicated"},
+            )
+            gist = conn.execute(
+                """
+                SELECT contribution_gist
+                FROM memory_moment_contributions
+                WHERE moment_id=? AND participant_key=?
+                """,
+                (moment_id, subject_key_for_user(42)),
+            ).fetchone()
+            conn.commit()
+        self.assertIsNotNone(gist)
+        return moment_id, gist[0]
 
     def latest_persisted_diagnostics(self):
         with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
@@ -325,6 +410,144 @@ class MemoryGovernanceCanaryIntegrationTests(unittest.TestCase):
         )
         self.assertFalse(persisted["global_live_enabled"])
         self.assertEqual(persisted["response_mode"], "governed")
+
+    def test_production_shaped_route_markers_reclassify_and_moment_gist_serves(self):
+        self.enable_canary()
+        for index in range(3):
+            self.insert_ledger(
+                f"restricted compatibility row {index}",
+                entry_id=f"restricted-{index}",
+                predicate="conversation",
+                source_policy="sealed_test",
+            )
+        moment_id, gist = self.insert_public_question_moment()
+        current_user_gist = gist.replace("The participant ", "You ", 1)
+        legacy = (
+            "Archive recall:\n"
+            "- raw wording that must not become governed output"
+        )
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            self.assertEqual(
+                moments.select_public_participant_moment_gists(
+                    conn,
+                    guild_id=1,
+                    participant_key=subject_key_for_user(43),
+                    topic_text="what do you remember about me?",
+                    broad_recall=True,
+                    allowed_channel_policies=(
+                        "public_home",
+                        "public_context",
+                    ),
+                ),
+                (),
+            )
+            self.assertEqual(
+                moments.select_public_participant_moment_gists(
+                    conn,
+                    guild_id=1,
+                    participant_key=subject_key_for_user(42),
+                    topic_text=(
+                        "quote exactly what I said in that dispute"
+                    ),
+                    broad_recall=True,
+                    allowed_channel_policies=(
+                        "public_home",
+                        "public_context",
+                    ),
+                ),
+                (),
+            )
+
+        response = self.govern(legacy)
+
+        self.assertIn("Here is what I can safely recall:", response)
+        self.assertIn(current_user_gist, response)
+        self.assertNotIn(gist, response)
+        self.assertIn("dreaming", response)
+        self.assertNotIn("raw wording", response)
+        diagnostics = bnl01_bot.memory_governance_canary_last_diagnostics(
+            42,
+            1,
+        )
+        self.assertEqual(diagnostics["response_mode"], "governed")
+        self.assertEqual(diagnostics["selected_count"], 1)
+        self.assertTrue(diagnostics["rendered"])
+        self.assertEqual(diagnostics["processing_error_count"], 0)
+        self.assertEqual(diagnostics["invalid_invariant_count"], 0)
+        self.assertEqual(diagnostics["raw_invalid_invariant_count"], 3)
+        self.assertEqual(diagnostics["reclassified_invariant_count"], 3)
+        persisted = self.latest_persisted_diagnostics()
+        self.assertEqual(
+            persisted["effective_invalid_invariant_count"],
+            0,
+        )
+        self.assertEqual(persisted["reclassified_invariant_count"], 3)
+        self.assertEqual(
+            persisted["selected_by_source"],
+            {"moment_gist": 1},
+        )
+
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            source_id = conn.execute(
+                """
+                SELECT ledger_entry_id
+                FROM memory_moment_contribution_sources
+                WHERE moment_id=? AND participant_key=?
+                ORDER BY ledger_entry_id
+                LIMIT 1
+                """,
+                (moment_id, subject_key_for_user(42)),
+            ).fetchone()[0]
+            conn.execute(
+                """
+                UPDATE memory_ledger_entries
+                SET visibility='private', public_usable=0
+                WHERE entry_id=?
+                """,
+                (source_id,),
+            )
+            conn.commit()
+
+        invalidated = self.govern(legacy)
+        self.assertEqual(
+            invalidated,
+            "I do not have eligible durable memories available for this recall.",
+        )
+        self.assertNotIn("dreaming", invalidated)
+        self.assertNotIn("raw wording", invalidated)
+
+    def test_unmatched_route_invariant_still_falls_back_fail_closed(self):
+        self.enable_canary()
+        unsafe = GovernanceResult(
+            rendered_context="must not render",
+            selected=(),
+            exclusions=(),
+            diagnostics=GovernanceDiagnostics(
+                invalid_invariants=[
+                    "invalid_route_channel_policy_selected"
+                ]
+            ),
+        )
+        legacy = "byte-exact legacy"
+
+        with mock.patch(
+            "bnl01_bot.build_governed_context",
+            return_value=unsafe,
+        ):
+            response = self.govern(legacy)
+
+        self.assertEqual(response, legacy)
+        diagnostics = bnl01_bot.memory_governance_canary_last_diagnostics(
+            42,
+            1,
+        )
+        self.assertEqual(
+            diagnostics["response_mode"],
+            "legacy_unsafe_fallback",
+        )
+        self.assertEqual(diagnostics["invalid_invariant_count"], 1)
+        self.assertEqual(diagnostics["raw_invalid_invariant_count"], 1)
+        self.assertEqual(diagnostics["reclassified_invariant_count"], 0)
 
     def test_correction_visibility_forget_and_delete_remain_fail_closed(self):
         self.enable_canary()


### PR DESCRIPTION
## What changed

- Applies the existing route-policy invariant reclassification before governed recall can gain canary or future live authority.
- Reclassifies only raw compatibility markers that are corroborated by matching safe pre-selection exclusions; any unmatched marker remains a fail-closed blocker.
- Connects scoped explicit recall to participant-specific Moment contribution gists through the existing Moment engine.
- Requires every served Moment to be finalized, public-usable, public-policy scoped, typed to the requesting Discord member, and fully revalidated against its canonical Moment, participant record, source links, lifecycle, visibility, and source digest.
- Keeps exact-quote and third-party attribution requests out of this path.
- Adds effective, raw, and reclassified invariant counts to canary diagnostics and persisted comparison evidence.
- Requires Moment shadow alongside Ledger and Governance shadow for the scoped canary.

## Root cause

The deployed canary treated safely excluded restricted-route compatibility markers as fatal before the acceptance layer reclassified them. After that false blocker, explicit Governance recall also had no eligible source because raw conversation rows are correctly non-durable and the existing Moment integration only counted Moments rather than selecting their validated participant gists.

## User impact

For the allowlisted guild/member only, `BNL, what do you remember about me?` can now return safe paraphrased Moment meaning even when no approved scalar fact exists. It never revives raw conversation text, quotes, restricted-route rows, private sources, or another participant's contribution. If any linked source becomes private, invalid, corrected, or otherwise ineligible, the Moment disappears immediately and recall returns safe-empty.

## Validation

- Python compilation passed.
- 135 focused Governance, Moment, privacy, rollback, and exact-quote tests passed.
- Full repository suite: 1,543 tests passed.
- Production-shaped fixture proves matched restricted-route markers reclassify, unmatched markers still fail closed, validated Moment gist serves, raw legacy wording does not serve, and linked-source privacy changes invalidate the gist.

## Boundaries

No global Memory Governance, Relationship, Active Engagement, or queue gate is enabled. Queue/rehearsal, website, Journal, Relay, dossiers, Source Files, reactions, typing, and service configuration are untouched. Rollback remains disabling the account-scoped Governance canary and restarting the service.