### PR TITLE
Add shadow source-linked atomic knowledge candidates

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -45,7 +45,10 @@ from bnl_occasion import (
 )
 from bnl_memory_ledger import (
     LedgerWriteResult,
+    backfill_atomic_knowledge_candidates,
     ensure_memory_ledger_schema,
+    form_atomic_candidate_from_ledger_entry,
+    record_atomic_knowledge_processing_error,
     subject_key_for_user,
     shadow_broadcast_memory_row,
     shadow_conversation_row,
@@ -5071,6 +5074,38 @@ def init_db():
                 reason="startup_orphan_reconciliation",
             )
         )
+        knowledge_backfill = {
+            "phase": "disabled",
+            "completed": False,
+            "counts": {},
+        }
+        if memory_ledger_shadow_enabled():
+            try:
+                knowledge_backfill = backfill_atomic_knowledge_candidates(
+                    evidence_conn,
+                    batch_size=250,
+                )
+            except Exception as knowledge_exc:
+                try:
+                    record_atomic_knowledge_processing_error(
+                        evidence_conn,
+                        guild_id=0,
+                        reason_code=(
+                            "startup_backfill_"
+                            + type(knowledge_exc).__name__
+                        )[:120],
+                    )
+                except Exception as diagnostic_exc:
+                    logging.debug(
+                        "atomic_knowledge_backfill_diagnostic_failed "
+                        "error_type=%s",
+                        type(diagnostic_exc).__name__,
+                    )
+                knowledge_backfill = {
+                    "phase": "error",
+                    "completed": False,
+                    "counts": {"processing_error": 1},
+                }
         evidence_conn.commit()
     finally:
         evidence_conn.close()
@@ -5078,6 +5113,13 @@ def init_db():
         logging.info(
             "memory_orphan_reconciliation counts=%s",
             orphan_reconciliation,
+        )
+    if memory_ledger_shadow_enabled():
+        logging.info(
+            "atomic_knowledge_backfill phase=%s completed=%s counts=%s",
+            knowledge_backfill.get("phase"),
+            int(bool(knowledge_backfill.get("completed"))),
+            knowledge_backfill.get("counts"),
         )
     logging.info("✅ Database initialized successfully.")
 
@@ -5099,6 +5141,37 @@ def _shadow_memory_ledger_write(writer_name: str, callback, *, guild_id: int = 0
             )
         except Exception as receipt_exc:
             logging.debug("memory_ledger_shadow_receipt_failed writer=%s error=%s", writer_name, receipt_exc)
