### PR TITLE
Repair memory source procurement

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -5003,6 +5003,23 @@ def init_db():
     _try_alter(cursor, "ALTER TABLE conversations ADD COLUMN channel_policy TEXT")
     _try_alter(cursor, "ALTER TABLE conversations ADD COLUMN channel_id INTEGER")
     _try_alter(cursor, "ALTER TABLE conversations ADD COLUMN message_id INTEGER")
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS conversation_history_backfill_cursors (
+            guild_id INTEGER NOT NULL,
+            channel_id INTEGER NOT NULL,
+            channel_name TEXT NOT NULL DEFAULT '',
+            channel_policy TEXT NOT NULL DEFAULT 'unknown',
+            before_message_id INTEGER,
+            completed INTEGER NOT NULL DEFAULT 0,
+            pages_completed INTEGER NOT NULL DEFAULT 0,
+            messages_scanned INTEGER NOT NULL DEFAULT 0,
+            messages_inserted INTEGER NOT NULL DEFAULT 0,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (guild_id, channel_id)
+        )
+        """
+    )
 
     cursor.execute(
         """
@@ -10064,6 +10081,29 @@ def insert_backfilled_conversation_row(*, guild_id: int, channel_id: int, channe
             )
         row_id = int(cur.lastrowid or 0)
         conn.commit()
+        _shadow_memory_ledger_write(
+            "conversations_backfill",
+            lambda ledger_conn: shadow_conversation_row(
+                ledger_conn,
+                row_id=row_id,
+                user_id=user_id,
+                user_name=user_name,
+                guild_id=guild_id,
+                role="user",
+                content=content,
+                channel_name=(channel_name or "").lower()[:80],
+                channel_policy=(channel_policy or "unknown")[:40],
+                channel_id=int(channel_id or 0),
+                message_id=int(message_id or 0) or None,
+                route_mode=ROUTE_MODE_CONVERSATION_CONTINUITY,
+                observed_at=timestamp,
+                source_sequence=int(message_id or 0) or row_id,
+            ),
+            guild_id=guild_id,
+            source_table="conversations",
+            source_row_id=row_id,
+            source_revision=str(row_id),
+        )
         if (channel_policy or "").strip().lower() in PUBLIC_CHAT_POLICIES:
             try:
                 occurred_at_ms = journal_timestamp_to_epoch_ms(timestamp)
@@ -10100,6 +10140,94 @@ def _iso_timestamp(value) -> str:
 
 def _message_clean_content(msg) -> str:
     return re.sub(r"\s+", " ", getattr(msg, "clean_content", None) or getattr(msg, "content", "") or "").strip()
