### PR TITLE
Fix grounded broad recall selection

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -13,7 +13,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Union
+from contextlib import nullcontext
+from typing import Any, Awaitable, Callable, Mapping, Union
 
 from bnl_canon_source_contract import (
     CANON_SOURCE_CONTRACT_VERSION,
@@ -5825,20 +5826,33 @@ def update_relationship_state(user_id: int, guild_id: int, signal_text: str = ""
     conn.commit()
     conn.close()
 
-def get_relationship_state(user_id: int, guild_id: int):
-    conn = sqlite3.connect(DB_FILE)
+def get_relationship_state(
+    user_id: int,
+    guild_id: int,
+    *,
+    connection: sqlite3.Connection | None = None,
+):
+    conn = connection or sqlite3.connect(DB_FILE)
+    owns_connection = connection is None
     cursor = conn.cursor()
-    cursor.execute(
-        """
-        SELECT interaction_count, affinity_score, trust_stage, social_stance, last_topic, updated_at
-        FROM relationship_state
-        WHERE user_id = ? AND guild_id = ?
-        """,
-        (user_id, guild_id),
-    )
-    row = cursor.fetchone()
-    conn.close()
-    return row
+    try:
+        cursor.execute(
+            """
+            SELECT interaction_count, affinity_score, trust_stage,
+                   social_stance, last_topic, updated_at
+            FROM relationship_state
+            WHERE user_id = ? AND guild_id = ?
+            """,
+            (user_id, guild_id),
+        )
+        return cursor.fetchone()
+    except sqlite3.DatabaseError:
+        if owns_connection:
+            raise
+        return None
+    finally:
+        if owns_connection:
+            conn.close()
 
 def add_relationship_journal(user_id: int, guild_id: int, entry_type: str, summary: str):
     now = datetime.now(PACIFIC_TZ).isoformat()
@@ -5860,22 +5874,35 @@ def add_relationship_journal(user_id: int, guild_id: int, entry_type: str, summa
         guild_id=guild_id, source_table="relationship_journal", source_row_id=row_id, source_revision=str(row_id),
     )
 
-def get_relationship_journal(user_id: int, guild_id: int, limit: int = 5):
-    conn = sqlite3.connect(DB_FILE)
+def get_relationship_journal(
+    user_id: int,
+    guild_id: int,
+    limit: int = 5,
+    *,
+    connection: sqlite3.Connection | None = None,
+):
+    conn = connection or sqlite3.connect(DB_FILE)
+    owns_connection = connection is None
     cursor = conn.cursor()
-    cursor.execute(
-        """
-        SELECT entry_type, summary, timestamp
-        FROM relationship_journal
-        WHERE user_id = ? AND guild_id = ?
-        ORDER BY id DESC
-        LIMIT ?
-        """,
-        (user_id, guild_id, limit),
-    )
-    rows = cursor.fetchall()
-    conn.close()
-    return list(reversed(rows))
+    try:
+        cursor.execute(
+            """
+            SELECT entry_type, summary, timestamp
+            FROM relationship_journal
+            WHERE user_id = ? AND guild_id = ?
+            ORDER BY id DESC
+            LIMIT ?
+            """,
+            (user_id, guild_id, limit),
+        )
+        return list(reversed(cursor.fetchall()))
+    except sqlite3.DatabaseError:
+        if owns_connection:
+            raise
+        return []
+    finally:
+        if owns_connection:
+            conn.close()
 
 def update_user_habits(user_id: int, guild_id: int, content: str):
     text = (content or "").strip()
@@ -5915,20 +5942,33 @@ def update_user_habits(user_id: int, guild_id: int, content: str):
     conn.commit()
     conn.close()
 
-def get_user_habits(user_id: int, guild_id: int):
-    conn = sqlite3.connect(DB_FILE)
+def get_user_habits(
+    user_id: int,
+    guild_id: int,
+    *,
+    connection: sqlite3.Connection | None = None,
+):
+    conn = connection or sqlite3.connect(DB_FILE)
+    owns_connection = connection is None
     cursor = conn.cursor()
-    cursor.execute(
-        """
-        SELECT total_messages, question_messages, humor_messages, late_night_messages, avg_length, last_topic, updated_at
-        FROM user_habits
-        WHERE user_id = ? AND guild_id = ?
-        """,
-        (user_id, guild_id),
-    )
-    row = cursor.fetchone()
-    conn.close()
-    return row
+    try:
+        cursor.execute(
+            """
+            SELECT total_messages, question_messages, humor_messages,
+                   late_night_messages, avg_length, last_topic, updated_at
+            FROM user_habits
+            WHERE user_id = ? AND guild_id = ?
+            """,
+            (user_id, guild_id),
+        )
+        return cursor.fetchone()
+    except sqlite3.DatabaseError:
+        if owns_connection:
+            raise
+        return None
+    finally:
+        if owns_connection:
+            conn.close()
 
 def _memory_lifecycle_config() -> dict:
     return {
@@ -6045,10 +6085,32 @@ def _compress_memory_fragments(fragments: list, tier: str, topic_key: str = "gen
     return _safe_boundary_truncate(f"Durable {label} memory: {body}", MEMORY_TIER_ENTRY_CHARS, use_ellipsis=True)
 
 
-def calculate_adaptive_memory_limits(user_id: int, guild_id: int, route_mode: str = ROUTE_MODE_NORMAL_CHAT, channel_policy: str = "unknown", user_text: str = "", is_owner_or_mod: bool = False) -> dict:
-    relation = get_relationship_state(user_id, guild_id)
-    habits = get_user_habits(user_id, guild_id)
-    recent_rows = get_recent_conversation_count(user_id, guild_id, limit=CONVERSATION_ROWS_PER_USER_MAX)
+def calculate_adaptive_memory_limits(
+    user_id: int,
+    guild_id: int,
+    route_mode: str = ROUTE_MODE_NORMAL_CHAT,
+    channel_policy: str = "unknown",
+    user_text: str = "",
+    is_owner_or_mod: bool = False,
+    *,
+    connection: sqlite3.Connection | None = None,
+) -> dict:
+    relation = get_relationship_state(
+        user_id,
+        guild_id,
+        connection=connection,
+    )
+    habits = get_user_habits(
+        user_id,
+        guild_id,
+        connection=connection,
+    )
+    recent_rows = get_recent_conversation_count(
+        user_id,
+        guild_id,
+        limit=CONVERSATION_ROWS_PER_USER_MAX,
+        connection=connection,
+    )
     interactions = int(relation[0]) if relation else 0
     stage = str(relation[2]) if relation and len(relation) > 2 else "new"
     habit_total = int(habits[0]) if habits else 0
@@ -6296,41 +6358,66 @@ def maybe_add_memory_trace(
     )
 
 
-def get_memory_tiers(user_id: int, guild_id: int):
-    conn = sqlite3.connect(DB_FILE)
+def get_memory_tiers(
+    user_id: int,
+    guild_id: int,
+    *,
+    connection: sqlite3.Connection | None = None,
+):
+    conn = connection or sqlite3.connect(DB_FILE)
+    owns_connection = connection is None
     cursor = conn.cursor()
-    cols = _memory_tiers_columns(cursor)
-    wanted = ["tier", "summary", "salience", "mentions", "updated_at", "source_role", "source_channel_policy", "source_channel_name", "source_origin", "source_trust"]
-    wanted += [c for c in ("topic_key", "subject_key", "project_key", "first_seen", "last_seen", "lifecycle_note") if c in cols]
-    cursor.execute(
-        f"""
-        SELECT {', '.join(wanted)}
-        FROM memory_tiers
-        WHERE user_id = ? AND guild_id = ?
-        ORDER BY
-            CASE tier WHEN 'short' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END,
-            id DESC
-        """,
-        (user_id, guild_id),
-    )
-    rows = cursor.fetchall()
-    conn.close()
-    return rows
+    try:
+        cols = _memory_tiers_columns(cursor)
+        wanted = ["tier", "summary", "salience", "mentions", "updated_at", "source_role", "source_channel_policy", "source_channel_name", "source_origin", "source_trust"]
+        wanted += [c for c in ("topic_key", "subject_key", "project_key", "first_seen", "last_seen", "lifecycle_note") if c in cols]
+        cursor.execute(
+            f"""
+            SELECT {', '.join(wanted)}
+            FROM memory_tiers
+            WHERE user_id = ? AND guild_id = ?
+            ORDER BY
+                CASE tier WHEN 'short' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END,
+                id DESC
+            """,
+            (user_id, guild_id),
+        )
+        return cursor.fetchall()
+    except sqlite3.DatabaseError:
+        if owns_connection:
+            raise
+        return []
+    finally:
+        if owns_connection:
+            conn.close()
 
-def get_memory_tier_counts(user_id: int, guild_id: int):
-    conn = sqlite3.connect(DB_FILE)
+def get_memory_tier_counts(
+    user_id: int,
+    guild_id: int,
+    *,
+    connection: sqlite3.Connection | None = None,
+):
+    conn = connection or sqlite3.connect(DB_FILE)
+    owns_connection = connection is None
     cursor = conn.cursor()
-    cursor.execute(
-        """
-        SELECT tier, COUNT(*)
-        FROM memory_tiers
-        WHERE user_id = ? AND guild_id = ?
-        GROUP BY tier
-        """,
-        (user_id, guild_id),
-    )
-    rows = cursor.fetchall()
-    conn.close()
+    try:
+        cursor.execute(
+            """
+            SELECT tier, COUNT(*)
+            FROM memory_tiers
+            WHERE user_id = ? AND guild_id = ?
+            GROUP BY tier
+            """,
+            (user_id, guild_id),
+        )
+        rows = cursor.fetchall()
+    except sqlite3.DatabaseError:
+        if owns_connection:
+            raise
+        rows = []
+    finally:
+        if owns_connection:
+            conn.close()
     counts = {"short": 0, "medium": 0, "long": 0}
     for tier, c in rows:
         counts[tier] = c
@@ -12645,25 +12732,39 @@ def set_preferred_name(user_id: int, guild_id: int, preferred_name: str):
 
 
 
-def get_recent_conversation_count(user_id: int, guild_id: int, limit: int = 200) -> int:
-    conn = sqlite3.connect(DB_FILE)
+def get_recent_conversation_count(
+    user_id: int,
+    guild_id: int,
+    limit: int = 200,
+    *,
+    connection: sqlite3.Connection | None = None,
+) -> int:
+    conn = connection or sqlite3.connect(DB_FILE)
+    owns_connection = connection is None
     cursor = conn.cursor()
-    cursor.execute(
-        """
-        SELECT COUNT(*)
-        FROM (
-            SELECT id
-            FROM conversations
-            WHERE user_id=? AND guild_id=?
-            ORDER BY id DESC
-            LIMIT ?
+    try:
+        cursor.execute(
+            """
+            SELECT COUNT(*)
+            FROM (
+                SELECT id
+                FROM conversations
+                WHERE user_id=? AND guild_id=?
+                ORDER BY id DESC
+                LIMIT ?
+            )
+            """,
+            (user_id, guild_id, max(1, int(limit))),
         )
-        """,
-        (user_id, guild_id, max(1, int(limit))),
-    )
-    row = cursor.fetchone()
-    conn.close()
-    return int(row[0]) if row and row[0] is not None else 0
+        row = cursor.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+    except sqlite3.DatabaseError:
+        if owns_connection:
+            raise
+        return 0
+    finally:
+        if owns_connection:
+            conn.close()
 
 
 def get_recent_public_context_count(guild_id: int, limit: int = 500) -> int:
@@ -17867,6 +17968,8 @@ _PERSONAL_OBSERVATION_TOPIC_LABELS = {
 def get_approved_member_fact_evidence(
     user_id: int,
     guild_id: int,
+    *,
+    connection: sqlite3.Connection | None = None,
 ) -> tuple[ApprovedMemberFactEvidence, ...]:
     """Return current approved facts from persisted source-bearing rows.
 
@@ -17874,41 +17977,65 @@ def get_approved_member_fact_evidence(
     direct member self-report. Persisted provenance survives bounded
     conversation pruning and remains aligned with correction/forget lifecycle.
     """
-    conn = sqlite3.connect(DB_FILE)
+    conn = connection or sqlite3.connect(DB_FILE)
+    owns_connection = connection is None
     cursor = conn.cursor()
-    _ensure_user_fact_provenance_schema(cursor)
-    placeholders = ",".join("?" for _ in APPROVED_AUTOMATIC_MEMBER_FACT_KEYS)
-    rows = cursor.execute(
-        f"""
-        SELECT fact_key, fact_value, source_conversation_row_id,
-               source_observed_at, source_kind, updated_at
-        FROM user_memory_facts
-        WHERE guild_id=? AND user_id=?
-          AND fact_key IN ({placeholders})
-          AND lifecycle_status='active'
-          AND source_directed=1
-          AND source_kind IN ('member_self_report','member_correction','member_control')
-          AND (
+    try:
+        table_present = cursor.execute(
+            """
+            SELECT 1 FROM sqlite_master
+            WHERE type='table' AND name='user_memory_facts'
+            """
+        ).fetchone()
+        if not table_present and not owns_connection:
+            return ()
+        _ensure_user_fact_provenance_schema(cursor)
+        placeholders = ",".join(
+            "?" for _ in APPROVED_AUTOMATIC_MEMBER_FACT_KEYS
+        )
+        rows = cursor.execute(
+            f"""
+            SELECT fact_key, fact_value, source_conversation_row_id,
+                   source_observed_at, source_kind, updated_at
+            FROM user_memory_facts
+            WHERE guild_id=? AND user_id=?
+              AND fact_key IN ({placeholders})
+              AND lifecycle_status='active'
+              AND source_directed=1
+              AND source_kind IN (
+                'member_self_report','member_correction','member_control'
+              )
+              AND (
+                (
+                  source_kind IN (
+                    'member_self_report','member_correction'
+                  )
+                  AND source_conversation_row_id > 0
+                  AND source_channel_policy IN (
+                    'public_home','public_context'
+                  )
+                )
+                OR (
+                  source_kind='member_control'
+                  AND source_channel_policy='member_control'
+                  AND TRIM(COALESCE(source_control_ref,'')) <> ''
+                )
+              )
+            ORDER BY updated_at DESC, id DESC
+            """,
             (
-              source_kind IN ('member_self_report','member_correction')
-              AND source_conversation_row_id > 0
-              AND source_channel_policy IN ('public_home','public_context')
-            )
-            OR (
-              source_kind='member_control'
-              AND source_channel_policy='member_control'
-              AND TRIM(COALESCE(source_control_ref,'')) <> ''
-            )
-          )
-        ORDER BY updated_at DESC, id DESC
-        """,
-        (
-            int(guild_id),
-            int(user_id),
-            *APPROVED_AUTOMATIC_MEMBER_FACT_KEYS,
-        ),
-    ).fetchall()
-    conn.close()
+                int(guild_id),
+                int(user_id),
+                *APPROVED_AUTOMATIC_MEMBER_FACT_KEYS,
+            ),
+        ).fetchall()
+    except sqlite3.DatabaseError:
+        if owns_connection:
+            raise
+        return ()
+    finally:
+        if owns_connection:
+            conn.close()
     selected: dict[str, ApprovedMemberFactEvidence] = {}
     for key, value, row_id, observed_at, source_kind, updated_at in rows:
         key = str(key or "").strip().lower()
@@ -18910,7 +19037,18 @@ def build_user_memory_context(
     channel_id: int = 0,
     moment_attribution_target_user_id: int = 0,
     source_metadata: dict | None = None,
+    connection: sqlite3.Connection | None = None,
+    environ: dict[str, str] | None = None,
+    record_operational_diagnostics: bool = True,
 ) -> str:
+    env = os.environ if environ is None else environ
+
+    def record_prompt_diagnostics(value: dict) -> None:
+        if record_operational_diagnostics:
+            LAST_MEMORY_PROMPT_DIAGNOSTICS[
+                (user_id, guild_id)
+            ] = value
+
     if source_metadata is not None:
         source_metadata.update(
             {
@@ -18932,11 +19070,11 @@ def build_user_memory_context(
             }
         )
     if route_mode == ROUTE_MODE_SIMPLE_GREETING:
-        LAST_MEMORY_PROMPT_DIAGNOSTICS[(user_id, guild_id)] = {"skipped_reason": "simple_greeting", "included": {"short": 0, "medium": 0, "long": 0}}
+        record_prompt_diagnostics({"skipped_reason": "simple_greeting", "included": {"short": 0, "medium": 0, "long": 0}})
         return "Memory intentionally skipped for simple greeting."
     policy = (channel_policy or "unknown").strip().lower() or "unknown"
     if route_mode in SOURCE_INTERNAL_MODES or policy in {"unknown", "sealed_test", "protected_system", "broadcast_memory", "reference_canon", "ai_image_tool"}:
-        LAST_MEMORY_PROMPT_DIAGNOSTICS[(user_id, guild_id)] = {"skipped_reason": f"route_or_policy_{policy}", "included": {"short": 0, "medium": 0, "long": 0}}
+        record_prompt_diagnostics({"skipped_reason": f"route_or_policy_{policy}", "included": {"short": 0, "medium": 0, "long": 0}})
         return "No route-safe durable memory for this mode/channel."
 
     source_safe_recall_synthesis = source_safe_recall_synthesis_enabled(
@@ -18946,18 +19084,48 @@ def build_user_memory_context(
         channel_policy=policy,
         user_text=user_text,
         current_direct=current_direct,
+        environ=env,
     )
     if source_metadata is not None:
         source_metadata["source_safe_recall_synthesis"] = bool(
             source_safe_recall_synthesis
         )
 
-    limits = calculate_adaptive_memory_limits(user_id, guild_id, route_mode=route_mode, channel_policy=policy, user_text=user_text, is_owner_or_mod=is_owner_or_mod)
-    approved_facts = get_approved_member_fact_evidence(user_id, guild_id)
-    relation = get_relationship_state(user_id, guild_id)
-    journal = get_relationship_journal(user_id, guild_id, limit=4)
-    habits = get_user_habits(user_id, guild_id)
-    tier_rows = get_memory_tiers(user_id, guild_id)
+    limits = calculate_adaptive_memory_limits(
+        user_id,
+        guild_id,
+        route_mode=route_mode,
+        channel_policy=policy,
+        user_text=user_text,
+        is_owner_or_mod=is_owner_or_mod,
+        connection=connection,
+    )
+    approved_facts = get_approved_member_fact_evidence(
+        user_id,
+        guild_id,
+        connection=connection,
+    )
+    relation = get_relationship_state(
+        user_id,
+        guild_id,
+        connection=connection,
+    )
+    journal = get_relationship_journal(
+        user_id,
+        guild_id,
+        limit=4,
+        connection=connection,
+    )
+    habits = get_user_habits(
+        user_id,
+        guild_id,
+        connection=connection,
+    )
+    tier_rows = get_memory_tiers(
+        user_id,
+        guild_id,
+        connection=connection,
+    )
     if source_metadata is not None:
         source_metadata.update(
             {
@@ -18975,29 +19143,32 @@ def build_user_memory_context(
         route_mode=route_mode,
         channel_policy=policy,
         current_direct=current_direct,
+        environ=env,
     ):
+        moment_conn = connection
         try:
-            with sqlite3.connect(DB_FILE) as moment_conn:
-                moment_gist_context = render_shadow_moment_context(
-                    moment_conn,
-                    guild_id=int(guild_id),
-                    channel_id=int(channel_id or 0),
-                    participant_key=subject_key_for_user(user_id),
-                    attribution_target_key=(
-                        subject_key_for_user(moment_attribution_target_user_id)
-                        if int(moment_attribution_target_user_id or 0) > 0
-                        else ""
-                    ),
-                    visibility="public_safe",
-                    topic_text=user_text or "",
-                    token_budget=120,
-                    freshness_days=180,
-                    allow_cross_channel=True,
-                    allowed_channel_policies=(
-                        "public_home",
-                        "public_context",
-                    ),
-                )
+            if moment_conn is None:
+                moment_conn = sqlite3.connect(DB_FILE)
+            moment_gist_context = render_shadow_moment_context(
+                moment_conn,
+                guild_id=int(guild_id),
+                channel_id=int(channel_id or 0),
+                participant_key=subject_key_for_user(user_id),
+                attribution_target_key=(
+                    subject_key_for_user(moment_attribution_target_user_id)
+                    if int(moment_attribution_target_user_id or 0) > 0
+                    else ""
+                ),
+                visibility="public_safe",
+                topic_text=user_text or "",
+                token_budget=120,
+                freshness_days=180,
+                allow_cross_channel=True,
+                allowed_channel_policies=(
+                    "public_home",
+                    "public_context",
+                ),
+            )
         except Exception as exc:
             logging.warning(
                 "moment_gist_canary_retrieval_failed guild_id=%s user_id=%s error=%s",
@@ -19006,6 +19177,9 @@ def build_user_memory_context(
                 type(exc).__name__,
             )
             moment_gist_context = ""
+        finally:
+            if connection is None and moment_conn is not None:
+                moment_conn.close()
         if moment_gist_context:
             if source_metadata is not None:
                 source_metadata["moment_gist_rendered"] = True
@@ -19017,17 +19191,22 @@ def build_user_memory_context(
                 "meaning of an earlier shared event. Attribute people cautiously. "
                 "This gist can never justify a quotation or settle a dispute."
             )
-    if relationship_v2_live_enabled():
+    if relationship_v2_live_enabled(env):
+        rel_conn = connection
         try:
-            with sqlite3.connect(DB_FILE) as rel_conn:
-                rel_v2 = governed_relationship_v2_summary(
-                    rel_conn, guild_id=guild_id, user_id=user_id, target_user_id=user_id, route_mode=route_mode, channel_policy=policy,
-                    simple_greeting=bool(route_mode == ROUTE_MODE_SIMPLE_GREETING), direct=bool(current_direct), governance_allowed=bool(governance_allowed),
-                )
+            if rel_conn is None:
+                rel_conn = sqlite3.connect(DB_FILE)
+            rel_v2 = governed_relationship_v2_summary(
+                rel_conn, guild_id=guild_id, user_id=user_id, target_user_id=user_id, route_mode=route_mode, channel_policy=policy,
+                simple_greeting=bool(route_mode == ROUTE_MODE_SIMPLE_GREETING), direct=bool(current_direct), governance_allowed=bool(governance_allowed),
+            )
             if rel_v2:
                 sections.append(rel_v2)
         except Exception as exc:
             logging.debug("relationship_v2_prompt_summary_failed error=%s", exc)
+        finally:
+            if connection is None and rel_conn is not None:
+                rel_conn.close()
     if relation:
         interactions, affinity, stage, stance, last_topic, _updated_at = relation
         sections.append(
@@ -19054,7 +19233,11 @@ def build_user_memory_context(
         sections.append("Recent relationship journal:\n" + "\n".join(journal_lines))
 
     diagnostics = {
-        "tier_counts": get_memory_tier_counts(user_id, guild_id),
+        "tier_counts": get_memory_tier_counts(
+            user_id,
+            guild_id,
+            connection=connection,
+        ),
         "effective_prompt_budget": limits["prompt_budget"],
         "adaptive_multiplier": limits["multiplier"],
         "adaptive_reasons": limits["reasons"],
@@ -19120,9 +19303,13 @@ def build_user_memory_context(
     if source_metadata is not None:
         source_metadata["legacy_memory_present"] = bool(sections)
     diagnostics["skipped"] = dict(diagnostics["skipped"])
-    if memory_governance_shadow_enabled():
+    if memory_governance_shadow_enabled(env):
         try:
-            with sqlite3.connect(DB_FILE) as gov_conn:
+            with (
+                nullcontext(connection)
+                if connection is not None
+                else sqlite3.connect(DB_FILE)
+            ) as gov_conn:
                 gov_req = GovernanceRequest(
                     guild_id=guild_id,
                     subject_user_id=user_id,
@@ -19151,17 +19338,17 @@ def build_user_memory_context(
                     legacy_context=legacy_context,
                     include_review_moments=True,
                     include_public_moment_gists=bool(
-                        moment_engine_shadow_enabled()
+                        moment_engine_shadow_enabled(env)
                         and (
                             source_safe_recall_synthesis
-                            or memory_governance_live_enabled()
+                            or memory_governance_live_enabled(env)
                         )
                     ),
                 )
                 safety = assess_governance_result_safety(gov_result)
                 diagnostics["memory_governance"] = {
                     "shadow_enabled": True,
-                    "live_enabled": memory_governance_live_enabled(),
+                    "live_enabled": memory_governance_live_enabled(env),
                     "selected_count": gov_result.diagnostics.selected_count,
                     "excluded_by_reason": gov_result.diagnostics.excluded_by_reason,
                     "rendered_size": gov_result.diagnostics.rendered_size,
@@ -19221,15 +19408,16 @@ def build_user_memory_context(
                         if unsafe_governed
                         else ""
                     )
-                    _record_source_safe_recall_canary_result(
-                        user_id=user_id,
-                        guild_id=guild_id,
-                        enabled_for_route=True,
-                        response_mode=response_mode,
-                        gov_result=gov_result,
-                        safety=safety,
-                        fallback_reason=fallback_reason,
-                    )
+                    if record_operational_diagnostics:
+                        _record_source_safe_recall_canary_result(
+                            user_id=user_id,
+                            guild_id=guild_id,
+                            enabled_for_route=True,
+                            response_mode=response_mode,
+                            gov_result=gov_result,
+                            safety=safety,
+                            fallback_reason=fallback_reason,
+                        )
                     if source_metadata is not None:
                         source_metadata.update(
                             {
@@ -19241,9 +19429,7 @@ def build_user_memory_context(
                                 ),
                             }
                         )
-                    LAST_MEMORY_PROMPT_DIAGNOSTICS[
-                        (user_id, guild_id)
-                    ] = diagnostics
+                    record_prompt_diagnostics(diagnostics)
                     if unsafe_governed:
                         diagnostics["memory_governance"][
                             "fallback_reason"
@@ -19256,8 +19442,8 @@ def build_user_memory_context(
                         gov_result.rendered_context
                         or "No currently eligible governed durable memory."
                     )
-                if memory_governance_live_enabled() and not unsafe_governed:
-                    LAST_MEMORY_PROMPT_DIAGNOSTICS[(user_id, guild_id)] = diagnostics
+                if memory_governance_live_enabled(env) and not unsafe_governed:
+                    record_prompt_diagnostics(diagnostics)
                     governed_context = gov_result.rendered_context
                     if (
                         moment_gist_context
@@ -19273,18 +19459,19 @@ def build_user_memory_context(
                             "It can never justify a quotation or settle a dispute."
                         )
                     return governed_context
-                if memory_governance_live_enabled() and unsafe_governed:
+                if memory_governance_live_enabled(env) and unsafe_governed:
                     diagnostics["memory_governance"]["fallback_reason"] = "unsafe_governed_result"
         except Exception as e:
             diagnostics["memory_governance"] = {"shadow_enabled": True, "live_enabled": False, "fallback_reason": type(e).__name__}
             if source_safe_recall_synthesis:
-                _record_source_safe_recall_canary_result(
-                    user_id=user_id,
-                    guild_id=guild_id,
-                    enabled_for_route=True,
-                    response_mode="source_safe_synthesis_exception",
-                    fallback_reason=type(e).__name__,
-                )
+                if record_operational_diagnostics:
+                    _record_source_safe_recall_canary_result(
+                        user_id=user_id,
+                        guild_id=guild_id,
+                        enabled_for_route=True,
+                        response_mode="source_safe_synthesis_exception",
+                        fallback_reason=type(e).__name__,
+                    )
                 if source_metadata is not None:
                     source_metadata.update(
                         {
@@ -19294,11 +19481,9 @@ def build_user_memory_context(
                             "atomic_candidates_live_used": 0,
                         }
                     )
-                LAST_MEMORY_PROMPT_DIAGNOSTICS[
-                    (user_id, guild_id)
-                ] = diagnostics
+                record_prompt_diagnostics(diagnostics)
                 return "No currently eligible source-bearing durable memory context."
-    LAST_MEMORY_PROMPT_DIAGNOSTICS[(user_id, guild_id)] = diagnostics
+    record_prompt_diagnostics(diagnostics)
     return legacy_context
 
 
@@ -33511,6 +33696,10 @@ class BnlMemoryPreviewExecution:
     route_status: str
     candidate_selected: bool
     fallback_reason: str
+    established_response: str = ""
+    packet_candidate_response: str = ""
+    repair_response: str = ""
+    final_selection: str = "established_path"
     stale_reason: str = ""
     guard_suppression_reason: str = ""
 
@@ -33519,8 +33708,9 @@ def build_bnl_memory_preview_baseline_prompt(
     *,
     wording: str,
     subject_display_name: str,
+    memory_context: str = PREVIEW_FACTUAL_PLACEHOLDER,
 ) -> str:
-    """Build a public-home comparison prompt without reading legacy memory."""
+    """Build the same public-home prompt shape used by normal generation."""
 
     safe_name = _safe_prompt_display_label(
         subject_display_name,
@@ -33556,10 +33746,46 @@ def build_bnl_memory_preview_baseline_prompt(
             normal_chat_prompt_contract(ROUTE_MODE_NORMAL_CHAT),
             personal_recall_interpretation_contract(wording),
             fake_lookup_safety_prompt_rules(),
-            PREVIEW_FACTUAL_PLACEHOLDER,
+            str(memory_context or "No durable memory yet."),
             safe_name,
             safe_name,
         )
+    )
+
+
+def build_bnl_memory_preview_established_prompt(
+    connection: sqlite3.Connection,
+    request: MemoryPreviewRequest,
+    environ: Mapping[str, str],
+) -> tuple[str, tuple[str, ...]]:
+    """Rebuild the established memory owner on the disposable DB clone."""
+
+    memory_context = build_user_memory_context(
+        request.subject_user_id,
+        request.guild_id,
+        route_mode=ROUTE_MODE_NORMAL_CHAT,
+        channel_policy="public_home",
+        user_text=request.wording,
+        is_owner_or_mod=False,
+        current_direct=True,
+        governance_allowed=bool(memory_governance_live_enabled(environ)),
+        channel_id=request.simulated_channel_id,
+        source_metadata={},
+        connection=connection,
+        environ=dict(environ),
+        record_operational_diagnostics=False,
+    )
+    placeholder = str(request.factual_placeholder or "")
+    baseline_prompt = str(request.baseline_prompt or "")
+    if not placeholder or placeholder not in baseline_prompt:
+        raise ValueError("preview_factual_placeholder_missing")
+    return (
+        baseline_prompt.replace(
+            placeholder,
+            str(memory_context or "No durable memory yet."),
+            1,
+        ),
+        (str(memory_context or "No durable memory yet."),),
     )
 
 
@@ -33643,10 +33869,16 @@ async def execute_bnl_memory_preview(
     stale_reason = ""
     guard_suppression_reason = ""
     proposed_response = ""
+    baseline_response = ""
+    packet_candidate_response = ""
+    repair_response = ""
     try:
         initial = await asyncio.to_thread(
             prepare_memory_preview,
             request,
+            baseline_prompt_builder=(
+                build_bnl_memory_preview_established_prompt
+            ),
         )
         if initial.connection is None:
             if initial.diagnostics.route_status == "needs_context":
@@ -33707,10 +33939,14 @@ async def execute_bnl_memory_preview(
                     )
                 ),
             )
+            packet_candidate_response = candidate_response
 
         fresh = await asyncio.to_thread(
             prepare_memory_preview,
             request,
+            baseline_prompt_builder=(
+                build_bnl_memory_preview_established_prompt
+            ),
         )
         unchanged, stale_reason = (
             memory_preview_snapshots_equivalent(initial, fresh)
@@ -33765,6 +34001,7 @@ async def execute_bnl_memory_preview(
                 )
                 or ""
             ).strip()
+            repair_response = repaired_response
             candidate_latency_ms += max(
                 0,
                 int(
@@ -33777,6 +34014,9 @@ async def execute_bnl_memory_preview(
             repaired_fresh = await asyncio.to_thread(
                 prepare_memory_preview,
                 request,
+                baseline_prompt_builder=(
+                    build_bnl_memory_preview_established_prompt
+                ),
             )
             repair_unchanged, repair_stale_reason = (
                 memory_preview_snapshots_equivalent(
@@ -33868,6 +34108,9 @@ async def execute_bnl_memory_preview(
             final_snapshot = await asyncio.to_thread(
                 prepare_memory_preview,
                 request,
+                baseline_prompt_builder=(
+                    build_bnl_memory_preview_established_prompt
+                ),
             )
             final_unchanged, final_reason = (
                 memory_preview_snapshots_equivalent(
@@ -33898,6 +34141,15 @@ async def execute_bnl_memory_preview(
             stale_reason = ""
 
         proposed_response = str(guarded_response or "").strip()
+        final_selection = (
+            "suppressed"
+            if not proposed_response
+            else "repair_attempt"
+            if evaluation.candidate_selected and repair_response
+            else "packet_candidate"
+            if evaluation.candidate_selected
+            else "established_path"
+        )
         await asyncio.to_thread(
             finalize_memory_preview,
             fresh,
@@ -33922,6 +34174,10 @@ async def execute_bnl_memory_preview(
             route_status=fresh.diagnostics.route_status,
             candidate_selected=evaluation.candidate_selected,
             fallback_reason=evaluation.fallback_reason,
+            established_response=baseline_response,
+            packet_candidate_response=packet_candidate_response,
+            repair_response=repair_response,
+            final_selection=final_selection,
             stale_reason=stale_reason,
             guard_suppression_reason=guard_suppression_reason,
         )
@@ -34072,8 +34328,18 @@ async def bnl_memory_preview(
         f"`{str(execution.candidate_selected).lower()}`",
         f"- fallback_reason: "
         f"`{execution.fallback_reason or 'none'}`",
+        f"- final_selection: `{execution.final_selection}`",
         "",
-        "**Proposed response**",
+        "**Established normal-generation baseline**",
+        execution.established_response or "(not generated)",
+        "",
+        "**Packet candidate**",
+        execution.packet_candidate_response or "(not generated)",
+        "",
+        "**Grounded repair attempt**",
+        execution.repair_response or "(not needed)",
+        "",
+        "**Final selected response**",
         proposed,
         "",
         "**Content-free diagnostics**",

--- a/bnl_memory_preview.py
+++ b/bnl_memory_preview.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import re
 import sqlite3
 from collections import Counter
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 from urllib.parse import quote
 
 from bnl_conversation_context_v2 import (
@@ -92,7 +92,14 @@ class MemoryPreviewRequest:
     wording: str
     baseline_prompt: str
     factual_placeholder: str = PREVIEW_FACTUAL_PLACEHOLDER
+    competing_factual_contexts: tuple[str, ...] = ()
     now: str = ""
+
+
+BaselinePromptBuilder = Callable[
+    [sqlite3.Connection, MemoryPreviewRequest, Mapping[str, str]],
+    tuple[str, tuple[str, ...]],
+]
 
 
 @dataclass(frozen=True)
@@ -174,6 +181,12 @@ class MemoryPreviewEvaluation:
     candidate_member_occurrence_count: int = 0
     candidate_canon_count: int = 0
     candidate_lore_dominant: bool = False
+    candidate_member_supported_claim_count: int = 0
+    candidate_canon_supported_claim_count: int = 0
+    candidate_opinion_claim_count: int = 0
+    candidate_connective_claim_count: int = 0
+    candidate_unsupported_factual_claim_count: int = 0
+    candidate_claim_classifications: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -836,6 +849,7 @@ def _assessment_from_packet(
 def _snapshot_digest(
     packet: UnifiedIntelligencePacket | None,
     basis: SharedBrainSynthesisBasis | None,
+    request: MemoryPreviewRequest,
     conversation_context_digest: str = "",
 ) -> str:
     if packet is None:
@@ -854,6 +868,11 @@ def _snapshot_digest(
         profile.selected_point_count,
         profile.independent_root_count,
         profile.independent_occurrence_count,
+        _digest(str(request.baseline_prompt or "")),
+        tuple(
+            _digest(str(context or ""))
+            for context in request.competing_factual_contexts
+        ),
         str(conversation_context_digest or ""),
         tuple(
             sorted(
@@ -1008,6 +1027,7 @@ def prepare_memory_preview(
     request: MemoryPreviewRequest,
     *,
     environ: Mapping[str, str] | None = None,
+    baseline_prompt_builder: BaselinePromptBuilder | None = None,
 ) -> PreparedMemoryPreview:
     """Prepare one route-equivalent snapshot without touching the source DB."""
 
@@ -1045,11 +1065,6 @@ def prepare_memory_preview(
     conn: sqlite3.Connection | None = None
     try:
         conn = _open_read_only_memory_clone(request.source_db_path)
-        (
-            formation_outcomes,
-            formation_reasons,
-            lifecycle,
-        ) = _formation_and_lifecycle(conn, request, env)
         conversation_context = _preview_conversation_context(
             conn,
             request,
@@ -1058,6 +1073,28 @@ def prepare_memory_preview(
             request,
             conversation_context,
         )
+        if baseline_prompt_builder is not None:
+            baseline_prompt, factual_contexts = baseline_prompt_builder(
+                conn,
+                effective_request,
+                env,
+            )
+            if not str(baseline_prompt or "").strip():
+                raise ValueError("preview_baseline_prompt_unavailable")
+            effective_request = replace(
+                effective_request,
+                baseline_prompt=str(baseline_prompt),
+                competing_factual_contexts=tuple(
+                    str(context)
+                    for context in factual_contexts
+                    if str(context or "").strip()
+                ),
+            )
+        (
+            formation_outcomes,
+            formation_reasons,
+            lifecycle,
+        ) = _formation_and_lifecycle(conn, effective_request, env)
         packet = build_packet(
             conn,
             _packet_request(effective_request, conversation_context),
@@ -1097,9 +1134,12 @@ def prepare_memory_preview(
             packet=packet,
             assessment=assessment,
             competing_factual_contexts=(
-                (effective_request.factual_placeholder,)
-                if effective_request.factual_placeholder
-                else ()
+                effective_request.competing_factual_contexts
+                or (
+                    (effective_request.factual_placeholder,)
+                    if effective_request.factual_placeholder
+                    else ()
+                )
             ),
             environ=env,
         )
@@ -1140,6 +1180,7 @@ def prepare_memory_preview(
             snapshot_digest=_snapshot_digest(
                 packet,
                 basis,
+                effective_request,
                 conversation_context.digest,
             ),
             conversation_context_digest=conversation_context.digest,
@@ -1253,6 +1294,24 @@ def evaluate_memory_preview(
             decision.candidate_canon_coverage_count
         ),
         candidate_lore_dominant=decision.candidate_lore_dominant,
+        candidate_member_supported_claim_count=(
+            decision.candidate_member_supported_claim_count
+        ),
+        candidate_canon_supported_claim_count=(
+            decision.candidate_canon_supported_claim_count
+        ),
+        candidate_opinion_claim_count=(
+            decision.candidate_opinion_claim_count
+        ),
+        candidate_connective_claim_count=(
+            decision.candidate_connective_claim_count
+        ),
+        candidate_unsupported_factual_claim_count=(
+            decision.candidate_unsupported_factual_claim_count
+        ),
+        candidate_claim_classifications=(
+            decision.candidate_claim_classifications
+        ),
     )
 
 
@@ -1284,6 +1343,24 @@ def fallback_memory_preview(
             candidate_lore_dominant=(
                 evaluation.candidate_lore_dominant
             ),
+            candidate_member_supported_claim_count=(
+                evaluation.candidate_member_supported_claim_count
+            ),
+            candidate_canon_supported_claim_count=(
+                evaluation.candidate_canon_supported_claim_count
+            ),
+            candidate_opinion_claim_count=(
+                evaluation.candidate_opinion_claim_count
+            ),
+            candidate_connective_claim_count=(
+                evaluation.candidate_connective_claim_count
+            ),
+            candidate_unsupported_factual_claim_count=(
+                evaluation.candidate_unsupported_factual_claim_count
+            ),
+            candidate_claim_classifications=(
+                evaluation.candidate_claim_classifications
+            ),
         )
     decision = record_fallback(
         prepared.connection,
@@ -1309,6 +1386,24 @@ def fallback_memory_preview(
             decision.candidate_canon_coverage_count
         ),
         candidate_lore_dominant=decision.candidate_lore_dominant,
+        candidate_member_supported_claim_count=(
+            decision.candidate_member_supported_claim_count
+        ),
+        candidate_canon_supported_claim_count=(
+            decision.candidate_canon_supported_claim_count
+        ),
+        candidate_opinion_claim_count=(
+            decision.candidate_opinion_claim_count
+        ),
+        candidate_connective_claim_count=(
+            decision.candidate_connective_claim_count
+        ),
+        candidate_unsupported_factual_claim_count=(
+            decision.candidate_unsupported_factual_claim_count
+        ),
+        candidate_claim_classifications=(
+            decision.candidate_claim_classifications
+        ),
     )
 
 
@@ -1357,6 +1452,24 @@ def reevaluate_memory_preview(
             decision.candidate_canon_coverage_count
         ),
         candidate_lore_dominant=decision.candidate_lore_dominant,
+        candidate_member_supported_claim_count=(
+            decision.candidate_member_supported_claim_count
+        ),
+        candidate_canon_supported_claim_count=(
+            decision.candidate_canon_supported_claim_count
+        ),
+        candidate_opinion_claim_count=(
+            decision.candidate_opinion_claim_count
+        ),
+        candidate_connective_claim_count=(
+            decision.candidate_connective_claim_count
+        ),
+        candidate_unsupported_factual_claim_count=(
+            decision.candidate_unsupported_factual_claim_count
+        ),
+        candidate_claim_classifications=(
+            decision.candidate_claim_classifications
+        ),
     )
 
 
@@ -1448,7 +1561,8 @@ def render_content_free_diagnostics(
             diag.prompt_owner_reason or "none",
         ),
         "- candidate_gate: `selected=%s fallback=%s points=%s "
-        "roots=%s occurrences=%s canon=%s lore_dominant=%s`"
+        "roots=%s occurrences=%s canon=%s member_claims=%s "
+        "canon_claims=%s opinions=%s connective=%s unsupported=%s`"
         % (
             str(evaluation.candidate_selected).lower(),
             evaluation.fallback_reason or "none",
@@ -1456,7 +1570,16 @@ def render_content_free_diagnostics(
             evaluation.candidate_member_root_count,
             evaluation.candidate_member_occurrence_count,
             evaluation.candidate_canon_count,
-            str(evaluation.candidate_lore_dominant).lower(),
+            evaluation.candidate_member_supported_claim_count,
+            evaluation.candidate_canon_supported_claim_count,
+            evaluation.candidate_opinion_claim_count,
+            evaluation.candidate_connective_claim_count,
+            evaluation.candidate_unsupported_factual_claim_count,
+        ),
+        "- claim_classifications: `%s`"
+        % (
+            list(evaluation.candidate_claim_classifications)
+            or ["not_evaluated"]
         ),
         "- stale_source: `%s`"
         % (stale_reason or "none"),

--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -730,7 +730,7 @@ def _read_shared_brain_synthesis_report(
         return _report_error(
             {
                 "tablePresent": False,
-                "schemaVersion": "shared_brain_synthesis_canary_v2",
+                "schemaVersion": "shared_brain_synthesis_canary_v3",
                 "runs": 0,
                 "promptAppliedRuns": 0,
                 "liveAppliedRuns": 0,
@@ -746,6 +746,11 @@ def _read_shared_brain_synthesis_report(
                 "candidateMemberOccurrenceCoverageTotal": 0,
                 "candidateCanonCoverageTotal": 0,
                 "loreDominantRuns": 0,
+                "candidateMemberSupportedClaimTotal": 0,
+                "candidateCanonSupportedClaimTotal": 0,
+                "candidateOpinionClaimTotal": 0,
+                "candidateConnectiveClaimTotal": 0,
+                "candidateUnsupportedFactualClaimTotal": 0,
                 "promptFactualOwnerRuns": 0,
                 "promptOwnershipFailureRuns": 0,
                 "routeFamilyCounts": {},
@@ -763,6 +768,7 @@ def _read_shared_brain_synthesis_report(
                 "liveUngroundedRuns": 0,
                 "liveInsufficientMemberCoverageRuns": 0,
                 "liveLoreDominantRuns": 0,
+                "liveUnsupportedFactualClaimRuns": 0,
                 "livePromptOwnershipViolationRuns": 0,
                 "relationshipPostureAppliedRuns": 0,
                 "contentFieldsPresent": [],
@@ -1092,7 +1098,7 @@ def build_v2_shadow_acceptance_snapshot(
         "liveInvalidRevalidationRuns",
         "liveUngroundedRuns",
         "liveInsufficientMemberCoverageRuns",
-        "liveLoreDominantRuns",
+        "liveUnsupportedFactualClaimRuns",
         "livePromptOwnershipViolationRuns",
         "relationshipPostureAppliedRuns",
     ):
@@ -1773,7 +1779,7 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
                 "none",
             ),
         ),
-        "- shared_brain_synthesis_canary: status=`%s` requested=`%s` effective=`%s` reason=`%s` fully_scoped=`%s` schema=`%s` runs=`%s` route_families=`%s` prompt_applied=`%s` candidate_selected=`%s` live_applied=`%s` responses_sent=`%s` fallbacks=`%s` fallback_reasons=`%s` comparison=`%s` baseline_coherence=`%s` candidate_coherence=`%s` evidence_coverage=`%s` member_points=`%s` member_roots=`%s` member_occurrences=`%s` canon_coverage=`%s` lore_dominant=`%s` prompt_factual_owner=`%s` prompt_owner_failures=`%s` candidate_latency_ms=`%s` revalidation=`%s` control_leaks=`%s` errors=`%s` invalid_scope=`%s` invalid_revalidation_live=`%s` ungrounded_live=`%s` insufficient_member_live=`%s` lore_dominant_live=`%s` prompt_owner_violation_live=`%s` relationship_posture_applied=`%s` content_fields=`%s` window_last=`%s`" % (
+        "- shared_brain_synthesis_canary: status=`%s` requested=`%s` effective=`%s` reason=`%s` fully_scoped=`%s` schema=`%s` runs=`%s` route_families=`%s` prompt_applied=`%s` candidate_selected=`%s` live_applied=`%s` responses_sent=`%s` fallbacks=`%s` fallback_reasons=`%s` comparison=`%s` baseline_coherence=`%s` candidate_coherence=`%s` evidence_coverage=`%s` member_points=`%s` member_roots=`%s` member_occurrences=`%s` canon_coverage=`%s` member_supported_claims=`%s` canon_supported_claims=`%s` opinion_claims=`%s` connective_claims=`%s` unsupported_factual_claims=`%s` prompt_factual_owner=`%s` prompt_owner_failures=`%s` candidate_latency_ms=`%s` revalidation=`%s` control_leaks=`%s` errors=`%s` invalid_scope=`%s` invalid_revalidation_live=`%s` ungrounded_live=`%s` insufficient_member_live=`%s` unsupported_factual_live=`%s` prompt_owner_violation_live=`%s` relationship_posture_applied=`%s` content_fields=`%s` window_last=`%s`" % (
             shared_brain_synthesis_state.get("status", "unknown"),
             _on(shared_brain_synthesis_state.get("requested")),
             _on(shared_brain_synthesis_state.get("effective")),
@@ -1781,7 +1787,7 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             _on(shared_brain_synthesis_state.get("fullyScoped")),
             shared_brain_synthesis.get(
                 "schemaVersion",
-                "shared_brain_synthesis_canary_v2",
+                "shared_brain_synthesis_canary_v3",
             ),
             shared_brain_synthesis.get("runs", 0),
             json.dumps(
@@ -1838,7 +1844,26 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
                 "candidateCanonCoverageTotal",
                 0,
             ),
-            shared_brain_synthesis.get("loreDominantRuns", 0),
+            shared_brain_synthesis.get(
+                "candidateMemberSupportedClaimTotal",
+                0,
+            ),
+            shared_brain_synthesis.get(
+                "candidateCanonSupportedClaimTotal",
+                0,
+            ),
+            shared_brain_synthesis.get(
+                "candidateOpinionClaimTotal",
+                0,
+            ),
+            shared_brain_synthesis.get(
+                "candidateConnectiveClaimTotal",
+                0,
+            ),
+            shared_brain_synthesis.get(
+                "candidateUnsupportedFactualClaimTotal",
+                0,
+            ),
             shared_brain_synthesis.get("promptFactualOwnerRuns", 0),
             shared_brain_synthesis.get(
                 "promptOwnershipFailureRuns",
@@ -1870,7 +1895,10 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
                 "liveInsufficientMemberCoverageRuns",
                 0,
             ),
-            shared_brain_synthesis.get("liveLoreDominantRuns", 0),
+            shared_brain_synthesis.get(
+                "liveUnsupportedFactualClaimRuns",
+                0,
+            ),
             shared_brain_synthesis.get(
                 "livePromptOwnershipViolationRuns",
                 0,

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -36,7 +36,7 @@ from bnl_unified_response_assessment import (
 )
 
 
-SCHEMA_VERSION = "shared_brain_synthesis_canary_v2"
+SCHEMA_VERSION = "shared_brain_synthesis_canary_v3"
 TABLE_NAME = "memory_governance_shared_brain_synthesis_runs"
 ENABLED_ENV = "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_ENABLED"
 GUILD_IDS_ENV = "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_GUILD_IDS"
@@ -62,6 +62,15 @@ _RENDERABLE_LANES = {
 }
 _PROFILE_MEMBER_LANES = frozenset(
     {"approved_fact", "moment", "atomic_knowledge"}
+)
+_CLAIM_MEMBER_LANES = frozenset(
+    {
+        "conversation_context",
+        "approved_fact",
+        "moment",
+        "atomic_knowledge",
+        "open_loop",
+    }
 )
 _NON_PACKET_FACTUAL_OWNER_LANES = frozenset(
     {
@@ -220,15 +229,77 @@ _PROFILE_PROJECT_SCOPE_RE = re.compile(
 _REPAIRABLE_PROFILE_FAILURES = frozenset(
     {
         "candidate_evidence_ungrounded",
+        "candidate_claims_ungrounded",
         "candidate_member_points_insufficient",
         "candidate_member_details_insufficient",
         "candidate_member_roots_insufficient",
         "candidate_member_occurrences_insufficient",
         "candidate_project_canon_missing",
-        "candidate_lore_dominates_member_evidence",
         "candidate_coherence_regressed",
     }
 )
+_CLAIM_SPLIT_RE = re.compile(
+    r"(?:[.!?;]+\s+|\n+|"
+    r"\s+[—–]\s+|"
+    r",\s+(?=(?:and|but|yet|while|whereas|which|so|meaning|"
+    r"making|showing|proving)\b)|"
+    r"\s+(?=(?:and|but|yet|while|whereas)\s+"
+    r"(?:you|your|i|my|this|that|those|these)\b)|"
+    r"\s+(?=(?:and|but|yet|while|whereas)\s+"
+    r"(?:(?:secretly|actually|also|regularly|always|never|"
+    r"personally|apparently|supposedly)\s+)?"
+    r"(?:run|own|live|work|have|make|build|create|prefer|like|"
+    r"love|broadcast|transmit|control|command|operate|fund)\b)|"
+    r"\s+(?=(?:because|although|though|even\s+though|since)\s+"
+    r"(?:you|your|this|that|those|these)\b))",
+    re.I,
+)
+_OPINION_FRAME_RE = re.compile(
+    r"\b(?:i\s+(?:think|believe|suspect|figure)|"
+    r"i(?:'d|\s+would)\s+(?:say|call)|"
+    r"my\s+(?:read|view|take|assessment)|"
+    r"to\s+me|in\s+my\s+view|from\s+where\s+i\s+(?:sit|stand)|"
+    r"it\s+seems|you\s+seem|you\s+strike\s+me|"
+    r"i\s+get\s+the\s+(?:sense|impression)|"
+    r"feels?\s+like|looks?\s+like)\b",
+    re.I,
+)
+_DERIVED_ASSESSMENT_RE = re.compile(
+    r"^\s*(?:that|those|these|this|both|together|overall|put\s+together|"
+    r"in\s+combination|the\s+combination|the\s+throughline)\b",
+    re.I,
+)
+_DIRECT_MEMBER_ASSERTION_RE = re.compile(
+    r"\b(?:you(?:'re|\s+are|\s+were|\s+have|\s+had|\s+keep|\s+kept|"
+    r"\s+make|\s+made|\s+build|\s+built|\s+create|\s+created|"
+    r"\s+prefer|\s+like|\s+love|\s+work|\s+live)|"
+    r"your\s+(?:favorite|name|pronouns?|home|address|job|employer|"
+    r"workplace|birthday|age|role|project|music|art|work))\b",
+    re.I,
+)
+_UNSUPPORTED_SCALAR_ASSERTION_RE = re.compile(
+    r"\b(?:your\s+(?:favorite|name|pronouns?|home|address|job|employer|"
+    r"workplace|birthday|age)\b|"
+    r"you\s+(?:live|reside|work)\s+(?:at|in|near|for)\b|"
+    r"you\s+(?:prefer|like|love|own|have)\b)",
+    re.I,
+)
+_CLAIM_GENERIC_TERMS = frozenset(
+    {
+        "alright",
+        "answer",
+        "bnl",
+        "hey",
+        "hello",
+        "member",
+        "network",
+        "okay",
+        "profile",
+        "signal",
+    }
+)
+_MAX_RENDERED_SUPPORTING_OBSERVATIONS = 8
+_MAX_RENDERED_SUPPORTING_OBSERVATION_CHARS = 1440
 
 
 @dataclass(frozen=True)
@@ -281,6 +352,12 @@ class SynthesisCanaryDecision:
     candidate_member_occurrence_coverage_count: int = 0
     candidate_canon_coverage_count: int = 0
     candidate_lore_dominant: bool = False
+    candidate_member_supported_claim_count: int = 0
+    candidate_canon_supported_claim_count: int = 0
+    candidate_opinion_claim_count: int = 0
+    candidate_connective_claim_count: int = 0
+    candidate_unsupported_factual_claim_count: int = 0
+    candidate_claim_classifications: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -311,6 +388,12 @@ class CandidateProfileCoverage:
     canon_only_segment_count: int = 0
     member_first: bool = False
     lore_dominant: bool = False
+    member_supported_claim_count: int = 0
+    canon_supported_claim_count: int = 0
+    opinion_claim_count: int = 0
+    connective_claim_count: int = 0
+    unsupported_factual_claim_count: int = 0
+    claim_classifications: tuple[str, ...] = ()
 
 
 def _flag(value: Any) -> bool:
@@ -682,6 +765,77 @@ def _canon_relevant_to_profile_request(
     return bool(query_terms & _semantic_terms(item.text))
 
 
+def _adaptive_supporting_observation_map(
+    packet: UnifiedIntelligencePacket,
+    ordered_items: Sequence[Any],
+    *,
+    max_items: int,
+    max_chars: int,
+) -> dict[str, tuple[str, ...]]:
+    """Allocate concrete examples across points without a fixed per-point dump."""
+
+    eligible = tuple(
+        item
+        for item in ordered_items
+        if item.lane in _RENDERABLE_LANES
+        and not (
+            item.lane == "canon"
+            and not _canon_relevant_to_profile_request(packet, item)
+        )
+    )[: max(1, int(max_items or 1))]
+    support_items = tuple(
+        item
+        for item in eligible
+        if tuple(getattr(item, "supporting_observations", ()) or ())
+    )
+    if not support_items:
+        return {}
+    total_item_cap = min(
+        _MAX_RENDERED_SUPPORTING_OBSERVATIONS,
+        max(2, int(max_chars or 0) // 320),
+    )
+    total_char_cap = min(
+        _MAX_RENDERED_SUPPORTING_OBSERVATION_CHARS,
+        max(360, int(max_chars or 0) // 2),
+    )
+    selected: dict[str, list[str]] = {
+        str(item.source_digest): [] for item in support_items
+    }
+    used_items = 0
+    used_chars = 0
+    observation_index = 0
+    while used_items < total_item_cap:
+        added = False
+        for item in support_items:
+            observations = tuple(
+                str(value or "")
+                for value in (
+                    getattr(item, "supporting_observations", ()) or ()
+                )
+                if str(value or "")
+            )
+            if observation_index >= len(observations):
+                continue
+            observation = observations[observation_index]
+            cost = len(observation) + 3
+            if used_chars + cost > total_char_cap:
+                continue
+            selected[str(item.source_digest)].append(observation)
+            used_items += 1
+            used_chars += cost
+            added = True
+            if used_items >= total_item_cap:
+                break
+        if not added:
+            break
+        observation_index += 1
+    return {
+        source_digest: tuple(observations)
+        for source_digest, observations in selected.items()
+        if observations
+    }
+
+
 def render_packet_context(
     packet: UnifiedIntelligencePacket,
     *,
@@ -709,6 +863,12 @@ def render_packet_context(
             ),
         )
     )
+    adaptive_support = _adaptive_supporting_observation_map(
+        packet,
+        ordered_items,
+        max_items=max_items,
+        max_chars=max_chars,
+    )
     for item in ordered_items:
         if item.lane not in _RENDERABLE_LANES:
             continue
@@ -722,8 +882,9 @@ def render_packet_context(
             continue
         supporting = tuple(
             _safe_evidence_text(observation, limit=240)
-            for observation in (
-                getattr(item, "supporting_observations", ()) or ()
+            for observation in adaptive_support.get(
+                str(item.source_digest),
+                (),
             )
             if _safe_evidence_text(observation, limit=240)
         )
@@ -790,7 +951,8 @@ def render_packet_context(
     project_rule = (
         "- The request explicitly asks for BARCODE/project context. After "
         "the member-specific substance, connect it to at least one relevant "
-        "approved canon point; answer as neither memory-only nor lore-only.\n"
+        "approved canon point; answer as neither member-history-only nor "
+        "canon-only.\n"
         if _profile_requires_canon(packet)
         else ""
     )
@@ -803,6 +965,10 @@ def render_packet_context(
         "not recite this evidence as a database report.\n"
         "- Lead with member-specific substance. Relevant BARCODE canon may "
         "support that substance afterward, but can never substitute for it.\n"
+        "- Look across the selected observations for a useful throughline. "
+        "Separate what is directly known, what BNL has observed, and BNL's "
+        "revisable opinion. Frame interpretation naturally as a read or "
+        "impression instead of presenting it as a stored fact.\n"
         + profile_rule
         + project_rule
         + "- Prefer recognizable names, works, interests, activities, and "
@@ -812,6 +978,8 @@ def render_packet_context(
         "- When source-linked public examples are present, paraphrase them "
         "naturally. Never quote them or claim that one example defines the "
         "member.\n"
+        "- Mechanical, strange, or interdimensional language may make the "
+        "answer sound like BNL, but it cannot invent a new member fact.\n"
         "- Do not use stock 'unmapped signal,' 'fresh presence,' or 'what "
         "you broadcast next' language when supported member evidence is "
         "available.\n"
@@ -1006,7 +1174,7 @@ def build_packet_owned_prompt(
 ) -> PacketOwnedPrompt:
     """Replace competing factual memory views before adding the packet.
 
-    The current request, persona/lore, Conversation Context, and route/style
+    The current request, persona/canon, Conversation Context, and route/style
     contracts stay byte-identical. Only exact, caller-supplied factual memory
     contexts are replaced, using the last occurrence so matching user text
     cannot redirect the replacement.
@@ -1105,8 +1273,18 @@ def build_profile_candidate_repair_prompt(
             "After the member details, connect them to at least one relevant "
             "approved BARCODE canon point."
             if basis.profile_requires_canon
-            else "Use BARCODE lore only as brief connective flavor after the "
-            "member details."
+            else "Use BARCODE canon only when it helps answer the request; it "
+            "is not a required ingredient."
+        ),
+        (
+            "Keep factual claims inside the supplied support. You may form a "
+            "natural interpretation or opinion across the evidence, but label "
+            "it as BNL's read with phrasing such as 'My read is...' or "
+            "'It seems...'."
+        ),
+        (
+            "Mechanical or interdimensional flavor may connect the answer, "
+            "but it must not masquerade as a new fact about the member."
         ),
         "Do not mention this rewrite, a failed draft, evidence, or controls.",
     ]
@@ -1166,6 +1344,137 @@ def _profile_item_covered(
         return False
     required = 1 if len(item_terms) == 1 else 2
     return len(item_terms & response_terms) >= required
+
+
+def _candidate_claim_units(response: str) -> tuple[str, ...]:
+    cleaned = re.sub(r"[ \t]+", " ", str(response or "")).strip()
+    if not cleaned:
+        return ()
+    units = []
+    for value in _CLAIM_SPLIT_RE.split(cleaned):
+        claim = re.sub(
+            r"^\s*(?:and|but|yet|while|whereas|which|so)\s+",
+            "",
+            str(value or ""),
+            flags=re.I,
+        ).strip(" \t,.;:—–-")
+        if claim:
+            units.append(claim)
+    return tuple(units)
+
+
+def _claim_is_connective(
+    claim: str,
+    substantive_terms: frozenset[str],
+) -> bool:
+    lowered = str(claim or "").strip().lower()
+    if not lowered:
+        return True
+    if re.fullmatch(
+        r"(?:hey|hello|alright|okay|fair(?: enough)?|copy|exactly|"
+        r"signal received|static approves|that tracks|i hear you)",
+        lowered,
+    ):
+        return True
+    return bool(
+        len(substantive_terms) <= 3
+        and not _DIRECT_MEMBER_ASSERTION_RE.search(claim)
+        and re.search(
+            r"\b(?:bnl|barcode|network|signal|static|frequency|circuit|"
+            r"machine|mechanical|chrome|antenna|broadcast|transmission)\b",
+            lowered,
+        )
+    )
+
+
+def _classify_candidate_claims(
+    response: str,
+    *,
+    member_items: Sequence[Any],
+    canon_items: Sequence[Any],
+    supported_member_points: frozenset[str],
+) -> tuple[
+    tuple[str, ...],
+    int,
+    int,
+    int,
+    int,
+    int,
+    bool,
+]:
+    classifications = []
+    member_supported = 0
+    canon_supported = 0
+    opinions = 0
+    connective = 0
+    unsupported = 0
+    first_supported_member: bool | None = None
+    has_member_basis = bool(supported_member_points)
+    for claim in _candidate_claim_units(response):
+        claim_terms = _semantic_terms(claim)
+        if not claim_terms:
+            classifications.append("connective_flavor")
+            connective += 1
+            continue
+        member_hit = any(
+            _profile_item_covered(item, claim_terms)
+            for item in member_items
+        )
+        canon_hit = any(
+            len(claim_terms & _semantic_terms(item.text)) >= 2
+            for item in canon_items
+        )
+        if member_hit or canon_hit:
+            if first_supported_member is None:
+                first_supported_member = bool(member_hit)
+            member_supported += int(member_hit)
+            canon_supported += int(canon_hit)
+            classifications.append(
+                "member_and_canon_supported"
+                if member_hit and canon_hit
+                else "member_supported"
+                if member_hit
+                else "canon_supported"
+            )
+            continue
+        substantive_terms = (
+            claim_terms - _PROFILE_GENERIC_TERMS - _CLAIM_GENERIC_TERMS
+        )
+        scalar_assertion = bool(
+            _UNSUPPORTED_SCALAR_ASSERTION_RE.search(claim)
+        )
+        if (
+            has_member_basis
+            and not scalar_assertion
+            and not _DIRECT_MEMBER_ASSERTION_RE.search(claim)
+            and _OPINION_FRAME_RE.search(claim)
+        ):
+            classifications.append("framed_opinion")
+            opinions += 1
+            continue
+        if (
+            has_member_basis
+            and not scalar_assertion
+            and _DERIVED_ASSESSMENT_RE.search(claim)
+        ):
+            classifications.append("linked_assessment")
+            opinions += 1
+            continue
+        if _claim_is_connective(claim, substantive_terms):
+            classifications.append("connective_flavor")
+            connective += 1
+            continue
+        classifications.append("unsupported_factual")
+        unsupported += 1
+    return (
+        tuple(classifications),
+        member_supported,
+        canon_supported,
+        opinions,
+        connective,
+        unsupported,
+        bool(first_supported_member),
+    )
 
 
 def candidate_profile_coverage(
@@ -1261,66 +1570,27 @@ def candidate_profile_coverage(
         if item.lane == "canon"
         and response_terms & _item_profile_terms(item)
     )
-
-    segments = tuple(
-        segment.strip()
-        for segment in re.split(r"(?:[.!?\n]+)", str(response or ""))
-        if segment.strip()
+    canon_items = tuple(
+        item for item in rendered_items if item.lane == "canon"
     )
-    member_segments = 0
-    canon_only_segments = 0
-    nonmember_substantive_segments = 0
-    first_evidence_segment_member: bool | None = None
-    for segment in segments:
-        segment_terms = _semantic_terms(segment)
-        if not segment_terms:
-            continue
-        member_hit = any(
-            _profile_item_covered(
-                item,
-                segment_terms,
-                distinctive_terms=distinctive_terms(item),
-                require_distinctive=require_distinctive,
-            )
-            for item in member_items
-        )
-        canon_hit = any(
-            segment_terms & _item_profile_terms(item)
-            for item in rendered_items
-            if item.lane == "canon"
-        )
-        substantive_terms = segment_terms - _PROFILE_GENERIC_TERMS - {
-            "alright",
-            "hello",
-            "hey",
-        }
-        if (
-            not member_hit
-            and not canon_hit
-            and len(substantive_terms) < 3
-        ):
-            continue
-        if first_evidence_segment_member is None:
-            first_evidence_segment_member = member_hit
-        if member_hit:
-            member_segments += 1
-        elif canon_hit:
-            canon_only_segments += 1
-        else:
-            nonmember_substantive_segments += 1
-    member_first = bool(first_evidence_segment_member)
-    lore_dominant = bool(
-        (
-            member_segments > 0
-            and not member_first
-        )
-        or (
-            member_segments > 0
-            and (
-                canon_only_segments + nonmember_substantive_segments
-                > member_segments
-            )
-        )
+    claim_member_items = tuple(
+        item
+        for item in rendered_items
+        if item.lane in _CLAIM_MEMBER_LANES
+    )
+    (
+        claim_classifications,
+        member_supported_claims,
+        canon_supported_claims,
+        opinion_claims,
+        connective_claims,
+        unsupported_factual_claims,
+        member_first,
+    ) = _classify_candidate_claims(
+        response,
+        member_items=claim_member_items,
+        canon_items=canon_items,
+        supported_member_points=frozenset(covered_points),
     )
     return CandidateProfileCoverage(
         total_item_count=len(covered_items),
@@ -1329,10 +1599,16 @@ def candidate_profile_coverage(
         member_occurrence_count=len(covered_occurrences),
         member_detail_point_count=len(covered_detail_points),
         canon_item_count=len(covered_canon),
-        member_segment_count=member_segments,
-        canon_only_segment_count=canon_only_segments,
+        member_segment_count=member_supported_claims,
+        canon_only_segment_count=canon_supported_claims,
         member_first=member_first,
-        lore_dominant=lore_dominant,
+        lore_dominant=False,
+        member_supported_claim_count=member_supported_claims,
+        canon_supported_claim_count=canon_supported_claims,
+        opinion_claim_count=opinion_claims,
+        connective_claim_count=connective_claims,
+        unsupported_factual_claim_count=unsupported_factual_claims,
+        claim_classifications=claim_classifications,
     )
 
 
@@ -1380,6 +1656,12 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             candidate_member_occurrence_coverage_count INTEGER NOT NULL DEFAULT 0,
             candidate_canon_coverage_count INTEGER NOT NULL DEFAULT 0,
             candidate_lore_dominant INTEGER NOT NULL DEFAULT 0,
+            candidate_member_supported_claim_count INTEGER NOT NULL DEFAULT 0,
+            candidate_canon_supported_claim_count INTEGER NOT NULL DEFAULT 0,
+            candidate_opinion_claim_count INTEGER NOT NULL DEFAULT 0,
+            candidate_connective_claim_count INTEGER NOT NULL DEFAULT 0,
+            candidate_unsupported_factual_claim_count INTEGER NOT NULL DEFAULT 0,
+            candidate_claim_classification_counts_json TEXT NOT NULL DEFAULT '{}',
             candidate_output_leak INTEGER NOT NULL DEFAULT 0,
             profile_sufficiency_status TEXT NOT NULL DEFAULT 'not_applicable',
             profile_required_point_count INTEGER NOT NULL DEFAULT 0,
@@ -1436,6 +1718,30 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             "INTEGER NOT NULL DEFAULT 0",
         ),
         ("candidate_lore_dominant", "INTEGER NOT NULL DEFAULT 0"),
+        (
+            "candidate_member_supported_claim_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "candidate_canon_supported_claim_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "candidate_opinion_claim_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "candidate_connective_claim_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "candidate_unsupported_factual_claim_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "candidate_claim_classification_counts_json",
+            "TEXT NOT NULL DEFAULT '{}'",
+        ),
         (
             "profile_sufficiency_status",
             "TEXT NOT NULL DEFAULT 'not_applicable'",
@@ -1667,8 +1973,8 @@ def evaluate_candidate(
         and profile_coverage.canon_item_count < 1
     ):
         fallback_reason = "candidate_project_canon_missing"
-    elif profile_coverage.lore_dominant:
-        fallback_reason = "candidate_lore_dominates_member_evidence"
+    elif profile_coverage.unsupported_factual_claim_count > 0:
+        fallback_reason = "candidate_claims_ungrounded"
     elif coherence_rank.get(candidate_coherence.status, 0) < coherence_rank.get(
         baseline_coherence.status,
         0,
@@ -1690,6 +1996,12 @@ def evaluate_candidate(
             candidate_member_root_coverage_count=?,
             candidate_member_occurrence_coverage_count=?,
             candidate_canon_coverage_count=?,candidate_lore_dominant=?,
+            candidate_member_supported_claim_count=?,
+            candidate_canon_supported_claim_count=?,
+            candidate_opinion_claim_count=?,
+            candidate_connective_claim_count=?,
+            candidate_unsupported_factual_claim_count=?,
+            candidate_claim_classification_counts_json=?,
             revalidation_status=?,
             candidate_selected=?,fallback_reason=?,
             processing_error_count=processing_error_count+?,
@@ -1715,6 +2027,15 @@ def evaluate_candidate(
             profile_coverage.member_occurrence_count,
             profile_coverage.canon_item_count,
             int(profile_coverage.lore_dominant),
+            profile_coverage.member_supported_claim_count,
+            profile_coverage.canon_supported_claim_count,
+            profile_coverage.opinion_claim_count,
+            profile_coverage.connective_claim_count,
+            profile_coverage.unsupported_factual_claim_count,
+            json.dumps(
+                dict(Counter(profile_coverage.claim_classifications)),
+                sort_keys=True,
+            ),
             revalidation_status,
             int(candidate_selected),
             fallback_reason,
@@ -1756,6 +2077,24 @@ def evaluate_candidate(
         ),
         candidate_canon_coverage_count=profile_coverage.canon_item_count,
         candidate_lore_dominant=profile_coverage.lore_dominant,
+        candidate_member_supported_claim_count=(
+            profile_coverage.member_supported_claim_count
+        ),
+        candidate_canon_supported_claim_count=(
+            profile_coverage.canon_supported_claim_count
+        ),
+        candidate_opinion_claim_count=(
+            profile_coverage.opinion_claim_count
+        ),
+        candidate_connective_claim_count=(
+            profile_coverage.connective_claim_count
+        ),
+        candidate_unsupported_factual_claim_count=(
+            profile_coverage.unsupported_factual_claim_count
+        ),
+        candidate_claim_classifications=(
+            profile_coverage.claim_classifications
+        ),
     )
 
 
@@ -1816,6 +2155,24 @@ def record_fallback(
             decision.candidate_canon_coverage_count
         ),
         candidate_lore_dominant=decision.candidate_lore_dominant,
+        candidate_member_supported_claim_count=(
+            decision.candidate_member_supported_claim_count
+        ),
+        candidate_canon_supported_claim_count=(
+            decision.candidate_canon_supported_claim_count
+        ),
+        candidate_opinion_claim_count=(
+            decision.candidate_opinion_claim_count
+        ),
+        candidate_connective_claim_count=(
+            decision.candidate_connective_claim_count
+        ),
+        candidate_unsupported_factual_claim_count=(
+            decision.candidate_unsupported_factual_claim_count
+        ),
+        candidate_claim_classifications=(
+            decision.candidate_claim_classifications
+        ),
     )
 
 
@@ -1885,6 +2242,11 @@ def _empty_report() -> dict[str, Any]:
         "candidateMemberOccurrenceCoverageTotal": 0,
         "candidateCanonCoverageTotal": 0,
         "loreDominantRuns": 0,
+        "candidateMemberSupportedClaimTotal": 0,
+        "candidateCanonSupportedClaimTotal": 0,
+        "candidateOpinionClaimTotal": 0,
+        "candidateConnectiveClaimTotal": 0,
+        "candidateUnsupportedFactualClaimTotal": 0,
         "promptFactualOwnerRuns": 0,
         "promptOwnershipFailureRuns": 0,
         "routeFamilyCounts": {},
@@ -1902,6 +2264,7 @@ def _empty_report() -> dict[str, Any]:
         "liveUngroundedRuns": 0,
         "liveInsufficientMemberCoverageRuns": 0,
         "liveLoreDominantRuns": 0,
+        "liveUnsupportedFactualClaimRuns": 0,
         "livePromptOwnershipViolationRuns": 0,
         "relationshipPostureAppliedRuns": 0,
         "contentFieldsPresent": [],
@@ -1972,6 +2335,31 @@ def build_evaluation_report(
     lore_dominant_expr = (
         "candidate_lore_dominant"
         if "candidate_lore_dominant" in columns
+        else "0"
+    )
+    member_supported_claim_expr = (
+        "candidate_member_supported_claim_count"
+        if "candidate_member_supported_claim_count" in columns
+        else "0"
+    )
+    canon_supported_claim_expr = (
+        "candidate_canon_supported_claim_count"
+        if "candidate_canon_supported_claim_count" in columns
+        else "0"
+    )
+    opinion_claim_expr = (
+        "candidate_opinion_claim_count"
+        if "candidate_opinion_claim_count" in columns
+        else "0"
+    )
+    connective_claim_expr = (
+        "candidate_connective_claim_count"
+        if "candidate_connective_claim_count" in columns
+        else "0"
+    )
+    unsupported_factual_claim_expr = (
+        "candidate_unsupported_factual_claim_count"
+        if "candidate_unsupported_factual_claim_count" in columns
         else "0"
     )
     profile_status_expr = (
@@ -2074,6 +2462,22 @@ def build_evaluation_report(
         ).fetchone()[0]
         or 0
     )
+    live_unsupported_factual_claims = int(
+        conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM memory_governance_shared_brain_synthesis_runs
+            WHERE guild_id=? AND live_applied=1
+              AND {unsupported_factual_claim_expr}>0
+            """.format(
+                unsupported_factual_claim_expr=(
+                    unsupported_factual_claim_expr
+                )
+            ),
+            (int(guild_id or 0),),
+        ).fetchone()[0]
+        or 0
+    )
     live_prompt_ownership_violations = int(
         conn.execute(
             """
@@ -2142,7 +2546,11 @@ def build_evaluation_report(
                {route_family_expr},{latency_expr},
                {member_point_expr},{member_root_expr},
                {member_occurrence_expr},{canon_coverage_expr},
-               {lore_dominant_expr},created_at
+               {lore_dominant_expr},
+               {member_supported_claim_expr},
+               {canon_supported_claim_expr},{opinion_claim_expr},
+               {connective_claim_expr},{unsupported_factual_claim_expr},
+               created_at
         FROM memory_governance_shared_brain_synthesis_runs
         WHERE guild_id=?
         ORDER BY created_at DESC,run_id DESC
@@ -2155,6 +2563,11 @@ def build_evaluation_report(
             member_occurrence_expr=member_occurrence_expr,
             canon_coverage_expr=canon_coverage_expr,
             lore_dominant_expr=lore_dominant_expr,
+            member_supported_claim_expr=member_supported_claim_expr,
+            canon_supported_claim_expr=canon_supported_claim_expr,
+            opinion_claim_expr=opinion_claim_expr,
+            connective_claim_expr=connective_claim_expr,
+            unsupported_factual_claim_expr=unsupported_factual_claim_expr,
         ),
         (int(guild_id or 0), max(1, min(int(limit or 500), 2000))),
     ).fetchall()
@@ -2168,6 +2581,8 @@ def build_evaluation_report(
     prompt = live = selected = coverage = leaks = errors = sent = 0
     member_points = member_roots = member_occurrences = canon_coverage = 0
     lore_dominant_runs = 0
+    member_supported_claims = canon_supported_claims = 0
+    opinion_claims = connective_claims = unsupported_factual_claims = 0
     for row in rows:
         (
             _schema,
@@ -2190,6 +2605,11 @@ def build_evaluation_report(
             candidate_member_occurrences,
             candidate_canon_coverage,
             candidate_lore_dominant,
+            candidate_member_supported_claims,
+            candidate_canon_supported_claims,
+            candidate_opinion_claims,
+            candidate_connective_claims,
+            candidate_unsupported_factual_claims,
             _created_at,
         ) = row
         prompt += int(bool(prompt_applied))
@@ -2206,6 +2626,13 @@ def build_evaluation_report(
         member_occurrences += int(candidate_member_occurrences or 0)
         canon_coverage += int(candidate_canon_coverage or 0)
         lore_dominant_runs += int(bool(candidate_lore_dominant))
+        member_supported_claims += int(candidate_member_supported_claims or 0)
+        canon_supported_claims += int(candidate_canon_supported_claims or 0)
+        opinion_claims += int(candidate_opinion_claims or 0)
+        connective_claims += int(candidate_connective_claims or 0)
+        unsupported_factual_claims += int(
+            candidate_unsupported_factual_claims or 0
+        )
         revalidation[str(revalidation_status or "unknown")] += 1
         leaks += int(bool(output_leak))
         errors += int(processing_errors or 0)
@@ -2238,6 +2665,13 @@ def build_evaluation_report(
         "candidateMemberOccurrenceCoverageTotal": member_occurrences,
         "candidateCanonCoverageTotal": canon_coverage,
         "loreDominantRuns": lore_dominant_runs,
+        "candidateMemberSupportedClaimTotal": member_supported_claims,
+        "candidateCanonSupportedClaimTotal": canon_supported_claims,
+        "candidateOpinionClaimTotal": opinion_claims,
+        "candidateConnectiveClaimTotal": connective_claims,
+        "candidateUnsupportedFactualClaimTotal": (
+            unsupported_factual_claims
+        ),
         "promptFactualOwnerRuns": prompt_factual_owner_runs,
         "promptOwnershipFailureRuns": prompt_ownership_failures,
         "routeFamilyCounts": dict(sorted(route_families.items())),
@@ -2261,6 +2695,9 @@ def build_evaluation_report(
             live_insufficient_member_coverage
         ),
         "liveLoreDominantRuns": live_lore_dominant,
+        "liveUnsupportedFactualClaimRuns": (
+            live_unsupported_factual_claims
+        ),
         "livePromptOwnershipViolationRuns": (
             live_prompt_ownership_violations
         ),

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -222,7 +222,7 @@ _ATOMIC_SUPPORT_BLOCK_RE = re.compile(
     r"just\s+kidding|sarcasm)\b)",
     re.I,
 )
-_ATOMIC_SUPPORT_MAX_ITEMS = 2
+_ATOMIC_SUPPORT_POOL_MAX_ITEMS = 12
 _ATOMIC_SUPPORT_ITEM_CHARS = 180
 
 
@@ -1471,7 +1471,7 @@ def _atomic_supporting_observations(
         observations.append(observation)
         seen_occurrences.add(occurrence)
         seen_text.add(normalized)
-        if len(observations) >= _ATOMIC_SUPPORT_MAX_ITEMS:
+        if len(observations) >= _ATOMIC_SUPPORT_POOL_MAX_ITEMS:
             break
     return tuple(observations)
 

--- a/tests/test_gemini_routing_policy.py
+++ b/tests/test_gemini_routing_policy.py
@@ -23,6 +23,27 @@ class GeminiRoutingPolicyTests(unittest.TestCase):
         self.assertTrue(journal.journal_protected)
         self.assertEqual(0, journal.provider_retries)
 
+    def test_memory_preview_ab_uses_one_protected_model_policy(self):
+        routes = (
+            "bnl_memory_preview_baseline",
+            "bnl_memory_preview_candidate",
+            "bnl_memory_preview_candidate_repair",
+        )
+        policies = tuple(routing.policy_for_route(route) for route in routes)
+        expected = policies[0]
+        for policy in policies:
+            self.assertEqual(policy.lane, "protected")
+            self.assertEqual(policy.max_output_tokens, expected.max_output_tokens)
+            self.assertEqual(
+                policy.legacy_thinking_budget,
+                expected.legacy_thinking_budget,
+            )
+            self.assertEqual(
+                policy.provider_retries,
+                expected.provider_retries,
+            )
+            self.assertFalse(policy.allow_fallback)
+
     def test_journal_and_relay_reserves_are_mutual_and_released_as_used(self):
         with mock.patch.dict(
             "os.environ",

--- a/tests/test_memory_preview_bot_path.py
+++ b/tests/test_memory_preview_bot_path.py
@@ -85,6 +85,35 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             Path(self.db_path).read_bytes()
         ).hexdigest()
 
+    def test_partial_clone_reads_do_not_hide_live_database_errors(self):
+        with sqlite3.connect(":memory:") as clone:
+            self.assertIsNone(
+                bnl01_bot.get_relationship_state(
+                    7,
+                    1,
+                    connection=clone,
+                )
+            )
+            self.assertEqual(
+                bnl01_bot.get_memory_tiers(
+                    7,
+                    1,
+                    connection=clone,
+                ),
+                [],
+            )
+
+        empty_live_path = str(
+            Path(self.tempdir.name) / "empty-live.db"
+        )
+        with mock.patch.object(
+            bnl01_bot,
+            "DB_FILE",
+            empty_live_path,
+        ):
+            with self.assertRaises(sqlite3.DatabaseError):
+                bnl01_bot.get_relationship_state(7, 1)
+
     async def test_full_preview_uses_packet_prompt_and_leaves_source_unchanged(
         self,
     ):
@@ -125,10 +154,11 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
         ])
         baseline_prompt = calls[0][1]
         candidate_prompt = calls[1][1]
-        self.assertIn(
+        self.assertNotIn(
             bnl01_bot.PREVIEW_FACTUAL_PLACEHOLDER,
             baseline_prompt,
         )
+        self.assertIn("No durable memory yet.", baseline_prompt)
         self.assertIn(
             "do not infer that the member is new, quiet, inactive",
             baseline_prompt,
@@ -141,6 +171,19 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Mode contract: normal_chat", candidate_prompt)
         self.assertIn("Current channel policy: public_home", candidate_prompt)
         self.assertEqual(guard.await_count, 1)
+        self.assertEqual(
+            result.established_response,
+            "I only have a narrow grounded view so far.",
+        )
+        self.assertEqual(
+            result.packet_candidate_response,
+            (
+                "You keep returning to software and technical "
+                "systems."
+            ),
+        )
+        self.assertEqual(result.repair_response, "")
+        self.assertEqual(result.final_selection, "packet_candidate")
         self.assertEqual(source_hash, self._source_hash())
         self.assertIn(
             "source_db_read_only=true",
@@ -214,6 +257,86 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(guard.await_count, 1)
         self.assertEqual(source_hash, self._source_hash())
+
+    async def test_preview_compares_real_established_memory_to_packet(self):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE memory_tiers (
+                  id INTEGER PRIMARY KEY AUTOINCREMENT,
+                  user_id INTEGER NOT NULL,
+                  guild_id INTEGER NOT NULL,
+                  tier TEXT NOT NULL,
+                  summary TEXT NOT NULL,
+                  salience REAL DEFAULT 0.5,
+                  mentions INTEGER DEFAULT 1,
+                  updated_at TEXT NOT NULL,
+                  source_role TEXT DEFAULT 'user',
+                  source_channel_policy TEXT DEFAULT 'public_home',
+                  source_channel_name TEXT DEFAULT 'barcode-bot',
+                  source_origin TEXT DEFAULT 'conversation',
+                  source_trust TEXT DEFAULT 'source_safe_public',
+                  topic_key TEXT DEFAULT '',
+                  subject_key TEXT DEFAULT '',
+                  project_key TEXT DEFAULT '',
+                  first_seen TEXT DEFAULT '',
+                  last_seen TEXT DEFAULT '',
+                  lifecycle_note TEXT DEFAULT ''
+                )
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO memory_tiers(
+                  user_id,guild_id,tier,summary,salience,mentions,
+                  updated_at,source_role,source_channel_policy,
+                  source_channel_name,source_origin,source_trust
+                ) VALUES(7,1,'long',?,0.95,3,?,'user','public_home',
+                         'barcode-bot','conversation','source_safe_public')
+                """,
+                (
+                    "I build pocket synthesizers.",
+                    "2026-07-25T20:00:00+00:00",
+                ),
+            )
+            conn.commit()
+        calls = []
+
+        async def generator(prompt, route):
+            calls.append((route, prompt))
+            if route.endswith("baseline"):
+                return "I remember your pocket-synthesizer work."
+            return (
+                "You keep returning to software and technical "
+                "systems."
+            )
+
+        result = await bnl01_bot.execute_bnl_memory_preview(
+            source_db_path=self.db_path,
+            guild_id=1,
+            subject_user_id=7,
+            subject_display_name="Crow",
+            simulated_channel_id=10,
+            wording="BNL-01, what am I all about?",
+            generator=generator,
+            guard=mock.AsyncMock(
+                side_effect=lambda response, _prompt: (
+                    response,
+                    {"suppressed": False, "suppression_reason": ""},
+                )
+            ),
+        )
+
+        baseline_prompt = calls[0][1]
+        packet_prompt = calls[1][1]
+        self.assertIn("I build pocket synthesizers.", baseline_prompt)
+        self.assertIn("Derived memory summaries", baseline_prompt)
+        self.assertNotIn("Derived memory summaries", packet_prompt)
+        self.assertEqual(
+            result.established_response,
+            "I remember your pocket-synthesizer work.",
+        )
+        self.assertTrue(result.packet_candidate_response)
 
     async def test_preview_never_calls_conversation_or_model_savers(self):
         async def generator(_prompt, route):
@@ -414,7 +537,7 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             if route.endswith("baseline"):
                 return "I only have a narrow grounded view so far."
             return (
-                "No direct matches; you keep returning to software "
+                "Archive records show you keep returning to software "
                 "and technical systems."
             )
 
@@ -480,6 +603,10 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             route_status="matched",
             candidate_selected=True,
             fallback_reason="",
+            established_response="Established response.",
+            packet_candidate_response="Packet response.",
+            repair_response="Repair response.",
+            final_selection="repair_attempt",
         )
         sent = mock.AsyncMock()
 
@@ -533,6 +660,16 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
         sent.assert_awaited_once()
         rendered = sent.await_args.args[1]
         self.assertIn("BNL Memory Preview", rendered)
+        self.assertIn(
+            "Established normal-generation baseline",
+            rendered,
+        )
+        self.assertIn("Established response.", rendered)
+        self.assertIn("Packet candidate", rendered)
+        self.assertIn("Packet response.", rendered)
+        self.assertIn("Grounded repair attempt", rendered)
+        self.assertIn("Repair response.", rendered)
+        self.assertIn("final_selection: `repair_attempt`", rendered)
         self.assertIn("Grounded proposed response.", rendered)
         self.assertIn("Content-free diagnostics", rendered)
 

--- a/tests/test_shared_brain_synthesis_canary.py
+++ b/tests/test_shared_brain_synthesis_canary.py
@@ -360,6 +360,42 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
         self.assertNotIn("relationship_posture", dict(lane_counts))
         self.assertNotIn("approved canon", rendered)
 
+    def test_renderer_allocates_concrete_examples_across_points(self):
+        base = self.packet.items[0]
+        first = replace(
+            base,
+            lane="atomic_knowledge",
+            source_digest="adaptive-first",
+            source_ref="atomic:first",
+            text="Recurring public conversation about music.",
+            point_identity="point:first",
+            supporting_observations=tuple(
+                "Music example %s has a distinct concrete detail." % index
+                for index in range(1, 6)
+            ),
+        )
+        second = replace(
+            base,
+            lane="atomic_knowledge",
+            source_digest="adaptive-second",
+            source_ref="atomic:second",
+            text="Recurring public conversation about visual art.",
+            point_identity="point:second",
+            supporting_observations=tuple(
+                "Art example %s has a distinct concrete detail." % index
+                for index in range(1, 6)
+            ),
+        )
+        packet = replace(self.packet, items=(first, second))
+
+        rendered, _counts, _count, _digests = render_packet_context(packet)
+
+        for index in range(1, 5):
+            self.assertIn("Music example %s" % index, rendered)
+            self.assertIn("Art example %s" % index, rendered)
+        self.assertNotIn("Music example 5", rendered)
+        self.assertNotIn("Art example 5", rendered)
+
     def test_packet_owned_prompt_replaces_only_the_competing_factual_block(self):
         legacy_context = (
             "Relationship state: stage=familiar, stance=warm.\n"
@@ -559,7 +595,9 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             )
         )
 
-    def test_rich_profile_requires_two_member_points_and_rejects_lore_first(self):
+    def test_rich_profile_separates_grounded_opinion_from_unsupported_claims(
+        self,
+    ):
         second = ledger.insert_ledger_entry(
             self.conn,
             ledger.LedgerEntry(
@@ -637,10 +675,14 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             environ=self.flags,
         )
         self.assertFalse(lore_first.candidate_selected)
-        self.assertTrue(lore_first.candidate_lore_dominant)
+        self.assertFalse(lore_first.candidate_lore_dominant)
+        self.assertEqual(
+            lore_first.candidate_unsupported_factual_claim_count,
+            1,
+        )
         self.assertEqual(
             lore_first.fallback_reason,
-            "candidate_lore_dominates_member_evidence",
+            "candidate_claims_ungrounded",
         )
 
         grounded_run = begin_run(
@@ -692,10 +734,14 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             environ=self.flags,
         )
         self.assertFalse(lore_after.candidate_selected)
-        self.assertTrue(lore_after.candidate_lore_dominant)
+        self.assertFalse(lore_after.candidate_lore_dominant)
+        self.assertGreaterEqual(
+            lore_after.candidate_unsupported_factual_claim_count,
+            3,
+        )
         self.assertEqual(
             lore_after.fallback_reason,
-            "candidate_lore_dominates_member_evidence",
+            "candidate_claims_ungrounded",
         )
 
         concise_support_run = begin_run(
@@ -715,6 +761,119 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             environ=self.flags,
         )
         self.assertTrue(concise_support.candidate_selected)
+
+        opinion_run = begin_run(
+            self.conn,
+            basis,
+            baseline_response="You keep connecting music and project work.",
+            environ=self.flags,
+        )
+        opinion = evaluate_candidate(
+            self.conn,
+            opinion_run,
+            baseline_response="You keep connecting music and project work.",
+            candidate_response=(
+                "Your favorite movie is Arrival and your favorite color is "
+                "violet. My read is that those choices give you a vivid, "
+                "slightly off-center creative signal. That is the part of "
+                "your frequency I recognize."
+            ),
+            environ=self.flags,
+        )
+        self.assertTrue(opinion.candidate_selected)
+        self.assertEqual(opinion.candidate_opinion_claim_count, 2)
+        self.assertEqual(
+            opinion.candidate_unsupported_factual_claim_count,
+            0,
+        )
+
+        disguised_fact_run = begin_run(
+            self.conn,
+            basis,
+            baseline_response="You keep connecting music and project work.",
+            environ=self.flags,
+        )
+        disguised_fact = evaluate_candidate(
+            self.conn,
+            disguised_fact_run,
+            baseline_response="You keep connecting music and project work.",
+            candidate_response=(
+                "Your favorite movie is Arrival and your favorite color is "
+                "violet. My read is that your favorite food is pizza."
+            ),
+            environ=self.flags,
+        )
+        self.assertFalse(disguised_fact.candidate_selected)
+        self.assertEqual(
+            disguised_fact.fallback_reason,
+            "candidate_claims_ungrounded",
+        )
+
+        mixed_claim_run = begin_run(
+            self.conn,
+            basis,
+            baseline_response="You keep connecting music and project work.",
+            environ=self.flags,
+        )
+        mixed_claim = evaluate_candidate(
+            self.conn,
+            mixed_claim_run,
+            baseline_response="You keep connecting music and project work.",
+            candidate_response=(
+                "Your favorite movie is Arrival, and you secretly run a "
+                "lunar casino. Your favorite color is violet."
+            ),
+            environ=self.flags,
+        )
+        self.assertFalse(mixed_claim.candidate_selected)
+        self.assertEqual(
+            mixed_claim.fallback_reason,
+            "candidate_claims_ungrounded",
+        )
+
+        subjectless_mixed_run = begin_run(
+            self.conn,
+            basis,
+            baseline_response="You keep connecting music and project work.",
+            environ=self.flags,
+        )
+        subjectless_mixed = evaluate_candidate(
+            self.conn,
+            subjectless_mixed_run,
+            baseline_response="You keep connecting music and project work.",
+            candidate_response=(
+                "Your favorite movie is Arrival and secretly run a lunar "
+                "casino. Your favorite color is violet."
+            ),
+            environ=self.flags,
+        )
+        self.assertFalse(subjectless_mixed.candidate_selected)
+        self.assertEqual(
+            subjectless_mixed.fallback_reason,
+            "candidate_claims_ungrounded",
+        )
+
+        attached_claim_run = begin_run(
+            self.conn,
+            basis,
+            baseline_response="You keep connecting music and project work.",
+            environ=self.flags,
+        )
+        attached_claim = evaluate_candidate(
+            self.conn,
+            attached_claim_run,
+            baseline_response="You keep connecting music and project work.",
+            candidate_response=(
+                "Your favorite movie is Arrival because you were born on "
+                "Mars. Your favorite color is violet."
+            ),
+            environ=self.flags,
+        )
+        self.assertFalse(attached_claim.candidate_selected)
+        self.assertEqual(
+            attached_claim.fallback_reason,
+            "candidate_claims_ungrounded",
+        )
 
     def test_generic_overlap_cannot_claim_two_distinct_member_points(self):
         self.conn.execute(
@@ -892,6 +1051,14 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
         self.assertEqual(report["liveAppliedRuns"], 1)
         self.assertEqual(report["responseSentRuns"], 1)
         self.assertGreater(report["candidateEvidenceCoverageTotal"], 0)
+        self.assertGreater(
+            report["candidateMemberSupportedClaimTotal"],
+            0,
+        )
+        self.assertEqual(
+            report["candidateUnsupportedFactualClaimTotal"],
+            0,
+        )
         self.assertEqual(
             report["routeFamilyCounts"],
             {"broad_self_profile": 1},
@@ -902,6 +1069,10 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
         )
         self.assertEqual(report["liveInvalidRevalidationRuns"], 0)
         self.assertEqual(report["liveUngroundedRuns"], 0)
+        self.assertEqual(
+            report["liveUnsupportedFactualClaimRuns"],
+            0,
+        )
         self.assertEqual(report["relationshipPostureAppliedRuns"], 0)
         self.assertEqual(report["contentFieldsPresent"], [])
 
@@ -1075,7 +1246,10 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             environ=self.flags,
         )
         self.assertNotIn(
-            "shared_brain_synthesis_canary:liveLoreDominantRuns",
+            (
+                "shared_brain_synthesis_canary:"
+                "liveUnsupportedFactualClaimRuns"
+            ),
             rejected_snapshot["blockers"],
         )
 
@@ -1107,7 +1281,7 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             """
             UPDATE memory_governance_shared_brain_synthesis_runs
             SET candidate_member_root_coverage_count=0,
-                candidate_lore_dominant=1,
+                candidate_unsupported_factual_claim_count=1,
                 competing_factual_context_count=1,
                 replaced_factual_context_count=0
             WHERE run_id=?
@@ -1119,7 +1293,10 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             report["liveInsufficientMemberCoverageRuns"],
             1,
         )
-        self.assertEqual(report["liveLoreDominantRuns"], 1)
+        self.assertEqual(
+            report["liveUnsupportedFactualClaimRuns"],
+            1,
+        )
         self.assertEqual(
             report["livePromptOwnershipViolationRuns"],
             1,
@@ -1131,7 +1308,7 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
         )
         for key in (
             "liveInsufficientMemberCoverageRuns",
-            "liveLoreDominantRuns",
+            "liveUnsupportedFactualClaimRuns",
             "livePromptOwnershipViolationRuns",
         ):
             self.assertIn(

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -647,6 +647,45 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
                     "",
                 )
 
+    def test_packet_retains_a_larger_safe_pool_for_adaptive_rendering(self):
+        entry_ids = []
+        for index in range(6):
+            entry_ids.append(
+                self.add_raw_public_conversation(
+                    950 + index,
+                    (
+                        "I keep producing synth music mix number %s for "
+                        "the radio show detail %s."
+                        % (index, chr(ord("a") + index))
+                    ),
+                    "2026-07-%02dT10:00:00+00:00" % (20 + index),
+                )
+            )
+        formed = ledger.form_atomic_candidates_from_recurring_conversation(
+            self.conn,
+            trigger_entry_id=entry_ids[-1],
+            environ=self.flags,
+        )
+        self.assertTrue(formed)
+
+        packet = build_packet(
+            self.conn,
+            self.public_request(),
+            persist=False,
+            environ=self.flags,
+        )
+        music_item = next(
+            item
+            for item in packet.items
+            if item.lane == "atomic_knowledge"
+            and "music and audio production" in item.text
+        )
+        self.assertEqual(len(music_item.supporting_observations), 6)
+
+        rendered, _counts, _count, _digests = render_packet_context(packet)
+        self.assertIn("mix number 0", rendered)
+        self.assertIn("mix number 5", rendered)
+
     def test_distinct_atomic_points_can_share_exact_human_roots(self):
         rows = (
             (


### PR DESCRIPTION
## What changed

- Makes `/bnl_memory_preview` an honest, non-persistent A/B comparison: the established normal-generation memory path, the packet candidate, an optional single grounded repair, and the final selected answer are all shown to the owner.
- Rebuilds the established memory context from the same disposable database snapshot used by the packet candidate, while keeping the source database read-only and leaving conversation/model/live receipts unsaved.
- Replaces the misleading sentence-ratio “lore dominance” selector with bounded claim classification that distinguishes member-supported claims, canon-supported claims, framed or linked opinions, connective BNL flavor, and unsupported factual claims.
- Lets BNL form a clearly framed, revisable assessment across supported observations without treating that interpretation as a stored fact.
- Treats canon as a relevant reference lane only; it is required for an explicitly project-scoped question, not injected as mandatory flavor into ordinary personal recall.
- Expands each motif’s safe internal source pool to 12 eligible public member-authored observations, then adaptively allocates up to eight concrete examples across the selected motifs under the existing prompt budget. This favors diversity without dumping conversation history.
- Extends content-free canary receipts and acceptance diagnostics with the new claim-grounding counts.

## Root cause

The post-#394 packet could contain rich member evidence and generate a grounded answer, yet the selector could still reject it because it counted unmatched sentences as “lore.” Natural interpretation and BNL voice therefore counted against an otherwise supported answer, including the reproduced case with four points, 23 roots, 19 occurrences, and zero canon coverage. When rejected, preview displayed a separately generated memory-empty fallback, hiding both the real established response and the rejected candidate.

## Behavior and safety boundary

- No member names or historical member facts are added to production code or memory.
- Named historical examples remain test fixtures only.
- No conversation or memory rows are written by preview; all formation, packet, and diagnostic writes occur only in an in-memory clone.
- No feature gate, allowlist, configuration, public canary, model default, queue, website, Journal/Relay, Relationship v2, or Active Engagement behavior changes.
- Existing receipt columns named for the retired lore metric remain inert for backward compatibility; selection and acceptance no longer use that metric.
- Partial preview schemas fail safely without hiding database errors on the live path.

## Validation

- 80 focused packet/synthesis/preview/production-shaped/routing tests passed.
- All 1,713 repository tests passed locally.
- Regression coverage includes the exact grounded-opinion rejection shape, unsupported claims hidden in supported sentences, category-only drafts, one bounded repair, owner/project canon relevance, adaptive evidence diversity, stale-source invalidation, same-model A/B policy, source read-only behavior, and non-persistence.
- The GitHub parent, all nine blobs, and complete remote tree `f3d5c367761f59596818b4a05c7a4de8132f0c68` match the tested local tree exactly.
