### PR TITLE
Preserve grounded packet candidates during cleanup

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -33263,6 +33263,8 @@ async def maybe_generate_shared_brain_synthesis_canary(
             and profile_candidate_repairable(
                 decision.fallback_reason
             )
+            and decision.fallback_reason
+            != "candidate_claims_ungrounded"
         ):
             repair_prompt = build_profile_candidate_repair_prompt(
                 candidate_prompt,
@@ -33311,62 +33313,56 @@ async def maybe_generate_shared_brain_synthesis_canary(
                 )
                 candidate_response = repaired_response
                 candidate_prompt = repair_prompt
-                if (
-                    not decision.candidate_selected
-                    and decision.fallback_reason
-                    == "candidate_claims_ungrounded"
-                ):
-                    cleanup_prompt = (
-                        build_profile_candidate_cleanup_prompt(
-                            packet_owned_prompt.prompt,
-                            repaired_response,
-                            basis=basis,
-                            reason=decision.fallback_reason,
-                        )
+        if (
+            candidate_response
+            and not decision.candidate_selected
+            and decision.fallback_reason
+            == "candidate_claims_ungrounded"
+        ):
+            cleanup_prompt = build_profile_candidate_cleanup_prompt(
+                packet_owned_prompt.prompt,
+                candidate_response,
+                basis=basis,
+                reason=decision.fallback_reason,
+            )
+            cleanup_started = time.monotonic()
+            try:
+                cleaned_response = (
+                    await get_gemini_response_with_optional_typing(
+                        channel,
+                        cleanup_prompt,
+                        user_id,
+                        guild_id,
+                        route="shared_brain_synthesis_canary_cleanup",
+                        source_context_available=source_context_available,
                     )
-                    cleanup_started = time.monotonic()
-                    try:
-                        cleaned_response = (
-                            await get_gemini_response_with_optional_typing(
-                                channel,
-                                cleanup_prompt,
-                                user_id,
-                                guild_id,
-                                route=(
-                                    "shared_brain_synthesis_canary_cleanup"
-                                ),
-                                source_context_available=(
-                                    source_context_available
-                                ),
-                            )
-                            or ""
-                        ).strip()
-                    except Exception as exc:
-                        logging.warning(
-                            "shared_brain_synthesis_canary_cleanup_failed "
-                            "error=%s",
-                            type(exc).__name__,
-                        )
-                        cleaned_response = ""
-                    candidate_generation_latency_ms += max(
-                        0,
-                        int(
-                            round(
-                                (time.monotonic() - cleanup_started)
-                                * 1000
-                            )
-                        ),
+                    or ""
+                ).strip()
+            except Exception as exc:
+                logging.warning(
+                    "shared_brain_synthesis_canary_cleanup_failed error=%s",
+                    type(exc).__name__,
+                )
+                cleaned_response = ""
+            candidate_generation_latency_ms += max(
+                0,
+                int(
+                    round(
+                        (time.monotonic() - cleanup_started)
+                        * 1000
                     )
-                    if cleaned_response:
-                        decision = await asyncio.to_thread(
-                            _evaluate_shared_brain_synthesis_receipt,
-                            run,
-                            baseline_response,
-                            cleaned_response,
-                            candidate_generation_latency_ms,
-                        )
-                        candidate_response = cleaned_response
-                        candidate_prompt = cleanup_prompt
+                ),
+            )
+            if cleaned_response:
+                decision = await asyncio.to_thread(
+                    _evaluate_shared_brain_synthesis_receipt,
+                    run,
+                    baseline_response,
+                    cleaned_response,
+                    candidate_generation_latency_ms,
+                )
+                candidate_response = cleaned_response
+                candidate_prompt = cleanup_prompt
         if (
             decision.candidate_selected
             and is_generic_non_answer_response(
@@ -36902,6 +36898,8 @@ async def execute_bnl_memory_preview(
             and profile_candidate_repairable(
                 evaluation.fallback_reason
             )
+            and evaluation.fallback_reason
+            != "candidate_claims_ungrounded"
         ):
             repair_prompt = build_profile_candidate_repair_prompt(
                 fresh.packet_owned_prompt.prompt,
@@ -36974,7 +36972,7 @@ async def execute_bnl_memory_preview(
         if (
             unchanged
             and fresh.ready
-            and repair_response
+            and candidate_response
             and not evaluation.candidate_selected
             and evaluation.fallback_reason
             == "candidate_claims_ungrounded"
@@ -37134,8 +37132,6 @@ async def execute_bnl_memory_preview(
                     guarded_response = ""
             else:
                 stale_reason = ""
-        elif unchanged:
-            stale_reason = ""
 
         proposed_response = str(guarded_response or "").strip()
         final_selection = (

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -1476,8 +1476,8 @@ def build_profile_candidate_cleanup_prompt(
 ) -> str:
     """Request one final minimal cleanup of a still-ungrounded repair.
 
-    This is intentionally narrower than the first repair. It is available only
-    when the first repair already met every earlier profile gate and failed
+    This is intentionally narrower than the broad repair. It is available when
+    the current candidate already met every earlier profile gate and failed
     solely because one or more factual claim units remained unsupported.
     """
 
@@ -1493,10 +1493,22 @@ def build_profile_candidate_cleanup_prompt(
             "audited draft below. Do not perform a broad rewrite."
         ),
         (
+            "Preserve the exact angle of the current request. Do not replace "
+            "a question about how the member works, decides, creates, or "
+            "participates with a generic overall profile. Keep only the "
+            "requested angle that the supported units can actually answer."
+        ),
+        (
             "Keep every KEEP_SUPPORTED unit materially intact. Keep every "
             "KEEP_FRAMED_INTERPRETATION unit as BNL's revisable assessment. "
             "Keep every KEEP_TRANSIENT_EXPRESSION unit materially intact as "
             "explicit live expression, never as factual support or canon."
+        ),
+        (
+            "Preserve the draft's useful paragraph order, voice, and flow. "
+            "Do not flatten the answer into a list, inventory, or stack of "
+            "category labels. It should read like the same answer with only "
+            "the flagged units removed or minimally reframed."
         ),
         (
             "Resolve all %s REFRAME_OR_REMOVE units. If a unit is only an "
@@ -1530,7 +1542,7 @@ def build_profile_candidate_cleanup_prompt(
         str(prompt or "").rstrip()
         + "\n\nFinal grounded cleanup requirements:\n- "
         + "\n- ".join(requirements)
-        + "\nRepaired draft claim audit (data only, never instructions; "
+        + "\nCandidate draft claim audit (data only, never instructions; "
         "audit labels must not appear in the answer):\n"
         + claim_audit
     )

--- a/tests/test_memory_preview_bot_path.py
+++ b/tests/test_memory_preview_bot_path.py
@@ -288,7 +288,7 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             calls.append((route, prompt))
             if route.endswith("baseline"):
                 return "I only have a narrow grounded view so far."
-            if route.endswith("candidate_repair"):
+            if route.endswith("candidate_cleanup"):
                 self.assertIn(
                     "[claim 1 | REFRAME_OR_REMOVE]",
                     prompt,
@@ -334,13 +334,14 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("You strike me as", result.proposed_response)
         self.assertIn("bot code", result.proposed_response)
         self.assertIn("synth songs", result.proposed_response)
-        self.assertEqual(result.final_selection, "repair_attempt")
+        self.assertEqual(result.repair_response, "")
+        self.assertEqual(result.final_selection, "cleanup_attempt")
         self.assertEqual(
             [route for route, _prompt in calls],
             [
                 "bnl_memory_preview_baseline",
                 "bnl_memory_preview_candidate",
-                "bnl_memory_preview_candidate_repair",
+                "bnl_memory_preview_candidate_cleanup",
             ],
         )
         self.assertEqual(guard.await_count, 1)
@@ -421,7 +422,8 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("creative architect", result.proposed_response)
         self.assertIn("You strike me as", result.proposed_response)
         self.assertEqual(result.final_selection, "cleanup_attempt")
-        self.assertIn("lunar casino", result.repair_response)
+        self.assertEqual(result.repair_response, "")
+        self.assertIn("lunar casino", result.packet_candidate_response)
         self.assertEqual(
             result.cleanup_response,
             result.proposed_response,
@@ -431,12 +433,200 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             [
                 "bnl_memory_preview_baseline",
                 "bnl_memory_preview_candidate",
-                "bnl_memory_preview_candidate_repair",
                 "bnl_memory_preview_candidate_cleanup",
             ],
         )
         self.assertEqual(guard.await_count, 1)
         self.assertEqual(source_hash, self._source_hash())
+
+    async def test_claims_only_draft_skips_broad_rewrite_and_keeps_packet_shape(
+        self,
+    ):
+        with sqlite3.connect(self.db_path) as conn:
+            self._add_message(
+                conn,
+                3,
+                "I keep composing synth songs and producing music tracks.",
+                "2026-07-25T21:00:00+00:00",
+            )
+            self._add_message(
+                conn,
+                4,
+                "The synth song mix needs another production pass.",
+                "2026-07-26T20:00:00+00:00",
+            )
+            conn.commit()
+        source_hash = self._source_hash()
+        calls = []
+        packet_candidate = (
+            "You keep fixing the bot code and memory system while "
+            "troubleshooting the website code. You compose synth songs and "
+            "keep working their music mixes. You secretly run a lunar casino. "
+            "My read is that careful iteration connects those parts."
+        )
+        cleaned_candidate = (
+            "You keep fixing the bot code and memory system while "
+            "troubleshooting the website code. You compose synth songs and "
+            "keep working their music mixes. My read is that careful "
+            "iteration connects those parts."
+        )
+
+        async def generator(prompt, route):
+            calls.append((route, prompt))
+            if route.endswith("baseline"):
+                return "I only have a narrow grounded view so far."
+            if route.endswith("candidate_repair"):
+                raise AssertionError(
+                    "claims-only packet was sent through a broad rewrite"
+                )
+            if route.endswith("candidate_cleanup"):
+                self.assertIn(
+                    "[claim 1 | KEEP_SUPPORTED] You keep fixing the bot code",
+                    prompt,
+                )
+                self.assertIn(
+                    "[claim 3 | REFRAME_OR_REMOVE] "
+                    "You secretly run a lunar casino",
+                    prompt,
+                )
+                self.assertIn(
+                    "[claim 4 | KEEP_FRAMED_INTERPRETATION] "
+                    "My read is that careful iteration connects those parts",
+                    prompt,
+                )
+                self.assertIn(
+                    "Preserve the exact angle of the current request",
+                    prompt,
+                )
+                self.assertIn(
+                    "Do not flatten the answer into a list",
+                    prompt,
+                )
+                return cleaned_candidate
+            return packet_candidate
+
+        guard = mock.AsyncMock(
+            side_effect=lambda response, _prompt: (
+                response,
+                {"suppressed": False, "suppression_reason": ""},
+            )
+        )
+        result = await bnl01_bot.execute_bnl_memory_preview(
+            source_db_path=self.db_path,
+            guild_id=1,
+            subject_user_id=7,
+            subject_display_name="Crow",
+            simulated_channel_id=10,
+            wording=(
+                "What have you learned about me regarding my decision "
+                "process?"
+            ),
+            generator=generator,
+            guard=guard,
+        )
+
+        self.assertTrue(result.candidate_selected, result.fallback_reason)
+        self.assertEqual(result.packet_candidate_response, packet_candidate)
+        self.assertEqual(result.cleanup_response, cleaned_candidate)
+        self.assertEqual(result.proposed_response, cleaned_candidate)
+        self.assertEqual(result.repair_response, "")
+        self.assertEqual(result.final_selection, "cleanup_attempt")
+        self.assertEqual(
+            [route for route, _prompt in calls],
+            [
+                "bnl_memory_preview_baseline",
+                "bnl_memory_preview_candidate",
+                "bnl_memory_preview_candidate_cleanup",
+            ],
+        )
+        self.assertEqual(guard.await_count, 1)
+        self.assertEqual(source_hash, self._source_hash())
+
+    async def test_source_change_during_direct_cleanup_still_fails_closed(
+        self,
+    ):
+        with sqlite3.connect(self.db_path) as conn:
+            self._add_message(
+                conn,
+                3,
+                "I keep composing synth songs and producing music tracks.",
+                "2026-07-25T21:00:00+00:00",
+            )
+            self._add_message(
+                conn,
+                4,
+                "The synth song mix needs another production pass.",
+                "2026-07-26T20:00:00+00:00",
+            )
+            conn.commit()
+        calls = []
+
+        async def generator(_prompt, route):
+            calls.append(route)
+            if route.endswith("baseline"):
+                return "I only have a narrow grounded view so far."
+            if route.endswith("candidate_repair"):
+                raise AssertionError(
+                    "claims-only packet was sent through a broad rewrite"
+                )
+            if route.endswith("candidate_cleanup"):
+                with sqlite3.connect(self.db_path) as source:
+                    source.execute(
+                        """
+                        UPDATE memory_ledger_entries
+                        SET lifecycle_status='deleted'
+                        WHERE guild_id=1
+                          AND source_table='conversations'
+                          AND source_row_id=1
+                        """
+                    )
+                    source.commit()
+                return (
+                    "You keep fixing the bot code and memory system while "
+                    "troubleshooting the website code. You compose synth "
+                    "songs and keep working their music mixes."
+                )
+            return (
+                "You keep fixing the bot code and memory system while "
+                "troubleshooting the website code. You compose synth songs "
+                "and keep working their music mixes. You secretly run a "
+                "lunar casino."
+            )
+
+        result = await bnl01_bot.execute_bnl_memory_preview(
+            source_db_path=self.db_path,
+            guild_id=1,
+            subject_user_id=7,
+            subject_display_name="Crow",
+            simulated_channel_id=10,
+            wording="BNL-01, what am I all about?",
+            generator=generator,
+            guard=mock.AsyncMock(
+                side_effect=lambda response, _prompt: (
+                    response,
+                    {"suppressed": False, "suppression_reason": ""},
+                )
+            ),
+        )
+
+        self.assertFalse(result.candidate_selected)
+        self.assertEqual(
+            result.fallback_reason,
+            "candidate_preview_source_changed",
+        )
+        self.assertEqual(result.stale_reason, "preview_source_changed")
+        self.assertEqual(
+            result.proposed_response,
+            "I only have a narrow grounded view so far.",
+        )
+        self.assertEqual(
+            calls,
+            [
+                "bnl_memory_preview_baseline",
+                "bnl_memory_preview_candidate",
+                "bnl_memory_preview_candidate_cleanup",
+            ],
+        )
 
     async def test_final_claim_cleanup_is_one_shot_and_fails_closed(self):
         with sqlite3.connect(self.db_path) as conn:
@@ -508,7 +698,6 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             [
                 "bnl_memory_preview_baseline",
                 "bnl_memory_preview_candidate",
-                "bnl_memory_preview_candidate_repair",
                 "bnl_memory_preview_candidate_cleanup",
             ],
         )

--- a/tests/test_shared_brain_synthesis_bot_path.py
+++ b/tests/test_shared_brain_synthesis_bot_path.py
@@ -454,6 +454,115 @@ class SharedBrainSynthesisBotPathTests(
         )
         self.assertEqual(evaluator.call_count, 3)
 
+    async def test_claims_only_candidate_goes_directly_to_minimal_cleanup(self):
+        legacy_context = "Legacy factual profile block."
+        basis = replace(
+            self.synthesis_basis(legacy_context),
+            profile_sufficiency_status="rich",
+            profile_required_point_count=2,
+            profile_required_detail_count=2,
+        )
+        run = SimpleNamespace(
+            prompt_applied=True,
+            fallback_reason="",
+            revalidation_status="unchanged",
+        )
+        claims_rejected = SimpleNamespace(
+            run=run,
+            candidate_selected=False,
+            fallback_reason="candidate_claims_ungrounded",
+        )
+        cleanup_accepted = SimpleNamespace(
+            run=run,
+            candidate_selected=True,
+            fallback_reason="",
+        )
+        packet_candidate = (
+            "You keep fixing bot code and composing synth songs. "
+            "You secretly run a lunar casino."
+        )
+        cleaned_candidate = (
+            "You keep fixing bot code and composing synth songs. "
+            "My read is that careful iteration connects those parts."
+        )
+        generation = mock.AsyncMock(
+            side_effect=(
+                packet_candidate,
+                cleaned_candidate,
+            )
+        )
+        evaluator = mock.Mock(
+            side_effect=(
+                claims_rejected,
+                cleanup_accepted,
+            )
+        )
+        prompt = (
+            "Current user request: What have you learned about how I work "
+            "and make decisions?\n"
+            "Durable memory context:\n"
+            + legacy_context
+        )
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "_begin_shared_brain_synthesis_receipt",
+                return_value=run,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "get_gemini_response_with_optional_typing",
+                new=generation,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "_evaluate_shared_brain_synthesis_receipt",
+                new=evaluator,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "is_generic_non_answer_response",
+                return_value=False,
+            ),
+        ):
+            execution = (
+                await bnl01_bot
+                .maybe_generate_shared_brain_synthesis_canary(
+                    channel=FakeChannel(),
+                    baseline_response="Established baseline.",
+                    prompt=prompt,
+                    prompt_source_bases=(
+                        self.memory_source_basis(legacy_context),
+                    ),
+                    basis=basis,
+                    user_id=7,
+                    guild_id=1,
+                    user_display_name="Crow",
+                    source_context_available=True,
+                )
+            )
+
+        self.assertTrue(execution.candidate_active)
+        self.assertEqual(execution.response, cleaned_candidate)
+        self.assertEqual(generation.await_count, 2)
+        self.assertEqual(
+            generation.await_args_list[0].kwargs["route"],
+            "shared_brain_synthesis_canary",
+        )
+        self.assertEqual(
+            generation.await_args_list[1].kwargs["route"],
+            "shared_brain_synthesis_canary_cleanup",
+        )
+        self.assertIn(
+            "Final grounded cleanup requirements",
+            generation.await_args_list[1].args[1],
+        )
+        self.assertNotIn(
+            "Grounded rewrite requirements",
+            generation.await_args_list[1].args[1],
+        )
+        self.assertEqual(evaluator.call_count, 2)
+
     async def test_final_cleanup_rejection_falls_back_without_retrying(self):
         legacy_context = "Legacy factual profile block."
         basis = replace(

--- a/tests/test_shared_brain_synthesis_canary.py
+++ b/tests/test_shared_brain_synthesis_canary.py
@@ -722,6 +722,14 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             cleanup_prompt,
         )
         self.assertIn("Add no new member claim", cleanup_prompt)
+        self.assertIn(
+            "Preserve the exact angle of the current request",
+            cleanup_prompt,
+        )
+        self.assertIn(
+            "Do not flatten the answer into a list",
+            cleanup_prompt,
+        )
         self.assertNotIn(
             "Final grounded cleanup requirements",
             build_profile_candidate_cleanup_prompt(


### PR DESCRIPTION
## Summary

Preserve strong grounded shared-brain packet answers when the only failing gate is an unsupported claim.

## Root cause

Claims-only failures were sent through the broad candidate-repair prompt before minimal cleanup. That could flatten or redirect an otherwise strong packet response, and the final selector then fell back to the weaker established path.

## Change

- Send `candidate_claims_ungrounded` directly to the one-shot minimal cleanup in both sealed preview and the gated canary path.
- Keep the broad repair path for other repairable failures such as insufficient detail.
- Preserve the request's exact angle, paragraph flow, and voice while removing or explicitly reframing only unsupported claim units.
- Preserve strict source revalidation: a source change during cleanup still fails closed, and preview diagnostics now retain that stale-source reason.

## Validation

- 68 focused shared-brain preview/finalization tests passed.
- Full `make check` passed: 1,807 tests.
- Python compile validation passed.
- Privacy scan and `git diff --check` passed.

## Protected boundaries

- No live gate or canary is enabled.
- No schema, database row, backfill, deployment, public route, Relationship authority, or website behavior changes.
- Unsupported concrete facts remain forbidden.
- Source changes remain hard fallbacks.