### PR TITLE
Preserve recall packet diagnostics after final revalidation

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -19557,8 +19557,9 @@ def prompt_source_basis_failure(
     bases: tuple[PromptSourceBasis, ...],
 ) -> str:
     """Return a fail-closed reason at the last synchronous pre-send boundary."""
+    bases = tuple(bases or ())
     try:
-        for basis in bases or ():
+        for basis in bases:
             _fresh, changed = refresh_prompt_source_basis(basis)
             if changed:
                 return (
@@ -19573,6 +19574,25 @@ def prompt_source_basis_failure(
                 )
     except Exception:
         return "source_revalidation_failed"
+    source_safe_memory_basis = next(
+        (
+            basis
+            for basis in bases
+            if isinstance(basis, MemoryPromptSourceBasis)
+            and basis.source_safe_recall_synthesis
+        ),
+        None,
+    )
+    if source_safe_memory_basis is not None:
+        _record_source_safe_recall_packet_assembled(
+            user_id=source_safe_memory_basis.user_id,
+            guild_id=source_safe_memory_basis.guild_id,
+            conversation_source_count=sum(
+                len(basis.evidence_items)
+                for basis in bases
+                if isinstance(basis, ConversationPromptSourceBasis)
+            ),
+        )
     return ""
 
 

--- a/tests/test_source_safe_multi_source_recall.py
+++ b/tests/test_source_safe_multi_source_recall.py
@@ -363,6 +363,43 @@ class SourceSafeMultiSourceRecallTests(unittest.IsolatedAsyncioTestCase):
             original_source_digest,
         )
 
+    def test_final_presend_revalidation_preserves_packet_diagnostics(self):
+        self.enable_canary()
+        self.insert_ledger(
+            "favorite color is green",
+            entry_id="source-a",
+            predicate="favorite_color",
+            entry_type="preference",
+            source_class="first_party_record",
+        )
+        room_context = (
+            "Conversation continuity (bounded same-room window):\n"
+            "- Test Member: I am still building the shared memory system."
+        )
+        _prompt, metadata = self.build_prompt(room_context)
+        bases = tuple(metadata["prompt_source_bases"])
+        before = bnl01_bot.memory_governance_canary_last_diagnostics(
+            42,
+            1,
+        )
+        self.assertTrue(before["synthesis_packet_assembled"])
+
+        self.assertEqual(
+            bnl01_bot.prompt_source_basis_failure(bases),
+            "",
+        )
+
+        after = bnl01_bot.memory_governance_canary_last_diagnostics(
+            42,
+            1,
+        )
+        self.assertTrue(after["synthesis_packet_assembled"])
+        self.assertGreaterEqual(after["packet_lane_count"], 2)
+        self.assertGreaterEqual(after["packet_source_count"], 2)
+        self.assertEqual(after["packet_conversation_source_count"], 0)
+        self.assertEqual(after["processing_error_count"], 0)
+        self.assertEqual(after["invalid_invariant_count"], 0)
+
     def test_canary_disable_after_prompt_assembly_fails_closed(self):
         self.enable_canary()
         self.insert_ledger(


### PR DESCRIPTION
## What changed

- Preserve the source-safe recall packet diagnostic after the final synchronous pre-send source revalidation succeeds.
- Count the surviving Conversation Context evidence at that same boundary.
- Add an end-to-end regression proving the assembled packet remains visible after revalidation.

## Root cause

The source-safe synthesis path assembled and revalidated its packet correctly, but the final refresh of its governed memory basis overwrote the last canary diagnostic before the Discord send. Production therefore reported `synthesis_packet_assembled: false`, `packet_lane_count: 0`, and `packet_source_count: 0` even when the packet had survived the safety check.

## Impact

This changes diagnostics only. It does not broaden source selection, alter response content, enable atomic candidates, weaken Governance, or change any live gate. Fail-closed behavior remains intact when a source changes or the canary is disabled.

## Validation

- Focused production-sequence regression: passed
- Recall/batching/Governance integration set: 259 tests passed
- Full `make check`: compilation plus 1,569 tests passed
- `git diff --check`: clean

## Protected boundaries

No website, queue, payment, overlay, rehearsal, Relationship v2, Active Engagement, dossier, Journal, Relay, personality, schema, or production-configuration changes.