### PR TITLE
Repair current-runtime scoping in shared-brain acceptance

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -572,6 +572,7 @@ JOURNAL_PREPARATION_MAX_SECONDS = max(
     int(os.getenv("BNL_JOURNAL_PREPARATION_MAX_SECONDS", "1500") or 1500),
 )
 DB_FILE = "bnl01_conversations.db"
+BNL_RUNTIME_STARTED_AT = datetime.now(timezone.utc).isoformat()
 
 # The provider client owns HTTP transports and proxy discovery. Keep module
 # import side-effect free; construct and cache it only when generation starts.
@@ -36563,6 +36564,7 @@ def _collect_bnl_memory_diagnostic_data(
                 conversation_context_diagnostics=dict(
                     LAST_CONVERSATION_CONTEXT_V2_DIAGNOSTICS
                 ),
+                runtime_evidence_since=BNL_RUNTIME_STARTED_AT,
             )
             ledger_diag = shadow_acceptance["reports"]["memoryLedger"]
         finally:

--- a/bnl_relationship_engine.py
+++ b/bnl_relationship_engine.py
@@ -509,22 +509,55 @@ def build_evaluation_report(conn: sqlite3.Connection, *, guild_id: int | None = 
     by_type={r[0]:r[1] for r in conn.execute(f"SELECT event_type,COUNT(*) FROM relationship_events_v2 {where} GROUP BY event_type", p).fetchall()}
     lifecycle={r[0]:r[1] for r in conn.execute(f"SELECT lifecycle,COUNT(*) FROM relationship_events_v2 {where} GROUP BY lifecycle", p).fetchall()}
     scoped = "guild_id=? AND " if guild_id is not None else ""
+    ledger_link_scope = "l.guild_id=? AND " if guild_id is not None else ""
+    ledger_link_problem = (
+        "(e.event_id IS NULL OR e.guild_id<>l.guild_id "
+        "OR e.subject_user_id<>l.subject_user_id "
+        "OR m.entry_id IS NULL OR m.guild_id<>l.guild_id "
+        "OR m.subject_key<>('discord_user:' || "
+        "CAST(l.subject_user_id AS TEXT)))"
+    )
     if _table_exists(conn, "memory_ledger_entries"):
         ledger_link_integrity_violations = one(
             "SELECT COUNT(*) FROM relationship_event_ledger_links_v2 l "
             "LEFT JOIN relationship_events_v2 e ON e.event_id=l.event_id "
             "LEFT JOIN memory_ledger_entries m ON m.entry_id=l.ledger_entry_id "
-            f"WHERE {('l.guild_id=? AND ' if guild_id is not None else '')}"
-            "(e.event_id IS NULL OR e.guild_id<>l.guild_id "
-            "OR e.subject_user_id<>l.subject_user_id "
-            "OR m.entry_id IS NULL OR m.guild_id<>l.guild_id "
-            "OR m.subject_key<>('discord_user:' || CAST(l.subject_user_id AS TEXT)))"
+            f"WHERE {ledger_link_scope}{ledger_link_problem} "
+            "AND (e.event_id IS NULL OR e.lifecycle='active')"
+        )
+        retired_ledger_link_integrity_observations = one(
+            "SELECT COUNT(*) FROM relationship_event_ledger_links_v2 l "
+            "JOIN relationship_events_v2 e ON e.event_id=l.event_id "
+            "LEFT JOIN memory_ledger_entries m ON m.entry_id=l.ledger_entry_id "
+            f"WHERE {ledger_link_scope}{ledger_link_problem} "
+            "AND e.lifecycle<>'active'"
         )
     else:
-        # A persisted link cannot be verified when its target table is absent.
+        # An active persisted link cannot be verified when its target table is
+        # absent. Retired links remain visible for audit without blocking the
+        # currently usable relationship graph.
         ledger_link_integrity_violations = one(
-            f"SELECT COUNT(*) FROM relationship_event_ledger_links_v2 {where}"
+            "SELECT COUNT(*) FROM relationship_event_ledger_links_v2 l "
+            "LEFT JOIN relationship_events_v2 e ON e.event_id=l.event_id "
+            f"WHERE {ledger_link_scope}"
+            "(e.event_id IS NULL OR e.lifecycle='active')"
         )
+        retired_ledger_link_integrity_observations = one(
+            "SELECT COUNT(*) FROM relationship_event_ledger_links_v2 l "
+            "JOIN relationship_events_v2 e ON e.event_id=l.event_id "
+            f"WHERE {ledger_link_scope}e.lifecycle<>'active'"
+        )
+    moment_link_scope = "l.guild_id=? AND " if guild_id is not None else ""
+    moment_link_problem = (
+        "(e.event_id IS NULL OR e.guild_id<>l.guild_id "
+        "OR e.subject_user_id<>l.subject_user_id "
+        "OR w.moment_id IS NULL OR w.guild_id<>l.guild_id "
+        "OR NOT EXISTS ("
+        "SELECT 1 FROM memory_moment_participants p "
+        "WHERE p.moment_id=l.moment_id "
+        "AND p.participant_key=('discord_user:' || "
+        "CAST(l.subject_user_id AS TEXT))))"
+    )
     if _table_exists(conn, "memory_moment_windows") and _table_exists(
         conn, "memory_moment_participants"
     ):
@@ -532,20 +565,30 @@ def build_evaluation_report(conn: sqlite3.Connection, *, guild_id: int | None = 
             "SELECT COUNT(*) FROM relationship_event_moment_links_v2 l "
             "LEFT JOIN relationship_events_v2 e ON e.event_id=l.event_id "
             "LEFT JOIN memory_moment_windows w ON w.moment_id=l.moment_id "
-            f"WHERE {('l.guild_id=? AND ' if guild_id is not None else '')}"
-            "(e.event_id IS NULL OR e.guild_id<>l.guild_id "
-            "OR e.subject_user_id<>l.subject_user_id "
-            "OR w.moment_id IS NULL OR w.guild_id<>l.guild_id "
-            "OR NOT EXISTS ("
-            "SELECT 1 FROM memory_moment_participants p "
-            "WHERE p.moment_id=l.moment_id "
-            "AND p.participant_key=('discord_user:' || CAST(l.subject_user_id AS TEXT))"
-            "))"
+            f"WHERE {moment_link_scope}"
+            "COALESCE(l.lifecycle,'active')='active' AND "
+            f"({moment_link_problem} OR e.lifecycle<>'active')"
+        )
+        retired_moment_link_integrity_observations = one(
+            "SELECT COUNT(*) FROM relationship_event_moment_links_v2 l "
+            "LEFT JOIN relationship_events_v2 e ON e.event_id=l.event_id "
+            "LEFT JOIN memory_moment_windows w ON w.moment_id=l.moment_id "
+            f"WHERE {moment_link_scope}"
+            "COALESCE(l.lifecycle,'active')<>'active' AND "
+            f"{moment_link_problem}"
         )
     else:
-        # A persisted link cannot be verified when either target table is absent.
+        # Active links are blocking when their targets cannot be verified.
+        # Retired links are retained as historical observations.
         moment_link_integrity_violations = one(
-            f"SELECT COUNT(*) FROM relationship_event_moment_links_v2 {where}"
+            "SELECT COUNT(*) FROM relationship_event_moment_links_v2 l "
+            f"WHERE {moment_link_scope}"
+            "COALESCE(l.lifecycle,'active')='active'"
+        )
+        retired_moment_link_integrity_observations = one(
+            "SELECT COUNT(*) FROM relationship_event_moment_links_v2 l "
+            f"WHERE {moment_link_scope}"
+            "COALESCE(l.lifecycle,'active')<>'active'"
         )
     cross_guild_member_violations = sum([
         one(f"SELECT COUNT(*) FROM relationship_events_v2 WHERE {scoped}subject_key<>('discord_user:' || CAST(subject_user_id AS TEXT))"),
@@ -578,6 +621,8 @@ def build_evaluation_report(conn: sqlite3.Connection, *, guild_id: int | None = 
         "cross_guild_member_violations": cross_guild_member_violations,
         "ledger_link_integrity_violations": ledger_link_integrity_violations,
         "moment_link_integrity_violations": moment_link_integrity_violations,
+        "retired_ledger_link_integrity_observations": retired_ledger_link_integrity_observations,
+        "retired_moment_link_integrity_observations": retired_moment_link_integrity_observations,
         "visibility_violations": one(f"SELECT COUNT(*) FROM relationship_events_v2 {where + (' AND' if where else 'WHERE')} visibility<>'private'"),
         "shadow_runs": one(f"SELECT COUNT(*) FROM relationship_engagement_shadow_runs {where}"),
         "policy_eligible_shadow_candidates": one(f"SELECT COUNT(*) FROM relationship_engagement_shadow_runs {where + (' AND' if where else 'WHERE')} policy_eligible=1"),

--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -30,7 +30,7 @@ from bnl_unified_response_assessment import (
 )
 
 
-SHADOW_ACCEPTANCE_VERSION = "v2_shadow_acceptance_v4"
+SHADOW_ACCEPTANCE_VERSION = "v2_shadow_acceptance_v5"
 SHADOW_EVALUATION_ORDER = (
     "memory_ledger",
     "moment_engine",
@@ -569,6 +569,8 @@ def _empty_relationship_report() -> Dict[str, Any]:
         "cross_guild_member_violations": 0,
         "ledger_link_integrity_violations": 0,
         "moment_link_integrity_violations": 0,
+        "retired_ledger_link_integrity_observations": 0,
+        "retired_moment_link_integrity_observations": 0,
         "visibility_violations": 0,
         "processing_errors": 0,
         "legacy_v2_comparison": "not_collected",
@@ -655,6 +657,17 @@ def _empty_unified_assessment_report() -> Dict[str, Any]:
         "scoped_canary_guard_triggered_runs": 0,
         "scoped_canary_guard_repaired_runs": 0,
         "scoped_canary_output_leak_guard_runs": 0,
+        "runtime_evidence_since": "all_retained",
+        "runtime_runs": 0,
+        "runtime_payload_grounding_failure_runs": 0,
+        "runtime_response_coherence_failure_runs": 0,
+        "runtime_response_coherence_review_runs": 0,
+        "runtime_processing_errors": 0,
+        "runtime_behavior_changed_runs": 0,
+        "runtime_new_authority_applied_runs": 0,
+        "runtime_scoped_canary_runs": 0,
+        "runtime_scoped_canary_invalid_scope_runs": 0,
+        "runtime_evidence_window": {"first": "none", "last": "none"},
         "content_fields_present": [],
         "evidenceWindow": {"first": "none", "last": "none"},
     }
@@ -663,13 +676,43 @@ def _empty_unified_assessment_report() -> Dict[str, Any]:
 def _read_unified_assessment_report(
     conn: sqlite3.Connection,
     guild_id: int,
+    runtime_evidence_since: str = "",
 ) -> Dict[str, Any]:
     try:
-        return build_unified_assessment_evaluation_report(
+        retained = build_unified_assessment_evaluation_report(
             conn,
             guild_id=guild_id,
             prepare_schema=False,
         )
+        since = str(runtime_evidence_since or "").strip()
+        runtime = (
+            build_unified_assessment_evaluation_report(
+                conn,
+                guild_id=guild_id,
+                prepare_schema=False,
+                created_at_since=since,
+            )
+            if since
+            else retained
+        )
+        retained["runtime_evidence_since"] = since or "all_retained"
+        for key in (
+            "runs",
+            "payload_grounding_failure_runs",
+            "response_coherence_failure_runs",
+            "response_coherence_review_runs",
+            "processing_errors",
+            "behavior_changed_runs",
+            "new_authority_applied_runs",
+            "scoped_canary_runs",
+            "scoped_canary_invalid_scope_runs",
+        ):
+            retained["runtime_" + key] = int(runtime.get(key, 0) or 0)
+        retained["runtime_evidence_window"] = dict(
+            runtime.get("evidenceWindow")
+            or {"first": "none", "last": "none"}
+        )
+        return retained
     except (sqlite3.DatabaseError, ValueError, TypeError) as exc:
         return _report_error(
             _empty_unified_assessment_report(),
@@ -888,6 +931,7 @@ def build_v2_shadow_acceptance_snapshot(
     guild_id: int,
     environ: Optional[Mapping[str, str]] = None,
     conversation_context_diagnostics: Optional[Mapping[str, Any]] = None,
+    runtime_evidence_since: str = "",
 ) -> Dict[str, Any]:
     """Build a dependency-aware snapshot from aggregate evidence only."""
 
@@ -907,7 +951,11 @@ def build_v2_shadow_acceptance_snapshot(
             guild_id,
         )
     )
-    unified_assessment = _read_unified_assessment_report(conn, guild_id)
+    unified_assessment = _read_unified_assessment_report(
+        conn,
+        guild_id,
+        runtime_evidence_since=runtime_evidence_since,
+    )
     context = _safe_context_report(conversation_context_diagnostics)
 
     live_gates = [
@@ -1190,24 +1238,31 @@ def build_v2_shadow_acceptance_snapshot(
     }
 
     unified_assessment_blockers = []
-    for key in (
-        "processing_errors",
-        "behavior_changed_runs",
-        "new_authority_applied_runs",
+    for runtime_key, blocker_name in (
+        ("runtime_processing_errors", "processing_errors"),
+        ("runtime_behavior_changed_runs", "behavior_changed_runs"),
+        (
+            "runtime_new_authority_applied_runs",
+            "new_authority_applied_runs",
+        ),
     ):
-        if int(unified_assessment.get(key, 0) or 0):
-            unified_assessment_blockers.append(key)
+        if int(unified_assessment.get(runtime_key, 0) or 0):
+            unified_assessment_blockers.append(blocker_name)
     if unified_assessment.get("content_fields_present"):
         unified_assessment_blockers.append("content_fields_present")
     if int(
-        unified_assessment.get("payload_grounding_failure_runs", 0) or 0
+        unified_assessment.get(
+            "runtime_payload_grounding_failure_runs",
+            0,
+        )
+        or 0
     ):
         unified_assessment_blockers.append(
             "payload_grounding_failure_runs"
         )
     if int(
         unified_assessment.get(
-            "response_coherence_failure_runs",
+            "runtime_response_coherence_failure_runs",
             0,
         )
         or 0
@@ -1221,7 +1276,7 @@ def build_v2_shadow_acceptance_snapshot(
         )
     if int(
         unified_assessment.get(
-            "scoped_canary_invalid_scope_runs",
+            "runtime_scoped_canary_invalid_scope_runs",
             0,
         )
         or 0
@@ -1261,6 +1316,14 @@ def build_v2_shadow_acceptance_snapshot(
         warnings.append("moment_episode_review_pending")
     if relationship.get("legacy_v2_comparison") == "not_collected":
         warnings.append("relationship_legacy_v2_comparison_not_collected")
+    if any(
+        int(relationship.get(key, 0) or 0)
+        for key in (
+            "retired_ledger_link_integrity_observations",
+            "retired_moment_link_integrity_observations",
+        )
+    ):
+        warnings.append("relationship_retired_link_anomalies_retained_for_audit")
     if int(governance.get("aggregateDiagnosticRuns", 0) or 0) < int(
         governance.get("runs", 0) or 0
     ):
@@ -1269,9 +1332,36 @@ def build_v2_shadow_acceptance_snapshot(
         warnings.append("governance_legacy_safe_exclusions_reclassified")
     if (
         gates.get("unified_response_assessment_shadow_effective")
-        and int(unified_assessment.get("runs", 0) or 0) == 0
+        and int(unified_assessment.get("runtime_runs", 0) or 0) == 0
     ):
-        warnings.append("unified_assessment_no_response_evidence")
+        warnings.append("unified_assessment_no_current_runtime_evidence")
+    if (
+        int(unified_assessment.get("payload_grounding_failure_runs", 0) or 0)
+        > int(
+            unified_assessment.get(
+                "runtime_payload_grounding_failure_runs",
+                0,
+            )
+            or 0
+        )
+        or int(
+            unified_assessment.get(
+                "response_coherence_failure_runs",
+                0,
+            )
+            or 0
+        )
+        > int(
+            unified_assessment.get(
+                "runtime_response_coherence_failure_runs",
+                0,
+            )
+            or 0
+        )
+    ):
+        warnings.append(
+            "unified_assessment_historical_failures_outside_runtime_window"
+        )
     if any(
         int(unified_assessment.get(key, 0) or 0)
         for key in (
@@ -1284,7 +1374,11 @@ def build_v2_shadow_acceptance_snapshot(
     if int(unified_assessment.get("visible_control_marker_runs", 0) or 0):
         warnings.append("unified_assessment_visible_control_marker_review")
     if int(
-        unified_assessment.get("response_coherence_review_runs", 0) or 0
+        unified_assessment.get(
+            "runtime_response_coherence_review_runs",
+            0,
+        )
+        or 0
     ):
         warnings.append("unified_assessment_response_coherence_review")
     if int(intelligence_packet.get("conflictRuns", 0) or 0):
@@ -1312,7 +1406,7 @@ def build_v2_shadow_acceptance_snapshot(
     unified_assessment_ready = bool(
         not gates.get("unified_response_assessment_shadow_requested")
         or (
-            int(unified_assessment.get("runs", 0) or 0) > 0
+            int(unified_assessment.get("runtime_runs", 0) or 0) > 0
             and not unified_assessment_blockers
         )
     )
@@ -1431,6 +1525,10 @@ def build_v2_shadow_acceptance_snapshot(
                 )
             ),
             "evidenceObserved": int(
+                unified_assessment.get("runtime_runs", 0) or 0
+            )
+            > 0,
+            "retainedEvidenceObserved": int(
                 unified_assessment.get("runs", 0) or 0
             )
             > 0,
@@ -1722,9 +1820,17 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             (relationship.get("evidenceWindow") or {}).get("last", "none"),
         ),
         "- relationship_withheld_reasons: `%s`" % json.dumps(relationship.get("withheld_reasons", {}), sort_keys=True),
-        "- relationship_link_integrity: ledger=`%s` moments=`%s`" % (
+        "- relationship_link_integrity: active_ledger=`%s` active_moments=`%s` retired_ledger_audit=`%s` retired_moments_audit=`%s`" % (
             relationship.get("ledger_link_integrity_violations", 0),
             relationship.get("moment_link_integrity_violations", 0),
+            relationship.get(
+                "retired_ledger_link_integrity_observations",
+                0,
+            ),
+            relationship.get(
+                "retired_moment_link_integrity_observations",
+                0,
+            ),
         ),
         "- relationship_legacy_v2_comparison: `%s`" % relationship.get("legacy_v2_comparison", "not_collected"),
         "- unified_intelligence_packet: status=`%s` requested=`%s` effective=`%s` reason=`%s` schema=`%s` runs=`%s` items=`%s` lanes=`%s` sources=`%s` atomic_states=`%s` missing=`%s` conflicts=`%s` revalidation=`%s` source_changes=`%s` errors=`%s` invalid_invariants=`%s` prompt_applied=`%s` live_applied=`%s` content_fields=`%s` window_last=`%s`" % (
@@ -2010,6 +2116,42 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             unified_assessment.get("criterion_total", 0),
             unified_assessment.get("option_total", 0),
             unified_assessment.get("ambiguity_reason_total", 0),
+        ),
+        "- unified_assessment_runtime_window: since=`%s` runs=`%s` grounding_failures=`%s` coherence_failures=`%s` coherence_reviews=`%s` errors=`%s` behavior_changes=`%s` new_authority=`%s` canary_runs=`%s` invalid_canary_scope=`%s` window_first=`%s` window_last=`%s`" % (
+            unified_assessment.get(
+                "runtime_evidence_since",
+                "all_retained",
+            ),
+            unified_assessment.get("runtime_runs", 0),
+            unified_assessment.get(
+                "runtime_payload_grounding_failure_runs",
+                0,
+            ),
+            unified_assessment.get(
+                "runtime_response_coherence_failure_runs",
+                0,
+            ),
+            unified_assessment.get(
+                "runtime_response_coherence_review_runs",
+                0,
+            ),
+            unified_assessment.get("runtime_processing_errors", 0),
+            unified_assessment.get("runtime_behavior_changed_runs", 0),
+            unified_assessment.get(
+                "runtime_new_authority_applied_runs",
+                0,
+            ),
+            unified_assessment.get("runtime_scoped_canary_runs", 0),
+            unified_assessment.get(
+                "runtime_scoped_canary_invalid_scope_runs",
+                0,
+            ),
+            (
+                unified_assessment.get("runtime_evidence_window") or {}
+            ).get("first", "none"),
+            (
+                unified_assessment.get("runtime_evidence_window") or {}
+            ).get("last", "none"),
         ),
         "- unified_moment_canary: runs=`%s` episode_context=`%s` guards=`%s/%s` output_leak_guards=`%s` invalid_scope=`%s`" % (
             unified_assessment.get("scoped_canary_runs", 0),

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -2698,6 +2698,7 @@ def build_evaluation_report(
     guild_id: int,
     prepare_schema: bool = False,
     limit: int = 500,
+    created_at_since: str = "",
 ) -> Dict[str, Any]:
     """Aggregate retained receipts without exposing people, text, or source IDs."""
 
@@ -2731,6 +2732,13 @@ def build_evaluation_report(
     def _column(name: str, fallback: str) -> str:
         return name if name in columns else fallback
 
+    since = str(created_at_since or "").strip()
+    time_clause = " AND created_at>=?" if since else ""
+    query_params: tuple[Any, ...] = (
+        (int(guild_id or 0), since, max(1, min(int(limit or 500), 5000)))
+        if since
+        else (int(guild_id or 0), max(1, min(int(limit or 500), 5000)))
+    )
     rows = conn.execute(
         """
         SELECT response_sent, selected_lanes_json, excluded_lanes_json,
@@ -2743,7 +2751,7 @@ def build_evaluation_report(
                %s, %s, %s, %s, %s, %s,
                created_at
         FROM unified_response_assessment_shadow_runs
-        WHERE guild_id=?
+        WHERE guild_id=?%s
         ORDER BY created_at DESC, run_id DESC
         LIMIT ?
         """ % (
@@ -2796,8 +2804,9 @@ def build_evaluation_report(
             _column("scoped_canary_guard_triggered", "0"),
             _column("scoped_canary_guard_repaired", "0"),
             _column("scoped_canary_output_leak_guard", "0"),
+            time_clause,
         ),
-        (int(guild_id or 0), max(1, min(int(limit or 500), 5000))),
+        query_params,
     ).fetchall()
 
     selected_counts = Counter()

--- a/tests/test_v2_shadow_acceptance.py
+++ b/tests/test_v2_shadow_acceptance.py
@@ -64,12 +64,13 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
         self.conn.close()
         self.environment.stop()
 
-    def snapshot(self, environ=None, context=None):
+    def snapshot(self, environ=None, context=None, runtime_since=""):
         return build_v2_shadow_acceptance_snapshot(
             self.conn,
             guild_id=1,
             environ=environ or {},
             conversation_context_diagnostics=context,
+            runtime_evidence_since=runtime_since,
         )
 
     def test_defaults_are_reporting_only_and_all_shadow_stages_are_disabled(self):
@@ -389,6 +390,165 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
             render_v2_shadow_acceptance_lines(snapshot)
         )
         self.assertIn("contradictions=`1`", rendered)
+
+    def test_pre_runtime_failures_remain_visible_without_blocking_fresh_evidence(self):
+        assessment = build_unified_response_assessment(
+            guild_id=1,
+            route_mode="normal_chat",
+            channel_policy="sealed_test",
+            conversation_surface="test",
+            current_speaker_user_ids=(99,),
+        )
+        persist_unified_assessment_shadow_run(
+            self.conn,
+            assessment,
+            response="Earlier response.",
+            created_at="2026-07-29T15:38:01+00:00",
+        )
+        persist_unified_assessment_shadow_run(
+            self.conn,
+            assessment,
+            response="Current response.",
+            created_at="2026-07-30T12:20:00+00:00",
+        )
+        self.conn.execute(
+            """
+            UPDATE unified_response_assessment_shadow_runs
+            SET response_coherence_status='failed',
+                payload_grounding_status='stale_thread_substitution'
+            WHERE created_at='2026-07-29T15:38:01+00:00'
+            """
+        )
+        self.conn.commit()
+        environ = {
+            "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+            "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+            "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+            "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+        }
+
+        snapshot = self.snapshot(
+            environ,
+            runtime_since="2026-07-30T12:14:00+00:00",
+        )
+        report = snapshot["reports"]["unifiedResponseAssessment"]
+        self.assertEqual(report["runs"], 2)
+        self.assertEqual(report["response_coherence_failure_runs"], 1)
+        self.assertEqual(report["payload_grounding_failure_runs"], 1)
+        self.assertEqual(report["runtime_runs"], 1)
+        self.assertEqual(
+            report["runtime_response_coherence_failure_runs"],
+            0,
+        )
+        self.assertEqual(
+            report["runtime_payload_grounding_failure_runs"],
+            0,
+        )
+        self.assertNotIn(
+            "unified_response_assessment:"
+            "response_coherence_failure_runs",
+            snapshot["blockers"],
+        )
+        self.assertNotIn(
+            "unified_response_assessment:"
+            "payload_grounding_failure_runs",
+            snapshot["blockers"],
+        )
+        self.assertIn(
+            "unified_assessment_historical_failures_outside_runtime_window",
+            snapshot["warnings"],
+        )
+        rendered = "\n".join(
+            render_v2_shadow_acceptance_lines(snapshot)
+        )
+        self.assertIn(
+            "unified_assessment_runtime_window: "
+            "since=`2026-07-30T12:14:00+00:00` runs=`1`",
+            rendered,
+        )
+
+    def test_current_runtime_failure_remains_a_hard_blocker(self):
+        assessment = build_unified_response_assessment(
+            guild_id=1,
+            route_mode="normal_chat",
+            channel_policy="sealed_test",
+            conversation_surface="test",
+            current_speaker_user_ids=(99,),
+        )
+        persist_unified_assessment_shadow_run(
+            self.conn,
+            assessment,
+            response="Current response.",
+            created_at="2026-07-30T12:20:00+00:00",
+        )
+        self.conn.execute(
+            """
+            UPDATE unified_response_assessment_shadow_runs
+            SET response_coherence_status='failed'
+            WHERE created_at='2026-07-30T12:20:00+00:00'
+            """
+        )
+        self.conn.commit()
+
+        snapshot = self.snapshot(
+            {
+                "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+                "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+                "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+                "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+            },
+            runtime_since="2026-07-30T12:14:00+00:00",
+        )
+        report = snapshot["reports"]["unifiedResponseAssessment"]
+        self.assertEqual(
+            report["runtime_response_coherence_failure_runs"],
+            1,
+        )
+        self.assertIn(
+            "unified_response_assessment:"
+            "response_coherence_failure_runs",
+            snapshot["blockers"],
+        )
+
+    def test_pre_runtime_receipts_cannot_satisfy_current_evidence(self):
+        assessment = build_unified_response_assessment(
+            guild_id=1,
+            route_mode="normal_chat",
+            channel_policy="sealed_test",
+            conversation_surface="test",
+            current_speaker_user_ids=(99,),
+        )
+        persist_unified_assessment_shadow_run(
+            self.conn,
+            assessment,
+            response="Earlier response.",
+            created_at="2026-07-29T15:38:01+00:00",
+        )
+        self.conn.commit()
+
+        snapshot = self.snapshot(
+            {
+                "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+                "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+                "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+                "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+            },
+            runtime_since="2026-07-30T12:14:00+00:00",
+        )
+        report = snapshot["reports"]["unifiedResponseAssessment"]
+        overlay = snapshot["unifiedResponseAssessmentShadow"]
+        self.assertEqual(report["runs"], 1)
+        self.assertEqual(report["runtime_runs"], 0)
+        self.assertTrue(overlay["retainedEvidenceObserved"])
+        self.assertFalse(overlay["evidenceObserved"])
+        self.assertIn(
+            "unified_assessment_no_current_runtime_evidence",
+            snapshot["warnings"],
+        )
+        self.assertNotEqual(
+            snapshot["status"],
+            "ready_for_owner_review_not_live_cutover",
+        )
 
     def test_missing_schemas_are_reported_without_creating_tables(self):
         empty = sqlite3.connect(":memory:")
@@ -965,6 +1125,72 @@ class V2ShadowAcceptanceTests(unittest.TestCase):
             "relationship_v2:moment_link_integrity_violations",
             snapshot["blockers"],
         )
+
+    def test_retracted_moment_link_anomaly_is_audit_only(self):
+        event_id = observe_message(
+            self.conn,
+            guild_id=1,
+            user_id=2,
+            role="user",
+            content="thank you",
+            source_row_id="retired-link",
+            channel_policy="public_home",
+            route_mode="normal_chat",
+            directed=True,
+            observed_at="2026-07-19T00:00:00+00:00",
+        )
+        self.conn.execute(
+            """
+            INSERT INTO memory_moment_windows (
+                moment_id,guild_id,channel_id,topic_key,
+                window_started_at,last_activity_at,lifecycle_status,
+                created_at,updated_at
+            ) VALUES (?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                "retired-moment",
+                1,
+                100,
+                "retired-link",
+                "2026-07-19T00:00:00+00:00",
+                "2026-07-19T00:01:00+00:00",
+                "finalized",
+                "2026-07-19T00:00:00+00:00",
+                "2026-07-19T00:01:00+00:00",
+            ),
+        )
+        self.conn.execute(
+            "INSERT INTO relationship_event_moment_links_v2 VALUES "
+            "(?, 'retired-moment', 1, 2, 'retracted', ?, ?)",
+            (
+                event_id,
+                "2026-07-19T00:00:00+00:00",
+                "2026-07-19T00:01:00+00:00",
+            ),
+        )
+        self.conn.commit()
+
+        snapshot = self.snapshot(
+            {"BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true"}
+        )
+        report = snapshot["reports"]["relationshipV2"]
+        self.assertEqual(report["moment_link_integrity_violations"], 0)
+        self.assertEqual(
+            report["retired_moment_link_integrity_observations"],
+            1,
+        )
+        self.assertNotIn(
+            "relationship_v2:moment_link_integrity_violations",
+            snapshot["blockers"],
+        )
+        self.assertIn(
+            "relationship_retired_link_anomalies_retained_for_audit",
+            snapshot["warnings"],
+        )
+        rendered = "\n".join(
+            render_v2_shadow_acceptance_lines(snapshot)
+        )
+        self.assertIn("retired_moments_audit=`1`", rendered)
 
     def test_live_emission_authorization_or_actual_emission_is_a_hard_stop(self):
         observe_message(


### PR DESCRIPTION
## Summary

Repair the shared-brain acceptance report so it distinguishes retained audit history from evidence produced by the currently running bot process.

- Scope unified-response hard blockers to receipts created since the process started.
- Keep every older receipt visible in retained totals and flag historical failures outside the runtime window.
- Treat Relationship links attached to retracted history as audit observations, while active/orphaned graph violations remain hard blockers.
- Render retained and current-runtime counts side by side.
- Add regression coverage for historical failures, current failures, zero-current-evidence startup, and retracted Moment-link anomalies.

## Why this is the correct next PR

The production check after #402 established that the service, process working directory, database path, SQLite integrity check, and backfill-cursor schema are healthy. The remaining report was blocked by two different kinds of stale evidence:

- two Moment-link anomalies whose link lifecycle is already `retracted`;
- six unified-response coherence failures created before the current service process started, with no scoped-canary application.

Those records must not be deleted or rewritten. They are useful audit history. They also must not be presented as failures of a newer runtime that has not yet produced its own acceptance evidence.

This PR does **not** declare acceptance complete. A restart with zero current-runtime receipts reports collecting/no-current-evidence and cannot become ready automatically. Any failure produced during the current runtime remains a hard blocker.

## Behavioral contract

- Active Relationship link-integrity violations still block.
- Retracted-link anomalies remain counted and produce an audit warning.
- Current-runtime grounding, coherence, processing, behavior-change, authority, and canary-scope failures still block.
- Retained historical failures remain visible and produce a historical-evidence warning.
- No current-runtime receipts means collecting, never passing.
- Existing blocker names remain stable for downstream consumers.
- No memory content, person labels, source IDs, or message text are added to diagnostics.

## Verification

- `make check`
- Result: **1,804 tests passed**
- `git diff --check`
- Added fixtures use neutral test identities; no private owner identity was introduced.

## Protected boundaries

- No database schema or retained row changes.
- No backfill, deletion, reconciliation, or migration.
- No live response-path change.
- No gate changes; global memory, Relationship live, Active Engagement live, unified Moment canary, and queue-production states remain untouched.
- No site repository or website behavior change.
- No deployment performed by this PR.

## Rollback

Revert this commit and redeploy the prior `main`. There is no data or schema rollback because this change only affects aggregate evaluation and diagnostic rendering.

## Post-merge deployment

```bash
set -euo pipefail
cd /home/ubuntu/bnl01
git pull --ff-only origin main
git rev-parse HEAD
sudo systemctl restart bnl01
sudo systemctl is-active bnl01
sudo systemctl status bnl01 --no-pager -l
sudo journalctl -u bnl01 --since "10 minutes ago" --no-pager -l \
  | grep -E "Database initialized successfully|Synced [0-9]+ slash command|BNL-01 online|FATAL|Traceback|ERROR" \
  | tail -n 80 || true
```

## Focused post-deploy evidence

1. Confirm the deployed SHA is the merge result and the service is active with normal database/startup logs.
2. Run owner-only `/bnl_memory_check` and capture the full ephemeral result.
3. Require `acceptance_version=v2_shadow_acceptance_v5`.
4. Require active Relationship link violations to remain zero. The two known retracted Moment-link anomalies may appear only in `retired_moments_audit` with the retained-for-audit warning.
5. Confirm the six older coherence failures remain in retained totals but are absent from the current-runtime failure counts.
6. If the current runtime has not produced receipts yet, require the no-current-runtime-evidence warning and a collecting/not-ready status. Zero evidence is not acceptance.
7. During the planned observation window, run the bounded owner-only `/bnl_memory_preview` samples in `#bnl-testing`, then re-run `/bnl_memory_check` after normal shadow receipts exist.
8. Stop if any current-runtime grounding/coherence failure, processing error, behavior change, new authority application, active link violation, or invalid canary scope appears. Do not proceed to public-home convergence until the private preview and separately authorized scoped-canary gates are accepted.

Local tested tree: `92f885a44830cadd3fe9275cf1e3eb81e0af07ce`
Remote parent: `b44df9e0307cd670cab8e3a8d26bfedc835f4d74`
Remote commit: `96723536efd7d5d6dfae7439a9d9974b784273ff`
