### PR TITLE
Fix broad recall with source-safe multi-source synthesis

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -719,6 +719,13 @@ DEFAULT_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS = {
     "invalid_invariant_count": 0,
     "raw_invalid_invariant_count": 0,
     "reclassified_invariant_count": 0,
+    "synthesis_requested": False,
+    "synthesis_packet_assembled": False,
+    "packet_lane_count": 0,
+    "packet_source_count": 0,
+    "packet_conversation_source_count": 0,
+    "packet_memory_source_classes": (),
+    "atomic_candidates_live_used": 0,
 }
 LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS = {}
 LAST_CONVERSATION_CONTEXT_V2_DIAGNOSTICS = {
@@ -884,16 +891,17 @@ def memory_governance_canary_last_diagnostics(
     user_id: int,
     guild_id: int,
 ) -> dict:
-    not_evaluated = {
+    baseline = {
         **DEFAULT_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS,
         **memory_governance_canary_configuration(),
     }
-    return dict(
-        LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS.get(
+    return {
+        **baseline,
+        **LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS.get(
             (int(user_id or 0), int(guild_id or 0)),
-            not_evaluated,
-        )
-    )
+            {},
+        ),
+    }
 
 
 def unified_moment_canary_configuration(
@@ -17317,6 +17325,112 @@ def _normalized_personal_recall_intent(text: str) -> str:
     return cleaned.strip(" \t\r\n.!?")
 
 
+_BROAD_PERSONAL_RECALL_PATTERNS = (
+    r"what do you remember about me",
+    r"what do you have on me",
+    r"what do you know about me",
+    r"tell me what you (?:remember|know) about me",
+    r"tell me everything you remember about me",
+    r"tell me everything you remember",
+    r"what have you learned about me",
+)
+_SOURCE_SAFE_RECALL_OUTPUT_LEAK_RE = re.compile(
+    r"\b(?:source-safe personal recall synthesis contract|"
+    r"source-safe recall packet|recall source lanes?|source lanes?|"
+    r"governed durable (?:records?|memory)|memory governance canary|"
+    r"packet memory source classes|atomic candidates live used|"
+    r"evidence (?:ids?|identifiers?))\b",
+    re.I,
+)
+
+
+def is_broad_personal_recall_request(user_text: str) -> bool:
+    """Recognize only the established broad first-person recall intent."""
+
+    recall_intent = _normalized_personal_recall_intent(user_text)
+    if not recall_intent or re.search(
+        r"\b(?:do not|don't|never|not yet|later|before you answer|"
+        r"don't answer|do not answer|hold off|wait)\b",
+        recall_intent,
+        flags=re.I,
+    ):
+        return False
+    return any(
+        re.fullmatch(pattern, recall_intent)
+        for pattern in _BROAD_PERSONAL_RECALL_PATTERNS
+    )
+
+
+def source_safe_recall_synthesis_enabled(
+    *,
+    guild_id: int,
+    user_id: int,
+    route_mode: str,
+    channel_policy: str,
+    user_text: str,
+    current_direct: bool,
+    environ: dict[str, str] | None = None,
+) -> bool:
+    """Reuse the governed-recall canary for one source-safe synthesis route."""
+
+    return bool(
+        current_direct
+        and is_broad_personal_recall_request(user_text)
+        and memory_governance_canary_enabled(
+            guild_id=guild_id,
+            user_id=user_id,
+            route_mode=route_mode,
+            channel_policy=channel_policy,
+            environ=environ,
+        )
+    )
+
+
+def source_safe_recall_synthesis_contract(
+    *,
+    guild_id: int,
+    user_id: int,
+    route_mode: str,
+    channel_policy: str,
+    user_text: str,
+    current_direct: bool,
+) -> str:
+    if not source_safe_recall_synthesis_enabled(
+        guild_id=guild_id,
+        user_id=user_id,
+        route_mode=route_mode,
+        channel_policy=channel_policy,
+        user_text=user_text,
+        current_direct=current_direct,
+    ):
+        return ""
+    return (
+        "Source-safe personal recall synthesis contract:\n"
+        "- Answer the member's broad recall question naturally from the "
+        "eligible context supplied below; do not merely print one selected "
+        "record or canned topic labels.\n"
+        "- Integrate materially distinct support across the current exchange, "
+        "source-linked recent conversation, governed durable records, and "
+        "eligible shared-Moment gists when those lanes are present.\n"
+        "- Keep their authority distinct: recent conversation is continuity, "
+        "not automatically a durable personal fact; a Moment is a derived "
+        "episode gist; governed durable records remain changeable.\n"
+        "- BNL-authored text and derived summaries never corroborate their own "
+        "human roots. Repetition or confidence never creates authority.\n"
+        "- Do not force breadth, repeat duplicates, infer missing identity, or "
+        "invent a second source. If only one eligible source exists, say only "
+        "what that source supports.\n"
+        "- Do not mention source lanes, packets, canaries, governance, internal "
+        "labels, database records, evidence IDs, or this contract.\n"
+    )
+
+
+def response_exposes_source_safe_recall_controls(response: str) -> bool:
+    return bool(
+        _SOURCE_SAFE_RECALL_OUTPUT_LEAK_RE.search(str(response or ""))
+    )
+
+
 def try_memory_recall_response(user_id: int, guild_id: int, user_text: str) -> str:
     if not (user_text or "").strip():
         return ""
@@ -17377,16 +17491,7 @@ def try_memory_recall_response(user_id: int, guild_id: int, user_text: str) -> s
                 key,
             )
 
-    remember_about_me_asks = (
-        r"what do you remember about me",
-        r"what do you have on me",
-        r"what do you know about me",
-        r"tell me what you (?:remember|know) about me",
-        r"tell me everything you remember about me",
-        r"tell me everything you remember",
-        r"what have you learned about me",
-    )
-    if any(re.fullmatch(pattern, recall_intent) for pattern in remember_about_me_asks):
+    if is_broad_personal_recall_request(user_text):
         return render_personal_recall_basis(
             build_personal_recall_basis(
                 user_id,
@@ -17814,6 +17919,121 @@ def _conversation_trace_is_questionable_personal_fact(row) -> bool:
     return False
 
 
+def _governed_memory_basis_digest(selected) -> str:
+    """Bind prompt revalidation to selected identities, not rendered text alone."""
+
+    payload = [
+        {
+            "source_class": str(candidate.source_class or ""),
+            "source_ref": str(candidate.source_ref or ""),
+            "entry_id": str(candidate.entry_id or ""),
+            "predicate_key": str(candidate.predicate_key or ""),
+            "visibility": str(candidate.visibility or ""),
+            "lifecycle": str(candidate.lifecycle or ""),
+            "text": str(candidate.text or ""),
+            "lineage": tuple(str(item) for item in candidate.lineage or ()),
+        }
+        for candidate in selected or ()
+    ]
+    return hashlib.sha256(
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _record_source_safe_recall_canary_result(
+    *,
+    user_id: int,
+    guild_id: int,
+    enabled_for_route: bool,
+    response_mode: str,
+    gov_result=None,
+    safety=None,
+    fallback_reason: str = "",
+) -> None:
+    selected = tuple(getattr(gov_result, "selected", ()) or ())
+    diagnostics = getattr(gov_result, "diagnostics", None)
+    source_classes = tuple(
+        dict.fromkeys(
+            str(candidate.source_class or "")
+            for candidate in selected
+            if str(candidate.source_class or "")
+        )
+    )
+    LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS[
+        (int(user_id or 0), int(guild_id or 0))
+    ] = {
+        **DEFAULT_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS,
+        **memory_governance_canary_configuration(),
+        "enabled_for_route": bool(enabled_for_route),
+        "evaluated": bool(gov_result is not None),
+        "response_mode": str(response_mode or "unknown")[:80],
+        "selected_count": len(selected),
+        "rendered": bool(getattr(gov_result, "rendered_context", "")),
+        "fallback_reason": str(fallback_reason or "")[:120],
+        "legacy_vs_governed": dict(
+            getattr(diagnostics, "legacy_vs_governed", {}) or {}
+        ),
+        "processing_error_count": len(
+            tuple(getattr(safety, "processing_errors", ()) or ())
+        ),
+        "invalid_invariant_count": len(
+            tuple(getattr(safety, "blocking_invariants", ()) or ())
+        ),
+        "raw_invalid_invariant_count": int(
+            getattr(safety, "raw_invalid_invariant_count", 0) or 0
+        ),
+        "reclassified_invariant_count": int(
+            getattr(safety, "reclassified_invariant_count", 0) or 0
+        ),
+        "synthesis_requested": True,
+        "packet_memory_source_classes": source_classes,
+        "atomic_candidates_live_used": 0,
+    }
+
+
+def _record_source_safe_recall_packet_assembled(
+    *,
+    user_id: int,
+    guild_id: int,
+    conversation_source_count: int,
+) -> None:
+    key = (int(user_id or 0), int(guild_id or 0))
+    diagnostics = dict(
+        LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS.get(key, {})
+    )
+    if not diagnostics.get("synthesis_requested"):
+        return
+    source_classes = tuple(
+        diagnostics.get("packet_memory_source_classes") or ()
+    )
+    memory_count = max(0, int(diagnostics.get("selected_count") or 0))
+    conversation_count = max(0, int(conversation_source_count or 0))
+    has_moment = "moment_gist" in source_classes
+    has_other_governed = any(
+        source_class != "moment_gist" for source_class in source_classes
+    )
+    diagnostics.update(
+        {
+            "synthesis_packet_assembled": True,
+            "packet_lane_count": (
+                1
+                + int(conversation_count > 0)
+                + int(has_moment)
+                + int(has_other_governed)
+            ),
+            "packet_source_count": 1 + conversation_count + memory_count,
+            "packet_conversation_source_count": conversation_count,
+            "atomic_candidates_live_used": 0,
+        }
+    )
+    LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS[key] = diagnostics
+
+
 def build_user_memory_context(
     user_id: int,
     guild_id: int,
@@ -17841,6 +18061,10 @@ def build_user_memory_context(
                 "governance_contradiction_count": 0,
                 "moment_candidate_count": 0,
                 "prompt_budget": 0,
+                "source_safe_recall_synthesis": False,
+                "governed_source_classes": (),
+                "governed_basis_digest": "",
+                "atomic_candidates_live_used": 0,
             }
         )
     if route_mode == ROUTE_MODE_SIMPLE_GREETING:
@@ -17850,6 +18074,19 @@ def build_user_memory_context(
     if route_mode in SOURCE_INTERNAL_MODES or policy in {"unknown", "sealed_test", "protected_system", "broadcast_memory", "reference_canon", "ai_image_tool"}:
         LAST_MEMORY_PROMPT_DIAGNOSTICS[(user_id, guild_id)] = {"skipped_reason": f"route_or_policy_{policy}", "included": {"short": 0, "medium": 0, "long": 0}}
         return "No route-safe durable memory for this mode/channel."
+
+    source_safe_recall_synthesis = source_safe_recall_synthesis_enabled(
+        guild_id=guild_id,
+        user_id=user_id,
+        route_mode=route_mode,
+        channel_policy=policy,
+        user_text=user_text,
+        current_direct=current_direct,
+    )
+    if source_metadata is not None:
+        source_metadata["source_safe_recall_synthesis"] = bool(
+            source_safe_recall_synthesis
+        )
 
     limits = calculate_adaptive_memory_limits(user_id, guild_id, route_mode=route_mode, channel_policy=policy, user_text=user_text, is_owner_or_mod=is_owner_or_mod)
     approved_facts = get_approved_member_fact_evidence(user_id, guild_id)
@@ -18027,14 +18264,37 @@ def build_user_memory_context(
                     subject_user_id=user_id,
                     route_mode=route_mode,
                     conversation_surface="discord_prompt_assembly",
+                    channel_id=int(channel_id or 0),
                     channel_policy=policy,
                     visibility_allowance=limits.get("visibility", "public_safe"),
                     user_text=user_text or "",
                     budget_chars=int(limits.get("prompt_budget") or 1200),
-                    allowed_source_classes=("owner_correction", "approved_canon", "first_party_record", "runtime_observation", "public_observation", "evidence_projection", "derived_summary"),
+                    allowed_source_classes=(
+                        "owner_correction",
+                        "approved_canon",
+                        "first_party_record",
+                        "runtime_observation",
+                        "public_observation",
+                        "moment_gist",
+                        "evidence_projection",
+                        "derived_summary",
+                    ),
                     now=datetime.now(PACIFIC_TZ).isoformat(),
                 )
-                gov_result = build_governed_context(gov_conn, gov_req, legacy_context=legacy_context, include_review_moments=True)
+                gov_result = build_governed_context(
+                    gov_conn,
+                    gov_req,
+                    legacy_context=legacy_context,
+                    include_review_moments=True,
+                    include_public_moment_gists=bool(
+                        moment_engine_shadow_enabled()
+                        and (
+                            source_safe_recall_synthesis
+                            or memory_governance_live_enabled()
+                        )
+                    ),
+                )
+                safety = assess_governance_result_safety(gov_result)
                 diagnostics["memory_governance"] = {
                     "shadow_enabled": True,
                     "live_enabled": memory_governance_live_enabled(),
@@ -18069,12 +18329,69 @@ def build_user_memory_context(
                                 gov_result.diagnostics.moment_candidate_count
                                 or 0
                             ),
+                            "governed_source_classes": tuple(
+                                dict.fromkeys(
+                                    str(candidate.source_class or "")
+                                    for candidate in gov_result.selected
+                                    if str(candidate.source_class or "")
+                                )
+                            ),
+                            "governed_basis_digest": (
+                                _governed_memory_basis_digest(
+                                    gov_result.selected
+                                )
+                            ),
+                            "atomic_candidates_live_used": 0,
                         }
                     )
                 persist_shadow_diagnostics(gov_conn, gov_req, gov_result, legacy_context)
-                unsafe_governed = assess_governance_result_safety(
-                    gov_result
-                ).unsafe
+                unsafe_governed = safety.unsafe
+                if source_safe_recall_synthesis:
+                    response_mode = (
+                        "source_safe_synthesis_blocked"
+                        if unsafe_governed
+                        else "source_safe_synthesis"
+                    )
+                    fallback_reason = (
+                        "unsafe_governed_result"
+                        if unsafe_governed
+                        else ""
+                    )
+                    _record_source_safe_recall_canary_result(
+                        user_id=user_id,
+                        guild_id=guild_id,
+                        enabled_for_route=True,
+                        response_mode=response_mode,
+                        gov_result=gov_result,
+                        safety=safety,
+                        fallback_reason=fallback_reason,
+                    )
+                    if source_metadata is not None:
+                        source_metadata.update(
+                            {
+                                "legacy_relationship_present": False,
+                                "legacy_memory_present": False,
+                                "moment_gist_rendered": any(
+                                    candidate.source_class == "moment_gist"
+                                    for candidate in gov_result.selected
+                                ),
+                            }
+                        )
+                    LAST_MEMORY_PROMPT_DIAGNOSTICS[
+                        (user_id, guild_id)
+                    ] = diagnostics
+                    if unsafe_governed:
+                        diagnostics["memory_governance"][
+                            "fallback_reason"
+                        ] = "unsafe_governed_result"
+                        return (
+                            "No currently eligible source-bearing durable "
+                            "memory context."
+                        )
+                    return (
+                        gov_result.rendered_context
+                        or "No currently eligible governed durable memory."
+                    )
                 if memory_governance_live_enabled() and not unsafe_governed:
                     LAST_MEMORY_PROMPT_DIAGNOSTICS[(user_id, guild_id)] = diagnostics
                     governed_context = gov_result.rendered_context
@@ -18096,6 +18413,27 @@ def build_user_memory_context(
                     diagnostics["memory_governance"]["fallback_reason"] = "unsafe_governed_result"
         except Exception as e:
             diagnostics["memory_governance"] = {"shadow_enabled": True, "live_enabled": False, "fallback_reason": type(e).__name__}
+            if source_safe_recall_synthesis:
+                _record_source_safe_recall_canary_result(
+                    user_id=user_id,
+                    guild_id=guild_id,
+                    enabled_for_route=True,
+                    response_mode="source_safe_synthesis_exception",
+                    fallback_reason=type(e).__name__,
+                )
+                if source_metadata is not None:
+                    source_metadata.update(
+                        {
+                            "legacy_relationship_present": False,
+                            "legacy_memory_present": False,
+                            "moment_gist_rendered": False,
+                            "atomic_candidates_live_used": 0,
+                        }
+                    )
+                LAST_MEMORY_PROMPT_DIAGNOSTICS[
+                    (user_id, guild_id)
+                ] = diagnostics
+                return "No currently eligible source-bearing durable memory context."
     LAST_MEMORY_PROMPT_DIAGNOSTICS[(user_id, guild_id)] = diagnostics
     return legacy_context
 
@@ -18189,6 +18527,8 @@ class MemoryPromptSourceBasis:
     channel_id: int
     moment_attribution_target_user_id: int
     has_moment_gist: bool = False
+    governed_basis_digest: str = ""
+    source_safe_recall_synthesis: bool = False
 
 
 @dataclass(frozen=True)
@@ -18880,6 +19220,8 @@ def build_memory_prompt_source_basis(
     channel_id: int,
     moment_attribution_target_user_id: int,
     has_moment_gist: bool = False,
+    governed_basis_digest: str = "",
+    source_safe_recall_synthesis: bool = False,
 ) -> MemoryPromptSourceBasis | None:
     value = str(rendered_context or "")
     if not any(marker in value for marker in _SOURCE_BEARING_MEMORY_MARKERS):
@@ -18900,6 +19242,10 @@ def build_memory_prompt_source_basis(
             moment_attribution_target_user_id or 0
         ),
         has_moment_gist=bool(has_moment_gist),
+        governed_basis_digest=str(governed_basis_digest or ""),
+        source_safe_recall_synthesis=bool(
+            source_safe_recall_synthesis
+        ),
     )
 
 
@@ -19090,10 +19436,20 @@ def refresh_prompt_source_basis(
             has_moment_gist=bool(
                 source_metadata.get("moment_gist_rendered")
             ),
+            governed_basis_digest=str(
+                source_metadata.get("governed_basis_digest") or ""
+            ),
+            source_safe_recall_synthesis=bool(
+                source_metadata.get("source_safe_recall_synthesis")
+            ),
         )
         return fresh, bool(
             fresh.expected_digest != basis.expected_digest
             or fresh.has_moment_gist != basis.has_moment_gist
+            or fresh.governed_basis_digest
+            != basis.governed_basis_digest
+            or fresh.source_safe_recall_synthesis
+            != basis.source_safe_recall_synthesis
         )
     if isinstance(basis, BatchMomentPromptSourceBasis):
         fresh_context = build_batch_moment_attribution_context(
@@ -19155,6 +19511,13 @@ def refresh_prompt_source_bases(
         )
         changed_kinds.append(kind)
         if isinstance(basis, ConversationPromptSourceBasis):
+            replacement_failed = True
+            continue
+        if (
+            isinstance(basis, MemoryPromptSourceBasis)
+            and basis.source_safe_recall_synthesis
+            != fresh.source_safe_recall_synthesis
+        ):
             replacement_failed = True
             continue
         if basis.rendered_context not in updated_prompt:
@@ -24116,8 +24479,18 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             if not memory_recall:
                 memory_recall = try_memory_recall_response(unique_user_ids[0], channel.guild.id, combined_text)
                 if memory_recall:
-                    memory_recall = apply_explicit_recall_governance(unique_user_ids[0], channel.guild.id, combined_text, memory_recall, ROUTE_MODE_NORMAL_CHAT, channel_policy, channel_id=channel_id, channel_name=getattr(channel, "name", ""), is_owner_or_mod=is_privileged_member(member, channel.guild))
-                    memory_recall = format_explicit_recall_for_chat(memory_recall)
+                    if source_safe_recall_synthesis_enabled(
+                        guild_id=channel.guild.id,
+                        user_id=unique_user_ids[0],
+                        route_mode=ROUTE_MODE_NORMAL_CHAT,
+                        channel_policy=channel_policy,
+                        user_text=combined_text,
+                        current_direct=True,
+                    ):
+                        memory_recall = ""
+                    else:
+                        memory_recall = apply_explicit_recall_governance(unique_user_ids[0], channel.guild.id, combined_text, memory_recall, ROUTE_MODE_NORMAL_CHAT, channel_policy, channel_id=channel_id, channel_name=getattr(channel, "name", ""), is_owner_or_mod=is_privileged_member(member, channel.guild))
+                        memory_recall = format_explicit_recall_for_chat(memory_recall)
             if memory_recall:
                 memory_recall = await validate_deterministic_normal_chat_response(
                     memory_recall,
@@ -24397,6 +24770,21 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     == first_uid
                     else 0
                 )
+                batch_source_safe_recall = (
+                    source_safe_recall_synthesis_enabled(
+                        guild_id=guild_id,
+                        user_id=first_uid,
+                        route_mode=ROUTE_MODE_NORMAL_CHAT,
+                        channel_policy=channel_policy,
+                        user_text=combined_text,
+                        current_direct=bool(
+                            active_packet.get("addressed_to_bot")
+                            or is_broad_personal_recall_request(
+                                combined_text
+                            )
+                        ),
+                    )
+                )
                 batch_memory_context = build_user_memory_context(
                     first_uid,
                     guild_id,
@@ -24404,7 +24792,10 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     channel_policy=channel_policy,
                     user_text=combined_text,
                     is_owner_or_mod=batch_member_is_privileged,
-                    current_direct=bool(active_packet.get("addressed_to_bot")),
+                    current_direct=bool(
+                        active_packet.get("addressed_to_bot")
+                        or is_broad_personal_recall_request(combined_text)
+                    ),
                     governance_allowed=bool(memory_governance_live_enabled()),
                     channel_id=channel_id,
                     moment_attribution_target_user_id=(
@@ -24458,6 +24849,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     is_owner_or_mod=batch_member_is_privileged,
                     current_direct=bool(
                         active_packet.get("addressed_to_bot")
+                        or is_broad_personal_recall_request(combined_text)
                     ),
                     governance_allowed=bool(
                         memory_governance_live_enabled()
@@ -24471,9 +24863,30 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                             "moment_gist_rendered"
                         )
                     ),
+                    governed_basis_digest=str(
+                        batch_memory_source_metadata.get(
+                            "governed_basis_digest"
+                        )
+                        or ""
+                    ),
+                    source_safe_recall_synthesis=bool(
+                        batch_memory_source_metadata.get(
+                            "source_safe_recall_synthesis"
+                        )
+                    ),
                 )
                 if batch_memory_basis is not None:
                     batch_prompt_source_bases.append(batch_memory_basis)
+            if len(unique_user_ids) == 1 and batch_source_safe_recall:
+                _record_source_safe_recall_packet_assembled(
+                    user_id=first_uid,
+                    guild_id=guild_id,
+                    conversation_source_count=(
+                        len(batch_conversation_basis.evidence_items)
+                        if batch_conversation_basis is not None
+                        else 0
+                    ),
+                )
             batch_moment_basis = build_batch_moment_prompt_source_basis(
                 batch_moment_attribution_context,
                 contract=batch_attribution_contract,
@@ -24510,7 +24923,12 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                             batch_conversation_basis is not None,
                         ),
                         (
-                            "legacy_memory",
+                            (
+                                "governed_memory"
+                                if len(unique_user_ids) == 1
+                                and batch_source_safe_recall
+                                else "legacy_memory"
+                            ),
                             any(
                                 isinstance(
                                     basis,
@@ -24632,6 +25050,26 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             )
             if continuity_contract:
                 prompt += "\n\n" + continuity_contract
+            if len(unique_user_ids) == 1:
+                batch_recall_synthesis_contract = (
+                    source_safe_recall_synthesis_contract(
+                        guild_id=guild_id,
+                        user_id=first_uid,
+                        route_mode=ROUTE_MODE_NORMAL_CHAT,
+                        channel_policy=channel_policy,
+                        user_text=combined_text,
+                        current_direct=bool(
+                            active_packet.get("addressed_to_bot")
+                            or is_broad_personal_recall_request(
+                                combined_text
+                            )
+                        ),
+                    )
+                )
+                if batch_recall_synthesis_contract:
+                    prompt += (
+                        "\n\n" + batch_recall_synthesis_contract
+                    )
             if batch_unified_moment_canary_basis is not None:
                 prompt += (
                     "\n\n"
@@ -25101,6 +25539,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             or guard_diagnostics.get(
                 "unified_moment_canary_output_leak_guard_triggered"
             )
+            or guard_diagnostics.get(
+                "source_safe_recall_output_leak_guard_triggered"
+            )
         )
         regenerated_for_mode_leak = bool(
             guard_diagnostics.get("regenerated_for_mode_leak")
@@ -25491,6 +25932,18 @@ def build_user_aware_prompt(
     safe_display_name = _safe_prompt_display_label(display_name, safe_fallback_display_name) if display_name else safe_fallback_display_name
     safe_preferred_name = _safe_prompt_display_label(preferred_name, "") if preferred_name else ""
     name_to_use = safe_preferred_name or safe_display_name
+    recall_current_direct = bool(
+        is_direct_interaction
+        or is_broad_personal_recall_request(clean_content)
+    )
+    source_safe_recall = source_safe_recall_synthesis_enabled(
+        guild_id=guild_id,
+        user_id=user_id,
+        route_mode=route_mode,
+        channel_policy=channel_policy,
+        user_text=clean_content,
+        current_direct=recall_current_direct,
+    )
 
     allow_greeting = should_allow_greeting(user_id, guild_id)
     greeting_rule = (
@@ -25519,7 +25972,7 @@ def build_user_aware_prompt(
         channel_policy=channel_policy,
         user_text=clean_content,
         is_owner_or_mod=prompt_operator_authority,
-        current_direct=bool(is_direct_interaction),
+        current_direct=recall_current_direct,
         governance_allowed=bool(memory_governance_live_enabled()),
         channel_id=channel_id,
         moment_attribution_target_user_id=moment_attribution_target_user_id,
@@ -25534,12 +25987,20 @@ def build_user_aware_prompt(
         channel_policy=channel_policy,
         user_text=clean_content,
         is_owner_or_mod=prompt_operator_authority,
-        current_direct=bool(is_direct_interaction),
+        current_direct=recall_current_direct,
         governance_allowed=bool(memory_governance_live_enabled()),
         channel_id=channel_id,
         moment_attribution_target_user_id=moment_attribution_target_user_id,
         has_moment_gist=bool(
             memory_source_metadata.get("moment_gist_rendered")
+        ),
+        governed_basis_digest=str(
+            memory_source_metadata.get("governed_basis_digest") or ""
+        ),
+        source_safe_recall_synthesis=bool(
+            memory_source_metadata.get(
+                "source_safe_recall_synthesis"
+            )
         ),
     )
     if memory_prompt_basis is not None:
@@ -25554,6 +26015,16 @@ def build_user_aware_prompt(
     )
     if conversation_prompt_basis is not None:
         prompt_source_bases.append(conversation_prompt_basis)
+    if source_safe_recall:
+        _record_source_safe_recall_packet_assembled(
+            user_id=user_id,
+            guild_id=guild_id,
+            conversation_source_count=(
+                len(conversation_prompt_basis.evidence_items)
+                if conversation_prompt_basis is not None
+                else 0
+            ),
+        )
     third_party_attribution_requested = bool(
         (
             int(moment_attribution_target_user_id or 0) > 0
@@ -25663,7 +26134,14 @@ def build_user_aware_prompt(
                     "conversation_context",
                     conversation_prompt_basis is not None,
                 ),
-                ("legacy_memory", memory_prompt_basis is not None),
+                (
+                    (
+                        "governed_memory"
+                        if source_safe_recall
+                        else "legacy_memory"
+                    ),
+                    memory_prompt_basis is not None,
+                ),
                 (
                     "relationship",
                     bool(
@@ -25771,6 +26249,9 @@ def build_user_aware_prompt(
             unified_moment_canary_basis is not None
             and unified_moment_canary_basis.episode_context_present
         )
+        prompt_metadata["source_safe_recall_synthesis"] = bool(
+            source_safe_recall
+        )
 
     room_prompt_block = ""
     if room_context:
@@ -25826,6 +26307,14 @@ def build_user_aware_prompt(
         )
 
     prompt_contract = normal_chat_prompt_contract(route_mode)
+    recall_synthesis_contract = source_safe_recall_synthesis_contract(
+        guild_id=guild_id,
+        user_id=user_id,
+        route_mode=route_mode,
+        channel_policy=channel_policy,
+        user_text=clean_content,
+        current_direct=recall_current_direct,
+    )
     if route_mode == ROUTE_MODE_NORMAL_CHAT and is_conversational_repair_intent(clean_content):
         prompt_contract += (
             "Correction-turn contract: use the visible prior exchange and make the corrected attempt now. "
@@ -25849,6 +26338,7 @@ def build_user_aware_prompt(
         "Source-authority basis rule: archive/record/source/dossier/scan/deployment/broadcast-memory language may be style or honest supplied-source reporting, but do not claim those sources prove/indicate/confirm something unless source/broadcast/show-state/read-model context is actually supplied.\n"
         "People-and-memory rule: preserve who said what and summarize another member's meaning in your own words by default. Do not act like a quote search engine. Use exact wording only when the user explicitly needs verification for a consequential dispute, the eligible current public source text is still present, and a minimal attributed quote is necessary. A derived summary, memory tier, relationship note, or Moment gist can never justify exact wording.\n"
         f"{prompt_contract}"
+        f"{recall_synthesis_contract}"
         f"{room_prompt_block}"
         f"{continuity_prompt_block}"
         f"{unified_moment_canary_prompt_block}"
@@ -27132,6 +27622,9 @@ async def apply_guarded_response_regeneration(
         "unified_moment_canary_coherence_regenerated": False,
         "unified_moment_canary_output_leak_guard_triggered": False,
         "unified_moment_canary_output_leak_regenerated": False,
+        "source_safe_recall_synthesis_applied": False,
+        "source_safe_recall_output_leak_guard_triggered": False,
+        "source_safe_recall_output_leak_regenerated": False,
         "suppressed": False,
         "suppression_reason": "",
         "guard_fallback_or_generic_non_answer": False,
@@ -27146,6 +27639,24 @@ async def apply_guarded_response_regeneration(
         third_party_attribution_requested
     )
     prompt_source_bases = tuple(prompt_source_bases or ())
+    source_safe_recall = bool(
+        source_safe_recall_synthesis_enabled(
+            guild_id=guild_id,
+            user_id=user_id,
+            route_mode=route_mode,
+            channel_policy=channel_policy,
+            user_text=current_user_text,
+            current_direct=True,
+        )
+        or any(
+            isinstance(basis, MemoryPromptSourceBasis)
+            and basis.source_safe_recall_synthesis
+            for basis in prompt_source_bases
+        )
+    )
+    diagnostics["source_safe_recall_synthesis_applied"] = bool(
+        source_safe_recall
+    )
     unified_moment_canary_basis = next(
         (
             basis
@@ -27332,6 +27843,12 @@ async def apply_guarded_response_regeneration(
             )
             or payload_grounding(candidate).failed
             or (
+                source_safe_recall
+                and response_exposes_source_safe_recall_controls(
+                    candidate
+                )
+            )
+            or (
                 unified_moment_canary_basis is not None
                 and response_exposes_canary_control_markers(candidate)
             )
@@ -27451,6 +27968,50 @@ async def apply_guarded_response_regeneration(
         if regenerated_invalid:
             logging.warning("source_grounding_response_suppressed_after_retry route_mode=%s channel_policy=%s", route_mode, channel_policy)
             diagnostics.update({"suppressed": True, "suppression_reason": "source_grounding_after_retry", "guard_fallback_or_generic_non_answer": True})
+            return "", diagnostics
+        response = regenerated
+    source_safe_recall_control_leak = bool(
+        source_safe_recall
+        and response_exposes_source_safe_recall_controls(response)
+    )
+    if source_safe_recall_control_leak:
+        diagnostics[
+            "source_safe_recall_output_leak_guard_triggered"
+        ] = True
+        if not regeneration_allowed:
+            diagnostics.update(
+                {
+                    "suppressed": True,
+                    "suppression_reason": (
+                        "source_safe_recall_output_leak_validation_only"
+                    ),
+                    "guard_fallback_or_generic_non_answer": True,
+                }
+            )
+            return "", diagnostics
+        regenerated = (
+            await regenerate(
+                prompt
+                + "\n\nRECALL OUTPUT CORRECTION REQUIRED: Answer the "
+                "member naturally from the eligible context. Never mention "
+                "the recall contract, source lanes, packet, canary, "
+                "governance, internal labels, or evidence identifiers."
+            )
+            or ""
+        ).strip()
+        diagnostics[
+            "source_safe_recall_output_leak_regenerated"
+        ] = True
+        if retry_has_guard_failure(regenerated):
+            diagnostics.update(
+                {
+                    "suppressed": True,
+                    "suppression_reason": (
+                        "source_safe_recall_output_leak_after_retry"
+                    ),
+                    "guard_fallback_or_generic_non_answer": True,
+                }
+            )
             return "", diagnostics
         response = regenerated
     exact_quote_failure = exact_quote_response_failure(
@@ -27865,6 +28426,21 @@ async def apply_guarded_response_regeneration(
             }
         )
         return "", diagnostics
+    if (
+        source_safe_recall
+        and response_exposes_source_safe_recall_controls(response)
+    ):
+        diagnostics.update(
+            {
+                "source_safe_recall_output_leak_guard_triggered": True,
+                "suppressed": True,
+                "suppression_reason": (
+                    "source_safe_recall_output_leak_before_send"
+                ),
+                "guard_fallback_or_generic_non_answer": True,
+            }
+        )
+        return "", diagnostics
     final_source_failure = prompt_source_basis_failure(
         prompt_source_bases
     )
@@ -27880,6 +28456,17 @@ async def apply_guarded_response_regeneration(
             }
         )
         return "", diagnostics
+    if source_safe_recall:
+        conversation_source_count = sum(
+            len(basis.evidence_items)
+            for basis in prompt_source_bases
+            if isinstance(basis, ConversationPromptSourceBasis)
+        )
+        _record_source_safe_recall_packet_assembled(
+            user_id=user_id,
+            guild_id=guild_id,
+            conversation_source_count=conversation_source_count,
+        )
     # Callers perform one more synchronous check immediately after their last
     # route-specific await (typing stop, quote fetch, or pacing grace). If this
     # guard rebuilt changed memory/Moment context and regenerated successfully,
@@ -28087,6 +28674,9 @@ async def send_planned_conversation_response(
         )
         or guard_diagnostics.get(
             "unified_moment_canary_output_leak_guard_triggered"
+        )
+        or guard_diagnostics.get(
+            "source_safe_recall_output_leak_guard_triggered"
         )
         or archive_guard_triggered
     )
@@ -29027,8 +29617,18 @@ async def on_message(message: discord.Message):
             if not memory_recall:
                 memory_recall = try_memory_recall_response(message.author.id, message.guild.id, direct_content)
                 if memory_recall:
-                    memory_recall = apply_explicit_recall_governance(message.author.id, message.guild.id, direct_content, memory_recall, route_mode, channel_policy, channel_id=getattr(message.channel, "id", 0), channel_name=getattr(message.channel, "name", ""), is_owner_or_mod=is_privileged_member(message.author, message.guild))
-                    memory_recall = format_explicit_recall_for_chat(memory_recall)
+                    if source_safe_recall_synthesis_enabled(
+                        guild_id=message.guild.id,
+                        user_id=message.author.id,
+                        route_mode=route_mode,
+                        channel_policy=channel_policy,
+                        user_text=direct_content,
+                        current_direct=True,
+                    ):
+                        memory_recall = ""
+                    else:
+                        memory_recall = apply_explicit_recall_governance(message.author.id, message.guild.id, direct_content, memory_recall, route_mode, channel_policy, channel_id=getattr(message.channel, "id", 0), channel_name=getattr(message.channel, "name", ""), is_owner_or_mod=is_privileged_member(message.author, message.guild))
+                        memory_recall = format_explicit_recall_for_chat(memory_recall)
             if memory_recall:
                 memory_recall = await validate_deterministic_normal_chat_response(
                     memory_recall,
@@ -29359,8 +29959,18 @@ async def on_message(message: discord.Message):
         if not memory_recall:
             memory_recall = try_memory_recall_response(message.author.id, message.guild.id, direct_content)
             if memory_recall:
-                memory_recall = apply_explicit_recall_governance(message.author.id, message.guild.id, direct_content, memory_recall, route_mode, channel_policy, channel_id=getattr(message.channel, "id", 0), channel_name=getattr(message.channel, "name", ""), is_owner_or_mod=is_privileged_member(message.author, message.guild))
-                memory_recall = format_explicit_recall_for_chat(memory_recall)
+                if source_safe_recall_synthesis_enabled(
+                    guild_id=message.guild.id,
+                    user_id=message.author.id,
+                    route_mode=route_mode,
+                    channel_policy=channel_policy,
+                    user_text=direct_content,
+                    current_direct=True,
+                ):
+                    memory_recall = ""
+                else:
+                    memory_recall = apply_explicit_recall_governance(message.author.id, message.guild.id, direct_content, memory_recall, route_mode, channel_policy, channel_id=getattr(message.channel, "id", 0), channel_name=getattr(message.channel, "name", ""), is_owner_or_mod=is_privileged_member(message.author, message.guild))
+                    memory_recall = format_explicit_recall_for_chat(memory_recall)
         if memory_recall:
             memory_recall = await validate_deterministic_normal_chat_response(
                 memory_recall,
@@ -29645,8 +30255,18 @@ async def on_message(message: discord.Message):
         if not memory_recall:
             memory_recall = try_memory_recall_response(message.author.id, message.guild.id, direct_content)
             if memory_recall:
-                memory_recall = apply_explicit_recall_governance(message.author.id, message.guild.id, direct_content, memory_recall, route_mode, channel_policy, channel_id=getattr(message.channel, "id", 0), channel_name=getattr(message.channel, "name", ""), is_owner_or_mod=is_privileged_member(message.author, message.guild))
-                memory_recall = format_explicit_recall_for_chat(memory_recall)
+                if source_safe_recall_synthesis_enabled(
+                    guild_id=message.guild.id,
+                    user_id=message.author.id,
+                    route_mode=route_mode,
+                    channel_policy=channel_policy,
+                    user_text=direct_content,
+                    current_direct=True,
+                ):
+                    memory_recall = ""
+                else:
+                    memory_recall = apply_explicit_recall_governance(message.author.id, message.guild.id, direct_content, memory_recall, route_mode, channel_policy, channel_id=getattr(message.channel, "id", 0), channel_name=getattr(message.channel, "name", ""), is_owner_or_mod=is_privileged_member(message.author, message.guild))
+                    memory_recall = format_explicit_recall_for_chat(memory_recall)
         if memory_recall:
             memory_recall = await validate_deterministic_normal_chat_response(
                 memory_recall,

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -1042,6 +1042,79 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("BARCODE Radio", channel.sent[0])
         self.assertNotRegex(channel.sent[0].lower(), r"archive recall|\[core\]|current project")
 
+    async def test_batched_broad_recall_canary_enters_source_safe_synthesis(self):
+        channel = self._channel(8120)
+        prompts = []
+
+        async def generate(prompt, **_kwargs):
+            prompts.append(prompt)
+            return (
+                "I remember your green preference, the shared dreaming "
+                "conversation, and the memory-system work we have been doing."
+            )
+
+        canary_env = {
+            "BNL_MEMORY_GOVERNANCE_CANARY_ENABLED": "true",
+            "BNL_MEMORY_GOVERNANCE_CANARY_GUILD_IDS": str(
+                channel.guild.id
+            ),
+            "BNL_MEMORY_GOVERNANCE_CANARY_USER_IDS": "100",
+            "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+            "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+            "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+        }
+        legacy = "Here is what I can safely recall:\n- one Moment only"
+        self._prime_flush(channel, "what do you remember about me?")
+        with (
+            self._flush_runtime(channel.id, generate),
+            mock.patch.dict(os.environ, canary_env, clear=False),
+            mock.patch.object(
+                bnl01_bot,
+                "resolve_channel_policy",
+                return_value="public_home",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "try_memory_recall_response",
+                return_value=legacy,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "apply_explicit_recall_governance",
+            ) as deterministic_governance,
+            mock.patch.object(
+                bnl01_bot,
+                "build_user_memory_context",
+                return_value=(
+                    "Durable memory (governed):\n"
+                    "- favorite color is green\n"
+                    "- shared dreaming Moment"
+                ),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "is_privileged_member",
+                return_value=False,
+            ),
+        ):
+            await bnl01_bot._flush_channel_buffer(channel)
+
+        deterministic_governance.assert_not_called()
+        self.assertEqual(len(prompts), 1)
+        self.assertIn(
+            "Source-safe personal recall synthesis contract:",
+            prompts[0],
+        )
+        self.assertIn("favorite color is green", prompts[0])
+        self.assertIn("shared dreaming Moment", prompts[0])
+        self.assertEqual(
+            channel.sent,
+            [
+                "I remember your green preference, the shared dreaming "
+                "conversation, and the memory-system work we have been doing."
+            ],
+        )
+
     async def test_batched_media_followup_wins_without_durable_governance(self):
         channel = self._channel(8119)
         provider = mock.AsyncMock(side_effect=AssertionError("deterministic media must not generate"))

--- a/tests/test_source_safe_multi_source_recall.py
+++ b/tests/test_source_safe_multi_source_recall.py
@@ -1,0 +1,552 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+from bnl_memory_governance import (
+    GovernanceDiagnostics,
+    GovernanceResult,
+    ensure_governance_schema,
+)
+from bnl_memory_ledger import subject_key_for_user
+
+
+class SourceSafeMultiSourceRecallTests(unittest.IsolatedAsyncioTestCase):
+    ENV_KEYS = (
+        "BNL_MEMORY_GOVERNANCE_CANARY_ENABLED",
+        "BNL_MEMORY_GOVERNANCE_CANARY_GUILD_IDS",
+        "BNL_MEMORY_GOVERNANCE_CANARY_USER_IDS",
+        "BNL_MEMORY_LEDGER_SHADOW_ENABLED",
+        "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED",
+        "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED",
+        "BNL_MOMENT_ENGINE_SHADOW_ENABLED",
+        "BNL_RELATIONSHIP_V2_LIVE_ENABLED",
+        "BNL_RELATIONSHIP_V2_SHADOW_ENABLED",
+        "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED",
+    )
+
+    async def asyncSetUp(self):
+        self.old_db = bnl01_bot.DB_FILE
+        self.tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.tmp.close()
+        bnl01_bot.DB_FILE = self.tmp.name
+        self.env = mock.patch.dict(os.environ, {}, clear=False)
+        self.env.start()
+        for key in self.ENV_KEYS:
+            os.environ.pop(key, None)
+        bnl01_bot.init_db()
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            ensure_governance_schema(conn)
+        self.old_canary_diagnostics = dict(
+            bnl01_bot.LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS
+        )
+        bnl01_bot.LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS.clear()
+
+    async def asyncTearDown(self):
+        bnl01_bot.LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS.clear()
+        bnl01_bot.LAST_MEMORY_GOVERNANCE_CANARY_DIAGNOSTICS.update(
+            self.old_canary_diagnostics
+        )
+        self.env.stop()
+        bnl01_bot.DB_FILE = self.old_db
+        try:
+            os.unlink(self.tmp.name)
+        except OSError:
+            pass
+
+    def enable_canary(self):
+        os.environ.update(
+            {
+                "BNL_MEMORY_GOVERNANCE_CANARY_ENABLED": "true",
+                "BNL_MEMORY_GOVERNANCE_CANARY_GUILD_IDS": "1",
+                "BNL_MEMORY_GOVERNANCE_CANARY_USER_IDS": "42",
+                "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+                "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+                "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+                "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED": "true",
+                "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+            }
+        )
+
+    def insert_ledger(
+        self,
+        value,
+        *,
+        entry_id,
+        predicate,
+        entry_type,
+        source_class,
+        lifecycle="active",
+        visibility="public_safe",
+        public_usable=1,
+        user_id=42,
+        source_policy="public_home",
+    ):
+        timestamp = "2026-07-25T18:00:00+00:00"
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            ensure_governance_schema(conn)
+            conn.execute(
+                """
+                INSERT INTO memory_ledger_entries (
+                    entry_id, schema_version, guild_id, subject_key,
+                    subject_display_name, entry_type, predicate_key,
+                    normalized_value, source_class, source_table,
+                    source_row_id, source_revision, source_role, visibility,
+                    confidence, public_usable, derived, projection, salience,
+                    observed_at, lifecycle_status, created_at, updated_at,
+                    route_mode, channel_policy
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    entry_id,
+                    "memory_ledger_v1",
+                    1,
+                    subject_key_for_user(user_id),
+                    "",
+                    entry_type,
+                    predicate,
+                    value,
+                    source_class,
+                    "test_source",
+                    entry_id,
+                    "revision:" + entry_id,
+                    "member",
+                    visibility,
+                    "high",
+                    public_usable,
+                    0,
+                    0,
+                    0.9,
+                    timestamp,
+                    lifecycle,
+                    timestamp,
+                    timestamp,
+                    bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                    source_policy,
+                ),
+            )
+            conn.commit()
+
+    def build_prompt(self, room_context=""):
+        metadata = {}
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "get_user_profile",
+                return_value=("Test Member", ""),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "should_allow_greeting",
+                return_value=False,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "choose_response_style",
+                return_value=("balanced", ""),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_broadcast_memory_context",
+                return_value="",
+            ),
+        ):
+            prompt, _allow_greeting, _style = (
+                bnl01_bot.build_user_aware_prompt(
+                    42,
+                    1,
+                    "Test Member",
+                    "BNL, what do you remember about me?",
+                    room_context=room_context,
+                    channel_name="barcode-bot",
+                    channel_policy="public_home",
+                    route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                    is_direct_interaction=True,
+                    channel_id=99,
+                    prompt_metadata=metadata,
+                )
+            )
+        return prompt, metadata
+
+    def test_scope_is_exact_broad_recall_and_kill_switch_restores_old_path(self):
+        self.enable_canary()
+        base = {
+            "guild_id": 1,
+            "user_id": 42,
+            "route_mode": bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            "channel_policy": "public_home",
+            "current_direct": True,
+        }
+        for text in (
+            "what do you remember about me?",
+            "BNL, what do you know about me?",
+            "please tell me everything you remember about me",
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(
+                    bnl01_bot.source_safe_recall_synthesis_enabled(
+                        **base,
+                        user_text=text,
+                    )
+                )
+        for text in (
+            "what is my favorite movie?",
+            "what habits have you noticed?",
+            "what do you remember about Crow?",
+            "what do you remember about me? wait",
+        ):
+            with self.subTest(text=text):
+                self.assertFalse(
+                    bnl01_bot.source_safe_recall_synthesis_enabled(
+                        **base,
+                        user_text=text,
+                    )
+                )
+        os.environ.pop("BNL_MEMORY_GOVERNANCE_CANARY_ENABLED")
+        self.assertFalse(
+            bnl01_bot.source_safe_recall_synthesis_enabled(
+                **base,
+                user_text="what do you remember about me?",
+            )
+        )
+
+    def test_prompt_assembles_governed_and_conversation_sources_for_synthesis(self):
+        self.enable_canary()
+        self.insert_ledger(
+            "favorite color is green",
+            entry_id="direct-color",
+            predicate="favorite_color",
+            entry_type="preference",
+            source_class="first_party_record",
+        )
+        self.insert_ledger(
+            "finishing the source-safe shared-brain connection",
+            entry_id="runtime-goal",
+            predicate="goal",
+            entry_type="goal",
+            source_class="runtime_observation",
+        )
+        bnl01_bot.save_user_message(
+            42,
+            "Test Member",
+            1,
+            "I want the memory system to connect ideas across our work.",
+            channel_name="barcode-bot",
+            channel_policy="public_home",
+            channel_id=99,
+            message_id=1001,
+            directed_to_bnl=True,
+        )
+        bnl01_bot.save_model_message(
+            42,
+            1,
+            "You want connected recall without flattening its sources.",
+            channel_name="barcode-bot",
+            channel_policy="public_home",
+            channel_id=99,
+        )
+        room_context = bnl01_bot.build_conversation_context_v2_for_prompt(
+            guild_id=1,
+            current_user_id=42,
+            channel_id=99,
+            channel_name="barcode-bot",
+            channel_policy="public_home",
+            route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            conversation_surface="mention_or_reply",
+            current_texts=("BNL, what do you remember about me?",),
+            current_participants={42},
+            is_direct_target=True,
+        )
+
+        prompt, metadata = self.build_prompt(room_context)
+
+        self.assertIn(
+            "Source-safe personal recall synthesis contract:",
+            prompt,
+        )
+        self.assertIn("favorite color is green", prompt)
+        self.assertIn(
+            "finishing the source-safe shared-brain connection",
+            prompt,
+        )
+        self.assertIn(
+            "I want the memory system to connect ideas across our work.",
+            prompt,
+        )
+        self.assertNotIn("Relationship state:", prompt)
+        self.assertNotIn("Observed habits:", prompt)
+        self.assertNotIn("Derived memory summaries", prompt)
+        self.assertFalse(
+            bnl01_bot.memory_governance_live_enabled()
+        )
+        self.assertTrue(metadata["source_safe_recall_synthesis"])
+        basis_types = {
+            type(basis)
+            for basis in metadata["prompt_source_bases"]
+        }
+        self.assertIn(bnl01_bot.MemoryPromptSourceBasis, basis_types)
+        self.assertIn(
+            bnl01_bot.ConversationPromptSourceBasis,
+            basis_types,
+        )
+        diagnostics = (
+            bnl01_bot.memory_governance_canary_last_diagnostics(42, 1)
+        )
+        self.assertEqual(
+            diagnostics["response_mode"],
+            "source_safe_synthesis",
+        )
+        self.assertTrue(diagnostics["synthesis_packet_assembled"])
+        self.assertGreaterEqual(diagnostics["packet_lane_count"], 3)
+        self.assertGreaterEqual(diagnostics["packet_source_count"], 4)
+        self.assertGreaterEqual(
+            diagnostics["packet_conversation_source_count"],
+            1,
+        )
+        self.assertEqual(diagnostics["atomic_candidates_live_used"], 0)
+        assessment = metadata["unified_response_assessment_shadow"]
+        self.assertIn("governed_memory", assessment.prompt_lanes)
+        self.assertIn("conversation_context", assessment.prompt_lanes)
+        self.assertNotIn("relationship", assessment.prompt_lanes)
+
+    def test_same_text_replacement_changes_typed_governed_source_basis(self):
+        self.enable_canary()
+        self.insert_ledger(
+            "favorite color is green",
+            entry_id="source-a",
+            predicate="favorite_color",
+            entry_type="preference",
+            source_class="first_party_record",
+        )
+        _prompt, metadata = self.build_prompt()
+        basis = next(
+            basis
+            for basis in metadata["prompt_source_bases"]
+            if isinstance(basis, bnl01_bot.MemoryPromptSourceBasis)
+        )
+        original_rendered_digest = basis.expected_digest
+        original_source_digest = basis.governed_basis_digest
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            conn.execute(
+                """
+                UPDATE memory_ledger_entries
+                SET lifecycle_status='superseded'
+                WHERE entry_id='source-a'
+                """
+            )
+            conn.commit()
+        self.insert_ledger(
+            "favorite color is green",
+            entry_id="source-b",
+            predicate="favorite_color",
+            entry_type="preference",
+            source_class="first_party_record",
+        )
+
+        fresh, changed = bnl01_bot.refresh_prompt_source_basis(basis)
+
+        self.assertTrue(changed)
+        self.assertEqual(
+            fresh.expected_digest,
+            original_rendered_digest,
+        )
+        self.assertNotEqual(
+            fresh.governed_basis_digest,
+            original_source_digest,
+        )
+
+    def test_canary_disable_after_prompt_assembly_fails_closed(self):
+        self.enable_canary()
+        self.insert_ledger(
+            "favorite color is green",
+            entry_id="source-a",
+            predicate="favorite_color",
+            entry_type="preference",
+            source_class="first_party_record",
+        )
+        prompt, metadata = self.build_prompt()
+        basis = next(
+            basis
+            for basis in metadata["prompt_source_bases"]
+            if isinstance(basis, bnl01_bot.MemoryPromptSourceBasis)
+        )
+        self.assertTrue(basis.source_safe_recall_synthesis)
+
+        os.environ.pop("BNL_MEMORY_GOVERNANCE_CANARY_ENABLED")
+        (
+            refreshed_prompt,
+            refreshed_bases,
+            changed_kinds,
+            replacement_failed,
+        ) = bnl01_bot.refresh_prompt_source_bases(prompt, (basis,))
+
+        self.assertEqual(refreshed_prompt, prompt)
+        self.assertEqual(changed_kinds, ("memory",))
+        self.assertTrue(replacement_failed)
+        self.assertFalse(
+            refreshed_bases[0].source_safe_recall_synthesis
+        )
+
+    def test_unsafe_governance_removes_durable_lane_without_legacy_fallback(self):
+        self.enable_canary()
+        unsafe = GovernanceResult(
+            rendered_context="legacy relationship material must not render",
+            selected=(),
+            exclusions=(),
+            diagnostics=GovernanceDiagnostics(
+                invalid_invariants=("cross_subject_selected",)
+            ),
+        )
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "build_governed_context",
+                return_value=unsafe,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "get_relationship_state",
+                return_value=(99, 1.0, "close", "trusted", "private", ""),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "get_user_habits",
+                return_value=(99, 1, 1, 1, 10.0, "private", ""),
+            ),
+        ):
+            context = bnl01_bot.build_user_memory_context(
+                42,
+                1,
+                route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                channel_policy="public_home",
+                user_text="what do you remember about me?",
+                current_direct=True,
+                channel_id=99,
+            )
+
+        self.assertEqual(
+            context,
+            "No currently eligible source-bearing durable memory context.",
+        )
+        self.assertNotIn("legacy relationship", context)
+        diagnostics = (
+            bnl01_bot.memory_governance_canary_last_diagnostics(42, 1)
+        )
+        self.assertEqual(
+            diagnostics["response_mode"],
+            "source_safe_synthesis_blocked",
+        )
+        self.assertEqual(diagnostics["invalid_invariant_count"], 1)
+        self.assertEqual(diagnostics["atomic_candidates_live_used"], 0)
+
+    async def test_internal_recall_controls_regenerate_once_then_fail_closed(self):
+        self.enable_canary()
+        provider = mock.AsyncMock(
+            return_value=(
+                "I remember your green preference and the shared memory "
+                "system work."
+            )
+        )
+        with mock.patch.object(
+            bnl01_bot,
+            "get_gemini_response_with_optional_typing",
+            new=provider,
+        ):
+            response, diagnostics = (
+                await bnl01_bot.apply_guarded_response_regeneration(
+                    "The source-safe recall packet has two source lanes.",
+                    prompt="eligible prompt",
+                    user_id=42,
+                    guild_id=1,
+                    route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy="public_home",
+                    current_user_text=(
+                        "BNL, what do you remember about me?"
+                    ),
+                    channel=SimpleNamespace(id=99),
+                )
+            )
+        self.assertIn("green preference", response)
+        self.assertTrue(
+            diagnostics[
+                "source_safe_recall_output_leak_guard_triggered"
+            ]
+        )
+        self.assertTrue(
+            diagnostics[
+                "source_safe_recall_output_leak_regenerated"
+            ]
+        )
+        provider.assert_awaited_once()
+
+        leaking_provider = mock.AsyncMock(
+            return_value="The recall source lane still says green."
+        )
+        with mock.patch.object(
+            bnl01_bot,
+            "get_gemini_response_with_optional_typing",
+            new=leaking_provider,
+        ):
+            response, diagnostics = (
+                await bnl01_bot.apply_guarded_response_regeneration(
+                    "The source-safe recall packet has two source lanes.",
+                    prompt="eligible prompt",
+                    user_id=42,
+                    guild_id=1,
+                    route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy="public_home",
+                    current_user_text=(
+                        "BNL, what do you remember about me?"
+                    ),
+                    channel=SimpleNamespace(id=99),
+                )
+            )
+        self.assertEqual(response, "")
+        self.assertTrue(diagnostics["suppressed"])
+        self.assertEqual(
+            diagnostics["suppression_reason"],
+            "source_safe_recall_output_leak_after_retry",
+        )
+
+    def test_all_four_recall_routes_keep_fallback_and_add_synthesis_branch(self):
+        source = Path("bnl01_bot.py").read_text()
+        offsets = [
+            index
+            for index in range(len(source))
+            if source.startswith("try_memory_recall_response", index)
+            and source[max(0, index - 4) : index].strip().endswith("=")
+        ]
+        self.assertEqual(len(offsets), 4)
+        for index in offsets:
+            window = source[index : index + 2200]
+            self.assertIn(
+                "source_safe_recall_synthesis_enabled",
+                window,
+            )
+            self.assertIn("memory_recall = \"\"", window)
+            self.assertIn("apply_explicit_recall_governance", window)
+            self.assertIn("format_explicit_recall_for_chat", window)
+
+    def test_atomic_candidate_table_is_not_a_recall_read_dependency(self):
+        governance_source = Path("bnl_memory_governance.py").read_text()
+        selector = governance_source[
+            governance_source.index("def build_governed_context") :
+            governance_source.index("def persist_shadow_diagnostics")
+        ]
+        self.assertNotIn(
+            "memory_ledger_atomic_knowledge_candidates",
+            selector,
+        )
+        self.assertNotIn("atomic_candidate", selector)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The production governed-recall canary safely selected an eligible Moment, but the broad `what do you remember about me?` route immediately formatted and sent the deterministic Governance result. That short-circuited Conversation Context v2 and the bot's normal synthesis path, so the visible answer could collapse to one source and one bullet even though other independently sourced context existed.

## What changed

- Routes only the existing allowlisted broad first-person recall canary into normal response synthesis instead of immediately sending the deterministic recall wrapper.
- Assembles the response from existing owners: the current exchange, source-linked Conversation Context v2, governed Ledger records, and eligible participant-scoped Moment gists.
- Keeps source authority distinct and forbids BNL-authored or derived material from corroborating its own roots.
- Does not force breadth: if only one eligible source survives Governance and visibility checks, the model must not invent another.
- Keeps specific-fact recall and all canary-disabled or out-of-scope routes on their prior deterministic behavior.
- Binds pre-send revalidation to governed source identities and lineage, not rendered text alone, and fails closed if the canary or source basis changes mid-response.
- Adds a one-retry output guard for leaked internal recall controls, then suppresses on a repeated leak.
- Adds aggregate packet diagnostics while explicitly reporting `atomic_candidates_live_used: 0`.

Atomic knowledge candidates remain shadow-only and are not read by this route. Global Memory Governance, Relationship v2, Active Engagement, queue/show operations, rehearsal, dossiers, website behavior, and production configuration are unchanged.

## Validation

- Focused source-safe recall and batched-path tests: 9 passed
- Full `make check`: compilation succeeded and 1,568 tests passed
- `git diff --check`: clean

## Post-merge deployment

```bash
cd /home/ubuntu/bnl01
git pull origin main
sudo systemctl restart bnl01
sudo systemctl status bnl01 --no-pager -l
git rev-parse HEAD
```

## Focused post-deploy evidence

Without changing any gate, send `@BNL-01, what do you remember about me?` in the same normal public canary route, then run owner-only `/bnl_memory_check` in `bnl-testing`.

Capture the complete reply and `memory_governance_canary_last`. Expected evidence:

- `response_mode: source_safe_synthesis`
- `synthesis_requested: True`
- `synthesis_packet_assembled: True`
- packet source/lane counts reflecting the actually eligible production context
- `atomic_candidates_live_used: 0`
- zero processing errors and blocking invariant violations
- no fallback or internal-control wording

The reply should naturally combine materially distinct eligible sources when more than one exists. If production exposes only one eligible source after Governance, privacy, identity, and relevance filtering, it must stay narrow rather than fabricate breadth.