### PR TITLE
Add shadow unified intelligence packet

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -114,6 +114,13 @@ from bnl_shadow_acceptance import (
     build_v2_shadow_acceptance_snapshot,
     render_v2_shadow_acceptance_lines,
 )
+from bnl_unified_intelligence_packet import (
+    IntelligencePacketRequest,
+    PacketConversationEvidence,
+    UnifiedIntelligencePacket,
+    build_packet as build_unified_intelligence_packet,
+    shadow_enabled as unified_intelligence_packet_shadow_enabled,
+)
 from bnl_unified_response_assessment import (
     ConversationEvidenceItem,
     UnifiedResponseAssessment,
@@ -18689,6 +18696,114 @@ def _active_episode_id_for_unified_assessment(
         return ""
 
 
+def _build_unified_intelligence_packet_shadow(
+    *,
+    guild_id: int,
+    route_mode: str,
+    channel_policy: str,
+    conversation_surface: str,
+    channel_id: int,
+    current_text: str,
+    current_speaker_user_ids: tuple[int, ...],
+    target_user_ids: tuple[int, ...],
+    participant_user_ids: tuple[int, ...],
+    conversation_evidence_items: tuple[ConversationEvidenceItem, ...],
+    source_context_snapshot: str,
+    source_context_authorized: bool,
+    current_direct: bool,
+) -> UnifiedIntelligencePacket | None:
+    """Build and persist one packet receipt without exposing it to the prompt."""
+
+    if (
+        not unified_intelligence_packet_shadow_enabled()
+        or DB_FILE == ":memory:"
+        or not os.path.exists(DB_FILE)
+    ):
+        return None
+    current_speakers = tuple(
+        dict.fromkeys(
+            int(user_id or 0)
+            for user_id in current_speaker_user_ids
+            if int(user_id or 0) > 0
+        )
+    )
+    targets = tuple(
+        dict.fromkeys(
+            int(user_id or 0)
+            for user_id in target_user_ids
+            if int(user_id or 0) > 0
+        )
+    )
+    if len(targets) == 1:
+        subject_user_id = targets[0]
+    elif len(current_speakers) == 1:
+        subject_user_id = current_speakers[0]
+    else:
+        subject_user_id = 0
+    participants = tuple(
+        dict.fromkeys(
+            int(user_id or 0)
+            for user_id in (
+                *participant_user_ids,
+                *current_speakers,
+                *targets,
+            )
+            if int(user_id or 0) > 0
+        )
+    )
+    evidence = tuple(
+        PacketConversationEvidence(
+            text=item.text,
+            source_id=int(item.source_id or 0),
+            speaker_user_id=int(item.speaker_user_id or 0),
+            speaker_label=item.speaker_label,
+            current_turn=bool(item.current_turn),
+        )
+        for item in conversation_evidence_items
+        if isinstance(item, ConversationEvidenceItem)
+        and str(item.text or "").strip()
+    )
+    if channel_policy in PUBLIC_CHAT_POLICIES:
+        visibility_allowance = "public_safe"
+    elif channel_policy == "sealed_test":
+        visibility_allowance = "sealed_test"
+    else:
+        visibility_allowance = "internal"
+    request = IntelligencePacketRequest(
+        guild_id=int(guild_id or 0),
+        subject_user_id=int(subject_user_id or 0),
+        route_mode=str(route_mode or "unknown"),
+        conversation_surface=str(conversation_surface or "unknown"),
+        channel_id=int(channel_id or 0),
+        channel_policy=str(channel_policy or "unknown"),
+        visibility_allowance=visibility_allowance,
+        user_text=str(current_text or "")[:8000],
+        participant_user_ids=participants,
+        direct_state="direct" if current_direct else "indirect",
+        conversation_evidence=evidence,
+        source_context_snapshot=str(source_context_snapshot or "")[:12000],
+        source_context_authorized=bool(source_context_authorized),
+        immediate_recap=immediate_room_recap_requested(current_text),
+    )
+    try:
+        with sqlite3.connect(DB_FILE, timeout=0.25) as packet_conn:
+            packet = build_unified_intelligence_packet(
+                packet_conn,
+                request,
+                persist=True,
+            )
+            packet_conn.commit()
+        return packet
+    except (OSError, sqlite3.DatabaseError, TypeError, ValueError) as exc:
+        logging.warning(
+            "unified_intelligence_packet_shadow_failed "
+            "route_mode=%s error=%s",
+            route_mode,
+            type(exc).__name__,
+        )
+        return None
+
+
 def build_unified_response_assessment_shadow(
     *,
     guild_id: int,
@@ -18712,6 +18827,8 @@ def build_unified_response_assessment_shadow(
     show_state_present: bool = False,
     website_read_model_present: bool = False,
     source_context_present: bool = False,
+    source_context_snapshot: str = "",
+    current_direct: bool = True,
     broadcast_memory_present: bool = False,
 ) -> UnifiedResponseAssessment | None:
     """Build a shadow view from evidence already selected by existing owners."""
@@ -18836,7 +18953,102 @@ def build_unified_response_assessment_shadow(
         current_text,
         conversation_contexts,
     )
+    intelligence_packet = _build_unified_intelligence_packet_shadow(
+        guild_id=guild_id,
+        route_mode=route_mode,
+        channel_policy=channel_policy,
+        conversation_surface=conversation_surface,
+        channel_id=channel_id,
+        current_text=current_text,
+        current_speaker_user_ids=current_speaker_user_ids,
+        target_user_ids=target_user_ids,
+        participant_user_ids=participant_user_ids,
+        conversation_evidence_items=semantic_evidence_items,
+        source_context_snapshot=source_context_snapshot,
+        source_context_authorized=bool(source_context_present),
+        current_direct=current_direct,
+    )
+    packet_usable = bool(
+        intelligence_packet is not None
+        and not intelligence_packet.diagnostics.processing_errors
+        and not intelligence_packet.diagnostics.invalid_invariants
+        and intelligence_packet.diagnostics.revalidation_status.startswith(
+            "passed"
+        )
+    )
     canon_relevant = _canon_relevant_to_response(current_text)
+    if intelligence_packet is None:
+        assessment_moment_refs = (
+            ("rendered_moment_gist",) if has_moment_gist else ()
+        )
+        assessment_governed_refs = tuple(
+            memory_meta.get("governed_entry_ids") or ()
+        )
+        assessment_relationship_refs = (
+            ("relationship_v2_candidate",)
+            if memory_meta.get("relationship_v2_candidate_present")
+            else ()
+        )
+        assessment_canon_refs = (
+            ("canon:%s" % CANON_SOURCE_CONTRACT_VERSION,)
+            if canon_relevant
+            else ()
+        )
+        assessment_moment_candidate_count = int(
+            memory_meta.get("moment_candidate_count") or 0
+        )
+        assessment_governed_candidate_count = int(
+            memory_meta.get("governed_candidate_count") or 0
+        )
+        assessment_exclusion_count = int(
+            memory_meta.get("governance_exclusion_count") or 0
+        )
+        assessment_contradiction_count = int(
+            memory_meta.get("governance_contradiction_count") or 0
+        )
+    else:
+        assessment_moment_refs = (
+            intelligence_packet.moment_refs if packet_usable else ()
+        )
+        assessment_governed_refs = (
+            intelligence_packet.governed_refs if packet_usable else ()
+        )
+        assessment_relationship_refs = (
+            intelligence_packet.relationship_refs if packet_usable else ()
+        )
+        assessment_canon_refs = (
+            intelligence_packet.canon_refs if packet_usable else ()
+        )
+        assessment_moment_candidate_count = int(
+            intelligence_packet.diagnostics.candidates_by_lane.get(
+                "moment",
+                0,
+            )
+            or 0
+        )
+        assessment_governed_candidate_count = sum(
+            int(
+                intelligence_packet.diagnostics.candidates_by_lane.get(
+                    lane,
+                    0,
+                )
+                or 0
+            )
+            for lane in (
+                "approved_fact",
+                "atomic_knowledge",
+                "open_loop",
+            )
+        )
+        assessment_exclusion_count = sum(
+            int(value or 0)
+            for value in (
+                intelligence_packet.diagnostics.excluded_by_reason.values()
+            )
+        )
+        assessment_contradiction_count = len(
+            intelligence_packet.diagnostics.conflict_reasons
+        )
     return build_unified_response_assessment(
         guild_id=guild_id,
         route_mode=route_mode,
@@ -18848,20 +19060,10 @@ def build_unified_response_assessment_shadow(
         speaker_labels=speaker_labels,
         current_exchange_source_ids=current_exchange_source_ids,
         active_episode_id=active_episode_id,
-        prior_moment_ids=("rendered_moment_gist",) if has_moment_gist else (),
-        governed_entry_ids=tuple(
-            memory_meta.get("governed_entry_ids") or ()
-        ),
-        relationship_candidate_keys=(
-            ("relationship_v2_candidate",)
-            if memory_meta.get("relationship_v2_candidate_present")
-            else ()
-        ),
-        canon_refs=(
-            ("canon:%s" % CANON_SOURCE_CONTRACT_VERSION,)
-            if canon_relevant
-            else ()
-        ),
+        prior_moment_ids=assessment_moment_refs,
+        governed_entry_ids=assessment_governed_refs,
+        relationship_candidate_keys=assessment_relationship_refs,
+        canon_refs=assessment_canon_refs,
         prompt_lanes=prompt_lanes,
         continuity_required=continuity_required,
         immediate_recap=immediate_room_recap_requested(current_text),
@@ -18869,18 +19071,10 @@ def build_unified_response_assessment_shadow(
         exact_quote_authority_present=exact_quote_authority_present,
         source_bases=prompt_source_bases,
         prompt_budget=int(memory_meta.get("prompt_budget") or 0),
-        moment_candidate_count=int(
-            memory_meta.get("moment_candidate_count") or 0
-        ),
-        governed_candidate_count=int(
-            memory_meta.get("governed_candidate_count") or 0
-        ),
-        governance_exclusion_count=int(
-            memory_meta.get("governance_exclusion_count") or 0
-        ),
-        governance_contradiction_count=int(
-            memory_meta.get("governance_contradiction_count") or 0
-        ),
+        moment_candidate_count=assessment_moment_candidate_count,
+        governed_candidate_count=assessment_governed_candidate_count,
+        governance_exclusion_count=assessment_exclusion_count,
+        governance_contradiction_count=assessment_contradiction_count,
         legacy_memory_present=bool(
             memory_meta.get("legacy_memory_present")
         ),
@@ -18888,9 +19082,9 @@ def build_unified_response_assessment_shadow(
             memory_meta.get("legacy_relationship_present")
         ),
         relationship_v2_candidate_present=bool(
-            memory_meta.get("relationship_v2_candidate_present")
+            assessment_relationship_refs
         ),
-        canon_relevant=canon_relevant,
+        canon_relevant=bool(assessment_canon_refs),
         show_state_present=show_state_present,
         website_read_model_present=website_read_model_present,
         source_context_present=source_context_present,
@@ -18900,6 +19094,41 @@ def build_unified_response_assessment_shadow(
         thread_focus_mode=thread_focus_mode,
         current_text=current_text,
         conversation_evidence_items=semantic_evidence_items,
+        packet_selected_lanes=(
+            intelligence_packet.assessment_lanes if packet_usable else ()
+        ),
+        packet_excluded_lanes=(
+            intelligence_packet.assessment_exclusions
+            if intelligence_packet is not None
+            else ()
+        ),
+        packet_conflict_reasons=(
+            (
+                *intelligence_packet.diagnostics.conflict_reasons,
+                *(
+                    ("packet_processing_error",)
+                    if intelligence_packet.diagnostics.processing_errors
+                    else ()
+                ),
+                *(
+                    ("packet_invalid_invariant",)
+                    if intelligence_packet.diagnostics.invalid_invariants
+                    else ()
+                ),
+            )
+            if intelligence_packet is not None
+            else ()
+        ),
+        packet_missing_lanes=(
+            intelligence_packet.assessment_missing_lanes
+            if intelligence_packet is not None
+            else ()
+        ),
+        packet_revalidation_status=(
+            intelligence_packet.diagnostics.revalidation_status
+            if intelligence_packet is not None
+            else ""
+        ),
     )
 
 
@@ -25127,6 +25356,10 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                         batch_attribution_contract.exact_quote_authority
                         is not None
                     ),
+                    current_direct=bool(
+                        active_packet.get("addressed_to_bot")
+                        or is_broad_personal_recall_request(combined_text)
+                    ),
                 )
             )
             batch_unified_moment_canary_basis = (
@@ -26305,6 +26538,7 @@ def build_user_aware_prompt(
         show_state_present=bool(show_state_context),
         website_read_model_present=bool(website_read_model_context),
         source_context_present=bool(source_context_block),
+        source_context_snapshot=source_context_block,
         broadcast_memory_present=bool(broadcast_context),
     )
     unified_moment_canary_basis = (

--- a/bnl_memory_governance.py
+++ b/bnl_memory_governance.py
@@ -119,6 +119,7 @@ class GovernanceRequest:
     budget_chars: int = 1200
     allowed_source_classes: Tuple[str, ...] = ()
     now: str = ""
+    broad_recall: bool = False
 
 @dataclass(frozen=True)
 class MemoryCandidate:
@@ -406,7 +407,7 @@ def build_governed_context(
     cands: List[MemoryCandidate] = []
     subject = subject_key_for_user(req.subject_user_id)
     request_terms = set(req.topic_terms) or _terms(req.user_text)
-    broad = _is_broad_recall(req.user_text)
+    broad = bool(req.broad_recall or _is_broad_recall(req.user_text))
     now_ts = _parse_time(req.now or _now())
     if req.route_mode == "simple_greeting" or (len(request_terms) <= 1 and re.fullmatch(r"\s*(hi|hello|hey|yo|sup|gm|good morning)[!. ]*\s*", req.user_text or "", re.I)):
         diag.fallback_reason = "simple_greeting_skip"

--- a/bnl_relationship_engine.py
+++ b/bnl_relationship_engine.py
@@ -303,6 +303,121 @@ def governed_summary(conn: sqlite3.Connection, *, guild_id: int, user_id: int, r
     return " ".join(safe)[:500]
 
 
+def shadow_packet_posture(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    user_id: int,
+    route_mode: str,
+    channel_policy: str,
+    direct: bool,
+    target_user_id: int | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Return private, tone-only posture for the shadow intelligence packet.
+
+    This adapter deliberately does not use the Relationship live gate and does
+    not render into a prompt.  It lets the later packet evaluator compare the
+    posture Relationship v2 would contribute while keeping that posture private
+    and non-factual.
+    """
+
+    if (
+        not shadow_enabled(environ)
+        or not direct
+        or int(user_id or 0) <= 0
+        or (
+            target_user_id is not None
+            and int(target_user_id or 0) != int(user_id or 0)
+        )
+        or channel_policy not in PUBLIC_POLICIES
+        or route_mode not in RELATIONSHIP_LIVE_ROUTES
+    ):
+        return {}
+    ensure_relationship_v2_schema(conn)
+    settings = get_member_settings(
+        conn,
+        guild_id=int(guild_id or 0),
+        user_id=int(user_id or 0),
+    )
+    row = conn.execute(
+        """
+        SELECT rapport,familiarity,friction,repair,relationship_stage,
+               rivalry_state,engagement_opt_out,updated_at,schema_version
+        FROM relationship_state_v2
+        WHERE guild_id=? AND subject_user_id=?
+        """,
+        (int(guild_id or 0), int(user_id or 0)),
+    ).fetchone()
+    if not row:
+        return {}
+    (
+        rapport,
+        familiarity,
+        friction,
+        repair,
+        stage,
+        rivalry,
+        opt_out,
+        updated_at,
+        schema_version,
+    ) = row
+    warmth = (
+        "warm"
+        if float(rapport or 0) >= 0.15
+        else "neutral_warm"
+        if float(rapport or 0) > 0.03
+        else "neutral"
+    )
+    familiarity_mode = (
+        "familiar"
+        if float(familiarity or 0) >= 0.15
+        else "lightly_familiar"
+        if float(familiarity or 0) > 0.05
+        else "low_history"
+    )
+    boundary_mode = (
+        "repair_aware"
+        if float(friction or 0) > 0.05 or float(repair or 0) > 0.05
+        else "ordinary"
+    )
+    proactive_allowed = bool(
+        not opt_out and settings.get("proactive_enabled", True)
+    )
+    rivalry_allowed = bool(
+        rivalry == "mutual_rivalry"
+        and settings.get("playful_rivalry_enabled", True)
+        and proactive_allowed
+    )
+    posture_text = (
+        "tone=%s; familiarity=%s; boundary=%s; proactive=%s; rivalry=%s"
+        % (
+            warmth,
+            familiarity_mode,
+            boundary_mode,
+            "allowed" if proactive_allowed else "disabled",
+            "current_turn_only" if rivalry_allowed else "disabled",
+        )
+    )
+    digest = _hash(
+        SCHEMA_VERSION,
+        guild_id,
+        user_id,
+        posture_text,
+        updated_at,
+        schema_version,
+    )
+    return {
+        "source_ref": "relationship:%s" % int(user_id or 0),
+        "source_digest": digest,
+        "posture": posture_text,
+        "visibility": "private",
+        "usage": "tone_only",
+        "updated_at": str(updated_at or ""),
+        "relationship_stage": str(stage or "new"),
+    }
+
+
 def _open_loop_count(conn: sqlite3.Connection, *, guild_id: int, user_id: int, channel_policy: str = "unknown") -> int:
     sk = subject_key_for_user(user_id)
     try:

--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -16,13 +16,17 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence
 from bnl_memory_ledger import build_memory_ledger_evaluation
 from bnl_moment_engine import build_moment_evaluation_report
 from bnl_relationship_engine import build_evaluation_report as build_relationship_evaluation_report
+from bnl_unified_intelligence_packet import (
+    build_evaluation_report as build_intelligence_packet_evaluation_report,
+    shadow_configuration as intelligence_packet_shadow_configuration,
+)
 from bnl_unified_response_assessment import (
     build_evaluation_report as build_unified_assessment_evaluation_report,
     shadow_configuration as unified_assessment_shadow_configuration,
 )
 
 
-SHADOW_ACCEPTANCE_VERSION = "v2_shadow_acceptance_v2"
+SHADOW_ACCEPTANCE_VERSION = "v2_shadow_acceptance_v3"
 SHADOW_EVALUATION_ORDER = (
     "memory_ledger",
     "moment_engine",
@@ -57,6 +61,7 @@ def build_gate_snapshot(environ: Optional[Mapping[str, str]] = None) -> Dict[str
     context_value = str(env.get("BNL_CONVERSATION_CONTEXT_V2_ENABLED", "true") or "true")
     context_enabled = context_value.strip().lower() not in {"false", "0", "off"}
     unified_assessment = unified_assessment_shadow_configuration(env)
+    intelligence_packet = intelligence_packet_shadow_configuration(env)
     return {
         "conversation_context_v2": context_enabled,
         "memory_ledger_shadow_requested": ledger,
@@ -76,6 +81,15 @@ def build_gate_snapshot(environ: Optional[Mapping[str, str]] = None) -> Dict[str
         ),
         "unified_response_assessment_shadow_reason": str(
             unified_assessment["reason"]
+        ),
+        "unified_intelligence_packet_shadow_requested": bool(
+            intelligence_packet["requested"]
+        ),
+        "unified_intelligence_packet_shadow_effective": bool(
+            intelligence_packet["effective"]
+        ),
+        "unified_intelligence_packet_shadow_reason": str(
+            intelligence_packet["reason"]
         ),
         "all_live_gates_clear": not (
             governance_live_requested or relationship_live or engagement_live
@@ -646,6 +660,45 @@ def _read_unified_assessment_report(
         )
 
 
+def _read_intelligence_packet_report(
+    conn: sqlite3.Connection,
+    guild_id: int,
+) -> Dict[str, Any]:
+    try:
+        return build_intelligence_packet_evaluation_report(
+            conn,
+            guild_id=guild_id,
+            prepare_schema=False,
+        )
+    except (sqlite3.DatabaseError, ValueError, TypeError) as exc:
+        return _report_error(
+            {
+                "tablePresent": False,
+                "schemaVersion": "unified_intelligence_packet_v1",
+                "runs": 0,
+                "itemTotal": 0,
+                "selectedByLane": {},
+                "selectedBySourceClass": {},
+                "selectedAtomicStates": {},
+                "excludedByReason": {},
+                "missingLaneCounts": {},
+                "conflictRuns": 0,
+                "visibilityExclusions": 0,
+                "budgetExclusions": 0,
+                "duplicateSuppressions": 0,
+                "processingErrors": 0,
+                "invalidInvariants": 0,
+                "revalidationStatusCounts": {},
+                "revalidationChangedRuns": 0,
+                "promptAppliedRuns": 0,
+                "liveAppliedRuns": 0,
+                "contentFieldsPresent": [],
+                "evidenceWindow": {"first": "none", "last": "none"},
+            },
+            exc,
+        )
+
+
 def _safe_context_report(diagnostics: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
     source = diagnostics or {}
     numeric = (
@@ -713,6 +766,7 @@ def build_v2_shadow_acceptance_snapshot(
     moments = _read_moment_report(conn, guild_id)
     governance = build_persisted_governance_report(conn, guild_id=guild_id)
     relationship = _read_relationship_report(conn, guild_id)
+    intelligence_packet = _read_intelligence_packet_report(conn, guild_id)
     unified_assessment = _read_unified_assessment_report(conn, guild_id)
     context = _safe_context_report(conversation_context_diagnostics)
 
@@ -852,6 +906,44 @@ def build_v2_shadow_acceptance_snapshot(
         blockers=relationship_blockers,
     )
 
+    intelligence_packet_blockers = []
+    for key in (
+        "processingErrors",
+        "invalidInvariants",
+        "revalidationChangedRuns",
+        "promptAppliedRuns",
+        "liveAppliedRuns",
+    ):
+        if int(intelligence_packet.get(key, 0) or 0):
+            intelligence_packet_blockers.append(key)
+    if intelligence_packet.get("contentFieldsPresent"):
+        intelligence_packet_blockers.append("contentFieldsPresent")
+    if intelligence_packet.get("reportError"):
+        intelligence_packet_blockers.append(
+            "report_error:%s" % intelligence_packet["reportError"]
+        )
+    intelligence_packet_evidence = (
+        int(intelligence_packet.get("runs", 0) or 0) > 0
+    )
+    intelligence_packet_prerequisites = [
+        name
+        for name, status in (
+            ("memory_ledger", ledger_status),
+            ("moment_engine", moment_status),
+            ("memory_governance", governance_status),
+            ("relationship_v2", relationship_status),
+        )
+        if not status.startswith("candidate_pass")
+    ]
+    intelligence_packet_status = _stage_status(
+        requested=gates[
+            "unified_intelligence_packet_shadow_requested"
+        ],
+        prerequisites=intelligence_packet_prerequisites,
+        evidence=intelligence_packet_evidence,
+        blockers=intelligence_packet_blockers,
+    )
+
     context_cross_channel = int(context.get("cross_channel_paired_turn_count", 0) or 0)
     if not gates["conversation_context_v2"]:
         context_status = "rollback_disabled"
@@ -939,6 +1031,10 @@ def build_v2_shadow_acceptance_snapshot(
         "unified_response_assessment:%s" % reason
         for reason in unified_assessment_blockers
     )
+    blockers.extend(
+        "unified_intelligence_packet:%s" % reason
+        for reason in intelligence_packet_blockers
+    )
 
     warnings = []
     if int(ledger.get("legacyToLedgerParityMismatches", 0) or 0):
@@ -979,6 +1075,15 @@ def build_v2_shadow_acceptance_snapshot(
         unified_assessment.get("response_coherence_review_runs", 0) or 0
     ):
         warnings.append("unified_assessment_response_coherence_review")
+    if int(intelligence_packet.get("conflictRuns", 0) or 0):
+        warnings.append("intelligence_packet_conflicts_safely_excluded")
+    if intelligence_packet.get("missingLaneCounts"):
+        warnings.append("intelligence_packet_missing_lanes_review")
+    if (
+        gates.get("unified_intelligence_packet_shadow_effective")
+        and not intelligence_packet_evidence
+    ):
+        warnings.append("intelligence_packet_no_packet_evidence")
 
     stage_statuses = [stage["status"] for stage in stages.values()]
     unified_assessment_ready = bool(
@@ -988,12 +1093,20 @@ def build_v2_shadow_acceptance_snapshot(
             and not unified_assessment_blockers
         )
     )
+    intelligence_packet_ready = bool(
+        not gates.get("unified_intelligence_packet_shadow_requested")
+        or (
+            intelligence_packet_evidence
+            and not intelligence_packet_blockers
+        )
+    )
     if live_gates:
         status = "blocked_live_authority_detected"
     elif blockers:
         status = "blocked_shadow_invariant_failure"
     elif (
         all(value.startswith("candidate_pass") for value in stage_statuses)
+        and intelligence_packet_ready
         and unified_assessment_ready
     ):
         status = "ready_for_owner_review_not_live_cutover"
@@ -1019,7 +1132,29 @@ def build_v2_shadow_acceptance_snapshot(
             "momentEngine": moments,
             "memoryGovernance": governance,
             "relationshipV2": relationship,
+            "unifiedIntelligencePacket": intelligence_packet,
             "unifiedResponseAssessment": unified_assessment,
+        },
+        "unifiedIntelligencePacketShadow": {
+            "status": intelligence_packet_status,
+            "requested": bool(
+                gates.get(
+                    "unified_intelligence_packet_shadow_requested"
+                )
+            ),
+            "effective": bool(
+                gates.get(
+                    "unified_intelligence_packet_shadow_effective"
+                )
+            ),
+            "reason": str(
+                gates.get(
+                    "unified_intelligence_packet_shadow_reason",
+                    "disabled",
+                )
+            ),
+            "evidenceObserved": intelligence_packet_evidence,
+            "blockers": intelligence_packet_blockers,
         },
         "unifiedResponseAssessmentShadow": {
             "requested": bool(
@@ -1050,6 +1185,7 @@ def build_v2_shadow_acceptance_snapshot(
             "restartRequiredAfterEnvironmentChange": True,
             "disableOrder": [
                 "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED",
+                "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED",
                 "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED",
                 "BNL_RELATIONSHIP_V2_LIVE_ENABLED",
                 "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED",
@@ -1081,7 +1217,11 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
     moments = reports.get("momentEngine") or {}
     governance = reports.get("memoryGovernance") or {}
     relationship = reports.get("relationshipV2") or {}
+    intelligence_packet = reports.get("unifiedIntelligencePacket") or {}
     unified_assessment = reports.get("unifiedResponseAssessment") or {}
+    intelligence_packet_state = (
+        snapshot.get("unifiedIntelligencePacketShadow") or {}
+    )
     unified_state = snapshot.get("unifiedResponseAssessmentShadow") or {}
     blockers = snapshot.get("blockers") or []
     warnings = snapshot.get("warnings") or []
@@ -1306,6 +1446,58 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             relationship.get("moment_link_integrity_violations", 0),
         ),
         "- relationship_legacy_v2_comparison: `%s`" % relationship.get("legacy_v2_comparison", "not_collected"),
+        "- unified_intelligence_packet: status=`%s` requested=`%s` effective=`%s` reason=`%s` schema=`%s` runs=`%s` items=`%s` lanes=`%s` sources=`%s` atomic_states=`%s` missing=`%s` conflicts=`%s` revalidation=`%s` source_changes=`%s` errors=`%s` invalid_invariants=`%s` prompt_applied=`%s` live_applied=`%s` content_fields=`%s` window_last=`%s`" % (
+            intelligence_packet_state.get(
+                "status",
+                "unknown",
+            ),
+            _on(intelligence_packet_state.get("requested")),
+            _on(intelligence_packet_state.get("effective")),
+            intelligence_packet_state.get("reason", "disabled"),
+            intelligence_packet.get(
+                "schemaVersion",
+                "unified_intelligence_packet_v1",
+            ),
+            intelligence_packet.get("runs", 0),
+            intelligence_packet.get("itemTotal", 0),
+            json.dumps(
+                intelligence_packet.get("selectedByLane", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                intelligence_packet.get("selectedBySourceClass", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                intelligence_packet.get("selectedAtomicStates", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                intelligence_packet.get("missingLaneCounts", {}),
+                sort_keys=True,
+            ),
+            intelligence_packet.get("conflictRuns", 0),
+            json.dumps(
+                intelligence_packet.get(
+                    "revalidationStatusCounts",
+                    {},
+                ),
+                sort_keys=True,
+            ),
+            intelligence_packet.get("revalidationChangedRuns", 0),
+            intelligence_packet.get("processingErrors", 0),
+            intelligence_packet.get("invalidInvariants", 0),
+            intelligence_packet.get("promptAppliedRuns", 0),
+            intelligence_packet.get("liveAppliedRuns", 0),
+            json.dumps(
+                intelligence_packet.get("contentFieldsPresent", []),
+                sort_keys=True,
+            ),
+            (intelligence_packet.get("evidenceWindow") or {}).get(
+                "last",
+                "none",
+            ),
+        ),
         "- unified_assessment: requested=`%s` effective=`%s` reason=`%s` runs=`%s` current_primary=`%s` comparison=`%s` alignments=`%s` thread_focus=`%s` grounding=`%s` grounding_applicable=`%s` grounding_failures=`%s` source_changes=`%s` guards=`%s/%s` visible_control_markers=`%s` errors=`%s` behavior_changes=`%s` new_authority=`%s` window_last=`%s`" % (
             _on(unified_state.get("requested")),
             _on(unified_state.get("effective")),

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -1,0 +1,2311 @@
+"""Shadow-only governed retrieval and unified intelligence packet assembly.
+
+This module owns no facts.  It coordinates references selected by the existing
+Conversation Context, Memory Governance, Ledger, Moment, Relationship, canon,
+and Source File owners into one bounded comparison packet.  The packet is never
+rendered into a live prompt in this stage.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import asdict, dataclass, field, is_dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import uuid
+from typing import Any, Mapping, Sequence
+
+from bnl_canon_source_contract import (
+    CANON_FACTS,
+    CANON_SOURCE_CONTRACT_VERSION,
+    Confidence,
+    SourceClass,
+)
+from bnl_memory_governance import (
+    GovernanceRequest,
+    assess_governance_result_safety,
+    build_governed_context,
+    ensure_governance_schema,
+)
+from bnl_memory_ledger import (
+    ATOMIC_KNOWLEDGE_LIFECYCLE_SCHEMA_VERSION,
+    subject_key_for_user,
+)
+from bnl_moment_engine import select_public_participant_moment_gists
+from bnl_relationship_engine import shadow_packet_posture
+
+
+SCHEMA_VERSION = "unified_intelligence_packet_v1"
+TABLE_NAME = "memory_governance_intelligence_packet_runs"
+SHADOW_ENV = "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED"
+_SHADOW_PREREQUISITES = (
+    "BNL_MEMORY_LEDGER_SHADOW_ENABLED",
+    "BNL_MOMENT_ENGINE_SHADOW_ENABLED",
+    "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED",
+    "BNL_RELATIONSHIP_V2_SHADOW_ENABLED",
+)
+_LIVE_GATES = (
+    "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED",
+    "BNL_RELATIONSHIP_V2_LIVE_ENABLED",
+    "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED",
+)
+_PUBLIC_POLICIES = {"public_home", "public_context", "public_selective"}
+_PUBLIC_VISIBILITIES = {"public", "public_safe", "reference_canon"}
+_INTERNAL_VISIBILITIES = _PUBLIC_VISIBILITIES | {
+    "internal",
+    "private",
+    "mod",
+    "operator_only",
+    "sealed_test",
+}
+_BLOCKED_LIFECYCLES = {
+    "corrected",
+    "superseded",
+    "retracted",
+    "expired",
+    "quarantined",
+    "review_only",
+    "needs_review",
+    "forgotten",
+    "deleted",
+    "rejected",
+    "unresolved",
+}
+_AUTHORITY_RANK = {
+    SourceClass.LEGACY_SOURCE_BLIND.value: 0,
+    SourceClass.DERIVED_SUMMARY.value: 1,
+    SourceClass.ENTITY_EVIDENCE_PROJECTION.value: 1,
+    SourceClass.DOSSIER_PROJECTION.value: 1,
+    SourceClass.SOURCE_FILE_PROJECTION.value: 1,
+    SourceClass.EVIDENCE_PROJECTION.value: 1,
+    "moment_gist": 2,
+    SourceClass.PUBLIC_OBSERVATION.value: 3,
+    SourceClass.RUNTIME_OBSERVATION.value: 4,
+    SourceClass.FIRST_PARTY_RECORD.value: 5,
+    SourceClass.APPROVED_CANON.value: 6,
+    SourceClass.OWNER_CORRECTION.value: 7,
+}
+_CONFIDENCE_RANK = {
+    Confidence.UNKNOWN.value: 0,
+    Confidence.LOW.value: 1,
+    Confidence.MEDIUM.value: 2,
+    Confidence.HIGH.value: 3,
+    Confidence.APPROVED.value: 4,
+}
+_LANE_CAPS = {
+    "current_intent": 8,
+    "conversation_context": 6,
+    "approved_fact": 4,
+    "moment": 3,
+    "atomic_knowledge": 6,
+    "open_loop": 3,
+    "canon": 4,
+    "source_file": 2,
+    "relationship_posture": 1,
+}
+_ASSESSMENT_LANE_MAP = {
+    "current_intent": "current_exchange",
+    "conversation_context": "conversation_context",
+    "approved_fact": "governed_memory",
+    "atomic_knowledge": "governed_memory",
+    "open_loop": "governed_memory",
+    "moment": "prior_moment",
+    "canon": "canon",
+    "source_file": "source_context",
+    "relationship_posture": "relationship",
+}
+_ADDITIVE_PREDICATES = {
+    "open_loop",
+    "commitment",
+    "goal",
+    "unresolved_question",
+    "shared_moment",
+    "topic_or_motif",
+}
+_TERM_RE = re.compile(r"[a-z0-9][a-z0-9'’-]*", re.I)
+_TERM_STOPWORDS = {
+    "a",
+    "about",
+    "all",
+    "am",
+    "an",
+    "and",
+    "are",
+    "at",
+    "be",
+    "do",
+    "does",
+    "for",
+    "from",
+    "have",
+    "i",
+    "in",
+    "is",
+    "it",
+    "know",
+    "me",
+    "my",
+    "of",
+    "on",
+    "or",
+    "remember",
+    "tell",
+    "that",
+    "the",
+    "this",
+    "to",
+    "what",
+    "who",
+    "with",
+    "you",
+}
+_BROAD_PROFILE_RE = re.compile(
+    r"\b(?:"
+    r"what\s+do\s+you\s+(?:know|remember)\s+about\s+me|"
+    r"what\s+do\s+you\s+have\s+on\s+me|"
+    r"what\s+am\s+i\s+all\s+about|"
+    r"what\s+have\s+you\s+learned\s+about\s+me|"
+    r"tell\s+me\s+(?:everything\s+)?(?:you\s+)?(?:know|remember)\s+about\s+me|"
+    r"tell\s+me\s+about\s+myself|"
+    r"who\s+am\s+i\s+to\s+you"
+    r")\b",
+    re.I,
+)
+_CURRENT_CORRECTION_RE = re.compile(
+    r"\b(?:correction|correcting|that's\s+wrong|that\s+is\s+wrong|"
+    r"not\s+anymore|no[,;:]?\s+(?:my|i|we)|"
+    r"i\s+(?:meant|mean)|replace\s+that)\b",
+    re.I,
+)
+_CURRENT_ACTUALLY_STATEMENT_RE = re.compile(
+    r"\bactually\b.{0,80}\b(?:my|i|we)\b.{0,80}"
+    r"\b(?:am|are|is|prefer|like|want|need|use|have)\b",
+    re.I,
+)
+
+
+@dataclass(frozen=True)
+class PacketConversationEvidence:
+    text: str
+    source_id: int = 0
+    speaker_user_id: int = 0
+    speaker_label: str = ""
+    current_turn: bool = False
+
+
+@dataclass(frozen=True)
+class IntelligencePacketRequest:
+    guild_id: int
+    subject_user_id: int
+    route_mode: str
+    conversation_surface: str
+    channel_id: int = 0
+    channel_name: str = ""
+    channel_policy: str = "unknown"
+    visibility_allowance: str = "public_safe"
+    user_text: str = ""
+    participant_user_ids: tuple[int, ...] = ()
+    direct_state: str = "direct"
+    budget_chars: int = 2400
+    conversation_evidence: tuple[PacketConversationEvidence, ...] = ()
+    source_context_snapshot: str = ""
+    source_context_authorized: bool = False
+    immediate_recap: bool = False
+    now: str = ""
+
+
+@dataclass(frozen=True)
+class IntelligencePacketItem:
+    lane: str
+    source_class: str
+    source_type: str
+    source_ref: str
+    source_digest: str
+    subject_key: str
+    predicate_key: str
+    text: str
+    visibility: str
+    confidence: str
+    lifecycle: str
+    authority: int
+    participants: tuple[str, ...] = ()
+    lineage: tuple[str, ...] = ()
+    observed_at: str = ""
+    usage: str = "content"
+    score: float = 0.0
+    revalidation_kind: str = ""
+    revalidation_key: str = ""
+
+
+@dataclass(frozen=True)
+class IntelligencePacketExclusion:
+    lane: str
+    reason: str
+    source_class: str = ""
+
+
+@dataclass
+class IntelligencePacketDiagnostics:
+    candidates_by_lane: dict[str, int] = field(default_factory=dict)
+    selected_by_lane: dict[str, int] = field(default_factory=dict)
+    selected_by_source_class: dict[str, int] = field(default_factory=dict)
+    selected_atomic_states: dict[str, int] = field(default_factory=dict)
+    excluded_by_reason: dict[str, int] = field(default_factory=dict)
+    missing_lanes: list[str] = field(default_factory=list)
+    conflict_reasons: list[str] = field(default_factory=list)
+    visibility_exclusions: int = 0
+    budget_exclusions: int = 0
+    duplicate_suppression: int = 0
+    processing_errors: list[str] = field(default_factory=list)
+    invalid_invariants: list[str] = field(default_factory=list)
+    revalidation_status: str = "not_evaluated"
+    revalidation_changed_count: int = 0
+    packet_digest: str = ""
+    prompt_applied: bool = False
+    live_applied: bool = False
+
+
+@dataclass(frozen=True)
+class PacketRevalidationResult:
+    valid: bool
+    status: str
+    changed_source_count: int = 0
+    processing_error_count: int = 0
+
+
+@dataclass(frozen=True)
+class UnifiedIntelligencePacket:
+    schema_version: str
+    packet_id: str
+    request: IntelligencePacketRequest
+    items: tuple[IntelligencePacketItem, ...]
+    exclusions: tuple[IntelligencePacketExclusion, ...]
+    diagnostics: IntelligencePacketDiagnostics
+
+    @property
+    def detailed_lanes(self) -> tuple[str, ...]:
+        return tuple(dict.fromkeys(item.lane for item in self.items))
+
+    @property
+    def assessment_lanes(self) -> tuple[str, ...]:
+        return tuple(
+            dict.fromkeys(
+                _ASSESSMENT_LANE_MAP[item.lane]
+                for item in self.items
+                if item.lane in _ASSESSMENT_LANE_MAP
+            )
+        )
+
+    @property
+    def governed_refs(self) -> tuple[str, ...]:
+        return tuple(
+            item.source_ref
+            for item in self.items
+            if item.lane in {"approved_fact", "atomic_knowledge", "open_loop"}
+        )
+
+    @property
+    def moment_refs(self) -> tuple[str, ...]:
+        return tuple(
+            item.source_ref for item in self.items if item.lane == "moment"
+        )
+
+    @property
+    def canon_refs(self) -> tuple[str, ...]:
+        return tuple(
+            item.source_ref for item in self.items if item.lane == "canon"
+        )
+
+    @property
+    def relationship_refs(self) -> tuple[str, ...]:
+        return tuple(
+            item.source_ref
+            for item in self.items
+            if item.lane == "relationship_posture"
+        )
+
+    @property
+    def assessment_exclusions(self) -> tuple[tuple[str, str], ...]:
+        return tuple(
+            dict.fromkeys(
+                (
+                    _ASSESSMENT_LANE_MAP[exclusion.lane],
+                    "packet:%s" % exclusion.reason,
+                )
+                for exclusion in self.exclusions
+                if exclusion.lane in _ASSESSMENT_LANE_MAP
+            )
+        )
+
+    @property
+    def assessment_missing_lanes(self) -> tuple[str, ...]:
+        return tuple(
+            dict.fromkeys(
+                _ASSESSMENT_LANE_MAP.get(lane, lane)
+                for lane in self.diagnostics.missing_lanes
+            )
+        )
+
+
+def _flag(value: Any) -> bool:
+    return str(value or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+        "enabled",
+    }
+
+
+def shadow_configuration(
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    env = os.environ if environ is None else environ
+    prerequisites = {name: _flag(env.get(name, "")) for name in _SHADOW_PREREQUISITES}
+    live_gates = {name: _flag(env.get(name, "")) for name in _LIVE_GATES}
+    explicitly_configured = SHADOW_ENV in env
+    requested = (
+        _flag(env.get(SHADOW_ENV, ""))
+        if explicitly_configured
+        else all(prerequisites.values())
+    )
+    missing = tuple(name for name, enabled in prerequisites.items() if not enabled)
+    active_live = tuple(name for name, enabled in live_gates.items() if enabled)
+    effective = bool(requested and not missing and not active_live)
+    if not requested:
+        reason = "disabled"
+    elif missing:
+        reason = "missing_shadow_prerequisites"
+    elif active_live:
+        reason = "live_authority_detected"
+    else:
+        reason = "shadow_only"
+    return {
+        "requested": requested,
+        "effective": effective,
+        "explicitly_configured": explicitly_configured,
+        "reason": reason,
+        "missing_prerequisites": missing,
+        "active_live_gates": active_live,
+    }
+
+
+def shadow_enabled(environ: Mapping[str, str] | None = None) -> bool:
+    return bool(shadow_configuration(environ)["effective"])
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _parse_time(value: Any) -> datetime | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _stable_json(value: Any) -> str:
+    if is_dataclass(value):
+        value = asdict(value)
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+
+
+def _digest(*values: Any) -> str:
+    payload = "\x1f".join(_stable_json(value) for value in values)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _terms(value: Any) -> set[str]:
+    return {
+        term
+        for term in _TERM_RE.findall(str(value or "").lower())
+        if len(term) > 1 and term not in _TERM_STOPWORDS
+    }
+
+
+def _broad_profile_request(value: str) -> bool:
+    return bool(_BROAD_PROFILE_RE.search(str(value or "")))
+
+
+def _public_route(request: IntelligencePacketRequest) -> bool:
+    return request.channel_policy in _PUBLIC_POLICIES or request.visibility_allowance in {
+        "public",
+        "public_safe",
+    }
+
+
+def _visibility_for_policy(policy: str) -> str:
+    return {
+        "public_home": "public",
+        "public_context": "public",
+        "public_selective": "public_safe",
+        "sealed_test": "sealed_test",
+        "internal_controlled": "internal",
+        "reference_canon": "reference_canon",
+    }.get(str(policy or "").lower(), "unknown")
+
+
+def _route_allows_item(
+    request: IntelligencePacketRequest,
+    item: IntelligencePacketItem,
+) -> bool:
+    if item.lane == "relationship_posture":
+        return bool(
+            item.visibility == "private"
+            and item.usage == "tone_only"
+            and request.direct_state == "direct"
+            and request.channel_policy in _PUBLIC_POLICIES
+        )
+    if _public_route(request):
+        return item.visibility in _PUBLIC_VISIBILITIES
+    return item.visibility in _INTERNAL_VISIBILITIES
+
+
+def _relevant(
+    *,
+    request_terms: set[str],
+    broad: bool,
+    lane: str,
+    text: str,
+    predicate_key: str = "",
+    tags: Sequence[str] = (),
+) -> bool:
+    if lane in {"current_intent", "conversation_context", "relationship_posture"}:
+        return True
+    if broad and lane in {
+        "approved_fact",
+        "moment",
+        "atomic_knowledge",
+        "open_loop",
+    }:
+        return True
+    if lane == "open_loop":
+        return True
+    candidate_terms = (
+        _terms(text)
+        | _terms(predicate_key.replace("_", " "))
+        | set(tags or ())
+    )
+    return bool(request_terms & candidate_terms)
+
+
+def _add_exclusion(
+    diagnostics: IntelligencePacketDiagnostics,
+    exclusions: list[IntelligencePacketExclusion],
+    *,
+    lane: str,
+    reason: str,
+    source_class: str = "",
+) -> None:
+    exclusions.append(
+        IntelligencePacketExclusion(
+            lane=lane,
+            reason=reason,
+            source_class=source_class,
+        )
+    )
+    diagnostics.excluded_by_reason[reason] = (
+        diagnostics.excluded_by_reason.get(reason, 0) + 1
+    )
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    ensure_governance_schema(conn)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_governance_intelligence_packet_runs (
+            run_id TEXT PRIMARY KEY,
+            packet_id TEXT NOT NULL,
+            schema_version TEXT NOT NULL,
+            guild_id INTEGER NOT NULL,
+            subject_hash TEXT NOT NULL,
+            route_mode TEXT NOT NULL,
+            channel_policy TEXT NOT NULL,
+            visibility_allowance TEXT NOT NULL,
+            item_count INTEGER NOT NULL DEFAULT 0,
+            selected_lane_counts_json TEXT NOT NULL DEFAULT '{}',
+            source_class_counts_json TEXT NOT NULL DEFAULT '{}',
+            atomic_state_counts_json TEXT NOT NULL DEFAULT '{}',
+            excluded_by_reason_json TEXT NOT NULL DEFAULT '{}',
+            missing_lanes_json TEXT NOT NULL DEFAULT '[]',
+            conflict_count INTEGER NOT NULL DEFAULT 0,
+            visibility_exclusion_count INTEGER NOT NULL DEFAULT 0,
+            budget_exclusion_count INTEGER NOT NULL DEFAULT 0,
+            duplicate_suppression_count INTEGER NOT NULL DEFAULT 0,
+            processing_error_count INTEGER NOT NULL DEFAULT 0,
+            invalid_invariant_count INTEGER NOT NULL DEFAULT 0,
+            revalidation_status TEXT NOT NULL DEFAULT 'not_evaluated',
+            revalidation_changed_count INTEGER NOT NULL DEFAULT 0,
+            packet_digest TEXT NOT NULL,
+            source_ref_digest TEXT NOT NULL,
+            prompt_applied INTEGER NOT NULL DEFAULT 0,
+            live_applied INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_intelligence_packet_guild
+        ON memory_governance_intelligence_packet_runs(guild_id,created_at)
+        """
+    )
+
+
+def _conversation_row(
+    conn: sqlite3.Connection,
+    source_id: int,
+) -> dict[str, Any]:
+    columns = {
+        str(row[1])
+        for row in conn.execute("PRAGMA table_info(conversations)").fetchall()
+    }
+    required = {
+        "id",
+        "guild_id",
+        "user_id",
+        "user_name",
+        "role",
+        "content",
+        "channel_id",
+        "channel_policy",
+        "timestamp",
+    }
+    if not required.issubset(columns):
+        return {}
+    row = conn.execute(
+        """
+        SELECT id,guild_id,user_id,user_name,role,content,channel_id,
+               channel_policy,timestamp
+        FROM conversations
+        WHERE id=?
+        """,
+        (int(source_id or 0),),
+    ).fetchone()
+    keys = (
+        "id",
+        "guild_id",
+        "user_id",
+        "user_name",
+        "role",
+        "content",
+        "channel_id",
+        "channel_policy",
+        "timestamp",
+    )
+    return dict(zip(keys, row)) if row else {}
+
+
+def _conversation_digest(row: Mapping[str, Any]) -> str:
+    return _digest(
+        "conversation",
+        {
+            key: row.get(key)
+            for key in (
+                "id",
+                "guild_id",
+                "user_id",
+                "role",
+                "content",
+                "channel_id",
+                "channel_policy",
+                "timestamp",
+            )
+        },
+    )
+
+
+def _conversation_items(
+    conn: sqlite3.Connection,
+    request: IntelligencePacketRequest,
+    diagnostics: IntelligencePacketDiagnostics,
+    exclusions: list[IntelligencePacketExclusion],
+) -> list[IntelligencePacketItem]:
+    items: list[IntelligencePacketItem] = []
+    for evidence in request.conversation_evidence:
+        text = re.sub(r"\s+", " ", str(evidence.text or "")).strip()
+        if not text:
+            continue
+        lane = "current_intent" if evidence.current_turn else "conversation_context"
+        diagnostics.candidates_by_lane[lane] = (
+            diagnostics.candidates_by_lane.get(lane, 0) + 1
+        )
+        if int(evidence.source_id or 0) > 0:
+            row = _conversation_row(conn, int(evidence.source_id))
+            if not row:
+                _add_exclusion(
+                    diagnostics,
+                    exclusions,
+                    lane=lane,
+                    reason="conversation_source_missing",
+                    source_class=SourceClass.PUBLIC_OBSERVATION.value,
+                )
+                continue
+            if (
+                int(row.get("guild_id") or 0) != int(request.guild_id or 0)
+                or str(row.get("role") or "").lower() != "user"
+                or (
+                    int(evidence.speaker_user_id or 0) > 0
+                    and int(row.get("user_id") or 0)
+                    != int(evidence.speaker_user_id or 0)
+                )
+            ):
+                _add_exclusion(
+                    diagnostics,
+                    exclusions,
+                    lane=lane,
+                    reason="conversation_identity_scope",
+                    source_class=SourceClass.PUBLIC_OBSERVATION.value,
+                )
+                continue
+            policy = str(row.get("channel_policy") or "unknown")
+            item = IntelligencePacketItem(
+                lane=lane,
+                source_class=SourceClass.PUBLIC_OBSERVATION.value,
+                source_type="conversation_row",
+                source_ref="conversation:%s" % int(row["id"]),
+                source_digest=_conversation_digest(row),
+                subject_key=subject_key_for_user(
+                    int(row.get("user_id") or 0)
+                ),
+                predicate_key="current_intent" if evidence.current_turn else "conversation_context",
+                text=str(row.get("content") or "")[:1200],
+                visibility=_visibility_for_policy(policy),
+                confidence=Confidence.HIGH.value,
+                lifecycle="current" if evidence.current_turn else "active",
+                authority=_AUTHORITY_RANK[SourceClass.PUBLIC_OBSERVATION.value],
+                participants=(
+                    subject_key_for_user(int(row.get("user_id") or 0)),
+                ),
+                observed_at=str(row.get("timestamp") or ""),
+                usage="current_intent" if evidence.current_turn else "continuity",
+                score=100.0 if evidence.current_turn else 88.0,
+                revalidation_kind="conversation",
+                revalidation_key=str(int(row["id"])),
+            )
+        else:
+            speaker_id = int(evidence.speaker_user_id or request.subject_user_id or 0)
+            source_digest = _digest(
+                "current_exchange",
+                request.guild_id,
+                speaker_id,
+                text,
+                request.channel_id,
+                request.channel_policy,
+            )
+            item = IntelligencePacketItem(
+                lane=lane,
+                source_class=SourceClass.RUNTIME_OBSERVATION.value,
+                source_type="current_exchange",
+                source_ref="current:%s" % source_digest[:24],
+                source_digest=source_digest,
+                subject_key=subject_key_for_user(speaker_id),
+                predicate_key="current_intent",
+                text=text[:1200],
+                visibility=_visibility_for_policy(request.channel_policy),
+                confidence=Confidence.HIGH.value,
+                lifecycle="current",
+                authority=_AUTHORITY_RANK[SourceClass.RUNTIME_OBSERVATION.value],
+                participants=(subject_key_for_user(speaker_id),) if speaker_id else (),
+                observed_at=request.now or _now(),
+                usage="current_intent",
+                score=100.0,
+                revalidation_kind="current",
+                revalidation_key=source_digest,
+            )
+        if not _route_allows_item(request, item):
+            diagnostics.visibility_exclusions += 1
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane=lane,
+                reason="conversation_visibility",
+                source_class=item.source_class,
+            )
+            continue
+        items.append(item)
+    return items
+
+
+def _ledger_entry_digest(
+    conn: sqlite3.Connection,
+    entry_id: str,
+) -> str:
+    columns = {
+        str(row[1])
+        for row in conn.execute("PRAGMA table_info(memory_ledger_entries)").fetchall()
+    }
+    if not columns or "entry_id" not in columns:
+        return ""
+    selected_columns = tuple(
+        column
+        for column in (
+            "entry_id",
+            "guild_id",
+            "subject_key",
+            "predicate_key",
+            "normalized_value",
+            "source_class",
+            "route_mode",
+            "channel_policy",
+            "visibility",
+            "confidence",
+            "public_usable",
+            "derived",
+            "projection",
+            "observed_at",
+            "lifecycle_status",
+            "updated_at",
+        )
+        if column in columns
+    )
+    row = conn.execute(
+        "SELECT %s FROM memory_ledger_entries WHERE entry_id=?"
+        % ",".join(selected_columns),
+        (entry_id,),
+    ).fetchone()
+    if not row:
+        return ""
+    data = dict(zip(selected_columns, row))
+    lineage = conn.execute(
+        """
+        SELECT lineage_type,target_entry_id
+        FROM memory_ledger_lineage
+        WHERE guild_id=? AND entry_id=?
+        ORDER BY lineage_type,target_entry_id
+        """,
+        (int(data.get("guild_id") or 0), entry_id),
+    ).fetchall()
+    incoming = conn.execute(
+        """
+        SELECT entry_id,lineage_type
+        FROM memory_ledger_lineage
+        WHERE guild_id=? AND target_entry_id=?
+          AND lineage_type IN ('correction_of','supersedes','retracts')
+        ORDER BY entry_id,lineage_type
+        """,
+        (int(data.get("guild_id") or 0), entry_id),
+    ).fetchall()
+    return _digest("ledger", data, lineage, incoming)
+
+
+def _governed_items(
+    conn: sqlite3.Connection,
+    request: IntelligencePacketRequest,
+    diagnostics: IntelligencePacketDiagnostics,
+    exclusions: list[IntelligencePacketExclusion],
+    *,
+    broad: bool,
+) -> list[IntelligencePacketItem]:
+    if int(request.subject_user_id or 0) <= 0:
+        return []
+    gov_request = GovernanceRequest(
+        guild_id=int(request.guild_id or 0),
+        subject_user_id=int(request.subject_user_id or 0),
+        route_mode=request.route_mode,
+        conversation_surface="unified_intelligence_packet_shadow",
+        channel_id=int(request.channel_id or 0),
+        channel_name=request.channel_name,
+        channel_policy=request.channel_policy,
+        visibility_allowance=request.visibility_allowance,
+        user_text=request.user_text,
+        participants=tuple(
+            subject_key_for_user(user_id)
+            for user_id in request.participant_user_ids
+            if int(user_id or 0) > 0
+        ),
+        direct_state=request.direct_state,
+        budget_chars=min(max(int(request.budget_chars or 2400), 400), 6000),
+        allowed_source_classes=(
+            "owner_correction",
+            "approved_canon",
+            "first_party_record",
+            "runtime_observation",
+            "public_observation",
+            "moment_gist",
+            "evidence_projection",
+            "derived_summary",
+        ),
+        now=request.now or _now(),
+        broad_recall=broad,
+    )
+    result = build_governed_context(
+        conn,
+        gov_request,
+        legacy_context="",
+        include_review_moments=True,
+        include_public_moment_gists=True,
+    )
+    safety = assess_governance_result_safety(result)
+    if safety.processing_errors:
+        diagnostics.processing_errors.extend(
+            "governance:%s" % error for error in safety.processing_errors
+        )
+    if safety.blocking_invariants:
+        diagnostics.invalid_invariants.extend(safety.blocking_invariants)
+        return []
+    for reason, count in result.diagnostics.excluded_by_reason.items():
+        diagnostics.excluded_by_reason[
+            "governance:%s" % reason
+        ] = diagnostics.excluded_by_reason.get(
+            "governance:%s" % reason,
+            0,
+        ) + int(count or 0)
+    items: list[IntelligencePacketItem] = []
+    for candidate in result.selected:
+        lane = (
+            "moment"
+            if candidate.source_class == "moment_gist"
+            else "open_loop"
+            if candidate.predicate_key
+            in {"open_loop", "commitment", "goal", "unresolved_question"}
+            else "approved_fact"
+        )
+        diagnostics.candidates_by_lane[lane] = (
+            diagnostics.candidates_by_lane.get(lane, 0) + 1
+        )
+        if candidate.source_class == "moment_gist":
+            source_digest = _digest(
+                "moment",
+                candidate.source_ref,
+                candidate.entry_id,
+                candidate.text,
+                candidate.visibility,
+                candidate.observed_at,
+            )
+            revalidation_kind = "moment"
+            revalidation_key = candidate.source_ref.removeprefix("moment:")
+        else:
+            source_digest = _ledger_entry_digest(conn, candidate.entry_id)
+            revalidation_kind = "ledger"
+            revalidation_key = candidate.entry_id
+        item = IntelligencePacketItem(
+            lane=lane,
+            source_class=candidate.source_class,
+            source_type=candidate.source_type,
+            source_ref=candidate.source_ref,
+            source_digest=source_digest,
+            subject_key=candidate.subject_key,
+            predicate_key=candidate.predicate_key,
+            text=candidate.text[:1000],
+            visibility=candidate.visibility,
+            confidence=candidate.confidence,
+            lifecycle=candidate.lifecycle,
+            authority=int(candidate.authority or 0),
+            participants=tuple(candidate.participants or ()),
+            lineage=tuple(
+                "%s:%s" % (lineage_type, target)
+                for lineage_type, target in candidate.lineage
+            ),
+            observed_at=candidate.observed_at,
+            usage="episodic_gist" if lane == "moment" else "content",
+            score=float(candidate.score or 0) + {
+                "approved_fact": 82.0,
+                "open_loop": 76.0,
+                "moment": 72.0,
+            }[lane],
+            revalidation_kind=revalidation_kind,
+            revalidation_key=revalidation_key,
+        )
+        if not source_digest:
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane=lane,
+                reason="governed_source_unversioned",
+                source_class=item.source_class,
+            )
+            continue
+        if not _route_allows_item(request, item):
+            diagnostics.visibility_exclusions += 1
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane=lane,
+                reason="governed_visibility",
+                source_class=item.source_class,
+            )
+            continue
+        items.append(item)
+    return items
+
+
+def _atomic_candidate_row(
+    conn: sqlite3.Connection,
+    candidate_id: str,
+) -> dict[str, Any]:
+    columns = (
+        "candidate_id",
+        "guild_id",
+        "candidate_type",
+        "subject_key",
+        "predicate_key",
+        "normalized_value",
+        "epistemic_status",
+        "currentness",
+        "candidate_state",
+        "visibility",
+        "authority_class",
+        "confidence_class",
+        "route_scope_json",
+        "retrieval_tags_json",
+        "candidate_eligible",
+        "live_eligible",
+        "invalidated_reason",
+        "lifecycle_schema_version",
+        "consolidation_id",
+        "canonical_candidate_id",
+        "eligible_independent_root_count",
+        "reinforcement_count",
+        "conflict_value_count",
+        "consolidated_authority_class",
+        "consolidated_confidence_class",
+        "lifecycle_support_digest",
+        "review_status",
+        "review_due_at",
+        "last_seen_at",
+    )
+    row = conn.execute(
+        "SELECT %s FROM memory_ledger_knowledge_candidates WHERE candidate_id=?"
+        % ",".join(columns),
+        (candidate_id,),
+    ).fetchone()
+    return dict(zip(columns, row)) if row else {}
+
+
+def _atomic_root_snapshot(
+    conn: sqlite3.Connection,
+    candidate_id: str,
+) -> tuple[dict[str, Any], ...]:
+    candidate = _atomic_candidate_row(conn, candidate_id)
+    consolidation_id = str(candidate.get("consolidation_id") or "")
+    rows = conn.execute(
+        """
+        SELECT DISTINCT r.root_entry_id,r.root_status,r.is_independent,
+               e.guild_id,e.subject_key,e.source_class,e.source_table,
+               e.source_row_id,e.source_revision,e.source_role,
+               e.route_mode,e.channel_id,e.channel_name,e.channel_policy,
+               e.visibility,e.public_usable,e.derived,e.projection,
+               e.lifecycle_status,e.updated_at
+        FROM memory_ledger_knowledge_roots r
+        JOIN memory_ledger_knowledge_candidates c
+          ON c.candidate_id=r.candidate_id
+        LEFT JOIN memory_ledger_entries e ON e.entry_id=r.root_entry_id
+        WHERE r.is_independent=1 AND r.root_status='eligible'
+          AND (
+            (?<>'' AND c.consolidation_id=?)
+            OR (?='' AND r.candidate_id=?)
+          )
+        ORDER BY r.root_entry_id
+        """,
+        (
+            consolidation_id,
+            consolidation_id,
+            consolidation_id,
+            candidate_id,
+        ),
+    ).fetchall()
+    keys = (
+        "root_entry_id",
+        "root_status",
+        "is_independent",
+        "guild_id",
+        "subject_key",
+        "source_class",
+        "source_table",
+        "source_row_id",
+        "source_revision",
+        "source_role",
+        "route_mode",
+        "channel_id",
+        "channel_name",
+        "channel_policy",
+        "visibility",
+        "public_usable",
+        "derived",
+        "projection",
+        "lifecycle_status",
+        "updated_at",
+    )
+    return tuple(dict(zip(keys, row)) for row in rows)
+
+
+def _atomic_candidate_digest(
+    conn: sqlite3.Connection,
+    candidate_id: str,
+) -> str:
+    candidate = _atomic_candidate_row(conn, candidate_id)
+    if not candidate:
+        return ""
+    roots = _atomic_root_snapshot(conn, candidate_id)
+    incoming = []
+    for root in roots:
+        incoming.extend(
+            conn.execute(
+                """
+                SELECT entry_id,lineage_type
+                FROM memory_ledger_lineage
+                WHERE guild_id=? AND target_entry_id=?
+                  AND lineage_type IN ('correction_of','supersedes','retracts')
+                ORDER BY entry_id,lineage_type
+                """,
+                (
+                    int(root.get("guild_id") or 0),
+                    str(root.get("root_entry_id") or ""),
+                ),
+            ).fetchall()
+        )
+    return _digest("atomic", candidate, roots, sorted(incoming))
+
+
+def _atomic_root_valid(
+    request: IntelligencePacketRequest,
+    candidate: Mapping[str, Any],
+    root: Mapping[str, Any],
+) -> bool:
+    if (
+        not root.get("root_entry_id")
+        or str(root.get("root_status") or "") != "eligible"
+        or not bool(root.get("is_independent"))
+        or int(root.get("guild_id") or 0) != int(request.guild_id or 0)
+        or str(root.get("subject_key") or "")
+        != str(candidate.get("subject_key") or "")
+        or str(root.get("lifecycle_status") or "") != "active"
+        or bool(root.get("derived"))
+        or bool(root.get("projection"))
+    ):
+        return False
+    if _public_route(request):
+        return bool(
+            str(root.get("visibility") or "") in _PUBLIC_VISIBILITIES
+            and bool(root.get("public_usable"))
+            and str(root.get("channel_policy") or "") in _PUBLIC_POLICIES
+            and str(root.get("route_mode") or "")
+            not in {
+                "operator_command",
+                "internal_control",
+                "internal_ops",
+                "protected_system",
+                "source_file_enrichment",
+                "source_file_lookup",
+                "approved_backfill",
+            }
+        )
+    return str(root.get("visibility") or "") in _INTERNAL_VISIBILITIES
+
+
+def _atomic_items(
+    conn: sqlite3.Connection,
+    request: IntelligencePacketRequest,
+    diagnostics: IntelligencePacketDiagnostics,
+    exclusions: list[IntelligencePacketExclusion],
+    *,
+    broad: bool,
+    request_terms: set[str],
+) -> list[IntelligencePacketItem]:
+    if int(request.subject_user_id or 0) <= 0:
+        return []
+    subject = subject_key_for_user(request.subject_user_id)
+    candidate_ids = tuple(
+        str(row[0])
+        for row in conn.execute(
+            """
+            SELECT candidate_id
+            FROM memory_ledger_knowledge_candidates
+            WHERE guild_id=? AND subject_key=?
+              AND (
+                COALESCE(canonical_candidate_id,'')=''
+                OR candidate_id=canonical_candidate_id
+              )
+            ORDER BY
+              CASE candidate_state
+                WHEN 'established' THEN 0
+                WHEN 'provisional' THEN 1
+                ELSE 2
+              END,
+              candidate_state,candidate_id
+            LIMIT 200
+            """,
+            (int(request.guild_id or 0), subject),
+        ).fetchall()
+    )
+    items: list[IntelligencePacketItem] = []
+    for candidate_id in candidate_ids:
+        candidate = _atomic_candidate_row(conn, candidate_id)
+        candidate_type = str(candidate.get("candidate_type") or "")
+        lane = (
+            "open_loop"
+            if candidate_type == "open_loop_or_question"
+            else "atomic_knowledge"
+        )
+        diagnostics.candidates_by_lane[lane] = (
+            diagnostics.candidates_by_lane.get(lane, 0) + 1
+        )
+        review_status = str(candidate.get("review_status") or "")
+        review_due = _parse_time(candidate.get("review_due_at"))
+        request_now = (
+            _parse_time(request.now) or datetime.now(timezone.utc)
+        )
+        reason = ""
+        if candidate.get("lifecycle_schema_version") != (
+            ATOMIC_KNOWLEDGE_LIFECYCLE_SCHEMA_VERSION
+        ):
+            reason = "atomic_lifecycle_not_reconciled"
+        elif str(candidate.get("candidate_state") or "") not in {
+            "established",
+            "provisional",
+        }:
+            reason = "atomic_state"
+        elif not bool(candidate.get("candidate_eligible")):
+            reason = "atomic_ineligible"
+        elif int(candidate.get("live_eligible") or 0):
+            diagnostics.invalid_invariants.append(
+                "atomic_live_eligible_selected_in_shadow"
+            )
+            reason = "atomic_live_eligible_invariant"
+        elif str(candidate.get("invalidated_reason") or ""):
+            reason = "atomic_invalidated"
+        elif int(candidate.get("conflict_value_count") or 0) > 1:
+            reason = "atomic_contested"
+        elif review_status in {"due", "retired_stale"} or (
+            review_due is not None and review_due <= request_now
+        ):
+            reason = "atomic_review_due"
+        elif review_status not in {
+            "current",
+            "not_required",
+        }:
+            reason = "atomic_review_not_current"
+        elif str(candidate.get("epistemic_status") or "") in {
+            "inference",
+            "contested",
+        }:
+            reason = "atomic_inference_or_contested"
+        visibility = str(candidate.get("visibility") or "unknown")
+        if not reason and _public_route(request) and visibility not in _PUBLIC_VISIBILITIES:
+            reason = "atomic_visibility"
+            diagnostics.visibility_exclusions += 1
+        elif not reason and not _public_route(request) and visibility not in _INTERNAL_VISIBILITIES:
+            reason = "atomic_visibility"
+            diagnostics.visibility_exclusions += 1
+        roots = _atomic_root_snapshot(conn, candidate_id)
+        if not reason and (
+            not roots
+            or len(roots)
+            != int(
+                candidate.get("eligible_independent_root_count") or 0
+            )
+            or not all(
+                _atomic_root_valid(request, candidate, root) for root in roots
+            )
+            or len(
+                {
+                    (
+                        str(root.get("source_table") or ""),
+                        str(root.get("source_row_id") or ""),
+                    )
+                    for root in roots
+                }
+            )
+            < int(candidate.get("reinforcement_count") or 0)
+        ):
+            reason = "atomic_root_revalidation"
+        if not reason:
+            for root in roots:
+                if conn.execute(
+                    """
+                    SELECT 1 FROM memory_ledger_lineage
+                    WHERE guild_id=? AND target_entry_id=?
+                      AND lineage_type IN (
+                        'correction_of','supersedes','retracts'
+                      )
+                    LIMIT 1
+                    """,
+                    (
+                        int(request.guild_id or 0),
+                        str(root.get("root_entry_id") or ""),
+                    ),
+                ).fetchone():
+                    reason = "atomic_root_superseded"
+                    break
+        try:
+            tags = tuple(
+                str(tag)
+                for tag in json.loads(
+                    str(candidate.get("retrieval_tags_json") or "[]")
+                )
+                if str(tag or "")
+            )
+            routes = json.loads(str(candidate.get("route_scope_json") or "[]"))
+            if not isinstance(routes, list):
+                raise ValueError("route scope")
+        except (TypeError, ValueError, json.JSONDecodeError):
+            tags = ()
+            reason = reason or "atomic_scope_json"
+        text = str(candidate.get("normalized_value") or "").strip()
+        if not reason and not _relevant(
+            request_terms=request_terms,
+            broad=broad,
+            lane=lane,
+            text=text,
+            predicate_key=str(candidate.get("predicate_key") or ""),
+            tags=tags,
+        ):
+            reason = "atomic_topic_relevance"
+        source_digest = (
+            _atomic_candidate_digest(conn, candidate_id) if not reason else ""
+        )
+        if not reason and not source_digest:
+            reason = "atomic_source_unversioned"
+        if reason:
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane=lane,
+                reason=reason,
+                source_class=str(
+                    candidate.get("consolidated_authority_class")
+                    or candidate.get("authority_class")
+                    or ""
+                ),
+            )
+            continue
+        state = str(candidate.get("candidate_state") or "")
+        authority_class = str(
+            candidate.get("consolidated_authority_class")
+            or candidate.get("authority_class")
+            or SourceClass.LEGACY_SOURCE_BLIND.value
+        )
+        confidence = str(
+            candidate.get("consolidated_confidence_class")
+            or candidate.get("confidence_class")
+            or Confidence.UNKNOWN.value
+        )
+        participants = tuple(
+            str(row[0])
+            for row in conn.execute(
+                """
+                SELECT participant_key
+                FROM memory_ledger_knowledge_participants
+                WHERE candidate_id=?
+                ORDER BY participant_role,participant_key
+                """,
+                (candidate_id,),
+            ).fetchall()
+        )
+        if str(candidate.get("epistemic_status") or "") == (
+            "source_abstraction"
+        ):
+            base_score = 72.0
+        else:
+            base_score = 96.0 if state == "established" else 69.0
+        items.append(
+            IntelligencePacketItem(
+                lane=lane,
+                source_class=authority_class,
+                source_type=candidate_type,
+                source_ref="atomic:%s" % candidate_id,
+                source_digest=source_digest,
+                subject_key=subject,
+                predicate_key=str(candidate.get("predicate_key") or ""),
+                text=text[:1000],
+                visibility=visibility,
+                confidence=confidence,
+                lifecycle=state,
+                authority=_AUTHORITY_RANK.get(authority_class, 0),
+                participants=participants,
+                lineage=tuple(
+                    str(root.get("root_entry_id") or "") for root in roots
+                ),
+                observed_at=str(candidate.get("last_seen_at") or ""),
+                usage="tentative" if state == "provisional" else "content",
+                score=base_score
+                + 0.4
+                * len(
+                    request_terms
+                    & (
+                        _terms(text)
+                        | _terms(str(candidate.get("predicate_key") or ""))
+                        | set(tags)
+                    )
+                ),
+                revalidation_kind="atomic",
+                revalidation_key=candidate_id,
+            )
+        )
+    return items
+
+
+def _canon_value(value: Any) -> str:
+    if is_dataclass(value):
+        value = asdict(value)
+    if isinstance(value, (list, tuple)):
+        return ", ".join(str(item) for item in value)
+    if isinstance(value, dict):
+        return "; ".join("%s=%s" % item for item in sorted(value.items()))
+    return str(value)
+
+
+def _canon_digest(fact: Any) -> str:
+    return _digest(
+        CANON_SOURCE_CONTRACT_VERSION,
+        fact.subject.key,
+        fact.predicate,
+        _canon_value(fact.value),
+        fact.source_class.value,
+        fact.visibility.value,
+        fact.confidence.value,
+    )
+
+
+def _canon_items(
+    request: IntelligencePacketRequest,
+    diagnostics: IntelligencePacketDiagnostics,
+    exclusions: list[IntelligencePacketExclusion],
+    *,
+    request_terms: set[str],
+) -> list[IntelligencePacketItem]:
+    items: list[IntelligencePacketItem] = []
+    lowered = str(request.user_text or "").lower()
+    for fact in CANON_FACTS:
+        value = _canon_value(fact.value)
+        fact_text = "%s %s: %s" % (
+            fact.subject.name,
+            fact.predicate.replace("_", " "),
+            value,
+        )
+        aliases = (fact.subject.name, *fact.subject.aliases)
+        alias_relevant = any(
+            re.search(r"\b%s\b" % re.escape(alias.lower()), lowered)
+            for alias in aliases
+            if alias
+        )
+        if not alias_relevant and not (
+            request_terms
+            & (
+                _terms(fact.subject.name)
+                | _terms(" ".join(fact.subject.aliases))
+                | _terms(fact.predicate)
+                | _terms(value)
+            )
+        ):
+            continue
+        diagnostics.candidates_by_lane["canon"] = (
+            diagnostics.candidates_by_lane.get("canon", 0) + 1
+        )
+        source_digest = _canon_digest(fact)
+        item = IntelligencePacketItem(
+            lane="canon",
+            source_class=fact.source_class.value,
+            source_type="canon_fact",
+            source_ref=(
+                "canon:%s:%s:%s"
+                % (
+                    CANON_SOURCE_CONTRACT_VERSION,
+                    fact.subject.key,
+                    fact.predicate,
+                )
+            ),
+            source_digest=source_digest,
+            subject_key=fact.subject.key,
+            predicate_key=fact.predicate,
+            text=fact_text[:1000],
+            visibility=fact.visibility.value,
+            confidence=fact.confidence.value,
+            lifecycle="approved",
+            authority=_AUTHORITY_RANK[fact.source_class.value],
+            observed_at="",
+            usage="content",
+            score=92.0,
+            revalidation_kind="canon",
+            revalidation_key=source_digest,
+        )
+        if not _route_allows_item(request, item):
+            diagnostics.visibility_exclusions += 1
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane="canon",
+                reason="canon_visibility",
+                source_class=item.source_class,
+            )
+            continue
+        items.append(item)
+    return items
+
+
+def _source_file_items(
+    request: IntelligencePacketRequest,
+    diagnostics: IntelligencePacketDiagnostics,
+    exclusions: list[IntelligencePacketExclusion],
+) -> list[IntelligencePacketItem]:
+    snapshot = str(request.source_context_snapshot or "").strip()
+    if not snapshot:
+        return []
+    diagnostics.candidates_by_lane["source_file"] = (
+        diagnostics.candidates_by_lane.get("source_file", 0) + 1
+    )
+    if (
+        not request.source_context_authorized
+        or request.channel_policy not in {"sealed_test", "internal_controlled"}
+        or _public_route(request)
+    ):
+        _add_exclusion(
+            diagnostics,
+            exclusions,
+            lane="source_file",
+            reason="source_file_route_not_authorized",
+            source_class=SourceClass.SOURCE_FILE_PROJECTION.value,
+        )
+        return []
+    source_digest = _digest("source_file_snapshot", snapshot)
+    return [
+        IntelligencePacketItem(
+            lane="source_file",
+            source_class=SourceClass.SOURCE_FILE_PROJECTION.value,
+            source_type="existing_source_context_snapshot",
+            source_ref="source_file:%s" % source_digest[:32],
+            source_digest=source_digest,
+            subject_key="source_file_subject",
+            predicate_key="source_file_context",
+            text=snapshot[:1800],
+            visibility="internal",
+            confidence=Confidence.MEDIUM.value,
+            lifecycle="snapshot",
+            authority=_AUTHORITY_RANK[
+                SourceClass.SOURCE_FILE_PROJECTION.value
+            ],
+            observed_at=request.now or _now(),
+            usage="internal_context",
+            score=74.0,
+            revalidation_kind="snapshot",
+            revalidation_key=source_digest,
+        )
+    ]
+
+
+def _relationship_items(
+    conn: sqlite3.Connection,
+    request: IntelligencePacketRequest,
+    diagnostics: IntelligencePacketDiagnostics,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> list[IntelligencePacketItem]:
+    if (
+        int(request.subject_user_id or 0) <= 0
+        or request.direct_state != "direct"
+        or tuple(
+            user_id
+            for user_id in request.participant_user_ids
+            if int(user_id or 0) > 0
+        )
+        not in {
+            (),
+            (int(request.subject_user_id or 0),),
+        }
+    ):
+        return []
+    posture = shadow_packet_posture(
+        conn,
+        guild_id=request.guild_id,
+        user_id=request.subject_user_id,
+        route_mode=request.route_mode,
+        channel_policy=request.channel_policy,
+        direct=True,
+        target_user_id=request.subject_user_id,
+        environ=environ,
+    )
+    if not posture:
+        return []
+    diagnostics.candidates_by_lane["relationship_posture"] = (
+        diagnostics.candidates_by_lane.get("relationship_posture", 0) + 1
+    )
+    return [
+        IntelligencePacketItem(
+            lane="relationship_posture",
+            source_class=SourceClass.DERIVED_SUMMARY.value,
+            source_type="relationship_v2_private_posture",
+            source_ref=str(posture["source_ref"]),
+            source_digest=str(posture["source_digest"]),
+            subject_key=subject_key_for_user(request.subject_user_id),
+            predicate_key="relationship_posture",
+            text=str(posture["posture"])[:500],
+            visibility="private",
+            confidence=Confidence.MEDIUM.value,
+            lifecycle="shadow",
+            authority=_AUTHORITY_RANK[SourceClass.DERIVED_SUMMARY.value],
+            participants=(subject_key_for_user(request.subject_user_id),),
+            observed_at=str(posture.get("updated_at") or ""),
+            usage="tone_only",
+            score=65.0,
+            revalidation_kind="relationship",
+            revalidation_key=str(request.subject_user_id),
+        )
+    ]
+
+
+def _resolve_cross_lane_conflicts(
+    candidates: list[IntelligencePacketItem],
+    diagnostics: IntelligencePacketDiagnostics,
+    exclusions: list[IntelligencePacketExclusion],
+) -> list[IntelligencePacketItem]:
+    groups: dict[tuple[str, str], list[IntelligencePacketItem]] = {}
+    passthrough: list[IntelligencePacketItem] = []
+    for item in candidates:
+        if (
+            item.lane not in {"approved_fact", "atomic_knowledge", "canon"}
+            or item.predicate_key in _ADDITIVE_PREDICATES
+        ):
+            passthrough.append(item)
+            continue
+        groups.setdefault((item.subject_key, item.predicate_key), []).append(item)
+    for (subject, predicate), group in groups.items():
+        values = {
+            re.sub(r"\W+", " ", item.text.lower()).strip() for item in group
+        }
+        if len(values) <= 1:
+            passthrough.extend(group)
+            continue
+        ordered = sorted(
+            group,
+            key=lambda item: (
+                -item.authority,
+                -_CONFIDENCE_RANK.get(item.confidence, 0),
+                -item.score,
+                item.source_ref,
+            ),
+        )
+        authoritative = [
+            item
+            for item in ordered
+            if item.source_class
+            in {
+                SourceClass.OWNER_CORRECTION.value,
+                SourceClass.APPROVED_CANON.value,
+            }
+        ]
+        conflict_key = _digest(subject, predicate)[:16]
+        if len(authoritative) == 1:
+            winner = authoritative[0]
+            passthrough.append(winner)
+            diagnostics.conflict_reasons.append(
+                "%s:authoritative_precedence" % conflict_key
+            )
+            for item in group:
+                if item is winner:
+                    continue
+                _add_exclusion(
+                    diagnostics,
+                    exclusions,
+                    lane=item.lane,
+                    reason="cross_lane_authoritative_precedence",
+                    source_class=item.source_class,
+                )
+        else:
+            diagnostics.conflict_reasons.append(
+                "%s:unresolved_cross_lane_contradiction" % conflict_key
+            )
+            for item in group:
+                _add_exclusion(
+                    diagnostics,
+                    exclusions,
+                    lane=item.lane,
+                    reason="unresolved_cross_lane_contradiction",
+                    source_class=item.source_class,
+                )
+    return passthrough
+
+
+def _apply_current_turn_precedence(
+    request: IntelligencePacketRequest,
+    candidates: list[IntelligencePacketItem],
+    diagnostics: IntelligencePacketDiagnostics,
+    exclusions: list[IntelligencePacketExclusion],
+) -> list[IntelligencePacketItem]:
+    """Withhold a scoped durable value contradicted in the current request."""
+
+    current_text = str(request.user_text or "").strip()
+    current_terms = _terms(current_text)
+    correction_signal = bool(
+        _CURRENT_CORRECTION_RE.search(current_text)
+        or (
+            "?" not in current_text
+            and _CURRENT_ACTUALLY_STATEMENT_RE.search(current_text)
+        )
+    )
+    if not current_text or not correction_signal:
+        return candidates
+    current_normalized = re.sub(r"\W+", " ", current_text.lower()).strip()
+    subject = subject_key_for_user(request.subject_user_id)
+    kept: list[IntelligencePacketItem] = []
+    for item in candidates:
+        predicate_terms = _terms(item.predicate_key.replace("_", " "))
+        item_value = re.sub(r"\W+", " ", item.text.lower()).strip()
+        if (
+            item.lane
+            in {"approved_fact", "atomic_knowledge", "open_loop"}
+            and item.subject_key == subject
+            and predicate_terms
+            and current_terms & predicate_terms
+            and item_value
+            and item_value not in current_normalized
+        ):
+            diagnostics.conflict_reasons.append(
+                "%s:current_turn_correction_precedence"
+                % _digest(item.subject_key, item.predicate_key)[:16]
+            )
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane=item.lane,
+                reason="current_turn_correction_precedence",
+                source_class=item.source_class,
+            )
+            continue
+        kept.append(item)
+    return kept
+
+
+def _select_items(
+    request: IntelligencePacketRequest,
+    candidates: list[IntelligencePacketItem],
+    diagnostics: IntelligencePacketDiagnostics,
+    exclusions: list[IntelligencePacketExclusion],
+) -> tuple[IntelligencePacketItem, ...]:
+    if request.immediate_recap:
+        kept = []
+        for item in candidates:
+            if item.lane in {"current_intent", "conversation_context"}:
+                kept.append(item)
+            else:
+                _add_exclusion(
+                    diagnostics,
+                    exclusions,
+                    lane=item.lane,
+                    reason="current_exchange_precedence",
+                    source_class=item.source_class,
+                )
+        candidates = kept
+    candidates = _apply_current_turn_precedence(
+        request,
+        candidates,
+        diagnostics,
+        exclusions,
+    )
+    candidates = _resolve_cross_lane_conflicts(
+        candidates,
+        diagnostics,
+        exclusions,
+    )
+    ordered = sorted(
+        candidates,
+        key=lambda item: (
+            -item.score,
+            -item.authority,
+            -_CONFIDENCE_RANK.get(item.confidence, 0),
+            item.source_ref,
+        ),
+    )
+    selected: list[IntelligencePacketItem] = []
+    seen_text: set[str] = set()
+    lane_counts: Counter[str] = Counter()
+    used = 0
+    budget = min(max(int(request.budget_chars or 2400), 400), 6000)
+    for item in ordered:
+        normalized = re.sub(r"\W+", " ", item.text.lower()).strip()
+        if normalized and normalized in seen_text:
+            diagnostics.duplicate_suppression += 1
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane=item.lane,
+                reason="duplicate_semantic_value",
+                source_class=item.source_class,
+            )
+            continue
+        if lane_counts[item.lane] >= _LANE_CAPS.get(item.lane, 2):
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane=item.lane,
+                reason="lane_cap",
+                source_class=item.source_class,
+            )
+            continue
+        item_cost = min(len(item.text), 500) + 36
+        if item.lane != "current_intent" and used + item_cost > budget:
+            diagnostics.budget_exclusions += 1
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane=item.lane,
+                reason="packet_budget",
+                source_class=item.source_class,
+            )
+            continue
+        selected.append(item)
+        if normalized:
+            seen_text.add(normalized)
+        lane_counts[item.lane] += 1
+        used += item_cost
+        diagnostics.selected_by_lane[item.lane] = (
+            diagnostics.selected_by_lane.get(item.lane, 0) + 1
+        )
+        diagnostics.selected_by_source_class[item.source_class] = (
+            diagnostics.selected_by_source_class.get(item.source_class, 0) + 1
+        )
+        if item.revalidation_kind == "atomic":
+            diagnostics.selected_atomic_states[item.lifecycle] = (
+                diagnostics.selected_atomic_states.get(item.lifecycle, 0) + 1
+            )
+    for lane, count in diagnostics.candidates_by_lane.items():
+        if int(count or 0) and not diagnostics.selected_by_lane.get(lane):
+            diagnostics.missing_lanes.append(lane)
+    if (
+        _broad_profile_request(request.user_text)
+        and not any(
+            item.lane
+            in {
+                "approved_fact",
+                "moment",
+                "atomic_knowledge",
+                "open_loop",
+            }
+            for item in selected
+        )
+    ):
+        diagnostics.missing_lanes.append("durable_memory")
+    diagnostics.missing_lanes = list(
+        dict.fromkeys(diagnostics.missing_lanes)
+    )
+    return tuple(selected)
+
+
+def _moment_version(
+    conn: sqlite3.Connection,
+    packet: UnifiedIntelligencePacket,
+    item: IntelligencePacketItem,
+) -> str:
+    subject = subject_key_for_user(packet.request.subject_user_id)
+    broad = _broad_profile_request(packet.request.user_text)
+    moments = select_public_participant_moment_gists(
+        conn,
+        guild_id=packet.request.guild_id,
+        participant_key=subject,
+        topic_text=packet.request.user_text,
+        broad_recall=broad,
+        token_budget=160,
+        freshness_days=3650,
+        allowed_channel_policies=("public_home", "public_context"),
+        max_results=4,
+    )
+    target = item.revalidation_key
+    for moment in moments:
+        if moment.moment_id != target:
+            continue
+        return _digest(
+            "moment",
+            "moment:%s" % moment.moment_id,
+            moment.canonical_ledger_entry_id or moment.moment_id,
+            moment.contribution_gist,
+            moment.visibility,
+            moment.last_activity_at,
+        )
+    return ""
+
+
+def _canon_version(item: IntelligencePacketItem) -> str:
+    for fact in CANON_FACTS:
+        if _canon_digest(fact) == item.revalidation_key:
+            return item.revalidation_key
+    return ""
+
+
+def _relationship_version(
+    conn: sqlite3.Connection,
+    packet: UnifiedIntelligencePacket,
+    item: IntelligencePacketItem,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    posture = shadow_packet_posture(
+        conn,
+        guild_id=packet.request.guild_id,
+        user_id=packet.request.subject_user_id,
+        route_mode=packet.request.route_mode,
+        channel_policy=packet.request.channel_policy,
+        direct=packet.request.direct_state == "direct",
+        target_user_id=packet.request.subject_user_id,
+        environ=environ,
+    )
+    return str(posture.get("source_digest") or "")
+
+
+def revalidate_packet(
+    conn: sqlite3.Connection,
+    packet: UnifiedIntelligencePacket,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> PacketRevalidationResult:
+    """Re-read every durable source without applying packet content live."""
+    changed = 0
+    errors = 0
+    for item in packet.items:
+        try:
+            if item.revalidation_kind == "conversation":
+                row = _conversation_row(conn, int(item.revalidation_key or 0))
+                current = _conversation_digest(row) if row else ""
+            elif item.revalidation_kind == "ledger":
+                current = _ledger_entry_digest(conn, item.revalidation_key)
+            elif item.revalidation_kind == "moment":
+                current = _moment_version(conn, packet, item)
+            elif item.revalidation_kind == "atomic":
+                current = _atomic_candidate_digest(conn, item.revalidation_key)
+            elif item.revalidation_kind == "canon":
+                current = _canon_version(item)
+            elif item.revalidation_kind == "relationship":
+                current = _relationship_version(
+                    conn,
+                    packet,
+                    item,
+                    environ=environ,
+                )
+            elif item.revalidation_kind in {"current", "snapshot"}:
+                current = item.revalidation_key
+            else:
+                current = ""
+            if not current or current != item.source_digest:
+                changed += 1
+        except (sqlite3.DatabaseError, TypeError, ValueError):
+            errors += 1
+    if errors:
+        status = "processing_error"
+    elif changed:
+        status = "source_changed"
+    elif any(item.revalidation_kind == "snapshot" for item in packet.items):
+        status = "passed_with_provider_snapshot"
+    else:
+        status = "passed"
+    return PacketRevalidationResult(
+        valid=not errors and not changed,
+        status=status,
+        changed_source_count=changed,
+        processing_error_count=errors,
+    )
+
+
+def _packet_invariants(
+    packet: UnifiedIntelligencePacket,
+) -> tuple[str, ...]:
+    invalid = []
+    subject = subject_key_for_user(packet.request.subject_user_id)
+    for item in packet.items:
+        if not _route_allows_item(packet.request, item):
+            invalid.append("selected_visibility_violation")
+        if (
+            item.lane
+            in {
+                "approved_fact",
+                "atomic_knowledge",
+                "open_loop",
+                "moment",
+                "relationship_posture",
+            }
+            and int(packet.request.subject_user_id or 0) > 0
+            and item.subject_key != subject
+        ):
+            invalid.append("selected_subject_violation")
+        if item.lane == "relationship_posture" and item.usage != "tone_only":
+            invalid.append("relationship_fact_authority_violation")
+        if item.revalidation_kind == "atomic" and item.lifecycle not in {
+            "established",
+            "provisional",
+        }:
+            invalid.append("atomic_state_violation")
+    return tuple(dict.fromkeys(invalid))
+
+
+def build_packet(
+    conn: sqlite3.Connection,
+    request: IntelligencePacketRequest,
+    *,
+    persist: bool = True,
+    environ: Mapping[str, str] | None = None,
+) -> UnifiedIntelligencePacket | None:
+    """Build one deterministic shadow packet from existing source owners."""
+    if not shadow_enabled(environ):
+        return None
+    ensure_schema(conn)
+    diagnostics = IntelligencePacketDiagnostics()
+    exclusions: list[IntelligencePacketExclusion] = []
+    broad = _broad_profile_request(request.user_text)
+    request_terms = _terms(request.user_text)
+    candidates: list[IntelligencePacketItem] = []
+    try:
+        candidates.extend(
+            _conversation_items(conn, request, diagnostics, exclusions)
+        )
+        candidates.extend(
+            _governed_items(
+                conn,
+                request,
+                diagnostics,
+                exclusions,
+                broad=broad,
+            )
+        )
+        candidates.extend(
+            _atomic_items(
+                conn,
+                request,
+                diagnostics,
+                exclusions,
+                broad=broad,
+                request_terms=request_terms,
+            )
+        )
+        candidates.extend(
+            _canon_items(
+                request,
+                diagnostics,
+                exclusions,
+                request_terms=request_terms,
+            )
+        )
+        candidates.extend(
+            _source_file_items(request, diagnostics, exclusions)
+        )
+        candidates.extend(
+            _relationship_items(
+                conn,
+                request,
+                diagnostics,
+                environ=environ,
+            )
+        )
+    except (sqlite3.DatabaseError, TypeError, ValueError) as exc:
+        diagnostics.processing_errors.append(type(exc).__name__)
+    selected = _select_items(
+        request,
+        candidates,
+        diagnostics,
+        exclusions,
+    )
+    digest_payload = tuple(
+        (
+            item.lane,
+            item.source_class,
+            item.source_ref,
+            item.source_digest,
+            item.lifecycle,
+            item.usage,
+        )
+        for item in selected
+    )
+    diagnostics.packet_digest = _digest(SCHEMA_VERSION, digest_payload)
+    packet_id = "uip_" + _digest(
+        SCHEMA_VERSION,
+        request.guild_id,
+        request.subject_user_id,
+        request.route_mode,
+        request.channel_policy,
+        diagnostics.packet_digest,
+    )[:40]
+    packet = UnifiedIntelligencePacket(
+        schema_version=SCHEMA_VERSION,
+        packet_id=packet_id,
+        request=request,
+        items=selected,
+        exclusions=tuple(exclusions),
+        diagnostics=diagnostics,
+    )
+    invalid = _packet_invariants(packet)
+    if invalid:
+        diagnostics.invalid_invariants.extend(invalid)
+    revalidation = revalidate_packet(conn, packet, environ=environ)
+    diagnostics.revalidation_status = revalidation.status
+    diagnostics.revalidation_changed_count = (
+        revalidation.changed_source_count
+    )
+    if revalidation.processing_error_count:
+        diagnostics.processing_errors.extend(
+            "revalidation_error"
+            for _ in range(revalidation.processing_error_count)
+        )
+    if not revalidation.valid:
+        diagnostics.invalid_invariants.append(
+            "packet_source_revalidation_failed"
+        )
+    diagnostics.invalid_invariants = list(
+        dict.fromkeys(diagnostics.invalid_invariants)
+    )
+    if persist:
+        persist_packet_run(conn, packet, created_at=request.now or "")
+    return packet
+
+
+def persist_packet_run(
+    conn: sqlite3.Connection,
+    packet: UnifiedIntelligencePacket,
+    *,
+    created_at: str = "",
+) -> str:
+    """Persist aggregate packet evidence without content or source identifiers."""
+    ensure_schema(conn)
+    run_id = "uipr_" + uuid.uuid4().hex
+    source_ref_digest = _digest(
+        tuple(sorted(item.source_ref for item in packet.items))
+    )
+    conn.execute(
+        """
+        INSERT INTO memory_governance_intelligence_packet_runs(
+          run_id,packet_id,schema_version,guild_id,subject_hash,route_mode,
+          channel_policy,visibility_allowance,item_count,
+          selected_lane_counts_json,source_class_counts_json,
+          atomic_state_counts_json,excluded_by_reason_json,
+          missing_lanes_json,conflict_count,visibility_exclusion_count,
+          budget_exclusion_count,duplicate_suppression_count,
+          processing_error_count,invalid_invariant_count,
+          revalidation_status,revalidation_changed_count,packet_digest,
+          source_ref_digest,prompt_applied,live_applied,created_at
+        ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        """,
+        (
+            run_id,
+            packet.packet_id,
+            packet.schema_version,
+            int(packet.request.guild_id or 0),
+            _digest(subject_key_for_user(packet.request.subject_user_id))[:16],
+            str(packet.request.route_mode or "unknown")[:80],
+            str(packet.request.channel_policy or "unknown")[:80],
+            str(packet.request.visibility_allowance or "unknown")[:80],
+            len(packet.items),
+            json.dumps(packet.diagnostics.selected_by_lane, sort_keys=True),
+            json.dumps(
+                packet.diagnostics.selected_by_source_class,
+                sort_keys=True,
+            ),
+            json.dumps(
+                packet.diagnostics.selected_atomic_states,
+                sort_keys=True,
+            ),
+            json.dumps(
+                packet.diagnostics.excluded_by_reason,
+                sort_keys=True,
+            ),
+            json.dumps(packet.diagnostics.missing_lanes),
+            len(packet.diagnostics.conflict_reasons),
+            int(packet.diagnostics.visibility_exclusions or 0),
+            int(packet.diagnostics.budget_exclusions or 0),
+            int(packet.diagnostics.duplicate_suppression or 0),
+            len(packet.diagnostics.processing_errors),
+            len(packet.diagnostics.invalid_invariants),
+            packet.diagnostics.revalidation_status,
+            int(packet.diagnostics.revalidation_changed_count or 0),
+            packet.diagnostics.packet_digest,
+            source_ref_digest,
+            0,
+            0,
+            created_at or _now(),
+        ),
+    )
+    conn.execute(
+        """
+        DELETE FROM memory_governance_intelligence_packet_runs
+        WHERE guild_id=? AND run_id NOT IN (
+          SELECT run_id FROM memory_governance_intelligence_packet_runs
+          WHERE guild_id=?
+          ORDER BY created_at DESC,run_id DESC LIMIT 1000
+        )
+        """,
+        (
+            int(packet.request.guild_id or 0),
+            int(packet.request.guild_id or 0),
+        ),
+    )
+    return run_id
+
+
+def _safe_json(value: Any, fallback: Any) -> Any:
+    try:
+        return json.loads(str(value or ""))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return fallback
+
+
+def _empty_report() -> dict[str, Any]:
+    return {
+        "tablePresent": False,
+        "schemaVersion": SCHEMA_VERSION,
+        "runs": 0,
+        "itemTotal": 0,
+        "selectedByLane": {},
+        "selectedBySourceClass": {},
+        "selectedAtomicStates": {},
+        "excludedByReason": {},
+        "missingLaneCounts": {},
+        "conflictRuns": 0,
+        "visibilityExclusions": 0,
+        "budgetExclusions": 0,
+        "duplicateSuppressions": 0,
+        "processingErrors": 0,
+        "invalidInvariants": 0,
+        "revalidationStatusCounts": {},
+        "revalidationChangedRuns": 0,
+        "promptAppliedRuns": 0,
+        "liveAppliedRuns": 0,
+        "contentFieldsPresent": [],
+        "evidenceWindow": {"first": "none", "last": "none"},
+    }
+
+
+def build_evaluation_report(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    prepare_schema: bool = False,
+    limit: int = 1000,
+) -> dict[str, Any]:
+    """Return aggregate-only packet evidence for owner review."""
+    if prepare_schema:
+        ensure_schema(conn)
+    if not conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (TABLE_NAME,),
+    ).fetchone():
+        return _empty_report()
+    columns = {
+        str(row[1]) for row in conn.execute("PRAGMA table_info(%s)" % TABLE_NAME)
+    }
+    disallowed = sorted(
+        columns
+        & {
+            "request_text",
+            "source_text",
+            "source_ids",
+            "source_refs",
+            "participant_ids",
+            "relationship_posture",
+            "packet_content",
+        }
+    )
+    rows = conn.execute(
+        """
+        SELECT schema_version,item_count,selected_lane_counts_json,
+               source_class_counts_json,atomic_state_counts_json,
+               excluded_by_reason_json,missing_lanes_json,conflict_count,
+               visibility_exclusion_count,budget_exclusion_count,
+               duplicate_suppression_count,processing_error_count,
+               invalid_invariant_count,revalidation_status,
+               revalidation_changed_count,prompt_applied,live_applied,
+               created_at
+        FROM memory_governance_intelligence_packet_runs
+        WHERE guild_id=?
+        ORDER BY created_at DESC,run_id DESC
+        LIMIT ?
+        """,
+        (int(guild_id or 0), max(1, min(int(limit or 1000), 5000))),
+    ).fetchall()
+    selected_lanes: Counter[str] = Counter()
+    source_classes: Counter[str] = Counter()
+    atomic_states: Counter[str] = Counter()
+    exclusions: Counter[str] = Counter()
+    missing: Counter[str] = Counter()
+    revalidation: Counter[str] = Counter()
+    item_total = conflicts = visibility = budget = duplicates = 0
+    errors = invalid = changed = prompt = live = 0
+    for row in rows:
+        (
+            _schema,
+            item_count,
+            lane_json,
+            source_json,
+            atomic_json,
+            exclusion_json,
+            missing_json,
+            conflict_count,
+            visibility_count,
+            budget_count,
+            duplicate_count,
+            error_count,
+            invalid_count,
+            revalidation_status,
+            changed_count,
+            prompt_applied,
+            live_applied,
+            _created_at,
+        ) = row
+        item_total += int(item_count or 0)
+        for counter, raw in (
+            (selected_lanes, lane_json),
+            (source_classes, source_json),
+            (atomic_states, atomic_json),
+            (exclusions, exclusion_json),
+        ):
+            parsed = _safe_json(raw, {})
+            if isinstance(parsed, dict):
+                counter.update(
+                    {
+                        str(key): max(0, int(value or 0))
+                        for key, value in parsed.items()
+                    }
+                )
+            else:
+                errors += 1
+        parsed_missing = _safe_json(missing_json, [])
+        if isinstance(parsed_missing, list):
+            missing.update(str(value) for value in parsed_missing)
+        else:
+            errors += 1
+        conflicts += int(conflict_count or 0)
+        visibility += int(visibility_count or 0)
+        budget += int(budget_count or 0)
+        duplicates += int(duplicate_count or 0)
+        errors += int(error_count or 0)
+        invalid += int(invalid_count or 0)
+        changed += int(bool(changed_count))
+        prompt += int(bool(prompt_applied))
+        live += int(bool(live_applied))
+        revalidation[str(revalidation_status or "unknown")] += 1
+    return {
+        "tablePresent": True,
+        "schemaVersion": str(rows[0][0]) if rows else SCHEMA_VERSION,
+        "runs": len(rows),
+        "itemTotal": item_total,
+        "selectedByLane": dict(sorted(selected_lanes.items())),
+        "selectedBySourceClass": dict(sorted(source_classes.items())),
+        "selectedAtomicStates": dict(sorted(atomic_states.items())),
+        "excludedByReason": dict(sorted(exclusions.items())),
+        "missingLaneCounts": dict(sorted(missing.items())),
+        "conflictRuns": conflicts,
+        "visibilityExclusions": visibility,
+        "budgetExclusions": budget,
+        "duplicateSuppressions": duplicates,
+        "processingErrors": errors,
+        "invalidInvariants": invalid,
+        "revalidationStatusCounts": dict(sorted(revalidation.items())),
+        "revalidationChangedRuns": changed,
+        "promptAppliedRuns": prompt,
+        "liveAppliedRuns": live,
+        "contentFieldsPresent": disallowed,
+        "evidenceWindow": {
+            "first": str(rows[-1][-1]) if rows else "none",
+            "last": str(rows[0][-1]) if rows else "none",
+        },
+    }

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 from bnl_conversation_context_v2 import assess_payload_grounding
 
 
-ASSESSMENT_VERSION = "unified_response_assessment_v5"
+ASSESSMENT_VERSION = "unified_response_assessment_v6"
 SHADOW_ENV = "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED"
 TABLE_NAME = "unified_response_assessment_shadow_runs"
 
@@ -866,6 +866,11 @@ def build_unified_response_assessment(
     conversation_evidence_items: Sequence[
         ConversationEvidenceItem
     ] = (),
+    packet_selected_lanes: Sequence[str] = (),
+    packet_excluded_lanes: Sequence[Tuple[str, str]] = (),
+    packet_conflict_reasons: Sequence[str] = (),
+    packet_missing_lanes: Sequence[str] = (),
+    packet_revalidation_status: str = "",
 ) -> UnifiedResponseAssessment:
     """Assemble one deterministic assessment without rendering it live."""
 
@@ -1020,6 +1025,33 @@ def build_unified_response_assessment(
         conflicts.append("current_exchange_precedence")
     if int(governance_contradiction_count or 0) > 0:
         conflicts.append("governance_contradiction_resolved")
+    packet_lanes = _known_lanes(packet_selected_lanes)
+    if packet_lanes:
+        for lane in packet_lanes:
+            if immediate_recap and lane in _LOWER_PRECEDENCE_LANES:
+                excluded.append((lane, "current_exchange_precedence"))
+            else:
+                selected.append(lane)
+        diagnostics.append("unified_intelligence_packet_shadow")
+    for lane, reason in packet_excluded_lanes or ():
+        normalized_lane = str(lane or "").strip()
+        normalized_reason = str(reason or "").strip()
+        if normalized_lane in _KNOWN_LANES and normalized_reason:
+            excluded.append((normalized_lane, normalized_reason))
+    conflicts.extend(
+        str(reason or "").strip()
+        for reason in packet_conflict_reasons or ()
+        if str(reason or "").strip()
+    )
+    for lane in packet_missing_lanes or ():
+        normalized_lane = str(lane or "").strip()
+        if normalized_lane:
+            diagnostics.append("packet_missing_lane:%s" % normalized_lane)
+    if packet_revalidation_status:
+        diagnostics.append(
+            "packet_revalidation:%s"
+            % str(packet_revalidation_status or "unknown").strip()[:80]
+        )
 
     selected_lanes = _unique_strings(selected)
     excluded_lanes = tuple(

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -1,0 +1,714 @@
+import os
+import sqlite3
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+from bnl_canon_source_contract import Confidence, SourceClass, Visibility
+import bnl_memory_ledger as ledger
+import bnl_moment_engine as moments
+import bnl_relationship_engine as relationships
+from bnl_shadow_acceptance import (
+    build_v2_shadow_acceptance_snapshot,
+    render_v2_shadow_acceptance_lines,
+)
+from bnl_unified_intelligence_packet import (
+    IntelligencePacketRequest,
+    PacketConversationEvidence,
+    build_evaluation_report,
+    build_packet,
+    revalidate_packet,
+    shadow_configuration,
+)
+from bnl_unified_response_assessment import (
+    build_unified_response_assessment,
+)
+
+
+class UnifiedIntelligencePacketTests(unittest.TestCase):
+    def setUp(self):
+        self.flags = {
+            "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+            "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+            "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+            "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+            "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED": "true",
+            "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
+            "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
+            "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+        }
+        self.env = mock.patch.dict(os.environ, self.flags, clear=False)
+        self.env.start()
+        self.conn = sqlite3.connect(":memory:")
+        ledger.ensure_memory_ledger_schema(self.conn)
+        moments.ensure_moment_schema(self.conn)
+        relationships.ensure_relationship_v2_schema(self.conn)
+        self.conn.execute(
+            """
+            CREATE TABLE conversations (
+                id INTEGER PRIMARY KEY,
+                guild_id INTEGER,
+                user_id INTEGER,
+                user_name TEXT,
+                role TEXT,
+                content TEXT,
+                channel_id INTEGER,
+                channel_policy TEXT,
+                timestamp TEXT
+            )
+            """
+        )
+
+    def tearDown(self):
+        self.conn.close()
+        self.env.stop()
+
+    def add_entry(
+        self,
+        row_id,
+        *,
+        subject_key="discord_user:7",
+        entry_type="preference",
+        predicate_key="favorite_movie",
+        value="Alien",
+        source_class=SourceClass.FIRST_PARTY_RECORD,
+        visibility=Visibility.PUBLIC,
+        confidence=Confidence.HIGH,
+        public_usable=True,
+        route_mode="normal_chat",
+        channel_policy="public_home",
+        lifecycle_status="active",
+        participants=None,
+    ):
+        if participants is None:
+            participants = (
+                ledger.LedgerParticipant(
+                    subject_key,
+                    "Crow",
+                    "author",
+                    0,
+                ),
+            )
+        result = ledger.insert_ledger_entry(
+            self.conn,
+            ledger.LedgerEntry(
+                guild_id=1,
+                source_table="conversations",
+                source_row_id=row_id,
+                source_revision=str(row_id),
+                source_role="member_self_report",
+                entry_type=entry_type,
+                subject_key=subject_key,
+                subject_display_name="Crow",
+                predicate_key=predicate_key,
+                value=value,
+                source_class=source_class,
+                route_mode=route_mode,
+                channel_id=10,
+                channel_name="barcode-bot",
+                channel_policy=channel_policy,
+                visibility=visibility,
+                confidence=confidence,
+                public_usable=public_usable,
+                observed_at=(
+                    datetime(2026, 7, 25, tzinfo=timezone.utc)
+                    + timedelta(seconds=int(row_id))
+                ).isoformat(),
+                lifecycle_status=lifecycle_status,
+                participants=tuple(participants),
+            ),
+        )
+        self.assertIn(result.outcome, {"inserted", "deduplicated"})
+        return result.entry_id
+
+    def add_established_atomic(
+        self,
+        *,
+        first_row=1,
+        predicate_key="favorite_instrument",
+        value="modular synths",
+        subject_key="discord_user:7",
+        visibility=Visibility.PUBLIC,
+        public_usable=True,
+    ):
+        roots = tuple(
+            self.add_entry(
+                row_id,
+                subject_key=subject_key,
+                predicate_key=predicate_key,
+                value=value,
+                visibility=visibility,
+                public_usable=public_usable,
+            )
+            for row_id in (first_row, first_row + 1)
+        )
+        results = tuple(
+            ledger.form_atomic_candidate_from_ledger_entry(
+                self.conn,
+                entry_id,
+            )
+            for entry_id in roots
+        )
+        canonical_id = self.conn.execute(
+            """
+            SELECT canonical_candidate_id
+            FROM memory_ledger_knowledge_candidates
+            WHERE candidate_id=?
+            """,
+            (results[-1].candidate_id,),
+        ).fetchone()[0]
+        return roots, canonical_id or results[-1].candidate_id
+
+    def add_public_moment(self):
+        base = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+        messages = (
+            (200, 7, "Crow", "The synth patch should open the chorus."),
+            (201, 8, "Moth", "The drums can answer that synth chorus."),
+            (202, 7, "Crow", "The modular patch and drums resolve together."),
+        )
+        for row_id, user_id, name, text in messages:
+            result = ledger.shadow_conversation_row(
+                self.conn,
+                row_id=row_id,
+                user_id=user_id,
+                user_name=name,
+                guild_id=1,
+                role="user",
+                content=text,
+                channel_policy="public_home",
+                channel_id=10,
+                channel_name="barcode-bot",
+                route_mode="normal_chat",
+                observed_at=(
+                    base + timedelta(seconds=row_id - 200)
+                ).isoformat(),
+            )
+            moments.observe_ledger_entry(self.conn, result.entry_id)
+        moments.sweep_expired_windows(
+            self.conn,
+            now=(base + timedelta(minutes=3)).isoformat(),
+        )
+        row = self.conn.execute(
+            """
+            SELECT moment_id
+            FROM memory_moment_windows
+            WHERE guild_id=1 AND lifecycle_status='finalized'
+            ORDER BY moment_id
+            LIMIT 1
+            """
+        ).fetchone()
+        self.assertIsNotNone(row)
+        return row[0]
+
+    def add_relationship_state(self):
+        event_id = relationships.observe_message(
+            self.conn,
+            guild_id=1,
+            user_id=7,
+            role="user",
+            content="Thanks for helping me with this project.",
+            source_row_id=300,
+            user_name="Crow",
+            channel_policy="public_home",
+            channel_name="barcode-bot",
+            channel_id=10,
+            route_mode="normal_chat",
+            directed=True,
+            observed_at="2026-07-25T12:05:00+00:00",
+        )
+        self.assertTrue(event_id)
+
+    def add_conversation_context_row(self):
+        self.conn.execute(
+            """
+            INSERT INTO conversations(
+                id,guild_id,user_id,user_name,role,content,channel_id,
+                channel_policy,timestamp
+            ) VALUES(?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                900,
+                1,
+                7,
+                "Crow",
+                "user",
+                "I want the archive to connect my music and project work.",
+                10,
+                "public_home",
+                "2026-07-25T12:06:00+00:00",
+            ),
+        )
+
+    def public_request(
+        self,
+        *,
+        text="BNL, what am I all about in the BARCODE project?",
+        immediate_recap=False,
+        source_context_snapshot="",
+    ):
+        return IntelligencePacketRequest(
+            guild_id=1,
+            subject_user_id=7,
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            channel_id=10,
+            channel_name="barcode-bot",
+            channel_policy="public_home",
+            visibility_allowance="public_safe",
+            user_text=text,
+            participant_user_ids=(7,),
+            direct_state="direct",
+            budget_chars=6000,
+            conversation_evidence=(
+                PacketConversationEvidence(
+                    text=(
+                        "I want the archive to connect my music and "
+                        "project work."
+                    ),
+                    source_id=900,
+                    speaker_user_id=7,
+                    speaker_label="Crow",
+                ),
+                PacketConversationEvidence(
+                    text=text,
+                    speaker_user_id=7,
+                    speaker_label="Crow",
+                    current_turn=True,
+                ),
+            ),
+            source_context_snapshot=source_context_snapshot,
+            source_context_authorized=bool(source_context_snapshot),
+            immediate_recap=immediate_recap,
+            now="2026-07-25T12:07:00+00:00",
+        )
+
+    def add_full_evidence(self):
+        self.add_conversation_context_row()
+        self.add_entry(
+            10,
+            predicate_key="favorite_movie",
+            value="Alien",
+        )
+        self.add_entry(
+            11,
+            entry_type="goal",
+            predicate_key="goal",
+            value="finish the source-linked archive",
+            source_class=SourceClass.RUNTIME_OBSERVATION,
+        )
+        self.add_established_atomic()
+        self.add_public_moment()
+        self.add_relationship_state()
+
+    def test_packet_combines_existing_owners_deterministically_in_shadow(self):
+        self.add_full_evidence()
+
+        first = build_packet(
+            self.conn,
+            self.public_request(),
+            environ=self.flags,
+        )
+        second = build_packet(
+            self.conn,
+            self.public_request(),
+            environ=self.flags,
+        )
+
+        self.assertIsNotNone(first)
+        self.assertEqual(first.packet_id, second.packet_id)
+        self.assertEqual(
+            tuple(item.source_digest for item in first.items),
+            tuple(item.source_digest for item in second.items),
+        )
+        self.assertTrue(
+            {
+                "current_intent",
+                "conversation_context",
+                "approved_fact",
+                "moment",
+                "atomic_knowledge",
+                "open_loop",
+                "canon",
+                "relationship_posture",
+            }.issubset(set(first.detailed_lanes))
+        )
+        relationship_item = next(
+            item
+            for item in first.items
+            if item.lane == "relationship_posture"
+        )
+        self.assertEqual(relationship_item.visibility, "private")
+        self.assertEqual(relationship_item.usage, "tone_only")
+        self.assertEqual(
+            first.diagnostics.selected_atomic_states,
+            {"established": 1},
+        )
+        self.assertEqual(first.diagnostics.revalidation_status, "passed")
+        self.assertFalse(first.diagnostics.processing_errors)
+        self.assertFalse(first.diagnostics.invalid_invariants)
+        self.assertFalse(first.diagnostics.prompt_applied)
+        self.assertFalse(first.diagnostics.live_applied)
+
+        assessment = build_unified_response_assessment(
+            guild_id=1,
+            route_mode="normal_chat",
+            channel_policy="public_home",
+            conversation_surface="mention_or_reply",
+            current_speaker_user_ids=(7,),
+            current_exchange_source_ids=(900,),
+            prior_moment_ids=first.moment_refs,
+            governed_entry_ids=first.governed_refs,
+            relationship_candidate_keys=first.relationship_refs,
+            canon_refs=first.canon_refs,
+            prompt_lanes=("current_exchange",),
+            current_text=first.request.user_text,
+            packet_selected_lanes=first.assessment_lanes,
+            packet_excluded_lanes=first.assessment_exclusions,
+            packet_conflict_reasons=first.diagnostics.conflict_reasons,
+            packet_missing_lanes=first.assessment_missing_lanes,
+            packet_revalidation_status=(
+                first.diagnostics.revalidation_status
+            ),
+        )
+        self.assertIn(
+            "unified_intelligence_packet_shadow",
+            assessment.diagnostic_reasons,
+        )
+        self.assertEqual(
+            assessment.comparison_status,
+            "prompt_underincluded",
+        )
+        self.assertIn("governed_memory", assessment.prompt_missing_lanes)
+        self.assertIn("prior_moment", assessment.prompt_missing_lanes)
+
+        report = build_evaluation_report(self.conn, guild_id=1)
+        self.assertEqual(report["runs"], 2)
+        self.assertEqual(report["promptAppliedRuns"], 0)
+        self.assertEqual(report["liveAppliedRuns"], 0)
+        self.assertEqual(report["contentFieldsPresent"], [])
+        self.assertEqual(report["invalidInvariants"], 0)
+        acceptance = build_v2_shadow_acceptance_snapshot(
+            self.conn,
+            guild_id=1,
+            environ=self.flags,
+        )
+        self.assertTrue(
+            acceptance["unifiedIntelligencePacketShadow"][
+                "evidenceObserved"
+            ]
+        )
+        rendered = "\n".join(
+            render_v2_shadow_acceptance_lines(acceptance)
+        )
+        self.assertIn("- unified_intelligence_packet:", rendered)
+        self.assertIn("prompt_applied=`0`", rendered)
+        self.assertIn("live_applied=`0`", rendered)
+        self.assertNotIn("modular synths", rendered)
+
+    def test_private_cross_subject_contested_and_live_rows_fail_closed(self):
+        self.add_conversation_context_row()
+        _roots, selected_candidate = self.add_established_atomic()
+        self.conn.execute(
+            """
+            UPDATE memory_ledger_knowledge_candidates
+            SET live_eligible=1
+            WHERE candidate_id=?
+            """,
+            (selected_candidate,),
+        )
+        _private_roots, private_candidate = self.add_established_atomic(
+            first_row=20,
+            predicate_key="private_preference",
+            value="a private preference",
+        )
+        self.conn.execute(
+            """
+            UPDATE memory_ledger_knowledge_candidates
+            SET visibility='private'
+            WHERE candidate_id=?
+            """,
+            (private_candidate,),
+        )
+        self.add_established_atomic(
+            first_row=30,
+            predicate_key="other_member_fact",
+            value="belongs only to member 8",
+            subject_key="discord_user:8",
+        )
+        red = self.add_entry(
+            40,
+            predicate_key="favorite_color",
+            value="red",
+        )
+        blue = self.add_entry(
+            41,
+            predicate_key="favorite_color",
+            value="blue",
+        )
+        ledger.form_atomic_candidate_from_ledger_entry(self.conn, red)
+        ledger.form_atomic_candidate_from_ledger_entry(self.conn, blue)
+
+        packet = build_packet(
+            self.conn,
+            self.public_request(text="What do you remember about me?"),
+            environ=self.flags,
+        )
+
+        self.assertNotIn(
+            "belongs only to member 8",
+            {item.text for item in packet.items},
+        )
+        self.assertNotIn(
+            "a private preference",
+            {item.text for item in packet.items},
+        )
+        self.assertNotIn(
+            "modular synths",
+            {item.text for item in packet.items},
+        )
+        self.assertIn(
+            "atomic_live_eligible_selected_in_shadow",
+            packet.diagnostics.invalid_invariants,
+        )
+        self.assertGreaterEqual(
+            packet.diagnostics.excluded_by_reason.get(
+                "atomic_live_eligible_invariant",
+                0,
+            ),
+            1,
+        )
+        self.assertGreaterEqual(
+            packet.diagnostics.excluded_by_reason.get(
+                "atomic_visibility",
+                0,
+            ),
+            1,
+        )
+        self.assertGreaterEqual(
+            packet.diagnostics.excluded_by_reason.get(
+                "atomic_state",
+                0,
+            ),
+            1,
+        )
+
+    def test_source_mutation_breaks_revalidation(self):
+        self.add_conversation_context_row()
+        roots, _candidate_id = self.add_established_atomic()
+        packet = build_packet(
+            self.conn,
+            self.public_request(text="What do you remember about me?"),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertTrue(
+            any(item.revalidation_kind == "atomic" for item in packet.items)
+        )
+
+        self.conn.execute(
+            """
+            UPDATE memory_ledger_entries
+            SET lifecycle_status='superseded'
+            WHERE entry_id=?
+            """,
+            (roots[0],),
+        )
+        revalidation = revalidate_packet(
+            self.conn,
+            packet,
+            environ=self.flags,
+        )
+
+        self.assertFalse(revalidation.valid)
+        self.assertEqual(revalidation.status, "source_changed")
+        self.assertGreaterEqual(revalidation.changed_source_count, 1)
+
+    def test_provisional_is_tentative_and_due_review_is_excluded(self):
+        self.add_conversation_context_row()
+        root = self.add_entry(
+            70,
+            predicate_key="favorite_instrument",
+            value="modular synths",
+        )
+        created = ledger.form_atomic_candidate_from_ledger_entry(
+            self.conn,
+            root,
+        )
+        packet = build_packet(
+            self.conn,
+            self.public_request(text="What do you remember about me?"),
+            environ=self.flags,
+        )
+        item = next(
+            item
+            for item in packet.items
+            if item.revalidation_key == created.candidate_id
+        )
+        self.assertEqual(item.lifecycle, "provisional")
+        self.assertEqual(item.usage, "tentative")
+        self.assertEqual(
+            packet.diagnostics.selected_atomic_states,
+            {"provisional": 1},
+        )
+
+        self.conn.execute(
+            """
+            UPDATE memory_ledger_knowledge_candidates
+            SET review_status='due',
+                review_due_at='2026-07-24T00:00:00+00:00'
+            WHERE candidate_id=?
+            """,
+            (created.candidate_id,),
+        )
+        due_packet = build_packet(
+            self.conn,
+            self.public_request(text="What do you remember about me?"),
+            environ=self.flags,
+        )
+        self.assertFalse(
+            any(
+                item.revalidation_key == created.candidate_id
+                for item in due_packet.items
+            )
+        )
+        self.assertEqual(
+            due_packet.diagnostics.excluded_by_reason.get(
+                "atomic_review_due"
+            ),
+            1,
+        )
+
+    def test_current_turn_correction_withholds_conflicting_durable_value(self):
+        self.add_conversation_context_row()
+        self.add_entry(
+            80,
+            predicate_key="favorite_movie",
+            value="Alien",
+        )
+        packet = build_packet(
+            self.conn,
+            self.public_request(
+                text="Actually, my favorite movie is Arrival."
+            ),
+            environ=self.flags,
+        )
+        self.assertNotIn("Alien", {item.text for item in packet.items})
+        self.assertEqual(
+            packet.diagnostics.excluded_by_reason.get(
+                "current_turn_correction_precedence"
+            ),
+            1,
+        )
+        self.assertTrue(
+            any(
+                reason.endswith("current_turn_correction_precedence")
+                for reason in packet.diagnostics.conflict_reasons
+            )
+        )
+        question = build_packet(
+            self.conn,
+            self.public_request(
+                text="Actually, what is my favorite movie?"
+            ),
+            environ=self.flags,
+        )
+        self.assertIn("Alien", {item.text for item in question.items})
+
+    def test_immediate_recap_excludes_all_lower_precedence_lanes(self):
+        self.add_full_evidence()
+
+        packet = build_packet(
+            self.conn,
+            self.public_request(
+                text="What did we just decide?",
+                immediate_recap=True,
+            ),
+            environ=self.flags,
+        )
+
+        self.assertEqual(
+            set(packet.detailed_lanes),
+            {"current_intent", "conversation_context"},
+        )
+        self.assertGreater(
+            packet.diagnostics.excluded_by_reason.get(
+                "current_exchange_precedence",
+                0,
+            ),
+            0,
+        )
+        self.assertEqual(packet.diagnostics.revalidation_status, "passed")
+
+    def test_source_file_snapshot_requires_existing_internal_authority(self):
+        self.add_conversation_context_row()
+        public = build_packet(
+            self.conn,
+            self.public_request(
+                source_context_snapshot="SOURCE FILE PRIVATE SENTINEL"
+            ),
+            environ=self.flags,
+        )
+        self.assertNotIn("source_file", public.detailed_lanes)
+        self.assertEqual(
+            public.diagnostics.excluded_by_reason.get(
+                "source_file_route_not_authorized"
+            ),
+            1,
+        )
+
+        internal_request = IntelligencePacketRequest(
+            guild_id=1,
+            subject_user_id=0,
+            route_mode="internal_ops",
+            conversation_surface="command_only",
+            channel_id=99,
+            channel_policy="internal_controlled",
+            visibility_allowance="internal",
+            user_text="Inspect the approved source snapshot.",
+            direct_state="direct",
+            source_context_snapshot="SOURCE FILE PRIVATE SENTINEL",
+            source_context_authorized=True,
+            now="2026-07-25T12:07:00+00:00",
+        )
+        internal = build_packet(
+            self.conn,
+            internal_request,
+            environ=self.flags,
+        )
+        self.assertIn("source_file", internal.detailed_lanes)
+        self.assertEqual(
+            internal.diagnostics.revalidation_status,
+            "passed_with_provider_snapshot",
+        )
+        self.assertFalse(internal.diagnostics.prompt_applied)
+        self.assertFalse(internal.diagnostics.live_applied)
+
+    def test_gate_requires_all_shadows_and_rejects_live_authority(self):
+        enabled = shadow_configuration(self.flags)
+        self.assertTrue(enabled["requested"])
+        self.assertTrue(enabled["effective"])
+        self.assertEqual(enabled["reason"], "shadow_only")
+
+        missing = dict(self.flags)
+        missing["BNL_MOMENT_ENGINE_SHADOW_ENABLED"] = "false"
+        self.assertEqual(
+            shadow_configuration(missing)["reason"],
+            "missing_shadow_prerequisites",
+        )
+        live = dict(self.flags)
+        live["BNL_MEMORY_GOVERNANCE_LIVE_ENABLED"] = "true"
+        self.assertEqual(
+            shadow_configuration(live)["reason"],
+            "live_authority_detected",
+        )
+        self.assertIsNone(
+            build_packet(
+                self.conn,
+                self.public_request(),
+                environ=live,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_unified_response_assessment_bot_paths.py
+++ b/tests/test_unified_response_assessment_bot_paths.py
@@ -88,6 +88,25 @@ class UnifiedResponseAssessmentBotPathTests(unittest.TestCase):
     def test_direct_prompt_is_byte_identical_with_shadow_on_or_off(self):
         visual_basis = SimpleNamespace(status="not_requested")
         conversation_basis = self.conversation_basis(3)
+        packet_only_sentinel = "PACKET-ONLY-PRIVATE-SENTINEL"
+        packet = SimpleNamespace(
+            private_packet_text=packet_only_sentinel,
+            diagnostics=SimpleNamespace(
+                processing_errors=(),
+                invalid_invariants=(),
+                revalidation_status="passed",
+                candidates_by_lane={"atomic_knowledge": 1},
+                excluded_by_reason={},
+                conflict_reasons=(),
+            ),
+            moment_refs=(),
+            governed_refs=("atomic:opaque-packet-ref",),
+            relationship_refs=(),
+            canon_refs=(),
+            assessment_lanes=("governed_memory",),
+            assessment_exclusions=(),
+            assessment_missing_lanes=(),
+        )
 
         def memory_context(*_args, **kwargs):
             metadata = kwargs.get("source_metadata")
@@ -198,6 +217,10 @@ class UnifiedResponseAssessmentBotPathTests(unittest.TestCase):
             bnl01_bot,
             "_active_episode_id_for_unified_assessment",
             return_value="mep_opaque_shadow_reference",
+        ), mock.patch.object(
+            bnl01_bot,
+            "_build_unified_intelligence_packet_shadow",
+            return_value=packet,
         ):
             prompt_on, *_ = bnl01_bot.build_user_aware_prompt(
                 101,
@@ -214,6 +237,7 @@ class UnifiedResponseAssessmentBotPathTests(unittest.TestCase):
             )
 
         self.assertEqual(prompt_on, prompt_off)
+        self.assertNotIn(packet_only_sentinel, prompt_on)
         self.assertIsNone(
             metadata_off["unified_response_assessment_shadow"]
         )

--- a/tests/test_v2_shadow_acceptance.py
+++ b/tests/test_v2_shadow_acceptance.py
@@ -49,6 +49,7 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
                 "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "",
                 "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "",
                 "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED": "",
+                "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED": "",
             },
             clear=False,
         )
@@ -1188,6 +1189,7 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
                 "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
                 "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
                 "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+                "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED": "false",
             },
             context={"same_room_paired_turn_count": 1},
         )


### PR DESCRIPTION
## What changed

- Adds a bounded, source-labelled unified intelligence packet that coordinates references from BNL's existing Conversation Context, Memory Governance, Ledger atomic lifecycle, Moment, canon/Source File, and Relationship owners.
- Revalidates selected source references immediately before generation and fails closed on identity, visibility, lifecycle, privacy, or source-change mismatches.
- Revalidates the full atomic consolidation group rather than trusting only the canonical row.
- Feeds packet lane/reference metadata into Unified Assessment so shadow selection can be compared with the lanes the live prompt actually received.
- Persists content-free aggregate packet receipts and exposes acceptance diagnostics for lane coverage, exclusions, conflicts, source changes, revalidation, and invariant failures.
- Adds focused regression coverage for cross-member isolation, private-source exclusion, contested/stale atomic states, source mutation, immediate-recap precedence, and source-file authorization.

## Why

Production evidence showed that BNL's useful intelligence already exists across several owners, but different wordings and response routes receive inconsistent subsets. This PR creates the controlled comparison packet needed to measure that gap before any owner-approved live rollout.

## Behavior and safety boundary

This stage is shadow-only.

- Packet text is never inserted into a live prompt.
- `prompt_applied` remains `0`.
- `live_applied` remains `0`.
- Atomic knowledge remains shadow-only with `live_eligible=0`.
- Memory, Relationship, and Active Engagement live gates remain unchanged.
- Queue/rehearsal gates, Auxchord production truth, Journal, Relay, dossier, and website behavior are untouched.

## Validation

- Focused unified-packet invariants: 8 passed
- Adjacent Ledger / lifecycle / Moment / Governance / Conversation Context / batching / Relationship / Source File / Assessment integration set: 568 passed
- Full repository gate: compilation plus 1,591 tests passed
