### PR TITLE
Blend public assessment with bounded canon

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -151,6 +151,7 @@ from bnl_shared_brain_synthesis import (
     record_fallback as record_shared_brain_synthesis_fallback,
     revalidate_basis as revalidate_shared_brain_synthesis_basis,
     route_scope_enabled as shared_brain_synthesis_route_scope_enabled,
+    salvage_profile_candidate_response,
 )
 from bnl_memory_preview import (
     MemoryPreviewEvaluation,
@@ -33363,6 +33364,29 @@ async def maybe_generate_shared_brain_synthesis_canary(
                 )
                 candidate_response = cleaned_response
                 candidate_prompt = cleanup_prompt
+                if (
+                    not decision.candidate_selected
+                    and decision.fallback_reason
+                    == "candidate_claims_ungrounded"
+                ):
+                    salvaged_response = (
+                        salvage_profile_candidate_response(
+                            cleaned_response,
+                            basis=basis,
+                            reason=decision.fallback_reason,
+                        )
+                    )
+                    if salvaged_response:
+                        salvaged_decision = await asyncio.to_thread(
+                            _evaluate_shared_brain_synthesis_receipt,
+                            run,
+                            baseline_response,
+                            salvaged_response,
+                            candidate_generation_latency_ms,
+                        )
+                        decision = salvaged_decision
+                        if salvaged_decision.candidate_selected:
+                            candidate_response = salvaged_response
         if (
             decision.candidate_selected
             and is_generic_non_answer_response(
@@ -36784,6 +36808,7 @@ async def execute_bnl_memory_preview(
     packet_candidate_response = ""
     repair_response = ""
     cleanup_response = ""
+    cleanup_salvage_applied = False
     try:
         initial = await asyncio.to_thread(
             prepare_memory_preview,
@@ -37030,6 +37055,32 @@ async def execute_bnl_memory_preview(
                 candidate_response = cleaned_response
                 candidate_prompt = cleanup_prompt
                 stale_reason = ""
+                if (
+                    not cleanup_evaluation.candidate_selected
+                    and cleanup_evaluation.fallback_reason
+                    == "candidate_claims_ungrounded"
+                ):
+                    salvaged_response = (
+                        salvage_profile_candidate_response(
+                            cleaned_response,
+                            basis=fresh.basis,
+                            reason=cleanup_evaluation.fallback_reason,
+                        )
+                    )
+                    if salvaged_response:
+                        salvaged_evaluation = await asyncio.to_thread(
+                            evaluate_memory_preview,
+                            fresh,
+                            baseline_response=baseline_response,
+                            candidate_response=salvaged_response,
+                            candidate_generation_latency_ms=(
+                                candidate_latency_ms
+                            ),
+                        )
+                        evaluation = salvaged_evaluation
+                        if salvaged_evaluation.candidate_selected:
+                            candidate_response = salvaged_response
+                            cleanup_salvage_applied = True
             else:
                 cleanup_fresh.close()
                 stale_reason = (
@@ -37137,6 +37188,8 @@ async def execute_bnl_memory_preview(
         final_selection = (
             "suppressed"
             if not proposed_response
+            else "cleanup_salvage"
+            if evaluation.candidate_selected and cleanup_salvage_applied
             else "cleanup_attempt"
             if evaluation.candidate_selected and cleanup_response
             else "repair_attempt"

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -265,6 +265,7 @@ _REPAIRABLE_PROFILE_FAILURES = frozenset(
         "candidate_member_roots_insufficient",
         "candidate_member_occurrences_insufficient",
         "candidate_project_canon_missing",
+        "candidate_canon_dominant",
         "candidate_request_angle_missed",
         "candidate_coherence_regressed",
     }
@@ -1105,9 +1106,9 @@ def render_packet_context(
             {
                 "approved_fact": 0,
                 "atomic_knowledge": 1,
-                "moment": 2,
-                "canon": 3,
-                "assessment_observation": 4,
+                "assessment_observation": 2,
+                "moment": 3,
+                "canon": 4,
             }
         )
     ordered_items = tuple(
@@ -1126,12 +1127,36 @@ def render_packet_context(
         max_items=max_items,
         max_chars=max_chars,
     )
+    required_canon_item = (
+        next(
+            (
+                item
+                for item in ordered_items
+                if item.lane == "canon"
+                and _canon_relevant_to_profile_request(packet, item)
+            ),
+            None,
+        )
+        if _profile_requires_canon(packet)
+        else None
+    )
+    canon_char_reserve = (
+        len(_safe_evidence_text(required_canon_item.text)) + 64
+        if required_canon_item is not None
+        else 0
+    )
     for item in ordered_items:
         if item.lane not in _RENDERABLE_LANES:
             continue
         if item.lane == "canon" and not _canon_relevant_to_profile_request(
             packet,
             item,
+        ):
+            continue
+        if (
+            required_canon_item is not None
+            and item.lane == "canon"
+            and item is not required_canon_item
         ):
             continue
         text = _safe_evidence_text(item.text)
@@ -1174,7 +1199,12 @@ def render_packet_context(
             qualifier,
             text,
         )
-        if used + len(line) > max_chars:
+        if required_canon_item is not None and item is not required_canon_item:
+            if len(lines) >= max(0, int(max_items or 0) - 1):
+                continue
+            if used + len(line) > max_chars - canon_char_reserve:
+                continue
+        elif used + len(line) > max_chars:
             break
         lines.append(line)
         lane_counts[item.lane] += 1
@@ -1211,10 +1241,10 @@ def render_packet_context(
     else:
         profile_rule = ""
     project_rule = (
-        "- The request explicitly asks for BARCODE/project context. After "
-        "the member-specific substance, connect it to at least one relevant "
-        "approved canon point; answer as neither member-history-only nor "
-        "canon-only.\n"
+        "- The request explicitly asks for BARCODE/project context. Use one "
+        "concise context anchor after the member assessment; canon may "
+        "clarify why the observed priorities fit BARCODE, but it must not "
+        "become the answer's organizing frame.\n"
         if _profile_requires_canon(packet)
         else ""
     )
@@ -1234,7 +1264,8 @@ def render_packet_context(
         "- Answer the current user naturally in BNL's established voice; do "
         "not recite this evidence as a database report.\n"
         "- Lead with member-specific substance. Relevant BARCODE canon may "
-        "support that substance afterward, but can never substitute for it.\n"
+        "add one concise context anchor afterward, but can never substitute "
+        "for the public assessment or become its governing frame.\n"
         "- Look across the selected observations for a useful throughline. "
         "Separate what is directly known, what BNL has observed, and BNL's "
         "revisable opinion. Frame interpretation naturally as a read or "
@@ -1632,11 +1663,13 @@ def build_profile_candidate_repair_prompt(
             else "Keep every personal claim within the supported evidence."
         ),
         (
-            "After the member details, connect them to at least one relevant "
-            "approved BARCODE canon point."
+            "After the member assessment, use one concise relevant approved "
+            "BARCODE canon point as context. Do not organize the answer "
+            "around canon or let it displace public member evidence."
             if basis.profile_requires_canon
             else "Use BARCODE canon only when it helps answer the request; it "
-            "is not a required ingredient."
+            "is not a required ingredient and must not become the answer's "
+            "organizing frame."
         ),
         (
             "Keep factual claims inside the supplied support. You may form a "
@@ -1725,6 +1758,13 @@ def build_profile_candidate_cleanup_prompt(
             "the flagged units removed or minimally reframed."
         ),
         (
+            "Keep no more than one concise approved BARCODE canon anchor, "
+            "and keep it after the member assessment. Canon may contextualize "
+            "the answer but must not become its organizing frame."
+            if basis.profile_requires_canon
+            else "Do not add canon that the current request does not need."
+        ),
+        (
             "Resolve all %s REFRAME_OR_REMOVE units. If a unit is only an "
             "abstract creative or personality interpretation that genuinely "
             "follows from KEEP_SUPPORTED details, retain its idea once and "
@@ -1760,6 +1800,57 @@ def build_profile_candidate_cleanup_prompt(
         "audit labels must not appear in the answer):\n"
         + claim_audit
     )
+
+
+def salvage_profile_candidate_response(
+    prior_response: str,
+    *,
+    basis: SharedBrainSynthesisBasis,
+    reason: str,
+) -> str:
+    """Remove one leftover unsupported claim without generating new prose.
+
+    The model already received one constrained cleanup opportunity. This
+    deterministic last step is intentionally limited to one independently
+    split unsupported unit. The normal candidate gate still decides whether
+    the remaining answer is sufficient, coherent, correctly angled, and
+    source-valid.
+    """
+
+    if str(reason or "") != "candidate_claims_ungrounded":
+        return ""
+    claims = _candidate_claim_units(prior_response)
+    try:
+        coverage = candidate_profile_coverage(basis, prior_response)
+    except (AttributeError, TypeError, ValueError):
+        return ""
+    classifications = tuple(coverage.claim_classifications)
+    if (
+        not claims
+        or len(claims) != len(classifications)
+        or int(coverage.unsupported_factual_claim_count or 0) != 1
+    ):
+        return ""
+    kept = tuple(
+        claim
+        for claim, classification in zip(claims, classifications)
+        if classification != "unsupported_factual"
+    )
+    if not kept or len(kept) == len(claims):
+        return ""
+    salvaged = " ".join(
+        claim
+        if claim.endswith((".", "!", "?"))
+        else claim + "."
+        for claim in kept
+    ).strip()
+    try:
+        salvaged_coverage = candidate_profile_coverage(basis, salvaged)
+    except (AttributeError, TypeError, ValueError):
+        return ""
+    if salvaged_coverage.unsupported_factual_claim_count:
+        return ""
+    return salvaged
 
 
 def response_exposes_controls(response: str) -> bool:
@@ -2232,6 +2323,17 @@ def candidate_profile_coverage(
         canon_items=canon_items,
         supported_member_points=frozenset(covered_points),
     )
+    canon_only_claims = sum(
+        classification == "canon_supported"
+        for classification in claim_classifications
+    )
+    lore_dominant = bool(
+        canon_only_claims
+        and (
+            not member_first
+            or canon_only_claims > member_supported_claims
+        )
+    )
     return CandidateProfileCoverage(
         total_item_count=len(covered_items),
         member_point_count=len(covered_points),
@@ -2240,9 +2342,9 @@ def candidate_profile_coverage(
         member_detail_point_count=len(covered_detail_points),
         canon_item_count=len(covered_canon),
         member_segment_count=member_supported_claims,
-        canon_only_segment_count=canon_supported_claims,
+        canon_only_segment_count=canon_only_claims,
         member_first=member_first,
-        lore_dominant=False,
+        lore_dominant=lore_dominant,
         member_supported_claim_count=member_supported_claims,
         canon_supported_claim_count=canon_supported_claims,
         opinion_claim_count=opinion_claims,
@@ -2613,6 +2715,8 @@ def evaluate_candidate(
         and profile_coverage.canon_item_count < 1
     ):
         fallback_reason = "candidate_project_canon_missing"
+    elif profile_coverage.lore_dominant:
+        fallback_reason = "candidate_canon_dominant"
     elif not _candidate_matches_profile_request_angle(
         run.basis,
         candidate,

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -120,14 +120,23 @@ _BROAD_PROFILE_LANE_CAPS = {
     "atomic_knowledge": 6,
     "moment": 2,
     "open_loop": 1,
-    "canon": 2,
+    "canon": 1,
     "source_file": 1,
 }
 _PROFILE_MEMBER_EVIDENCE_LANES = frozenset(
     {"approved_fact", "atomic_knowledge", "moment"}
 )
+_PROFILE_CANON_MATCH_LANES = (
+    _PROFILE_MEMBER_EVIDENCE_LANES
+    | {"assessment_observation", "conversation_context"}
+)
 _ROOT_COLLAPSE_MEMBER_LANES = (
     _PROFILE_MEMBER_EVIDENCE_LANES | {"conversation_context"}
+)
+_PROFILE_PROJECT_SCOPE_RE = re.compile(
+    r"\b(?:barcode(?:\s+(?:network|radio))?|"
+    r"project|collective|broadcast)\b",
+    re.I,
 )
 _ASSESSMENT_LANE_MAP = {
     "current_intent": "current_exchange",
@@ -646,6 +655,59 @@ def _root_bearing_member_item(
 
 def _broad_profile_request(value: str) -> bool:
     return classify_personal_recall_intent(value).broad_self_profile
+
+
+def _profile_project_request(value: str) -> bool:
+    return bool(_PROFILE_PROJECT_SCOPE_RE.search(str(value or "")))
+
+
+def _profile_canon_anchor(
+    request: IntelligencePacketRequest,
+    candidates: Sequence[IntelligencePacketItem],
+) -> IntelligencePacketItem | None:
+    """Choose one canon point that best contextualizes selected public work."""
+
+    if (
+        not _broad_profile_request(request.user_text)
+        or not _profile_project_request(request.user_text)
+    ):
+        return None
+    subject = subject_key_for_user(request.subject_user_id)
+    member_terms: set[str] = set()
+    for item in candidates:
+        if (
+            item.subject_key != subject
+            or item.lane not in _PROFILE_CANON_MATCH_LANES
+        ):
+            continue
+        member_terms.update(_terms(item.text))
+        for observation in item.supporting_observations:
+            member_terms.update(_terms(observation))
+    query = re.sub(
+        r"^\s*(?:hey\s+|yo\s+|hi\s+)?"
+        r"(?:bnl(?:-?01)?|barcode bot)\s*[,;:—-]*\s*",
+        "",
+        str(request.user_text or ""),
+        flags=re.I,
+    )
+    request_terms = _terms(query)
+    canon_items = tuple(
+        item
+        for item in candidates
+        if item.lane == "canon"
+        and request_terms.intersection(_terms(item.text))
+    )
+    if not canon_items:
+        return None
+    return sorted(
+        canon_items,
+        key=lambda item: (
+            -len(member_terms & _terms(item.text)),
+            -len(request_terms & _terms(item.text)),
+            -len(_terms(item.text)),
+            item.source_ref,
+        ),
+    )[0]
 
 
 def _public_route(request: IntelligencePacketRequest) -> bool:
@@ -2275,24 +2337,29 @@ def _select_items(
         diagnostics,
         exclusions,
     )
+    canon_anchor = _profile_canon_anchor(request, candidates)
     profile_candidates: list[IntelligencePacketItem] = []
     broad_lane_priority = {
         "current_intent": 0,
         "approved_fact": 1,
-        "atomic_knowledge": 2,
-        "conversation_context": 3,
-        "assessment_observation": 4,
-        "moment": 5,
-        "open_loop": 6,
-        "canon": 7,
-        "source_file": 8,
-        "relationship_posture": 9,
+        "atomic_knowledge": 3,
+        "conversation_context": 4,
+        "assessment_observation": 5,
+        "moment": 6,
+        "open_loop": 7,
+        "canon": 8,
+        "source_file": 9,
+        "relationship_posture": 10,
     }
     ordered = sorted(
         candidates,
         key=lambda item: (
             (
-                broad_lane_priority.get(item.lane, 9)
+                (
+                    2
+                    if item is canon_anchor
+                    else broad_lane_priority.get(item.lane, 10)
+                )
                 if broad
                 else 0
             ),

--- a/tests/test_memory_preview_bot_path.py
+++ b/tests/test_memory_preview_bot_path.py
@@ -628,7 +628,7 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
-    async def test_final_claim_cleanup_is_one_shot_and_fails_closed(self):
+    async def test_final_cleanup_salvages_one_stubborn_clause(self):
         with sqlite3.connect(self.db_path) as conn:
             self._add_message(
                 conn,
@@ -649,7 +649,10 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
         async def generator(prompt, route):
             calls.append((route, prompt))
             if route.endswith("baseline"):
-                return "I only have a narrow grounded view so far."
+                return (
+                    "BARCODE is the Network signal, and its founding "
+                    "members define the whole answer."
+                )
             if route.endswith("candidate_cleanup"):
                 return (
                     "You keep fixing the bot code and composing synth songs. "
@@ -682,17 +685,14 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             guard=guard,
         )
 
-        self.assertFalse(result.candidate_selected)
-        self.assertEqual(
-            result.fallback_reason,
-            "candidate_claims_ungrounded",
-        )
+        self.assertTrue(result.candidate_selected, result.fallback_reason)
         self.assertEqual(
             result.proposed_response,
-            "I only have a narrow grounded view so far.",
+            "You keep fixing the bot code and composing synth songs.",
         )
-        self.assertEqual(result.final_selection, "established_path")
+        self.assertEqual(result.final_selection, "cleanup_salvage")
         self.assertIn("lunar casino", result.cleanup_response)
+        self.assertNotIn("BARCODE is the Network", result.proposed_response)
         self.assertEqual(
             [route for route, _prompt in calls],
             [
@@ -703,6 +703,61 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(guard.await_count, 1)
         self.assertEqual(source_hash, self._source_hash())
+
+    async def test_final_cleanup_with_multiple_bad_claims_still_falls_back(
+        self,
+    ):
+        with sqlite3.connect(self.db_path) as conn:
+            self._add_message(
+                conn,
+                3,
+                "I keep composing synth songs and producing music tracks.",
+                "2026-07-25T21:00:00+00:00",
+            )
+            self._add_message(
+                conn,
+                4,
+                "The synth song mix needs another production pass.",
+                "2026-07-26T20:00:00+00:00",
+            )
+            conn.commit()
+        unsafe = (
+            "You keep fixing the bot code and composing synth songs. "
+            "You secretly run a lunar casino. "
+            "You secretly own an orbital bank."
+        )
+
+        async def generator(_prompt, route):
+            if route.endswith("baseline"):
+                return "I only have a narrow grounded view so far."
+            return unsafe
+
+        result = await bnl01_bot.execute_bnl_memory_preview(
+            source_db_path=self.db_path,
+            guild_id=1,
+            subject_user_id=7,
+            subject_display_name="Crow",
+            simulated_channel_id=10,
+            wording="BNL-01, what am I all about?",
+            generator=generator,
+            guard=mock.AsyncMock(
+                side_effect=lambda response, _prompt: (
+                    response,
+                    {"suppressed": False, "suppression_reason": ""},
+                )
+            ),
+        )
+
+        self.assertFalse(result.candidate_selected)
+        self.assertEqual(
+            result.fallback_reason,
+            "candidate_claims_ungrounded",
+        )
+        self.assertEqual(result.final_selection, "established_path")
+        self.assertEqual(
+            result.proposed_response,
+            "I only have a narrow grounded view so far.",
+        )
 
     async def test_preview_compares_real_established_memory_to_packet(self):
         with sqlite3.connect(self.db_path) as conn:

--- a/tests/test_production_shaped_broad_recall_acceptance.py
+++ b/tests/test_production_shaped_broad_recall_acceptance.py
@@ -849,9 +849,10 @@ class ProductionShapedBroadRecallAcceptanceTests(unittest.TestCase):
             candidate=(
                 "You keep debugging the bot memory system and carefully "
                 "testing the website, while writing songs and producing "
-                "synth tracks. As a founding BARCODE member, that puts "
-                "your software and music work inside the Network's "
-                "community and live-broadcast signal."
+                "synth tracks. In BARCODE, the Network connects music, "
+                "live broadcasts, community, software, archive, characters, "
+                "and story; that context connects your software and music "
+                "work without replacing the observed pattern."
             ),
             expected_status="rich",
             expected_points=2,

--- a/tests/test_shared_brain_synthesis_canary.py
+++ b/tests/test_shared_brain_synthesis_canary.py
@@ -26,6 +26,7 @@ from bnl_shared_brain_synthesis import (
     finalize_run,
     render_packet_context,
     revalidate_basis,
+    salvage_profile_candidate_response,
     scope_enabled,
 )
 from bnl_unified_intelligence_packet import (
@@ -845,8 +846,10 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             run,
             baseline_response="Established response.",
             candidate_response=(
-                "Your favorite movie is Arrival. In BARCODE, 6 Bit is an "
-                "artist, MC, host, and founding member."
+                "Your favorite movie is Arrival. In BARCODE, the Network "
+                "grew around the music and collective and connects music, "
+                "live broadcasts, community, software, archive, characters, "
+                "and story."
             ),
             environ=self.flags,
         )
@@ -859,6 +862,125 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
         self.assertGreaterEqual(
             decision.candidate_canon_supported_claim_count,
             1,
+        )
+
+    def test_canon_must_follow_and_support_the_member_assessment(self):
+        self._add_profile_fact(
+            source_row_id=902,
+            predicate_key="favorite_color",
+            value="violet",
+            observed_at="2026-07-26T12:00:01+00:00",
+        )
+        wording = (
+            "What parts of BARCODE seem to matter most to me, and why?"
+        )
+        request = replace(
+            self._request(),
+            user_text=wording,
+            conversation_evidence=(
+                *self._request().conversation_evidence[:-1],
+                replace(
+                    self._request().conversation_evidence[-1],
+                    text=wording,
+                ),
+            ),
+        )
+        packet = build_packet(
+            self.conn,
+            request,
+            persist=True,
+            environ=self.flags,
+        )
+        basis = self._build_basis(
+            packet,
+            self._build_assessment(packet),
+        )
+        canon_first = (
+            "BARCODE Network grew around the music and collective and "
+            "connects music, live broadcasts, community, software, archive, "
+            "characters, and story. Your favorite movie is Arrival, and "
+            "your favorite color is violet."
+        )
+        run = begin_run(
+            self.conn,
+            basis,
+            baseline_response="Established response.",
+            environ=self.flags,
+        )
+        rejected = evaluate_candidate(
+            self.conn,
+            run,
+            baseline_response="Established response.",
+            candidate_response=canon_first,
+            environ=self.flags,
+        )
+
+        self.assertFalse(rejected.candidate_selected)
+        self.assertEqual(
+            rejected.fallback_reason,
+            "candidate_canon_dominant",
+        )
+        self.assertTrue(rejected.candidate_lore_dominant)
+
+        member_first = (
+            "Your favorite movie is Arrival, and your favorite color is "
+            "violet. In BARCODE, that sits inside a Network connecting "
+            "music, live broadcasts, community, software, archive, "
+            "characters, and story."
+        )
+        balanced_run = begin_run(
+            self.conn,
+            basis,
+            baseline_response="Established response.",
+            environ=self.flags,
+        )
+        balanced = evaluate_candidate(
+            self.conn,
+            balanced_run,
+            baseline_response="Established response.",
+            candidate_response=member_first,
+            environ=self.flags,
+        )
+
+        self.assertTrue(balanced.candidate_selected)
+        self.assertFalse(balanced.candidate_lore_dominant)
+
+    def test_single_unsupported_clause_can_be_removed_without_rewriting(self):
+        self._add_profile_fact(
+            source_row_id=902,
+            predicate_key="favorite_color",
+            value="violet",
+            observed_at="2026-07-26T12:00:01+00:00",
+        )
+        packet = self._build_packet()
+        basis = self._build_basis(
+            packet,
+            self._build_assessment(packet),
+        )
+        stubborn_cleanup = (
+            "Your favorite movie is Arrival. Your favorite color is violet. "
+            "You secretly run a lunar casino. My read is that those choices "
+            "share a taste for vivid atmosphere."
+        )
+
+        salvaged = salvage_profile_candidate_response(
+            stubborn_cleanup,
+            basis=basis,
+            reason="candidate_claims_ungrounded",
+        )
+
+        self.assertNotIn("lunar casino", salvaged)
+        self.assertIn("favorite movie is Arrival", salvaged)
+        self.assertIn("favorite color is violet", salvaged)
+        self.assertIn("My read is", salvaged)
+        self.assertEqual(
+            salvage_profile_candidate_response(
+                stubborn_cleanup
+                + " You secretly own an orbital bank.",
+                basis=basis,
+                reason="candidate_claims_ungrounded",
+            ),
+            "",
         )
 
     def test_nonpacket_factual_owner_records_a_fail_closed_fallback(self):

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -795,6 +795,103 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
         self.assertIn("selected after considering the full eligible", rendered)
         self.assertNotIn("completely different plan", rendered)
 
+    def test_barcode_profile_blends_one_relevant_canon_anchor_last(self):
+        rows = (
+            (
+                980,
+                (
+                    "I keep comparing BARCODE music mixes before choosing "
+                    "the strongest track."
+                ),
+                "2026-07-20T10:00:00+00:00",
+            ),
+            (
+                981,
+                (
+                    "The live broadcast format needs another careful test "
+                    "before release."
+                ),
+                "2026-07-21T10:00:00+00:00",
+            ),
+            (
+                982,
+                (
+                    "I want the community involved while the software and "
+                    "archive keep improving."
+                ),
+                "2026-07-22T10:00:00+00:00",
+            ),
+            (
+                983,
+                (
+                    "The character visuals and story need another revision "
+                    "pass."
+                ),
+                "2026-07-23T10:00:00+00:00",
+            ),
+            (
+                984,
+                (
+                    "I keep refining songs and the radio show with the "
+                    "artists."
+                ),
+                "2026-07-24T10:00:00+00:00",
+            ),
+            (
+                985,
+                (
+                    "The Network should connect real participation before "
+                    "deeper lore."
+                ),
+                "2026-07-25T10:00:00+00:00",
+            ),
+        )
+        entry_ids = tuple(
+            self.add_raw_public_conversation(*row) for row in rows
+        )
+        ledger.form_atomic_candidates_from_recurring_conversation(
+            self.conn,
+            trigger_entry_id=entry_ids[-1],
+            environ=self.flags,
+        )
+
+        packet = build_packet(
+            self.conn,
+            self.public_request(
+                text=(
+                    "What parts of BARCODE seem to matter most to me, "
+                    "and why?"
+                )
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        selected_canon = tuple(
+            item for item in packet.items if item.lane == "canon"
+        )
+
+        self.assertEqual(len(selected_canon), 1)
+        self.assertIn(
+            "connects music, live broadcasts, community, software, "
+            "archive, characters, and story",
+            selected_canon[0].text,
+        )
+        rendered, counts, _count, _digests = render_packet_context(packet)
+        rendered_counts = dict(counts)
+        self.assertEqual(rendered_counts.get("canon"), 1)
+        self.assertGreaterEqual(
+            rendered_counts.get("assessment_observation", 0),
+            3,
+        )
+        self.assertLess(
+            rendered.index("question-scoped public observation"),
+            rendered.index("approved canon"),
+        )
+        self.assertIn(
+            "one concise context anchor after the member assessment",
+            rendered,
+        )
+
     def test_distinct_atomic_points_can_share_exact_human_roots(self):
         rows = (
             (


### PR DESCRIPTION
## Summary

- keep broad-profile answers led by the governed public/member assessment
- select at most one request-relevant BARCODE canon anchor and place it after that assessment
- reject canon-first or canon-dominant profile candidates
- preserve an otherwise good constrained cleanup by deterministically removing one remaining unsupported factual clause
- keep multi-claim failures and source-change failures fail-closed on the established path

## Acceptance regressions

- question 3 (`What parts of BARCODE seem to matter most to me, and why?`) receives one evidence-relevant canon anchor rather than a canon-first identity frame
- a member-first public assessment with one additive canon anchor passes
- a canon-first response is rejected
- one unsupported clause can be removed without discarding the grounded response
- multiple unsupported clauses still force fallback

## Verification

- 244 focused packet, preview, routing, synthesis, source-change, and production-shaped tests
- 1,816 repository-wide tests via `make check`
- `git diff --check`
- exact published tree: `6082cefa0f38118ee0b733a0c7a27a430670e3fc`

No merge, deployment, backfill, database/schema write, configuration change, live gate, or canary activation is included.