### PR TITLE
Require explicit memory preview question

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -37242,12 +37242,12 @@ async def execute_bnl_memory_preview(
 )
 @app_commands.describe(
     subject="Member whose public-safe broad recall should be simulated.",
-    wording="Broad self-recall wording to simulate as that member.",
+    question="Required question to simulate as that member.",
 )
 async def bnl_memory_preview(
     interaction: discord.Interaction,
     subject: discord.Member,
-    wording: str = "BNL-01, what am I all about?",
+    question: str,
 ):
     if not BNL_OWNER_USER_ID:
         await interaction.response.send_message(
@@ -37296,10 +37296,10 @@ async def bnl_memory_preview(
             ephemeral=True,
         )
         return
-    clean_wording = re.sub(r"\s+", " ", str(wording or "")).strip()
+    clean_wording = re.sub(r"\s+", " ", str(question or "")).strip()
     if not clean_wording or len(clean_wording) > 1000:
         await interaction.response.send_message(
-            "❌ Preview wording must contain 1–1000 characters.",
+            "❌ Preview question must contain 1–1000 characters.",
             ephemeral=True,
         )
         return

--- a/tests/test_memory_preview_bot_path.py
+++ b/tests/test_memory_preview_bot_path.py
@@ -80,6 +80,20 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             ),
         )
 
+    def test_slash_command_requires_explicit_question_argument(self):
+        parameters = {
+            parameter.name: parameter
+            for parameter in bnl01_bot.bnl_memory_preview.parameters
+        }
+        self.assertIn("subject", parameters)
+        self.assertIn("question", parameters)
+        self.assertNotIn("wording", parameters)
+        self.assertTrue(parameters["question"].required)
+        self.assertEqual(
+            parameters["question"].description,
+            "Required question to simulate as that member.",
+        )
+
     def _source_hash(self):
         return hashlib.sha256(
             Path(self.db_path).read_bytes()
@@ -1159,6 +1173,10 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
         )
         interaction.response.send_message.assert_not_awaited()
         execute.assert_awaited_once()
+        self.assertEqual(
+            execute.await_args.kwargs["wording"],
+            "What am I all about?",
+        )
         sent.assert_awaited_once()
         rendered = sent.await_args.args[1]
         self.assertIn("BNL Memory Preview", rendered)
@@ -1220,6 +1238,7 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             await bnl01_bot.bnl_memory_preview.callback(
                 interaction,
                 subject,
+                "What am I all about?",
             )
 
         interaction.response.send_message.assert_awaited_once()
@@ -1285,6 +1304,7 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             await bnl01_bot.bnl_memory_preview.callback(
                 interaction,
                 subject,
+                "What am I all about?",
             )
 
         interaction.response.send_message.assert_awaited_once()
@@ -1328,6 +1348,7 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             await bnl01_bot.bnl_memory_preview.callback(
                 interaction,
                 subject,
+                "What am I all about?",
             )
 
         interaction.response.send_message.assert_awaited_once()


### PR DESCRIPTION
## What changed

- Replaces the optional `wording` slash-command option with a plainly named, required `question` option.
- Removes the silent default question.
- Keeps the selected question flowing into the existing non-persistent preview engine.
- Adds command-registration and forwarding regressions.

## Why

The three post-#407 preview attempts supplied only the selected subject. Because `wording` was optional, Discord submitted the command with its default every time, so all three diagnostics evaluated `BNL-01, what am I all about?` even though different text had been typed outside the option.

## Impact

Discord will refuse to submit `/bnl_memory_preview` until both the member and exact question fields are filled. This prevents a missing optional argument from looking like a shared-brain routing or synthesis failure.

No shared-brain selection, memory storage, canon composition, privacy logic, canary, configuration, or production gate changes are included.

## Validation

- 95 focused command, routing, packet, synthesis, source-revalidation, and production-shaped tests passed.
- All 84 test modules passed: 1,817 tests total.
- Compile and diff checks passed.
- Exact tested/published tree: `232410f7925063588d647e8533b3d734338f9c34`.
