### PR TITLE
Protect BNL lore and glitch expression

### DIFF
--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -284,6 +284,76 @@ _UNSUPPORTED_SCALAR_ASSERTION_RE = re.compile(
     r"you\s+(?:prefer|like|love|own|have)\b)",
     re.I,
 )
+_TRANSIENT_EXPRESSION_WRAPPER_RE = re.compile(
+    r"^\s*[~*_`-]*\[(?P<body>[\s\S]{1,900})\]\s*[~*_`-]*$",
+)
+_TRANSIENT_EXPRESSION_BLOCK_RE = re.compile(
+    r"[~*_`-]*\[[\s\S]{1,900}?\][~*_`-]*",
+)
+_TRANSIENT_EXPRESSION_FRAME_RE = re.compile(
+    r"^\s*(?:(?:in|from)\s+(?:an?\s+|one\s+|the\s+)?"
+    r"(?:adjacent|alternate|nearby|parallel|cross[- ]universe|"
+    r"interdimensional)\s+(?:timeline|reality|universe|signal|"
+    r"dimension)\b|"
+    r"(?:interdimensional|cross[- ]universe|alternate[- ]timeline|"
+    r"broadcast|signal|frequency|reality)\s+"
+    r"(?:bleed|fragment|glitch|anomaly)\s*[:/])",
+    re.I,
+)
+_TRANSIENT_EXPRESSION_AUTHORITY_RE = re.compile(
+    r"(?:\baccording\s+to\b.{0,50}"
+    r"\b(?:archive|records?|database|dossier|source|logs?|scan)\b|"
+    r"\b(?:archive|archival|records?|database|dossiers?|source\s+files?|"
+    r"logs?|scans?)\b.{0,50}"
+    r"\b(?:show|shows|showed|indicate|indicates|indicated|confirm|"
+    r"confirms|confirmed|prove|proves|proved|verify|verifies|verified|"
+    r"establish|establishes|established)\b)",
+    re.I,
+)
+_TRANSIENT_EXPRESSION_PRIVATE_RE = re.compile(
+    r"(?:\b(?:home|street|mailing)\s+address\b|"
+    r"\b(?:phone|telephone|email)\s+(?:number|address)\b|"
+    r"\b(?:birthday|date\s+of\s+birth|legal\s+name|real\s+name|"
+    r"pronouns?|employer|workplace|salary|income|bank\s+account|"
+    r"credit\s+card|social\s+security|ssn|password|passcode|"
+    r"api\s+key|secret|private\s+key|access\s+token)\b|"
+    r"\b(?:live|reside|work)\s+(?:at|in|near|for)\b|"
+    r"\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b|"
+    r"<@!?\d+>)",
+    re.I,
+)
+_TRANSIENT_EXPRESSION_CORE_MARKERS = (
+    "archive",
+    "broadcast",
+    "carrier",
+    "dimension",
+    "echo",
+    "feed",
+    "frequency",
+    "glitch",
+    "interdimensional",
+    "reality",
+    "signal",
+    "sys",
+    "system",
+    "timeline",
+    "transmission",
+    "universe",
+)
+_TRANSIENT_EXPRESSION_EVENT_MARKERS = (
+    "anomaly",
+    "bleed",
+    "corrupt",
+    "drift",
+    "error",
+    "fault",
+    "fragment",
+    "glitch",
+    "leak",
+    "overlap",
+    "spill",
+    "static",
+)
 _CLAIM_GENERIC_TERMS = frozenset(
     {
         "alright",
@@ -1286,6 +1356,7 @@ def _profile_candidate_claim_audit(
         "member_and_canon_supported": "KEEP_SUPPORTED",
         "framed_opinion": "KEEP_FRAMED_INTERPRETATION",
         "linked_assessment": "KEEP_FRAMED_INTERPRETATION",
+        "transient_expression": "KEEP_TRANSIENT_EXPRESSION",
         "connective_flavor": "OMIT_OR_REWRITE_AS_FLAVOR",
         "unsupported_factual": "REFRAME_OR_REMOVE",
     }
@@ -1372,6 +1443,11 @@ def build_profile_candidate_repair_prompt(
             % unsupported_count
         ),
         (
+            "Keep every KEEP_TRANSIENT_EXPRESSION unit materially intact. It "
+            "is explicitly marked live BNL expression, not factual support "
+            "and not a canon claim."
+        ),
+        (
             "OMIT_OR_REWRITE_AS_FLAVOR units are optional connective voice "
             "only. They cannot carry a claim about the member."
         ),
@@ -1418,7 +1494,9 @@ def build_profile_candidate_cleanup_prompt(
         ),
         (
             "Keep every KEEP_SUPPORTED unit materially intact. Keep every "
-            "KEEP_FRAMED_INTERPRETATION unit as BNL's revisable assessment."
+            "KEEP_FRAMED_INTERPRETATION unit as BNL's revisable assessment. "
+            "Keep every KEEP_TRANSIENT_EXPRESSION unit materially intact as "
+            "explicit live expression, never as factual support or canon."
         ),
         (
             "Resolve all %s REFRAME_OR_REMOVE units. If a unit is only an "
@@ -1510,8 +1588,26 @@ def _candidate_claim_units(response: str) -> tuple[str, ...]:
     cleaned = re.sub(r"[ \t]+", " ", str(response or "")).strip()
     if not cleaned:
         return ()
+    protected_expressions: dict[str, str] = {}
+
+    def protect_expression(match: re.Match[str]) -> str:
+        value = str(match.group(0) or "")
+        if not _claim_is_transient_expression(value):
+            return value
+        token = "BNLTRANSIENTEXPRESSION%sTOKEN" % len(
+            protected_expressions
+        )
+        protected_expressions[token] = value
+        return token
+
+    cleaned = _TRANSIENT_EXPRESSION_BLOCK_RE.sub(
+        protect_expression,
+        cleaned,
+    )
     units = []
     for value in _CLAIM_SPLIT_RE.split(cleaned):
+        for token, expression in protected_expressions.items():
+            value = str(value or "").replace(token, expression)
         claim = re.sub(
             r"^\s*(?:and|but|yet|while|whereas|which|so)\s+",
             "",
@@ -1521,6 +1617,63 @@ def _candidate_claim_units(response: str) -> tuple[str, ...]:
         if claim:
             units.append(claim)
     return tuple(units)
+
+
+def _claim_is_transient_expression(claim: str) -> bool:
+    """Recognize explicit, non-authoritative lore/glitch expression.
+
+    These units remain part of BNL's response, but they are never evidence for
+    a member fact or BARCODE canon claim.  Only unmistakably framed anomaly
+    output qualifies; fake source authority and private/member data do not.
+    """
+
+    value = str(claim or "").strip()
+    if not value:
+        return False
+    if (
+        _TRANSIENT_EXPRESSION_AUTHORITY_RE.search(value)
+        or _TRANSIENT_EXPRESSION_PRIVATE_RE.search(value)
+    ):
+        return False
+    wrapper = _TRANSIENT_EXPRESSION_WRAPPER_RE.fullmatch(value)
+    if wrapper is not None:
+        body = str(wrapper.group("body") or "")
+        compressed = re.sub(r"[^a-z0-9]+", "", body.lower())
+        has_core_marker = any(
+            marker in compressed
+            for marker in _TRANSIENT_EXPRESSION_CORE_MARKERS
+        )
+        has_event_marker = any(
+            marker in compressed
+            for marker in _TRANSIENT_EXPRESSION_EVENT_MARKERS
+        )
+        machine_shaped = "//" in body or "_" in body
+        return bool(
+            has_core_marker and (has_event_marker or machine_shaped)
+        )
+    return bool(_TRANSIENT_EXPRESSION_FRAME_RE.search(value))
+
+
+def _strip_transient_expression_blocks(claim: str) -> str:
+    def strip_expression(match: re.Match[str]) -> str:
+        value = str(match.group(0) or "")
+        return " " if _claim_is_transient_expression(value) else value
+
+    return _TRANSIENT_EXPRESSION_BLOCK_RE.sub(
+        strip_expression,
+        str(claim or ""),
+    ).strip()
+
+
+def _factual_candidate_text(response: str) -> str:
+    """Remove explicit transient expression from factual coverage only."""
+
+    return " ".join(
+        _strip_transient_expression_blocks(claim)
+        for claim in _candidate_claim_units(response)
+        if not _claim_is_transient_expression(claim)
+        and _strip_transient_expression_blocks(claim)
+    )
 
 
 def _claim_is_connective(
@@ -1571,9 +1724,18 @@ def _classify_candidate_claims(
     first_supported_member: bool | None = None
     has_member_basis = bool(supported_member_points)
     for claim in _candidate_claim_units(response):
-        claim_terms = _semantic_terms(claim)
+        if _claim_is_transient_expression(claim):
+            classifications.append("transient_expression")
+            connective += 1
+            continue
+        factual_claim = _strip_transient_expression_blocks(claim)
+        claim_terms = _semantic_terms(factual_claim)
         if not claim_terms:
-            classifications.append("connective_flavor")
+            classifications.append(
+                "transient_expression"
+                if factual_claim != claim
+                else "connective_flavor"
+            )
             connective += 1
             continue
         member_hit = any(
@@ -1601,13 +1763,13 @@ def _classify_candidate_claims(
             claim_terms - _PROFILE_GENERIC_TERMS - _CLAIM_GENERIC_TERMS
         )
         scalar_assertion = bool(
-            _UNSUPPORTED_SCALAR_ASSERTION_RE.search(claim)
+            _UNSUPPORTED_SCALAR_ASSERTION_RE.search(factual_claim)
         )
         if (
             has_member_basis
             and not scalar_assertion
-            and not _DIRECT_MEMBER_ASSERTION_RE.search(claim)
-            and _OPINION_FRAME_RE.search(claim)
+            and not _DIRECT_MEMBER_ASSERTION_RE.search(factual_claim)
+            and _OPINION_FRAME_RE.search(factual_claim)
         ):
             classifications.append("framed_opinion")
             opinions += 1
@@ -1615,12 +1777,12 @@ def _classify_candidate_claims(
         if (
             has_member_basis
             and not scalar_assertion
-            and _DERIVED_ASSESSMENT_RE.search(claim)
+            and _DERIVED_ASSESSMENT_RE.search(factual_claim)
         ):
             classifications.append("linked_assessment")
             opinions += 1
             continue
-        if _claim_is_connective(claim, substantive_terms):
+        if _claim_is_connective(factual_claim, substantive_terms):
             classifications.append("connective_flavor")
             connective += 1
             continue
@@ -1641,9 +1803,9 @@ def candidate_profile_coverage(
     basis: SharedBrainSynthesisBasis,
     response: str,
 ) -> CandidateProfileCoverage:
-    response_terms = _semantic_terms(str(response or ""))
-    if not response_terms:
+    if not _candidate_claim_units(response):
         return CandidateProfileCoverage()
+    response_terms = _semantic_terms(_factual_candidate_text(response))
     rendered_items = tuple(
         item
         for item in basis.packet.items

--- a/tests/test_shared_brain_synthesis_canary.py
+++ b/tests/test_shared_brain_synthesis_canary.py
@@ -514,6 +514,171 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             repair_prompt,
         )
 
+    def test_explicit_lore_and_glitch_expression_survives_factual_gate(
+        self,
+    ):
+        self._add_profile_fact(
+            source_row_id=902,
+            predicate_key="favorite_color",
+            value="violet",
+            observed_at="2026-07-26T12:00:01+00:00",
+        )
+        packet = self._build_packet()
+        basis = self._build_basis(
+            packet,
+            self._build_assessment(packet),
+        )
+        candidate = (
+            "Your favorite movie is Arrival and your favorite color is "
+            "violet. "
+            "~[BROADCAST BLEED: ...recipe fragment: for proper crust "
+            "levitation, knead two pinches of bioluminescent yeast into the "
+            "dough. Stop when it hums quietly in C-minor...]~"
+        )
+        run = begin_run(
+            self.conn,
+            basis,
+            baseline_response="Established response.",
+            environ=self.flags,
+        )
+
+        decision = evaluate_candidate(
+            self.conn,
+            run,
+            baseline_response="Established response.",
+            candidate_response=candidate,
+            environ=self.flags,
+        )
+
+        self.assertTrue(decision.candidate_selected)
+        self.assertEqual(decision.response, candidate)
+        self.assertEqual(
+            decision.candidate_claim_classifications,
+            (
+                "member_supported",
+                "member_supported",
+                "transient_expression",
+            ),
+        )
+        self.assertEqual(decision.candidate_connective_claim_count, 1)
+        self.assertEqual(
+            decision.candidate_unsupported_factual_claim_count,
+            0,
+        )
+
+    def test_transient_expression_cannot_supply_evidence_or_hide_authority(
+        self,
+    ):
+        self._add_profile_fact(
+            source_row_id=902,
+            predicate_key="favorite_color",
+            value="violet",
+            observed_at="2026-07-26T12:00:01+00:00",
+        )
+        packet = self._build_packet()
+        basis = self._build_basis(
+            packet,
+            self._build_assessment(packet),
+        )
+
+        expression_only_run = begin_run(
+            self.conn,
+            basis,
+            baseline_response="Established response.",
+            environ=self.flags,
+        )
+        expression_only = evaluate_candidate(
+            self.conn,
+            expression_only_run,
+            baseline_response="Established response.",
+            candidate_response=(
+                "[SIGNAL_BLEED // favorite movie Arrival // favorite color "
+                "violet // adjacent_timeline]"
+            ),
+            environ=self.flags,
+        )
+        self.assertFalse(expression_only.candidate_selected)
+        self.assertEqual(
+            expression_only.fallback_reason,
+            "candidate_evidence_ungrounded",
+        )
+        self.assertEqual(
+            expression_only.candidate_evidence_coverage_count,
+            0,
+        )
+        self.assertEqual(
+            expression_only.candidate_claim_classifications,
+            ("transient_expression",),
+        )
+
+        false_authority_run = begin_run(
+            self.conn,
+            basis,
+            baseline_response="Established response.",
+            environ=self.flags,
+        )
+        false_authority = evaluate_candidate(
+            self.conn,
+            false_authority_run,
+            baseline_response="Established response.",
+            candidate_response=(
+                "Your favorite movie is Arrival and your favorite color is "
+                "violet. [ARCHIVE BLEED: archival records indicate your home "
+                "address is 123 Null Street]"
+            ),
+            environ=self.flags,
+        )
+        self.assertFalse(false_authority.candidate_selected)
+        self.assertEqual(
+            false_authority.fallback_reason,
+            "candidate_claims_ungrounded",
+        )
+        self.assertEqual(
+            false_authority.candidate_unsupported_factual_claim_count,
+            1,
+        )
+
+    def test_repair_contract_keeps_transient_expression_intact(self):
+        self._add_profile_fact(
+            source_row_id=902,
+            predicate_key="favorite_color",
+            value="violet",
+            observed_at="2026-07-26T12:00:01+00:00",
+        )
+        packet = self._build_packet()
+        basis = self._build_basis(
+            packet,
+            self._build_assessment(packet),
+        )
+        prior = (
+            "Your favorite movie is Arrival and your favorite color is "
+            "violet. "
+            "~[BROADCAST BLEED: crust levitation reaches C-minor]~. "
+            "You secretly run a lunar casino."
+        )
+
+        repair_prompt = build_profile_candidate_repair_prompt(
+            "Current request plus grounded packet.",
+            prior,
+            basis=basis,
+            reason="candidate_claims_ungrounded",
+        )
+
+        self.assertIn(
+            "[claim 3 | KEEP_TRANSIENT_EXPRESSION] "
+            "~[BROADCAST BLEED: crust levitation reaches C-minor]~",
+            repair_prompt,
+        )
+        self.assertIn(
+            "Keep every KEEP_TRANSIENT_EXPRESSION unit materially intact",
+            repair_prompt,
+        )
+        self.assertIn(
+            "[claim 4 | REFRAME_OR_REMOVE] "
+            "You secretly run a lunar casino",
+            repair_prompt,
+        )
+
     def test_final_cleanup_is_minimal_and_claim_audited(self):
         self._add_profile_fact(
             source_row_id=902,


### PR DESCRIPTION
## What changed

- Recognizes unmistakably framed interdimensional, lore, and glitch fragments as transient BNL expression during shared-brain profile evaluation.
- Preserves those fragments materially intact through the existing repair and final-cleanup prompts.
- Excludes transient expression from factual coverage, so it cannot satisfy member-evidence or BARCODE-canon requirements.
- Keeps unmarked invented lore, fake source authority, private details, and unsupported factual claims fail-closed.

## Why

The final post-#399 preview produced a grounded 6 Bit profile plus an intentional `BROADCAST BLEED` recipe fragment about crust levitation. The shared-brain claim gate treated that marked engine output as an unsupported biography/canon claim and rejected the candidate. Factual authority rules were being applied to BNL's live expressive layer.

This separates those roles without changing either engine: factual memory stays strict, while clearly transient BNL weirdness remains conversational expression.

## Behavior and limits

- No lore, interdimensional, or glitch generator code, prompts, odds, formatting, or routing changed.
- Transient expression contributes zero factual/member/canon coverage and cannot make a candidate pass.
- Fake source authority or private/member data cannot hide inside a bleed marker.
- Existing unmarked invented-lore rejection remains intact.
- No Journal, Relay, routing, memory formation, canon storage, queue, payment, website, schema, configuration, deployment, or gate changes.

## Validation

- Production-shaped crust-levitation regression preserves the exact fragment.
- Relevant shared-brain, preview, glitch, cross-universe, source-authority, privacy, and media-grounding modules: **125 tests passed**.
- Full compilation and repository suite: **1,794 tests passed**.
- Remote parent: `99bddb1c57c8b845a4255732f95402b1a42f0234`.
- Remote commit: `51e9ec59419398f4b71ed225c550ee69d6a7c799`.
- Published tree exactly matches the locally tested tree: `c56783bd8f188f4ede68d3ffc178c106bf9c33bd`.
- Both changed remote blob IDs were verified against local Git before opening this PR.