### PR TITLE
Expand governed broad recall route

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -67,9 +67,11 @@ from bnl_memory_governance import (
     GovernanceRequest,
     assess_governance_result_safety,
     build_governed_context,
+    classify_personal_recall_intent,
     complete_delete_member_data,
     correct_member_memory,
     forget_member_memory,
+    normalize_personal_recall_intent,
     persist_shadow_diagnostics,
     purge_conversation_ledger_sources,
     reconcile_orphaned_conversation_ledger_sources,
@@ -133,6 +135,7 @@ from bnl_shared_brain_synthesis import (
     finalize_run as finalize_shared_brain_synthesis_run,
     record_fallback as record_shared_brain_synthesis_fallback,
     revalidate_basis as revalidate_shared_brain_synthesis_basis,
+    route_scope_enabled as shared_brain_synthesis_route_scope_enabled,
 )
 from bnl_unified_response_assessment import (
     ConversationEvidenceItem,
@@ -17372,39 +17375,7 @@ def _escape_discord_markdown(value: str) -> str:
 
 
 def _normalized_personal_recall_intent(text: str) -> str:
-    cleaned = re.sub(r"\s+", " ", str(text or "").lower().replace("’", "'")).strip()
-    cleaned = re.sub(
-        r"^(?:hey\s+|yo\s+|hi\s+)?(?:bnl(?:-?01)?|barcode bot)\s*[,;:—-]*\s*",
-        "",
-        cleaned,
-        flags=re.I,
-    )
-    cleaned = re.sub(r"^(?:(?:so|okay|ok|well)\s*[,;:—-]*\s*)+", "", cleaned)
-    cleaned = re.sub(
-        r"^(?:please\s+)?(?:(?:can|could|would|will)\s+you\s+)?",
-        "",
-        cleaned,
-        flags=re.I,
-    )
-    cleaned = cleaned.strip(" \t\r\n.!?")
-    cleaned = re.sub(
-        r"\s*(?:,?\s+(?:please|honestly|again|currently|right now|now|so far))+$",
-        "",
-        cleaned,
-        flags=re.I,
-    )
-    return cleaned.strip(" \t\r\n.!?")
-
-
-_BROAD_PERSONAL_RECALL_PATTERNS = (
-    r"what do you remember about me",
-    r"what do you have on me",
-    r"what do you know about me",
-    r"tell me what you (?:remember|know) about me",
-    r"tell me everything you remember about me",
-    r"tell me everything you remember",
-    r"what have you learned about me",
-)
+    return normalize_personal_recall_intent(text)
 _SOURCE_SAFE_RECALL_OUTPUT_LEAK_RE = re.compile(
     r"\b(?:source-safe personal recall synthesis contract|"
     r"source-safe recall packet|recall source lanes?|source lanes?|"
@@ -17416,19 +17387,67 @@ _SOURCE_SAFE_RECALL_OUTPUT_LEAK_RE = re.compile(
 
 
 def is_broad_personal_recall_request(user_text: str) -> bool:
-    """Recognize only the established broad first-person recall intent."""
+    """Use Memory Governance's single broad self-profile interpretation."""
 
-    recall_intent = _normalized_personal_recall_intent(user_text)
-    if not recall_intent or re.search(
-        r"\b(?:do not|don't|never|not yet|later|before you answer|"
-        r"don't answer|do not answer|hold off|wait)\b",
-        recall_intent,
-        flags=re.I,
-    ):
-        return False
-    return any(
-        re.fullmatch(pattern, recall_intent)
-        for pattern in _BROAD_PERSONAL_RECALL_PATTERNS
+    return classify_personal_recall_intent(
+        user_text
+    ).broad_self_profile
+
+
+def governed_broad_recall_route_expansion_enabled(
+    *,
+    guild_id: int,
+    user_id: int,
+    channel_id: int,
+    route_mode: str,
+    channel_policy: str,
+    user_text: str,
+    current_direct: bool,
+    has_media: bool = False,
+    exact_quote_requested: bool = False,
+    third_party_attribution_requested: bool = False,
+    environ: dict[str, str] | None = None,
+) -> bool:
+    """Authorize normal-generation parity for one allowlisted route family."""
+
+    return shared_brain_synthesis_route_scope_enabled(
+        guild_id=guild_id,
+        user_id=user_id,
+        channel_id=channel_id,
+        route_mode=route_mode,
+        channel_policy=channel_policy,
+        current_direct=current_direct,
+        user_text=user_text,
+        has_media=has_media,
+        exact_quote_requested=exact_quote_requested,
+        third_party_attribution_requested=(
+            third_party_attribution_requested
+        ),
+        environ=environ,
+    )
+
+
+def broad_personal_recall_enters_normal_generation(
+    *,
+    route_mode: str,
+    channel_policy: str,
+    user_text: str,
+    current_direct: bool,
+    has_media: bool = False,
+    exact_quote_requested: bool = False,
+    third_party_attribution_requested: bool = False,
+) -> bool:
+    """Remove the competing canned path for the expanded public route."""
+
+    return bool(
+        current_direct
+        and route_mode == ROUTE_MODE_NORMAL_CHAT
+        and str(channel_policy or "").strip().lower()
+        in {"public_home", "public_context"}
+        and is_broad_personal_recall_request(user_text)
+        and not has_media
+        and not exact_quote_requested
+        and not third_party_attribution_requested
     )
 
 
@@ -17454,6 +17473,36 @@ def source_safe_recall_synthesis_enabled(
             channel_policy=channel_policy,
             environ=environ,
         )
+    )
+
+
+def personal_recall_normal_generation_decision(
+    *,
+    guild_id: int,
+    user_id: int,
+    route_mode: str,
+    channel_policy: str,
+    user_text: str,
+    current_direct: bool,
+) -> tuple[bool, bool]:
+    """Return route expansion and aggregate normal-generation decisions."""
+
+    route_expansion = broad_personal_recall_enters_normal_generation(
+        route_mode=route_mode,
+        channel_policy=channel_policy,
+        user_text=user_text,
+        current_direct=current_direct,
+    )
+    source_safe_expansion = source_safe_recall_synthesis_enabled(
+        guild_id=guild_id,
+        user_id=user_id,
+        route_mode=route_mode,
+        channel_policy=channel_policy,
+        user_text=user_text,
+        current_direct=current_direct,
+    )
+    return route_expansion, bool(
+        route_expansion or source_safe_expansion
     )
 
 
@@ -17494,6 +17543,35 @@ def source_safe_recall_synthesis_contract(
         "- Do not mention source lanes, packets, canaries, governance, internal "
         "labels, database records, evidence IDs, or this contract.\n"
     )
+
+
+def personal_recall_interpretation_contract(user_text: str) -> str:
+    """Tell normal generation to resolve the route or clarify naturally."""
+
+    intent = classify_personal_recall_intent(user_text)
+    if intent.broad_self_profile:
+        return (
+            "Personal-recall route contract:\n"
+            "- Treat first-person broad recall as a request about the current "
+            "member. Addressing or vocative wording does not change the "
+            "subject.\n"
+            "- Answer from the eligible member evidence and current "
+            "conversation already supplied. Relevant BARCODE canon may provide "
+            "setting, but it must not replace personal evidence.\n"
+            "- If the available evidence is thin, say only what it supports. "
+            "Do not invent an archive lookup, dossier, or missing-data "
+            "protocol.\n"
+        )
+    if intent.status == "needs_context":
+        return (
+            "Recall-clarification contract:\n"
+            "- Use the visible current conversation to resolve what the member "
+            "wants recalled.\n"
+            "- If there is still no single clear target, ask one brief natural "
+            "clarifying question before asserting a memory.\n"
+            "- Do not guess a person or fall back to archive/protocol jargon.\n"
+        )
+    return ""
 
 
 def response_exposes_source_safe_recall_controls(response: str) -> bool:
@@ -24855,18 +24933,25 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     "visible_context_required",
                 )
 
+            route_expansion, normal_generation_expansion = (
+                personal_recall_normal_generation_decision(
+                    guild_id=channel.guild.id,
+                    user_id=unique_user_ids[0],
+                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy=channel_policy,
+                    user_text=combined_text,
+                    current_direct=True,
+                )
+            )
+            deterministic_recall_bypassed = False
             memory_recall = resolve_recent_media_followup(unique_user_ids[0], channel.guild.id, channel_id, channel_policy, combined_text)
             if not memory_recall:
                 memory_recall = try_memory_recall_response(unique_user_ids[0], channel.guild.id, combined_text)
                 if memory_recall:
-                    if source_safe_recall_synthesis_enabled(
-                        guild_id=channel.guild.id,
-                        user_id=unique_user_ids[0],
-                        route_mode=ROUTE_MODE_NORMAL_CHAT,
-                        channel_policy=channel_policy,
-                        user_text=combined_text,
-                        current_direct=True,
-                    ):
+                    # normal_generation_expansion already includes the
+                    # source_safe_recall_synthesis_enabled decision.
+                    if normal_generation_expansion:
+                        deterministic_recall_bypassed = True
                         memory_recall = ""
                     else:
                         memory_recall = apply_explicit_recall_governance(unique_user_ids[0], channel.guild.id, combined_text, memory_recall, ROUTE_MODE_NORMAL_CHAT, channel_policy, channel_id=channel_id, channel_name=getattr(channel, "name", ""), is_owner_or_mod=is_privileged_member(member, channel.guild))
@@ -24882,6 +24967,15 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 )
                 if not memory_recall:
                     return
+            if deterministic_recall_bypassed and route_expansion:
+                _log_batch_event(
+                    logging.INFO,
+                    "governed_broad_recall_route_expansion",
+                    guild_id,
+                    channel_id,
+                    len(collapsed_items),
+                    "deterministic_shortcut_bypassed",
+                )
             if memory_recall:
                 await send_channel_then_save_model(channel, memory_recall, user_id=unique_user_ids[0], guild_id=channel.guild.id, channel_name=getattr(channel, "name", ""), channel_policy=channel_policy, channel_id=channel_id, route_mode=ROUTE_MODE_NORMAL_CHAT, allowed_mentions=safe_mentions)
                 _channel_last_reply_at[channel_id] = datetime.now(PACIFIC_TZ)
@@ -25342,6 +25436,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     channel_policy=channel_policy,
                 )
             )