+
+
+def get_channel_backfill_cursor(guild_id: int, channel_id: int) -> dict:
+    """Return content-free paging state for one Discord history source."""
+    conn = sqlite3.connect(DB_FILE)
+    try:
+        row = conn.execute(
+            """
+            SELECT before_message_id,completed,pages_completed,
+                   messages_scanned,messages_inserted
+            FROM conversation_history_backfill_cursors
+            WHERE guild_id=? AND channel_id=?
+            """,
+            (int(guild_id or 0), int(channel_id or 0)),
+        ).fetchone()
+    finally:
+        conn.close()
+    if not row:
+        return {
+            "before_message_id": 0,
+            "completed": False,
+            "pages_completed": 0,
+            "messages_scanned": 0,
+            "messages_inserted": 0,
+        }
+    return {
+        "before_message_id": int(row[0] or 0),
+        "completed": bool(row[1]),
+        "pages_completed": int(row[2] or 0),
+        "messages_scanned": int(row[3] or 0),
+        "messages_inserted": int(row[4] or 0),
+    }
+
+
+def advance_channel_backfill_cursor(
+    *,
+    guild_id: int,
+    channel_id: int,
+    channel_name: str,
+    channel_policy: str,
+    before_message_id: int,
+    completed: bool,
+    messages_scanned: int,
+    messages_inserted: int,
+) -> dict:
+    """Advance one page without deriving progress from scattered stored rows."""
+    now = datetime.now(timezone.utc).isoformat()
+    conn = sqlite3.connect(DB_FILE)
+    try:
+        conn.execute(
+            """
+            INSERT INTO conversation_history_backfill_cursors(
+              guild_id,channel_id,channel_name,channel_policy,
+              before_message_id,completed,pages_completed,
+              messages_scanned,messages_inserted,updated_at
+            ) VALUES(?,?,?,?,?,?,?,?,?,?)
+            ON CONFLICT(guild_id,channel_id) DO UPDATE SET
+              channel_name=excluded.channel_name,
+              channel_policy=excluded.channel_policy,
+              before_message_id=excluded.before_message_id,
+              completed=excluded.completed,
+              pages_completed=
+                conversation_history_backfill_cursors.pages_completed+1,
+              messages_scanned=
+                conversation_history_backfill_cursors.messages_scanned+
+                excluded.messages_scanned,
+              messages_inserted=
+                conversation_history_backfill_cursors.messages_inserted+
+                excluded.messages_inserted,
+              updated_at=excluded.updated_at
+            """,
+            (
+                int(guild_id or 0),
+                int(channel_id or 0),
+                (channel_name or "").lower()[:80],
+                (channel_policy or "unknown")[:40],
+                int(before_message_id or 0) or None,
+                1 if completed else 0,
+                1,
+                int(messages_scanned or 0),
+                int(messages_inserted or 0),
+                now,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return get_channel_backfill_cursor(guild_id, channel_id)
 
 
 def mark_backfill_status(channel_name: str = "", status: str = "", scanned: int = 0, inserted: int = 0, skipped: int = 0, error: str = "none", dry_run: bool = True) -> None:
@@ -10147,12 +10275,52 @@ async def run_channel_backfill(channel, *, limit: int = BACKFILL_DEFAULT_LIMIT, 
         return result
     per_user = Counter()
     guild = getattr(channel, "guild", None)
+    guild_id = int(getattr(guild, "id", 0) or 0)
+    channel_id = int(getattr(channel, "id", 0) or 0)
+    cursor_state = get_channel_backfill_cursor(guild_id, channel_id)
+    result["cursorBeforeMessageId"] = int(
+        cursor_state.get("before_message_id") or 0
+    )
+    result["cursorAfterMessageId"] = result["cursorBeforeMessageId"]
+    result["historyComplete"] = bool(cursor_state.get("completed"))
+    result["pagesCompleted"] = int(
+        cursor_state.get("pages_completed") or 0
+    )
+    if cursor_state.get("completed") and not dry_run:
+        result["status"] = "complete"
+        result["skipReasons"] = {}
+        mark_backfill_status(
+            result["channelName"],
+            "complete",
+            0,
+            0,
+            0,
+            "none",
+            dry_run,
+        )
+        return result
+    oldest_scanned_message_id = 0
     try:
-        async for msg in channel.history(limit=limit, oldest_first=True):
+        # Page newest-to-oldest with a Discord `before` cursor. Passing
+        # `oldest_first=True` switches discord.py to its `after` strategy,
+        # which would repeatedly start at the beginning of the channel and
+        # can leave the middle of a long history uncollected.
+        history_kwargs = {"limit": limit, "oldest_first": False}
+        if result["cursorBeforeMessageId"]:
+            history_kwargs["before"] = discord.Object(
+                id=result["cursorBeforeMessageId"]
+            )
+        async for msg in channel.history(**history_kwargs):
             result["messagesScanned"] += 1
             author = getattr(msg, "author", None)
             content = _message_clean_content(msg)
             message_id = int(getattr(msg, "id", 0) or 0) or None
+            if message_id:
+                oldest_scanned_message_id = (
+                    min(oldest_scanned_message_id, message_id)
+                    if oldest_scanned_message_id
+                    else message_id
+                )
             timestamp = _iso_timestamp(getattr(msg, "created_at", None))
             if not guild:
                 result["skipReasons"]["dm_or_missing_guild"] += 1; continue
@@ -10201,7 +10369,33 @@ async def run_channel_backfill(channel, *, limit: int = BACKFILL_DEFAULT_LIMIT, 
     result["uniqueUsersFound"] = len(per_user)
     result["topUsers"] = per_user.most_common(5)
     result["skipReasons"] = dict(result["skipReasons"])
-    result["status"] = "dry_run" if dry_run else "stored"
+    page_exhausted = result["messagesScanned"] < limit
+    result["cursorAfterMessageId"] = (
+        oldest_scanned_message_id
+        or result["cursorBeforeMessageId"]
+    )
+    result["historyComplete"] = bool(page_exhausted)
+    if not dry_run:
+        cursor_state = advance_channel_backfill_cursor(
+            guild_id=guild_id,
+            channel_id=channel_id,
+            channel_name=result["channelName"],
+            channel_policy=policy,
+            before_message_id=result["cursorAfterMessageId"],
+            completed=page_exhausted,
+            messages_scanned=result["messagesScanned"],
+            messages_inserted=result["messagesInserted"],
+        )
+        result["pagesCompleted"] = int(
+            cursor_state.get("pages_completed") or 0
+        )
+    result["status"] = (
+        "dry_run"
+        if dry_run
+        else "complete"
+        if result["historyComplete"]
+        else "stored_page"
+    )
     mark_backfill_status(result["channelName"], result["status"], result["messagesScanned"], result["messagesInserted"], sum(result["skipReasons"].values()), "none", dry_run)
     logging.info("approved_channel_backfill channel=%s policy=%s dry_run=%s scanned=%s eligible=%s inserted=%s skipped=%s", result["channelName"], policy, dry_run, result["messagesScanned"], result["messagesEligible"], result["messagesInserted"], sum(result["skipReasons"].values()))
     return result
@@ -10221,6 +10415,7 @@ def format_channel_backfill_result(result: dict) -> str:
         f"channel policy: `{result.get('channelPolicy')}` | eligible: `{'yes' if result.get('eligible') else 'no'}` ({result.get('eligibilityReason')})",
         f"dry_run: `{'yes' if result.get('dryRun') else 'no'}` | limit: `{result.get('limit')}` | status: `{result.get('status')}`",
         f"messages scanned: `{result.get('messagesScanned')}` | eligible: `{result.get('messagesEligible')}` | inserted: `{result.get('messagesInserted')}` | truncated: `{result.get('messagesTruncated')}` | already_exists: `{result.get('rowsAlreadyExist')}`",
+        f"history paging: pages=`{result.get('pagesCompleted', 0)}` complete=`{'yes' if result.get('historyComplete') else 'no'}` cursor_before=`{result.get('cursorBeforeMessageId') or 'none'}` cursor_after=`{result.get('cursorAfterMessageId') or 'none'}`",
         f"messages skipped by reason: `{skip_text}`",
         f"unique users found: `{result.get('uniqueUsersFound')}` | top users by eligible count: `{top_text}`",
         f"tables {'would update' if result.get('dryRun') else 'updated'}: `{tables}`",

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -205,8 +205,8 @@ _CONVERSATION_MOTIF_ROLEPLAY_RE = re.compile(
     r"hypothetically|just\s+kidding|j/?k|sarcasm)\b",
     re.I,
 )
-_CONVERSATION_MOTIF_URL_OR_MENTION_RE = re.compile(
-    r"(?:\bhttps?://|\bwww\.|"
+_CONVERSATION_MOTIF_URL_OR_MENTION_TOKEN_RE = re.compile(
+    r"(?:https?://\S+|www\.\S+|"
     r"\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b|<@!?\d+>)",
     re.I,
 )
@@ -536,9 +536,12 @@ _CONVERSATION_MOTIF_ANCHORS = {
 _CONVERSATION_MOTIF_WINDOW_SECONDS = 30 * 60
 _CONVERSATION_OCCURRENCE_MAX_SCAN = 64
 _CONVERSATION_CORRECTION_MAX_SCAN = 40
-_CONVERSATION_MOTIF_MAX_SCAN = 240
+_CONVERSATION_MOTIF_MAX_SCAN = 1200
 _CONVERSATION_MOTIF_MAX_CANDIDATES = 6
 _CONVERSATION_MOTIF_MAX_ROOTS = 12
+_CONVERSATION_MOTIF_PUBLIC_POLICIES = frozenset(
+    {"public_home", "public_context", "public_selective"}
+)
 
 APPROVED_SELF_AUTHORED_FACT_KEYS = frozenset({
     "preferred_name",
@@ -4466,24 +4469,32 @@ def _conversation_motif_terms(
     include_correction: bool = False,
     include_direct_fact: bool = False,
 ) -> tuple[str, ...]:
-    text = re.sub(r"\s+", " ", str(value or "")).strip()
+    source_text = re.sub(r"\s+", " ", str(value or "")).strip()
     if (
-        not text
-        or len(text.split()) < 4
+        not source_text
         or (
             not include_correction
-            and _CONVERSATION_CORRECTION_RE.search(text)
+            and _CONVERSATION_CORRECTION_RE.search(source_text)
         )
-        or _CONVERSATION_MOTIF_RECALL_RE.search(text)
-        or _CONVERSATION_MOTIF_UNSAFE_RE.search(text)
+        or _CONVERSATION_MOTIF_RECALL_RE.search(source_text)
+        or _CONVERSATION_MOTIF_UNSAFE_RE.search(source_text)
         or (
             not include_direct_fact
-            and _CONVERSATION_MOTIF_DIRECT_FACT_RE.search(text)
+            and _CONVERSATION_MOTIF_DIRECT_FACT_RE.search(source_text)
         )
-        or _CONVERSATION_MOTIF_SENSITIVE_RE.search(text)
-        or _CONVERSATION_MOTIF_ROLEPLAY_RE.search(text)
-        or _CONVERSATION_MOTIF_URL_OR_MENTION_RE.search(text)
+        or _CONVERSATION_MOTIF_SENSITIVE_RE.search(source_text)
+        or _CONVERSATION_MOTIF_ROLEPLAY_RE.search(source_text)
     ):
+        return ()
+    text = re.sub(
+        r"\s+",
+        " ",
+        _CONVERSATION_MOTIF_URL_OR_MENTION_TOKEN_RE.sub(
+            " ",
+            source_text,
+        ),
+    ).strip()
+    if not text or len(text.split()) < 4:
         return ()
     return tuple(
         dict.fromkeys(
@@ -5014,7 +5025,9 @@ def _sync_bounded_conversation_motif_corrections(
           AND entry_type='observation' AND predicate_key='conversation'
           AND source_table='conversations' AND source_role='user'
           AND source_class='public_observation'
-          AND channel_policy IN ('public_home','public_context')
+          AND channel_policy IN (
+            'public_home','public_context','public_selective'
+          )
           AND visibility IN ('public','public_safe')
           AND public_usable=1 AND derived=0 AND projection=0
           AND lifecycle_status='active'
@@ -5118,6 +5131,7 @@ def _conversation_motif_history(
     guild_id: int,
     subject_key: str,
     max_scan: int,
+    diagnostics: dict[str, int] | None = None,
 ) -> list[dict[str, Any]]:
     rows = conn.execute(
         """
@@ -5130,7 +5144,9 @@ def _conversation_motif_history(
           AND entry_type='observation' AND predicate_key='conversation'
           AND source_table='conversations' AND source_role='user'
           AND source_class='public_observation'
-          AND channel_policy IN ('public_home','public_context')
+          AND channel_policy IN (
+            'public_home','public_context','public_selective'
+          )
           AND visibility IN ('public','public_safe')
           AND public_usable=1 AND derived=0 AND projection=0
           AND lifecycle_status='active'
@@ -5174,18 +5190,55 @@ def _conversation_motif_history(
         "lifecycle_status",
     )
     history: list[dict[str, Any]] = []
+    if diagnostics is not None:
+        diagnostics["ledger_rows_scanned"] = len(rows)
     for row in rows:
         entry = dict(zip(keys, row))
         terms = _conversation_motif_terms(
             str(entry.get("normalized_value") or "")
         )
         if not terms:
+            if diagnostics is not None:
+                diagnostics["ledger_rows_term_excluded"] = (
+                    int(
+                        diagnostics.get(
+                            "ledger_rows_term_excluded",
+                            0,
+                        )
+                        or 0
+                    )
+                    + 1
+                )
             continue
         full_entry = _knowledge_entry_rows(
             conn,
             (str(entry.get("entry_id") or ""),),
         ).get(str(entry.get("entry_id") or ""))
         if not full_entry:
+            if diagnostics is not None:
+                diagnostics["ledger_rows_missing_root"] = (
+                    int(
+                        diagnostics.get(
+                            "ledger_rows_missing_root",
+                            0,
+                        )
+                        or 0
+                    )
+                    + 1
+                )
+            continue
+        if _knowledge_operational_or_test_source(full_entry):
+            if diagnostics is not None:
+                diagnostics["ledger_rows_operational_excluded"] = (
+                    int(
+                        diagnostics.get(
+                            "ledger_rows_operational_excluded",
+                            0,
+                        )
+                        or 0
+                    )
+                    + 1
+                )
             continue
         entry["terms"] = terms
         entry["occurrence_identity"] = _knowledge_occurrence_identity(
@@ -5193,9 +5246,260 @@ def _conversation_motif_history(
             full_entry,
         )
         if not entry["occurrence_identity"]:
+            if diagnostics is not None:
+                diagnostics["ledger_rows_occurrence_excluded"] = (
+                    int(
+                        diagnostics.get(
+                            "ledger_rows_occurrence_excluded",
+                            0,
+                        )
+                        or 0
+                    )
+                    + 1
+                )
             continue
         history.append(entry)
+    if diagnostics is not None:
+        diagnostics["ledger_rows_motif_eligible"] = len(history)
     return history
+
+
+def _conversation_projection_columns(
+    conn: sqlite3.Connection,
+) -> set[str]:
+    if not conn.execute(
+        """
+        SELECT 1 FROM sqlite_master
+        WHERE type='table' AND name='conversations'
+        """
+    ).fetchone():
+        return set()
+    return {
+        str(row[1] or "")
+        for row in conn.execute(
+            "PRAGMA table_info(conversations)"
+        ).fetchall()
+        if len(row) > 1 and str(row[1] or "")
+    }
+
+
+def project_retained_conversations_to_ledger(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    subject_key: str,
+    max_scan: int = _CONVERSATION_MOTIF_MAX_SCAN,
+    diagnostics: dict[str, int] | None = None,
+    environ: dict[str, str] | None = None,
+) -> dict[str, int]:
+    """Project retained public rows through the existing Ledger write owner.
+
+    The operation is bounded, subject-isolated, and idempotent. It is enabled
+    only with the recurring-conversation formation gate, so ordinary startup
+    and normal chat do not silently backfill production history.
+    """
+    counts: dict[str, int] = {}
+    if not conversation_motif_formation_enabled(environ):
+        counts["projection_gate_disabled"] = 1
+        if diagnostics is not None:
+            diagnostics.update(counts)
+        return counts
+    if (
+        not int(guild_id or 0)
+        or not str(subject_key or "").startswith("discord_user:")
+    ):
+        counts["projection_scope_invalid"] = 1
+        if diagnostics is not None:
+            diagnostics.update(counts)
+        return counts
+    try:
+        subject_user_id = int(str(subject_key).split(":", 1)[1])
+    except (IndexError, TypeError, ValueError):
+        counts["projection_scope_invalid"] = 1
+        if diagnostics is not None:
+            diagnostics.update(counts)
+        return counts
+    columns = _conversation_projection_columns(conn)
+    required = {
+        "id",
+        "guild_id",
+        "user_id",
+        "role",
+        "content",
+        "channel_policy",
+    }
+    if not required.issubset(columns):
+        counts["retained_source_unavailable"] = 1
+        if diagnostics is not None:
+            diagnostics.update(counts)
+        return counts
+    ensure_memory_ledger_schema(conn)
+    safe_limit = max(
+        1,
+        min(
+            int(max_scan or _CONVERSATION_MOTIF_MAX_SCAN),
+            _CONVERSATION_MOTIF_MAX_SCAN,
+        ),
+    )
+    counts["retained_rows_total"] = int(
+        conn.execute(
+            """
+            SELECT COUNT(*) FROM conversations
+            WHERE guild_id=? AND user_id=? AND role='user'
+            """,
+            (int(guild_id or 0), subject_user_id),
+        ).fetchone()[0]
+        or 0
+    )
+    optional = {
+        "user_name": "''",
+        "channel_name": "''",
+        "channel_id": "0",
+        "message_id": "NULL",
+        "timestamp": "''",
+    }
+    select = [
+        "id",
+        "user_id",
+        (
+            "user_name"
+            if "user_name" in columns
+            else "%s AS user_name" % optional["user_name"]
+        ),
+        "content",
+        (
+            "channel_name"
+            if "channel_name" in columns
+            else "%s AS channel_name" % optional["channel_name"]
+        ),
+        "channel_policy",
+        (
+            "channel_id"
+            if "channel_id" in columns
+            else "%s AS channel_id" % optional["channel_id"]
+        ),
+        (
+            "message_id"
+            if "message_id" in columns
+            else "%s AS message_id" % optional["message_id"]
+        ),
+        (
+            "timestamp"
+            if "timestamp" in columns
+            else "%s AS timestamp" % optional["timestamp"]
+        ),
+    ]
+    order = (
+        "timestamp DESC,id DESC"
+        if "timestamp" in columns
+        else "id DESC"
+    )
+    rows = conn.execute(
+        """
+        SELECT %s
+        FROM conversations
+        WHERE guild_id=? AND user_id=? AND role='user'
+        ORDER BY %s
+        LIMIT ?
+        """
+        % (",".join(select), order),
+        (int(guild_id or 0), subject_user_id, safe_limit),
+    ).fetchall()
+    counts["retained_rows_scanned"] = len(rows)
+    counts["retained_rows_outside_scan"] = max(
+        0,
+        counts["retained_rows_total"] - len(rows),
+    )
+    existing = {
+        str(row[0] or "")
+        for row in conn.execute(
+            """
+            SELECT source_row_id
+            FROM memory_ledger_entries
+            WHERE guild_id=? AND subject_key=?
+              AND source_table='conversations' AND source_role='user'
+            """,
+            (int(guild_id or 0), str(subject_key or "")),
+        ).fetchall()
+        if str(row[0] or "")
+    }
+    keys = (
+        "id",
+        "user_id",
+        "user_name",
+        "content",
+        "channel_name",
+        "channel_policy",
+        "channel_id",
+        "message_id",
+        "timestamp",
+    )
+    for raw in reversed(rows):
+        row = dict(zip(keys, raw))
+        row_id = int(row.get("id") or 0)
+        policy = _canon(row.get("channel_policy"))
+        if (
+            row_id <= 0
+            or not str(row.get("content") or "").strip()
+        ):
+            counts["retained_rows_invalid"] = (
+                int(counts.get("retained_rows_invalid", 0) or 0) + 1
+            )
+            continue
+        if policy not in _CONVERSATION_MOTIF_PUBLIC_POLICIES:
+            counts["retained_rows_policy_excluded"] = (
+                int(
+                    counts.get(
+                        "retained_rows_policy_excluded",
+                        0,
+                    )
+                    or 0
+                )
+                + 1
+            )
+            continue
+        counts["retained_rows_public_safe"] = (
+            int(counts.get("retained_rows_public_safe", 0) or 0) + 1
+        )
+        if str(row_id) in existing:
+            counts["ledger_projection_existing"] = (
+                int(
+                    counts.get(
+                        "ledger_projection_existing",
+                        0,
+                    )
+                    or 0
+                )
+                + 1
+            )
+            continue
+        result = shadow_conversation_row(
+            conn,
+            row_id=row_id,
+            user_id=subject_user_id,
+            user_name=str(row.get("user_name") or ""),
+            guild_id=int(guild_id or 0),
+            role="user",
+            content=str(row.get("content") or "")[:1000],
+            channel_name=str(row.get("channel_name") or "")[:80],
+            channel_policy=policy,
+            channel_id=int(row.get("channel_id") or 0),
+            message_id=(
+                int(row.get("message_id") or 0) or None
+            ),
+            route_mode="conversation_continuity",
+            observed_at=str(row.get("timestamp") or ""),
+            source_sequence=(
+                int(row.get("message_id") or 0) or row_id
+            ),
+            environ=environ,
+        )
+        outcome = str(result.outcome or "unknown")
+        key = "ledger_projection_%s" % outcome
+        counts[key] = int(counts.get(key, 0) or 0) + 1
+    if diagnostics is not None:
+        diagnostics.update(counts)
+    return counts
 
 
 def form_atomic_candidates_from_recurring_conversation(
@@ -5206,6 +5510,7 @@ def form_atomic_candidates_from_recurring_conversation(
     trigger_entry_id: str = "",
     max_scan: int = _CONVERSATION_MOTIF_MAX_SCAN,
     environ: dict[str, str] | None = None,
+    diagnostics: dict[str, int] | None = None,
 ) -> list[AtomicKnowledgeResult]:
     """Form conservative motifs from repeated production-shaped public chat.
 
@@ -5236,6 +5541,14 @@ def form_atomic_candidates_from_recurring_conversation(
     ):
         return []
 
+    project_retained_conversations_to_ledger(
+        conn,
+        guild_id=int(guild_id or 0),
+        subject_key=str(subject_key),
+        max_scan=max_scan,
+        diagnostics=diagnostics,
+        environ=environ,
+    )
     _sync_bounded_conversation_motif_corrections(
         conn,
         guild_id=int(guild_id or 0),
@@ -5247,6 +5560,7 @@ def form_atomic_candidates_from_recurring_conversation(
         guild_id=int(guild_id or 0),
         subject_key=str(subject_key),
         max_scan=max_scan,
+        diagnostics=diagnostics,
     )
     if not history:
         _record_knowledge_receipt(
@@ -5263,6 +5577,17 @@ def form_atomic_candidates_from_recurring_conversation(
         matches = _conversation_motif_family_matches(
             tuple(entry.get("terms") or ())
         )
+        if not matches and diagnostics is not None:
+            diagnostics["ledger_rows_family_unmatched"] = (
+                int(
+                    diagnostics.get(
+                        "ledger_rows_family_unmatched",
+                        0,
+                    )
+                    or 0
+                )
+                + 1
+            )
         for family, label in matches:
             group = grouped.setdefault(
                 "family:%s" % family,
@@ -5274,6 +5599,8 @@ def form_atomic_candidates_from_recurring_conversation(
                 },
             )
             group["entries"].append(entry)
+    if diagnostics is not None:
+        diagnostics["motif_families_matched"] = len(grouped)
 
     results: list[AtomicKnowledgeResult] = []
     ranked_groups: list[tuple[int, float, str, dict[str, Any]]] = []
@@ -5316,6 +5643,17 @@ def form_atomic_candidates_from_recurring_conversation(
             list(group["entries"])
         )
         if len(occurrence_ids) < 2 or len(root_ids) < 2:
+            if diagnostics is not None:
+                diagnostics["motif_families_recurrence_not_met"] = (
+                    int(
+                        diagnostics.get(
+                            "motif_families_recurrence_not_met",
+                            0,
+                        )
+                        or 0
+                    )
+                    + 1
+                )
             continue
         display_name = next(
             (
@@ -5362,6 +5700,8 @@ def form_atomic_candidates_from_recurring_conversation(
         results.append(result)
         if len(results) >= _CONVERSATION_MOTIF_MAX_CANDIDATES:
             break
+    if diagnostics is not None:
+        diagnostics["motif_candidates_returned"] = len(results)
     if not results:
         _record_knowledge_receipt(
             conn,
@@ -6017,7 +6357,8 @@ def _finalized_conversation_correction_resolution(
     """Resolve only one same-author finalized source; ambiguity never guesses."""
     if (
         not _CONVERSATION_CORRECTION_RE.search(correction_value or "")
-        or _canon(channel_policy) not in {"public_home", "public_context"}
+        or _canon(channel_policy)
+        not in _CONVERSATION_MOTIF_PUBLIC_POLICIES
         or not conn.execute(
             """
             SELECT 1 FROM sqlite_master
@@ -6046,7 +6387,9 @@ def _finalized_conversation_correction_resolution(
           AND e.entry_type='observation'
           AND e.lifecycle_status='active'
           AND e.public_usable=1
-          AND e.channel_policy IN ('public_home','public_context')
+          AND e.channel_policy IN (
+            'public_home','public_context','public_selective'
+          )
           AND w.guild_id=e.guild_id
           AND w.lifecycle_status='finalized'
           AND w.public_usable=1
@@ -6101,7 +6444,8 @@ def _raw_conversation_correction_resolution(
     """Resolve one bounded raw source only when the evidence is unambiguous."""
     if (
         not _CONVERSATION_CORRECTION_RE.search(correction_value or "")
-        or _canon(channel_policy) not in {"public_home", "public_context"}
+        or _canon(channel_policy)
+        not in _CONVERSATION_MOTIF_PUBLIC_POLICIES
     ):
         return "", ()
     correction_tokens = _conversation_correction_topic_tokens(
@@ -6222,6 +6566,7 @@ def shadow_conversation_row(
     message_id: int | None = None,
     route_mode: str = "unknown",
     observed_at: str = "",
+    source_sequence: int | None = None,
     conversation_target_user_ids: tuple[int, ...] = (),
     environ: dict[str, str] | None = None,
 ) -> LedgerWriteResult:
@@ -6256,7 +6601,7 @@ def shadow_conversation_row(
                 )
             ),
         )
-        entry = LedgerEntry(guild_id=guild_id, source_table="conversations", source_row_id=row_id, source_revision=str(row_id), source_role="model", entry_type="derived_summary", subject_key=BNL_SUBJECT_KEY, subject_display_name="BNL-01", predicate_key="model_output", value=(content or "")[:500], source_class=SourceClass.DERIVED_SUMMARY, route_mode=route_mode, channel_id=channel_id, channel_name=channel_name, channel_policy=channel_policy, source_message_id=message_id, visibility=visibility, confidence=Confidence.LOW, public_usable=False, derived=True, projection=True, salience=0.1, observed_at=observed_at or _now(), source_sequence=row_id, participants=participants)
+        entry = LedgerEntry(guild_id=guild_id, source_table="conversations", source_row_id=row_id, source_revision=str(row_id), source_role="model", entry_type="derived_summary", subject_key=BNL_SUBJECT_KEY, subject_display_name="BNL-01", predicate_key="model_output", value=(content or "")[:500], source_class=SourceClass.DERIVED_SUMMARY, route_mode=route_mode, channel_id=channel_id, channel_name=channel_name, channel_policy=channel_policy, source_message_id=message_id, visibility=visibility, confidence=Confidence.LOW, public_usable=False, derived=True, projection=True, salience=0.1, observed_at=observed_at or _now(), source_sequence=int(source_sequence or row_id), participants=participants)
         return insert_ledger_entry(conn, entry)
     subject_key = subject_key_for_user(user_id)
     source_class = _source_class("conversation_continuity", SourceClass.PUBLIC_OBSERVATION)
@@ -6293,7 +6638,7 @@ def shadow_conversation_row(
             public_usable=public_ok,
             salience=0.2,
             observed_at=observed_at or _now(),
-            source_sequence=row_id,
+            source_sequence=int(source_sequence or row_id),
             participants=(LedgerParticipant(subject_key, user_name or "", "author", 0),),
         ),
     )

--- a/bnl_memory_preview.py
+++ b/bnl_memory_preview.py
@@ -109,6 +109,7 @@ class MemoryPreviewDiagnostics:
     route_reason: str = ""
     formation_outcomes: tuple[tuple[str, int], ...] = ()
     formation_reason_codes: tuple[str, ...] = ()
+    source_funnel_counts: tuple[tuple[str, int], ...] = ()
     lifecycle_scopes: int = 0
     lifecycle_candidates: int = 0
     lifecycle_state_changes: int = 0
@@ -675,12 +676,14 @@ def _formation_and_lifecycle(
 ) -> tuple[
     tuple[tuple[str, int], ...],
     tuple[str, ...],
+    tuple[tuple[str, int], ...],
     dict[str, int],
 ]:
     ledger.ensure_memory_ledger_schema(conn)
     moments.ensure_moment_schema(conn)
     relationships.ensure_relationship_v2_schema(conn)
     governance.ensure_governance_schema(conn)
+    source_funnel: dict[str, int] = {}
     results = ledger.form_atomic_candidates_from_recurring_conversation(
         conn,
         guild_id=request.guild_id,
@@ -688,6 +691,7 @@ def _formation_and_lifecycle(
             request.subject_user_id
         ),
         environ=dict(environ),
+        diagnostics=source_funnel,
     )
     candidate_ids = tuple(
         dict.fromkeys(
@@ -719,6 +723,7 @@ def _formation_and_lifecycle(
     return (
         tuple(sorted(outcomes.items())),
         reason_codes,
+        tuple(sorted(source_funnel.items())),
         {
             "scopes": int(lifecycle.get("scopes", 0) or 0),
             "candidates": int(
@@ -894,6 +899,7 @@ def _diagnostics(
     route_reason: str,
     formation_outcomes: tuple[tuple[str, int], ...] = (),
     formation_reason_codes: tuple[str, ...] = (),
+    source_funnel_counts: tuple[tuple[str, int], ...] = (),
     lifecycle: Mapping[str, int] | None = None,
     packet: UnifiedIntelligencePacket | None = None,
     assessment: UnifiedResponseAssessment | None = None,
@@ -951,6 +957,7 @@ def _diagnostics(
         route_reason=str(route_reason or ""),
         formation_outcomes=formation_outcomes,
         formation_reason_codes=formation_reason_codes,
+        source_funnel_counts=source_funnel_counts,
         lifecycle_scopes=int(lifecycle.get("scopes", 0) or 0),
         lifecycle_candidates=int(
             lifecycle.get("candidates", 0) or 0
@@ -1093,6 +1100,7 @@ def prepare_memory_preview(
         (
             formation_outcomes,
             formation_reasons,
+            source_funnel,
             lifecycle,
         ) = _formation_and_lifecycle(conn, effective_request, env)
         packet = build_packet(
@@ -1107,6 +1115,7 @@ def prepare_memory_preview(
                 route_reason="packet_unavailable",
                 formation_outcomes=formation_outcomes,
                 formation_reason_codes=formation_reasons,
+                source_funnel_counts=source_funnel,
                 lifecycle=lifecycle,
             )
             return PreparedMemoryPreview(
@@ -1163,6 +1172,7 @@ def prepare_memory_preview(
             route_reason=intent.reason,
             formation_outcomes=formation_outcomes,
             formation_reason_codes=formation_reasons,
+            source_funnel_counts=source_funnel,
             lifecycle=lifecycle,
             packet=packet,
             assessment=assessment,
@@ -1527,6 +1537,8 @@ def render_content_free_diagnostics(
         % dict(diag.formation_outcomes),
         "- formation_reasons: `%s`"
         % (list(diag.formation_reason_codes) or ["none"]),
+        "- source_funnel: `%s`"
+        % dict(diag.source_funnel_counts),
         "- lifecycle: `scopes=%s candidates=%s state_changes=%s`"
         % (
             diag.lifecycle_scopes,

--- a/tests/test_channel_audit_passive_capture.py
+++ b/tests/test_channel_audit_passive_capture.py
@@ -47,6 +47,7 @@ class FakeChannel:
         self._perms = perms or FakePerms()
         self.sent = []
         self._history = []
+        self.history_calls = []
 
     def permissions_for(self, _member):
         return self._perms
@@ -54,8 +55,24 @@ class FakeChannel:
     async def send(self, content):
         self.sent.append(content)
 
-    def history(self, limit=100, oldest_first=False, **_kwargs):
-        rows = list(self._history)[:limit]
+    def history(self, limit=100, oldest_first=False, **kwargs):
+        self.history_calls.append(
+            {
+                "limit": limit,
+                "oldest_first": oldest_first,
+                **kwargs,
+            }
+        )
+        rows = list(self._history)
+        before = kwargs.get("before")
+        before_id = int(getattr(before, "id", 0) or 0)
+        if before_id:
+            rows = [
+                row
+                for row in rows
+                if int(getattr(row, "id", 0) or 0) < before_id
+            ]
+        rows = rows[-limit:]
         if not oldest_first:
             rows = list(reversed(rows))
         class _History:
@@ -286,10 +303,81 @@ class ChannelAuditPassiveCaptureTests(unittest.TestCase):
         self.assertGreaterEqual(presence, 1)
         again = asyncio.run(bnl01_bot.run_channel_backfill(channel, limit=50, dry_run=False))
         self.assertEqual(again["messagesInserted"], 0)
-        self.assertGreaterEqual(again["rowsAlreadyExist"], 1)
+        self.assertTrue(again["historyComplete"])
+        self.assertEqual(again["status"], "complete")
         diag = bnl01_bot.build_dossier_recommendation_diagnostics(123)
         self.assertTrue(diag["backfill_available"])
         self.assertEqual(diag["backfill_last_channel"], "hellcat-nz")
+
+    def test_backfill_pages_oldest_history_with_a_dedicated_cursor(self):
+        guild, channel = self.make_guild_channel("hellcat-nz", 991)
+        channel._history = [
+            FakeMessage(
+                f"Historical music note {index} about a track mix.",
+                channel,
+                guild=guild,
+                author=FakeAuthor(42, "HellcatNZ"),
+                message_id=9000 + index,
+                created_at=f"2026-05-{index:02d}T00:00:00+00:00",
+            )
+            for index in range(1, 6)
+        ]
+
+        first = asyncio.run(
+            bnl01_bot.run_channel_backfill(
+                channel,
+                limit=2,
+                dry_run=False,
+            )
+        )
+        second = asyncio.run(
+            bnl01_bot.run_channel_backfill(
+                channel,
+                limit=2,
+                dry_run=False,
+            )
+        )
+        third = asyncio.run(
+            bnl01_bot.run_channel_backfill(
+                channel,
+                limit=2,
+                dry_run=False,
+            )
+        )
+
+        self.assertEqual(first["messagesInserted"], 2)
+        self.assertEqual(first["cursorAfterMessageId"], 9004)
+        self.assertFalse(first["historyComplete"])
+        self.assertFalse(channel.history_calls[0]["oldest_first"])
+        self.assertEqual(second["messagesInserted"], 2)
+        self.assertEqual(second["cursorBeforeMessageId"], 9004)
+        self.assertEqual(second["cursorAfterMessageId"], 9002)
+        self.assertFalse(second["historyComplete"])
+        self.assertEqual(channel.history_calls[1]["before"].id, 9004)
+        self.assertEqual(third["messagesInserted"], 1)
+        self.assertEqual(third["cursorBeforeMessageId"], 9002)
+        self.assertEqual(third["cursorAfterMessageId"], 9001)
+        self.assertTrue(third["historyComplete"])
+        self.assertEqual(third["pagesCompleted"], 3)
+        conn = sqlite3.connect(self.tmp.name)
+        try:
+            self.assertEqual(
+                conn.execute(
+                    "SELECT COUNT(*) FROM conversations"
+                ).fetchone()[0],
+                5,
+            )
+            cursor_row = conn.execute(
+                """
+                SELECT before_message_id,completed,pages_completed,
+                       messages_scanned,messages_inserted
+                FROM conversation_history_backfill_cursors
+                WHERE guild_id=123 AND channel_id=991
+                """
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertEqual(cursor_row, (9001, 1, 3, 5, 5))
 
     def test_backfill_keeps_bounded_long_public_messages(self):
         guild, channel = self.make_guild_channel("hellcat-nz", 991)

--- a/tests/test_memory_preview.py
+++ b/tests/test_memory_preview.py
@@ -594,6 +594,180 @@ class MemoryPreviewTests(unittest.TestCase):
         finally:
             prepared.close()
 
+    def test_retained_public_history_reaches_multiple_profile_points(self):
+        raw_markers = (
+            "NEON MIX SOURCE",
+            "GLASS ART SOURCE",
+            "PRIVATE SOURCE SENTINEL",
+        )
+        with sqlite3.connect(self.db_path) as source:
+            self._ensure_conversation_context_schema(source)
+            rows = (
+                (
+                    401,
+                    "user",
+                    (
+                        "NEON MIX SOURCE: I am revising the music track "
+                        "with <@123456789012345678> at "
+                        "https://example.com/one."
+                    ),
+                    "2026-07-20T10:00:00+00:00",
+                    20,
+                    "artist-room",
+                    "public_selective",
+                    7,
+                    "Crow",
+                ),
+                (
+                    402,
+                    "user",
+                    (
+                        "The album vocals and music mix need another "
+                        "production pass."
+                    ),
+                    "2026-07-21T10:00:00+00:00",
+                    21,
+                    "music-chat",
+                    "public_context",
+                    7,
+                    "Crow",
+                ),
+                (
+                    403,
+                    "user",
+                    (
+                        "GLASS ART SOURCE: I am comparing artwork and "
+                        "visual design for the cover."
+                    ),
+                    "2026-07-22T10:00:00+00:00",
+                    10,
+                    "barcode-bot",
+                    "public_home",
+                    7,
+                    "Crow",
+                ),
+                (
+                    404,
+                    "user",
+                    (
+                        "The animation and artwork need a stronger visual "
+                        "style."
+                    ),
+                    "2026-07-23T10:00:00+00:00",
+                    20,
+                    "artist-room",
+                    "public_selective",
+                    7,
+                    "Crow",
+                ),
+                (
+                    405,
+                    "user",
+                    "The queue rehearsal website code needs another test.",
+                    "2026-07-24T10:00:00+00:00",
+                    10,
+                    "barcode-bot",
+                    "public_home",
+                    7,
+                    "Crow",
+                ),
+                (
+                    406,
+                    "user",
+                    "PRIVATE SOURCE SENTINEL about visual design.",
+                    "2026-07-25T10:00:00+00:00",
+                    30,
+                    "operations",
+                    "internal_controlled",
+                    7,
+                    "Crow",
+                ),
+                (
+                    407,
+                    "user",
+                    "Another member is mixing an unrelated music track.",
+                    "2026-07-25T11:00:00+00:00",
+                    10,
+                    "barcode-bot",
+                    "public_home",
+                    8,
+                    "Other Member",
+                ),
+            )
+            for (
+                row_id,
+                role,
+                content,
+                observed_at,
+                channel_id,
+                channel_name,
+                channel_policy,
+                user_id,
+                user_name,
+            ) in rows:
+                self._insert_conversation_context_row(
+                    source,
+                    row_id=row_id,
+                    role=role,
+                    content=content,
+                    observed_at=observed_at,
+                    channel_id=channel_id,
+                    channel_name=channel_name,
+                    channel_policy=channel_policy,
+                    user_id=user_id,
+                    user_name=user_name,
+                )
+            source.commit()
+        source_hash = self._source_hash()
+
+        prepared = prepare_memory_preview(self._request())
+        try:
+            self.assertTrue(prepared.ready)
+            self.assertEqual(prepared.diagnostics.profile_status, "rich")
+            self.assertGreaterEqual(
+                prepared.diagnostics.profile_selected_point_count,
+                2,
+            )
+            self.assertGreaterEqual(
+                dict(prepared.diagnostics.packet_lane_counts).get(
+                    "atomic_knowledge",
+                    0,
+                ),
+                2,
+            )
+            funnel = dict(prepared.diagnostics.source_funnel_counts)
+            self.assertEqual(funnel["retained_rows_total"], 6)
+            self.assertEqual(funnel["retained_rows_public_safe"], 5)
+            self.assertEqual(funnel["retained_rows_policy_excluded"], 1)
+            self.assertEqual(funnel["ledger_projection_inserted"], 5)
+            self.assertEqual(
+                funnel["ledger_rows_operational_excluded"],
+                1,
+            )
+            self.assertGreaterEqual(funnel["motif_candidates_returned"], 2)
+            diagnostics = "\n".join(
+                render_content_free_diagnostics(prepared)
+            )
+            self.assertIn("source_funnel", diagnostics)
+            for marker in raw_markers:
+                self.assertNotIn(marker, diagnostics)
+            self.assertNotIn("Other Member", diagnostics)
+        finally:
+            prepared.close()
+
+        self.assertEqual(source_hash, self._source_hash())
+        with sqlite3.connect(self.db_path) as source:
+            self.assertEqual(
+                source.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM memory_ledger_entries
+                    WHERE source_row_id IN ('401','402','403','404','405')
+                    """
+                ).fetchone()[0],
+                0,
+            )
+
     def test_diagnostics_are_content_free(self):
         prepared = prepare_memory_preview(self._request())
         try:

--- a/tests/test_production_shaped_memory_formation.py
+++ b/tests/test_production_shaped_memory_formation.py
@@ -1039,6 +1039,240 @@ class ProductionShapedMemoryFormationTests(unittest.TestCase):
         self.assertEqual(results, [])
         self.assertEqual(self.candidate_rows(), [])
 
+    def test_public_selective_linked_rows_can_form_a_safe_motif(self):
+        first = self.add_conversation(
+            120,
+            (
+                "I am revising the track mix with <@123456789012345678> "
+                "after sharing https://example.com/demo."
+            ),
+            "2026-07-20T10:00:00+00:00",
+            channel_policy="public_selective",
+            visibility=Visibility.PUBLIC_SAFE,
+        )
+        self.add_conversation(
+            121,
+            (
+                "The album vocals and music mix need another pass at "
+                "https://example.com/revision."
+            ),
+            "2026-07-22T10:00:00+00:00",
+            channel_policy="public_selective",
+            visibility=Visibility.PUBLIC_SAFE,
+        )
+        diagnostics = {}
+
+        results = ledger.form_atomic_candidates_from_recurring_conversation(
+            self.conn,
+            trigger_entry_id=first,
+            environ=self.env,
+            diagnostics=diagnostics,
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].outcome, "created")
+        self.assertEqual(diagnostics["ledger_rows_motif_eligible"], 2)
+        self.assertEqual(diagnostics["motif_families_matched"], 1)
+        self.assertIn(
+            "music and audio production",
+            self.candidate_rows()[0][1],
+        )
+
+    def test_operational_root_is_filtered_without_poisoning_safe_topic(self):
+        self.add_conversation(
+            130,
+            "I keep fixing the bot code and memory system carefully.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        self.add_conversation(
+            131,
+            "The queue rehearsal website code needs another test.",
+            "2026-07-21T10:00:00+00:00",
+        )
+        self.add_conversation(
+            132,
+            "The website code needs another careful architecture pass.",
+            "2026-07-22T10:00:00+00:00",
+        )
+        diagnostics = {}
+
+        results = ledger.form_atomic_candidates_from_recurring_conversation(
+            self.conn,
+            guild_id=1,
+            subject_key="discord_user:7",
+            environ=self.env,
+            diagnostics=diagnostics,
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].outcome, "created")
+        self.assertEqual(
+            diagnostics["ledger_rows_operational_excluded"],
+            1,
+        )
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT eligible_independent_root_count
+                FROM memory_ledger_knowledge_candidates
+                """
+            ).fetchone()[0],
+            2,
+        )
+
+    def test_retained_rows_project_through_ledger_subject_isolation(self):
+        self.conn.execute(
+            """
+            CREATE TABLE conversations (
+              id INTEGER PRIMARY KEY,
+              guild_id INTEGER NOT NULL,
+              user_id INTEGER NOT NULL,
+              user_name TEXT,
+              role TEXT NOT NULL,
+              content TEXT NOT NULL,
+              channel_name TEXT,
+              channel_policy TEXT,
+              channel_id INTEGER,
+              message_id INTEGER,
+              timestamp TEXT
+            )
+            """
+        )
+        self.conn.executemany(
+            """
+            INSERT INTO conversations(
+              id,guild_id,user_id,user_name,role,content,channel_name,
+              channel_policy,channel_id,message_id,timestamp
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                (
+                    1,
+                    1,
+                    7,
+                    "Crow",
+                    "user",
+                    "I am mixing a new music track tonight.",
+                    "barcode-bot",
+                    "public_home",
+                    10,
+                    7001,
+                    "2026-07-20T10:00:00+00:00",
+                ),
+                (
+                    2,
+                    1,
+                    7,
+                    "Crow",
+                    "user",
+                    "The album vocals need another production pass.",
+                    "artist-room",
+                    "public_selective",
+                    11,
+                    7002,
+                    "2026-07-22T10:00:00+00:00",
+                ),
+                (
+                    3,
+                    1,
+                    7,
+                    "Crow",
+                    "user",
+                    "Private internal visual planning.",
+                    "operations",
+                    "internal_controlled",
+                    12,
+                    7003,
+                    "2026-07-23T10:00:00+00:00",
+                ),
+                (
+                    4,
+                    1,
+                    8,
+                    "Other Member",
+                    "user",
+                    "Another member is mixing a music track.",
+                    "barcode-bot",
+                    "public_home",
+                    10,
+                    7004,
+                    "2026-07-24T10:00:00+00:00",
+                ),
+            ),
+        )
+        diagnostics = {}
+
+        first = ledger.project_retained_conversations_to_ledger(
+            self.conn,
+            guild_id=1,
+            subject_key="discord_user:7",
+            diagnostics=diagnostics,
+            environ=self.env,
+        )
+        second = ledger.project_retained_conversations_to_ledger(
+            self.conn,
+            guild_id=1,
+            subject_key="discord_user:7",
+            environ=self.env,
+        )
+
+        self.assertEqual(first["retained_rows_total"], 3)
+        self.assertEqual(first["retained_rows_public_safe"], 2)
+        self.assertEqual(first["retained_rows_policy_excluded"], 1)
+        self.assertEqual(first["ledger_projection_inserted"], 2)
+        self.assertEqual(second["ledger_projection_existing"], 2)
+        projected = self.conn.execute(
+            """
+            SELECT source_row_id,subject_key,channel_policy
+            FROM memory_ledger_entries
+            WHERE source_table='conversations'
+            ORDER BY source_row_id
+            """
+        ).fetchall()
+        self.assertEqual(
+            projected,
+            [
+                ("1", "discord_user:7", "public_home"),
+                ("2", "discord_user:7", "public_selective"),
+            ],
+        )
+
+    def test_motif_scan_reaches_supported_history_beyond_240_rows(self):
+        started = datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc)
+        self.add_conversation(
+            1,
+            "I am mixing the music track and adjusting vocals.",
+            started.isoformat(),
+        )
+        self.add_conversation(
+            2,
+            "The album mix and drums need another production pass.",
+            (started + timedelta(days=1)).isoformat(),
+        )
+        for index in range(3, 243):
+            self.add_conversation(
+                index,
+                "Planning details continue around an unrelated subject.",
+                (started + timedelta(days=index)).isoformat(),
+            )
+        diagnostics = {}
+
+        results = ledger.form_atomic_candidates_from_recurring_conversation(
+            self.conn,
+            guild_id=1,
+            subject_key="discord_user:7",
+            environ=self.env,
+            diagnostics=diagnostics,
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].outcome, "created")
+        self.assertEqual(diagnostics["ledger_rows_scanned"], 242)
+        self.assertEqual(
+            diagnostics["ledger_rows_family_unmatched"],
+            240,
+        )
+
     def test_incremental_motif_refresh_stays_one_candidate_and_twelve_roots(self):
         roots = []
         last_trigger = ""


### PR DESCRIPTION
## Problem

The shared-brain preview was not choosing repetitive anecdotes from the full Discord history. The response path was receiving one usable atomic point because retained conversations, Ledger projection, motif eligibility, and packet formation were disconnected or too narrow.

## What this changes

- Add a dedicated resumable `before` cursor for approved Discord-history backfill so scattered existing rows cannot create gaps.
- Page Discord newest-to-oldest with the correct API strategy and retain source ordering through message snowflakes.
- Project already-retained, subject-authored public conversation rows through the existing governed Ledger owner when the Ledger shadow and recurring-motif formation gates are both enabled.
- Include `public_selective` sources while continuing to exclude private/internal, unsafe, sensitive, role-play, correction, and operational/rehearsal evidence.
- Strip URL/email/mention tokens instead of discarding an otherwise eligible public observation.
- Increase the bounded recurring-conversation scan from 240 to 1,200 rows.
- Filter an ineligible operational row individually instead of poisoning its entire topic family.
- Add content-free source-funnel diagnostics to the non-persistent memory preview.

## Safety boundary

- No feature flag or gate default changes.
- No production backfill, migration command, preview, Discord post, or live canary is run by this PR.
- Preview continues to clone the source database in memory; the source database remains read-only.
- Projection is subject-isolated, bounded, idempotent, and routed through the existing Ledger schema and write owner.
- Private/internal rows and other members' rows remain excluded.
- Relationship, Active Engagement, queue, Journal, Relay, website, dossier, and Source File behavior are unchanged.

## Verification

- `git diff --check`
- 48 focused source-procurement, formation, preview, and backfill tests passed.
- `make check PYTHON=/tmp/bnl-source-procurement-venv/bin/python`
- Compile plus all 1,800 repository tests passed.
- Remote parent, all six blob SHAs, and complete tree SHA were matched to the locally tested commit before this PR was opened.

## Post-merge deployment

This changes additive memory schema and collection code. Back up the production SQLite database before restarting:

```bash
cd /home/ubuntu/bnl01

pre_deploy_sha="$(git rev-parse HEAD)"
mkdir -p backups/pre-memory
backup_stamp="$(date -u +%Y%m%dT%H%M%SZ)"
backup_path="backups/pre-memory/bnl01_conversations-${backup_stamp}.db"
python3 - "${backup_path}" <<'PY'
import sqlite3
import sys

source = sqlite3.connect(
    "file:bnl01_conversations.db?mode=ro",
    uri=True,
    timeout=5,
)
backup = sqlite3.connect(sys.argv[1])
try:
    source.backup(backup)
    result = backup.execute("PRAGMA quick_check").fetchone()[0]
    if result != "ok":
        raise SystemExit("backup quick_check failed: " + str(result))
finally:
    backup.close()
    source.close()
PY
sha256sum "${backup_path}" > "${backup_path}.sha256"

sudo systemctl stop bnl01
git pull --ff-only origin main
post_pull_sha="$(git rev-parse HEAD)"
sudo systemctl start bnl01
sudo systemctl status bnl01 --no-pager -l
printf 'pre=%s\npost=%s\nbackup=%s\n' \
  "${pre_deploy_sha}" "${post_pull_sha}" "${backup_path}"
```

Do not run a backfill or enable motif/synthesis gates during deployment.

## Focused post-deploy evidence

```bash
cd /home/ubuntu/bnl01
bnl_pid="$(systemctl show -p MainPID --value bnl01)"

sudo /home/ubuntu/bnl01/venv/bin/python - "${bnl_pid}" <<'PY'
import sqlite3
import sys
from pathlib import Path

from bnl_memory_ledger import conversation_motif_formation_enabled
from bnl_shared_brain_synthesis import configuration

env = {}
for item in Path(f"/proc/{sys.argv[1]}/environ").read_bytes().split(b"\0"):
    if b"=" in item:
        key, value = item.split(b"=", 1)
        env[key.decode()] = value.decode()

with sqlite3.connect(
    "file:bnl01_conversations.db?mode=ro",
    uri=True,
) as conn:
    schema_ready = bool(
        conn.execute(
            "SELECT 1 FROM sqlite_master "
            "WHERE type='table' "
            "AND name='conversation_history_backfill_cursors'"
        ).fetchone()
    )
    cursor_rows = conn.execute(
        "SELECT COUNT(*) FROM conversation_history_backfill_cursors"
    ).fetchone()[0]

synthesis = configuration(env)
assert schema_ready
assert cursor_rows == 0, cursor_rows
assert not conversation_motif_formation_enabled(env)
assert not synthesis["effective"], synthesis
print({
    "schema_ready": schema_ready,
    "backfill_cursor_rows": cursor_rows,
    "motif_formation_enabled": False,
    "synthesis_effective": synthesis["effective"],
})
PY

sudo journalctl -u bnl01 --since "5 minutes ago" --no-pager -l | tail -n 120
```

Expected evidence: deployed merge SHA recorded, service active, `schema_ready: True`, zero cursor rows before any approved backfill, motif formation off, synthesis ineffective, and no startup traceback. Stop and roll back to the recorded pre-deploy SHA/database backup if schema creation or startup fails; do not toggle another memory gate to compensate.