+        if (
+            result.entry_id
+            and result.outcome in {"inserted", "deduplicated"}
+        ):
+            try:
+                form_atomic_candidate_from_ledger_entry(
+                    conn,
+                    result.entry_id,
+                )
+            except Exception as knowledge_exc:
+                logging.debug(
+                    "atomic_knowledge_shadow_failed writer=%s error_type=%s",
+                    writer_name,
+                    type(knowledge_exc).__name__,
+                )
+                try:
+                    record_atomic_knowledge_processing_error(
+                        conn,
+                        guild_id=result.guild_id or int(guild_id or 0),
+                        reason_code=(
+                            "shadow_write_" + type(knowledge_exc).__name__
+                        )[:120],
+                        root_entry_ids=(result.entry_id,),
+                    )
+                except Exception as diagnostic_exc:
+                    logging.debug(
+                        "atomic_knowledge_shadow_diagnostic_failed "
+                        "writer=%s error_type=%s",
+                        writer_name,
+                        type(diagnostic_exc).__name__,
+                    )
         conn.commit()
         if (
             result
@@ -30536,6 +30609,26 @@ async def bnl_memory_check(interaction: discord.Interaction):
         f"- memory_ledger_unmapped_provenance: `{ledger_diag.get('missingUnmappedProvenance', 0)}`",
         f"- memory_ledger_public_rejections: `{ledger_diag.get('publicUsabilityRejections', 0)}`",
         f"- memory_ledger_multiple_active_values: `{ledger_diag.get('entriesWithMultipleActiveValues', 0)}`",
+        f"- atomic_knowledge_schema: `{ledger_diag.get('knowledgeCandidateSchemaVersion', 'absent')}`",
+        f"- atomic_knowledge_by_type: `{ledger_diag.get('knowledgeCandidateTotalsByType', {})}`",
+        f"- atomic_knowledge_by_state: `{ledger_diag.get('knowledgeCandidateTotalsByState', {})}`",
+        f"- atomic_knowledge_by_visibility: `{ledger_diag.get('knowledgeCandidateTotalsByVisibility', {})}`",
+        f"- atomic_knowledge_by_authority: `{ledger_diag.get('knowledgeCandidateTotalsByAuthority', {})}`",
+        f"- atomic_knowledge_by_confidence: `{ledger_diag.get('knowledgeCandidateTotalsByConfidence', {})}`",
+        f"- atomic_knowledge_by_epistemic_status: `{ledger_diag.get('knowledgeCandidateTotalsByEpistemicStatus', {})}`",
+        f"- atomic_knowledge_by_currentness: `{ledger_diag.get('knowledgeCandidateTotalsByCurrentness', {})}`",
+        f"- atomic_knowledge_root_kinds: `{ledger_diag.get('knowledgeCandidateRootKinds', {})}`",
+        f"- atomic_knowledge_receipt_events: `{ledger_diag.get('knowledgeCandidateReceiptEvents', {})}`",
+        f"- atomic_knowledge_rejections: `{ledger_diag.get('knowledgeCandidateRejectionsByReason', {})}`",
+        f"- atomic_knowledge_invalidations: `{ledger_diag.get('knowledgeCandidateInvalidationsByReason', {})}`",
+        f"- atomic_knowledge_orphaned_roots: `{ledger_diag.get('knowledgeCandidateOrphanedRoots', 0)}`",
+        f"- atomic_knowledge_missing_independent_roots: `{ledger_diag.get('knowledgeCandidateMissingIndependentRoots', 0)}`",
+        f"- atomic_knowledge_participant_isolation_violations: `{ledger_diag.get('knowledgeCandidateParticipantIsolationViolations', 0)}`",
+        f"- atomic_knowledge_derivative_only_rejections: `{ledger_diag.get('knowledgeCandidateDerivativeOnlyRejections', 0)}`",
+        f"- atomic_knowledge_live_eligible: `{ledger_diag.get('knowledgeCandidateLiveEligibleCount', 0)}`",
+        f"- atomic_knowledge_processing_errors: `{ledger_diag.get('knowledgeCandidateProcessingErrors', 0)}`",
+        f"- atomic_knowledge_correction_delete_privacy_invalidations: `{ledger_diag.get('knowledgeCandidateCorrectionDeletePrivacyInvalidations', 0)}`",
+        f"- atomic_knowledge_backfill: `{ledger_diag.get('knowledgeCandidateBackfill', {})}`",
         f"- memory_tiers_source_policy: `{memory_tier_source_policy_state}`",
         "- sealed_test_passive_capture: `disabled`",
         f"- sealed_test_conversation_rows: `{'present' if sealed_test_rows_present else 'none'}`",

--- a/bnl_memory_governance.py
+++ b/bnl_memory_governance.py
@@ -25,7 +25,13 @@ from bnl_journal_source_store import (
     journal_release_privacy_fence,
     purge_user_discord_sources_on_connection,
 )
-from bnl_memory_ledger import ensure_memory_ledger_schema, subject_key_for_user
+from bnl_memory_ledger import (
+    ensure_memory_ledger_schema,
+    form_atomic_candidate_from_ledger_entry,
+    purge_atomic_knowledge_for_subject,
+    record_atomic_knowledge_processing_error,
+    subject_key_for_user,
+)
 from bnl_moment_engine import select_public_participant_moment_gists
 from bnl_relationship_engine import complete_delete_relationship_v2, ensure_relationship_v2_schema, propagate_ledger_lifecycle
 
@@ -1361,6 +1367,23 @@ def correct_member_memory(conn: sqlite3.Connection, *, guild_id: int, user_id: i
             return {"ok": False, "reason": "invalid_correction_value"}
         entry_id = "mle_" + hashlib.sha256(("correction|%s|%s|%s|%s" % (guild_id, subject, target, _hash(corrected_text))).encode("utf-8")).hexdigest()[:40]
         conn.execute("INSERT OR IGNORE INTO memory_ledger_entries (entry_id,schema_version,guild_id,subject_key,subject_display_name,entry_type,predicate_key,normalized_value,source_class,source_table,source_row_id,source_role,visibility,confidence,public_usable,derived,projection,salience,observed_at,lifecycle_status,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", (entry_id, "memory_ledger_v1", guild_id, subject, "", "claim", prior[0], corrected_value[:1000], "first_party_record", "member_memory_control", rid, "member_control", "private", "high", 0, 0, 0, 1.0, now, "active", now, now))
+        conn.execute(
+            """
+            UPDATE memory_ledger_entries
+            SET route_mode='member_control',channel_policy='member_control'
+            WHERE guild_id=? AND entry_id=?
+            """,
+            (guild_id, entry_id),
+        )
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO memory_ledger_participants(
+              entry_id,guild_id,participant_key,display_name,
+              participant_role,order_index,created_at
+            ) VALUES(?,?,?,?,?,?,?)
+            """,
+            (entry_id, guild_id, subject, "", "control_actor", 0, now),
+        )
         conn.execute("INSERT OR IGNORE INTO memory_ledger_lineage VALUES (?,?,?,?,?)", (entry_id, guild_id, "correction_of", target, now)); conn.execute("INSERT OR IGNORE INTO memory_ledger_lineage VALUES (?,?,?,?,?)", (entry_id, guild_id, "supersedes", target, now))
         contribution_counts = _invalidate_contributions_for_ledger_entries(
             conn,
@@ -1387,6 +1410,21 @@ def correct_member_memory(conn: sqlite3.Connection, *, guild_id: int, user_id: i
             "live_facts": live_fact_updates,
         }
         receipt_counts.update(contribution_counts)
+        try:
+            form_atomic_candidate_from_ledger_entry(conn, entry_id)
+        except Exception as knowledge_exc:
+            try:
+                record_atomic_knowledge_processing_error(
+                    conn,
+                    guild_id=guild_id,
+                    reason_code=(
+                        "member_correction_" + type(knowledge_exc).__name__
+                    )[:120],
+                    candidate_type="person_role_fact",
+                    root_entry_ids=(entry_id,),
+                )
+            except Exception:
+                pass
         conn.execute("INSERT INTO memory_governance_receipts VALUES (?,?,?,?,?,?,?)", (rid, guild_id, _subject_hash(user_id), "correct", safe_ref, now, json.dumps(receipt_counts, sort_keys=True)))
     return {"ok": True, "receipt": rid, "ref": safe_ref}
 
@@ -2232,6 +2270,13 @@ def _complete_delete_member_data(conn: sqlite3.Connection, *, guild_id: int, use
             owned_ledger_ids
             | participant_model_ids
             | source_bound_raw_ids
+        )
+        counts.update(
+            purge_atomic_knowledge_for_subject(
+                conn,
+                guild_id=guild_id,
+                subject_key=subject,
+            )
         )
         deleted_ledger_source_refs: Set[Tuple[str, str]] = set()
         if delete_ledger_ids:

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 import hashlib
+import json
 import os
 import re
 import sqlite3
@@ -28,6 +29,8 @@ from bnl_canon_source_contract import (
 )
 
 MEMORY_LEDGER_SCHEMA_VERSION = "memory_ledger_v1"
+ATOMIC_KNOWLEDGE_SCHEMA_VERSION = "memory_ledger_atomic_knowledge_v1"
+ATOMIC_KNOWLEDGE_BACKFILL = "atomic_knowledge_backfill_v1"
 MEMORY_LEDGER_SHADOW_ENV = "BNL_MEMORY_LEDGER_SHADOW_ENABLED"
 BNL_SUBJECT_KEY = "bnl_01"
 
@@ -41,6 +44,88 @@ ACTIVE_LIFECYCLE = "active"
 REVIEW_ONLY_LIFECYCLE = "review_only"
 RESOLVED_LIFECYCLE = "resolved"
 REJECTED_LIFECYCLE = "rejected"
+
+KNOWLEDGE_CANDIDATE_TYPES = frozenset(
+    {
+        "topic_or_motif",
+        "person_role_fact",
+        "project_event_or_milestone",
+        "open_loop_or_question",
+        "inference_or_contested_claim",
+    }
+)
+KNOWLEDGE_EPISTEMIC_STATUSES = frozenset(
+    {
+        "stated",
+        "observed",
+        "source_abstraction",
+        "inference",
+        "contested",
+        "question",
+    }
+)
+KNOWLEDGE_CURRENTNESS = frozenset(
+    {"current", "historical", "open", "unresolved", "uncertain"}
+)
+KNOWLEDGE_CANDIDATE_STATES = frozenset(
+    {"candidate", "contested", "superseded", "invalidated"}
+)
+KNOWLEDGE_TERMINAL_ROOT_LIFECYCLES = frozenset(
+    {
+        "corrected",
+        "superseded",
+        "retracted",
+        "expired",
+        "quarantined",
+        "needs_review",
+        "forgotten",
+        "deleted",
+        "rejected",
+        "unresolved",
+    }
+)
+KNOWLEDGE_DERIVATIVE_SOURCE_CLASSES = frozenset(
+    {
+        SourceClass.DERIVED_SUMMARY.value,
+        SourceClass.EVIDENCE_PROJECTION.value,
+        SourceClass.SOURCE_FILE_PROJECTION.value,
+        SourceClass.DOSSIER_PROJECTION.value,
+        SourceClass.ENTITY_EVIDENCE_PROJECTION.value,
+        SourceClass.LEGACY_SOURCE_BLIND.value,
+    }
+)
+_KNOWLEDGE_AUTHORITY_RANK = {
+    SourceClass.LEGACY_SOURCE_BLIND.value: 0,
+    SourceClass.DERIVED_SUMMARY.value: 1,
+    SourceClass.ENTITY_EVIDENCE_PROJECTION.value: 1,
+    SourceClass.DOSSIER_PROJECTION.value: 1,
+    SourceClass.SOURCE_FILE_PROJECTION.value: 1,
+    SourceClass.EVIDENCE_PROJECTION.value: 1,
+    SourceClass.PUBLIC_OBSERVATION.value: 2,
+    SourceClass.RUNTIME_OBSERVATION.value: 3,
+    SourceClass.FIRST_PARTY_RECORD.value: 4,
+    SourceClass.APPROVED_CANON.value: 5,
+    SourceClass.OWNER_CORRECTION.value: 6,
+}
+_KNOWLEDGE_RESTRICTED_VISIBILITIES = frozenset(
+    {
+        Visibility.SEALED_TEST.value,
+        Visibility.PROTECTED.value,
+        Visibility.AI_IMAGE_TOOL.value,
+        Visibility.UNKNOWN.value,
+    }
+)
+_KNOWLEDGE_TEST_OR_OPERATIONAL_RE = re.compile(
+    r"\b(?:queue|rehearsal|synthetic[-\s]?artist|test[-\s]?payment|"
+    r"payment[-\s]?test|queue[-\s]?simulation|simulation[-\s]?queue|"
+    r"wheel(?:\s+spin)?|now[-\s]?playing|up[-\s]?next|priority[-\s]?signal|"
+    r"show[-\s]?test|showtest)\b",
+    re.I,
+)
+_KNOWLEDGE_TEST_OR_OPERATIONAL_SOURCE_RE = re.compile(
+    r"(?:queue|payment|wheel|rehearsal|show[_-]?test|simulation)",
+    re.I,
+)
 
 APPROVED_SELF_AUTHORED_FACT_KEYS = frozenset({
     "preferred_name",
@@ -97,6 +182,37 @@ class LedgerWriteResult:
 
     def __bool__(self) -> bool:
         return self.outcome in {"inserted", "deduplicated"} and bool(self.entry_id)
+
+
+@dataclass(frozen=True)
+class AtomicKnowledgeProposal:
+    candidate_type: str
+    subject_key: str
+    predicate_key: str
+    meaning: str
+    root_entry_ids: tuple[str, ...]
+    derivative_entry_ids: tuple[str, ...] = field(default_factory=tuple)
+    subject_display_name: str = ""
+    participant_keys: tuple[str, ...] = field(default_factory=tuple)
+    epistemic_status: str = "stated"
+    uncertainty_note: str = ""
+    currentness: str = "current"
+    contradiction_key: str = ""
+    retrieval_tags: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class AtomicKnowledgeResult:
+    candidate_id: str = ""
+    outcome: str = "rejected"
+    reason_code: str = "not_attempted"
+    candidate_type: str = ""
+    root_count: int = 0
+
+    def __bool__(self) -> bool:
+        return self.outcome in {"created", "matched_existing"} and bool(
+            self.candidate_id
+        )
 
 
 def shadow_enabled(environ: dict[str, str] | None = None) -> bool:
@@ -227,6 +343,120 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
             attempted_at TEXT NOT NULL, outcome TEXT NOT NULL, reason_code TEXT NOT NULL, entry_id TEXT DEFAULT ''
         )
     """)
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_ledger_knowledge_candidates (
+            candidate_id TEXT PRIMARY KEY,
+            schema_version TEXT NOT NULL,
+            guild_id INTEGER NOT NULL,
+            candidate_type TEXT NOT NULL,
+            subject_key TEXT NOT NULL,
+            subject_display_name TEXT DEFAULT '',
+            predicate_key TEXT NOT NULL,
+            normalized_value TEXT NOT NULL,
+            value_digest TEXT NOT NULL,
+            epistemic_status TEXT NOT NULL,
+            uncertainty_note TEXT DEFAULT '',
+            currentness TEXT NOT NULL,
+            candidate_state TEXT NOT NULL,
+            contradiction_key TEXT NOT NULL,
+            supersedes_candidate_id TEXT DEFAULT '',
+            visibility TEXT NOT NULL,
+            authority_class TEXT NOT NULL,
+            confidence_class TEXT NOT NULL,
+            route_scope_json TEXT NOT NULL,
+            participant_scope_digest TEXT NOT NULL,
+            first_seen_at TEXT DEFAULT '',
+            last_seen_at TEXT DEFAULT '',
+            retrieval_tags_json TEXT NOT NULL,
+            root_digest TEXT NOT NULL,
+            independent_root_count INTEGER NOT NULL DEFAULT 0,
+            derivative_root_count INTEGER NOT NULL DEFAULT 0,
+            candidate_eligible INTEGER NOT NULL DEFAULT 1,
+            live_eligible INTEGER NOT NULL DEFAULT 0,
+            promotion_status TEXT NOT NULL DEFAULT 'unpromoted',
+            invalidated_reason TEXT DEFAULT '',
+            invalidated_at TEXT DEFAULT '',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            UNIQUE(
+                schema_version, guild_id, candidate_type, subject_key,
+                predicate_key, contradiction_key, root_digest
+            )
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_ledger_knowledge_roots (
+            candidate_id TEXT NOT NULL,
+            guild_id INTEGER NOT NULL,
+            root_entry_id TEXT NOT NULL,
+            root_kind TEXT NOT NULL,
+            is_independent INTEGER NOT NULL DEFAULT 0,
+            source_class TEXT NOT NULL,
+            source_table TEXT NOT NULL,
+            source_row_id TEXT NOT NULL,
+            source_revision TEXT DEFAULT '',
+            source_role TEXT NOT NULL,
+            visibility TEXT NOT NULL,
+            confidence TEXT NOT NULL,
+            lifecycle_status TEXT NOT NULL,
+            root_status TEXT NOT NULL,
+            root_digest TEXT NOT NULL,
+            lineage_path_json TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY(candidate_id, root_entry_id)
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_ledger_knowledge_participants (
+            candidate_id TEXT NOT NULL,
+            guild_id INTEGER NOT NULL,
+            participant_key TEXT NOT NULL,
+            participant_role TEXT NOT NULL DEFAULT 'subject',
+            created_at TEXT NOT NULL,
+            PRIMARY KEY(candidate_id, participant_key, participant_role)
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_ledger_knowledge_receipts (
+            receipt_id TEXT PRIMARY KEY,
+            guild_id INTEGER NOT NULL,
+            candidate_id TEXT DEFAULT '',
+            event_type TEXT NOT NULL,
+            reason_code TEXT NOT NULL,
+            candidate_type TEXT DEFAULT '',
+            root_count INTEGER NOT NULL DEFAULT 0,
+            occurred_at TEXT NOT NULL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_ledger_knowledge_backfill (
+            migration_key TEXT PRIMARY KEY,
+            phase TEXT NOT NULL,
+            cursor_value TEXT DEFAULT '',
+            completed INTEGER NOT NULL DEFAULT 0,
+            counts_json TEXT NOT NULL DEFAULT '{}',
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    for sql in (
+        "ALTER TABLE memory_ledger_knowledge_candidates ADD COLUMN confidence_class TEXT NOT NULL DEFAULT 'unknown'",
+        "ALTER TABLE memory_ledger_knowledge_roots ADD COLUMN confidence TEXT NOT NULL DEFAULT 'unknown'",
+    ):
+        try:
+            cur.execute(sql)
+        except sqlite3.OperationalError:
+            pass
     for sql in [
         "CREATE INDEX IF NOT EXISTS idx_mle_guild ON memory_ledger_entries(guild_id)",
         "CREATE INDEX IF NOT EXISTS idx_mle_subject ON memory_ledger_entries(guild_id, subject_key)",
@@ -239,8 +469,242 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_mll_guild ON memory_ledger_lineage(guild_id, lineage_type, target_entry_id)",
         "CREATE INDEX IF NOT EXISTS idx_mlp_participant ON memory_ledger_participants(guild_id, participant_key, order_index)",
         "CREATE INDEX IF NOT EXISTS idx_mlr_guild ON memory_ledger_shadow_receipts(guild_id, writer, outcome, reason_code)",
+        "CREATE INDEX IF NOT EXISTS idx_mlkc_guild_type ON memory_ledger_knowledge_candidates(guild_id, candidate_type, candidate_state)",
+        "CREATE INDEX IF NOT EXISTS idx_mlkc_subject ON memory_ledger_knowledge_candidates(guild_id, subject_key, candidate_state)",
+        "CREATE INDEX IF NOT EXISTS idx_mlkc_contradiction ON memory_ledger_knowledge_candidates(guild_id, contradiction_key, candidate_state)",
+        "CREATE INDEX IF NOT EXISTS idx_mlkc_visibility ON memory_ledger_knowledge_candidates(guild_id, visibility, authority_class)",
+        "CREATE INDEX IF NOT EXISTS idx_mlkr_root ON memory_ledger_knowledge_roots(guild_id, root_entry_id, root_status)",
+        "CREATE INDEX IF NOT EXISTS idx_mlkp_participant ON memory_ledger_knowledge_participants(guild_id, participant_key)",
+        "CREATE INDEX IF NOT EXISTS idx_mlkreceipt_event ON memory_ledger_knowledge_receipts(guild_id, event_type, reason_code)",
     ]:
         cur.execute(sql)
+    cur.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_atomic_knowledge_root_delete
+        AFTER DELETE ON memory_ledger_entries
+        BEGIN
+          INSERT OR IGNORE INTO memory_ledger_knowledge_receipts(
+            receipt_id,guild_id,candidate_id,event_type,reason_code,
+            candidate_type,root_count,occurred_at
+          )
+          SELECT
+            'trigger:root_deleted:' || c.candidate_id || ':' || OLD.entry_id,
+            c.guild_id,c.candidate_id,'invalidated','root_deleted',
+            c.candidate_type,c.independent_root_count + c.derivative_root_count,
+            CURRENT_TIMESTAMP
+          FROM memory_ledger_knowledge_candidates c
+          JOIN memory_ledger_knowledge_roots r
+            ON r.candidate_id=c.candidate_id AND r.guild_id=c.guild_id
+          WHERE r.root_entry_id=OLD.entry_id;
+
+          UPDATE memory_ledger_knowledge_candidates
+          SET normalized_value='',candidate_state='invalidated',
+              candidate_eligible=0,live_eligible=0,
+              invalidated_reason='root_deleted',
+              invalidated_at=CURRENT_TIMESTAMP,updated_at=CURRENT_TIMESTAMP
+          WHERE candidate_id IN (
+            SELECT candidate_id FROM memory_ledger_knowledge_roots
+            WHERE root_entry_id=OLD.entry_id
+          );
+
+          UPDATE memory_ledger_knowledge_roots
+          SET lifecycle_status='deleted',root_status='deleted',
+              updated_at=CURRENT_TIMESTAMP
+          WHERE root_entry_id=OLD.entry_id;
+        END
+        """
+    )
+    cur.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_atomic_knowledge_root_change
+        AFTER UPDATE OF lifecycle_status,normalized_value,public_usable,
+          visibility,source_class,confidence,subject_key,channel_policy,
+          route_mode
+        ON memory_ledger_entries
+        WHEN
+          NEW.lifecycle_status IS NOT OLD.lifecycle_status
+          OR NEW.normalized_value IS NOT OLD.normalized_value
+          OR NEW.public_usable IS NOT OLD.public_usable
+          OR NEW.visibility IS NOT OLD.visibility
+          OR NEW.source_class IS NOT OLD.source_class
+          OR NEW.confidence IS NOT OLD.confidence
+          OR NEW.subject_key IS NOT OLD.subject_key
+          OR NEW.channel_policy IS NOT OLD.channel_policy
+          OR NEW.route_mode IS NOT OLD.route_mode
+        BEGIN
+          INSERT OR IGNORE INTO memory_ledger_knowledge_receipts(
+            receipt_id,guild_id,candidate_id,event_type,reason_code,
+            candidate_type,root_count,occurred_at
+          )
+          SELECT
+            'trigger:root_changed:' || c.candidate_id || ':' ||
+              NEW.entry_id || ':' || NEW.lifecycle_status,
+            c.guild_id,c.candidate_id,
+            CASE
+              WHEN NEW.lifecycle_status IN ('corrected','superseded')
+                THEN 'superseded'
+              ELSE 'invalidated'
+            END,
+            CASE
+              WHEN NEW.lifecycle_status IN ('corrected','superseded')
+                THEN 'root_superseded'
+              WHEN NEW.lifecycle_status IN ('forgotten','deleted','retracted')
+                THEN 'root_privacy_or_deletion'
+              WHEN NEW.public_usable IS NOT OLD.public_usable
+                OR NEW.visibility IS NOT OLD.visibility
+                OR NEW.source_class IS NOT OLD.source_class
+                OR NEW.subject_key IS NOT OLD.subject_key
+                OR NEW.channel_policy IS NOT OLD.channel_policy
+                OR NEW.route_mode IS NOT OLD.route_mode
+                THEN 'root_privacy_or_provenance_changed'
+              WHEN NEW.confidence IS NOT OLD.confidence
+                THEN 'root_confidence_changed'
+              ELSE 'root_changed'
+            END,
+            c.candidate_type,c.independent_root_count + c.derivative_root_count,
+            CURRENT_TIMESTAMP
+          FROM memory_ledger_knowledge_candidates c
+          JOIN memory_ledger_knowledge_roots r
+            ON r.candidate_id=c.candidate_id AND r.guild_id=c.guild_id
+          WHERE r.root_entry_id=NEW.entry_id;
+
+          UPDATE memory_ledger_knowledge_candidates
+          SET
+            normalized_value=CASE
+              WHEN NEW.lifecycle_status IN ('forgotten','deleted','retracted')
+                OR COALESCE(NEW.normalized_value,'')=''
+                OR NEW.public_usable IS NOT OLD.public_usable
+                OR NEW.visibility IS NOT OLD.visibility
+                OR NEW.source_class IS NOT OLD.source_class
+                OR NEW.subject_key IS NOT OLD.subject_key
+                OR NEW.channel_policy IS NOT OLD.channel_policy
+                OR NEW.route_mode IS NOT OLD.route_mode
+                THEN ''
+              ELSE normalized_value
+            END,
+            candidate_state=CASE
+              WHEN NEW.lifecycle_status IN ('corrected','superseded')
+                THEN 'superseded'
+              ELSE 'invalidated'
+            END,
+            candidate_eligible=0,live_eligible=0,
+            invalidated_reason=CASE
+              WHEN NEW.lifecycle_status IN ('corrected','superseded')
+                THEN 'root_superseded'
+              WHEN NEW.lifecycle_status IN ('forgotten','deleted','retracted')
+                THEN 'root_privacy_or_deletion'
+              WHEN NEW.public_usable IS NOT OLD.public_usable
+                OR NEW.visibility IS NOT OLD.visibility
+                OR NEW.source_class IS NOT OLD.source_class
+                OR NEW.subject_key IS NOT OLD.subject_key
+                OR NEW.channel_policy IS NOT OLD.channel_policy
+                OR NEW.route_mode IS NOT OLD.route_mode
+                THEN 'root_privacy_or_provenance_changed'
+              WHEN NEW.confidence IS NOT OLD.confidence
+                THEN 'root_confidence_changed'
+              ELSE 'root_changed'
+            END,
+            invalidated_at=CURRENT_TIMESTAMP,updated_at=CURRENT_TIMESTAMP
+          WHERE candidate_id IN (
+            SELECT candidate_id FROM memory_ledger_knowledge_roots
+            WHERE root_entry_id=NEW.entry_id
+          );
+
+          UPDATE memory_ledger_knowledge_roots
+          SET lifecycle_status=NEW.lifecycle_status,
+              source_class=NEW.source_class,
+              visibility=NEW.visibility,
+              confidence=NEW.confidence,
+              root_status=CASE
+                WHEN NEW.lifecycle_status IN ('active','review_only')
+                  THEN 'changed'
+                ELSE NEW.lifecycle_status
+              END,
+              updated_at=CURRENT_TIMESTAMP
+          WHERE root_entry_id=NEW.entry_id;
+        END
+        """
+    )
+    cur.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_atomic_knowledge_participant_delete
+        AFTER DELETE ON memory_ledger_participants
+        BEGIN
+          INSERT OR IGNORE INTO memory_ledger_knowledge_receipts(
+            receipt_id,guild_id,candidate_id,event_type,reason_code,
+            candidate_type,root_count,occurred_at
+          )
+          SELECT
+            'trigger:participant_deleted:' || c.candidate_id || ':' ||
+              OLD.entry_id || ':' || OLD.participant_key,
+            c.guild_id,c.candidate_id,'invalidated','participant_deleted',
+            c.candidate_type,c.independent_root_count + c.derivative_root_count,
+            CURRENT_TIMESTAMP
+          FROM memory_ledger_knowledge_candidates c
+          JOIN memory_ledger_knowledge_roots r
+            ON r.candidate_id=c.candidate_id AND r.guild_id=c.guild_id
+          WHERE r.root_entry_id=OLD.entry_id;
+
+          UPDATE memory_ledger_knowledge_candidates
+          SET normalized_value='',candidate_state='invalidated',
+              candidate_eligible=0,live_eligible=0,
+              invalidated_reason='participant_deleted',
+              invalidated_at=CURRENT_TIMESTAMP,updated_at=CURRENT_TIMESTAMP
+          WHERE candidate_id IN (
+            SELECT candidate_id FROM memory_ledger_knowledge_roots
+            WHERE root_entry_id=OLD.entry_id
+          );
+        END
+        """
+    )
+    cur.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_atomic_knowledge_lineage_change
+        AFTER INSERT ON memory_ledger_lineage
+        WHEN NEW.lineage_type IN ('correction_of','supersedes','retracts')
+        BEGIN
+          INSERT OR IGNORE INTO memory_ledger_knowledge_receipts(
+            receipt_id,guild_id,candidate_id,event_type,reason_code,
+            candidate_type,root_count,occurred_at
+          )
+          SELECT
+            'trigger:lineage:' || NEW.lineage_type || ':' ||
+              c.candidate_id || ':' || NEW.entry_id,
+            c.guild_id,c.candidate_id,
+            CASE
+              WHEN NEW.lineage_type='supersedes' THEN 'superseded'
+              WHEN NEW.lineage_type='correction_of' THEN 'contested'
+              ELSE 'invalidated'
+            END,
+            'root_' || NEW.lineage_type,
+            c.candidate_type,c.independent_root_count + c.derivative_root_count,
+            CURRENT_TIMESTAMP
+          FROM memory_ledger_knowledge_candidates c
+          JOIN memory_ledger_knowledge_roots r
+            ON r.candidate_id=c.candidate_id AND r.guild_id=c.guild_id
+          WHERE r.root_entry_id=NEW.target_entry_id;
+
+          UPDATE memory_ledger_knowledge_candidates
+          SET
+            normalized_value=CASE
+              WHEN NEW.lineage_type='retracts' THEN ''
+              ELSE normalized_value
+            END,
+            candidate_state=CASE
+              WHEN NEW.lineage_type='supersedes' THEN 'superseded'
+              WHEN NEW.lineage_type='correction_of' THEN 'contested'
+              ELSE 'invalidated'
+            END,
+            candidate_eligible=0,live_eligible=0,
+            invalidated_reason='root_' || NEW.lineage_type,
+            invalidated_at=CURRENT_TIMESTAMP,updated_at=CURRENT_TIMESTAMP
+          WHERE candidate_id IN (
+            SELECT candidate_id FROM memory_ledger_knowledge_roots
+            WHERE root_entry_id=NEW.target_entry_id
+          );
+        END
+        """
+    )
 
 
 def record_shadow_receipt(conn: sqlite3.Connection, *, guild_id: int, writer: str, source_table: str, source_row_id: int | str, source_revision: str = "", source_event_key: str = "", outcome: str, reason_code: str, entry_id: str = "") -> None:
@@ -278,6 +742,1602 @@ def insert_ledger_entry(conn: sqlite3.Connection, entry: LedgerEntry) -> LedgerW
             if lineage_type in LINEAGE_TYPES and target:
                 cur.execute("INSERT OR IGNORE INTO memory_ledger_lineage VALUES (?, ?, ?, ?, ?)", (entry.entry_id, entry.guild_id, lineage_type, target, now))
     return LedgerWriteResult(entry.entry_id, outcome, "ok" if outcome == "inserted" else "exact_source_duplicate", entry.source_table, str(entry.source_row_id), entry.source_revision, entry.source_event_key, entry.guild_id)
+
+
+def _knowledge_text(value: Any, limit: int = 1000) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip()[:limit]
+
+
+def _knowledge_tag(value: Any) -> str:
+    return re.sub(
+        r"[^a-z0-9_.:-]+",
+        "_",
+        str(value or "").strip().lower(),
+    ).strip("_")[:64]
+
+
+def _knowledge_digest(*parts: Any) -> str:
+    return hashlib.sha256(
+        "\x1f".join(str(part or "") for part in parts).encode("utf-8")
+    ).hexdigest()
+
+
+def _stable_knowledge_candidate_id(
+    *,
+    guild_id: int,
+    candidate_type: str,
+    subject_key: str,
+    predicate_key: str,
+    contradiction_key: str,
+    root_entry_ids: tuple[str, ...],
+) -> str:
+    digest = _knowledge_digest(
+        ATOMIC_KNOWLEDGE_SCHEMA_VERSION,
+        int(guild_id or 0),
+        candidate_type,
+        subject_key,
+        predicate_key,
+        contradiction_key,
+        *sorted(set(root_entry_ids)),
+    )
+    return "mlkc_" + digest[:40]
+
+
+def _knowledge_receipt_id(
+    *,
+    event_type: str,
+    reason_code: str,
+    candidate_id: str,
+    candidate_type: str,
+    root_entry_ids: tuple[str, ...],
+    proposal_digest: str = "",
+) -> str:
+    return "mlkrec_" + _knowledge_digest(
+        event_type,
+        reason_code,
+        candidate_id,
+        candidate_type,
+        proposal_digest,
+        *sorted(set(root_entry_ids)),
+    )[:40]
+
+
+def _record_knowledge_receipt(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    event_type: str,
+    reason_code: str,
+    candidate_id: str = "",
+    candidate_type: str = "",
+    root_entry_ids: tuple[str, ...] = (),
+    proposal_digest: str = "",
+) -> None:
+    ensure_memory_ledger_schema(conn)
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO memory_ledger_knowledge_receipts(
+          receipt_id,guild_id,candidate_id,event_type,reason_code,
+          candidate_type,root_count,occurred_at
+        ) VALUES(?,?,?,?,?,?,?,?)
+        """,
+        (
+            _knowledge_receipt_id(
+                event_type=event_type,
+                reason_code=reason_code,
+                candidate_id=candidate_id,
+                candidate_type=candidate_type,
+                root_entry_ids=root_entry_ids,
+                proposal_digest=proposal_digest,
+            ),
+            int(guild_id or 0),
+            candidate_id,
+            event_type[:40],
+            reason_code[:120],
+            candidate_type[:80],
+            len(set(root_entry_ids)),
+            _now(),
+        ),
+    )
+
+
+def record_atomic_knowledge_processing_error(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    reason_code: str = "processing_error",
+    candidate_type: str = "",
+    root_entry_ids: tuple[str, ...] = (),
+) -> None:
+    _record_knowledge_receipt(
+        conn,
+        guild_id=guild_id,
+        event_type="error",
+        reason_code=reason_code,
+        candidate_type=candidate_type,
+        root_entry_ids=root_entry_ids,
+    )
+
+
+def _reject_atomic_knowledge(
+    conn: sqlite3.Connection,
+    proposal: AtomicKnowledgeProposal,
+    *,
+    guild_id: int,
+    reason_code: str,
+    root_entry_ids: tuple[str, ...],
+) -> AtomicKnowledgeResult:
+    if not int(guild_id or 0) and root_entry_ids:
+        placeholders = ",".join("?" for _entry_id in root_entry_ids)
+        guild_rows = conn.execute(
+            """
+            SELECT DISTINCT guild_id
+            FROM memory_ledger_entries
+            WHERE entry_id IN (%s)
+            """ % placeholders,
+            tuple(root_entry_ids),
+        ).fetchall()
+        if len(guild_rows) == 1:
+            guild_id = int(guild_rows[0][0] or 0)
+    _record_knowledge_receipt(
+        conn,
+        guild_id=guild_id,
+        event_type="rejected",
+        reason_code=reason_code,
+        candidate_type=proposal.candidate_type,
+        root_entry_ids=root_entry_ids,
+        proposal_digest=_knowledge_digest(
+            proposal.subject_key,
+            proposal.predicate_key,
+            _canon(proposal.meaning),
+        ),
+    )
+    return AtomicKnowledgeResult(
+        outcome="rejected",
+        reason_code=reason_code,
+        candidate_type=proposal.candidate_type,
+        root_count=len(set(root_entry_ids)),
+    )
+
+
+def _knowledge_entry_rows(
+    conn: sqlite3.Connection,
+    entry_ids: tuple[str, ...],
+) -> dict[str, dict[str, Any]]:
+    if not entry_ids:
+        return {}
+    placeholders = ",".join("?" for _entry_id in entry_ids)
+    rows = conn.execute(
+        """
+        SELECT
+          entry_id,guild_id,subject_key,subject_display_name,entry_type,
+          predicate_key,normalized_value,source_class,source_table,
+          source_row_id,source_revision,source_role,route_mode,channel_id,
+          channel_name,channel_policy,visibility,confidence,public_usable,
+          derived,projection,observed_at,lifecycle_status
+        FROM memory_ledger_entries
+        WHERE entry_id IN (%s)
+        """ % placeholders,
+        tuple(entry_ids),
+    ).fetchall()
+    by_id: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        by_id[str(row[0])] = {
+            "entry_id": str(row[0]),
+            "guild_id": int(row[1] or 0),
+            "subject_key": str(row[2] or ""),
+            "subject_display_name": str(row[3] or ""),
+            "entry_type": str(row[4] or ""),
+            "predicate_key": str(row[5] or ""),
+            "normalized_value": str(row[6] or ""),
+            "source_class": str(row[7] or ""),
+            "source_table": str(row[8] or ""),
+            "source_row_id": str(row[9] or ""),
+            "source_revision": str(row[10] or ""),
+            "source_role": str(row[11] or ""),
+            "route_mode": str(row[12] or ""),
+            "channel_id": int(row[13] or 0),
+            "channel_name": str(row[14] or ""),
+            "channel_policy": str(row[15] or ""),
+            "visibility": str(row[16] or ""),
+            "confidence": str(row[17] or "unknown"),
+            "public_usable": bool(row[18]),
+            "derived": bool(row[19]),
+            "projection": bool(row[20]),
+            "observed_at": str(row[21] or ""),
+            "lifecycle_status": str(row[22] or ""),
+        }
+    if by_id:
+        placeholders = ",".join("?" for _entry_id in by_id)
+        for entry_id, participant_key, participant_role in conn.execute(
+            """
+            SELECT entry_id,participant_key,participant_role
+            FROM memory_ledger_participants
+            WHERE entry_id IN (%s)
+            ORDER BY entry_id,order_index,participant_key
+            """ % placeholders,
+            tuple(by_id),
+        ).fetchall():
+            by_id[str(entry_id)].setdefault("participants", []).append(
+                (str(participant_key or ""), str(participant_role or "participant"))
+            )
+    for row in by_id.values():
+        row.setdefault("participants", [])
+    return by_id
+
+
+def _derivation_paths(
+    conn: sqlite3.Connection,
+    derivative_entry_id: str,
+    *,
+    max_depth: int = 8,
+    max_nodes: int = 128,
+) -> dict[str, tuple[str, ...]]:
+    """Return bounded derived-from paths without treating them as authority."""
+    paths: dict[str, tuple[str, ...]] = {}
+    frontier: list[tuple[str, tuple[str, ...]]] = [
+        (derivative_entry_id, (derivative_entry_id,))
+    ]
+    visited = {derivative_entry_id}
+    while frontier and len(visited) <= max_nodes:
+        current, path = frontier.pop(0)
+        if len(path) > max_depth:
+            continue
+        targets = conn.execute(
+            """
+            SELECT target_entry_id
+            FROM memory_ledger_lineage
+            WHERE entry_id=? AND lineage_type='derived_from'
+            ORDER BY target_entry_id
+            """,
+            (current,),
+        ).fetchall()
+        for (target_raw,) in targets:
+            target = str(target_raw or "")
+            if not target:
+                continue
+            candidate_path = (*path, target)
+            paths.setdefault(target, candidate_path)
+            if target not in visited:
+                visited.add(target)
+                frontier.append((target, candidate_path))
+    return paths
+
+
+def _knowledge_visibility(values: set[str]) -> tuple[str, str]:
+    values = {str(value or "unknown") for value in values}
+    if values.intersection(_KNOWLEDGE_RESTRICTED_VISIBILITIES):
+        return "", "restricted_or_unknown_visibility"
+    nonpublic = values.intersection({"internal", "private", "mod"})
+    if len(nonpublic) > 1:
+        return "", "ambiguous_nonpublic_visibility"
+    if nonpublic:
+        return next(iter(nonpublic)), ""
+    if values == {Visibility.REFERENCE_CANON.value}:
+        return Visibility.REFERENCE_CANON.value, ""
+    if values.issubset(
+        {
+            Visibility.PUBLIC.value,
+            Visibility.PUBLIC_SAFE.value,
+            Visibility.REFERENCE_CANON.value,
+        }
+    ):
+        return (
+            Visibility.PUBLIC.value
+            if values == {Visibility.PUBLIC.value}
+            else Visibility.PUBLIC_SAFE.value
+        ), ""
+    return "", "ambiguous_visibility"
+
+
+def _knowledge_route_visibility_is_explicit(entry: dict[str, Any]) -> bool:
+    policy = str(entry.get("channel_policy") or "").strip()
+    visibility = str(entry.get("visibility") or "").strip()
+    if policy == "member_control":
+        return visibility in {
+            Visibility.PRIVATE.value,
+            Visibility.PUBLIC_SAFE.value,
+        }
+    if not has_explicit_channel_policy_mapping(policy):
+        return False
+    return map_channel_policy_visibility(policy).value == visibility
+
+
+def _knowledge_is_derivative(entry: dict[str, Any]) -> bool:
+    return bool(
+        entry.get("derived")
+        or entry.get("projection")
+        or entry.get("source_class") in KNOWLEDGE_DERIVATIVE_SOURCE_CLASSES
+        or str(entry.get("source_role") or "").lower() in {"model", "assistant"}
+    )
+
+
+def _knowledge_operational_or_test_source(
+    entry: dict[str, Any],
+) -> bool:
+    metadata = " ".join(
+        str(entry.get(key) or "")
+        for key in (
+            "source_table",
+            "source_role",
+            "entry_type",
+            "predicate_key",
+            "route_mode",
+            "channel_name",
+            "channel_policy",
+        )
+    )
+    if _KNOWLEDGE_TEST_OR_OPERATIONAL_SOURCE_RE.search(metadata):
+        return True
+    return bool(
+        _KNOWLEDGE_TEST_OR_OPERATIONAL_RE.search(
+            str(entry.get("normalized_value") or "")
+        )
+    )
+
+
+def _knowledge_participant_scope(
+    proposal: AtomicKnowledgeProposal,
+    independent_entries: list[dict[str, Any]],
+) -> tuple[tuple[str, ...], str]:
+    scopes: list[tuple[str, ...]] = []
+    for entry in independent_entries:
+        scope = tuple(
+            sorted(
+                {
+                    str(participant_key or "")
+                    for participant_key, _role in entry.get("participants", [])
+                    if str(participant_key or "")
+                }
+            )
+        )
+        scopes.append(scope)
+    if scopes and any(scope != scopes[0] for scope in scopes[1:]):
+        return (), "participant_scope_mismatch"
+    derived_scope = scopes[0] if scopes else ()
+    requested = tuple(
+        sorted(
+            {
+                str(participant_key or "")
+                for participant_key in proposal.participant_keys
+                if str(participant_key or "")
+            }
+        )
+    )
+    if requested and requested != derived_scope:
+        return (), "participant_scope_mismatch"
+    participants = requested or derived_scope
+    if proposal.subject_key.startswith("discord_user:"):
+        if proposal.subject_key not in participants:
+            return (), "ambiguous_subject_participant_identity"
+    return participants, ""
+
+
+def form_atomic_knowledge_candidate(
+    conn: sqlite3.Connection,
+    proposal: AtomicKnowledgeProposal,
+) -> AtomicKnowledgeResult:
+    """Atomically form one candidate without owning the caller transaction."""
+    ensure_memory_ledger_schema(conn)
+    savepoint = f"atomic_knowledge_{id(proposal):x}"
+    conn.execute(f"SAVEPOINT {savepoint}")
+    try:
+        result = _form_atomic_knowledge_candidate_impl(conn, proposal)
+    except Exception:
+        conn.execute(f"ROLLBACK TO {savepoint}")
+        conn.execute(f"RELEASE {savepoint}")
+        raise
+    conn.execute(f"RELEASE {savepoint}")
+    return result
+
+
+def _form_atomic_knowledge_candidate_impl(
+    conn: sqlite3.Connection,
+    proposal: AtomicKnowledgeProposal,
+) -> AtomicKnowledgeResult:
+    """Create one unpromoted candidate from exact revalidated Ledger roots."""
+    candidate_type = _canon(proposal.candidate_type)
+    subject_key = str(proposal.subject_key or "").strip()
+    predicate_key = _knowledge_tag(proposal.predicate_key)
+    meaning = _knowledge_text(proposal.meaning)
+    independent_ids = tuple(
+        sorted(
+            {
+                str(entry_id or "").strip()
+                for entry_id in proposal.root_entry_ids
+                if str(entry_id or "").strip()
+            }
+        )
+    )
+    derivative_ids = tuple(
+        sorted(
+            {
+                str(entry_id or "").strip()
+                for entry_id in proposal.derivative_entry_ids
+                if str(entry_id or "").strip()
+            }
+        )
+    )
+    all_ids = tuple(sorted(set(independent_ids + derivative_ids)))
+    guild_hint = 0
+    if candidate_type not in KNOWLEDGE_CANDIDATE_TYPES:
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_hint,
+            reason_code="unsupported_candidate_type",
+            root_entry_ids=all_ids,
+        )
+    if (
+        not subject_key
+        or subject_key == "unknown"
+        or subject_key.startswith("moment:")
+    ):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_hint,
+            reason_code="ambiguous_subject_identity",
+            root_entry_ids=all_ids,
+        )
+    if not predicate_key or not meaning:
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_hint,
+            reason_code="missing_candidate_meaning",
+            root_entry_ids=all_ids,
+        )
+    if not independent_ids:
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_hint,
+            reason_code="derivative_only_no_independent_root",
+            root_entry_ids=all_ids,
+        )
+    if len(independent_ids) > 16 or len(derivative_ids) > 4:
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_hint,
+            reason_code="root_set_too_large",
+            root_entry_ids=all_ids,
+        )
+    if set(independent_ids).intersection(derivative_ids):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_hint,
+            reason_code="ambiguous_root_role",
+            root_entry_ids=all_ids,
+        )
+    if proposal.epistemic_status not in KNOWLEDGE_EPISTEMIC_STATUSES:
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_hint,
+            reason_code="ambiguous_epistemic_status",
+            root_entry_ids=all_ids,
+        )
+    if proposal.currentness not in KNOWLEDGE_CURRENTNESS:
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_hint,
+            reason_code="ambiguous_currentness",
+            root_entry_ids=all_ids,
+        )
+    if (
+        candidate_type == "inference_or_contested_claim"
+        and proposal.epistemic_status not in {"inference", "contested"}
+    ):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_hint,
+            reason_code="inference_label_required",
+            root_entry_ids=all_ids,
+        )
+
+    entries = _knowledge_entry_rows(conn, all_ids)
+    if len(entries) != len(all_ids):
+        present_guilds = {
+            int(entry.get("guild_id") or 0) for entry in entries.values()
+        }
+        guild_hint = next(iter(present_guilds)) if len(present_guilds) == 1 else 0
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_hint,
+            reason_code="missing_or_orphaned_root",
+            root_entry_ids=all_ids,
+        )
+    guilds = {int(entry.get("guild_id") or 0) for entry in entries.values()}
+    if len(guilds) != 1 or not next(iter(guilds)):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=0,
+            reason_code="cross_guild_or_ambiguous_provenance",
+            root_entry_ids=all_ids,
+        )
+    guild_id = next(iter(guilds))
+    guild_hint = guild_id
+    independent_entries = [entries[entry_id] for entry_id in independent_ids]
+    derivative_entries = [entries[entry_id] for entry_id in derivative_ids]
+
+    if any(
+        entry.get("source_class") == SourceClass.LEGACY_SOURCE_BLIND.value
+        for entry in entries.values()
+    ):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code="source_blind_provenance",
+            root_entry_ids=all_ids,
+        )
+    if any(_knowledge_is_derivative(entry) for entry in independent_entries):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code="derivative_misclassified_as_independent",
+            root_entry_ids=all_ids,
+        )
+    if any(not _knowledge_is_derivative(entry) for entry in derivative_entries):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code="ambiguous_derivative_provenance",
+            root_entry_ids=all_ids,
+        )
+    if any(
+        _knowledge_operational_or_test_source(entry)
+        for entry in entries.values()
+    ):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code="operational_or_rehearsal_source_excluded",
+            root_entry_ids=all_ids,
+        )
+    if any(
+        entry.get("lifecycle_status") != ACTIVE_LIFECYCLE
+        for entry in independent_entries
+    ):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code="ineligible_root_lifecycle",
+            root_entry_ids=all_ids,
+        )
+    if any(
+        entry.get("lifecycle_status")
+        not in {ACTIVE_LIFECYCLE, REVIEW_ONLY_LIFECYCLE}
+        for entry in derivative_entries
+    ):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code="ineligible_derivative_lifecycle",
+            root_entry_ids=all_ids,
+        )
+    if conn.execute(
+        """
+        SELECT 1
+        FROM memory_ledger_lineage
+        WHERE target_entry_id IN (%s)
+          AND lineage_type IN ('supersedes','retracts')
+        LIMIT 1
+        """ % ",".join("?" for _entry_id in independent_ids),
+        independent_ids,
+    ).fetchone():
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code="root_superseded_or_retracted",
+            root_entry_ids=all_ids,
+        )
+    if any(
+        not str(entry.get("route_mode") or "").strip()
+        or str(entry.get("route_mode") or "").strip() == "unknown"
+        or not str(entry.get("channel_policy") or "").strip()
+        or str(entry.get("channel_policy") or "").strip() == "unknown"
+        for entry in entries.values()
+    ):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code="ambiguous_route_or_policy",
+            root_entry_ids=all_ids,
+        )
+    if any(
+        not _knowledge_route_visibility_is_explicit(entry)
+        for entry in entries.values()
+    ):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code="route_visibility_contract_mismatch",
+            root_entry_ids=all_ids,
+        )
+
+    root_subjects = {
+        str(entry.get("subject_key") or "") for entry in independent_entries
+    }
+    if root_subjects != {subject_key}:
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code="subject_root_isolation_failure",
+            root_entry_ids=all_ids,
+        )
+    participants, participant_reason = _knowledge_participant_scope(
+        proposal,
+        independent_entries,
+    )
+    if participant_reason:
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code=participant_reason,
+            root_entry_ids=all_ids,
+        )
+    for derivative in derivative_entries:
+        derivative_participants = {
+            participant_key
+            for participant_key, _role in derivative.get("participants", [])
+            if participant_key
+        }
+        if derivative_participants and subject_key not in derivative_participants:
+            return _reject_atomic_knowledge(
+                conn,
+                proposal,
+                guild_id=guild_id,
+                reason_code="derivative_participant_isolation_failure",
+                root_entry_ids=all_ids,
+            )
+
+    derivation_paths: dict[str, dict[str, tuple[str, ...]]] = {}
+    for derivative_id in derivative_ids:
+        paths = _derivation_paths(conn, derivative_id)
+        derivation_paths[derivative_id] = paths
+        if any(root_id not in paths for root_id in independent_ids):
+            return _reject_atomic_knowledge(
+                conn,
+                proposal,
+                guild_id=guild_id,
+                reason_code="derivative_lineage_incomplete",
+                root_entry_ids=all_ids,
+            )
+
+    visibility, visibility_reason = _knowledge_visibility(
+        {str(entry.get("visibility") or "unknown") for entry in entries.values()}
+    )
+    if visibility_reason:
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code=visibility_reason,
+            root_entry_ids=all_ids,
+        )
+    if (
+        visibility
+        in {
+            Visibility.PUBLIC.value,
+            Visibility.PUBLIC_SAFE.value,
+            Visibility.REFERENCE_CANON.value,
+        }
+        and any(not entry.get("public_usable") for entry in independent_entries)
+    ):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code="public_source_not_usable",
+            root_entry_ids=all_ids,
+        )
+    if any(
+        entry.get("public_usable")
+        and str(entry.get("visibility") or "")
+        not in {
+            Visibility.PUBLIC.value,
+            Visibility.PUBLIC_SAFE.value,
+            Visibility.REFERENCE_CANON.value,
+        }
+        for entry in entries.values()
+    ):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code="nonpublic_source_marked_public_usable",
+            root_entry_ids=all_ids,
+        )
+
+    authority_values = {
+        str(entry.get("source_class") or "") for entry in independent_entries
+    }
+    if any(value not in _KNOWLEDGE_AUTHORITY_RANK for value in authority_values):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code="ambiguous_authority",
+            root_entry_ids=all_ids,
+        )
+    authority_class = min(
+        authority_values,
+        key=lambda value: (_KNOWLEDGE_AUTHORITY_RANK[value], value),
+    )
+    confidence_rank = {
+        Confidence.UNKNOWN.value: 0,
+        Confidence.LOW.value: 1,
+        Confidence.MEDIUM.value: 2,
+        Confidence.HIGH.value: 3,
+        Confidence.APPROVED.value: 4,
+    }
+    confidence_values = {
+        str(entry.get("confidence") or Confidence.UNKNOWN.value)
+        for entry in independent_entries
+    }
+    confidence_class = min(
+        confidence_values,
+        key=lambda value: (confidence_rank.get(value, 0), value),
+    )
+    contradiction_key = _knowledge_tag(
+        proposal.contradiction_key
+        or f"{subject_key}:{predicate_key}"
+    )
+    if not contradiction_key:
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_id,
+            reason_code="ambiguous_contradiction_scope",
+            root_entry_ids=all_ids,
+        )
+    tags = tuple(
+        sorted(
+            {
+                tag
+                for tag in (
+                    _knowledge_tag(raw_tag)
+                    for raw_tag in proposal.retrieval_tags
+                )
+                if tag
+            }
+        )[:16]
+    )
+    routes = sorted(
+        {
+            (
+                str(entry.get("route_mode") or ""),
+                str(entry.get("channel_policy") or ""),
+                int(entry.get("channel_id") or 0),
+                str(entry.get("channel_name") or "")[:120],
+            )
+            for entry in entries.values()
+        }
+    )
+    route_scope_json = json.dumps(
+        [
+            {
+                "route_mode": route_mode,
+                "channel_policy": channel_policy,
+                "channel_id": channel_id,
+                "channel_name": channel_name,
+            }
+            for route_mode, channel_policy, channel_id, channel_name in routes
+        ],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    root_digest = _knowledge_digest(*independent_ids)
+    participant_scope_digest = _knowledge_digest(*participants)
+    candidate_id = _stable_knowledge_candidate_id(
+        guild_id=guild_id,
+        candidate_type=candidate_type,
+        subject_key=subject_key,
+        predicate_key=predicate_key,
+        contradiction_key=contradiction_key,
+        root_entry_ids=independent_ids,
+    )
+    value_digest = _knowledge_digest(_canon(meaning))
+    first_seen = min(
+        (str(entry.get("observed_at") or "") for entry in independent_entries),
+        default="",
+    )
+    last_seen = max(
+        (str(entry.get("observed_at") or "") for entry in independent_entries),
+        default="",
+    )
+    existing = conn.execute(
+        """
+        SELECT normalized_value,candidate_state,candidate_eligible
+        FROM memory_ledger_knowledge_candidates
+        WHERE candidate_id=?
+        """,
+        (candidate_id,),
+    ).fetchone()
+    if existing:
+        if _canon(existing[0]) != _canon(meaning):
+            conn.execute(
+                """
+                UPDATE memory_ledger_knowledge_candidates
+                SET candidate_state='contested',candidate_eligible=0,
+                    live_eligible=0,invalidated_reason='same_roots_meaning_mismatch',
+                    invalidated_at=?,updated_at=?
+                WHERE candidate_id=?
+                """,
+                (_now(), _now(), candidate_id),
+            )
+            _record_knowledge_receipt(
+                conn,
+                guild_id=guild_id,
+                event_type="contested",
+                reason_code="same_roots_meaning_mismatch",
+                candidate_id=candidate_id,
+                candidate_type=candidate_type,
+                root_entry_ids=all_ids,
+                proposal_digest=value_digest,
+            )
+            return AtomicKnowledgeResult(
+                candidate_id,
+                "contested",
+                "same_roots_meaning_mismatch",
+                candidate_type,
+                len(all_ids),
+            )
+        conn.execute(
+            """
+            UPDATE memory_ledger_knowledge_candidates
+            SET last_seen_at=CASE
+                  WHEN ? > COALESCE(last_seen_at,'') THEN ?
+                  ELSE last_seen_at
+                END,
+                updated_at=?
+            WHERE candidate_id=?
+            """,
+            (last_seen, last_seen, _now(), candidate_id),
+        )
+        _record_knowledge_receipt(
+            conn,
+            guild_id=guild_id,
+            event_type="matched_existing",
+            reason_code=(
+                "matched_terminal_candidate"
+                if str(existing[1]) != "candidate" or not bool(existing[2])
+                else "exact_candidate_match"
+            ),
+            candidate_id=candidate_id,
+            candidate_type=candidate_type,
+            root_entry_ids=all_ids,
+            proposal_digest=value_digest,
+        )
+        return AtomicKnowledgeResult(
+            candidate_id,
+            "matched_existing",
+            (
+                "matched_terminal_candidate"
+                if str(existing[1]) != "candidate" or not bool(existing[2])
+                else "exact_candidate_match"
+            ),
+            candidate_type,
+            len(all_ids),
+        )
+
+    conflicts = conn.execute(
+        """
+        SELECT candidate_id,normalized_value,candidate_state,
+               candidate_eligible
+        FROM memory_ledger_knowledge_candidates
+        WHERE guild_id=? AND subject_key=? AND candidate_type=?
+          AND contradiction_key=? AND candidate_id<>?
+        ORDER BY candidate_id
+        """,
+        (
+            guild_id,
+            subject_key,
+            candidate_type,
+            contradiction_key,
+            candidate_id,
+        ),
+    ).fetchall()
+    conflicting_rows = [
+        (
+            str(row[0]),
+            str(row[2] or ""),
+            bool(row[3]),
+        )
+        for row in conflicts
+        if _canon(row[1]) != _canon(meaning)
+    ]
+    explicitly_superseded: list[str] = []
+    unresolved_conflicts: list[str] = []
+    for conflict_id, conflict_state, conflict_eligible in conflicting_rows:
+        old_roots = tuple(
+            str(row[0])
+            for row in conn.execute(
+                """
+                SELECT root_entry_id
+                FROM memory_ledger_knowledge_roots
+                WHERE candidate_id=? AND is_independent=1
+                ORDER BY root_entry_id
+                """,
+                (conflict_id,),
+            ).fetchall()
+        )
+        if old_roots and conn.execute(
+            """
+            SELECT 1 FROM memory_ledger_lineage
+            WHERE entry_id IN (%s)
+              AND target_entry_id IN (%s)
+              AND lineage_type='supersedes'
+            LIMIT 1
+            """
+            % (
+                ",".join("?" for _entry_id in independent_ids),
+                ",".join("?" for _entry_id in old_roots),
+            ),
+            tuple(independent_ids + old_roots),
+        ).fetchone():
+            explicitly_superseded.append(conflict_id)
+        elif conflict_state == "candidate" and conflict_eligible:
+            unresolved_conflicts.append(conflict_id)
+
+    initial_state = (
+        "contested"
+        if proposal.epistemic_status == "contested" or unresolved_conflicts
+        else "candidate"
+    )
+    now = _now()
+    conn.execute(
+        """
+        INSERT INTO memory_ledger_knowledge_candidates(
+          candidate_id,schema_version,guild_id,candidate_type,subject_key,
+          subject_display_name,predicate_key,normalized_value,value_digest,
+          epistemic_status,uncertainty_note,currentness,candidate_state,
+          contradiction_key,supersedes_candidate_id,visibility,
+          authority_class,confidence_class,route_scope_json,
+          participant_scope_digest,first_seen_at,last_seen_at,
+          retrieval_tags_json,root_digest,independent_root_count,
+          derivative_root_count,candidate_eligible,live_eligible,
+          promotion_status,invalidated_reason,invalidated_at,created_at,
+          updated_at
+        ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        """,
+        (
+            candidate_id,
+            ATOMIC_KNOWLEDGE_SCHEMA_VERSION,
+            guild_id,
+            candidate_type,
+            subject_key,
+            _knowledge_text(proposal.subject_display_name, 120),
+            predicate_key,
+            meaning,
+            value_digest,
+            proposal.epistemic_status,
+            _knowledge_text(proposal.uncertainty_note, 240),
+            proposal.currentness,
+            initial_state,
+            contradiction_key,
+            explicitly_superseded[0] if len(explicitly_superseded) == 1 else "",
+            visibility,
+            authority_class,
+            confidence_class,
+            route_scope_json,
+            participant_scope_digest,
+            first_seen,
+            last_seen,
+            json.dumps(tags, separators=(",", ":")),
+            root_digest,
+            len(independent_ids),
+            len(derivative_ids),
+            1 if initial_state == "candidate" else 0,
+            0,
+            "unpromoted",
+            "unresolved_contradiction" if initial_state == "contested" else "",
+            now if initial_state == "contested" else "",
+            now,
+            now,
+        ),
+    )
+    for participant_key in participants:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO memory_ledger_knowledge_participants(
+              candidate_id,guild_id,participant_key,participant_role,created_at
+            ) VALUES(?,?,?,?,?)
+            """,
+            (
+                candidate_id,
+                guild_id,
+                participant_key,
+                "subject" if participant_key == subject_key else "participant",
+                now,
+            ),
+        )
+    for entry_id in all_ids:
+        entry = entries[entry_id]
+        independent = entry_id in independent_ids
+        if independent:
+            root_kind = (
+                "human_source"
+                if str(entry.get("source_role") or "").lower()
+                in {
+                    "user",
+                    "member_self_report",
+                    "member_control",
+                    "owner",
+                    "operator",
+                }
+                else "source_record"
+            )
+            paths: list[list[str]] = [[entry_id]]
+        else:
+            root_kind = "bnl_derivative"
+            paths = [
+                list(path)
+                for path in derivation_paths.get(entry_id, {}).values()
+                if path[-1] in independent_ids
+            ]
+        entry_digest = _knowledge_digest(
+            entry_id,
+            entry.get("source_revision"),
+            _canon(entry.get("normalized_value")),
+        )
+        conn.execute(
+            """
+            INSERT INTO memory_ledger_knowledge_roots(
+              candidate_id,guild_id,root_entry_id,root_kind,is_independent,
+              source_class,source_table,source_row_id,source_revision,
+              source_role,visibility,confidence,lifecycle_status,root_status,
+              root_digest,lineage_path_json,created_at,updated_at
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                candidate_id,
+                guild_id,
+                entry_id,
+                root_kind,
+                1 if independent else 0,
+                entry.get("source_class"),
+                entry.get("source_table"),
+                entry.get("source_row_id"),
+                entry.get("source_revision"),
+                entry.get("source_role"),
+                entry.get("visibility"),
+                entry.get("confidence"),
+                entry.get("lifecycle_status"),
+                "eligible",
+                entry_digest,
+                json.dumps(paths, sort_keys=True, separators=(",", ":")),
+                now,
+                now,
+            ),
+        )
+
+    for superseded_id in explicitly_superseded:
+        conn.execute(
+            """
+            UPDATE memory_ledger_knowledge_candidates
+            SET candidate_state='superseded',candidate_eligible=0,
+                live_eligible=0,invalidated_reason='explicit_root_supersession',
+                invalidated_at=?,updated_at=?
+            WHERE candidate_id=?
+            """,
+            (now, now, superseded_id),
+        )
+        _record_knowledge_receipt(
+            conn,
+            guild_id=guild_id,
+            event_type="superseded",
+            reason_code="explicit_root_supersession",
+            candidate_id=superseded_id,
+            candidate_type=candidate_type,
+            root_entry_ids=independent_ids,
+        )
+    if unresolved_conflicts:
+        placeholders = ",".join("?" for _candidate_id in unresolved_conflicts)
+        conn.execute(
+            """
+            UPDATE memory_ledger_knowledge_candidates
+            SET candidate_state='contested',candidate_eligible=0,
+                live_eligible=0,invalidated_reason='unresolved_contradiction',
+                invalidated_at=?,updated_at=?
+            WHERE candidate_id IN (%s)
+            """ % placeholders,
+            tuple([now, now] + unresolved_conflicts),
+        )
+        for conflict_id in unresolved_conflicts:
+            _record_knowledge_receipt(
+                conn,
+                guild_id=guild_id,
+                event_type="contested",
+                reason_code="unresolved_contradiction",
+                candidate_id=conflict_id,
+                candidate_type=candidate_type,
+                root_entry_ids=independent_ids,
+            )
+    event_type = "contested" if initial_state == "contested" else "created"
+    reason_code = (
+        "unresolved_contradiction"
+        if initial_state == "contested"
+        else "source_linked_candidate_created"
+    )
+    _record_knowledge_receipt(
+        conn,
+        guild_id=guild_id,
+        event_type=event_type,
+        reason_code=reason_code,
+        candidate_id=candidate_id,
+        candidate_type=candidate_type,
+        root_entry_ids=all_ids,
+        proposal_digest=value_digest,
+    )
+    return AtomicKnowledgeResult(
+        candidate_id,
+        event_type,
+        reason_code,
+        candidate_type,
+        len(all_ids),
+    )
+
+
+def form_atomic_candidate_from_ledger_entry(
+    conn: sqlite3.Connection,
+    entry_id: str,
+) -> AtomicKnowledgeResult | None:
+    """Map only already-typed durable Ledger entries; raw chat stays raw."""
+    ensure_memory_ledger_schema(conn)
+    rows = _knowledge_entry_rows(conn, (entry_id,))
+    entry = rows.get(entry_id)
+    if not entry:
+        proposal = AtomicKnowledgeProposal(
+            "person_role_fact",
+            "unknown",
+            "missing",
+            "",
+            (entry_id,),
+        )
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=0,
+            reason_code="missing_or_orphaned_root",
+            root_entry_ids=(entry_id,),
+        )
+    entry_type = str(entry.get("entry_type") or "")
+    if entry_type not in {
+        "claim",
+        "preference",
+        "boundary",
+        "goal",
+        "open_loop",
+        "commitment",
+        "unresolved_question",
+        "event",
+        "canon_reference",
+    }:
+        return None
+    subject_key = str(entry.get("subject_key") or "")
+    predicate_key = str(entry.get("predicate_key") or "")
+    if entry_type in {"open_loop", "unresolved_question"}:
+        candidate_type = "open_loop_or_question"
+        currentness = "open"
+        epistemic = "question" if entry_type == "unresolved_question" else "stated"
+    elif entry_type == "event":
+        candidate_type = "project_event_or_milestone"
+        currentness = "historical"
+        epistemic = "observed"
+    elif (
+        subject_key.startswith("discord_user:")
+        or any(
+            token in predicate_key
+            for token in (
+                "name",
+                "pronoun",
+                "role",
+                "identity",
+                "favorite",
+                "preference",
+                "boundary",
+            )
+        )
+    ):
+        candidate_type = "person_role_fact"
+        currentness = "current"
+        epistemic = "stated"
+    elif entry_type == "canon_reference":
+        candidate_type = "project_event_or_milestone"
+        currentness = "current"
+        epistemic = "stated"
+    else:
+        candidate_type = "open_loop_or_question"
+        currentness = "open"
+        epistemic = "stated"
+    if str(entry.get("lifecycle_status") or "") != ACTIVE_LIFECYCLE:
+        proposal = AtomicKnowledgeProposal(
+            candidate_type=candidate_type,
+            subject_key=subject_key,
+            subject_display_name=str(entry.get("subject_display_name") or ""),
+            predicate_key=predicate_key,
+            meaning=str(entry.get("normalized_value") or ""),
+            root_entry_ids=(entry_id,),
+            epistemic_status=epistemic,
+            currentness=currentness,
+        )
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=int(entry.get("guild_id") or 0),
+            reason_code="ineligible_root_lifecycle",
+            root_entry_ids=(entry_id,),
+        )
+    participant_keys = tuple(
+        sorted(
+            {
+                participant_key
+                for participant_key, _role in entry.get("participants", [])
+                if participant_key
+            }
+        )
+    )
+    return form_atomic_knowledge_candidate(
+        conn,
+        AtomicKnowledgeProposal(
+            candidate_type=candidate_type,
+            subject_key=subject_key,
+            subject_display_name=str(entry.get("subject_display_name") or ""),
+            predicate_key=predicate_key,
+            meaning=str(entry.get("normalized_value") or ""),
+            root_entry_ids=(entry_id,),
+            participant_keys=participant_keys,
+            epistemic_status=epistemic,
+            currentness=currentness,
+            contradiction_key=f"{subject_key}:{predicate_key}",
+            retrieval_tags=(
+                candidate_type,
+                predicate_key,
+                str(entry.get("source_table") or ""),
+            ),
+        ),
+    )
+
+
+def form_atomic_candidates_from_moment(
+    conn: sqlite3.Connection,
+    moment_id: str,
+) -> list[AtomicKnowledgeResult]:
+    """Project participant gists while retaining every actual human root."""
+    ensure_memory_ledger_schema(conn)
+    required_tables = {
+        "memory_moment_windows",
+        "memory_moment_contributions",
+        "memory_moment_contribution_sources",
+    }
+    existing_tables = {
+        str(row[0])
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    if not required_tables.issubset(existing_tables):
+        return []
+    window = conn.execute(
+        """
+        SELECT guild_id,topic_key,topic_family,lifecycle_status,
+               canonical_ledger_entry_id,last_activity_at,channel_policy,
+               route_mode,visibility
+        FROM memory_moment_windows WHERE moment_id=?
+        """,
+        (moment_id,),
+    ).fetchone()
+    if not window or str(window[3] or "") != "finalized":
+        return []
+    canonical_entry_id = str(window[4] or "")
+    if not canonical_entry_id:
+        return []
+    results: list[AtomicKnowledgeResult] = []
+    contributions = conn.execute(
+        """
+        SELECT participant_key,contribution_gist,frame_type,lifecycle_status,
+               public_usable
+        FROM memory_moment_contributions
+        WHERE moment_id=?
+        ORDER BY participant_key
+        """,
+        (moment_id,),
+    ).fetchall()
+    for participant_key, gist, frame_type, lifecycle_status, public_usable in contributions:
+        participant_key = str(participant_key or "")
+        if (
+            not participant_key
+            or not str(gist or "").strip()
+            or str(lifecycle_status or "") != REVIEW_ONLY_LIFECYCLE
+            or not bool(public_usable)
+        ):
+            continue
+        root_ids = tuple(
+            str(row[0])
+            for row in conn.execute(
+                """
+                SELECT ledger_entry_id
+                FROM memory_moment_contribution_sources
+                WHERE moment_id=? AND participant_key=?
+                ORDER BY ledger_entry_id
+                """,
+                (moment_id, participant_key),
+            ).fetchall()
+        )
+        frame_type = str(frame_type or "observation")
+        if frame_type in {"question", "question_thread", "plan", "proposal", "conditional_plan"}:
+            candidate_type = "open_loop_or_question"
+            currentness = "open"
+            epistemic = "question" if frame_type.startswith("question") else "source_abstraction"
+        elif frame_type in {
+            "correction",
+            "correction_replacement",
+            "replacement",
+            "disagreement",
+            "rejection",
+        }:
+            candidate_type = "inference_or_contested_claim"
+            currentness = "uncertain"
+            epistemic = "contested"
+        elif frame_type == "preference":
+            candidate_type = "person_role_fact"
+            currentness = "current"
+            epistemic = "source_abstraction"
+        else:
+            candidate_type = "topic_or_motif"
+            currentness = "historical"
+            epistemic = "source_abstraction"
+        result = form_atomic_knowledge_candidate(
+            conn,
+            AtomicKnowledgeProposal(
+                candidate_type=candidate_type,
+                subject_key=participant_key,
+                predicate_key=f"moment_{frame_type}_{window[1]}",
+                meaning=str(gist or ""),
+                root_entry_ids=root_ids,
+                derivative_entry_ids=(canonical_entry_id,),
+                participant_keys=(participant_key,),
+                epistemic_status=epistemic,
+                uncertainty_note=(
+                    "Participant-specific Moment abstraction; not an exact quote."
+                ),
+                currentness=currentness,
+                contradiction_key=f"{participant_key}:{frame_type}:{window[1]}",
+                retrieval_tags=(
+                    str(window[1] or ""),
+                    str(window[2] or ""),
+                    frame_type,
+                    candidate_type,
+                ),
+            ),
+        )
+        results.append(result)
+    return results
+
+
+def _merge_backfill_count(counts: dict[str, int], outcome: str) -> None:
+    key = str(outcome or "unknown")
+    counts[key] = int(counts.get(key, 0) or 0) + 1
+
+
+def backfill_atomic_knowledge_candidates(
+    conn: sqlite3.Connection,
+    *,
+    batch_size: int = 250,
+) -> dict[str, Any]:
+    """Run one bounded, resumable historical pass; ordinary writes stay live."""
+    ensure_memory_ledger_schema(conn)
+    safe_batch = max(1, min(int(batch_size or 250), 500))
+    state = conn.execute(
+        """
+        SELECT phase,cursor_value,completed,counts_json
+        FROM memory_ledger_knowledge_backfill
+        WHERE migration_key=?
+        """,
+        (ATOMIC_KNOWLEDGE_BACKFILL,),
+    ).fetchone()
+    if state:
+        phase = str(state[0] or "entries")
+        cursor = str(state[1] or "")
+        completed = bool(state[2])
+        try:
+            counts = {
+                str(key): int(value or 0)
+                for key, value in json.loads(str(state[3] or "{}")).items()
+            }
+        except (TypeError, ValueError, json.JSONDecodeError):
+            counts = {}
+    else:
+        phase, cursor, completed, counts = "entries", "", False, {}
+        conn.execute(
+            """
+            INSERT INTO memory_ledger_knowledge_backfill(
+              migration_key,phase,cursor_value,completed,counts_json,updated_at
+            ) VALUES(?,?,?,?,?,?)
+            """,
+            (
+                ATOMIC_KNOWLEDGE_BACKFILL,
+                phase,
+                cursor,
+                0,
+                "{}",
+                _now(),
+            ),
+        )
+    if completed:
+        return {
+            "migration": ATOMIC_KNOWLEDGE_BACKFILL,
+            "phase": phase,
+            "completed": True,
+            "counts": counts,
+        }
+
+    if phase == "entries":
+        rows = conn.execute(
+            """
+            SELECT entry_id
+            FROM memory_ledger_entries
+            WHERE entry_id>?
+              AND entry_type IN (
+                'claim','preference','boundary','goal','open_loop',
+                'commitment','unresolved_question','event','canon_reference'
+              )
+            ORDER BY entry_id
+            LIMIT ?
+            """,
+            (cursor, safe_batch),
+        ).fetchall()
+        for (entry_id,) in rows:
+            result = form_atomic_candidate_from_ledger_entry(
+                conn,
+                str(entry_id),
+            )
+            _merge_backfill_count(
+                counts,
+                result.outcome if result is not None else "not_candidate",
+            )
+        if rows:
+            cursor = str(rows[-1][0] or "")
+        if len(rows) < safe_batch:
+            phase, cursor = "moments", ""
+
+    if phase == "moments":
+        if conn.execute(
+            """
+            SELECT 1 FROM sqlite_master
+            WHERE type='table' AND name='memory_moment_windows'
+            """
+        ).fetchone():
+            rows = conn.execute(
+                """
+                SELECT moment_id
+                FROM memory_moment_windows
+                WHERE moment_id>? AND lifecycle_status='finalized'
+                ORDER BY moment_id
+                LIMIT ?
+                """,
+                (cursor, safe_batch),
+            ).fetchall()
+        else:
+            rows = []
+        for (moment_id,) in rows:
+            results = form_atomic_candidates_from_moment(
+                conn,
+                str(moment_id),
+            )
+            if not results:
+                _merge_backfill_count(counts, "moment_without_candidate")
+            for result in results:
+                _merge_backfill_count(counts, result.outcome)
+        if rows:
+            cursor = str(rows[-1][0] or "")
+        if len(rows) < safe_batch:
+            phase, cursor, completed = "complete", "", True
+
+    conn.execute(
+        """
+        UPDATE memory_ledger_knowledge_backfill
+        SET phase=?,cursor_value=?,completed=?,counts_json=?,updated_at=?
+        WHERE migration_key=?
+        """,
+        (
+            phase,
+            cursor,
+            1 if completed else 0,
+            json.dumps(counts, sort_keys=True),
+            _now(),
+            ATOMIC_KNOWLEDGE_BACKFILL,
+        ),
+    )
+    return {
+        "migration": ATOMIC_KNOWLEDGE_BACKFILL,
+        "phase": phase,
+        "completed": bool(completed),
+        "counts": counts,
+    }
+
+
+def purge_atomic_knowledge_for_subject(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    subject_key: str,
+) -> dict[str, int]:
+    """Complete-delete helper; ordinary forget uses lifecycle triggers."""
+    ensure_memory_ledger_schema(conn)
+    candidate_ids = {
+        str(row[0])
+        for row in conn.execute(
+            """
+            SELECT candidate_id
+            FROM memory_ledger_knowledge_candidates
+            WHERE guild_id=? AND subject_key=?
+            UNION
+            SELECT candidate_id
+            FROM memory_ledger_knowledge_participants
+            WHERE guild_id=? AND participant_key=?
+            """,
+            (guild_id, subject_key, guild_id, subject_key),
+        ).fetchall()
+    }
+    counts = {
+        "memory_ledger_knowledge_candidates": 0,
+        "memory_ledger_knowledge_roots": 0,
+        "memory_ledger_knowledge_participants": 0,
+        "memory_ledger_knowledge_receipts": 0,
+    }
+    if not candidate_ids:
+        return counts
+    placeholders = ",".join("?" for _candidate_id in candidate_ids)
+    params = tuple(sorted(candidate_ids))
+    counts["memory_ledger_knowledge_receipts"] = conn.execute(
+        """
+        DELETE FROM memory_ledger_knowledge_receipts
+        WHERE candidate_id IN (%s)
+        """ % placeholders,
+        params,
+    ).rowcount
+    counts["memory_ledger_knowledge_participants"] = conn.execute(
+        """
+        DELETE FROM memory_ledger_knowledge_participants
+        WHERE candidate_id IN (%s)
+        """ % placeholders,
+        params,
+    ).rowcount
+    counts["memory_ledger_knowledge_roots"] = conn.execute(
+        """
+        DELETE FROM memory_ledger_knowledge_roots
+        WHERE candidate_id IN (%s)
+        """ % placeholders,
+        params,
+    ).rowcount
+    counts["memory_ledger_knowledge_candidates"] = conn.execute(
+        """
+        DELETE FROM memory_ledger_knowledge_candidates
+        WHERE candidate_id IN (%s)
+        """ % placeholders,
+        params,
+    ).rowcount
+    return counts
 
 
 def _visibility(policy: str) -> Visibility:
@@ -840,7 +2900,7 @@ def shadow_broadcast_status_event(conn: sqlite3.Connection, *, row_id: int, guil
 def shadow_canon_reference(conn: sqlite3.Connection, *, guild_id: int, canon_id: str, subject_key: str, subject_display_name: str, predicate_key: str, value: str, observed_at: str = "") -> LedgerWriteResult:
     if not canon_id or not subject_key or not predicate_key:
         return skipped_result(guild_id=guild_id, source_table="approved_canon", source_row_id=canon_id or "", reason_code="missing_canon_source_identity")
-    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="approved_canon", source_row_id=canon_id, source_revision=str(canon_id), source_role="approved_canon", entry_type="canon_reference", subject_key=subject_key, subject_display_name=subject_display_name, predicate_key=predicate_key, value=(value or "")[:500], source_class=SourceClass.APPROVED_CANON, visibility=Visibility.REFERENCE_CANON, confidence=Confidence.APPROVED, public_usable=True, observed_at=observed_at or _now(), lifecycle_status=ACTIVE_LIFECYCLE))
+    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="approved_canon", source_row_id=canon_id, source_revision=str(canon_id), source_role="approved_canon", entry_type="canon_reference", subject_key=subject_key, subject_display_name=subject_display_name, predicate_key=predicate_key, value=(value or "")[:500], source_class=SourceClass.APPROVED_CANON, route_mode="approved_canon", channel_policy="reference_canon", visibility=Visibility.REFERENCE_CANON, confidence=Confidence.APPROVED, public_usable=True, observed_at=observed_at or _now(), lifecycle_status=ACTIVE_LIFECYCLE))
 
 
 def build_memory_ledger_evaluation(
@@ -888,4 +2948,298 @@ def build_memory_ledger_evaluation(
     dangling_lineage = int(cur.fetchone()[0] or 0)
     report["danglingLineageTargets"] = dangling_lineage
     report["legacyToLedgerParityMismatches"] = missing_receipt_entries + entries_without_receipts + dangling_lineage + int(report.get("shadowWriteErrors", 0)) + int(report.get("unresolvedCorrectionAttempts", 0))
+    knowledge_tables_present = bool(
+        cur.execute(
+            """
+            SELECT COUNT(*) FROM sqlite_master
+            WHERE type='table' AND name IN (
+              'memory_ledger_knowledge_candidates',
+              'memory_ledger_knowledge_roots',
+              'memory_ledger_knowledge_participants',
+              'memory_ledger_knowledge_receipts'
+            )
+            """
+        ).fetchone()[0]
+        == 4
+    )
+    report["knowledgeCandidateSchemaVersion"] = (
+        ATOMIC_KNOWLEDGE_SCHEMA_VERSION if knowledge_tables_present else "absent"
+    )
+    report["knowledgeCandidateTablesPresent"] = knowledge_tables_present
+    report["knowledgeCandidateTotalsByType"] = {}
+    report["knowledgeCandidateTotalsByState"] = {}
+    report["knowledgeCandidateTotalsByVisibility"] = {}
+    report["knowledgeCandidateTotalsByAuthority"] = {}
+    report["knowledgeCandidateTotalsByConfidence"] = {}
+    report["knowledgeCandidateTotalsByEpistemicStatus"] = {}
+    report["knowledgeCandidateTotalsByCurrentness"] = {}
+    report["knowledgeCandidateReceiptEvents"] = {}
+    report["knowledgeCandidateRejectionsByReason"] = {}
+    report["knowledgeCandidateInvalidationsByReason"] = {}
+    report["knowledgeCandidateRootKinds"] = {}
+    report["knowledgeCandidateRootCount"] = 0
+    report["knowledgeCandidateIndependentRootCount"] = 0
+    report["knowledgeCandidateDerivativeRootCount"] = 0
+    report["knowledgeCandidateDerivativeOnlyRejections"] = 0
+    report["knowledgeCandidateAmbiguousRejections"] = 0
+    report["knowledgeCandidateOrphanedRoots"] = 0
+    report["knowledgeCandidateMissingIndependentRoots"] = 0
+    report["knowledgeCandidateParticipantIsolationViolations"] = 0
+    report["knowledgeCandidateLiveEligibleCount"] = 0
+    report["knowledgeCandidateProcessingErrors"] = 0
+    report["knowledgeCandidateCorrectionDeletePrivacyInvalidations"] = 0
+    report["knowledgeCandidateBackfill"] = {
+        "phase": "not_started",
+        "completed": False,
+        "counts": {},
+    }
+    if knowledge_tables_present:
+        candidate_where = ""
+        candidate_params: list[Any] = []
+        if guild_id is not None:
+            candidate_where = " WHERE guild_id=?"
+            candidate_params = [guild_id]
+        for key, column in (
+            ("knowledgeCandidateTotalsByType", "candidate_type"),
+            ("knowledgeCandidateTotalsByState", "candidate_state"),
+            ("knowledgeCandidateTotalsByVisibility", "visibility"),
+            ("knowledgeCandidateTotalsByAuthority", "authority_class"),
+            ("knowledgeCandidateTotalsByConfidence", "confidence_class"),
+            (
+                "knowledgeCandidateTotalsByEpistemicStatus",
+                "epistemic_status",
+            ),
+            ("knowledgeCandidateTotalsByCurrentness", "currentness"),
+        ):
+            cur.execute(
+                f"""
+                SELECT {column},COUNT(*)
+                FROM memory_ledger_knowledge_candidates
+                {candidate_where}
+                GROUP BY {column}
+                """,
+                candidate_params,
+            )
+            report[key] = dict(cur.fetchall())
+        cur.execute(
+            f"""
+            SELECT event_type,COUNT(*)
+            FROM memory_ledger_knowledge_receipts
+            {candidate_where}
+            GROUP BY event_type
+            """,
+            candidate_params,
+        )
+        report["knowledgeCandidateReceiptEvents"] = dict(cur.fetchall())
+        rejection_suffix = " AND" if candidate_where else " WHERE"
+        cur.execute(
+            f"""
+            SELECT reason_code,COUNT(*)
+            FROM memory_ledger_knowledge_receipts
+            {candidate_where}{rejection_suffix} event_type='rejected'
+            GROUP BY reason_code
+            """,
+            candidate_params,
+        )
+        report["knowledgeCandidateRejectionsByReason"] = dict(cur.fetchall())
+        cur.execute(
+            f"""
+            SELECT invalidated_reason,COUNT(*)
+            FROM memory_ledger_knowledge_candidates
+            {candidate_where}{rejection_suffix}
+              COALESCE(invalidated_reason,'')<>''
+            GROUP BY invalidated_reason
+            """,
+            candidate_params,
+        )
+        report["knowledgeCandidateInvalidationsByReason"] = dict(
+            cur.fetchall()
+        )
+        cur.execute(
+            f"""
+            SELECT root_kind,COUNT(*)
+            FROM memory_ledger_knowledge_roots
+            {candidate_where}
+            GROUP BY root_kind
+            """,
+            candidate_params,
+        )
+        report["knowledgeCandidateRootKinds"] = dict(cur.fetchall())
+        cur.execute(
+            f"""
+            SELECT
+              COUNT(*),
+              COALESCE(SUM(CASE WHEN is_independent=1 THEN 1 ELSE 0 END),0),
+              COALESCE(SUM(CASE WHEN is_independent=0 THEN 1 ELSE 0 END),0)
+            FROM memory_ledger_knowledge_roots
+            {candidate_where}
+            """,
+            candidate_params,
+        )
+        root_counts = cur.fetchone() or (0, 0, 0)
+        report["knowledgeCandidateRootCount"] = int(root_counts[0] or 0)
+        report["knowledgeCandidateIndependentRootCount"] = int(
+            root_counts[1] or 0
+        )
+        report["knowledgeCandidateDerivativeRootCount"] = int(
+            root_counts[2] or 0
+        )
+        cur.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM memory_ledger_knowledge_receipts
+            {candidate_where}{rejection_suffix}
+              event_type='rejected'
+              AND reason_code LIKE 'derivative%'
+            """,
+            candidate_params,
+        )
+        report["knowledgeCandidateDerivativeOnlyRejections"] = int(
+            cur.fetchone()[0] or 0
+        )
+        cur.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM memory_ledger_knowledge_receipts
+            {candidate_where}{rejection_suffix}
+              event_type='rejected'
+              AND (
+                reason_code LIKE 'ambiguous%'
+                OR reason_code LIKE '%isolation%'
+                OR reason_code='participant_scope_mismatch'
+                OR reason_code='cross_guild_or_ambiguous_provenance'
+              )
+            """,
+            candidate_params,
+        )
+        report["knowledgeCandidateAmbiguousRejections"] = int(
+            cur.fetchone()[0] or 0
+        )
+        root_alias_where = ""
+        root_alias_params: list[Any] = []
+        if guild_id is not None:
+            root_alias_where = " AND r.guild_id=?"
+            root_alias_params = [guild_id]
+        cur.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM memory_ledger_knowledge_roots r
+            LEFT JOIN memory_ledger_entries e
+              ON e.guild_id=r.guild_id AND e.entry_id=r.root_entry_id
+            WHERE e.entry_id IS NULL
+              AND r.root_status NOT IN (
+                'deleted','forgotten','retracted','superseded','corrected'
+              )
+              {root_alias_where}
+            """,
+            root_alias_params,
+        )
+        report["knowledgeCandidateOrphanedRoots"] = int(
+            cur.fetchone()[0] or 0
+        )
+        candidate_alias_where = ""
+        candidate_alias_params: list[Any] = []
+        if guild_id is not None:
+            candidate_alias_where = " WHERE c.guild_id=?"
+            candidate_alias_params = [guild_id]
+        cur.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM memory_ledger_knowledge_candidates c
+            {candidate_alias_where}
+            {"AND" if candidate_alias_where else "WHERE"} NOT EXISTS (
+              SELECT 1 FROM memory_ledger_knowledge_roots r
+              WHERE r.candidate_id=c.candidate_id AND r.is_independent=1
+            )
+            """,
+            candidate_alias_params,
+        )
+        report["knowledgeCandidateMissingIndependentRoots"] = int(
+            cur.fetchone()[0] or 0
+        )
+        cur.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM memory_ledger_knowledge_candidates c
+            {candidate_alias_where}
+            {"AND" if candidate_alias_where else "WHERE"}
+              c.subject_key LIKE 'discord_user:%'
+              AND NOT EXISTS (
+                SELECT 1 FROM memory_ledger_knowledge_participants p
+                WHERE p.candidate_id=c.candidate_id
+                  AND p.participant_key=c.subject_key
+              )
+            """,
+            candidate_alias_params,
+        )
+        report["knowledgeCandidateParticipantIsolationViolations"] = int(
+            cur.fetchone()[0] or 0
+        )
+        cur.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM memory_ledger_knowledge_candidates
+            {candidate_where}{rejection_suffix} live_eligible<>0
+            """,
+            candidate_params,
+        )
+        report["knowledgeCandidateLiveEligibleCount"] = int(
+            cur.fetchone()[0] or 0
+        )
+        if guild_id is None:
+            cur.execute(
+                """
+                SELECT COUNT(*)
+                FROM memory_ledger_knowledge_receipts
+                WHERE event_type='error'
+                """
+            )
+        else:
+            cur.execute(
+                """
+                SELECT COUNT(*)
+                FROM memory_ledger_knowledge_receipts
+                WHERE guild_id IN (?,0) AND event_type='error'
+                """,
+                (guild_id,),
+            )
+        report["knowledgeCandidateProcessingErrors"] = int(
+            cur.fetchone()[0] or 0
+        )
+        cur.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM memory_ledger_knowledge_receipts
+            {candidate_where}{rejection_suffix}
+              event_type IN ('invalidated','superseded')
+              AND reason_code IN (
+                'root_privacy_or_deletion','root_deleted','root_changed',
+                'root_privacy_or_provenance_changed',
+                'root_correction_of','root_supersedes','root_retracts',
+                'explicit_root_supersession'
+              )
+            """,
+            candidate_params,
+        )
+        report[
+            "knowledgeCandidateCorrectionDeletePrivacyInvalidations"
+        ] = int(cur.fetchone()[0] or 0)
+        backfill = cur.execute(
+            """
+            SELECT phase,completed,counts_json
+            FROM memory_ledger_knowledge_backfill
+            WHERE migration_key=?
+            """,
+            (ATOMIC_KNOWLEDGE_BACKFILL,),
+        ).fetchone()
+        if backfill:
+            try:
+                backfill_counts = json.loads(str(backfill[2] or "{}"))
+            except (TypeError, ValueError, json.JSONDecodeError):
+                backfill_counts = {"invalid_json": 1}
+            report["knowledgeCandidateBackfill"] = {
+                "phase": str(backfill[0] or "unknown"),
+                "completed": bool(backfill[1]),
+                "counts": backfill_counts,
+            }
     return report

--- a/bnl_moment_engine.py
+++ b/bnl_moment_engine.py
@@ -22,7 +22,9 @@ from bnl_memory_ledger import (
     LedgerEntry,
     LedgerParticipant,
     ensure_memory_ledger_schema,
+    form_atomic_candidates_from_moment,
     insert_ledger_entry,
+    record_atomic_knowledge_processing_error,
     shadow_enabled as ledger_shadow_enabled,
 )
 
@@ -4477,6 +4479,21 @@ def finalize_moment(
         rows,
         public_usable=public_usable,
     )
+    try:
+        form_atomic_candidates_from_moment(conn, moment_id)
+    except Exception as knowledge_exc:
+        try:
+            record_atomic_knowledge_processing_error(
+                conn,
+                guild_id=int(win[0] or 0),
+                reason_code=(
+                    "moment_projection_" + type(knowledge_exc).__name__
+                )[:120],
+                candidate_type="topic_or_motif",
+                root_entry_ids=tuple(source_ids),
+            )
+        except Exception:
+            pass
     _diag(conn, int(win[0] or 0), "window_finalized", reason, moment_id, moment_entry_id)
     observe_finalized_moment_episode(conn, moment_id)
     return MomentObservationResult(result.outcome, result.reason_code, moment_id, moment_entry_id)

--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -137,6 +137,30 @@ def _empty_ledger_report() -> Dict[str, Any]:
         "entriesWithMultipleActiveValues": 0,
         "danglingLineageTargets": 0,
         "legacyToLedgerParityMismatches": 0,
+        "knowledgeCandidateSchemaVersion": "absent",
+        "knowledgeCandidateTotalsByType": {},
+        "knowledgeCandidateTotalsByState": {},
+        "knowledgeCandidateTotalsByVisibility": {},
+        "knowledgeCandidateTotalsByAuthority": {},
+        "knowledgeCandidateTotalsByConfidence": {},
+        "knowledgeCandidateTotalsByEpistemicStatus": {},
+        "knowledgeCandidateTotalsByCurrentness": {},
+        "knowledgeCandidateReceiptEvents": {},
+        "knowledgeCandidateRejectionsByReason": {},
+        "knowledgeCandidateInvalidationsByReason": {},
+        "knowledgeCandidateRootKinds": {},
+        "knowledgeCandidateOrphanedRoots": 0,
+        "knowledgeCandidateMissingIndependentRoots": 0,
+        "knowledgeCandidateParticipantIsolationViolations": 0,
+        "knowledgeCandidateDerivativeOnlyRejections": 0,
+        "knowledgeCandidateLiveEligibleCount": 0,
+        "knowledgeCandidateProcessingErrors": 0,
+        "knowledgeCandidateCorrectionDeletePrivacyInvalidations": 0,
+        "knowledgeCandidateBackfill": {
+            "phase": "not_started",
+            "completed": False,
+            "counts": {},
+        },
     }
 
 