+            batch_intelligence_packet_out: dict = {}
             batch_unified_assessment = (
                 build_unified_response_assessment_shadow(
                     guild_id=guild_id,
@@ -25400,6 +25495,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                         active_packet.get("addressed_to_bot")
                         or is_broad_personal_recall_request(combined_text)
                     ),
+                    intelligence_packet_out=(
+                        batch_intelligence_packet_out
+                    ),
                 )
             )
             batch_unified_moment_canary_basis = (
@@ -25426,6 +25524,32 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 batch_prompt_source_bases.append(
                     batch_unified_moment_canary_basis
                 )
+            batch_shared_brain_synthesis_basis = (
+                build_shared_brain_synthesis_basis(
+                    guild_id=guild_id,
+                    user_id=first_uid,
+                    channel_id=channel_id,
+                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy=channel_policy,
+                    current_direct=bool(
+                        active_packet.get("addressed_to_bot")
+                        or is_broad_personal_recall_request(combined_text)
+                    ),
+                    user_text=combined_text,
+                    packet=batch_intelligence_packet_out.get("packet"),
+                    assessment=batch_unified_assessment,
+                    has_media=bool(active_packet.get("media_present")),
+                    exact_quote_requested=(
+                        batch_attribution_contract.exact_quote_requested
+                    ),
+                    third_party_attribution_requested=(
+                        batch_attribution_contract
+                        .third_party_attribution_requested
+                    ),
+                )
+                if len(unique_user_ids) == 1
+                else None
+            )
             continuity_contract = build_general_conversation_continuity_contract(
                 combined_text,
                 batch_continuity_source,
@@ -25453,6 +25577,16 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 if batch_recall_synthesis_contract:
                     prompt += (
                         "\n\n" + batch_recall_synthesis_contract
+                    )
+                batch_recall_interpretation_contract = (
+                    personal_recall_interpretation_contract(
+                        combined_text
+                    )
+                )
+                if batch_recall_interpretation_contract:
+                    prompt += (
+                        "\n\n"
+                        + batch_recall_interpretation_contract
                     )
             if batch_unified_moment_canary_basis is not None:
                 prompt += (
@@ -25876,6 +26010,42 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             ack_escalated_to_generation=bool(locals().get("ack_diag", {}).get("ack_escalated_to_generation", False)),
         )
 
+        batch_baseline_response = response or ""
+        batch_baseline_prompt = prompt
+        batch_baseline_source_bases = tuple(
+            batch_prompt_source_bases
+        )
+        batch_synthesis_execution = (
+            await maybe_generate_shared_brain_synthesis_canary(
+                channel=channel,
+                baseline_response=batch_baseline_response,
+                prompt=batch_baseline_prompt,
+                prompt_source_bases=batch_baseline_source_bases,
+                basis=batch_shared_brain_synthesis_basis,
+                user_id=first_uid,
+                guild_id=guild_id,
+                user_display_name=(
+                    collapsed_items[-1][0] if collapsed_items else ""
+                ),
+                source_context_available=False,
+            )
+        )
+        batch_synthesis_decision = (
+            batch_synthesis_execution.decision
+            if batch_synthesis_execution is not None
+            else None
+        )
+        batch_synthesis_candidate_active = bool(
+            batch_synthesis_execution is not None
+            and batch_synthesis_execution.candidate_active
+        )
+        if batch_synthesis_execution is not None:
+            response = batch_synthesis_execution.response
+            prompt = batch_synthesis_execution.prompt
+            batch_prompt_source_bases = list(
+                batch_synthesis_execution.prompt_source_bases
+            )
+        batch_canary_guard_fallback_triggered = False
         archive_guard_triggered = bool(_contains_unsupported_source_authority_claim(response or ""))
         response, guard_diagnostics = await apply_guarded_response_regeneration(
             response or "",
@@ -25906,6 +26076,116 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             ),
             prompt_source_bases=tuple(batch_prompt_source_bases),
         )
+        if (
+            batch_synthesis_candidate_active
+            and batch_synthesis_decision is not None
+        ):
+            batch_fallback_reason = ""
+            if guard_diagnostics.get("suppressed"):
+                batch_fallback_reason = "candidate_guard_suppressed"
+            else:
+                try:
+                    batch_synthesis_decision = await asyncio.to_thread(
+                        _evaluate_shared_brain_synthesis_receipt,
+                        batch_synthesis_decision.run,
+                        batch_baseline_response,
+                        response or "",
+                    )
+                    if (
+                        batch_synthesis_decision.candidate_selected
+                        and is_generic_non_answer_response(
+                            response or "",
+                            (
+                                collapsed_items[-1][0]
+                                if collapsed_items
+                                else ""
+                            ),
+                        )
+                    ):
+                        batch_fallback_reason = (
+                            "candidate_generic_non_answer"
+                        )
+                    elif not batch_synthesis_decision.candidate_selected:
+                        batch_fallback_reason = (
+                            batch_synthesis_decision.fallback_reason
+                            or "candidate_post_guard_rejected"
+                        )
+                except Exception as exc:
+                    logging.warning(
+                        "shared_brain_synthesis_batch_post_guard_failed "
+                        "error=%s",
+                        type(exc).__name__,
+                    )
+                    batch_fallback_reason = (
+                        "candidate_post_guard_evaluation_failed"
+                    )
+            if batch_fallback_reason:
+                batch_synthesis_decision = (
+                    await safely_fallback_shared_brain_synthesis(
+                        batch_synthesis_decision,
+                        batch_fallback_reason,
+                    )
+                )
+                batch_synthesis_candidate_active = False
+                batch_canary_guard_fallback_triggered = True
+                response = batch_baseline_response
+                prompt = batch_baseline_prompt
+                batch_prompt_source_bases = list(
+                    batch_baseline_source_bases
+                )
+                archive_guard_triggered = bool(
+                    _contains_unsupported_source_authority_claim(
+                        response or ""
+                    )
+                )
+                response, guard_diagnostics = (
+                    await apply_guarded_response_regeneration(
+                        response or "",
+                        prompt=prompt,
+                        user_id=first_uid,
+                        guild_id=guild_id,
+                        route_mode=ROUTE_MODE_NORMAL_CHAT,
+                        channel_policy=channel_policy,
+                        directness=batch_directness,
+                        user_display_name=(
+                            collapsed_items[-1][0]
+                            if collapsed_items
+                            else ""
+                        ),
+                        current_user_text=combined_text,
+                        has_media=bool(
+                            active_packet.get("media_present", False)
+                        ),
+                        is_reply=False,
+                        generation_route=(
+                            generation_route
+                            if "generation_route" in locals()
+                            else "get_gemini_response"
+                        ),
+                        channel=channel,
+                        source_context_available=False,
+                        batch_generation_id=local_generation_id,
+                        conversation_continuity_required=(
+                            batch_continuity_required
+                        ),
+                        community_visual_basis=community_visual_basis,
+                        exact_quote_requested=(
+                            batch_attribution_contract
+                            .exact_quote_requested
+                        ),
+                        exact_quote_authority=(
+                            batch_attribution_contract
+                            .exact_quote_authority
+                        ),
+                        third_party_attribution_requested=(
+                            batch_attribution_contract
+                            .third_party_attribution_requested
+                        ),
+                        prompt_source_bases=tuple(
+                            batch_prompt_source_bases
+                        ),
+                    )
+                )
         guard_triggered = bool(
             archive_guard_triggered
             or guard_diagnostics.get("scripted_mode_leak_guard_triggered")
@@ -25926,6 +26206,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             or guard_diagnostics.get(
                 "source_safe_recall_output_leak_guard_triggered"
             )
+            or batch_canary_guard_fallback_triggered
         )
         regenerated_for_mode_leak = bool(
             guard_diagnostics.get("regenerated_for_mode_leak")
@@ -25958,9 +26239,30 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 )
             _channel_preempted_generation_id[channel_id] = 0
             _channel_message_interrupt_generation_id[channel_id] = 0
+            if batch_synthesis_decision is not None:
+                batch_synthesis_decision = (
+                    await safely_fallback_shared_brain_synthesis(
+                        batch_synthesis_decision,
+                        "stale_after_batch_candidate_guard",
+                    )
+                )
+                await safely_finalize_shared_brain_synthesis(
+                    batch_synthesis_decision,
+                    final_response=batch_baseline_response,
+                    response_sent=False,
+                    candidate_live=False,
+                    guard_status="stale_after_batch_candidate_guard",
+                )
             return
         if guard_diagnostics.get("suppressed"):
             logging.info("continuation_mark_skipped reason=guard_fallback_or_generic_non_answer route=%s channel_policy=%s", ROUTE_MODE_NORMAL_CHAT, channel_policy)
+            await safely_finalize_shared_brain_synthesis(
+                batch_synthesis_decision,
+                final_response=response or batch_baseline_response,
+                response_sent=False,
+                candidate_live=False,
+                guard_status="batch_guard_suppressed",
+            )
             return
         batch_presend_source_bases = tuple(
             guard_diagnostics.get("_revalidated_prompt_source_bases")
@@ -25987,10 +26289,142 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     presend_quote_failure,
                     channel_id,
                 )
+                await safely_finalize_shared_brain_synthesis(
+                    batch_synthesis_decision,
+                    final_response=response,
+                    response_sent=False,
+                    candidate_live=False,
+                    guard_status="batch_exact_quote_presend_failed",
+                )
                 return
         batch_source_failure = prompt_source_basis_failure(
             batch_presend_source_bases
         )
+        if (
+            batch_source_failure
+            and batch_synthesis_candidate_active
+            and batch_synthesis_decision is not None
+        ):
+            batch_synthesis_decision = (
+                await safely_fallback_shared_brain_synthesis(
+                    batch_synthesis_decision,
+                    "candidate_presend_%s" % batch_source_failure,
+                )
+            )
+            batch_synthesis_candidate_active = False
+            response = batch_baseline_response
+            prompt = batch_baseline_prompt
+            batch_prompt_source_bases = list(
+                batch_baseline_source_bases
+            )
+            response, guard_diagnostics = (
+                await apply_guarded_response_regeneration(
+                    response or "",
+                    prompt=prompt,
+                    user_id=first_uid,
+                    guild_id=guild_id,
+                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy=channel_policy,
+                    directness=batch_directness,
+                    user_display_name=(
+                        collapsed_items[-1][0]
+                        if collapsed_items
+                        else ""
+                    ),
+                    current_user_text=combined_text,
+                    has_media=bool(
+                        active_packet.get("media_present", False)
+                    ),
+                    is_reply=False,
+                    generation_route=(
+                        generation_route
+                        if "generation_route" in locals()
+                        else "get_gemini_response"
+                    ),
+                    channel=channel,
+                    source_context_available=False,
+                    batch_generation_id=local_generation_id,
+                    conversation_continuity_required=(
+                        batch_continuity_required
+                    ),
+                    community_visual_basis=community_visual_basis,
+                    exact_quote_requested=(
+                        batch_attribution_contract.exact_quote_requested
+                    ),
+                    exact_quote_authority=(
+                        batch_attribution_contract.exact_quote_authority
+                    ),
+                    third_party_attribution_requested=(
+                        batch_attribution_contract
+                        .third_party_attribution_requested
+                    ),
+                    prompt_source_bases=tuple(
+                        batch_prompt_source_bases
+                    ),
+                )
+            )
+            if guard_diagnostics.get("suppressed"):
+                await safely_finalize_shared_brain_synthesis(
+                    batch_synthesis_decision,
+                    final_response=response,
+                    response_sent=False,
+                    candidate_live=False,
+                    guard_status=(
+                        "batch_baseline_guard_suppressed_at_presend"
+                    ),
+                )
+                return
+            batch_presend_source_bases = tuple(
+                guard_diagnostics.get(
+                    "_revalidated_prompt_source_bases"
+                )
+                or batch_prompt_source_bases
+            )
+            fallback_hard_interrupt = (
+                _hard_interrupt_active_for_generation(
+                    channel_id,
+                    local_generation_id,
+                )
+            )
+            fallback_buffered_count = len(
+                _channel_buffers[channel_id]
+            )
+            if fallback_hard_interrupt or fallback_buffered_count > 0:
+                _log_batch_event(
+                    logging.INFO,
+                    "stale_response_blocked_after_presend_fallback",
+                    guild_id,
+                    channel_id,
+                    fallback_buffered_count,
+                    (
+                        "hard_interrupt=%s;generation_id=%s"
+                        % (
+                            int(fallback_hard_interrupt),
+                            local_generation_id,
+                        )
+                    ),
+                )
+                if fallback_buffered_count > 0:
+                    _channel_interrupt_handoff[channel_id] = list(items)
+                    _channel_first_seen.setdefault(
+                        channel_id,
+                        datetime.now(PACIFIC_TZ),
+                    )
+                _channel_preempted_generation_id[channel_id] = 0
+                _channel_message_interrupt_generation_id[channel_id] = 0
+                await safely_finalize_shared_brain_synthesis(
+                    batch_synthesis_decision,
+                    final_response=response,
+                    response_sent=False,
+                    candidate_live=False,
+                    guard_status=(
+                        "stale_after_batch_presend_fallback"
+                    ),
+                )
+                return
+            batch_source_failure = prompt_source_basis_failure(
+                batch_presend_source_bases
+            )
         if batch_source_failure:
             _log_batch_event(
                 logging.INFO,
@@ -25999,6 +26433,13 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 channel_id,
                 len(items),
                 f"reason={batch_source_failure}",
+            )
+            await safely_finalize_shared_brain_synthesis(
+                batch_synthesis_decision,
+                final_response=response,
+                response_sent=False,
+                candidate_live=False,
+                guard_status="batch_prompt_source_presend_failed",
             )
             return
         _log_batch_event(
@@ -26020,7 +26461,25 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             logging.info("response_send_succeeded route=%s channel_id=%s message_length=%s", generation_route if 'generation_route' in locals() else "get_gemini_response", channel_id, len(response or ""))
         except Exception as exc:
             logging.error("response_send_failed route=%s channel_id=%s discord_error_type=%s", generation_route if 'generation_route' in locals() else "get_gemini_response", channel_id, type(exc).__name__)
+            await safely_finalize_shared_brain_synthesis(
+                batch_synthesis_decision,
+                final_response=response,
+                response_sent=False,
+                candidate_live=False,
+                guard_status="batch_discord_send_failed",
+            )
             return
+        await safely_finalize_shared_brain_synthesis(
+            batch_synthesis_decision,
+            final_response=response,
+            response_sent=True,
+            candidate_live=batch_synthesis_candidate_active,
+            guard_status=(
+                "batch_candidate_sent"
+                if batch_synthesis_candidate_active
+                else "batch_established_path_sent"
+            ),
+        )
         _log_batch_event(logging.INFO, "response_send_commit_complete", guild_id, channel_id, len(items), f"generation_id={local_generation_id}")
         for uid in unique_user_ids:
             meaningful_followup_question = _response_contains_direct_question_to_user(response) and not is_generic_non_answer_response(response)
@@ -26722,6 +27181,9 @@ def build_user_aware_prompt(
         user_text=clean_content,
         current_direct=recall_current_direct,
     )
+    recall_interpretation_contract = (
+        personal_recall_interpretation_contract(clean_content)
+    )
     if route_mode == ROUTE_MODE_NORMAL_CHAT and is_conversational_repair_intent(clean_content):
         prompt_contract += (
             "Correction-turn contract: use the visible prior exchange and make the corrected attempt now. "
@@ -26745,6 +27207,7 @@ def build_user_aware_prompt(
         "Source-authority basis rule: archive/record/source/dossier/scan/deployment/broadcast-memory language may be style or honest supplied-source reporting, but do not claim those sources prove/indicate/confirm something unless source/broadcast/show-state/read-model context is actually supplied.\n"
         "People-and-memory rule: preserve who said what and summarize another member's meaning in your own words by default. Do not act like a quote search engine. Use exact wording only when the user explicitly needs verification for a consequential dispute, the eligible current public source text is still present, and a minimal attributed quote is necessary. A derived summary, memory tier, relationship note, or Moment gist can never justify exact wording.\n"
         f"{prompt_contract}"
+        f"{recall_interpretation_contract}"
         f"{recall_synthesis_contract}"
         f"{room_prompt_block}"
         f"{continuity_prompt_block}"
@@ -29001,6 +29464,7 @@ def _evaluate_shared_brain_synthesis_receipt(
     run,
     baseline_response: str,
     candidate_response: str,
+    candidate_generation_latency_ms: int | None = None,
 ) -> SynthesisCanaryDecision:
     with sqlite3.connect(DB_FILE, timeout=0.25) as conn:
         decision = evaluate_shared_brain_synthesis_candidate(
@@ -29008,6 +29472,9 @@ def _evaluate_shared_brain_synthesis_receipt(
             run,
             baseline_response=baseline_response,
             candidate_response=candidate_response,
+            candidate_generation_latency_ms=(
+                candidate_generation_latency_ms
+            ),
         )
         conn.commit()
         return decision
@@ -29148,6 +29615,7 @@ async def maybe_generate_shared_brain_synthesis_canary(
         + "\n\n"
         + basis.rendered_context
     )
+    candidate_generation_started = time.monotonic()
     try:
         candidate_response = await get_gemini_response_with_optional_typing(
             channel,
@@ -29163,12 +29631,22 @@ async def maybe_generate_shared_brain_synthesis_canary(
             type(exc).__name__,
         )
         candidate_response = ""
+    candidate_generation_latency_ms = max(
+        0,
+        int(
+            round(
+                (time.monotonic() - candidate_generation_started)
+                * 1000
+            )
+        ),
+    )
     try:
         decision = await asyncio.to_thread(
             _evaluate_shared_brain_synthesis_receipt,
             run,
             baseline_response,
             candidate_response or "",
+            candidate_generation_latency_ms,
         )
         if (
             decision.candidate_selected
@@ -30526,18 +31004,23 @@ async def on_message(message: discord.Message):
                 _finish_direct_repair_generation(direct_repair_generation, "deterministic_self_reflection")
                 return
 
+            route_expansion, normal_generation_expansion = (
+                personal_recall_normal_generation_decision(
+                    guild_id=message.guild.id,
+                    user_id=message.author.id,
+                    route_mode=route_mode,
+                    channel_policy=channel_policy,
+                    user_text=direct_content,
+                    current_direct=True,
+                )
+            )
             memory_recall = resolve_recent_media_followup(message.author.id, message.guild.id, message.channel.id, channel_policy, direct_content)
             if not memory_recall:
                 memory_recall = try_memory_recall_response(message.author.id, message.guild.id, direct_content)
                 if memory_recall:
-                    if source_safe_recall_synthesis_enabled(
-                        guild_id=message.guild.id,
-                        user_id=message.author.id,
-                        route_mode=route_mode,
-                        channel_policy=channel_policy,
-                        user_text=direct_content,
-                        current_direct=True,
-                    ):
+                    # normal_generation_expansion already includes the
+                    # source_safe_recall_synthesis_enabled decision.
+                    if normal_generation_expansion:
                         memory_recall = ""
                     else:
                         memory_recall = apply_explicit_recall_governance(message.author.id, message.guild.id, direct_content, memory_recall, route_mode, channel_policy, channel_id=getattr(message.channel, "id", 0), channel_name=getattr(message.channel, "name", ""), is_owner_or_mod=is_privileged_member(message.author, message.guild))
@@ -30871,18 +31354,23 @@ async def on_message(message: discord.Message):
             _finish_direct_repair_generation(direct_repair_generation, "deterministic_self_reflection")
             return
 
+        route_expansion, normal_generation_expansion = (
+            personal_recall_normal_generation_decision(
+                guild_id=message.guild.id,
+                user_id=message.author.id,
+                route_mode=route_mode,
+                channel_policy=channel_policy,
+                user_text=direct_content,
+                current_direct=True,
+            )
+        )
         memory_recall = resolve_recent_media_followup(message.author.id, message.guild.id, message.channel.id, channel_policy, direct_content)
         if not memory_recall:
             memory_recall = try_memory_recall_response(message.author.id, message.guild.id, direct_content)
             if memory_recall:
-                if source_safe_recall_synthesis_enabled(
-                    guild_id=message.guild.id,
-                    user_id=message.author.id,
-                    route_mode=route_mode,
-                    channel_policy=channel_policy,
-                    user_text=direct_content,
-                    current_direct=True,
-                ):
+                # normal_generation_expansion already includes the
+                # source_safe_recall_synthesis_enabled decision.
+                if normal_generation_expansion:
                     memory_recall = ""
                 else:
                     memory_recall = apply_explicit_recall_governance(message.author.id, message.guild.id, direct_content, memory_recall, route_mode, channel_policy, channel_id=getattr(message.channel, "id", 0), channel_name=getattr(message.channel, "name", ""), is_owner_or_mod=is_privileged_member(message.author, message.guild))
@@ -31170,18 +31658,23 @@ async def on_message(message: discord.Message):
             _finish_direct_repair_generation(direct_repair_generation, "deterministic_self_reflection")
             return
 
+        route_expansion, normal_generation_expansion = (
+            personal_recall_normal_generation_decision(
+                guild_id=message.guild.id,
+                user_id=message.author.id,
+                route_mode=route_mode,
+                channel_policy=channel_policy,
+                user_text=direct_content,
+                current_direct=True,
+            )
+        )
         memory_recall = resolve_recent_media_followup(message.author.id, message.guild.id, message.channel.id, channel_policy, direct_content)
         if not memory_recall:
             memory_recall = try_memory_recall_response(message.author.id, message.guild.id, direct_content)
             if memory_recall:
-                if source_safe_recall_synthesis_enabled(
-                    guild_id=message.guild.id,
-                    user_id=message.author.id,
-                    route_mode=route_mode,
-                    channel_policy=channel_policy,
-                    user_text=direct_content,
-                    current_direct=True,
-                ):
+                # normal_generation_expansion already includes the
+                # source_safe_recall_synthesis_enabled decision.
+                if normal_generation_expansion:
                     memory_recall = ""
                 else:
                     memory_recall = apply_explicit_recall_governance(message.author.id, message.guild.id, direct_content, memory_recall, route_mode, channel_policy, channel_id=getattr(message.channel, "id", 0), channel_name=getattr(message.channel, "name", ""), is_owner_or_mod=is_privileged_member(message.author, message.guild))

--- a/bnl_memory_governance.py
+++ b/bnl_memory_governance.py
@@ -99,8 +99,144 @@ RAW_CONVERSATION_LEDGER_SQL = """
   )
 )
 """
-BROAD_RECALL_RE = re.compile(r"\b(what do you (?:know|remember) about me|what do you remember|my memory|everything you know|recall my)\b", re.I)
 RECALL_RE = re.compile(r"\b(remember|memory|recall|what do you know|what is my|what's my|my)\b", re.I)
+PERSONAL_RECALL_ROUTE_FAMILY = "broad_self_profile"
+_PERSONAL_RECALL_HOLD_RE = re.compile(
+    r"\b(?:do not|don't|never|not yet|later|before you answer|"
+    r"don't answer|do not answer|hold off|wait)\b",
+    re.I,
+)
+_PROFILE_SCOPE_SUFFIX = (
+    r"(?: (?:in|within|around|for|regarding) "
+    r"(?!.*\b(?:and|also|then|plus)\b).+)?"
+)
+_BROAD_SELF_PROFILE_PATTERNS = (
+    rf"what do you (?:know|remember) about me{_PROFILE_SCOPE_SUFFIX}",
+    r"what do you have on me",
+    rf"what am i all about{_PROFILE_SCOPE_SUFFIX}",
+    rf"what have you learned about me{_PROFILE_SCOPE_SUFFIX}",
+    rf"tell me (?:everything )?(?:you )?(?:know|remember) about me"
+    rf"{_PROFILE_SCOPE_SUFFIX}",
+    r"tell me everything you remember",
+    r"tell me about myself",
+    r"who am i to you",
+)
+_AMBIGUOUS_RECALL_PATTERNS = (
+    r"what do you (?:know|remember)",
+    r"what do you recall",
+    r"do you remember",
+    r"tell me what you remember",
+    r"what can you tell me",
+)
+
+
+@dataclass(frozen=True)
+class PersonalRecallIntent:
+    """Canonical interpretation of one possible personal-recall request."""
+
+    normalized_text: str
+    status: str
+    route_family: str = ""
+    reason: str = ""
+
+    @property
+    def broad_self_profile(self) -> bool:
+        return bool(
+            self.status == "matched"
+            and self.route_family == PERSONAL_RECALL_ROUTE_FAMILY
+        )
+
+
+def normalize_personal_recall_intent(text: str) -> str:
+    """Remove Discord/vocative wording without changing the request meaning."""
+
+    value = re.sub(
+        r"\s+",
+        " ",
+        str(text or "").replace("’", "'"),
+    ).strip()
+    value = re.sub(r"^\s*<@!?\d+>\s*", "", value, flags=re.I)
+    value = re.sub(r"^[,;:!?—–-]+\s*", "", value)
+    value = re.sub(
+        r"^(?:(?:hey|yo|hi|hello)\s+)?"
+        r"(?:bnl(?:-?01)?|barcode bot|b|bud|buddy)"
+        r"(?:\s*[,;:!?—–-]+\s*|\s+)",
+        "",
+        value,
+        flags=re.I,
+    )
+    value = re.sub(
+        r"^(?:(?:so|okay|ok|well)\s*[,;:—–-]*\s*)+",
+        "",
+        value,
+        flags=re.I,
+    )
+    value = re.sub(
+        r"^(?:please\s+)?(?:(?:can|could|would|will)\s+you\s+)?",
+        "",
+        value,
+        flags=re.I,
+    )
+    value = value.strip(" \t\r\n.,!?;:—–-").lower()
+    value = re.sub(
+        r"\s*(?:,?\s+(?:please|honestly|again|currently|"
+        r"right now|now|so far))+$",
+        "",
+        value,
+        flags=re.I,
+    )
+    return value.strip(" \t\r\n.,!?;:—–-")
+
+
+def classify_personal_recall_intent(text: str) -> PersonalRecallIntent:
+    """Return one shared routing decision for broad self-profile wording."""
+
+    normalized = normalize_personal_recall_intent(text)
+    if not normalized:
+        return PersonalRecallIntent(
+            normalized,
+            "not_recall",
+            reason="empty",
+        )
+    if _PERSONAL_RECALL_HOLD_RE.search(normalized):
+        return PersonalRecallIntent(
+            normalized,
+            "blocked",
+            reason="answer_deferred_or_negated",
+        )
+    if any(
+        re.fullmatch(pattern, normalized, flags=re.I)
+        for pattern in _BROAD_SELF_PROFILE_PATTERNS
+    ):
+        return PersonalRecallIntent(
+            normalized,
+            "matched",
+            route_family=PERSONAL_RECALL_ROUTE_FAMILY,
+            reason="canonical_broad_self_profile",
+        )
+    if any(
+        re.fullmatch(pattern, normalized, flags=re.I)
+        for pattern in _AMBIGUOUS_RECALL_PATTERNS
+    ):
+        return PersonalRecallIntent(
+            normalized,
+            "needs_context",
+            reason="recall_target_ambiguous",
+        )
+    if any(
+        re.search(pattern, normalized, flags=re.I)
+        for pattern in _BROAD_SELF_PROFILE_PATTERNS
+    ):
+        return PersonalRecallIntent(
+            normalized,
+            "not_recall",
+            reason="mixed_or_unsupported_request",
+        )
+    return PersonalRecallIntent(
+        normalized,
+        "not_recall",
+        reason="not_personal_recall",
+    )
 
 @dataclass(frozen=True)
 class GovernanceRequest:
@@ -356,7 +492,7 @@ def _classify_kind(source_class: str, entry_type: str, derived: bool, lifecycle:
     return "observation"
 
 def _is_broad_recall(text: str) -> bool:
-    return bool(BROAD_RECALL_RE.search(text or ""))
+    return classify_personal_recall_intent(text).broad_self_profile
 
 def _explicit_recall(text: str) -> bool:
     return bool(RECALL_RE.search(text or ""))

--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -741,6 +741,12 @@ def _read_shared_brain_synthesis_report(
                 "baselineCoherenceStatusCounts": {},
                 "candidateCoherenceStatusCounts": {},
                 "candidateEvidenceCoverageTotal": 0,
+                "routeFamilyCounts": {},
+                "candidateGenerationLatencyMs": {
+                    "average": 0,
+                    "maximum": 0,
+                    "samples": 0,
+                },
                 "revalidationStatusCounts": {},
                 "controlMarkerLeakRuns": 0,
                 "processingErrors": 0,
@@ -1754,7 +1760,7 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
                 "none",
             ),
         ),
-        "- shared_brain_synthesis_canary: status=`%s` requested=`%s` effective=`%s` reason=`%s` fully_scoped=`%s` schema=`%s` runs=`%s` prompt_applied=`%s` candidate_selected=`%s` live_applied=`%s` responses_sent=`%s` fallbacks=`%s` fallback_reasons=`%s` comparison=`%s` baseline_coherence=`%s` candidate_coherence=`%s` evidence_coverage=`%s` revalidation=`%s` control_leaks=`%s` errors=`%s` invalid_scope=`%s` invalid_revalidation_live=`%s` ungrounded_live=`%s` relationship_posture_applied=`%s` content_fields=`%s` window_last=`%s`" % (
+        "- shared_brain_synthesis_canary: status=`%s` requested=`%s` effective=`%s` reason=`%s` fully_scoped=`%s` schema=`%s` runs=`%s` route_families=`%s` prompt_applied=`%s` candidate_selected=`%s` live_applied=`%s` responses_sent=`%s` fallbacks=`%s` fallback_reasons=`%s` comparison=`%s` baseline_coherence=`%s` candidate_coherence=`%s` evidence_coverage=`%s` candidate_latency_ms=`%s` revalidation=`%s` control_leaks=`%s` errors=`%s` invalid_scope=`%s` invalid_revalidation_live=`%s` ungrounded_live=`%s` relationship_posture_applied=`%s` content_fields=`%s` window_last=`%s`" % (
             shared_brain_synthesis_state.get("status", "unknown"),
             _on(shared_brain_synthesis_state.get("requested")),
             _on(shared_brain_synthesis_state.get("effective")),
@@ -1765,6 +1771,10 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
                 "shared_brain_synthesis_canary_v1",
             ),
             shared_brain_synthesis.get("runs", 0),
+            json.dumps(
+                shared_brain_synthesis.get("routeFamilyCounts", {}),
+                sort_keys=True,
+            ),
             shared_brain_synthesis.get("promptAppliedRuns", 0),
             shared_brain_synthesis.get("candidateSelectedRuns", 0),
             shared_brain_synthesis.get("liveAppliedRuns", 0),
@@ -1798,6 +1808,13 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             shared_brain_synthesis.get(
                 "candidateEvidenceCoverageTotal",
                 0,
+            ),
+            json.dumps(
+                shared_brain_synthesis.get(
+                    "candidateGenerationLatencyMs",
+                    {},
+                ),
+                sort_keys=True,
             ),
             json.dumps(
                 shared_brain_synthesis.get(

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -18,6 +18,10 @@ import sqlite3
 import uuid
 from typing import Any, Mapping
 
+from bnl_memory_governance import (
+    PERSONAL_RECALL_ROUTE_FAMILY,
+    classify_personal_recall_intent,
+)
 from bnl_memory_ledger import subject_key_for_user
 from bnl_unified_intelligence_packet import (
     UnifiedIntelligencePacket,
@@ -39,7 +43,9 @@ GUILD_IDS_ENV = "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_GUILD_IDS"
 USER_IDS_ENV = "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_USER_IDS"
 CHANNEL_IDS_ENV = "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_CHANNEL_IDS"
 _ROUTE_MODE = "normal_chat"
-_CHANNEL_POLICY = "public_context"
+_CHANNEL_POLICIES = frozenset({"public_home", "public_context"})
+_MAX_SCOPED_USERS = 8
+_MAX_SCOPED_CHANNELS = 4
 _LIVE_GATES = (
     "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED",
     "BNL_RELATIONSHIP_V2_LIVE_ENABLED",
@@ -63,19 +69,6 @@ _LANE_LABELS = {
     "canon": "approved canon",
     "source_file": "authorized source context",
 }
-_BROAD_PROFILE_RE = re.compile(
-    r"(?:"
-    r"what\s+do\s+you\s+(?:know|remember)\s+about\s+me|"
-    r"what\s+do\s+you\s+have\s+on\s+me|"
-    r"what\s+am\s+i\s+all\s+about|"
-    r"what\s+have\s+you\s+learned\s+about\s+me|"
-    r"tell\s+me\s+(?:everything\s+)?(?:you\s+)?(?:know|remember)\s+about\s+me|"
-    r"tell\s+me\s+everything\s+you\s+remember|"
-    r"tell\s+me\s+about\s+myself|"
-    r"who\s+am\s+i\s+to\s+you"
-    r")",
-    re.I,
-)
 _CONTROL_MARKERS = (
     "unified intelligence packet",
     "shared-brain canary",
@@ -166,6 +159,15 @@ class SynthesisCanaryDecision:
     candidate_coherence_status: str
     candidate_evidence_coverage_count: int
     revalidation_status: str
+    candidate_generation_latency_ms: int = 0
+
+
+@dataclass(frozen=True)
+class RouteScopeDecision:
+    eligible: bool
+    reason: str
+    intent_status: str
+    route_family: str
 
 
 def _flag(value: Any) -> bool:
@@ -215,11 +217,14 @@ def configuration(
     guilds = _positive_ids(env.get(GUILD_IDS_ENV, ""))
     users = _positive_ids(env.get(USER_IDS_ENV, ""))
     channels = _positive_ids(env.get(CHANNEL_IDS_ENV, ""))
+    scope_present = bool(requested and guilds and users and channels)
+    scope_within_limits = bool(
+        len(guilds) == 1
+        and 1 <= len(users) <= _MAX_SCOPED_USERS
+        and 1 <= len(channels) <= _MAX_SCOPED_CHANNELS
+    )
     fully_scoped = bool(
-        requested
-        and len(guilds) == 1
-        and len(users) == 1
-        and len(channels) == 1
+        scope_present and scope_within_limits
     )
     packet_ready = packet_shadow_enabled(env)
     assessment_ready = assessment_shadow_enabled(env)
@@ -234,6 +239,8 @@ def configuration(
     )
     if not requested:
         reason = "disabled"
+    elif scope_present and not scope_within_limits:
+        reason = "scope_limit_exceeded"
     elif not fully_scoped:
         reason = "scope_incomplete"
     elif active_live_gates:
@@ -251,22 +258,79 @@ def configuration(
         "effective": effective,
         "reason": reason,
         "route_mode": _ROUTE_MODE,
-        "channel_policy": _CHANNEL_POLICY,
+        "route_family": PERSONAL_RECALL_ROUTE_FAMILY,
+        "channel_policies": tuple(sorted(_CHANNEL_POLICIES)),
+        "max_scoped_users": _MAX_SCOPED_USERS,
+        "max_scoped_channels": _MAX_SCOPED_CHANNELS,
         "active_live_gates": active_live_gates,
     }
 
 
 def broad_profile_request(text: str) -> bool:
-    value = re.sub(r"\s+", " ", str(text or "")).strip().replace("’", "'")
-    value = re.sub(
-        r"^(?:hey\s+|yo\s+|hi\s+)?"
-        r"(?:bnl(?:-?01)?|barcode bot)\s*[,;:—-]*\s*",
-        "",
-        value,
-        flags=re.I,
+    return classify_personal_recall_intent(text).broad_self_profile
+
+
+def route_scope_decision(
+    *,
+    guild_id: int,
+    user_id: int,
+    channel_id: int,
+    route_mode: str,
+    channel_policy: str,
+    current_direct: bool,
+    user_text: str,
+    has_media: bool = False,
+    exact_quote_requested: bool = False,
+    third_party_attribution_requested: bool = False,
+    environ: Mapping[str, str] | None = None,
+) -> RouteScopeDecision:
+    """Evaluate the route family before packet/assessment availability."""
+
+    env = os.environ if environ is None else environ
+    config = configuration(env)
+    intent = classify_personal_recall_intent(user_text)
+    if not config["effective"]:
+        reason = "configuration_%s" % config["reason"]
+    elif int(guild_id or 0) not in _positive_ids(
+        env.get(GUILD_IDS_ENV, "")
+    ):
+        reason = "guild_not_allowlisted"
+    elif int(user_id or 0) not in _positive_ids(
+        env.get(USER_IDS_ENV, "")
+    ):
+        reason = "user_not_allowlisted"
+    elif int(channel_id or 0) not in _positive_ids(
+        env.get(CHANNEL_IDS_ENV, "")
+    ):
+        reason = "channel_not_allowlisted"
+    elif str(route_mode or "") != _ROUTE_MODE:
+        reason = "route_mode_not_supported"
+    elif str(channel_policy or "").strip().lower() not in _CHANNEL_POLICIES:
+        reason = "channel_policy_not_supported"
+    elif not current_direct:
+        reason = "not_direct"
+    elif not intent.broad_self_profile:
+        reason = "intent_%s" % (intent.reason or intent.status)
+    elif has_media:
+        reason = "media_present"
+    elif exact_quote_requested:
+        reason = "exact_quote_requested"
+    elif third_party_attribution_requested:
+        reason = "third_party_attribution_requested"
+    else:
+        reason = "eligible"
+    return RouteScopeDecision(
+        eligible=reason == "eligible",
+        reason=reason,
+        intent_status=intent.status,
+        route_family=(
+            intent.route_family or PERSONAL_RECALL_ROUTE_FAMILY
+        ),
     )
-    value = value.strip(" .!?")
-    return bool(_BROAD_PROFILE_RE.fullmatch(value))
+
+
+def route_scope_enabled(**kwargs: Any) -> bool:
+    return route_scope_decision(**kwargs).eligible
 
 
 def _packet_usable(packet: UnifiedIntelligencePacket | None) -> bool:
@@ -297,32 +361,34 @@ def scope_enabled(
     environ: Mapping[str, str] | None = None,
 ) -> bool:
     env = os.environ if environ is None else environ
-    config = configuration(env)
-    guilds = _positive_ids(env.get(GUILD_IDS_ENV, ""))
-    users = _positive_ids(env.get(USER_IDS_ENV, ""))
-    channels = _positive_ids(env.get(CHANNEL_IDS_ENV, ""))
     return bool(
-        config["effective"]
-        and int(guild_id or 0) in guilds
-        and int(user_id or 0) in users
-        and int(channel_id or 0) in channels
-        and str(route_mode or "") == _ROUTE_MODE
-        and str(channel_policy or "").strip().lower() == _CHANNEL_POLICY
-        and current_direct
-        and broad_profile_request(user_text)
-        and not has_media
-        and not exact_quote_requested
-        and not third_party_attribution_requested
+        route_scope_enabled(
+            guild_id=guild_id,
+            user_id=user_id,
+            channel_id=channel_id,
+            route_mode=route_mode,
+            channel_policy=channel_policy,
+            current_direct=current_direct,
+            user_text=user_text,
+            has_media=has_media,
+            exact_quote_requested=exact_quote_requested,
+            third_party_attribution_requested=(
+                third_party_attribution_requested
+            ),
+            environ=env,
+        )
         and _packet_usable(packet)
         and isinstance(assessment, UnifiedResponseAssessment)
         and packet.request.guild_id == int(guild_id or 0)
         and packet.request.subject_user_id == int(user_id or 0)
         and packet.request.channel_id == int(channel_id or 0)
         and packet.request.route_mode == _ROUTE_MODE
-        and packet.request.channel_policy == _CHANNEL_POLICY
+        and packet.request.channel_policy
+        == str(channel_policy or "").strip().lower()
         and packet.request.direct_state == "direct"
         and assessment.guild_id == int(guild_id or 0)
-        and assessment.channel_policy == _CHANNEL_POLICY
+        and assessment.channel_policy
+        == str(channel_policy or "").strip().lower()
     )
 
 
@@ -534,7 +600,7 @@ def revalidate_basis(
             env.get(CHANNEL_IDS_ENV, "")
         )
         or basis.route_mode != _ROUTE_MODE
-        or basis.channel_policy != _CHANNEL_POLICY
+        or basis.channel_policy not in _CHANNEL_POLICIES
         or basis.packet.request.subject_user_id != basis.user_id
         or basis.packet.request.guild_id != basis.guild_id
         or basis.packet.request.channel_id != basis.channel_id
@@ -586,6 +652,7 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             guild_id INTEGER NOT NULL,
             subject_hash TEXT NOT NULL,
             channel_scope_hash TEXT NOT NULL,
+            route_family TEXT NOT NULL DEFAULT 'broad_self_profile',
             route_mode TEXT NOT NULL,
             channel_policy TEXT NOT NULL,
             packet_item_count INTEGER NOT NULL DEFAULT 0,
@@ -600,6 +667,7 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             final_response_hash TEXT NOT NULL DEFAULT '',
             baseline_response_length INTEGER NOT NULL DEFAULT 0,
             candidate_response_length INTEGER NOT NULL DEFAULT 0,
+            candidate_generation_latency_ms INTEGER NOT NULL DEFAULT 0,
             final_response_length INTEGER NOT NULL DEFAULT 0,
             comparison_status TEXT NOT NULL DEFAULT 'not_evaluated',
             baseline_coherence_status TEXT NOT NULL DEFAULT 'not_evaluated',
@@ -619,6 +687,26 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         )
         """
     )
+    columns = {
+        str(row[1])
+        for row in conn.execute("PRAGMA table_info(%s)" % TABLE_NAME)
+    }
+    if "route_family" not in columns:
+        conn.execute(
+            """
+            ALTER TABLE memory_governance_shared_brain_synthesis_runs
+            ADD COLUMN route_family TEXT NOT NULL
+            DEFAULT 'broad_self_profile'
+            """
+        )
+    if "candidate_generation_latency_ms" not in columns:
+        conn.execute(
+            """
+            ALTER TABLE memory_governance_shared_brain_synthesis_runs
+            ADD COLUMN candidate_generation_latency_ms INTEGER NOT NULL
+            DEFAULT 0
+            """
+        )
     conn.execute(
         """
         CREATE INDEX IF NOT EXISTS idx_shared_brain_synthesis_guild
@@ -670,13 +758,14 @@ def begin_run(
         """
         INSERT INTO memory_governance_shared_brain_synthesis_runs(
           run_id,packet_run_id,packet_id,schema_version,guild_id,
-          subject_hash,channel_scope_hash,route_mode,channel_policy,
+          subject_hash,channel_scope_hash,route_family,route_mode,
+          channel_policy,
           packet_item_count,rendered_item_count,rendered_lane_counts_json,
           packet_digest,source_ref_digest,baseline_generated,
           baseline_response_hash,baseline_response_length,
           revalidation_status,prompt_applied,fallback_reason,
           processing_error_count,created_at,updated_at
-        ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         """,
         (
             run_id,
@@ -686,6 +775,7 @@ def begin_run(
             basis.guild_id,
             _digest(subject_key_for_user(basis.user_id))[:16],
             _digest(basis.guild_id, basis.channel_id)[:16],
+            PERSONAL_RECALL_ROUTE_FAMILY,
             basis.route_mode,
             basis.channel_policy,
             len(basis.packet.items),
@@ -731,6 +821,7 @@ def evaluate_candidate(
     *,
     baseline_response: str,
     candidate_response: str,
+    candidate_generation_latency_ms: int | None = None,
     environ: Mapping[str, str] | None = None,
 ) -> SynthesisCanaryDecision:
     baseline = str(baseline_response or "").strip()
@@ -785,7 +876,10 @@ def evaluate_candidate(
         """
         UPDATE memory_governance_shared_brain_synthesis_runs
         SET candidate_generated=?,candidate_response_hash=?,
-            candidate_response_length=?,comparison_status=?,
+            candidate_response_length=?,
+            candidate_generation_latency_ms=COALESCE(
+              ?,candidate_generation_latency_ms
+            ),comparison_status=?,
             baseline_coherence_status=?,candidate_coherence_status=?,
             candidate_evidence_coverage_count=?,candidate_output_leak=?,
             revalidation_status=?,
@@ -798,6 +892,11 @@ def evaluate_candidate(
             int(bool(candidate)),
             _digest(candidate),
             len(candidate),
+            (
+                max(0, int(candidate_generation_latency_ms))
+                if candidate_generation_latency_ms is not None
+                else None
+            ),
             comparison_status,
             baseline_coherence.status,
             candidate_coherence.status,
@@ -811,6 +910,17 @@ def evaluate_candidate(
             run.run_id,
         ),
     )
+    stored_latency = int(
+        conn.execute(
+            """
+            SELECT candidate_generation_latency_ms
+            FROM memory_governance_shared_brain_synthesis_runs
+            WHERE run_id=?
+            """,
+            (run.run_id,),
+        ).fetchone()[0]
+        or 0
+    )
     return SynthesisCanaryDecision(
         run=run,
         response=selected,
@@ -821,6 +931,7 @@ def evaluate_candidate(
         candidate_coherence_status=candidate_coherence.status,
         candidate_evidence_coverage_count=evidence_coverage,
         revalidation_status=revalidation_status,
+        candidate_generation_latency_ms=stored_latency,
     )
 
 
@@ -865,6 +976,9 @@ def record_fallback(
             decision.candidate_evidence_coverage_count
         ),
         revalidation_status=decision.revalidation_status,
+        candidate_generation_latency_ms=(
+            decision.candidate_generation_latency_ms
+        ),
     )
 
 
@@ -929,6 +1043,12 @@ def _empty_report() -> dict[str, Any]:
         "baselineCoherenceStatusCounts": {},
         "candidateCoherenceStatusCounts": {},
         "candidateEvidenceCoverageTotal": 0,
+        "routeFamilyCounts": {},
+        "candidateGenerationLatencyMs": {
+            "average": 0,
+            "maximum": 0,
+            "samples": 0,
+        },
         "revalidationStatusCounts": {},
         "controlMarkerLeakRuns": 0,
         "processingErrors": 0,
@@ -972,6 +1092,16 @@ def build_evaluation_report(
             "source_refs",
         }
     )
+    route_family_expr = (
+        "route_family"
+        if "route_family" in columns
+        else "'broad_self_profile'"
+    )
+    latency_expr = (
+        "candidate_generation_latency_ms"
+        if "candidate_generation_latency_ms" in columns
+        else "0"
+    )
     invalid_scope_runs = int(
         conn.execute(
             """
@@ -979,11 +1109,12 @@ def build_evaluation_report(
             FROM memory_governance_shared_brain_synthesis_runs
             WHERE guild_id=?
               AND (
-                route_mode<>? OR channel_policy<>?
+                route_mode<>?
+                OR channel_policy NOT IN ('public_home','public_context')
                 OR subject_hash='' OR channel_scope_hash=''
               )
             """,
-            (int(guild_id or 0), _ROUTE_MODE, _CHANNEL_POLICY),
+            (int(guild_id or 0), _ROUTE_MODE),
         ).fetchone()[0]
         or 0
     )
@@ -1030,12 +1161,16 @@ def build_evaluation_report(
                baseline_coherence_status,candidate_coherence_status,
                candidate_evidence_coverage_count,revalidation_status,
                candidate_output_leak,
-               processing_error_count,response_sent,created_at
+               processing_error_count,response_sent,
+               {route_family_expr},{latency_expr},created_at
         FROM memory_governance_shared_brain_synthesis_runs
         WHERE guild_id=?
         ORDER BY created_at DESC,run_id DESC
         LIMIT ?
-        """,
+        """.format(
+            route_family_expr=route_family_expr,
+            latency_expr=latency_expr,
+        ),
         (int(guild_id or 0), max(1, min(int(limit or 500), 2000))),
     ).fetchall()
     fallbacks: Counter[str] = Counter()
@@ -1043,6 +1178,8 @@ def build_evaluation_report(
     baseline_coherence: Counter[str] = Counter()
     candidate_coherence: Counter[str] = Counter()
     revalidation: Counter[str] = Counter()
+    route_families: Counter[str] = Counter()
+    latency_values: list[int] = []
     prompt = live = selected = coverage = leaks = errors = sent = 0
     for row in rows:
         (
@@ -1059,6 +1196,8 @@ def build_evaluation_report(
             output_leak,
             processing_errors,
             response_sent,
+            route_family,
+            candidate_latency_ms,
             _created_at,
         ) = row
         prompt += int(bool(prompt_applied))
@@ -1074,6 +1213,12 @@ def build_evaluation_report(
         leaks += int(bool(output_leak))
         errors += int(processing_errors or 0)
         sent += int(bool(response_sent))
+        route_families[
+            str(route_family or PERSONAL_RECALL_ROUTE_FAMILY)
+        ] += 1
+        latency = max(0, int(candidate_latency_ms or 0))
+        if latency:
+            latency_values.append(latency)
     return {
         "tablePresent": True,
         "schemaVersion": str(rows[0][0]) if rows else SCHEMA_VERSION,
@@ -1091,6 +1236,16 @@ def build_evaluation_report(
             sorted(candidate_coherence.items())
         ),
         "candidateEvidenceCoverageTotal": coverage,
+        "routeFamilyCounts": dict(sorted(route_families.items())),
+        "candidateGenerationLatencyMs": {
+            "average": (
+                int(round(sum(latency_values) / len(latency_values)))
+                if latency_values
+                else 0
+            ),
+            "maximum": max(latency_values, default=0),
+            "samples": len(latency_values),
+        },
         "revalidationStatusCounts": dict(sorted(revalidation.items())),
         "controlMarkerLeakRuns": leaks,
         "processingErrors": errors,

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -28,6 +28,7 @@ from bnl_memory_governance import (
     GovernanceRequest,
     assess_governance_result_safety,
     build_governed_context,
+    classify_personal_recall_intent,
     ensure_governance_schema,
 )
 from bnl_memory_ledger import (
@@ -162,18 +163,6 @@ _TERM_STOPWORDS = {
     "with",
     "you",
 }
-_BROAD_PROFILE_RE = re.compile(
-    r"\b(?:"
-    r"what\s+do\s+you\s+(?:know|remember)\s+about\s+me|"
-    r"what\s+do\s+you\s+have\s+on\s+me|"
-    r"what\s+am\s+i\s+all\s+about|"
-    r"what\s+have\s+you\s+learned\s+about\s+me|"
-    r"tell\s+me\s+(?:everything\s+)?(?:you\s+)?(?:know|remember)\s+about\s+me|"
-    r"tell\s+me\s+about\s+myself|"
-    r"who\s+am\s+i\s+to\s+you"
-    r")\b",
-    re.I,
-)
 _CURRENT_CORRECTION_RE = re.compile(
     r"\b(?:correction|correcting|that's\s+wrong|that\s+is\s+wrong|"
     r"not\s+anymore|no[,;:]?\s+(?:my|i|we)|"
@@ -441,7 +430,7 @@ def _terms(value: Any) -> set[str]:
 
 
 def _broad_profile_request(value: str) -> bool:
-    return bool(_BROAD_PROFILE_RE.search(str(value or "")))
+    return classify_personal_recall_intent(value).broad_self_profile
 
 
 def _public_route(request: IntelligencePacketRequest) -> bool:

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -1115,6 +1115,225 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_batched_broad_recall_route_uses_normal_baseline_and_packet_canary(self):
+        channel = self._channel(8126)
+        baseline = (
+            "You keep building strange music and helping the BARCODE room."
+        )
+        candidate = (
+            "You keep turning strange music into shared BARCODE projects, "
+            "and you show up for the people building them with you."
+        )
+        legacy = "Here is what I can safely recall:\n- community banter"
+        run = SimpleNamespace(run_id="batch-route-run")
+        first_decision = SimpleNamespace(
+            run=run,
+            candidate_selected=True,
+            fallback_reason="",
+        )
+        execution = bnl01_bot.SharedBrainSynthesisExecution(
+            decision=first_decision,
+            response=candidate,
+            prompt="baseline prompt\n\nprivate packet evidence",
+            prompt_source_bases=("packet-basis",),
+            candidate_active=True,
+        )
+        final_decision = SimpleNamespace(
+            run=run,
+            candidate_selected=True,
+            fallback_reason="",
+        )
+        finalized = mock.AsyncMock(return_value=True)
+
+        self._prime_flush(
+            channel,
+            "Hey bud what do you know about me",
+        )
+        with (
+            self._flush_runtime(
+                channel.id,
+                mock.AsyncMock(return_value=baseline),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "resolve_channel_policy",
+                return_value="public_home",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "try_memory_recall_response",
+                return_value=legacy,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "apply_explicit_recall_governance",
+            ) as deterministic_governance,
+            mock.patch.object(
+                bnl01_bot,
+                "build_user_memory_context",
+                return_value=(
+                    "Derived memory summaries:\n"
+                    "- strange music\n"
+                    "- helps the community"
+                ),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_unified_response_assessment_shadow",
+                return_value=object(),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_shared_brain_synthesis_basis",
+                return_value=object(),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_shared_brain_synthesis_canary",
+                new=mock.AsyncMock(return_value=execution),
+            ) as synthesize,
+            mock.patch.object(
+                bnl01_bot,
+                "_evaluate_shared_brain_synthesis_receipt",
+                return_value=final_decision,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "prompt_source_basis_failure",
+                return_value="",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "safely_finalize_shared_brain_synthesis",
+                new=finalized,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "record_unified_response_assessment_shadow_after_send",
+                new=mock.AsyncMock(),
+            ),
+        ):
+            await bnl01_bot._flush_channel_buffer(channel)
+
+        deterministic_governance.assert_not_called()
+        synthesize.assert_awaited_once()
+        self.assertEqual(channel.sent, [candidate])
+        finalized.assert_awaited_once()
+        self.assertTrue(finalized.await_args.kwargs["response_sent"])
+        self.assertTrue(finalized.await_args.kwargs["candidate_live"])
+
+    async def test_batched_packet_source_change_falls_back_to_normal_baseline(self):
+        channel = self._channel(8127)
+        baseline = (
+            "You keep building strange music and helping the BARCODE room."
+        )
+        candidate = (
+            "You keep turning strange music into shared BARCODE projects."
+        )
+        run = SimpleNamespace(run_id="batch-source-fallback-run")
+        selected = SimpleNamespace(
+            run=run,
+            candidate_selected=True,
+            fallback_reason="",
+        )
+        execution = bnl01_bot.SharedBrainSynthesisExecution(
+            decision=selected,
+            response=candidate,
+            prompt="baseline prompt\n\nprivate packet evidence",
+            prompt_source_bases=("packet-basis",),
+            candidate_active=True,
+        )
+        fallback = SimpleNamespace(
+            run=run,
+            candidate_selected=False,
+            fallback_reason="candidate_presend_packet_source_changed",
+        )
+        finalized = mock.AsyncMock(return_value=True)
+        source_results = iter(("packet_source_changed", ""))
+
+        self._prime_flush(
+            channel,
+            "Hey BNL what do you know about me?",
+        )
+        with (
+            self._flush_runtime(
+                channel.id,
+                mock.AsyncMock(return_value=baseline),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "resolve_channel_policy",
+                return_value="public_home",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "try_memory_recall_response",
+                return_value=(
+                    "Here is what I can safely recall:\n"
+                    "- community banter"
+                ),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_user_memory_context",
+                return_value=(
+                    "Derived memory summaries:\n"
+                    "- strange music\n"
+                    "- helps the community"
+                ),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_unified_response_assessment_shadow",
+                return_value=object(),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_shared_brain_synthesis_basis",
+                return_value=object(),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_shared_brain_synthesis_canary",
+                new=mock.AsyncMock(return_value=execution),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "_evaluate_shared_brain_synthesis_receipt",
+                return_value=selected,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "prompt_source_basis_failure",
+                side_effect=lambda _bases: next(source_results),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "safely_fallback_shared_brain_synthesis",
+                new=mock.AsyncMock(return_value=fallback),
+            ) as fall_back,
+            mock.patch.object(
+                bnl01_bot,
+                "safely_finalize_shared_brain_synthesis",
+                new=finalized,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "record_unified_response_assessment_shadow_after_send",
+                new=mock.AsyncMock(),
+            ),
+        ):
+            await bnl01_bot._flush_channel_buffer(channel)
+
+        self.assertEqual(channel.sent, [baseline])
+        fall_back.assert_awaited_once()
+        self.assertEqual(
+            fall_back.await_args.args[1],
+            "candidate_presend_packet_source_changed",
+        )
+        finalized.assert_awaited_once()
+        self.assertFalse(finalized.await_args.kwargs["candidate_live"])
+
     async def test_batched_media_followup_wins_without_durable_governance(self):
         channel = self._channel(8119)
         provider = mock.AsyncMock(side_effect=AssertionError("deterministic media must not generate"))

--- a/tests/test_governed_broad_recall_route_expansion.py
+++ b/tests/test_governed_broad_recall_route_expansion.py
@@ -1,0 +1,182 @@
+import os
+import unittest
+from unittest import mock
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+from bnl_memory_governance import classify_personal_recall_intent
+from bnl_shared_brain_synthesis import (
+    configuration,
+    route_scope_decision,
+)
+
+
+class GovernedBroadRecallRouteExpansionTests(unittest.TestCase):
+    def setUp(self):
+        self.flags = {
+            "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+            "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+            "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+            "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+            "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED": "true",
+            "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED": "true",
+            "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_ENABLED": "true",
+            "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_GUILD_IDS": "1",
+            "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_USER_IDS": "7,8,9,10",
+            "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_CHANNEL_IDS": "10,11",
+            "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
+            "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
+            "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+        }
+
+    def test_four_production_wordings_share_one_route_family(self):
+        transcripts = (
+            "hey B? what do you know about me?",
+            "Hey bud what do you know about me",
+            "Hey BNL what do you know about me?",
+            "Hey BNL, what am I all about?",
+        )
+        for text in transcripts:
+            with self.subTest(text=text):
+                intent = classify_personal_recall_intent(text)
+                self.assertTrue(intent.broad_self_profile)
+                self.assertEqual(
+                    intent.route_family,
+                    "broad_self_profile",
+                )
+                self.assertTrue(
+                    bnl01_bot.is_broad_personal_recall_request(text)
+                )
+
+    def test_real_mention_residue_and_full_mention_normalize_identically(self):
+        for text in (
+            ", what am I all about?",
+            "<@1444786398153539605>, what am I all about?",
+            "<@!1444786398153539605> what am I all about?",
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(
+                    classify_personal_recall_intent(
+                        text
+                    ).broad_self_profile
+                )
+
+    def test_profile_route_accepts_a_single_topic_scope(self):
+        for text in (
+            "BNL, what am I all about in the BARCODE project?",
+            "What do you know about me within this community?",
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(
+                    classify_personal_recall_intent(
+                        text
+                    ).broad_self_profile
+                )
+
+    def test_mixed_negated_and_third_party_requests_do_not_enter_route(self):
+        for text in (
+            "What do you know about me and tell me a joke?",
+            "Do not tell me what you know about me yet.",
+            "What do you know about WittyFox?",
+        ):
+            with self.subTest(text=text):
+                self.assertFalse(
+                    classify_personal_recall_intent(
+                        text
+                    ).broad_self_profile
+                )
+
+    def test_ambiguous_recall_uses_understand_or_clarify_contract(self):
+        intent = classify_personal_recall_intent(
+            "Hey BNL, what do you remember?"
+        )
+        self.assertEqual(intent.status, "needs_context")
+        contract = bnl01_bot.personal_recall_interpretation_contract(
+            "Hey BNL, what do you remember?"
+        )
+        self.assertIn("visible current conversation", contract)
+        self.assertIn("one brief natural", contract)
+
+    def test_public_route_parity_is_not_tied_to_canary_allowlist(self):
+        for text in (
+            "hey B? what do you know about me?",
+            "Hey bud what do you know about me",
+            "Hey BNL what do you know about me?",
+            "Hey BNL, what am I all about?",
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(
+                    bnl01_bot
+                    .broad_personal_recall_enters_normal_generation(
+                        route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                        channel_policy="public_home",
+                        user_text=text,
+                        current_direct=True,
+                    )
+                )
+        self.assertFalse(
+            bnl01_bot.broad_personal_recall_enters_normal_generation(
+                route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                channel_policy="sealed_test",
+                user_text="What do you know about me?",
+                current_direct=True,
+            )
+        )
+
+    def test_explicit_multi_member_multi_channel_scope_stays_bounded(self):
+        configured = configuration(self.flags)
+        self.assertTrue(configured["effective"])
+        self.assertEqual(configured["user_allowlist_count"], 4)
+        self.assertEqual(configured["channel_allowlist_count"], 2)
+        self.assertEqual(configured["max_scoped_users"], 8)
+        self.assertEqual(configured["max_scoped_channels"], 4)
+
+        for policy, channel_id in (
+            ("public_home", 10),
+            ("public_context", 11),
+        ):
+            with self.subTest(policy=policy):
+                decision = route_scope_decision(
+                    guild_id=1,
+                    user_id=7,
+                    channel_id=channel_id,
+                    route_mode="normal_chat",
+                    channel_policy=policy,
+                    current_direct=True,
+                    user_text="Hey BNL, what do you know about me?",
+                    environ=self.flags,
+                )
+                self.assertTrue(decision.eligible)
+                self.assertEqual(decision.reason, "eligible")
+
+        oversized = {
+            **self.flags,
+            "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_USER_IDS": ",".join(
+                str(value) for value in range(1, 10)
+            ),
+        }
+        self.assertFalse(configuration(oversized)["effective"])
+        self.assertEqual(
+            configuration(oversized)["reason"],
+            "scope_limit_exceeded",
+        )
+
+    def test_packet_canary_still_rejects_non_allowlisted_identity(self):
+        decision = route_scope_decision(
+            guild_id=1,
+            user_id=99,
+            channel_id=10,
+            route_mode="normal_chat",
+            channel_policy="public_home",
+            current_direct=True,
+            user_text="What do you know about me?",
+            environ=self.flags,
+        )
+        self.assertFalse(decision.eligible)
+        self.assertEqual(decision.reason, "user_not_allowlisted")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shared_brain_synthesis_canary.py
+++ b/tests/test_shared_brain_synthesis_canary.py
@@ -209,7 +209,7 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
         self.assertIsNotNone(basis)
         return basis
 
-    def test_configuration_requires_one_exact_scope_and_no_global_live_gate(self):
+    def test_configuration_requires_bounded_scope_and_no_global_live_gate(self):
         configured = configuration(self.flags)
         self.assertTrue(configured["effective"])
         self.assertEqual(configured["reason"], "scoped_canary")
@@ -217,10 +217,22 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
         self.assertEqual(configured["user_allowlist_count"], 1)
         self.assertEqual(configured["channel_allowlist_count"], 1)
 
-        incomplete = configuration(
+        bounded_expansion = configuration(
             {
                 **self.flags,
                 "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_CHANNEL_IDS": "10,11",
+            }
+        )
+        self.assertTrue(bounded_expansion["effective"])
+        self.assertEqual(
+            bounded_expansion["channel_allowlist_count"],
+            2,
+        )
+
+        incomplete = configuration(
+            {
+                **self.flags,
+                "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_USER_IDS": "",
             }
         )
         self.assertFalse(incomplete["effective"])
@@ -308,6 +320,7 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
                 "You are about modular synths, music, and building "
                 "the archive project into something shared."
             ),
+            candidate_generation_latency_ms=125,
             environ=self.flags,
         )
         self.assertTrue(decision.candidate_selected)
@@ -333,6 +346,14 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
         self.assertEqual(report["liveAppliedRuns"], 1)
         self.assertEqual(report["responseSentRuns"], 1)
         self.assertGreater(report["candidateEvidenceCoverageTotal"], 0)
+        self.assertEqual(
+            report["routeFamilyCounts"],
+            {"broad_self_profile": 1},
+        )
+        self.assertEqual(
+            report["candidateGenerationLatencyMs"],
+            {"average": 125, "maximum": 125, "samples": 1},
+        )
         self.assertEqual(report["liveInvalidRevalidationRuns"], 0)
         self.assertEqual(report["liveUngroundedRuns"], 0)
         self.assertEqual(report["relationshipPostureAppliedRuns"], 0)


### PR DESCRIPTION
## Summary

This is the next planned **route-by-route governed memory expansion** after #388. It expands the first route family—explicit broad self-profile recall—without enabling a global memory or Relationship gate.

- Give equivalent first-person profile requests one canonical interpretation across Memory Governance, the unified packet, synthesis, active-channel batching, and direct replies.
- Route the Chris, LostMarbles, WittyFox, and SlayGoat wording variants through the same established normal-generation behavior instead of the competing canned broad-recall shortcut.
- Preserve understand-or-clarify behavior for genuinely ambiguous recall targets.
- Connect the scoped packet synthesis canary to the active-channel batch send path used by all four production cases; #388 previously covered only the direct-send seam.
- Keep baseline-first generation and fail safely to that established answer on candidate generation, coherence, grounding, guard, source revalidation, stale-turn, or Discord-send failure.
- Allow one explicitly configured guild, up to eight members, and up to four public-home/public-context channels for this one route family.
- Record route family and candidate-generation latency alongside the existing packet selection, omission, conflict, fallback, revalidation, and application receipts.

## Regression evidence

The exact production wording family is covered:

- Chris: `hey B? what do you know about me?`
- LostMarbles: `Hey bud what do you know about me`
- WittyFox: `Hey BNL what do you know about me?`
- SlayGoat: `Hey BNL, what am I all about?`
- Real Discord mention residue and a single topical qualifier are covered.
- Mixed, negated, media, exact-quote, third-party, private/sealed, and unsupported routes remain excluded.

## Boundaries

- Memory Governance, Relationship v2, and Active Engagement global live gates remain off.
- Relationship posture is not rendered as factual evidence and Relationship behavior is not changed.
- No queue, Journal, Relay, Source File, dossier, website, deployment, or configuration change.
- No automatic cutover.
- The deterministic Governance wrapper remains intact for routes that are not expanded.

## Validation

- Adjacent memory/packet/Governance/Assessment/batching/synthesis gate: **261 passed**
- Full repository gate: compilation plus **1,611 passed**
