### PR TITLE
Improve grounded profile selection fidelity

### DIFF
--- a/bnl_memory_preview.py
+++ b/bnl_memory_preview.py
@@ -123,6 +123,7 @@ class MemoryPreviewDiagnostics:
     profile_satisfied: bool = False
     profile_required_point_count: int = 0
     profile_selected_point_count: int = 0
+    profile_candidate_point_count: int = 0
     profile_independent_root_count: int = 0
     profile_independent_occurrence_count: int = 0
     profile_reason_codes: tuple[str, ...] = ()
@@ -924,7 +925,7 @@ def _diagnostics(
     omission_reasons = {
         "excluded:%s" % reason
         for reason, count in exclusion_counts
-        if int(count or 0) > 0
+        if int(count or 0) > 0 and reason != "lane_cap"
     }
     omission_reasons.update(
         "missing_lane:%s" % lane for lane in missing_lanes
@@ -937,6 +938,11 @@ def _diagnostics(
         if str(reason or "")
     )
     if packet is not None:
+        omission_reasons.update(
+            "excluded:lane_cap:%s" % exclusion.lane
+            for exclusion in packet.exclusions
+            if exclusion.reason == "lane_cap"
+        )
         omission_reasons.update(
             "packet_error:%s" % reason
             for reason in packet.diagnostics.processing_errors
@@ -1000,6 +1006,9 @@ def _diagnostics(
         ),
         profile_selected_point_count=int(
             getattr(profile, "selected_point_count", 0) or 0
+        ),
+        profile_candidate_point_count=int(
+            getattr(profile, "candidate_point_count", 0) or 0
         ),
         profile_independent_root_count=int(
             getattr(profile, "independent_root_count", 0) or 0
@@ -1561,12 +1570,14 @@ def render_content_free_diagnostics(
             ).lower(),
         ),
         "- profile_sufficiency: `%s` satisfied=`%s` "
-        "points=`%s/%s` roots=`%s` occurrences=`%s` reasons=`%s`"
+        "points=`%s/%s` eligible_points=`%s` roots=`%s` "
+        "occurrences=`%s` reasons=`%s`"
         % (
             diag.profile_status,
             str(diag.profile_satisfied).lower(),
             diag.profile_selected_point_count,
             diag.profile_required_point_count,
+            diag.profile_candidate_point_count,
             diag.profile_independent_root_count,
             diag.profile_independent_occurrence_count,
             list(diag.profile_reason_codes) or ["none"],

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -241,15 +241,24 @@ _REPAIRABLE_PROFILE_FAILURES = frozenset(
 _CLAIM_SPLIT_RE = re.compile(
     r"(?:[.!?;]+\s+|\n+|"
     r"\s+[—–]\s+|"
-    r",\s+(?=(?:and|but|yet|while|whereas|which|so|meaning|"
-    r"making|showing|proving)\b)|"
+    r",\s+(?=(?:but|yet|while|whereas|which|so|meaning|proving)\b)|"
+    r",\s+(?=(?:making|showing)\s+"
+    r"(?:you|your|it|this|that|those|these)\b)|"
     r"\s+(?=(?:and|but|yet|while|whereas)\s+"
     r"(?:you|your|i|my|this|that|those|these)\b)|"
     r"\s+(?=(?:and|but|yet|while|whereas)\s+"
     r"(?:(?:secretly|actually|also|regularly|always|never|"
     r"personally|apparently|supposedly)\s+)?"
-    r"(?:run|own|live|work|have|make|build|create|prefer|like|"
-    r"love|broadcast|transmit|control|command|operate|fund)\b)|"
+    r"(?:run|own|have|make|build|create|prefer|like|love|"
+    r"transmit|control|command|operate|fund)\b)|"
+    r"\s+(?=(?:and|but|yet|while|whereas)\s+"
+    r"(?:(?:secretly|actually|also|regularly|always|never|"
+    r"personally|apparently|supposedly)\s+)?"
+    r"(?:live|work)\s+(?:at|in|near|for|on)\b)|"
+    r"\s+(?=(?:and|but|yet|while|whereas)\s+"
+    r"(?:(?:secretly|actually|also|regularly|always|never|"
+    r"personally|apparently|supposedly)\s+)?"
+    r"broadcast\s+(?:at|on|every|each|from|to)\b)|"
     r"\s+(?=(?:because|although|though|even\s+though|since)\s+"
     r"(?:you|your|this|that|those|these)\b))",
     re.I,
@@ -258,6 +267,9 @@ _OPINION_FRAME_RE = re.compile(
     r"\b(?:i\s+(?:think|believe|suspect|figure)|"
     r"i(?:'d|\s+would)\s+(?:say|call)|"
     r"my\s+(?:read|view|take|assessment)|"
+    r"based\s+on\s+my\s+observations?|"
+    r"from\s+(?:my\s+observations?|what\s+i\s+observe|my\s+perspective)|"
+    r"if\s+i\s+had\s+to\s+summarize(?:\s+my\s+read)?|"
     r"to\s+me|in\s+my\s+view|from\s+where\s+i\s+(?:sit|stand)|"
     r"it\s+seems|you\s+seem|you\s+strike\s+me|"
     r"i\s+get\s+the\s+(?:sense|impression)|"
@@ -266,7 +278,8 @@ _OPINION_FRAME_RE = re.compile(
 )
 _DERIVED_ASSESSMENT_RE = re.compile(
     r"^\s*(?:that|those|these|this|both|together|overall|put\s+together|"
-    r"in\s+combination|the\s+combination|the\s+throughline)\b",
+    r"in\s+combination|in\s+short|in\s+sum|summed\s+up|"
+    r"the\s+combination|the\s+throughline)\b",
     re.I,
 )
 _DIRECT_MEMBER_ASSERTION_RE = re.compile(
@@ -284,6 +297,22 @@ _UNSUPPORTED_SCALAR_ASSERTION_RE = re.compile(
     r"you\s+(?:prefer|like|love|own|have)\b)",
     re.I,
 )
+_UNSUPPORTED_FRAMED_CONCRETE_RE = re.compile(
+    r"(?:https?://|www\.|<@!?\d+>|"
+    r"\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b|"
+    r"\b\d+(?:[.:/-]\d+)*\b|"
+    r"\byou\s+(?:(?:secretly|actually|also|regularly|always|never|"
+    r"personally|apparently|supposedly)\s+)?"
+    r"(?:run|own|host|manage|lead|found|founded|join|joined|"
+    r"release|released|write|wrote|visit|visited|attend|attended|"
+    r"buy|bought|sell|sold|pay|paid|earn|earned|live|reside|work)\b|"
+    r"\byou\s+(?:are|were)\s+(?:a|an|the|from|in|at|near)\b|"
+    r"\byou\s+(?:were\s+)?born\b|"
+    r"\byour\s+(?:favorite|name|pronouns?|home|address|job|employer|"
+    r"workplace|birthday|age|role|project)\b)",
+    re.I,
+)
+_INTERNAL_PROPER_NOUN_RE = re.compile(r"(?<!^)(?<![.!?]\s)\b[A-Z][\w'-]{2,}\b")
 _TRANSIENT_EXPRESSION_WRAPPER_RE = re.compile(
     r"^\s*[~*_`-]*\[(?P<body>[\s\S]{1,900})\]\s*[~*_`-]*$",
 )
@@ -1777,10 +1806,14 @@ def _classify_candidate_claims(
         scalar_assertion = bool(
             _UNSUPPORTED_SCALAR_ASSERTION_RE.search(factual_claim)
         )
+        framed_concrete_assertion = bool(
+            scalar_assertion
+            or _UNSUPPORTED_FRAMED_CONCRETE_RE.search(factual_claim)
+            or _INTERNAL_PROPER_NOUN_RE.search(factual_claim)
+        )
         if (
             has_member_basis
-            and not scalar_assertion
-            and not _DIRECT_MEMBER_ASSERTION_RE.search(factual_claim)
+            and not framed_concrete_assertion
             and _OPINION_FRAME_RE.search(factual_claim)
         ):
             classifications.append("framed_opinion")
@@ -1788,7 +1821,7 @@ def _classify_candidate_claims(
             continue
         if (
             has_member_basis
-            and not scalar_assertion
+            and not framed_concrete_assertion
             and _DERIVED_ASSESSMENT_RE.search(factual_claim)
         ):
             classifications.append("linked_assessment")

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -114,7 +114,7 @@ _LANE_CAPS = {
 _BROAD_PROFILE_LANE_CAPS = {
     **_LANE_CAPS,
     "conversation_context": 2,
-    "atomic_knowledge": 4,
+    "atomic_knowledge": 6,
     "moment": 2,
     "open_loop": 1,
     "canon": 2,

--- a/tests/test_production_shaped_broad_recall_acceptance.py
+++ b/tests/test_production_shaped_broad_recall_acceptance.py
@@ -543,6 +543,89 @@ class ProductionShapedBroadRecallAcceptanceTests(unittest.TestCase):
         finally:
             prepared.close()
 
+    def test_broad_profile_keeps_all_six_bounded_recurrent_points(self):
+        user_id = 102
+        user_name = "Test Member"
+        topics = (
+            (
+                "I keep producing synth music and mixing audio tracks.",
+                "The song vocals and drum mix need another pass.",
+            ),
+            (
+                "I keep designing visual artwork and animation sprites.",
+                "The image style and banner design need another pass.",
+            ),
+            (
+                "I keep debugging bot code and testing deployments.",
+                "The website system still has another bug to fix.",
+            ),
+            (
+                "I keep organizing community collaboration in Discord.",
+                "The server team has another shared project to coordinate.",
+            ),
+            (
+                "I keep writing lore and shaping the worldbuilding.",
+                "The story narrative and canon need another writing pass.",
+            ),
+            (
+                "I keep balancing game battles and creature cards.",
+                "The player classes and monster levels need another pass.",
+            ),
+        )
+        for index, (first, second) in enumerate(topics):
+            self.add_recurring_topic(
+                user_id=user_id,
+                user_name=user_name,
+                first=first,
+                second=second,
+                day_offset=index,
+            )
+
+        prepared = prepare_memory_preview(
+            self.request(
+                user_id=user_id,
+                user_name=user_name,
+                wording="BNL-01, what am I all about?",
+            )
+        )
+        try:
+            funnel = dict(prepared.diagnostics.source_funnel_counts)
+            self.assertEqual(funnel["motif_candidates_returned"], 6)
+            atomic_items = tuple(
+                item
+                for item in prepared.packet.items
+                if item.lane == "atomic_knowledge"
+            )
+            self.assertEqual(len(atomic_items), 6)
+            self.assertEqual(
+                prepared.packet.profile_sufficiency.candidate_point_count,
+                6,
+            )
+            self.assertEqual(
+                prepared.packet.profile_sufficiency.selected_point_count,
+                6,
+            )
+            self.assertEqual(
+                prepared.diagnostics.profile_candidate_point_count,
+                6,
+            )
+            self.assertEqual(
+                dict(prepared.basis.rendered_lane_counts).get(
+                    "atomic_knowledge",
+                    0,
+                ),
+                6,
+            )
+            self.assertFalse(
+                any(
+                    exclusion.lane == "atomic_knowledge"
+                    and exclusion.reason == "lane_cap"
+                    for exclusion in prepared.packet.exclusions
+                ),
+            )
+        finally:
+            prepared.close()
+
     def test_lostmarbles_never_inherits_wittyfox_evidence(self):
         self.add_recurring_topic(
             user_id=103,

--- a/tests/test_shared_brain_synthesis_canary.py
+++ b/tests/test_shared_brain_synthesis_canary.py
@@ -13,6 +13,7 @@ from bnl_shadow_acceptance import (
     render_v2_shadow_acceptance_lines,
 )
 from bnl_shared_brain_synthesis import (
+    _candidate_claim_units,
     begin_run,
     build_basis,
     build_evaluation_report,
@@ -740,6 +741,69 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             ),
         )
 
+    def test_claim_splitter_preserves_coordinated_profile_language(self):
+        first_cleanup = (
+            "Based on my observations, you are largely driven by audio, "
+            "visual craft, and community alignment. You're consistently "
+            "hyping up synth-driven tracks, showing appreciation for badass "
+            "song art, and diving into lore and worldbuilding. Parallel to "
+            "that, your focus stays on bringing people together—welcoming "
+            "collaborators, encouraging shared projects, and making room for "
+            "others to host. In short: creative signal and community "
+            "connection intersect in what you do."
+        )
+        second_cleanup = (
+            "From what I observe, you strike me as a central creative pulse. "
+            "You are thoroughly anchored in the music and live broadcast "
+            "signal—hyping up synth tracks, shouting out track art, and "
+            "welcoming collaborators. You maintain a steady hand on lore, "
+            "character visual design, and community spaces. In short: you "
+            "keep the signal moving, connected, and continuously building."
+        )
+
+        first_claims = _candidate_claim_units(first_cleanup)
+        second_claims = _candidate_claim_units(second_cleanup)
+
+        self.assertEqual(len(first_claims), 4)
+        self.assertIn(
+            "audio, visual craft, and community alignment",
+            first_claims[0],
+        )
+        self.assertIn(
+            "tracks, showing appreciation for badass song art, and diving",
+            first_claims[1],
+        )
+        self.assertIn(
+            "collaborators, encouraging shared projects, and making room",
+            first_claims[2],
+        )
+        self.assertEqual(len(second_claims), 4)
+        self.assertIn(
+            "music and live broadcast signal",
+            second_claims[1],
+        )
+        self.assertIn(
+            "tracks, shouting out track art, and welcoming collaborators",
+            second_claims[1],
+        )
+        self.assertIn(
+            "moving, connected, and continuously building",
+            second_claims[3],
+        )
+
+        unsafe_claims = _candidate_claim_units(
+            "Your favorite movie is Arrival and secretly run a lunar casino. "
+            "Your favorite color is violet."
+        )
+        self.assertEqual(
+            unsafe_claims,
+            (
+                "Your favorite movie is Arrival",
+                "secretly run a lunar casino",
+                "Your favorite color is violet",
+            ),
+        )
+
     def test_project_wording_retains_relevant_canon_for_evaluation(self):
         wording = "BNL, what am I all about in the BARCODE project?"
         request = self._request()
@@ -1146,6 +1210,63 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
         self.assertEqual(
             opinion.candidate_unsupported_factual_claim_count,
             0,
+        )
+
+        production_frame_run = begin_run(
+            self.conn,
+            basis,
+            baseline_response="You keep connecting music and project work.",
+            environ=self.flags,
+        )
+        production_frame = evaluate_candidate(
+            self.conn,
+            production_frame_run,
+            baseline_response="You keep connecting music and project work.",
+            candidate_response=(
+                "Your favorite movie is Arrival and your favorite color is "
+                "violet. Based on my observations, those choices create a "
+                "vivid, coherent, and slightly off-center creative signal. "
+                "In short: you keep the signal distinct, connected, and "
+                "continuously evolving."
+            ),
+            environ=self.flags,
+        )
+        self.assertTrue(production_frame.candidate_selected)
+        self.assertEqual(
+            production_frame.candidate_unsupported_factual_claim_count,
+            0,
+        )
+        self.assertEqual(
+            production_frame.candidate_claim_classifications,
+            (
+                "member_supported",
+                "member_supported",
+                "framed_opinion",
+                "linked_assessment",
+            ),
+        )
+
+        framed_concrete_run = begin_run(
+            self.conn,
+            basis,
+            baseline_response="You keep connecting music and project work.",
+            environ=self.flags,
+        )
+        framed_concrete = evaluate_candidate(
+            self.conn,
+            framed_concrete_run,
+            baseline_response="You keep connecting music and project work.",
+            candidate_response=(
+                "Your favorite movie is Arrival and your favorite color is "
+                "violet. Based on my observations, you secretly run a lunar "
+                "casino."
+            ),
+            environ=self.flags,
+        )
+        self.assertFalse(framed_concrete.candidate_selected)
+        self.assertEqual(
+            framed_concrete.fallback_reason,
+            "candidate_claims_ungrounded",
         )
 
         disguised_fact_run = begin_run(


### PR DESCRIPTION
## Why

Three sealed broad-recall previews showed that BNL had rich evidence (21–23 independent roots and 13–14 occurrences) but still rejected two strong grounded cleanups. The cause was not missing memory: the claim splitter fragmented coordinated language into fake unsupported claims, while the broad-profile packet silently capped six already-bounded motif points at four.

## What changed

- Preserve ordinary coordinated profile language during claim segmentation while still splitting explicit risky subjectless assertions.
- Recognize a small set of natural opinion/summary frames for abstract synthesis.
- Keep framed concrete claims fail-closed: names, roles, actions, locations, numbers, contact details, personal facts, and unsupported scalar assertions still require evidence.
- Raise the broad-profile atomic lane cap from 4 to the motif system's existing bound of 6; no new source type, permission, backfill, or raw-evidence dump is introduced.
- Report eligible profile points and lane-specific cap exclusions in sealed preview diagnostics.

## Safety boundaries retained

- Unsupported concrete facts still reject the candidate.
- Source changes still fail closed.
- Guild/subject isolation and governed-source eligibility are unchanged.
- Live/global memory, Relationship, Active Engagement, queue, and canary gates remain off.
- No database, schema, backfill, website, deployment, or production-data change.

## Verification

- 89 focused packet/preview/synthesis/production-shaped tests passed.
- Full `make check`: 1,809 tests passed.
- `git diff --check` passed.
- Published branch is exactly one commit ahead of PR #404's merge and contains only the intended five files.
- Exact tested/published tree: `8d131413c41ea40c612cfa0f4a49ea18397bbfc1`.