@@ -1065,6 +1089,73 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             (ledger.get("evidenceWindow") or {}).get("last", "none"),
         ),
         "- ledger_parity_metric: `%s` (`informational`; intentional derived rows are included)" % ledger.get("legacyToLedgerParityMismatches", 0),
+        "- atomic_knowledge: schema=`%s` types=`%s` states=`%s` visibility=`%s` authority=`%s` confidence=`%s` epistemic=`%s` currentness=`%s` roots=`%s` events=`%s` rejected=`%s` invalidated=`%s` orphaned=`%s` missing_independent=`%s` participant_isolation=`%s` derivative_only=`%s` live_eligible=`%s` errors=`%s` privacy_lifecycle=`%s` backfill=`%s`" % (
+            ledger.get("knowledgeCandidateSchemaVersion", "absent"),
+            json.dumps(
+                ledger.get("knowledgeCandidateTotalsByType", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                ledger.get("knowledgeCandidateTotalsByState", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                ledger.get("knowledgeCandidateTotalsByVisibility", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                ledger.get("knowledgeCandidateTotalsByAuthority", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                ledger.get("knowledgeCandidateTotalsByConfidence", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                ledger.get(
+                    "knowledgeCandidateTotalsByEpistemicStatus",
+                    {},
+                ),
+                sort_keys=True,
+            ),
+            json.dumps(
+                ledger.get("knowledgeCandidateTotalsByCurrentness", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                ledger.get("knowledgeCandidateRootKinds", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                ledger.get("knowledgeCandidateReceiptEvents", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                ledger.get("knowledgeCandidateRejectionsByReason", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                ledger.get("knowledgeCandidateInvalidationsByReason", {}),
+                sort_keys=True,
+            ),
+            ledger.get("knowledgeCandidateOrphanedRoots", 0),
+            ledger.get("knowledgeCandidateMissingIndependentRoots", 0),
+            ledger.get(
+                "knowledgeCandidateParticipantIsolationViolations",
+                0,
+            ),
+            ledger.get("knowledgeCandidateDerivativeOnlyRejections", 0),
+            ledger.get("knowledgeCandidateLiveEligibleCount", 0),
+            ledger.get("knowledgeCandidateProcessingErrors", 0),
+            ledger.get(
+                "knowledgeCandidateCorrectionDeletePrivacyInvalidations",
+                0,
+            ),
+            json.dumps(
+                ledger.get("knowledgeCandidateBackfill", {}),
+                sort_keys=True,
+            ),
+        ),
         "- moments: status=`%s` requested=`%s` effective=`%s` eligible=`%s` open=`%s` finalized=`%s` rejected=`%s` active_episodes=`%s` finalized_episodes=`%s` episode_open_loops=`%s` errors=`%s` safety_violations=`%s` window_last=`%s`" % (
             (stages.get("moment_engine") or {}).get("status", "unknown"),
             _on(gates.get("moment_engine_shadow_requested")),

--- a/tests/test_atomic_knowledge_candidates.py
+++ b/tests/test_atomic_knowledge_candidates.py
@@ -1,0 +1,1142 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+
+from bnl_canon_source_contract import Confidence, SourceClass, Visibility
+from bnl_memory_governance import (
+    GovernanceRequest,
+    build_governed_context,
+    complete_delete_member_data,
+    correct_member_memory,
+    forget_member_memory,
+    view_member_memory,
+)
+import bnl_memory_ledger as ledger
+import bnl_moment_engine as moments
+
+
+class AtomicKnowledgeCandidateTests(unittest.TestCase):
+    def setUp(self):
+        self.conn = sqlite3.connect(":memory:")
+        ledger.ensure_memory_ledger_schema(self.conn)
+
+    def tearDown(self):
+        self.conn.close()
+
+    def add_root(
+        self,
+        row_id,
+        *,
+        guild_id=1,
+        subject_key="discord_user:7",
+        entry_type="preference",
+        predicate_key="favorite_color",
+        value="green",
+        source_class=SourceClass.FIRST_PARTY_RECORD,
+        source_role="member_self_report",
+        route_mode="normal_chat",
+        channel_policy="public_home",
+        visibility=Visibility.PUBLIC,
+        confidence=Confidence.HIGH,
+        public_usable=None,
+        derived=False,
+        projection=False,
+        participants=None,
+        lineage=(),
+        lifecycle_status="active",
+        source_table="conversations",
+    ):
+        if public_usable is None:
+            public_usable = visibility in {
+                Visibility.PUBLIC,
+                Visibility.PUBLIC_SAFE,
+                Visibility.REFERENCE_CANON,
+            }
+        if participants is None:
+            participants = (
+                (
+                    ledger.LedgerParticipant(
+                        subject_key,
+                        "Crow",
+                        "author",
+                        0,
+                    ),
+                )
+                if subject_key.startswith("discord_user:")
+                else ()
+            )
+        entry = ledger.LedgerEntry(
+            guild_id=guild_id,
+            source_table=source_table,
+            source_row_id=row_id,
+            source_revision=str(row_id),
+            source_role=source_role,
+            entry_type=entry_type,
+            subject_key=subject_key,
+            subject_display_name="Crow"
+            if subject_key.startswith("discord_user:")
+            else "BARCODE Network",
+            predicate_key=predicate_key,
+            value=value,
+            source_class=source_class,
+            route_mode=route_mode,
+            channel_id=10,
+            channel_name="barcode-bot",
+            channel_policy=channel_policy,
+            visibility=visibility,
+            confidence=confidence,
+            public_usable=public_usable,
+            derived=derived,
+            projection=projection,
+            observed_at=f"2026-07-25T00:00:{int(row_id) % 60:02d}+00:00",
+            source_sequence=int(row_id),
+            lifecycle_status=lifecycle_status,
+            participants=tuple(participants),
+            lineage=tuple(lineage),
+        )
+        result = ledger.insert_ledger_entry(self.conn, entry)
+        self.assertIn(result.outcome, {"inserted", "deduplicated"})
+        return result.entry_id
+
+    def candidate_row(self, candidate_id):
+        return self.conn.execute(
+            """
+            SELECT candidate_type,subject_key,normalized_value,
+                   epistemic_status,currentness,candidate_state,
+                   visibility,authority_class,confidence_class,
+                   independent_root_count,derivative_root_count,
+                   candidate_eligible,live_eligible,promotion_status,
+                   invalidated_reason,supersedes_candidate_id
+            FROM memory_ledger_knowledge_candidates
+            WHERE candidate_id=?
+            """,
+            (candidate_id,),
+        ).fetchone()
+
+    def test_schema_and_exact_replay_are_deterministic_and_idempotent(self):
+        ledger.ensure_memory_ledger_schema(self.conn)
+        root = self.add_root(1)
+
+        created = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            root,
+        )
+        replayed = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            root,
+        )
+
+        self.assertEqual(created.outcome, "created")
+        self.assertEqual(replayed.outcome, "matched_existing")
+        self.assertEqual(created.candidate_id, replayed.candidate_id)
+        self.assertEqual(
+            self.conn.execute(
+                "SELECT COUNT(*) FROM memory_ledger_knowledge_candidates"
+            ).fetchone()[0],
+            1,
+        )
+        row = self.candidate_row(created.candidate_id)
+        self.assertEqual(row[0], "person_role_fact")
+        self.assertEqual(row[11:14], (1, 0, "unpromoted"))
+
+    def test_supported_atomic_types_remain_unpromoted_and_shadow_only(self):
+        person_root = self.add_root(2)
+        event_root = self.add_root(
+            3,
+            subject_key="barcode_network",
+            entry_type="event",
+            predicate_key="shared_brain_checkpoint",
+            value="The shared brain checkpoint was production-proven.",
+            source_role="operator",
+            participants=(),
+            source_table="project_evidence",
+        )
+        open_root = self.add_root(
+            4,
+            subject_key="barcode_network",
+            entry_type="open_loop",
+            predicate_key="durable_knowledge_layer",
+            value="Source-linked candidate runtime behavior remains to assess.",
+            source_role="operator",
+            participants=(),
+            source_table="project_evidence",
+        )
+        inference_root = self.add_root(
+            5,
+            value="Crow returned to modular synthesis discussions.",
+            entry_type="claim",
+            predicate_key="modular_synthesis_return",
+            source_class=SourceClass.PUBLIC_OBSERVATION,
+            source_role="user",
+        )
+        bnl_role_root = ledger.shadow_canon_reference(
+            self.conn,
+            canon_id="b001",
+            guild_id=1,
+            subject_key=ledger.BNL_SUBJECT_KEY,
+            subject_display_name="BNL-01",
+            predicate_key="roles",
+            value="BNL-01 is the Network's memory and continuity layer.",
+            observed_at="2026-07-25T00:00:05+00:00",
+        ).entry_id
+
+        results = [
+            ledger.form_atomic_candidate_from_ledger_entry(
+                self.conn,
+                person_root,
+            ),
+            ledger.form_atomic_candidate_from_ledger_entry(
+                self.conn,
+                event_root,
+            ),
+            ledger.form_atomic_candidate_from_ledger_entry(
+                self.conn,
+                open_root,
+            ),
+            ledger.form_atomic_knowledge_candidate(
+                self.conn,
+                ledger.AtomicKnowledgeProposal(
+                    candidate_type="inference_or_contested_claim",
+                    subject_key="discord_user:7",
+                    predicate_key="modular_synthesis_motif",
+                    meaning=(
+                        "Inference: modular synthesis may be a recurring "
+                        "topic for this participant."
+                    ),
+                    root_entry_ids=(inference_root,),
+                    participant_keys=("discord_user:7",),
+                    epistemic_status="inference",
+                    uncertainty_note=(
+                        "A single source supports only a tentative inference."
+                    ),
+                    currentness="uncertain",
+                ),
+            ),
+            ledger.form_atomic_candidate_from_ledger_entry(
+                self.conn,
+                bnl_role_root,
+            ),
+        ]
+
+        self.assertEqual(
+            {result.candidate_type for result in results},
+            {
+                "person_role_fact",
+                "project_event_or_milestone",
+                "open_loop_or_question",
+                "inference_or_contested_claim",
+            },
+        )
+        self.assertTrue(all(result.outcome == "created" for result in results))
+        bnl_candidate = self.candidate_row(results[-1].candidate_id)
+        self.assertEqual(bnl_candidate[0], "person_role_fact")
+        self.assertEqual(bnl_candidate[1], ledger.BNL_SUBJECT_KEY)
+        self.assertEqual(
+            bnl_candidate[7],
+            SourceClass.APPROVED_CANON.value,
+        )
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT COUNT(*) FROM memory_ledger_knowledge_candidates
+                WHERE live_eligible<>0 OR promotion_status<>'unpromoted'
+                """
+            ).fetchone()[0],
+            0,
+        )
+
+    def test_derivative_lineage_is_retained_without_self_corroboration(self):
+        human_root = self.add_root(
+            6,
+            entry_type="observation",
+            predicate_key="conversation",
+            value="I keep returning to modular synth patch design.",
+            source_class=SourceClass.PUBLIC_OBSERVATION,
+            source_role="user",
+        )
+        derivative = self.add_root(
+            7,
+            subject_key="moment:one",
+            entry_type="shared_moment",
+            predicate_key="shared_moment",
+            value="BNL summary: a modular synthesis motif.",
+            source_class=SourceClass.DERIVED_SUMMARY,
+            source_role="derived_assessment",
+            confidence=Confidence.APPROVED,
+            derived=True,
+            projection=True,
+            participants=(
+                ledger.LedgerParticipant(
+                    "discord_user:7",
+                    "Crow",
+                    "participant",
+                    0,
+                ),
+            ),
+            lineage=(("derived_from", human_root),),
+            source_table="memory_moment_windows",
+        )
+        proposal = ledger.AtomicKnowledgeProposal(
+            candidate_type="topic_or_motif",
+            subject_key="discord_user:7",
+            predicate_key="modular_synthesis_motif",
+            meaning="Modular synthesis has appeared as a conversation motif.",
+            root_entry_ids=(human_root,),
+            derivative_entry_ids=(derivative,),
+            participant_keys=("discord_user:7",),
+            epistemic_status="source_abstraction",
+            uncertainty_note="This is a bounded abstraction, not a quote.",
+            currentness="historical",
+        )
+
+        result = ledger.form_atomic_knowledge_candidate(self.conn, proposal)
+
+        self.assertEqual(result.outcome, "created")
+        row = self.candidate_row(result.candidate_id)
+        self.assertEqual(row[7], SourceClass.PUBLIC_OBSERVATION.value)
+        self.assertEqual(row[8], Confidence.HIGH.value)
+        self.assertEqual(row[9:11], (1, 1))
+        roots = self.conn.execute(
+            """
+            SELECT root_entry_id,root_kind,is_independent,lineage_path_json
+            FROM memory_ledger_knowledge_roots
+            WHERE candidate_id=?
+            ORDER BY is_independent DESC,root_entry_id
+            """,
+            (result.candidate_id,),
+        ).fetchall()
+        self.assertEqual(roots[0][0:3], (human_root, "human_source", 1))
+        self.assertEqual(roots[1][0:3], (derivative, "bnl_derivative", 0))
+        self.assertIn(human_root, roots[1][3])
+
+        derivative_only = ledger.form_atomic_knowledge_candidate(
+            self.conn,
+            ledger.AtomicKnowledgeProposal(
+                candidate_type="topic_or_motif",
+                subject_key="discord_user:7",
+                predicate_key="derivative_only",
+                meaning="A derivative cannot establish this.",
+                root_entry_ids=(),
+                derivative_entry_ids=(derivative,),
+                participant_keys=("discord_user:7",),
+                epistemic_status="source_abstraction",
+                currentness="uncertain",
+            ),
+        )
+        misclassified = ledger.form_atomic_knowledge_candidate(
+            self.conn,
+            ledger.AtomicKnowledgeProposal(
+                candidate_type="topic_or_motif",
+                subject_key="discord_user:7",
+                predicate_key="misclassified_derivative",
+                meaning="A derivative cannot be an independent root.",
+                root_entry_ids=(derivative,),
+                participant_keys=("discord_user:7",),
+                epistemic_status="source_abstraction",
+                currentness="uncertain",
+            ),
+        )
+        self.assertEqual(
+            derivative_only.reason_code,
+            "derivative_only_no_independent_root",
+        )
+        self.assertEqual(
+            misclassified.reason_code,
+            "derivative_misclassified_as_independent",
+        )
+
+    def test_repetition_and_confidence_never_create_authority(self):
+        low_root = self.add_root(
+            8,
+            value="Crow likes modular synthesis.",
+            source_class=SourceClass.PUBLIC_OBSERVATION,
+            confidence=Confidence.LOW,
+            visibility=Visibility.INTERNAL,
+            public_usable=False,
+            channel_policy="internal_controlled",
+            source_role="user",
+        )
+        approved_root = self.add_root(
+            9,
+            value="Crow likes modular synthesis.",
+            source_class=SourceClass.PUBLIC_OBSERVATION,
+            confidence=Confidence.APPROVED,
+            visibility=Visibility.INTERNAL,
+            public_usable=False,
+            channel_policy="internal_controlled",
+            source_role="user",
+        )
+        results = [
+            ledger.form_atomic_candidate_from_ledger_entry(
+                self.conn,
+                low_root,
+            ),
+            ledger.form_atomic_candidate_from_ledger_entry(
+                self.conn,
+                approved_root,
+            ),
+        ]
+
+        rows = [
+            self.candidate_row(result.candidate_id)
+            for result in results
+        ]
+        self.assertEqual(
+            [row[7] for row in rows],
+            [
+                SourceClass.PUBLIC_OBSERVATION.value,
+                SourceClass.PUBLIC_OBSERVATION.value,
+            ],
+        )
+        self.assertEqual(
+            [row[8] for row in rows],
+            [Confidence.LOW.value, Confidence.APPROVED.value],
+        )
+        self.assertTrue(all(row[6] == Visibility.INTERNAL.value for row in rows))
+        self.assertTrue(all(row[9:14] == (1, 0, 1, 0, "unpromoted") for row in rows))
+
+    def test_identity_provenance_visibility_and_authority_fail_closed(self):
+        subject_one = self.add_root(10)
+        subject_two = self.add_root(
+            11,
+            subject_key="discord_user:8",
+            participants=(
+                ledger.LedgerParticipant(
+                    "discord_user:8",
+                    "Other",
+                    "author",
+                    0,
+                ),
+            ),
+        )
+        other_guild = self.add_root(12, guild_id=2)
+        unknown_visibility = self.add_root(
+            13,
+            visibility=Visibility.UNKNOWN,
+            public_usable=False,
+            channel_policy="unknown",
+        )
+        source_blind = self.add_root(
+            14,
+            source_class=SourceClass.LEGACY_SOURCE_BLIND,
+            visibility=Visibility.PRIVATE,
+            public_usable=False,
+            channel_policy="internal_controlled",
+        )
+
+        cross_subject = ledger.form_atomic_knowledge_candidate(
+            self.conn,
+            ledger.AtomicKnowledgeProposal(
+                "topic_or_motif",
+                "discord_user:7",
+                "mixed_subjects",
+                "Subjects must not be combined.",
+                (subject_one, subject_two),
+                participant_keys=("discord_user:7",),
+                epistemic_status="source_abstraction",
+                currentness="uncertain",
+            ),
+        )
+        cross_guild = ledger.form_atomic_knowledge_candidate(
+            self.conn,
+            ledger.AtomicKnowledgeProposal(
+                "topic_or_motif",
+                "discord_user:7",
+                "mixed_guilds",
+                "Guild evidence must not be combined.",
+                (subject_one, other_guild),
+                participant_keys=("discord_user:7",),
+                epistemic_status="source_abstraction",
+                currentness="uncertain",
+            ),
+        )
+        visibility = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            unknown_visibility,
+        )
+        authority = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            source_blind,
+        )
+
+        self.assertEqual(
+            cross_subject.reason_code,
+            "subject_root_isolation_failure",
+        )
+        self.assertEqual(
+            cross_guild.reason_code,
+            "cross_guild_or_ambiguous_provenance",
+        )
+        self.assertEqual(
+            visibility.reason_code,
+            "ambiguous_route_or_policy",
+        )
+        self.assertEqual(authority.reason_code, "source_blind_provenance")
+
+    def test_participant_scope_mismatch_fails_closed(self):
+        one = self.add_root(15)
+        two = self.add_root(
+            16,
+            participants=(
+                ledger.LedgerParticipant(
+                    "discord_user:7",
+                    "Crow",
+                    "author",
+                    0,
+                ),
+                ledger.LedgerParticipant(
+                    "discord_user:8",
+                    "Other",
+                    "participant",
+                    1,
+                ),
+            ),
+        )
+        result = ledger.form_atomic_knowledge_candidate(
+            self.conn,
+            ledger.AtomicKnowledgeProposal(
+                "topic_or_motif",
+                "discord_user:7",
+                "scope_mismatch",
+                "Participant scopes cannot be merged ambiguously.",
+                (one, two),
+                participant_keys=("discord_user:7",),
+                epistemic_status="source_abstraction",
+                currentness="uncertain",
+            ),
+        )
+        self.assertEqual(result.reason_code, "participant_scope_mismatch")
+
+    def test_contradictions_and_explicit_supersession_are_diagnosable(self):
+        old_root = self.add_root(
+            17,
+            predicate_key="favorite_color",
+            value="green",
+        )
+        old = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            old_root,
+        )
+        conflict_root = self.add_root(
+            18,
+            predicate_key="favorite_color",
+            value="blue",
+        )
+        conflict = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            conflict_root,
+        )
+        self.assertEqual(conflict.outcome, "contested")
+        self.assertEqual(self.candidate_row(old.candidate_id)[5], "contested")
+        self.assertEqual(self.candidate_row(conflict.candidate_id)[5], "contested")
+
+        corrected_old_root = self.add_root(
+            19,
+            predicate_key="favorite_movie",
+            value="Hackers",
+        )
+        corrected_old = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            corrected_old_root,
+        )
+        replacement_root = self.add_root(
+            20,
+            predicate_key="favorite_movie",
+            value="The Matrix",
+            lineage=(
+                ("correction_of", corrected_old_root),
+                ("supersedes", corrected_old_root),
+            ),
+        )
+        replacement = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            replacement_root,
+        )
+
+        self.assertEqual(replacement.outcome, "created")
+        replacement_row = self.candidate_row(replacement.candidate_id)
+        self.assertEqual(replacement_row[5], "candidate")
+        self.assertEqual(
+            replacement_row[15],
+            corrected_old.candidate_id,
+        )
+        self.assertEqual(
+            self.candidate_row(corrected_old.candidate_id)[5],
+            "superseded",
+        )
+
+    def test_same_roots_with_different_meaning_becomes_contested(self):
+        root = self.add_root(
+            21,
+            entry_type="observation",
+            predicate_key="conversation",
+            value="We discussed an unresolved signal.",
+            source_class=SourceClass.PUBLIC_OBSERVATION,
+            source_role="user",
+        )
+        base = dict(
+            candidate_type="inference_or_contested_claim",
+            subject_key="discord_user:7",
+            predicate_key="unresolved_signal",
+            root_entry_ids=(root,),
+            participant_keys=("discord_user:7",),
+            epistemic_status="inference",
+            currentness="uncertain",
+        )
+        first = ledger.form_atomic_knowledge_candidate(
+            self.conn,
+            ledger.AtomicKnowledgeProposal(
+                meaning="Inference: the signal may be recurring.",
+                **base,
+            ),
+        )
+        second = ledger.form_atomic_knowledge_candidate(
+            self.conn,
+            ledger.AtomicKnowledgeProposal(
+                meaning="Inference: the signal may be isolated.",
+                **base,
+            ),
+        )
+        self.assertEqual(first.outcome, "created")
+        self.assertEqual(second.outcome, "contested")
+        self.assertEqual(self.candidate_row(first.candidate_id)[5], "contested")
+        self.assertEqual(
+            self.candidate_row(first.candidate_id)[14],
+            "same_roots_meaning_mismatch",
+        )
+
+    def test_privacy_source_invalidation_and_deletion_propagate(self):
+        privacy_root = self.add_root(22)
+        privacy_candidate = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            privacy_root,
+        )
+        self.conn.execute(
+            """
+            UPDATE memory_ledger_entries
+            SET visibility='private',public_usable=0
+            WHERE entry_id=?
+            """,
+            (privacy_root,),
+        )
+        privacy_row = self.candidate_row(privacy_candidate.candidate_id)
+        self.assertEqual(privacy_row[2], "")
+        self.assertEqual(privacy_row[5], "invalidated")
+        self.assertEqual(
+            privacy_row[14],
+            "root_privacy_or_provenance_changed",
+        )
+
+        invalid_root = self.add_root(23, predicate_key="favorite_movie")
+        invalid_candidate = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            invalid_root,
+        )
+        self.conn.execute(
+            """
+            UPDATE memory_ledger_entries
+            SET lifecycle_status='quarantined'
+            WHERE entry_id=?
+            """,
+            (invalid_root,),
+        )
+        self.assertEqual(
+            self.candidate_row(invalid_candidate.candidate_id)[5],
+            "invalidated",
+        )
+
+        deleted_root = self.add_root(24, predicate_key="preferred_name")
+        deleted_candidate = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            deleted_root,
+        )
+        self.conn.execute(
+            "DELETE FROM memory_ledger_entries WHERE entry_id=?",
+            (deleted_root,),
+        )
+        deleted_row = self.candidate_row(deleted_candidate.candidate_id)
+        self.assertEqual(deleted_row[2], "")
+        self.assertEqual(deleted_row[5], "invalidated")
+        self.assertEqual(deleted_row[14], "root_deleted")
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT root_status
+                FROM memory_ledger_knowledge_roots
+                WHERE candidate_id=? AND root_entry_id=?
+                """,
+                (deleted_candidate.candidate_id, deleted_root),
+            ).fetchone()[0],
+            "deleted",
+        )
+
+    def test_member_correction_and_forget_propagate_without_reintroduction(self):
+        original = ledger.shadow_first_party_user_fact(
+            self.conn,
+            row_id=25,
+            user_id=7,
+            user_name="Crow",
+            guild_id=1,
+            fact_key="favorite_color",
+            fact_value="green",
+            channel_name="barcode-bot",
+            channel_policy="public_home",
+            channel_id=10,
+            message_id=1025,
+            route_mode="normal_chat",
+            observed_at="2026-07-25T00:00:25+00:00",
+        )
+        original_candidate = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            original.entry_id,
+        )
+        safe_ref = view_member_memory(
+            self.conn,
+            guild_id=1,
+            user_id=7,
+        )[0]["ref"]
+
+        corrected = correct_member_memory(
+            self.conn,
+            guild_id=1,
+            user_id=7,
+            safe_ref=safe_ref,
+            corrected_text="violet",
+        )
+        self.assertTrue(corrected["ok"])
+        corrected_candidate_id = self.conn.execute(
+            """
+            SELECT candidate_id
+            FROM memory_ledger_knowledge_candidates
+            WHERE subject_key='discord_user:7'
+              AND normalized_value='violet'
+            """
+        ).fetchone()[0]
+        self.assertEqual(
+            self.candidate_row(original_candidate.candidate_id)[5],
+            "superseded",
+        )
+        self.assertEqual(
+            self.candidate_row(corrected_candidate_id)[15],
+            original_candidate.candidate_id,
+        )
+
+        forgotten = forget_member_memory(
+            self.conn,
+            guild_id=1,
+            user_id=7,
+            safe_ref=safe_ref,
+        )
+        self.assertTrue(forgotten["ok"])
+        rows = self.conn.execute(
+            """
+            SELECT normalized_value,candidate_state,candidate_eligible,
+                   live_eligible
+            FROM memory_ledger_knowledge_candidates
+            WHERE subject_key='discord_user:7'
+            """
+        ).fetchall()
+        self.assertTrue(rows)
+        self.assertTrue(
+            all(
+                value == ""
+                and state in {"invalidated", "superseded"}
+                and not candidate_eligible
+                and not live_eligible
+                for value, state, candidate_eligible, live_eligible in rows
+            )
+        )
+        replay = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            original.entry_id,
+        )
+        self.assertEqual(
+            replay.reason_code,
+            "ineligible_root_lifecycle",
+        )
+
+    def test_complete_delete_purges_candidate_boundary(self):
+        root = self.add_root(26)
+        created = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            root,
+        )
+        self.assertTrue(created)
+
+        result = complete_delete_member_data(
+            self.conn,
+            guild_id=1,
+            user_id=7,
+            confirmation="DELETE MY BNL DATA 1",
+        )
+
+        self.assertTrue(result["ok"])
+        for table in (
+            "memory_ledger_knowledge_candidates",
+            "memory_ledger_knowledge_roots",
+            "memory_ledger_knowledge_participants",
+        ):
+            self.assertEqual(
+                self.conn.execute(
+                    f"SELECT COUNT(*) FROM {table}"
+                ).fetchone()[0],
+                0,
+            )
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM memory_ledger_knowledge_receipts
+                WHERE candidate_id=?
+                """,
+                (created.candidate_id,),
+            ).fetchone()[0],
+            0,
+        )
+
+    def test_backfill_is_bounded_resumable_and_restart_safe(self):
+        fd, path = tempfile.mkstemp(prefix="bnl-atomic-", suffix=".sqlite3")
+        os.close(fd)
+        try:
+            conn = sqlite3.connect(path)
+            ledger.ensure_memory_ledger_schema(conn)
+            for row_id, predicate in ((27, "favorite_color"), (28, "favorite_movie")):
+                entry = ledger.LedgerEntry(
+                    guild_id=1,
+                    source_table="conversations",
+                    source_row_id=row_id,
+                    source_revision=str(row_id),
+                    source_role="member_self_report",
+                    entry_type="preference",
+                    subject_key="discord_user:7",
+                    predicate_key=predicate,
+                    value=f"value-{row_id}",
+                    source_class=SourceClass.FIRST_PARTY_RECORD,
+                    route_mode="normal_chat",
+                    channel_policy="public_home",
+                    visibility=Visibility.PUBLIC,
+                    confidence=Confidence.HIGH,
+                    public_usable=True,
+                    observed_at=f"2026-07-25T00:00:{row_id}+00:00",
+                    participants=(
+                        ledger.LedgerParticipant(
+                            "discord_user:7",
+                            "Crow",
+                            "author",
+                            0,
+                        ),
+                    ),
+                )
+                ledger.insert_ledger_entry(conn, entry)
+            first = ledger.backfill_atomic_knowledge_candidates(
+                conn,
+                batch_size=1,
+            )
+            conn.commit()
+            self.assertFalse(first["completed"])
+            self.assertEqual(
+                conn.execute(
+                    "SELECT COUNT(*) FROM memory_ledger_knowledge_candidates"
+                ).fetchone()[0],
+                1,
+            )
+            conn.close()
+
+            conn = sqlite3.connect(path)
+            second = ledger.backfill_atomic_knowledge_candidates(
+                conn,
+                batch_size=1,
+            )
+            third = ledger.backfill_atomic_knowledge_candidates(
+                conn,
+                batch_size=1,
+            )
+            fourth = ledger.backfill_atomic_knowledge_candidates(
+                conn,
+                batch_size=1,
+            )
+            conn.commit()
+            self.assertFalse(second["completed"])
+            self.assertTrue(third["completed"])
+            self.assertTrue(fourth["completed"])
+            self.assertEqual(
+                conn.execute(
+                    "SELECT COUNT(*) FROM memory_ledger_knowledge_candidates"
+                ).fetchone()[0],
+                2,
+            )
+            self.assertEqual(third["counts"]["created"], 2)
+            self.assertEqual(third, fourth)
+            conn.close()
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_moment_candidate_uses_participant_gist_and_actual_roots(self):
+        moments.ensure_moment_schema(self.conn)
+        source = self.add_root(
+            29,
+            entry_type="observation",
+            predicate_key="conversation",
+            value="I keep returning to modular synth patch design.",
+            source_class=SourceClass.PUBLIC_OBSERVATION,
+            source_role="user",
+        )
+        canonical = self.add_root(
+            30,
+            subject_key="moment:moment-one",
+            entry_type="shared_moment",
+            predicate_key="shared_moment",
+            value="A source-bounded Moment abstraction.",
+            source_class=SourceClass.DERIVED_SUMMARY,
+            source_role="derived_assessment",
+            confidence=Confidence.LOW,
+            derived=True,
+            projection=True,
+            participants=(
+                ledger.LedgerParticipant(
+                    "discord_user:7",
+                    "Crow",
+                    "participant",
+                    0,
+                ),
+            ),
+            lineage=(("derived_from", source),),
+            source_table="memory_moment_windows",
+        )
+        self.conn.execute(
+            """
+            INSERT INTO memory_moment_windows(
+              moment_id,guild_id,channel_id,channel_name,channel_policy,
+              route_mode,topic_key,topic_family,window_started_at,
+              last_activity_at,lifecycle_status,visibility,public_usable,
+              canonical_ledger_entry_id,created_at,updated_at
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                "moment-one",
+                1,
+                10,
+                "barcode-bot",
+                "public_home",
+                "normal_chat",
+                "modular_synth",
+                "music_production",
+                "2026-07-25T00:00:29+00:00",
+                "2026-07-25T00:00:30+00:00",
+                "finalized",
+                "public",
+                1,
+                canonical,
+                "now",
+                "now",
+            ),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO memory_moment_contributions(
+              moment_id,participant_key,contribution_gist,frame_type,
+              source_digest,source_count,gist_version,lifecycle_status,
+              public_usable,created_at,updated_at
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                "moment-one",
+                "discord_user:7",
+                "The participant returned to modular synth patch design.",
+                "observation",
+                "digest",
+                1,
+                "test",
+                "review_only",
+                1,
+                "now",
+                "now",
+            ),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO memory_moment_contribution_sources(
+              moment_id,participant_key,ledger_entry_id,gist_version,
+              created_at
+            ) VALUES(?,?,?,?,?)
+            """,
+            ("moment-one", "discord_user:7", source, "test", "now"),
+        )
+
+        results = ledger.form_atomic_candidates_from_moment(
+            self.conn,
+            "moment-one",
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].outcome, "created")
+        row = self.candidate_row(results[0].candidate_id)
+        self.assertEqual(row[0], "topic_or_motif")
+        self.assertEqual(row[3], "source_abstraction")
+        self.assertEqual(row[9:11], (1, 1))
+
+    def test_rehearsal_and_show_operational_sources_are_excluded(self):
+        excluded_values = (
+            "Queue rehearsal with a synthetic artist passed.",
+            "A test payment was recorded for the wheel spin.",
+            "The queue simulation marked a track up next.",
+        )
+        results = []
+        for offset, value in enumerate(excluded_values, start=31):
+            root = self.add_root(
+                offset,
+                subject_key="barcode_network",
+                entry_type="event",
+                predicate_key=f"operational_event_{offset}",
+                value=value,
+                source_role="operator",
+                participants=(),
+                source_table="project_evidence",
+            )
+            results.append(
+                ledger.form_atomic_candidate_from_ledger_entry(
+                    self.conn,
+                    root,
+                )
+            )
+        ordinary = self.add_root(
+            34,
+            subject_key="barcode_network",
+            entry_type="event",
+            predicate_key="shared_brain_checkpoint",
+            value="The governed recall canary was production-proven.",
+            source_role="operator",
+            participants=(),
+            source_table="project_evidence",
+        )
+        ordinary_result = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            ordinary,
+        )
+
+        self.assertTrue(
+            all(
+                result.reason_code
+                == "operational_or_rehearsal_source_excluded"
+                for result in results
+            )
+        )
+        self.assertEqual(ordinary_result.outcome, "created")
+
+    def test_diagnostics_are_aggregate_and_expose_invariants_not_content(self):
+        secret = "candidate-only-diagnostic-secret-417"
+        root = self.add_root(35, value="green")
+        created = ledger.form_atomic_knowledge_candidate(
+            self.conn,
+            ledger.AtomicKnowledgeProposal(
+                candidate_type="person_role_fact",
+                subject_key="discord_user:7",
+                predicate_key="favorite_color",
+                meaning=secret,
+                root_entry_ids=(root,),
+                participant_keys=("discord_user:7",),
+                epistemic_status="stated",
+                currentness="current",
+            ),
+        )
+        self.assertTrue(created)
+        ledger.form_atomic_knowledge_candidate(
+            self.conn,
+            ledger.AtomicKnowledgeProposal(
+                candidate_type="topic_or_motif",
+                subject_key="unknown",
+                predicate_key="ambiguous",
+                meaning="This must be rejected.",
+                root_entry_ids=(root,),
+                epistemic_status="source_abstraction",
+                currentness="uncertain",
+            ),
+        )
+
+        report = ledger.build_memory_ledger_evaluation(
+            self.conn,
+            guild_id=1,
+        )
+
+        self.assertEqual(
+            report["knowledgeCandidateSchemaVersion"],
+            ledger.ATOMIC_KNOWLEDGE_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            report["knowledgeCandidateTotalsByType"]["person_role_fact"],
+            1,
+        )
+        self.assertEqual(
+            report["knowledgeCandidateTotalsByEpistemicStatus"]["stated"],
+            1,
+        )
+        self.assertEqual(
+            report["knowledgeCandidateTotalsByCurrentness"]["current"],
+            1,
+        )
+        self.assertEqual(
+            report["knowledgeCandidateTotalsByConfidence"]["high"],
+            1,
+        )
+        self.assertEqual(report["knowledgeCandidateLiveEligibleCount"], 0)
+        self.assertEqual(report["knowledgeCandidateOrphanedRoots"], 0)
+        self.assertEqual(
+            report["knowledgeCandidateParticipantIsolationViolations"],
+            0,
+        )
+        self.assertGreaterEqual(
+            report["knowledgeCandidateAmbiguousRejections"],
+            1,
+        )
+        self.assertNotIn(secret, repr(report))
+
+    def test_candidate_table_is_not_a_live_governance_source(self):
+        root = self.add_root(
+            36,
+            predicate_key="favorite_movie",
+            value="favorite movie is RootFilm",
+        )
+        candidate_only_text = "candidate-only phrase 8675309"
+        result = ledger.form_atomic_knowledge_candidate(
+            self.conn,
+            ledger.AtomicKnowledgeProposal(
+                candidate_type="person_role_fact",
+                subject_key="discord_user:7",
+                predicate_key="favorite_movie",
+                meaning=candidate_only_text,
+                root_entry_ids=(root,),
+                participant_keys=("discord_user:7",),
+                epistemic_status="stated",
+                currentness="current",
+            ),
+        )
+        self.assertTrue(result)
+
+        governed = build_governed_context(
+            self.conn,
+            GovernanceRequest(
+                guild_id=1,
+                subject_user_id=7,
+                route_mode="normal_chat",
+                conversation_surface="test",
+                channel_policy="public_home",
+                visibility_allowance="public_safe",
+                user_text="what is my favorite movie?",
+                budget_chars=500,
+                allowed_source_classes=(
+                    "first_party_record",
+                    "owner_correction",
+                    "public_observation",
+                ),
+                now="2026-07-25T01:00:00+00:00",
+            ),
+        )
+
+        self.assertIn("RootFilm", governed.rendered_context)
+        self.assertNotIn(candidate_only_text, governed.rendered_context)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add Ledger-owned, source-linked atomic knowledge candidates for person/role facts, project milestones, recurring topics, open loops, and explicitly labeled inference/contested claims
- preserve independent root evidence, BNL-derivative lineage, subject/participant/route/visibility/authority/currentness metadata, and deterministic restart-safe identity
- propagate correction, supersession, retraction, deletion, privacy, route, authority, participant, and source invalidation through additive Ledger tables/triggers
- add aggregate diagnostics and a bounded resumable shadow backfill under the existing Memory Ledger shadow gate

## Safety boundary

- candidates are always unpromoted and live-ineligible
- no live retrieval or response selector reads the candidate tables
- derivative-only evidence cannot corroborate itself; ambiguity fails closed
- ordinary candidate formation excludes rehearsal, queue simulation, synthetic-artist, test-payment, wheel, and other show-test data
- no gate/config, Relationship v2, Active Engagement, queue/payment/overlay, site, dossier, Journal, Relay, reaction, typing, or personality behavior changes

## Validation

- focused lifecycle/lineage/privacy/authority/isolation/restart/diagnostic/rehearsal/live-response tests: 16 passed
- related integration modules: 253 passed
- `make check PYTHON=/tmp/bnl01-atomic-venv/bin/python`: compiled bot/modules/tests and passed all 1,559 tests
- `git diff --check`: clean

## Rollback

Revert this PR's merge commit and restart the service. The additive SQLite tables/triggers may remain inert; do not drop production tables as part of an emergency code rollback.