### PR TITLE
Isolate Journal and Relay generation capacity

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -351,6 +351,7 @@ from bnl_gemini_routing import (
     policy_for_route,
     provider_failure_kind,
     provider_status_code,
+    relay_protected_tokens,
     retry_delay_seconds,
     retryable_failure,
     single_attempt_reservation,
@@ -440,6 +441,16 @@ GENERATION_ERROR_LOCAL_MODEL_BUDGET = "local_model_budget_exhausted"
 class LocalModelBudgetExhausted(RuntimeError):
     """Raised when BNL's own daily API-token safety budget is exhausted."""
 
+
+class LocalBudgetReservation(int):
+    """Integer-compatible reservation that remembers its protected lane."""
+
+    def __new__(cls, amount: int, lane: str):
+        instance = int.__new__(cls, int(amount))
+        instance.lane = str(lane or "conversation")
+        return instance
+
+
 PUBLIC_GENERATION_FALLBACK = (
     "BNL-01 received the message, but the upper processing layer is refusing clean output right now. "
     "I’m holding the channel open until the connection stabilizes."
@@ -524,6 +535,9 @@ def _bounded_env_int(
 # Gemini 3 thinking_level. Route policies therefore protect quality with
 # route-specific output allowances and leave Gemini 3 reasoning provider-managed.
 BNL_GEMINI_JOURNAL_PROTECTED_TOKENS = journal_protected_tokens(
+    DAILY_TOKEN_LIMIT
+)
+BNL_GEMINI_RELAY_PROTECTED_TOKENS = relay_protected_tokens(
     DAILY_TOKEN_LIMIT
 )
 PACIFIC_TZ = pytz.timezone("US/Pacific")
@@ -15968,6 +15982,7 @@ def build_dynamic_curiosity_payload(guild_id: int):
 
 _token_budget_reservation_lock = threading.Lock()
 _token_budget_reserved_tokens = 0
+_token_budget_reserved_by_lane: dict[str, int] = {}
 
 
 def _pacific_usage_date() -> str:
@@ -16077,9 +16092,29 @@ def check_quota_availability(route: str = ""):
         result = conn.execute(
             "SELECT tokens_used_today FROM token_usage WHERE id = 1"
         ).fetchone()
+        usage_date = _pacific_usage_date()
+        lane_usage = _generation_lane_usage_on_connection(
+            conn,
+            usage_date,
+        )
     tokens_used = result[0] if result else 0
-    ceiling = budget_ceiling_for_route(DAILY_TOKEN_LIMIT, route)
-    return tokens_used < ceiling
+    with _token_budget_reservation_lock:
+        journal_used = (
+            lane_usage["journal"]
+            + _token_budget_reserved_by_lane.get("journal", 0)
+        )
+        relay_used = (
+            lane_usage["relay"]
+            + _token_budget_reserved_by_lane.get("relay", 0)
+        )
+        ceiling = budget_ceiling_for_route(
+            DAILY_TOKEN_LIMIT,
+            route,
+            journal_used=journal_used,
+            relay_used=relay_used,
+        )
+        projected = tokens_used + _token_budget_reserved_tokens
+    return projected < ceiling
 
 
 def _usage_int(value) -> int:
@@ -16332,15 +16367,63 @@ def _estimated_generation_reservation(
     )
 
 
+def _protected_usage_lane(route: str) -> str:
+    policy = policy_for_route(route)
+    if policy.journal_protected:
+        return "journal"
+    if policy.relay_protected:
+        return "relay"
+    return "ordinary"
+
+
+def _generation_lane_usage_on_connection(
+    conn: sqlite3.Connection,
+    usage_date: str,
+) -> dict[str, int]:
+    _ensure_token_usage_schema(conn.cursor())
+    totals = {"journal": 0, "relay": 0, "ordinary": 0}
+    for route, total in conn.execute(
+        """
+        SELECT route, COALESCE(SUM(total_tokens), 0)
+        FROM token_usage_events
+        WHERE usage_date=?
+        GROUP BY route
+        """,
+        (str(usage_date),),
+    ).fetchall():
+        lane = _protected_usage_lane(str(route or ""))
+        totals[lane] += _usage_int(total)
+    return totals
+
+
 def reserve_local_model_budget(
     contents: str,
     route: str = "",
 ) -> int:
     global _token_budget_reserved_tokens
     reservation = _estimated_generation_reservation(contents, route)
-    ceiling = budget_ceiling_for_route(DAILY_TOKEN_LIMIT, route)
+    lane = _protected_usage_lane(route)
     with _token_budget_reservation_lock:
-        tokens_used, _ = get_usage_stats()
+        tokens_used, usage_date = get_usage_stats()
+        with sqlite3.connect(DB_FILE) as conn:
+            lane_usage = _generation_lane_usage_on_connection(
+                conn,
+                usage_date,
+            )
+        journal_used = (
+            lane_usage["journal"]
+            + _token_budget_reserved_by_lane.get("journal", 0)
+        )
+        relay_used = (
+            lane_usage["relay"]
+            + _token_budget_reserved_by_lane.get("relay", 0)
+        )
+        ceiling = budget_ceiling_for_route(
+            DAILY_TOKEN_LIMIT,
+            route,
+            journal_used=journal_used,
+            relay_used=relay_used,
+        )
         projected_total = (
             tokens_used
             + _token_budget_reserved_tokens
@@ -16351,16 +16434,33 @@ def reserve_local_model_budget(
                 "local_model_budget_exhausted"
             )
         _token_budget_reserved_tokens += reservation
-    return reservation
+        _token_budget_reserved_by_lane[lane] = (
+            _token_budget_reserved_by_lane.get(lane, 0)
+            + reservation
+        )
+    return LocalBudgetReservation(reservation, lane)
 
 
 def release_local_model_budget(reservation: int) -> None:
     global _token_budget_reserved_tokens
+    lane = str(
+        getattr(reservation, "lane", "ordinary")
+        or "ordinary"
+    )
+    amount = _usage_int(reservation)
     with _token_budget_reservation_lock:
         _token_budget_reserved_tokens = max(
             0,
-            _token_budget_reserved_tokens - _usage_int(reservation),
+            _token_budget_reserved_tokens - amount,
         )
+        remaining = max(
+            0,
+            _token_budget_reserved_by_lane.get(lane, 0) - amount,
+        )
+        if remaining:
+            _token_budget_reserved_by_lane[lane] = remaining
+        else:
+            _token_budget_reserved_by_lane.pop(lane, None)
 
 def get_usage_stats():
     check_and_reset_daily_counters()
@@ -16381,6 +16481,10 @@ def get_usage_breakdown() -> dict:
     tokens_used, last_reset = get_usage_stats()
     with sqlite3.connect(DB_FILE) as conn:
         _ensure_token_usage_schema(conn.cursor())
+        lane_usage = _generation_lane_usage_on_connection(
+            conn,
+            last_reset,
+        )
         totals = conn.execute(
             """
             SELECT
@@ -16409,6 +16513,20 @@ def get_usage_breakdown() -> dict:
     ordinary_route_ceiling = budget_ceiling_for_route(
         DAILY_TOKEN_LIMIT,
         "normal_chat",
+        journal_used=lane_usage["journal"],
+        relay_used=lane_usage["relay"],
+    )
+    journal_route_ceiling = budget_ceiling_for_route(
+        DAILY_TOKEN_LIMIT,
+        JOURNAL_ROUTE,
+        journal_used=lane_usage["journal"],
+        relay_used=lane_usage["relay"],
+    )
+    relay_route_ceiling = budget_ceiling_for_route(
+        DAILY_TOKEN_LIMIT,
+        "website_relay_event",
+        journal_used=lane_usage["journal"],
+        relay_used=lane_usage["relay"],
     )
     return {
         "usage_date": last_reset,
@@ -16419,8 +16537,15 @@ def get_usage_breakdown() -> dict:
         ),
         "journal_protected_tokens": max(
             0,
-            DAILY_TOKEN_LIMIT - ordinary_route_ceiling,
+            BNL_GEMINI_JOURNAL_PROTECTED_TOKENS,
         ),
+        "relay_protected_tokens": max(
+            0,
+            BNL_GEMINI_RELAY_PROTECTED_TOKENS,
+        ),
+        "journal_route_ceiling": journal_route_ceiling,
+        "relay_route_ceiling": relay_route_ceiling,
+        "lane_usage": lane_usage,
         "total_tokens": _usage_int(tokens_used),
         "tracked_calls": _usage_int(totals[0] if totals else 0),
         "tracked_total_tokens": tracked_total,

--- a/bnl_gemini_routing.py
+++ b/bnl_gemini_routing.py
@@ -32,6 +32,7 @@ class GeminiRoutePolicy:
     provider_retries: int
     allow_fallback: bool
     journal_protected: bool = False
+    relay_protected: bool = False
 
 
 def _bounded_env_int(
@@ -52,6 +53,16 @@ def journal_protected_tokens(daily_limit: int) -> int:
     configured = _bounded_env_int(
         "BNL_GEMINI_JOURNAL_PROTECTED_TOKENS",
         250_000,
+        minimum=0,
+        maximum=max(0, int(daily_limit)),
+    )
+    return min(configured, max(0, int(daily_limit) // 2))
+
+
+def relay_protected_tokens(daily_limit: int) -> int:
+    configured = _bounded_env_int(
+        "BNL_GEMINI_RELAY_PROTECTED_TOKENS",
+        100_000,
         minimum=0,
         maximum=max(0, int(daily_limit)),
     )
@@ -92,6 +103,11 @@ def _route_lane(route: str) -> str:
 
 def policy_for_route(route: str) -> GeminiRoutePolicy:
     lane = _route_lane(route)
+    normalized_route = re.sub(
+        r"[^a-z0-9_:-]+",
+        "_",
+        str(route or "").lower(),
+    )
     retries = _bounded_env_int(
         "BNL_GEMINI_PROVIDER_RETRIES",
         1,
@@ -113,7 +129,15 @@ def policy_for_route(route: str) -> GeminiRoutePolicy:
                 minimum=0,
                 maximum=24_576,
             ),
-            provider_retries=retries,
+            # The Journal already has four validator-guided generation
+            # attempts. Retrying each provider call underneath that loop
+            # multiplies shared-project pressure without adding a new repair.
+            provider_retries=_bounded_env_int(
+                "BNL_GEMINI_JOURNAL_PROVIDER_RETRIES",
+                0,
+                minimum=0,
+                maximum=1,
+            ),
             allow_fallback=False,
             journal_protected=True,
         )
@@ -152,6 +176,7 @@ def policy_for_route(route: str) -> GeminiRoutePolicy:
             ),
             provider_retries=retries,
             allow_fallback=True,
+            relay_protected="relay" in normalized_route,
         )
     return GeminiRoutePolicy(
         lane=lane,
@@ -186,11 +211,38 @@ def estimated_generation_reservation(
     return single_attempt_reservation(contents, policy) * model_count * attempts_per_model
 
 
-def budget_ceiling_for_route(daily_limit: int, route: str) -> int:
+def budget_ceiling_for_route(
+    daily_limit: int,
+    route: str,
+    *,
+    journal_used: int = 0,
+    relay_used: int = 0,
+) -> int:
+    """Return the shared-total ceiling while preserving unused protected lanes.
+
+    The reserves are mutual rather than one-way. A Journal call leaves only the
+    *unused* Relay reserve untouched, a Relay call leaves only the unused
+    Journal reserve untouched, and ordinary calls leave both. Once a protected
+    lane has used its own reserve, those tokens no longer need to be held back
+    from the other lane.
+    """
+    limit = max(0, int(daily_limit))
     policy = policy_for_route(route)
+    journal_remaining = max(
+        0,
+        journal_protected_tokens(limit) - max(0, int(journal_used)),
+    )
+    relay_remaining = max(
+        0,
+        relay_protected_tokens(limit) - max(0, int(relay_used)),
+    )
     if policy.journal_protected:
-        return max(0, int(daily_limit))
-    return max(0, int(daily_limit) - journal_protected_tokens(daily_limit))
+        protected_remaining = relay_remaining
+    elif policy.relay_protected:
+        protected_remaining = journal_remaining
+    else:
+        protected_remaining = journal_remaining + relay_remaining
+    return max(0, limit - min(limit, protected_remaining))
 
 
 def provider_status_code(exc: Exception | None) -> int:

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -51,6 +51,10 @@ MAX_RUMOR_CONTEXT = 4
 MAX_REFLECTION_SOURCE_CONTEXT = 8
 MAX_REFLECTION_MEMORY_CONTEXT = 4
 MAX_REFLECTION_CANON_CONTEXT = 4
+SOURCE_HEALTH_BASELINE_WINDOWS = 3
+SOURCE_HEALTH_MIN_BASELINE_WINDOWS = 2
+SOURCE_HEALTH_RELAY_RATIO_PERCENT = 65
+SOURCE_HEALTH_MIN_CURRENT_CONVERSATIONS = 12
 JOURNAL_PUBLIC_BROADCAST_SCOPES = {"ambient", "direct", "journal", "relay", "show_status"}
 JOURNAL_CONTEXT_LANE_TYPES = {
     "established_broadcast_memory",
@@ -2169,7 +2173,7 @@ def _minimum_fresh_sources_for_entry(entry_kind: str, total: int) -> int:
     if entry_kind == "weekly":
         return min(total, 14)
     if entry_kind == "daily":
-        return min(total, 10)
+        return min(total, max(10, (total + 9) // 10))
     return min(total, 8)
 
 
@@ -2241,13 +2245,187 @@ def build_evidence_coverage_contract(
     else:
         target_segments = 1
 
-    return {
-        "minimumDistinctFreshSources": _minimum_fresh_sources_for_entry(entry_kind, total),
+    minimum_sources = _minimum_fresh_sources_for_entry(
+        entry_kind,
+        total,
+    )
+    contract = {
+        "minimumDistinctFreshSources": minimum_sources,
         "requiredSourceKinds": required_kinds,
         "minimumDistinctParticipants": required_participants,
         "minimumDistinctWindowSegments": min(target_segments, len(available_segments)),
         "segmentBySourceRef": segment_by_ref,
     }
+    if total >= 75 and entry_kind in {"daily", "weekly"}:
+        contract["minimumDistinctFreshSourcesByKind"] = {
+            kind: min(
+                kind_counts[kind],
+                max(
+                    1,
+                    (
+                        minimum_sources * kind_counts[kind]
+                        + total
+                        - 1
+                    )
+                    // total,
+                ),
+            )
+            for kind in required_kinds
+        }
+    return contract
+
+
+def _median_int(values: list[int]) -> int:
+    ordered = sorted(max(0, int(value)) for value in values)
+    if not ordered:
+        return 0
+    midpoint = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[midpoint]
+    return (ordered[midpoint - 1] + ordered[midpoint]) // 2
+
+
+def _relay_source_health(
+    db_path: str,
+    guild_id: int,
+    start: str,
+    end: str,
+    *,
+    entry_kind: str,
+    relay_count: int,
+    conversation_count: int,
+) -> dict[str, Any]:
+    """Detect a current Relay collapse against fully covered recent windows."""
+    health = {
+        "status": "not_evaluated",
+        "reason": "",
+        "currentRelaySources": max(0, int(relay_count)),
+        "currentConversationSources": max(
+            0,
+            int(conversation_count),
+        ),
+        "baselineRelayCounts": [],
+        "baselineMedianRelaySources": 0,
+        "minimumHealthyRelaySources": 0,
+        "relayAttemptCount": 0,
+        "relayFailedAttemptCount": 0,
+    }
+    if entry_kind != "daily":
+        health["reason"] = "daily_only_contract"
+        return health
+    if conversation_count < SOURCE_HEALTH_MIN_CURRENT_CONVERSATIONS:
+        health["status"] = "sparse_window"
+        health["reason"] = "insufficient_current_activity_for_comparison"
+        return health
+
+    start_ms = timestamp_to_epoch_ms(start)
+    end_ms = timestamp_to_epoch_ms(end)
+    if start_ms is None or end_ms is None or end_ms <= start_ms:
+        health["status"] = "unobserved"
+        health["reason"] = "invalid_source_window"
+        return health
+    duration_ms = end_ms - start_ms
+
+    try:
+        with sqlite3.connect(db_path) as conn:
+            if not table_exists(conn, "bnl_journal_source_events"):
+                health["status"] = "unobserved"
+                health["reason"] = "source_archive_unavailable"
+                return health
+            activation = conn.execute(
+                "SELECT activated_at_ms "
+                "FROM bnl_journal_source_archive_state "
+                "WHERE guild_id=?",
+                (int(guild_id),),
+            ).fetchone()
+            activated_at_ms = (
+                int(activation[0])
+                if activation and activation[0] is not None
+                else None
+            )
+            baseline_counts: list[int] = []
+            for offset in range(
+                1,
+                SOURCE_HEALTH_BASELINE_WINDOWS + 1,
+            ):
+                prior_end = start_ms - duration_ms * (offset - 1)
+                prior_start = prior_end - duration_ms
+                if (
+                    activated_at_ms is None
+                    or prior_start < activated_at_ms
+                ):
+                    continue
+                row = conn.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM bnl_journal_source_events
+                    WHERE guild_id=?
+                      AND source_kind='website_relay'
+                      AND public_usable=1
+                      AND sanitized_summary<>''
+                      AND occurred_at_ms>=?
+                      AND occurred_at_ms<?
+                    """,
+                    (int(guild_id), prior_start, prior_end),
+                ).fetchone()
+                baseline_counts.append(int((row or [0])[0] or 0))
+            health["baselineRelayCounts"] = baseline_counts
+
+            if table_exists(conn, "website_relay_attempts"):
+                attempts = conn.execute(
+                    """
+                    SELECT
+                        COUNT(*),
+                        COALESCE(SUM(
+                            CASE
+                                WHEN outcome='provider_failed'
+                                  OR reason IN (
+                                      'provider_failure',
+                                      'relay_generation_timeout',
+                                      'local_model_budget_exhausted'
+                                  )
+                                THEN 1 ELSE 0
+                            END
+                        ),0)
+                    FROM website_relay_attempts
+                    WHERE guild_id=? AND started_at>=? AND started_at<?
+                    """,
+                    (int(guild_id), start, end),
+                ).fetchone()
+                health["relayAttemptCount"] = int(
+                    (attempts or [0, 0])[0] or 0
+                )
+                health["relayFailedAttemptCount"] = int(
+                    (attempts or [0, 0])[1] or 0
+                )
+    except sqlite3.Error:
+        health["status"] = "unobserved"
+        health["reason"] = "source_health_query_failed"
+        return health
+
+    baseline_counts = list(health["baselineRelayCounts"])
+    if len(baseline_counts) < SOURCE_HEALTH_MIN_BASELINE_WINDOWS:
+        health["status"] = "insufficient_history"
+        health["reason"] = "comparable_windows_unavailable"
+        return health
+    median_count = _median_int(baseline_counts)
+    minimum_healthy = max(
+        1,
+        (
+            median_count * SOURCE_HEALTH_RELAY_RATIO_PERCENT
+            + 99
+        )
+        // 100,
+    )
+    health["baselineMedianRelaySources"] = median_count
+    health["minimumHealthyRelaySources"] = minimum_healthy
+    if relay_count < minimum_healthy:
+        health["status"] = "degraded"
+        health["reason"] = "relay_source_supply_below_recent_baseline"
+    else:
+        health["status"] = "healthy"
+        health["reason"] = "relay_source_supply_within_recent_baseline"
+    return health
 
 
 def _count_legacy_sources(conn: sqlite3.Connection, guild_id: int, start: str, end: str) -> tuple[int, int]:
@@ -2533,17 +2711,30 @@ def build_packet_from_sources(
         end,
         safe_sources,
     )
-    if (
+    source_health = _relay_source_health(
+        db_path,
+        guild_id,
+        start,
+        end,
+        entry_kind=packet["entryKind"],
+        relay_count=len(relays),
+        conversation_count=len(conversations),
+    )
+    packet["sourceHealth"] = source_health
+    source_recovery = source_health.get("status") == "degraded"
+    if source_recovery:
+        packet["sourceRecoveryMode"] = True
+    low_activity = (
         packet["entryKind"] in {"daily", "weekly"}
         and not journal_source_packet_has_meaningful_activity(packet)
-    ):
+    )
+    if low_activity or source_recovery:
         reflection_basis, private_reflection_provenance = _build_reflection_basis(
             db_path,
             guild_id,
             start,
             end,
         )
-        packet["lowActivityMode"] = True
         packet["reflectionBasis"] = reflection_basis
         packet["reflectionBasisContract"] = {
             "version": 1,
@@ -2555,6 +2746,8 @@ def build_packet_from_sources(
         packet["privateReflectionBasisProvenance"] = (
             private_reflection_provenance
         )
+    if low_activity:
+        packet["lowActivityMode"] = True
         packet["evidenceCoverageContract"] = {
             **packet["evidenceCoverageContract"],
             "minimumDistinctFreshSources": 0,
@@ -2788,6 +2981,8 @@ def _eligible_reflection_basis(packet: dict[str, Any]) -> list[dict[str, Any]]:
 def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", previous_output: str = "") -> str:
     entry_kind = str(packet.get("entryKind") or "manual")
     low_activity = bool(packet.get("lowActivityMode"))
+    source_recovery = bool(packet.get("sourceRecoveryMode"))
+    historical_basis_mode = low_activity or source_recovery
     context_lanes = packet.get("generationContextLanes") if isinstance(packet.get("generationContextLanes"), dict) else {}
     safe_sources = packet.get("safeSources", [])[:MAX_PROMPT_SOURCES]
     reflection_basis = _eligible_reflection_basis(packet)
@@ -2817,12 +3012,15 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
         "windowSegmentActivity": packet.get("windowSegmentActivity", []),
         "privateGenerationContextLanes": context_lanes,
     }
-    if low_activity:
+    if source_recovery:
+        safe_packet["sourceRecoveryMode"] = True
+    if historical_basis_mode:
         safe_packet["reflectionBasis"] = reflection_basis
         safe_packet["reflectionBasisContract"] = packet.get(
             "reflectionBasisContract",
             {},
         )
+    if low_activity:
         safe_packet["editorialContract"] = {
             "requiresFirstPersonReaction": False,
             "requiredBeatsAcrossEntry": [
@@ -2840,6 +3038,10 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
     elif low_activity:
         cadence_rule = (
             "\nThis is a daily Journal entry covering one complete source window. Low activity does not cancel the entry and does not authorize a claim that something happened in that window. Build a coherent grounded reflection from the supplied basis, using current-window material only when a fresh sourceRefId supports it."
+        )
+    elif source_recovery:
+        cadence_rule = (
+            "\nThis is a daily Journal entry covering one complete source window, but the Relay supply is materially below recent fully observed windows. Treat the supplied fresh evidence as real but not as a complete Relay chronology. Build the current story from what the fresh sources actually establish, using reflectionBasis only for clearly historical continuity. Never mention source health, capacity, retries, providers, or an internal pipeline in public prose."
         )
     else:
         cadence_rule = (
@@ -2880,12 +3082,20 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
     daily_spine_rule = (
         "\nFor a low-activity daily entry, do not manufacture a relay chronology or Discord digest. A reflection may connect eligible historical, canon, or continuity material, but every claim about activity inside the current window must cite a fresh sourceRefId from that window."
         if low_activity
-        else "\nFor a daily entry, the relay stream is the primary chronology and narrative spine. Conversation sources are supporting public context: use them to ground or explain the context surrounding the relays, and do not turn the Journal into a Discord digest. When relay and conversation sources describe the same episode, connect them instead of presenting them as unrelated events."
+        else (
+            "\nFor this source-recovery daily entry, do not treat the Relay stream as a complete chronology or claim it represents the whole day. Relay and conversation sources are coequal fresh evidence. Connect them when they support the same episode, and write a selective, honest chronicle without turning it into a Discord digest."
+            if source_recovery
+            else "\nFor a daily entry, the relay stream is the primary chronology and narrative spine. Conversation sources are supporting public context: use them to ground or explain the context surrounding the relays, and do not turn the Journal into a Discord digest. When relay and conversation sources describe the same episode, connect them instead of presenting them as unrelated events."
+        )
     )
     window_rule = (
         "\nTreat windowSegmentActivity and aggregate counts as coverage metadata, not an event. Do not convert absence, thin counts, or quiet markers into a scene or a claim that the community moved."
         if low_activity
-        else "\nKeep the whole daily source window in view. Use both relaySources and conversationSources in windowSegmentActivity: relaySources shows the relay arc and conversationSources shows its public context. The busiest or strongest stretch may lead, but give meaningful earlier and middle activity proportionate narrative attention. Do not make a multi-segment day sound as though it began with the latest cluster."
+        else (
+            "\nKeep the whole daily source window in view without implying that thin Relay coverage proves quiet activity. Use windowSegmentActivity only to distribute the fresh evidence honestly across the window; it is coverage metadata, not an event."
+            if source_recovery
+            else "\nKeep the whole daily source window in view. Use both relaySources and conversationSources in windowSegmentActivity: relaySources shows the relay arc and conversationSources shows its public context. The busiest or strongest stretch may lead, but give meaningful earlier and middle activity proportionate narrative attention. Do not make a multi-segment day sound as though it began with the latest cluster."
+        )
     )
     people_rule = (
         "\nKeep historical community members anonymous. Use a role such as producer, listener, or artist only when the cited reflection basis establishes it. Named approved-canon subjects may retain their supplied canon names. Never invent nicknames, honorifics, or a person acting in the current window."
@@ -2895,12 +3105,20 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
     coverage_rule = (
         "\nThe evidenceCoverageContract remains mandatory for fresh evidence. Reflection-basis refs never count as fresh sources, current participants, current source kinds, or current-window segments. Every cited fresh or reflection ref must materially support its section."
         if low_activity
-        else "\nThe evidenceCoverageContract is mandatory. Across all section sourceRefIds, meet its minimum distinct fresh sources, participants, source kinds, and available window segments. Every cited ref must materially support that section. Use this breadth to identify a few connected patterns rather than listing sources."
+        else (
+            "\nThe evidenceCoverageContract is mandatory and remains entirely fresh-evidence based. Meet its total and per-kind minimums, participant breadth, and window-segment breadth. Reflection-basis refs may add historical continuity but never count toward those minimums or prove current activity."
+            if source_recovery
+            else "\nThe evidenceCoverageContract is mandatory. Across all section sourceRefIds, meet its minimum distinct fresh sources, participants, source kinds, and available window segments. Every cited ref must materially support that section. Use this breadth to identify a few connected patterns rather than listing sources."
+        )
     )
     section_source_rule = (
         "\nEvery section must cite at least one supplied fresh or reflection sourceRefId. A purely reflective section may cite reflectionBasis refs. A section that says or implies something happened today, tonight, this day, this week, or in the current window must cite at least one fresh sourceRefId in that same section. Reflection basis is historical-or-canon only and is never proof of current activity."
         if low_activity
-        else "\nEvery section must cite at least one fresh sourceRefId from the current window. Older Journal material is continuity and callback context only, never proof of current activity. Do not repeat an older conclusion when the current evidence changes it."
+        else (
+            "\nEvery section must cite at least one fresh sourceRefId from the current window. Reflection refs may supplement a section only as explicitly historical continuity and never replace its fresh evidence."
+            if source_recovery
+            else "\nEvery section must cite at least one fresh sourceRefId from the current window. Older Journal material is continuity and callback context only, never proof of current activity. Do not repeat an older conclusion when the current evidence changes it."
+        )
     )
     quote_rule = (
         "\nParaphrase reflection summaries. Do not turn a historical summary into dialogue or a quote. Use a direct quote only from an unusually valuable fresh public-safe source, cite it in that section, and keep the speaker anonymous."
@@ -2910,7 +3128,11 @@ def build_generation_prompt(packet: dict[str, Any], *, repair_reason: str = "", 
     reflection_rule = (
         "\nLOW-ACTIVITY EVIDENCE RULE: This is the same Journal voice, prose standard, validator, and four-attempt generation path—not a fallback persona or a stock nothing-happened template. Use only supplied reflectionBasis records. Their stable reflection: refs are valid citations but never fresh evidence. Keep historical and canon tense explicit, preserve corrected canon, and never describe 6 Bit as BARCODE's music producer; the supplied corrected canon identifies GALAKNOISE as the producer."
         if low_activity
-        else ""
+        else (
+            "\nSOURCE-RECOVERY EVIDENCE RULE: This is the normal Journal voice, validator, and four-attempt generation path. The recovery flag changes evidence handling, not quality. Use reflectionBasis only as explicitly historical continuity; never use it to fill a missing current chronology, and never disclose the recovery condition publicly."
+            if source_recovery
+            else ""
+        )
     )
     return (
         "You are BNL-01 writing a BARCODE Network Journal entry. Return strict JSON only; no markdown fences."
@@ -3093,6 +3315,17 @@ def _evidence_coverage_reason(article: dict[str, Any], packet: dict[str, Any]) -
     cited_kinds = {str(source.get("sourceKind") or "") for source in cited_sources}
     if not set(str(kind) for kind in contract.get("requiredSourceKinds", []) if str(kind)) <= cited_kinds:
         return "insufficient_source_breadth"
+    minimum_by_kind = contract.get("minimumDistinctFreshSourcesByKind")
+    if not isinstance(minimum_by_kind, dict):
+        minimum_by_kind = {}
+    for kind, minimum in minimum_by_kind.items():
+        cited_kind_count = sum(
+            1
+            for source in cited_sources
+            if str(source.get("sourceKind") or "") == str(kind)
+        )
+        if cited_kind_count < int(minimum or 0):
+            return "insufficient_source_breadth"
 
     cited_participants = {
         str(source.get("participantAlias") or "")
@@ -3124,6 +3357,8 @@ def validate_article(
     blocking_only: bool = False,
 ) -> str:
     low_activity = bool(packet.get("lowActivityMode"))
+    source_recovery = bool(packet.get("sourceRecoveryMode"))
+    historical_basis_mode = low_activity or source_recovery
     sections = article.get("sections")
     if not isinstance(sections, list) or not (1 <= len(sections) <= 3):
         return "invalid_section_count"
@@ -3160,8 +3395,13 @@ def validate_article(
         if not refs or any(str(r) not in valid_refs for r in refs):
             return "invalid_section_source_refs"
         if (
-            low_activity
+            historical_basis_mode
             and _CURRENT_WINDOW_CLAIM_RE.search(str(section.get("body") or ""))
+            and not ({str(ref) for ref in refs} & fresh_refs)
+        ):
+            return "current_activity_without_fresh_source"
+        if (
+            source_recovery
             and not ({str(ref) for ref in refs} & fresh_refs)
         ):
             return "current_activity_without_fresh_source"
@@ -3174,7 +3414,7 @@ def validate_article(
         ):
             return "reflection_scope_not_explicit"
     if (
-        low_activity
+        historical_basis_mode
         and _CURRENT_WINDOW_CLAIM_RE.search(
             "\n".join(
                 [
@@ -3588,6 +3828,8 @@ def _draft_records(
         "usedGenerationContextLanes": used_context_lanes,
         "usedContextLaneProvenance": used_context_provenance,
         "lowActivityMode": bool(packet.get("lowActivityMode")),
+        "sourceRecoveryMode": bool(packet.get("sourceRecoveryMode")),
+        "sourceHealth": dict(packet.get("sourceHealth") or {}),
         "reflectionBasisCandidateCounts": {
             kind: len(
                 [

--- a/bnl_journal_automation.py
+++ b/bnl_journal_automation.py
@@ -41,6 +41,8 @@ LEASE_MINUTES = 30
 DELIVERY_LEASE_MINUTES = 2
 PREPARATION_RETRY_MINUTES = 30
 DELIVERY_RETRY_MINUTES = 15
+MAX_AUTOMATIC_GENERATION_CYCLES = 4
+GENERATION_CYCLE_WINDOW_HOURS = 24
 TERMINAL_RUN_STATES = {"published", "quiet", "incomplete", "superseded"}
 DELIVERY_PREFLIGHT_INVALIDATION_REASONS = frozenset({
     "prepared_revision_missing",
@@ -1250,6 +1252,39 @@ def _record_generation_attempt_event(
         conn.commit()
 
 
+def _generation_cycle_retry_at_on_connection(
+    conn: sqlite3.Connection,
+    run_id: str,
+    now: datetime,
+) -> str:
+    """Bound automatic full-quality cycles without abandoning the occurrence."""
+    cutoff = _utc_iso(
+        now.astimezone(timezone.utc)
+        - timedelta(hours=GENERATION_CYCLE_WINDOW_HOURS)
+    )
+    rows = conn.execute(
+        """
+        SELECT p.started_at
+        FROM bnl_journal_preparation_attempts p
+        WHERE p.run_id=? AND p.started_at>?
+          AND EXISTS (
+              SELECT 1
+              FROM bnl_journal_generation_attempts g
+              WHERE g.run_id=p.run_id
+                AND g.preparation_epoch=p.preparation_epoch
+          )
+        ORDER BY p.started_at ASC,p.preparation_epoch ASC
+        """,
+        (run_id, cutoff),
+    ).fetchall()
+    if len(rows) < MAX_AUTOMATIC_GENERATION_CYCLES:
+        return ""
+    return _utc_iso(
+        _parse_utc(str(rows[0][0]))
+        + timedelta(hours=GENERATION_CYCLE_WINDOW_HOURS)
+    )
+
+
 def _claim_preparation(
     db_path: str,
     guild_id: int,
@@ -1310,6 +1345,26 @@ def _claim_preparation(
                     preparation_epoch=int(current.get("preparation_epoch") or 0),
                     now=now_iso,
                 )
+            if not force:
+                generation_retry_at = (
+                    _generation_cycle_retry_at_on_connection(
+                        conn,
+                        run_id,
+                        now,
+                    )
+                )
+                if generation_retry_at and _parse_utc(
+                    generation_retry_at
+                ) > now:
+                    current["retry_at"] = generation_retry_at
+                    current["reason"] = "generation_cycle_limit"
+                    conn.commit()
+                    return (
+                        "generation_backoff",
+                        run_id,
+                        int(current.get("preparation_epoch") or 0),
+                        current,
+                    )
             epoch = int(current.get("preparation_epoch") or 0) + 1
             conn.execute("""UPDATE bnl_journal_automation_runs
                 SET lifecycle_state='preparing',reason='',attempt_count=attempt_count+1,
@@ -1429,6 +1484,12 @@ def _result_from_existing(cadence: str, row: dict[str, Any], *, claim: str = "co
     elif claim == "backoff":
         status = "backoff"
         reason = "retry_after_" + str(row.get("retry_at") or "later")
+    elif claim == "generation_backoff":
+        status = "backoff"
+        reason = (
+            "generation_cycle_limit_until_"
+            + str(row.get("retry_at") or "later")
+        )
     elif claim == "prepared":
         status = "prepared"
         reason = "prepared_waiting_release"
@@ -4128,6 +4189,15 @@ def _run_recovery_ready(
     lifecycle = str(row.get("lifecycle_state") or "")
     if lifecycle in TERMINAL_RUN_STATES:
         return False
+    generation_retry_at = str(
+        row.get("generation_retry_at") or ""
+    )
+    if (
+        lifecycle in {"held", "deferred"}
+        and generation_retry_at
+        and _parse_utc(generation_retry_at) > now
+    ):
+        return False
     if lifecycle in {"running", "preparing"}:
         lease = str(row.get("lease_expires_at") or "")
         return not lease or _parse_utc(lease) <= now
@@ -4171,20 +4241,32 @@ def _pending_daily_day(db_path: str, guild_id: int, now_utc: Optional[datetime])
     latest = _latest_daily_day(now_utc)
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
-        rows = {
-            (
-                str(row["cadence"]),
-                str(row["source_window_start"]),
-                str(row["source_window_end"]),
-            ): dict(row)
-            for row in conn.execute(
-                "SELECT * "
-                "FROM bnl_journal_automation_runs "
-                "WHERE guild_id=? AND cadence='daily' "
-                "AND COALESCE(schedule_contract_version,1)=?",
-                (guild_id, CADENCE_CONTRACT_VERSION),
-            ).fetchall()
-        }
+        rows = {}
+        now = (now_utc or datetime.now(timezone.utc)).astimezone(
+            timezone.utc
+        )
+        for row in conn.execute(
+            "SELECT * "
+            "FROM bnl_journal_automation_runs "
+            "WHERE guild_id=? AND cadence='daily' "
+            "AND COALESCE(schedule_contract_version,1)=?",
+            (guild_id, CADENCE_CONTRACT_VERSION),
+        ).fetchall():
+            current = dict(row)
+            current["generation_retry_at"] = (
+                _generation_cycle_retry_at_on_connection(
+                    conn,
+                    str(current.get("run_id") or ""),
+                    now,
+                )
+            )
+            rows[
+                (
+                    str(row["cadence"]),
+                    str(row["source_window_start"]),
+                    str(row["source_window_end"]),
+                )
+            ] = current
     candidates: list[tuple[date, str, Optional[dict[str, Any]]]] = []
     if first <= latest:
         current = latest
@@ -4255,19 +4337,31 @@ def _pending_week_monday(db_path: str, guild_id: int, now_utc: Optional[datetime
     latest = _latest_week_monday(now_utc)
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
-        rows = {
-            (
-                str(row["source_window_start"]),
-                str(row["source_window_end"]),
-            ): dict(row)
-            for row in conn.execute(
-                "SELECT * "
-                "FROM bnl_journal_automation_runs "
-                "WHERE guild_id=? AND cadence='weekly' "
-                "AND COALESCE(schedule_contract_version,1)=?",
-                (guild_id, CADENCE_CONTRACT_VERSION),
-            ).fetchall()
-        }
+        rows = {}
+        now = (now_utc or datetime.now(timezone.utc)).astimezone(
+            timezone.utc
+        )
+        for row in conn.execute(
+            "SELECT * "
+            "FROM bnl_journal_automation_runs "
+            "WHERE guild_id=? AND cadence='weekly' "
+            "AND COALESCE(schedule_contract_version,1)=?",
+            (guild_id, CADENCE_CONTRACT_VERSION),
+        ).fetchall():
+            current = dict(row)
+            current["generation_retry_at"] = (
+                _generation_cycle_retry_at_on_connection(
+                    conn,
+                    str(current.get("run_id") or ""),
+                    now,
+                )
+            )
+            rows[
+                (
+                    str(row["source_window_start"]),
+                    str(row["source_window_end"]),
+                )
+            ] = current
     candidates: list[tuple[date, str, Optional[dict[str, Any]]]] = []
     if first_monday <= latest:
         current = latest
@@ -4323,15 +4417,25 @@ def _pending_legacy_run(
     ensure_cadence_activation(db_path, guild_id, now_utc=now_utc)
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
-        rows = [
-            dict(row)
-            for row in conn.execute(
-                "SELECT * FROM bnl_journal_automation_runs "
-                "WHERE guild_id=? AND COALESCE(schedule_contract_version,1)=? "
-                "ORDER BY source_window_end DESC,created_at DESC",
-                (int(guild_id), LEGACY_CADENCE_CONTRACT_VERSION),
-            ).fetchall()
-        ]
+        now = (now_utc or datetime.now(timezone.utc)).astimezone(
+            timezone.utc
+        )
+        rows = []
+        for row in conn.execute(
+            "SELECT * FROM bnl_journal_automation_runs "
+            "WHERE guild_id=? AND COALESCE(schedule_contract_version,1)=? "
+            "ORDER BY source_window_end DESC,created_at DESC",
+            (int(guild_id), LEGACY_CADENCE_CONTRACT_VERSION),
+        ).fetchall():
+            current = dict(row)
+            current["generation_retry_at"] = (
+                _generation_cycle_retry_at_on_connection(
+                    conn,
+                    str(current.get("run_id") or ""),
+                    now,
+                )
+            )
+            rows.append(current)
     candidates: list[dict[str, Any]] = []
     for row in rows:
         if str(row.get("lifecycle_state") or "") in TERMINAL_RUN_STATES:

--- a/tests/test_async_relay_offload.py
+++ b/tests/test_async_relay_offload.py
@@ -166,7 +166,7 @@ class GeminiOffloadTests(unittest.IsolatedAsyncioTestCase):
                     bnl01_bot.JOURNAL_ROUTE,
                 )
 
-        self.assertEqual(len(calls), 2)
+        self.assertEqual(len(calls), 1)
         self.assertTrue(
             all(
                 model

--- a/tests/test_bnl_journal_automation.py
+++ b/tests/test_bnl_journal_automation.py
@@ -497,6 +497,133 @@ class JournalAutomationTests(unittest.TestCase):
             ),
         )
 
+    def test_generation_cycle_cap_yields_to_a_new_missing_day(self):
+        self.add_day("2026-07-18")
+        self.add_day("2026-07-20")
+        self.set_archive_activation("2026-07-18T01:30:00Z")
+        automation.ensure_cadence_activation(
+            self.db,
+            1,
+            now_utc=datetime(2026, 7, 21, 1, 0, tzinfo=timezone.utc),
+        )
+
+        held = automation.run_daily(
+            self.db,
+            1,
+            lambda _packet, _prompt: (_ for _ in ()).throw(
+                RuntimeError("provider down")
+            ),
+            "https://site.example",
+            "key",
+            target_day=date(2026, 7, 18),
+            now_utc=datetime(2026, 7, 22, 1, 0, tzinfo=timezone.utc),
+            force=True,
+            opener=self.opener,
+        )
+        self.assertEqual("held", held.status)
+
+        with sqlite3.connect(self.db) as conn:
+            run = conn.execute(
+                "SELECT run_id,source_window_start,source_window_end "
+                "FROM bnl_journal_automation_runs "
+                "WHERE source_window_start=?",
+                (held.source_window_start,),
+            ).fetchone()
+            self.assertIsNotNone(run)
+            run_id, source_start, source_end = run
+            for epoch in range(
+                2,
+                automation.MAX_AUTOMATIC_GENERATION_CYCLES + 1,
+            ):
+                started_at = automation._utc_iso(
+                    datetime(
+                        2026,
+                        7,
+                        22,
+                        1,
+                        epoch * 5,
+                        tzinfo=timezone.utc,
+                    )
+                )
+                automation._start_preparation_attempt_on_connection(
+                    conn,
+                    run_id=run_id,
+                    preparation_epoch=epoch,
+                    guild_id=1,
+                    cadence="daily",
+                    start=source_start,
+                    end=source_end,
+                    lease_expires_at=automation._utc_iso(
+                        automation._parse_utc(started_at)
+                        + timedelta(minutes=30)
+                    ),
+                    now=started_at,
+                )
+                conn.execute(
+                    """
+                    INSERT INTO bnl_journal_generation_attempts(
+                        run_id,preparation_epoch,generation_attempt,
+                        started_at,finished_at,outcome,
+                        outcome_reason,created_at,updated_at
+                    ) VALUES(?,?,?,?,?,'provider_failure',
+                             'provider down',?,?)
+                    """,
+                    (
+                        run_id,
+                        epoch,
+                        1,
+                        started_at,
+                        started_at,
+                        started_at,
+                        started_at,
+                    ),
+                )
+                automation._finish_preparation_attempt_on_connection(
+                    conn,
+                    run_id=run_id,
+                    preparation_epoch=epoch,
+                    result_status="held",
+                    result_reason="provider_failure",
+                    finished_at=started_at,
+                )
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs "
+                "SET updated_at='2026-07-22T01:00:00Z' "
+                "WHERE run_id=?",
+                (run_id,),
+            )
+
+        results = automation.run_scheduled(
+            self.db,
+            1,
+            lambda packet, _prompt: article_json(packet),
+            "https://site.example",
+            "key",
+            {
+                "journalAutoPublishEnabled": True,
+                "journalDailyEnabled": True,
+                "journalWeeklyEnabled": False,
+            },
+            now_utc=datetime(2026, 7, 22, 3, 0, tzinfo=timezone.utc),
+            opener=self.opener,
+        )
+
+        self.assertEqual(1, len(results))
+        self.assertEqual("published", results[0].status)
+        expected_start, expected_end, _ = automation._daily_period_for_day(
+            date(2026, 7, 20)
+        )
+        self.assertEqual(expected_start, results[0].source_window_start)
+        self.assertEqual(expected_end, results[0].source_window_end)
+        self.assertEqual(
+            date(2026, 7, 18),
+            automation._pending_daily_day(
+                self.db,
+                1,
+                datetime(2026, 7, 22, 3, 0, tzinfo=timezone.utc),
+            ),
+        )
+
     def test_saved_delivery_runs_before_retry_ready_preparation_backlog(self):
         self.add_day("2026-07-18")
         self.add_day("2026-07-20")

--- a/tests/test_bnl_journal_evidence_voice.py
+++ b/tests/test_bnl_journal_evidence_voice.py
@@ -1,9 +1,11 @@
 import json
+import sqlite3
 import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
 
 import bnl_journal as journal
+import bnl_journal_source_store as source_store
 
 
 def _article(
@@ -83,6 +85,7 @@ class JournalEvidenceVoiceTests(unittest.TestCase):
         contract = self.packet["evidenceCoverageContract"]
         self.assertEqual(5, contract["minimumDistinctFreshSources"])
         self.assertEqual(["conversation", "relay"], contract["requiredSourceKinds"])
+        self.assertNotIn("minimumDistinctFreshSourcesByKind", contract)
         self.assertEqual(3, contract["minimumDistinctParticipants"])
         self.assertEqual(3, contract["minimumDistinctWindowSegments"])
 
@@ -107,6 +110,155 @@ class JournalEvidenceVoiceTests(unittest.TestCase):
         self.assertIn("Use both relaySources and conversationSources", prompt)
         self.assertIn("windowSegmentActivity", prompt)
         self.assertNotIn("Do not include direct quotes", prompt)
+
+    def test_degraded_relay_window_enters_source_recovery_and_rejects_thin_citations(self):
+        source_store.ensure_schema(self.db)
+        current_start = datetime(2026, 7, 23, 7, tzinfo=timezone.utc)
+        current_end = current_start + timedelta(days=1)
+        baseline_counts = (50, 60, 69)
+        oldest_start = current_start - timedelta(days=len(baseline_counts))
+
+        with sqlite3.connect(self.db) as conn:
+            oldest_ms = int(oldest_start.timestamp() * 1000)
+            conn.execute(
+                """
+                INSERT INTO bnl_journal_source_archive_state(
+                    guild_id,activated_at_ms,created_at_ms
+                ) VALUES(?,?,?)
+                ON CONFLICT(guild_id) DO UPDATE
+                SET activated_at_ms=excluded.activated_at_ms
+                """,
+                (1, oldest_ms, oldest_ms),
+            )
+            for window_offset, count in enumerate(
+                baseline_counts,
+                1,
+            ):
+                window_start = (
+                    current_start - timedelta(days=window_offset)
+                )
+                for index in range(count):
+                    occurred = window_start + timedelta(
+                        seconds=(index + 1) * 86_400 / (count + 1)
+                    )
+                    key = f"baseline-{window_offset}-{index}"
+                    conn.execute(
+                        """
+                        INSERT INTO bnl_journal_source_events(
+                            guild_id,source_kind,source_key,
+                            occurred_at_ms,ingested_at_ms,
+                            channel_id,channel_policy,subject_ref,
+                            private_display_name,raw_text,
+                            sanitized_summary,content_hash,
+                            public_usable,metadata_json
+                        ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                        """,
+                        (
+                            1,
+                            "website_relay",
+                            key,
+                            int(occurred.timestamp() * 1000),
+                            oldest_ms,
+                            None,
+                            "public_home",
+                            "",
+                            "",
+                            "A public Relay captured community activity.",
+                            "A public Relay captured community activity.",
+                            key,
+                            1,
+                            "{}",
+                        ),
+                    )
+
+        def stamp(index, count):
+            return (
+                current_start
+                + timedelta(seconds=(index + 1) * 86_400 / (count + 1))
+            ).isoformat().replace("+00:00", "Z")
+
+        relays = [
+            {
+                "refId": f"fresh:degraded-relay-{index}",
+                "sourceKind": "relay",
+                "summary": f"A Relay preserved current public moment {index}.",
+                "observedAt": stamp(index, 27),
+                "eventType": "fresh_public_discord_activity",
+            }
+            for index in range(27)
+        ]
+        conversations = [
+            {
+                "refId": f"fresh:degraded-conversation-{index}",
+                "sourceKind": "conversation",
+                "summary": f"A regular shared current public detail {index}.",
+                "observedAt": stamp(index, 153),
+                "participantAlias": f"participant-recovery-{index}",
+                "subjectRef": f"discord_user:{10_000 + index}",
+                "displayName": f"RecoveryMember{index:03d}",
+                "channelPolicy": "public_home",
+            }
+            for index in range(153)
+        ]
+        packet = journal.build_packet_from_sources(
+            self.db,
+            1,
+            current_start.isoformat().replace("+00:00", "Z"),
+            current_end.isoformat().replace("+00:00", "Z"),
+            relays,
+            conversations,
+            entry_kind="daily",
+        )
+
+        self.assertTrue(packet["sourceRecoveryMode"])
+        self.assertFalse(packet.get("lowActivityMode", False))
+        self.assertEqual("degraded", packet["sourceHealth"]["status"])
+        self.assertEqual(
+            [50, 60, 69],
+            sorted(packet["sourceHealth"]["baselineRelayCounts"]),
+        )
+        self.assertEqual(
+            60,
+            packet["sourceHealth"]["baselineMedianRelaySources"],
+        )
+        self.assertEqual(
+            39,
+            packet["sourceHealth"]["minimumHealthyRelaySources"],
+        )
+        contract = packet["evidenceCoverageContract"]
+        self.assertEqual(18, contract["minimumDistinctFreshSources"])
+        self.assertEqual(
+            {"conversation": 16, "relay": 3},
+            contract["minimumDistinctFreshSourcesByKind"],
+        )
+
+        prompt = journal.build_generation_prompt(packet)
+        self.assertIn("SOURCE-RECOVERY EVIDENCE RULE", prompt)
+        self.assertIn("coequal fresh evidence", prompt)
+        self.assertNotIn(
+            "relay stream is the primary chronology and narrative spine",
+            prompt,
+        )
+
+        thin = _article(
+            packet,
+            refs=[
+                source["refId"]
+                for source in packet["safeSources"][:17]
+            ],
+        )
+        self.assertEqual(
+            "insufficient_source_breadth",
+            journal.validate_article(thin, packet, []),
+        )
+        self.assertEqual(
+            "",
+            journal.validate_article(
+                _article(packet),
+                packet,
+                [],
+            ),
+        )
 
     def test_daily_packet_keeps_relay_spine_and_balances_conversation_context(self):
         start_at = datetime(2026, 7, 19, tzinfo=timezone.utc)

--- a/tests/test_bnl_journal_prepared_release.py
+++ b/tests/test_bnl_journal_prepared_release.py
@@ -738,6 +738,108 @@ class PreparedReleaseTests(unittest.TestCase):
         self.assertEqual(1, len(generation_calls))
         self.assertEqual(first_attempt[0], generation_calls[0])
 
+    def test_automatic_generation_cycles_are_bounded_but_occurrence_stays_owed(self):
+        generation_calls = []
+
+        def provider_down(_packet, _prompt):
+            generation_calls.append(1)
+            raise RuntimeError("provider down")
+
+        first = self.prepare(provider_down)
+        self.assertEqual("held", first.status, first)
+
+        for _index in range(
+            1,
+            automation.MAX_AUTOMATIC_GENERATION_CYCLES,
+        ):
+            with sqlite3.connect(self.db) as conn:
+                conn.execute(
+                    "UPDATE bnl_journal_automation_runs SET updated_at=? "
+                    "WHERE cadence='daily'",
+                    (
+                        automation._utc_iso(
+                            datetime.now(timezone.utc)
+                            - timedelta(minutes=31)
+                        ),
+                    ),
+                )
+            failed = automation.prepare_daily(
+                self.db,
+                1,
+                provider_down,
+                target_day=TARGET_DAY,
+                force=False,
+            )
+            self.assertEqual("held", failed.status, failed)
+
+        self.assertEqual(
+            automation.MAX_AUTOMATIC_GENERATION_CYCLES,
+            len(generation_calls),
+        )
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs SET updated_at=? "
+                "WHERE cadence='daily'",
+                (
+                    automation._utc_iso(
+                        datetime.now(timezone.utc)
+                        - timedelta(minutes=31)
+                    ),
+                ),
+            )
+        capped = automation.prepare_daily(
+            self.db,
+            1,
+            lambda *_args: self.fail(
+                "generation ran after the rolling cycle cap"
+            ),
+            target_day=TARGET_DAY,
+            force=False,
+        )
+        self.assertEqual("backoff", capped.status, capped)
+        self.assertTrue(
+            capped.reason.startswith(
+                "generation_cycle_limit_until_"
+            ),
+            capped,
+        )
+        self.assertEqual(
+            "held",
+            self.run_row()["lifecycle_state"],
+        )
+
+        expired = automation._utc_iso(
+            datetime.now(timezone.utc)
+            - timedelta(
+                hours=automation.GENERATION_CYCLE_WINDOW_HOURS,
+                minutes=1,
+            )
+        )
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "UPDATE bnl_journal_preparation_attempts "
+                "SET started_at=?,finished_at=?",
+                (expired, expired),
+            )
+            conn.execute(
+                "UPDATE bnl_journal_automation_runs SET updated_at=? "
+                "WHERE cadence='daily'",
+                (
+                    automation._utc_iso(
+                        datetime.now(timezone.utc)
+                        - timedelta(minutes=31)
+                    ),
+                ),
+            )
+        recovered = automation.prepare_daily(
+            self.db,
+            1,
+            lambda packet, _prompt: article_json(packet),
+            target_day=TARGET_DAY,
+            force=False,
+        )
+        self.assertEqual("prepared", recovered.status, recovered)
+
     def test_delivery_retry_waits_fifteen_minutes_and_never_regenerates(self):
         prepared = self.prepare()
         attempts = []

--- a/tests/test_gemini_routing_policy.py
+++ b/tests/test_gemini_routing_policy.py
@@ -21,21 +21,48 @@ class GeminiRoutingPolicyTests(unittest.TestCase):
         self.assertFalse(memory.allow_fallback)
         self.assertTrue(chat.allow_fallback)
         self.assertTrue(journal.journal_protected)
+        self.assertEqual(0, journal.provider_retries)
 
-    def test_non_journal_routes_preserve_daily_journal_capacity(self):
+    def test_journal_and_relay_reserves_are_mutual_and_released_as_used(self):
         with mock.patch.dict(
             "os.environ",
-            {"BNL_GEMINI_JOURNAL_PROTECTED_TOKENS": "250000"},
+            {
+                "BNL_GEMINI_JOURNAL_PROTECTED_TOKENS": "250000",
+                "BNL_GEMINI_RELAY_PROTECTED_TOKENS": "100000",
+            },
             clear=False,
         ):
             self.assertEqual(
                 routing.budget_ceiling_for_route(1_350_000, "normal_chat"),
-                1_100_000,
+                1_000_000,
             )
             self.assertEqual(
                 routing.budget_ceiling_for_route(
                     1_350_000,
                     "bnl_journal_generation",
+                ),
+                1_250_000,
+            )
+            self.assertEqual(
+                routing.budget_ceiling_for_route(
+                    1_350_000,
+                    "website_relay_event",
+                ),
+                1_100_000,
+            )
+            self.assertEqual(
+                routing.budget_ceiling_for_route(
+                    1_350_000,
+                    "website_relay_event",
+                    journal_used=250_000,
+                ),
+                1_350_000,
+            )
+            self.assertEqual(
+                routing.budget_ceiling_for_route(
+                    1_350_000,
+                    "bnl_journal_generation",
+                    relay_used=100_000,
                 ),
                 1_350_000,
             )

--- a/tests/test_token_budget_accounting.py
+++ b/tests/test_token_budget_accounting.py
@@ -47,11 +47,13 @@ class TokenBudgetAccountingTests(unittest.TestCase):
         bnl01_bot.DB_FILE = self.db_path
         with bnl01_bot._token_budget_reservation_lock:
             bnl01_bot._token_budget_reserved_tokens = 0
+            bnl01_bot._token_budget_reserved_by_lane.clear()
 
     def tearDown(self):
         bnl01_bot.DB_FILE = self.original_db_file
         with bnl01_bot._token_budget_reservation_lock:
             bnl01_bot._token_budget_reserved_tokens = 0
+            bnl01_bot._token_budget_reserved_by_lane.clear()
         self.tempdir.cleanup()
 
     def test_provider_metadata_is_recorded_once_with_route_breakdown(self):
@@ -245,6 +247,10 @@ class TokenBudgetAccountingTests(unittest.TestCase):
 
     def test_reservation_blocks_new_call_before_soft_counter_is_crossed(self):
         today = "2026-07-26"
+        journal_ceiling = bnl01_bot.budget_ceiling_for_route(
+            bnl01_bot.DAILY_TOKEN_LIMIT,
+            bnl01_bot.JOURNAL_ROUTE,
+        )
         with sqlite3.connect(self.db_path) as conn:
             bnl01_bot._ensure_token_usage_schema(conn.cursor())
             conn.execute(
@@ -254,7 +260,7 @@ class TokenBudgetAccountingTests(unittest.TestCase):
                     last_reset_date = ?
                 WHERE id = 1
                 """,
-                (bnl01_bot.DAILY_TOKEN_LIMIT - 100, today),
+                (journal_ceiling - 100, today),
             )
         with mock.patch.object(
             bnl01_bot,
@@ -286,6 +292,14 @@ class TokenBudgetAccountingTests(unittest.TestCase):
                 bnl01_bot,
                 "DAILY_TOKEN_LIMIT",
                 reservation * 2 - 1,
+            ),
+            mock.patch.dict(
+                "os.environ",
+                {
+                    "BNL_GEMINI_JOURNAL_PROTECTED_TOKENS": "0",
+                    "BNL_GEMINI_RELAY_PROTECTED_TOKENS": "0",
+                },
+                clear=False,
             ),
         ):
             first = bnl01_bot.reserve_local_model_budget(prompt, "normal_chat")
@@ -365,6 +379,91 @@ class TokenBudgetAccountingTests(unittest.TestCase):
             )
             bnl01_bot.release_local_model_budget(journal_reservation)
         self.assertEqual(bnl01_bot._token_budget_reserved_tokens, 0)
+
+    def test_journal_usage_cannot_consume_unused_relay_capacity(self):
+        today = "2026-07-26"
+        with sqlite3.connect(self.db_path) as conn:
+            bnl01_bot._ensure_token_usage_schema(conn.cursor())
+            conn.execute(
+                """
+                UPDATE token_usage
+                SET tokens_used_today = ?, last_reset_date = ?
+                WHERE id = 1
+                """,
+                (1_240_000, today),
+            )
+            conn.execute(
+                """
+                INSERT INTO token_usage_events(
+                    usage_date,recorded_at,route,model,total_tokens
+                ) VALUES(?,?,?,?,?)
+                """,
+                (
+                    today,
+                    "2026-07-26T20:00:00Z",
+                    bnl01_bot.JOURNAL_ROUTE,
+                    "gemini-3.6-flash",
+                    250_000,
+                ),
+            )
+        with mock.patch.object(
+            bnl01_bot,
+            "_pacific_usage_date",
+            return_value=today,
+        ):
+            with self.assertRaises(bnl01_bot.LocalModelBudgetExhausted):
+                bnl01_bot.reserve_local_model_budget(
+                    "small prompt",
+                    "normal_chat",
+                )
+            relay_reservation = bnl01_bot.reserve_local_model_budget(
+                "small prompt",
+                "website_relay_event",
+            )
+            self.assertEqual("relay", relay_reservation.lane)
+            bnl01_bot.release_local_model_budget(relay_reservation)
+        self.assertEqual(0, bnl01_bot._token_budget_reserved_tokens)
+        self.assertEqual({}, bnl01_bot._token_budget_reserved_by_lane)
+
+    def test_relay_usage_cannot_consume_unused_journal_capacity(self):
+        today = "2026-07-26"
+        with sqlite3.connect(self.db_path) as conn:
+            bnl01_bot._ensure_token_usage_schema(conn.cursor())
+            conn.execute(
+                """
+                UPDATE token_usage
+                SET tokens_used_today = ?, last_reset_date = ?
+                WHERE id = 1
+                """,
+                (1_240_000, today),
+            )
+            conn.execute(
+                """
+                INSERT INTO token_usage_events(
+                    usage_date,recorded_at,route,model,total_tokens
+                ) VALUES(?,?,?,?,?)
+                """,
+                (
+                    today,
+                    "2026-07-26T20:00:00Z",
+                    "website_relay_event",
+                    "gemini-3.6-flash",
+                    100_000,
+                ),
+            )
+        with mock.patch.object(
+            bnl01_bot,
+            "_pacific_usage_date",
+            return_value=today,
+        ):
+            journal_reservation = bnl01_bot.reserve_local_model_budget(
+                "small prompt",
+                bnl01_bot.JOURNAL_ROUTE,
+            )
+            self.assertEqual("journal", journal_reservation.lane)
+            bnl01_bot.release_local_model_budget(journal_reservation)
+        self.assertEqual(0, bnl01_bot._token_budget_reserved_tokens)
+        self.assertEqual({}, bnl01_bot._token_budget_reserved_by_lane)
 
     def test_gemini3_journal_config_preserves_large_output_without_legacy_cap(self):
         config = bnl01_bot._generation_config_for_model(


### PR DESCRIPTION
## What changed

- Protect Relay generation capacity independently from Journal generation capacity.
- Bound Journal regeneration cycles so an owed occurrence cannot launch fresh four-call cycles indefinitely.
- Detect degraded Relay evidence windows and enter recovery mode without treating historical continuity as fresh evidence.
- Strengthen mixed-source citation floors so a lopsided packet cannot be frozen as healthy.
- Add regression coverage for retry fairness, route budgeting, degraded source recovery, and the observed 27-Relay versus 50/60/69-window failure case.

## Why

The existing reserve protected Journal capacity from ordinary routes in only one direction. Repeated Journal recovery cycles could still consume shared provider capacity and suppress the 20-minute Relay route. The scheduler could then begin another four-call generation cycle every 30 minutes, while the editorial gate could accept a Journal built from an abnormally thin Relay window.

## Impact

Journal retries no longer crowd Relay generation out of the shared budget, regeneration is bounded, unhealthy source breadth is surfaced before freeze, and drafts must satisfy stronger current mixed-source evidence requirements. No production configuration, public gate, deployment, or scheduler owner is changed.

## Validation

- 249 focused Journal/Relay tests passed.
- Full repository suite passed: 1,703 tests, 0 failures.
- Published tree: `3e37ba0eed93c26d9b3ffed676b90640dfba1b4e`
- Exact tested local source commit: `5fa234f0380a650efc4b6c401aa6c4f864199477`
- Connector-authored remote commit: `364bb8a7b00de4024b6cce1d202997b1093861ba` (same tree; metadata-only SHA difference)
