### PR TITLE
Converge public-home broad recall owner

### DIFF
--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -30,7 +30,7 @@ from bnl_unified_response_assessment import (
 )
 
 
-SHADOW_ACCEPTANCE_VERSION = "v2_shadow_acceptance_v5"
+SHADOW_ACCEPTANCE_VERSION = "v2_shadow_acceptance_v6"
 SHADOW_EVALUATION_ORDER = (
     "memory_ledger",
     "moment_engine",
@@ -97,16 +97,41 @@ def build_gate_snapshot(environ: Optional[Mapping[str, str]] = None) -> Dict[str
             intelligence_packet["reason"]
         ),
         "shared_brain_synthesis_canary_requested": bool(
-            shared_brain_synthesis["configured_enabled"]
+            shared_brain_synthesis["canary_requested"]
         ),
         "shared_brain_synthesis_canary_effective": bool(
-            shared_brain_synthesis["effective"]
+            shared_brain_synthesis["canary_effective"]
         ),
         "shared_brain_synthesis_canary_reason": str(
             shared_brain_synthesis["reason"]
         ),
         "shared_brain_synthesis_canary_fully_scoped": bool(
             shared_brain_synthesis["fully_scoped"]
+            and shared_brain_synthesis["canary_requested"]
+        ),
+        "public_home_broad_recall_owner_requested": bool(
+            shared_brain_synthesis["public_home_owner_requested"]
+        ),
+        "public_home_broad_recall_owner_effective": bool(
+            shared_brain_synthesis["public_home_owner_effective"]
+        ),
+        "shared_brain_synthesis_requested": bool(
+            shared_brain_synthesis["configured_enabled"]
+        ),
+        "shared_brain_synthesis_effective": bool(
+            shared_brain_synthesis["effective"]
+        ),
+        "shared_brain_synthesis_reason": str(
+            shared_brain_synthesis["reason"]
+        ),
+        "shared_brain_synthesis_fully_scoped": bool(
+            shared_brain_synthesis["fully_scoped"]
+        ),
+        "shared_brain_synthesis_authority_mode": str(
+            shared_brain_synthesis["authority_mode"]
+        ),
+        "shared_brain_synthesis_kill_switch_env": str(
+            shared_brain_synthesis["kill_switch_env"]
         ),
         "all_live_gates_clear": not (
             governance_live_requested or relationship_live or engagement_live
@@ -773,7 +798,7 @@ def _read_shared_brain_synthesis_report(
         return _report_error(
             {
                 "tablePresent": False,
-                "schemaVersion": "shared_brain_synthesis_canary_v3",
+                "schemaVersion": "shared_brain_synthesis_v4",
                 "runs": 0,
                 "promptAppliedRuns": 0,
                 "liveAppliedRuns": 0,
@@ -1193,7 +1218,7 @@ def build_v2_shadow_acceptance_snapshot(
     ]
     shared_brain_synthesis_status = _stage_status(
         requested=bool(
-            gates.get("shared_brain_synthesis_canary_requested")
+            gates.get("shared_brain_synthesis_requested")
         ),
         prerequisites=shared_brain_synthesis_prerequisites,
         evidence=shared_brain_synthesis_evidence,
@@ -1397,10 +1422,10 @@ def build_v2_shadow_acceptance_snapshot(
     ):
         warnings.append("shared_brain_synthesis_selected_not_sent_review")
     if (
-        gates.get("shared_brain_synthesis_canary_effective")
+        gates.get("shared_brain_synthesis_effective")
         and not shared_brain_synthesis_evidence
     ):
-        warnings.append("shared_brain_synthesis_no_canary_evidence")
+        warnings.append("shared_brain_synthesis_no_route_evidence")
 
     stage_statuses = [stage["status"] for stage in stages.values()]
     unified_assessment_ready = bool(
@@ -1418,7 +1443,7 @@ def build_v2_shadow_acceptance_snapshot(
         )
     )
     shared_brain_synthesis_ready = bool(
-        not gates.get("shared_brain_synthesis_canary_requested")
+        not gates.get("shared_brain_synthesis_requested")
         or (
             shared_brain_synthesis_evidence
             and not shared_brain_synthesis_blockers
@@ -1458,6 +1483,7 @@ def build_v2_shadow_acceptance_snapshot(
             "memoryGovernance": governance,
             "relationshipV2": relationship,
             "unifiedIntelligencePacket": intelligence_packet,
+            "sharedBrainSynthesis": shared_brain_synthesis,
             "sharedBrainSynthesisCanary": shared_brain_synthesis,
             "unifiedResponseAssessment": unified_assessment,
         },
@@ -1499,6 +1525,41 @@ def build_v2_shadow_acceptance_snapshot(
             "fullyScoped": bool(
                 gates.get(
                     "shared_brain_synthesis_canary_fully_scoped"
+                )
+            ),
+            "evidenceObserved": shared_brain_synthesis_evidence,
+            "blockers": shared_brain_synthesis_blockers,
+            "unauthorizedPacketApplications": (
+                unauthorized_packet_applications
+            ),
+        },
+        "sharedBrainSynthesis": {
+            "status": shared_brain_synthesis_status,
+            "requested": bool(
+                gates.get("shared_brain_synthesis_requested")
+            ),
+            "effective": bool(
+                gates.get("shared_brain_synthesis_effective")
+            ),
+            "reason": str(
+                gates.get(
+                    "shared_brain_synthesis_reason",
+                    "disabled",
+                )
+            ),
+            "fullyScoped": bool(
+                gates.get("shared_brain_synthesis_fully_scoped")
+            ),
+            "authorityMode": str(
+                gates.get(
+                    "shared_brain_synthesis_authority_mode",
+                    "none",
+                )
+            ),
+            "killSwitchEnv": str(
+                gates.get(
+                    "shared_brain_synthesis_kill_switch_env",
+                    "none",
                 )
             ),
             "evidenceObserved": shared_brain_synthesis_evidence,
@@ -1586,14 +1647,18 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
     relationship = reports.get("relationshipV2") or {}
     intelligence_packet = reports.get("unifiedIntelligencePacket") or {}
     shared_brain_synthesis = (
-        reports.get("sharedBrainSynthesisCanary") or {}
+        reports.get("sharedBrainSynthesis")
+        or reports.get("sharedBrainSynthesisCanary")
+        or {}
     )
     unified_assessment = reports.get("unifiedResponseAssessment") or {}
     intelligence_packet_state = (
         snapshot.get("unifiedIntelligencePacketShadow") or {}
     )
     shared_brain_synthesis_state = (
-        snapshot.get("sharedBrainSynthesisCanary") or {}
+        snapshot.get("sharedBrainSynthesis")
+        or snapshot.get("sharedBrainSynthesisCanary")
+        or {}
     )
     unified_state = snapshot.get("unifiedResponseAssessmentShadow") or {}
     blockers = snapshot.get("blockers") or []
@@ -1605,7 +1670,10 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
         "- overall_status: `%s`" % snapshot.get("status", "unknown"),
         "- behavior_changes_applied: `%s`"
         % (
-            "scoped_shared_brain_synthesis_canary"
+            shared_brain_synthesis_state.get(
+                "authorityMode",
+                "scoped_shared_brain_synthesis_canary",
+            )
             if snapshot.get("behaviorChangesApplied")
             else "none"
         ),
@@ -1885,7 +1953,28 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
                 "none",
             ),
         ),
-        "- shared_brain_synthesis_canary: status=`%s` requested=`%s` effective=`%s` reason=`%s` fully_scoped=`%s` schema=`%s` runs=`%s` route_families=`%s` prompt_applied=`%s` candidate_selected=`%s` live_applied=`%s` responses_sent=`%s` fallbacks=`%s` fallback_reasons=`%s` comparison=`%s` baseline_coherence=`%s` candidate_coherence=`%s` evidence_coverage=`%s` member_points=`%s` member_roots=`%s` member_occurrences=`%s` canon_coverage=`%s` member_supported_claims=`%s` canon_supported_claims=`%s` opinion_claims=`%s` connective_claims=`%s` unsupported_factual_claims=`%s` prompt_factual_owner=`%s` prompt_owner_failures=`%s` candidate_latency_ms=`%s` revalidation=`%s` control_leaks=`%s` errors=`%s` invalid_scope=`%s` invalid_revalidation_live=`%s` ungrounded_live=`%s` insufficient_member_live=`%s` unsupported_factual_live=`%s` prompt_owner_violation_live=`%s` relationship_posture_applied=`%s` content_fields=`%s` window_last=`%s`" % (
+        "- public_home_broad_recall_owner: requested=`%s` effective=`%s` authority_mode=`%s` fully_scoped=`%s` kill_switch=`%s`" % (
+            _on(
+                gates.get(
+                    "public_home_broad_recall_owner_requested"
+                )
+            ),
+            _on(
+                gates.get(
+                    "public_home_broad_recall_owner_effective"
+                )
+            ),
+            shared_brain_synthesis_state.get(
+                "authorityMode",
+                "none",
+            ),
+            _on(shared_brain_synthesis_state.get("fullyScoped")),
+            shared_brain_synthesis_state.get(
+                "killSwitchEnv",
+                "none",
+            ),
+        ),
+        "- shared_brain_synthesis_canary: status=`%s` requested=`%s` effective=`%s` reason=`%s` fully_scoped=`%s` schema=`%s` runs=`%s` route_families=`%s` authority_modes=`%s` prompt_applied=`%s` candidate_selected=`%s` live_applied=`%s` responses_sent=`%s` fallbacks=`%s` fallback_reasons=`%s` comparison=`%s` baseline_coherence=`%s` candidate_coherence=`%s` evidence_coverage=`%s` member_points=`%s` member_roots=`%s` member_occurrences=`%s` canon_coverage=`%s` member_supported_claims=`%s` canon_supported_claims=`%s` opinion_claims=`%s` connective_claims=`%s` unsupported_factual_claims=`%s` prompt_factual_owner=`%s` prompt_owner_failures=`%s` candidate_latency_ms=`%s` revalidation=`%s` control_leaks=`%s` errors=`%s` invalid_scope=`%s` invalid_revalidation_live=`%s` ungrounded_live=`%s` insufficient_member_live=`%s` unsupported_factual_live=`%s` prompt_owner_violation_live=`%s` relationship_posture_applied=`%s` content_fields=`%s` window_last=`%s`" % (
             shared_brain_synthesis_state.get("status", "unknown"),
             _on(shared_brain_synthesis_state.get("requested")),
             _on(shared_brain_synthesis_state.get("effective")),
@@ -1893,11 +1982,15 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             _on(shared_brain_synthesis_state.get("fullyScoped")),
             shared_brain_synthesis.get(
                 "schemaVersion",
-                "shared_brain_synthesis_canary_v3",
+                "shared_brain_synthesis_v4",
             ),
             shared_brain_synthesis.get("runs", 0),
             json.dumps(
                 shared_brain_synthesis.get("routeFamilyCounts", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                shared_brain_synthesis.get("authorityModeCounts", {}),
                 sort_keys=True,
             ),
             shared_brain_synthesis.get("promptAppliedRuns", 0),

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -1,9 +1,10 @@
-"""Scoped live synthesis canary for the unified intelligence packet.
+"""Guarded synthesis for the unified intelligence packet.
 
 The established response is always generated first.  This module may prepare a
-second, packet-grounded comparison only for one explicitly configured
-guild/member/channel route.  It owns no knowledge and persists no packet or
-response content.
+second, packet-grounded comparison for either the scoped acceptance canary or
+the separately gated public-home broad-recall owner.  Both modes reuse the same
+packet, selector, fallback, revalidation, and content-free receipt path.  This
+module owns no knowledge and persists no packet or response content.
 """
 from __future__ import annotations
 
@@ -36,16 +37,29 @@ from bnl_unified_response_assessment import (
 )
 
 
-SCHEMA_VERSION = "shared_brain_synthesis_canary_v3"
+SCHEMA_VERSION = "shared_brain_synthesis_v4"
 TABLE_NAME = "memory_governance_shared_brain_synthesis_runs"
 ENABLED_ENV = "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_ENABLED"
 GUILD_IDS_ENV = "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_GUILD_IDS"
 USER_IDS_ENV = "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_USER_IDS"
 CHANNEL_IDS_ENV = "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_CHANNEL_IDS"
+PUBLIC_HOME_OWNER_ENABLED_ENV = (
+    "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_ENABLED"
+)
+PUBLIC_HOME_OWNER_GUILD_IDS_ENV = (
+    "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_GUILD_IDS"
+)
+PUBLIC_HOME_OWNER_CHANNEL_IDS_ENV = (
+    "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_CHANNEL_IDS"
+)
+SCOPED_CANARY_AUTHORITY = "scoped_canary"
+PUBLIC_HOME_OWNER_AUTHORITY = "public_home_broad_recall_owner"
 _ROUTE_MODE = "normal_chat"
-_CHANNEL_POLICIES = frozenset({"public_home", "public_context"})
+_CANARY_CHANNEL_POLICIES = frozenset({"public_home", "public_context"})
+_PUBLIC_HOME_OWNER_CHANNEL_POLICIES = frozenset({"public_home"})
 _MAX_SCOPED_USERS = 8
 _MAX_SCOPED_CHANNELS = 4
+_MAX_PUBLIC_HOME_OWNER_CHANNELS = 1
 _LIVE_GATES = (
     "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED",
     "BNL_RELATIONSHIP_V2_LIVE_ENABLED",
@@ -516,6 +530,7 @@ class SharedBrainSynthesisBasis:
     rendered_item_count: int
     rendered_lane_counts: tuple[tuple[str, int], ...]
     rendered_source_digests: tuple[str, ...]
+    authority_mode: str = SCOPED_CANARY_AUTHORITY
     competing_factual_contexts: tuple[str, ...] = ()
     competing_factual_context_digests: tuple[str, ...] = ()
     blocking_factual_owner_lanes: tuple[str, ...] = ()
@@ -565,6 +580,7 @@ class RouteScopeDecision:
     reason: str
     intent_status: str
     route_family: str
+    authority_mode: str = "none"
 
 
 @dataclass(frozen=True)
@@ -632,29 +648,67 @@ def _digest(*values: Any) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-def configuration(
-    environ: Mapping[str, str] | None = None,
+def _configuration_details(
+    environ: Mapping[str, str],
 ) -> dict[str, Any]:
-    """Return safe configuration state without exposing allowlisted IDs."""
+    """Resolve one authority without exposing its opaque IDs publicly."""
 
-    env = os.environ if environ is None else environ
-    requested = _flag(env.get(ENABLED_ENV, ""))
-    guilds = _positive_ids(env.get(GUILD_IDS_ENV, ""))
-    users = _positive_ids(env.get(USER_IDS_ENV, ""))
-    channels = _positive_ids(env.get(CHANNEL_IDS_ENV, ""))
-    scope_present = bool(requested and guilds and users and channels)
-    scope_within_limits = bool(
-        len(guilds) == 1
-        and 1 <= len(users) <= _MAX_SCOPED_USERS
-        and 1 <= len(channels) <= _MAX_SCOPED_CHANNELS
+    canary_requested = _flag(environ.get(ENABLED_ENV, ""))
+    owner_requested = _flag(
+        environ.get(PUBLIC_HOME_OWNER_ENABLED_ENV, "")
     )
+    authority_conflict = bool(canary_requested and owner_requested)
+
+    if canary_requested and not authority_conflict:
+        authority_mode = SCOPED_CANARY_AUTHORITY
+        guilds = _positive_ids(environ.get(GUILD_IDS_ENV, ""))
+        users = _positive_ids(environ.get(USER_IDS_ENV, ""))
+        channels = _positive_ids(environ.get(CHANNEL_IDS_ENV, ""))
+        channel_policies = _CANARY_CHANNEL_POLICIES
+        user_scope_required = True
+        scope_present = bool(guilds and users and channels)
+        scope_within_limits = bool(
+            len(guilds) == 1
+            and 1 <= len(users) <= _MAX_SCOPED_USERS
+            and 1 <= len(channels) <= _MAX_SCOPED_CHANNELS
+        )
+    elif owner_requested and not authority_conflict:
+        authority_mode = PUBLIC_HOME_OWNER_AUTHORITY
+        guilds = _positive_ids(
+            environ.get(PUBLIC_HOME_OWNER_GUILD_IDS_ENV, "")
+        )
+        users = frozenset()
+        channels = _positive_ids(
+            environ.get(PUBLIC_HOME_OWNER_CHANNEL_IDS_ENV, "")
+        )
+        channel_policies = _PUBLIC_HOME_OWNER_CHANNEL_POLICIES
+        user_scope_required = False
+        scope_present = bool(guilds and channels)
+        scope_within_limits = bool(
+            len(guilds) == 1
+            and len(channels) == _MAX_PUBLIC_HOME_OWNER_CHANNELS
+        )
+    else:
+        authority_mode = "conflict" if authority_conflict else "none"
+        guilds = frozenset()
+        users = frozenset()
+        channels = frozenset()
+        channel_policies = frozenset()
+        user_scope_required = False
+        scope_present = False
+        scope_within_limits = False
+
+    requested = bool(canary_requested or owner_requested)
     fully_scoped = bool(
-        scope_present and scope_within_limits
+        requested
+        and not authority_conflict
+        and scope_present
+        and scope_within_limits
     )
-    packet_ready = packet_shadow_enabled(env)
-    assessment_ready = assessment_shadow_enabled(env)
+    packet_ready = packet_shadow_enabled(environ)
+    assessment_ready = assessment_shadow_enabled(environ)
     active_live_gates = tuple(
-        name for name in _LIVE_GATES if _flag(env.get(name, ""))
+        name for name in _LIVE_GATES if _flag(environ.get(name, ""))
     )
     effective = bool(
         fully_scoped
@@ -664,6 +718,8 @@ def configuration(
     )
     if not requested:
         reason = "disabled"
+    elif authority_conflict:
+        reason = "authority_conflict"
     elif scope_present and not scope_within_limits:
         reason = "scope_limit_exceeded"
     elif not fully_scoped:
@@ -673,21 +729,75 @@ def configuration(
     elif not packet_ready or not assessment_ready:
         reason = "missing_shadow_prerequisites"
     else:
-        reason = "scoped_canary"
+        reason = authority_mode
+
     return {
-        "configured_enabled": requested,
-        "guild_allowlist_count": len(guilds),
-        "user_allowlist_count": len(users),
-        "channel_allowlist_count": len(channels),
+        "requested": requested,
+        "canary_requested": canary_requested,
+        "public_home_owner_requested": owner_requested,
+        "authority_mode": authority_mode,
+        "guilds": guilds,
+        "users": users,
+        "channels": channels,
+        "channel_policies": channel_policies,
+        "user_scope_required": user_scope_required,
         "fully_scoped": fully_scoped,
         "effective": effective,
         "reason": reason,
+        "packet_ready": packet_ready,
+        "assessment_ready": assessment_ready,
+        "active_live_gates": active_live_gates,
+    }
+
+
+def configuration(
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Return safe configuration state without exposing allowlisted IDs."""
+
+    env = os.environ if environ is None else environ
+    details = _configuration_details(env)
+    return {
+        "configured_enabled": details["requested"],
+        "canary_requested": details["canary_requested"],
+        "canary_effective": bool(
+            details["effective"]
+            and details["authority_mode"] == SCOPED_CANARY_AUTHORITY
+        ),
+        "public_home_owner_requested": details[
+            "public_home_owner_requested"
+        ],
+        "public_home_owner_effective": bool(
+            details["effective"]
+            and details["authority_mode"]
+            == PUBLIC_HOME_OWNER_AUTHORITY
+        ),
+        "authority_mode": details["authority_mode"],
+        "guild_allowlist_count": len(details["guilds"]),
+        "user_allowlist_count": len(details["users"]),
+        "channel_allowlist_count": len(details["channels"]),
+        "user_scope_required": details["user_scope_required"],
+        "fully_scoped": details["fully_scoped"],
+        "effective": details["effective"],
+        "reason": details["reason"],
         "route_mode": _ROUTE_MODE,
         "route_family": PERSONAL_RECALL_ROUTE_FAMILY,
-        "channel_policies": tuple(sorted(_CHANNEL_POLICIES)),
+        "channel_policies": tuple(
+            sorted(details["channel_policies"])
+        ),
         "max_scoped_users": _MAX_SCOPED_USERS,
         "max_scoped_channels": _MAX_SCOPED_CHANNELS,
-        "active_live_gates": active_live_gates,
+        "max_public_home_owner_channels": (
+            _MAX_PUBLIC_HOME_OWNER_CHANNELS
+        ),
+        "active_live_gates": details["active_live_gates"],
+        "kill_switch_env": (
+            PUBLIC_HOME_OWNER_ENABLED_ENV
+            if details["authority_mode"] == PUBLIC_HOME_OWNER_AUTHORITY
+            else ENABLED_ENV
+            if details["authority_mode"] == SCOPED_CANARY_AUTHORITY
+            else "none"
+        ),
     }
 
 
@@ -742,25 +852,26 @@ def route_scope_decision(
     """Evaluate the route family before packet/assessment availability."""
 
     env = os.environ if environ is None else environ
+    details = _configuration_details(env)
     config = configuration(env)
     intent = classify_personal_recall_intent(user_text)
     if not config["effective"]:
         reason = "configuration_%s" % config["reason"]
-    elif int(guild_id or 0) not in _positive_ids(
-        env.get(GUILD_IDS_ENV, "")
-    ):
+    elif int(guild_id or 0) not in details["guilds"]:
         reason = "guild_not_allowlisted"
-    elif int(user_id or 0) not in _positive_ids(
-        env.get(USER_IDS_ENV, "")
+    elif (
+        details["user_scope_required"]
+        and int(user_id or 0) not in details["users"]
     ):
         reason = "user_not_allowlisted"
-    elif int(channel_id or 0) not in _positive_ids(
-        env.get(CHANNEL_IDS_ENV, "")
-    ):
+    elif int(channel_id or 0) not in details["channels"]:
         reason = "channel_not_allowlisted"
     elif str(route_mode or "") != _ROUTE_MODE:
         reason = "route_mode_not_supported"
-    elif str(channel_policy or "").strip().lower() not in _CHANNEL_POLICIES:
+    elif (
+        str(channel_policy or "").strip().lower()
+        not in details["channel_policies"]
+    ):
         reason = "channel_policy_not_supported"
     elif not current_direct:
         reason = "not_direct"
@@ -781,6 +892,7 @@ def route_scope_decision(
         route_family=(
             intent.route_family or PERSONAL_RECALL_ROUTE_FAMILY
         ),
+        authority_mode=str(config["authority_mode"]),
     )
 
 
@@ -1344,6 +1456,7 @@ def build_basis(
     competing_factual_contexts: Sequence[str] = (),
     environ: Mapping[str, str] | None = None,
 ) -> SharedBrainSynthesisBasis | None:
+    env = os.environ if environ is None else environ
     if not scope_enabled(
         guild_id=guild_id,
         user_id=user_id,
@@ -1359,9 +1472,10 @@ def build_basis(
         third_party_attribution_requested=(
             third_party_attribution_requested
         ),
-        environ=environ,
+        environ=env,
     ):
         return None
+    authority_mode = str(configuration(env)["authority_mode"])
     (
         rendered,
         lane_counts,
@@ -1392,6 +1506,7 @@ def build_basis(
         rendered_item_count=item_count,
         rendered_lane_counts=lane_counts,
         rendered_source_digests=source_digests,
+        authority_mode=authority_mode,
         competing_factual_contexts=factual_contexts,
         competing_factual_context_digests=tuple(
             _digest(value) for value in factual_contexts
@@ -1424,17 +1539,20 @@ def revalidate_basis(
     environ: Mapping[str, str] | None = None,
 ) -> tuple[bool, str]:
     env = os.environ if environ is None else environ
+    details = _configuration_details(env)
     config = configuration(env)
     if not config["effective"]:
         return False, "scope_disabled"
     if (
-        basis.guild_id not in _positive_ids(env.get(GUILD_IDS_ENV, ""))
-        or basis.user_id not in _positive_ids(env.get(USER_IDS_ENV, ""))
-        or basis.channel_id not in _positive_ids(
-            env.get(CHANNEL_IDS_ENV, "")
+        basis.authority_mode != config["authority_mode"]
+        or basis.guild_id not in details["guilds"]
+        or (
+            details["user_scope_required"]
+            and basis.user_id not in details["users"]
         )
+        or basis.channel_id not in details["channels"]
         or basis.route_mode != _ROUTE_MODE
-        or basis.channel_policy not in _CHANNEL_POLICIES
+        or basis.channel_policy not in details["channel_policies"]
         or basis.packet.request.subject_user_id != basis.user_id
         or basis.packet.request.guild_id != basis.guild_id
         or basis.packet.request.channel_id != basis.channel_id
@@ -2448,6 +2566,7 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             subject_hash TEXT NOT NULL,
             channel_scope_hash TEXT NOT NULL,
             route_family TEXT NOT NULL DEFAULT 'broad_self_profile',
+            authority_mode TEXT NOT NULL DEFAULT 'scoped_canary',
             route_mode TEXT NOT NULL,
             channel_policy TEXT NOT NULL,
             packet_item_count INTEGER NOT NULL DEFAULT 0,
@@ -2515,6 +2634,14 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             ALTER TABLE memory_governance_shared_brain_synthesis_runs
             ADD COLUMN candidate_generation_latency_ms INTEGER NOT NULL
             DEFAULT 0
+            """
+        )
+    if "authority_mode" not in columns:
+        conn.execute(
+            """
+            ALTER TABLE memory_governance_shared_brain_synthesis_runs
+            ADD COLUMN authority_mode TEXT NOT NULL
+            DEFAULT 'scoped_canary'
             """
         )
     for column, definition in (
@@ -2645,8 +2772,8 @@ def begin_run(
         """
         INSERT INTO memory_governance_shared_brain_synthesis_runs(
           run_id,packet_run_id,packet_id,schema_version,guild_id,
-          subject_hash,channel_scope_hash,route_family,route_mode,
-          channel_policy,
+          subject_hash,channel_scope_hash,route_family,authority_mode,
+          route_mode,channel_policy,
           packet_item_count,rendered_item_count,rendered_lane_counts_json,
           packet_digest,source_ref_digest,baseline_generated,
           baseline_response_hash,baseline_response_length,
@@ -2654,7 +2781,7 @@ def begin_run(
           competing_factual_context_count,replaced_factual_context_count,
           revalidation_status,prompt_applied,fallback_reason,
           processing_error_count,created_at,updated_at
-        ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         """,
         (
             run_id,
@@ -2665,6 +2792,7 @@ def begin_run(
             _digest(subject_key_for_user(basis.user_id))[:16],
             _digest(basis.guild_id, basis.channel_id)[:16],
             PERSONAL_RECALL_ROUTE_FAMILY,
+            basis.authority_mode,
             basis.route_mode,
             basis.channel_policy,
             len(basis.packet.items),
@@ -3074,6 +3202,7 @@ def _empty_report() -> dict[str, Any]:
         "promptFactualOwnerRuns": 0,
         "promptOwnershipFailureRuns": 0,
         "routeFamilyCounts": {},
+        "authorityModeCounts": {},
         "candidateGenerationLatencyMs": {
             "average": 0,
             "maximum": 0,
@@ -3130,6 +3259,11 @@ def build_evaluation_report(
         "route_family"
         if "route_family" in columns
         else "'broad_self_profile'"
+    )
+    authority_mode_expr = (
+        "authority_mode"
+        if "authority_mode" in columns
+        else "'scoped_canary'"
     )
     latency_expr = (
         "candidate_generation_latency_ms"
@@ -3210,9 +3344,16 @@ def build_evaluation_report(
               AND (
                 route_mode<>?
                 OR channel_policy NOT IN ('public_home','public_context')
+                OR {authority_mode_expr} NOT IN (
+                  'scoped_canary','public_home_broad_recall_owner'
+                )
+                OR (
+                  {authority_mode_expr}='public_home_broad_recall_owner'
+                  AND channel_policy<>'public_home'
+                )
                 OR subject_hash='' OR channel_scope_hash=''
               )
-            """,
+            """.format(authority_mode_expr=authority_mode_expr),
             (int(guild_id or 0), _ROUTE_MODE),
         ).fetchone()[0]
         or 0
@@ -3367,7 +3508,7 @@ def build_evaluation_report(
                candidate_evidence_coverage_count,revalidation_status,
                candidate_output_leak,
                processing_error_count,response_sent,
-               {route_family_expr},{latency_expr},
+               {route_family_expr},{authority_mode_expr},{latency_expr},
                {member_point_expr},{member_root_expr},
                {member_occurrence_expr},{canon_coverage_expr},
                {lore_dominant_expr},
@@ -3381,6 +3522,7 @@ def build_evaluation_report(
         LIMIT ?
         """.format(
             route_family_expr=route_family_expr,
+            authority_mode_expr=authority_mode_expr,
             latency_expr=latency_expr,
             member_point_expr=member_point_expr,
             member_root_expr=member_root_expr,
@@ -3401,6 +3543,7 @@ def build_evaluation_report(
     candidate_coherence: Counter[str] = Counter()
     revalidation: Counter[str] = Counter()
     route_families: Counter[str] = Counter()
+    authority_modes: Counter[str] = Counter()
     latency_values: list[int] = []
     prompt = live = selected = coverage = leaks = errors = sent = 0
     member_points = member_roots = member_occurrences = canon_coverage = 0
@@ -3423,6 +3566,7 @@ def build_evaluation_report(
             processing_errors,
             response_sent,
             route_family,
+            authority_mode,
             candidate_latency_ms,
             candidate_member_points,
             candidate_member_roots,
@@ -3464,6 +3608,9 @@ def build_evaluation_report(
         route_families[
             str(route_family or PERSONAL_RECALL_ROUTE_FAMILY)
         ] += 1
+        authority_modes[
+            str(authority_mode or SCOPED_CANARY_AUTHORITY)
+        ] += 1
         latency = max(0, int(candidate_latency_ms or 0))
         if latency:
             latency_values.append(latency)
@@ -3499,6 +3646,7 @@ def build_evaluation_report(
         "promptFactualOwnerRuns": prompt_factual_owner_runs,
         "promptOwnershipFailureRuns": prompt_ownership_failures,
         "routeFamilyCounts": dict(sorted(route_families.items())),
+        "authorityModeCounts": dict(sorted(authority_modes.items())),
         "candidateGenerationLatencyMs": {
             "average": (
                 int(round(sum(latency_values) / len(latency_values)))

--- a/docs/BNL01_PUBLIC_HOME_BROAD_RECALL_OWNER.md
+++ b/docs/BNL01_PUBLIC_HOME_BROAD_RECALL_OWNER.md
@@ -1,0 +1,54 @@
+# Public-Home Broad-Recall Owner
+
+This route promotes the accepted shared-brain packet selector for one narrow
+conversation family: direct, first-person broad-profile requests in the
+configured `public_home` channel.
+
+It does not enable global Memory Governance, Relationship v2, Active
+Engagement, or any queue capability. The established response is still
+generated first and remains the fallback whenever packet construction,
+factual-prompt ownership, candidate evaluation, guard checks, source
+revalidation, or delivery preparation fails.
+
+## Default-off gate
+
+The route is effective only when all three values are present:
+
+- `BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_ENABLED=true`
+- `BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_GUILD_IDS=<one guild id>`
+- `BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_CHANNEL_IDS=<one public-home channel id>`
+
+The scoped synthesis canary and the public-home owner are mutually exclusive.
+If both enable switches are true, synthesis fails closed with
+`authority_conflict`. The public-home owner also fails closed when a global
+Memory Governance, Relationship v2, or Active Engagement live gate is active,
+or when the packet and response-assessment shadows are unavailable.
+
+## Authority and safety
+
+- The governed packet is the only stored factual prompt owner for this route.
+- Competing legacy factual context is replaced before the candidate call.
+- Current-turn and exact-reply authority remain ahead of stored memory.
+- The subject is always the requesting member; cross-member facts remain
+  ineligible.
+- Relationship stays tone-only and is not rendered as factual evidence.
+- BNL-authored derivatives cannot corroborate themselves.
+- Every candidate is revalidated before send; any failure returns to the
+  established response.
+
+## Diagnostics and rollback
+
+Content-free synthesis receipts record `authority_mode` as either
+`scoped_canary` or `public_home_broad_recall_owner`. Owner diagnostics report
+the requested/effective state, authority mode, scope status, kill switch,
+route counts, selection/fallback totals, revalidation, prompt ownership, guard
+outcomes, and live applications.
+
+Rollback is the independent kill switch:
+
+1. Set `BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_ENABLED=false` or remove it.
+2. Restart the bot.
+3. Confirm diagnostics show the owner as requested/effective `off`.
+
+With the gate off, no packet candidate is generated and the established path
+is preserved byte-for-byte.

--- a/tests/test_governed_broad_recall_route_expansion.py
+++ b/tests/test_governed_broad_recall_route_expansion.py
@@ -8,6 +8,7 @@ os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
 import bnl01_bot
 from bnl_memory_governance import classify_personal_recall_intent
 from bnl_shared_brain_synthesis import (
+    PUBLIC_HOME_OWNER_AUTHORITY,
     configuration,
     route_scope_decision,
 )
@@ -196,6 +197,93 @@ class GovernedBroadRecallRouteExpansionTests(unittest.TestCase):
         self.assertFalse(decision.eligible)
         self.assertEqual(decision.reason, "user_not_allowlisted")
 
+    def test_public_home_owner_is_a_separate_default_off_route_gate(self):
+        owner_flags = {
+            **self.flags,
+            "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_ENABLED": "false",
+            "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_ENABLED": "true",
+            "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_GUILD_IDS": "1",
+            "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_CHANNEL_IDS": "10",
+        }
+        configured = configuration(owner_flags)
+        self.assertTrue(configured["effective"])
+        self.assertFalse(configured["canary_effective"])
+        self.assertTrue(configured["public_home_owner_effective"])
+        self.assertEqual(
+            configured["authority_mode"],
+            PUBLIC_HOME_OWNER_AUTHORITY,
+        )
+        self.assertFalse(configured["user_scope_required"])
+        self.assertEqual(configured["user_allowlist_count"], 0)
+        self.assertEqual(configured["channel_policies"], ("public_home",))
+        self.assertEqual(
+            configured["kill_switch_env"],
+            "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_ENABLED",
+        )
+
+        for user_id in (7, 99):
+            with self.subTest(user_id=user_id):
+                decision = route_scope_decision(
+                    guild_id=1,
+                    user_id=user_id,
+                    channel_id=10,
+                    route_mode="normal_chat",
+                    channel_policy="public_home",
+                    current_direct=True,
+                    user_text="What do you know about me?",
+                    environ=owner_flags,
+                )
+                self.assertTrue(decision.eligible)
+                self.assertEqual(
+                    decision.authority_mode,
+                    PUBLIC_HOME_OWNER_AUTHORITY,
+                )
+
+        for override in (
+            {"guild_id": 2},
+            {"channel_id": 11},
+            {"channel_policy": "public_context"},
+            {"route_mode": "direct_payload"},
+            {"current_direct": False},
+            {"user_text": "Tell me a joke."},
+        ):
+            common = {
+                "guild_id": 1,
+                "user_id": 99,
+                "channel_id": 10,
+                "route_mode": "normal_chat",
+                "channel_policy": "public_home",
+                "current_direct": True,
+                "user_text": "What do you know about me?",
+                "environ": owner_flags,
+            }
+            with self.subTest(override=override):
+                self.assertFalse(
+                    route_scope_decision(
+                        **{**common, **override}
+                    ).eligible
+                )
+
+    def test_route_authorities_conflict_and_kill_switch_fail_closed(self):
+        owner_scope = {
+            **self.flags,
+            "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_ENABLED": "true",
+            "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_GUILD_IDS": "1",
+            "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_CHANNEL_IDS": "10",
+        }
+        conflict = configuration(owner_scope)
+        self.assertFalse(conflict["effective"])
+        self.assertEqual(conflict["reason"], "authority_conflict")
+
+        disabled = configuration(
+            {
+                **owner_scope,
+                "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_ENABLED": "false",
+                "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_ENABLED": "false",
+            }
+        )
+        self.assertFalse(disabled["effective"])
+        self.assertEqual(disabled["reason"], "disabled")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_shared_brain_synthesis_canary.py
+++ b/tests/test_shared_brain_synthesis_canary.py
@@ -13,6 +13,7 @@ from bnl_shadow_acceptance import (
     render_v2_shadow_acceptance_lines,
 )
 from bnl_shared_brain_synthesis import (
+    PUBLIC_HOME_OWNER_AUTHORITY,
     _candidate_claim_units,
     begin_run,
     build_basis,
@@ -346,6 +347,111 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             {"third_party_attribution_requested": True},
         ):
             self.assertFalse(scope_enabled(**{**common, **override}))
+
+    def test_public_home_owner_revalidates_through_its_own_kill_switch(self):
+        owner_flags = {
+            **self.flags,
+            "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_ENABLED": "false",
+            "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_ENABLED": "true",
+            "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_GUILD_IDS": "1",
+            "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_CHANNEL_IDS": "10",
+        }
+        owner_packet = replace(
+            self.packet,
+            request=replace(
+                self.packet.request,
+                channel_policy="public_home",
+            ),
+        )
+        owner_assessment = replace(
+            self.assessment,
+            channel_policy="public_home",
+        )
+        owner_basis = build_basis(
+            guild_id=1,
+            user_id=7,
+            channel_id=10,
+            route_mode="normal_chat",
+            channel_policy="public_home",
+            current_direct=True,
+            user_text=owner_packet.request.user_text,
+            packet=owner_packet,
+            assessment=owner_assessment,
+            environ=owner_flags,
+        )
+        self.assertIsNotNone(owner_basis)
+        self.assertEqual(
+            owner_basis.authority_mode,
+            PUBLIC_HOME_OWNER_AUTHORITY,
+        )
+
+        ensure_schema(self.conn)
+        run = begin_run(
+            self.conn,
+            owner_basis,
+            baseline_response="Established response.",
+        )
+        stored_authority = self.conn.execute(
+            """
+            SELECT authority_mode
+            FROM memory_governance_shared_brain_synthesis_runs
+            WHERE run_id=?
+            """,
+            (run.run_id,),
+        ).fetchone()[0]
+        self.assertEqual(
+            stored_authority,
+            PUBLIC_HOME_OWNER_AUTHORITY,
+        )
+        snapshot = build_v2_shadow_acceptance_snapshot(
+            self.conn,
+            guild_id=1,
+            environ=owner_flags,
+        )
+        owner_state = snapshot["sharedBrainSynthesis"]
+        self.assertTrue(owner_state["requested"])
+        self.assertTrue(owner_state["effective"])
+        self.assertEqual(
+            owner_state["authorityMode"],
+            PUBLIC_HOME_OWNER_AUTHORITY,
+        )
+        rendered = "\n".join(
+            render_v2_shadow_acceptance_lines(snapshot)
+        )
+        self.assertIn(
+            "- public_home_broad_recall_owner: requested=`on`",
+            rendered,
+        )
+        self.assertIn(
+            'authority_modes=`{"public_home_broad_recall_owner": 1}`',
+            rendered,
+        )
+
+        with mock.patch(
+            "bnl_shared_brain_synthesis.revalidate_packet",
+            return_value=mock.Mock(valid=True, status="passed_owner"),
+        ):
+            self.assertEqual(
+                revalidate_basis(
+                    self.conn,
+                    owner_basis,
+                    environ=owner_flags,
+                ),
+                (True, "passed_owner"),
+            )
+            self.assertEqual(
+                revalidate_basis(
+                    self.conn,
+                    owner_basis,
+                    environ={
+                        **owner_flags,
+                        "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_ENABLED": (
+                            "false"
+                        ),
+                    },
+                ),
+                (False, "scope_disabled"),
+            )
 
     def test_renderer_excludes_current_intent_and_relationship_posture(self):
         (
@@ -1668,6 +1774,10 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             {"broad_self_profile": 1},
         )
         self.assertEqual(
+            report["authorityModeCounts"],
+            {"scoped_canary": 1},
+        )
+        self.assertEqual(
             report["candidateGenerationLatencyMs"],
             {"average": 125, "maximum": 125, "samples": 1},
         )
@@ -1943,6 +2053,7 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             "source_refs",
         }
         self.assertFalse(columns & forbidden)
+        self.assertIn("authority_mode", columns)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Converges direct first-person broad-profile requests in one configured `public_home` channel on the existing governed shared-brain packet as the single factual prompt owner.

- adds a separate default-off public-home route-owner gate
- limits the route to exactly one guild and one public-home channel
- keeps the requesting member as the subject without creating a second memory store
- makes the acceptance canary and route owner mutually exclusive
- preserves baseline-first generation, prompt replacement, selector, guard, source revalidation, exact-reply/current-turn authority, and deterministic fallback
- records `authority_mode` in content-free receipts and exposes route-owner state plus its kill switch in shadow diagnostics
- documents activation prerequisites and immediate rollback

## Why

The accepted shared-brain selector existed only behind the scoped acceptance-canary authority. Public-home broad recall therefore had no separately gated production owner and could continue to receive competing legacy factual context. This change promotes only that accepted route family while preserving every broader gate boundary.

## Safety / impact

- default off; this PR does not activate the route
- no global Memory Governance, Relationship v2, Active Engagement, or queue gate changes
- no backfill, migration of memory content, deployment, or website change
- any scope conflict, missing shadow prerequisite, active global live authority, revalidation failure, or kill-switch removal fails back to the established response
- receipt migration is additive and content-free

## Verification

- focused route-owner, synthesis, preview, and production-shaped suite: 78 tests passed
- full repository check: 1,821 tests passed
- compile and diff checks passed
- owner-identity privacy boundary verified

Tested complete tree: `008f36a16ea72fa44ee7c75aec97fe86363e48e7`
