### PR TITLE
Preserve grounded process cleanup

### DIFF
--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -299,11 +299,12 @@ _OPINION_FRAME_RE = re.compile(
     r"\b(?:i\s+(?:think|believe|suspect|figure)|"
     r"i(?:'d|\s+would)\s+(?:say|call)|"
     r"my\s+(?:read|view|take|assessment)|"
+    r"my\s+(?:observation|impression)\s+is|"
     r"based\s+on\s+my\s+observations?|"
     r"from\s+(?:my\s+observations?|what\s+i\s+observe|my\s+perspective)|"
     r"if\s+i\s+had\s+to\s+summarize(?:\s+my\s+read)?|"
     r"to\s+me|in\s+my\s+view|from\s+where\s+i\s+(?:sit|stand)|"
-    r"it\s+seems|you\s+seem|you\s+strike\s+me|"
+    r"it\s+seems|it\s+strikes?\s+me|you\s+seem|you\s+strike\s+me|"
     r"i\s+get\s+the\s+(?:sense|impression)|"
     r"feels?\s+like|looks?\s+like)\b",
     re.I,
@@ -404,6 +405,14 @@ _CONCRETE_RELATION_ACTION_CANON = {
     "writing": "write",
     "wrote": "write",
 }
+_PROCESS_ASSESSMENT_CONCEPTS = (
+    ("adjust", re.compile(r"\b(?:adjust\w*|calibrat\w*)\b", re.I)),
+    ("compare", re.compile(r"\b(?:compar\w*|weigh\w*)\b", re.I)),
+    ("decide", re.compile(r"\b(?:cho(?:ose|oses|se|sen|osing)|decid\w*)\b", re.I)),
+    ("observe", re.compile(r"\b(?:observ\w*|review\w*)\b", re.I)),
+    ("refine", re.compile(r"\b(?:refin\w*|revis\w*)\b", re.I)),
+    ("test", re.compile(r"\b(?:test\w*|trial\w*)\b", re.I)),
+)
 _TRANSIENT_EXPRESSION_WRAPPER_RE = re.compile(
     r"^\s*[~*_`-]*\[(?P<body>[\s\S]{1,900})\]\s*[~*_`-]*$",
 )
@@ -1808,13 +1817,14 @@ def salvage_profile_candidate_response(
     basis: SharedBrainSynthesisBasis,
     reason: str,
 ) -> str:
-    """Remove one leftover unsupported claim without generating new prose.
+    """Resolve one leftover unsupported claim without model generation.
 
     The model already received one constrained cleanup opportunity. This
     deterministic last step is intentionally limited to one independently
-    split unsupported unit. The normal candidate gate still decides whether
-    the remaining answer is sufficient, coherent, correctly angled, and
-    source-valid.
+    split unsupported unit. A locally linked conditional process assessment
+    may be explicitly framed as BNL's read; every other unsupported unit is
+    removed. The normal candidate gate still decides whether the remaining
+    answer is sufficient, coherent, correctly angled, and source-valid.
     """
 
     if str(reason or "") != "candidate_claims_ungrounded":
@@ -1831,12 +1841,24 @@ def salvage_profile_candidate_response(
         or int(coverage.unsupported_factual_claim_count or 0) != 1
     ):
         return ""
-    kept = tuple(
-        claim
-        for claim, classification in zip(claims, classifications)
-        if classification != "unsupported_factual"
+    unsupported_index = classifications.index("unsupported_factual")
+    unsupported_claim = claims[unsupported_index]
+    replacement = _reframe_locally_linked_process_assessment(
+        unsupported_claim,
+        prior_claims=claims[:unsupported_index],
+        prior_classifications=classifications[:unsupported_index],
+        basis=basis,
     )
-    if not kept or len(kept) == len(claims):
+    kept = tuple(
+        replacement
+        if index == unsupported_index and replacement
+        else claim
+        for index, (claim, classification) in enumerate(
+            zip(claims, classifications)
+        )
+        if classification != "unsupported_factual" or replacement
+    )
+    if not kept or (len(kept) == len(claims) and not replacement):
         return ""
     salvaged = " ".join(
         claim
@@ -1851,6 +1873,59 @@ def salvage_profile_candidate_response(
     if salvaged_coverage.unsupported_factual_claim_count:
         return ""
     return salvaged
+
+
+def _process_assessment_concepts(value: str) -> frozenset[str]:
+    return frozenset(
+        concept
+        for concept, pattern in _PROCESS_ASSESSMENT_CONCEPTS
+        if pattern.search(str(value or ""))
+    )
+
+
+def _reframe_locally_linked_process_assessment(
+    claim: str,
+    *,
+    prior_claims: Sequence[str],
+    prior_classifications: Sequence[str],
+    basis: SharedBrainSynthesisBasis,
+) -> str:
+    """Make one locally supported process inference explicitly revisable.
+
+    This does not license a new concrete fact. It is limited to a conditional
+    process interpretation that repeats a process concept already present in
+    an earlier supported member unit from the same response.
+    """
+
+    value = str(claim or "").strip()
+    if (
+        not value
+        or not _profile_process_request(_basis_profile_request_text(basis))
+        or not re.match(r"^(?:if|when|whenever)\b", value, re.I)
+        or _UNSUPPORTED_SCALAR_ASSERTION_RE.search(value)
+        or _UNSUPPORTED_FRAMED_CONCRETE_RE.search(value)
+        or _INTERNAL_PROPER_NOUN_RE.search(value)
+    ):
+        return ""
+    supported_process_concepts = frozenset().union(
+        *(
+            _process_assessment_concepts(prior_claim)
+            for prior_claim, classification in zip(
+                prior_claims,
+                prior_classifications,
+            )
+            if classification
+            in {"member_supported", "member_and_canon_supported"}
+        )
+    )
+    if not (
+        supported_process_concepts
+        and supported_process_concepts.intersection(
+            _process_assessment_concepts(value)
+        )
+    ):
+        return ""
+    return "My read is that " + value[:1].lower() + value[1:]
 
 
 def response_exposes_controls(response: str) -> bool:

--- a/tests/test_memory_preview_bot_path.py
+++ b/tests/test_memory_preview_bot_path.py
@@ -718,6 +718,82 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(guard.await_count, 1)
         self.assertEqual(source_hash, self._source_hash())
 
+    async def test_process_cleanup_preserves_a_linked_revisable_assessment(
+        self,
+    ):
+        with sqlite3.connect(self.db_path) as conn:
+            self._add_message(
+                conn,
+                3,
+                "I compare test results before choosing the next pass.",
+                "2026-07-25T21:00:00+00:00",
+            )
+            self._add_message(
+                conn,
+                4,
+                "I adjust the implementation after checking failures.",
+                "2026-07-26T20:00:00+00:00",
+            )
+            self._add_message(
+                conn,
+                5,
+                "I keep composing synth songs and producing music tracks.",
+                "2026-07-27T20:00:00+00:00",
+            )
+            self._add_message(
+                conn,
+                6,
+                "The synth song mix needs another production pass.",
+                "2026-07-28T20:00:00+00:00",
+            )
+            conn.commit()
+        source_hash = self._source_hash()
+        cleanup = (
+            "My observation is that you operate through live iteration "
+            "rather than rigid pre-planning. You compare test results "
+            "before choosing the next pass and adjust the implementation "
+            "after checking failures. If a feature or handoff hits a "
+            "friction point, you calibrate on the fly rather than halting "
+            "the system. In short: test, observe, adjust. It strikes me as "
+            "an unusually adaptive way to operate."
+        )
+
+        async def generator(_prompt, route):
+            if route.endswith("baseline"):
+                return "I do not have enough context to describe your process."
+            return cleanup
+
+        result = await bnl01_bot.execute_bnl_memory_preview(
+            source_db_path=self.db_path,
+            guild_id=1,
+            subject_user_id=7,
+            subject_display_name="Crow",
+            simulated_channel_id=10,
+            wording=(
+                "What have you learned about how I work and make decisions?"
+            ),
+            generator=generator,
+            guard=mock.AsyncMock(
+                side_effect=lambda response, _prompt: (
+                    response,
+                    {"suppressed": False, "suppression_reason": ""},
+                )
+            ),
+        )
+
+        self.assertTrue(result.candidate_selected, result.fallback_reason)
+        self.assertEqual(result.final_selection, "cleanup_salvage")
+        self.assertIn(
+            "My read is that if a feature or handoff hits a friction point",
+            result.proposed_response,
+        )
+        self.assertIn(
+            "It strikes me as an unusually adaptive way to operate",
+            result.proposed_response,
+        )
+        self.assertNotIn("do not have enough context", result.proposed_response)
+        self.assertEqual(source_hash, self._source_hash())
+
     async def test_final_cleanup_with_multiple_bad_claims_still_falls_back(
         self,
     ):


### PR DESCRIPTION
## What changed

- Recognizes natural revisable-assessment frames such as `My observation is`, `My impression is`, and `It strikes me`.
- Preserves one locally linked conditional process inference by explicitly framing it as BNL's read instead of discarding the entire grounded cleanup.
- Limits that path to process/decision questions where the inference repeats a process concept from an earlier supported member claim.
- Keeps the existing fail-closed behavior for concrete or unrelated claims, multiple unsupported claims, changed sources, and failed post-generation gates.

## Why

The post-#408 acceptance batch showed that questions 1 and 3 selected good responses. Question 2 produced a good constrained cleanup, but the finalizer classified two abstract assessment units as unsupported and replaced the whole answer with the established low-context fallback. One unit already used a natural opinion frame the classifier did not recognize; the other was a conditional process conclusion directly linked to an earlier supported test/adjust example.

## Impact

For this bounded broad-profile route, an otherwise grounded process assessment can survive finalization as an explicitly revisable BNL interpretation. The repair does not add a memory owner, persist an assessment, enable the synthesis canary, change source selection, or alter privacy/governance boundaries.

## Validation

- 66 focused preview, synthesis, production-shaped, routing, canon-balance, source-revalidation, and fail-closed tests passed.
- Full repository check passed: 1,818 tests.
- Exact tested and published tree: `0fc258e2e2b37c1dc5101213e492f3bd4909a82e`.
- Remote branch is one commit and two files over merge `3d62549a18b1a3b2bea8331c60d9a19c3abdf040`.