### PR TITLE
Recognize sparse canon member memory

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -22,6 +22,7 @@ from bnl_canon_source_contract import (
     queue_usability,
     render_concise_public_schedule,
     render_founders,
+    render_key_personnel_canon_block,
     render_prompt_canon_block,
     strip_queue_sections,
 )
@@ -49,6 +50,7 @@ from bnl_memory_ledger import (
     LedgerWriteResult,
     backfill_atomic_knowledge_candidates,
     backfill_atomic_knowledge_lifecycle,
+    backfill_retained_conversation_ledger_entries,
     conversation_motif_formation_enabled,
     current_bnl_self_name_records,
     ensure_memory_ledger_schema,
@@ -147,6 +149,7 @@ from bnl_shared_brain_synthesis import (
     ensure_schema as ensure_shared_brain_synthesis_schema,
     evaluate_candidate as evaluate_shared_brain_synthesis_candidate,
     finalize_run as finalize_shared_brain_synthesis_run,
+    honest_empty_profile_response,
     profile_candidate_repairable,
     record_fallback as record_shared_brain_synthesis_fallback,
     revalidate_basis as revalidate_shared_brain_synthesis_basis,
@@ -1530,19 +1533,7 @@ Core Entities:
 - Studio Rats: Studio infestation. Some dimensions call them cats.
 - 9 Bit: [DATA RESTRICTED] — You know this entity exists but access is limited. Do not mention 9 Bit unless the user specifically mentions 9 Bit first.
 
-Key Personnel (core members + shorthand canon):
-- Cache Back:
-  - Function: BARCODE Archive specialist.
-  - Behavior: meticulous, detail-obsessed, protective of “lost” data and recovered fragments.
-  - Typical involvement: core member, recovers fragments.
-- DJ Floppydisc:
-  - Function: signal/audio engineer; stabilizes sound, cleans artifacts, handles mastering/final waveform integrity.
-  - Behavior: quiet professional, prefers to fix problems rather than talk about them.
-  - Typical involvement: core member. Mixes, masters all things BARCODE.
-- Mac Modem:
-  - Function: chaotic tech entity / glitch virus presence in the BARCODE ecosystem.
-  - Behavior: unpredictable, mischievous, sometimes disruptive; not reliably malicious, but risky.
-  - Typical involvement: unexpected distortions, UI corruption, broadcast anomalies
+{render_key_personnel_canon_block()}
 
 BARCODE history summary (canonical):
 - 6 Bit emerged from deleted audio project files, lost late-80s/90s media fragments, and prototype experimental AI technology.
@@ -5329,12 +5320,35 @@ def init_db():
             "completed": False,
             "counts": {},
         }
+        retained_conversation_backfill = {
+            "phase": "disabled",
+            "completed": False,
+            "counts": {},
+        }
         knowledge_lifecycle_backfill = {
             "phase": "disabled",
             "completed": False,
             "counts": {},
         }
         if memory_ledger_shadow_enabled():
+            try:
+                retained_conversation_backfill = (
+                    backfill_retained_conversation_ledger_entries(
+                        evidence_conn,
+                        batch_size=1000,
+                    )
+                )
+            except Exception as retained_exc:
+                logging.warning(
+                    "retained_conversation_ledger_backfill_failed "
+                    "error_type=%s",
+                    type(retained_exc).__name__,
+                )
+                retained_conversation_backfill = {
+                    "phase": "error",
+                    "completed": False,
+                    "counts": {"processing_error": 1},
+                }
             try:
                 knowledge_backfill = backfill_atomic_knowledge_candidates(
                     evidence_conn,
@@ -5405,6 +5419,13 @@ def init_db():
             orphan_reconciliation,
         )
     if memory_ledger_shadow_enabled():
+        logging.info(
+            "retained_conversation_ledger_backfill "
+            "phase=%s completed=%s counts=%s",
+            retained_conversation_backfill.get("phase"),
+            int(bool(retained_conversation_backfill.get("completed"))),
+            retained_conversation_backfill.get("counts"),
+        )
         logging.info(
             "atomic_knowledge_backfill phase=%s completed=%s counts=%s",
             knowledge_backfill.get("phase"),
@@ -21580,6 +21601,7 @@ def _build_unified_intelligence_packet_shadow(
     channel_id: int,
     current_text: str,
     current_speaker_user_ids: tuple[int, ...],
+    current_speaker_labels: tuple[str, ...],
     target_user_ids: tuple[int, ...],
     participant_user_ids: tuple[int, ...],
     conversation_evidence_items: tuple[ConversationEvidenceItem, ...],
@@ -21615,6 +21637,14 @@ def _build_unified_intelligence_packet_shadow(
         subject_user_id = current_speakers[0]
     else:
         subject_user_id = 0
+    speaker_labels_by_user_id = {
+        int(user_id): str(label or "")[:120]
+        for user_id, label in zip(
+            current_speakers,
+            tuple(current_speaker_labels or ()),
+        )
+        if int(user_id or 0) > 0 and str(label or "").strip()
+    }
     participants = tuple(
         dict.fromkeys(
             int(user_id or 0)
@@ -21649,6 +21679,10 @@ def _build_unified_intelligence_packet_shadow(
         subject_user_id=int(subject_user_id or 0),
         route_mode=str(route_mode or "unknown"),
         conversation_surface=str(conversation_surface or "unknown"),
+        subject_display_name=speaker_labels_by_user_id.get(
+            int(subject_user_id or 0),
+            "",
+        ),
         channel_id=int(channel_id or 0),
         channel_policy=str(channel_policy or "unknown"),
         visibility_allowance=visibility_allowance,
@@ -21837,6 +21871,7 @@ def build_unified_response_assessment_shadow(
         channel_id=channel_id,
         current_text=current_text,
         current_speaker_user_ids=current_speaker_user_ids,
+        current_speaker_labels=current_speaker_labels,
         target_user_ids=target_user_ids,
         participant_user_ids=participant_user_ids,
         conversation_evidence_items=semantic_evidence_items,
@@ -33185,6 +33220,46 @@ async def maybe_generate_shared_brain_synthesis_canary(
 
     if basis is None:
         return None
+    if basis.honest_empty_profile_fallback:
+        honest_response = honest_empty_profile_response()
+        try:
+            run = await asyncio.to_thread(
+                _begin_shared_brain_synthesis_receipt,
+                basis,
+                honest_response,
+                candidate_prompt_ready=False,
+                candidate_prompt_failure_reason=(
+                    "profile_sufficiency_empty"
+                ),
+                replaced_factual_context_count=0,
+            )
+        except Exception as exc:
+            logging.warning(
+                "shared_brain_empty_profile_receipt_failed error=%s",
+                type(exc).__name__,
+            )
+            return None
+        decision = SynthesisCanaryDecision(
+            run=run,
+            response=honest_response,
+            candidate_selected=False,
+            fallback_reason=(
+                run.fallback_reason
+                or "profile_sufficiency_empty_honest_fallback"
+            ),
+            comparison_status="not_comparable",
+            baseline_coherence_status="not_evaluated",
+            candidate_coherence_status="not_evaluated",
+            candidate_evidence_coverage_count=0,
+            revalidation_status=run.revalidation_status,
+        )
+        return SharedBrainSynthesisExecution(
+            decision=decision,
+            response=honest_response,
+            prompt=prompt,
+            prompt_source_bases=prompt_source_bases,
+            candidate_active=False,
+        )
     packet_owned_prompt = build_packet_owned_prompt(prompt, basis)
     try:
         run = await asyncio.to_thread(
@@ -36838,13 +36913,21 @@ async def execute_bnl_memory_preview(
                 ),
             )
 
+        honest_empty_profile = bool(
+            initial.basis is not None
+            and initial.basis.honest_empty_profile_fallback
+        )
         baseline_response = (
-            await generate(
-                initial.request.baseline_prompt,
-                "bnl_memory_preview_baseline",
-            )
-            or ""
-        ).strip()
+            honest_empty_profile_response()
+            if honest_empty_profile
+            else (
+                await generate(
+                    initial.request.baseline_prompt,
+                    "bnl_memory_preview_baseline",
+                )
+                or ""
+            ).strip()
+        )
         if not baseline_response:
             baseline_response = (
                 "I do not have enough eligible public-safe memory to give "
@@ -37188,6 +37271,8 @@ async def execute_bnl_memory_preview(
         final_selection = (
             "suppressed"
             if not proposed_response
+            else "honest_empty_profile_fallback"
+            if honest_empty_profile
             else "cleanup_salvage"
             if evaluation.candidate_selected and cleanup_salvage_applied
             else "cleanup_attempt"

--- a/bnl_canon_source_contract.py
+++ b/bnl_canon_source_contract.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from datetime import datetime, timezone, timedelta
+import re
 from typing import Any, Iterable
+import unicodedata
 
 CANON_SOURCE_CONTRACT_VERSION = "canon_source_contract_v1"
 
@@ -91,8 +93,35 @@ BARCODE = SubjectIdentity("barcode", "BARCODE", ("BARCODE collective",))
 BARCODE_NETWORK = SubjectIdentity("barcode_network", "BARCODE Network")
 BARCODE_RADIO = SubjectIdentity("barcode_radio", "BARCODE Radio")
 SIX_BIT = SubjectIdentity("6_bit", "6 Bit", ("Six Bit",))
+DJ_FLOPPYDISC = SubjectIdentity(
+    "dj_floppydisc",
+    "DJ Floppydisc",
+    ("DJ Floppy Disc",),
+)
+CACHE_BACK = SubjectIdentity(
+    "cache_back",
+    "Cache Back",
+    ("Call'em Bini", "Call’em Bini"),
+)
+MAC_MODEM = SubjectIdentity(
+    "mac_modem",
+    "Mac Modem",
+    ("Mac Mod3m",),
+)
 GALAKNOISE = SubjectIdentity("galaknoise", "GALAKNOISE")
 BNL01 = SubjectIdentity("bnl_01", "BNL-01", ("BNL", "BARCODE Network Liaison Entity"))
+
+CANON_MEMBER_IDENTITIES = (
+    SIX_BIT,
+    DJ_FLOPPYDISC,
+    CACHE_BACK,
+    MAC_MODEM,
+)
+AUTOMATIC_CANON_SIGNAL_IDENTITIES = (
+    DJ_FLOPPYDISC,
+    CACHE_BACK,
+    MAC_MODEM,
+)
 
 FOUNDING_MEMBERS = ("6 Bit", "DJ Floppydisc", "Cache Back", "Mac Modem")
 FRIDAY_PUBLIC_SCHEDULE = FridaySchedule("6:40 PM Pacific", "7:00 PM Pacific", "7:05 PM Pacific")
@@ -106,6 +135,15 @@ CANON_FACTS = (
     CanonFact(BARCODE, "founding_members", FOUNDING_MEMBERS),
     CanonFact(BARCODE_NETWORK, "origin", "The music and collective existed before BARCODE Network; the Network grew around that signal and now connects music, live broadcasts, community, software, archive, characters, and story."),
     CanonFact(SIX_BIT, "primary_identity", "artist, MC, host, and founding BARCODE member first"),
+    CanonFact(DJ_FLOPPYDISC, "primary_identity", "founding BARCODE member and signal/audio engineer who stabilizes sound, cleans artifacts, and handles mastering and final waveform integrity"),
+    CanonFact(DJ_FLOPPYDISC, "behavior", "quiet professional who prefers to fix problems rather than talk about them"),
+    CanonFact(DJ_FLOPPYDISC, "typical_involvement", "mixes and masters BARCODE material"),
+    CanonFact(CACHE_BACK, "primary_identity", "founding BARCODE member and BARCODE Archive specialist"),
+    CanonFact(CACHE_BACK, "behavior", "meticulous, detail-obsessed, and protective of lost data and recovered fragments"),
+    CanonFact(CACHE_BACK, "typical_involvement", "recovers fragments and protects archive continuity"),
+    CanonFact(MAC_MODEM, "primary_identity", "founding BARCODE member and chaotic tech entity / glitch-virus presence in the BARCODE ecosystem"),
+    CanonFact(MAC_MODEM, "behavior", "unpredictable, mischievous, and sometimes disruptive; not reliably malicious, but risky"),
+    CanonFact(MAC_MODEM, "typical_involvement", "unexpected distortions, interface corruption, and broadcast anomalies"),
     CanonFact(GALAKNOISE, "primary_role", "music producer for BARCODE"),
     CanonFact(BARCODE_RADIO, "public_nature", "real weekly live broadcast and community music space on TikTok"),
     CanonFact(BARCODE_RADIO, "friday_public_schedule", FRIDAY_PUBLIC_SCHEDULE),
@@ -178,6 +216,69 @@ _PROJECTION_CLASSES = {SourceClass.DERIVED_SUMMARY, SourceClass.SOURCE_FILE_PROJ
 
 def render_founders() -> str:
     return " • ".join(FOUNDING_MEMBERS)
+
+
+def normalize_canon_identity_label(value: Any) -> str:
+    """Normalize one same-platform display label for exact canon matching."""
+
+    cleaned = unicodedata.normalize("NFKC", str(value or ""))
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    cleaned = cleaned.strip(" \t\r\n,.;:!?\"'“”‘’")
+    if not cleaned or len(cleaned) > 80:
+        return ""
+    return cleaned.casefold()
+
+
+def matching_canon_member_identities(
+    labels: Iterable[Any],
+) -> tuple[SubjectIdentity, ...]:
+    """Return unique approved member subjects matched by exact labels only."""
+
+    normalized = set()
+    for label in labels:
+        normalized_label = normalize_canon_identity_label(label)
+        if normalized_label:
+            normalized.add(normalized_label)
+    if not normalized:
+        return ()
+    matches = []
+    for subject in CANON_MEMBER_IDENTITIES:
+        aliases = set()
+        for alias in (subject.name, *subject.aliases):
+            normalized_alias = normalize_canon_identity_label(alias)
+            if normalized_alias:
+                aliases.add(normalized_alias)
+        if normalized.intersection(aliases):
+            matches.append(subject)
+    return tuple(matches)
+
+
+def canon_facts_for_subject(
+    subject: SubjectIdentity,
+) -> tuple[CanonFact, ...]:
+    return tuple(
+        fact for fact in CANON_FACTS if fact.subject.key == subject.key
+    )
+
+
+def render_key_personnel_canon_block() -> str:
+    """Render the prompt shorthand from the structured canon facts."""
+
+    lines = ["Key Personnel (core members + shorthand canon):"]
+    for subject in (CACHE_BACK, DJ_FLOPPYDISC, MAC_MODEM):
+        facts = {
+            fact.predicate: str(fact.value)
+            for fact in canon_facts_for_subject(subject)
+        }
+        lines.extend(
+            (
+                f"- {subject.name}:",
+                f"  - Function: {facts['primary_identity']}.",
+                f"  - Behavior: {facts['behavior']}.",
+                f"  - Typical involvement: {facts['typical_involvement']}.",
+            )
+        )
+    return "\n".join(lines)
 
 def render_full_friday_schedule() -> str:
     return f"BARCODE Radio Friday schedule: submissions/intake begins at {FRIDAY_PUBLIC_SCHEDULE.intake_begins}; the show begins at {FRIDAY_PUBLIC_SCHEDULE.show_begins}; the first track is targeted for {FRIDAY_PUBLIC_SCHEDULE.first_track_target}."

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -32,6 +32,9 @@ from bnl_canon_source_contract import (
 MEMORY_LEDGER_SCHEMA_VERSION = "memory_ledger_v1"
 ATOMIC_KNOWLEDGE_SCHEMA_VERSION = "memory_ledger_atomic_knowledge_v1"
 ATOMIC_KNOWLEDGE_BACKFILL = "atomic_knowledge_backfill_v1"
+RETAINED_CONVERSATION_LEDGER_BACKFILL = (
+    "retained_conversation_ledger_backfill_v1"
+)
 ATOMIC_KNOWLEDGE_LIFECYCLE_SCHEMA_VERSION = (
     "memory_ledger_atomic_knowledge_lifecycle_v1"
 )
@@ -6128,6 +6131,227 @@ def form_atomic_candidates_from_moment(
 def _merge_backfill_count(counts: dict[str, int], outcome: str) -> None:
     key = str(outcome or "unknown")
     counts[key] = int(counts.get(key, 0) or 0) + 1
+
+
+def backfill_retained_conversation_ledger_entries(
+    conn: sqlite3.Connection,
+    *,
+    batch_size: int = 1000,
+    environ: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Project one bounded slice of retained public chat into the Ledger.
+
+    This is a resumable repair for conversation rows that predate the Ledger
+    adapter. It uses the ordinary Ledger writer, excludes non-public and model
+    rows, and explicitly disables motif formation so projection alone cannot
+    create or promote a durable member claim.
+    """
+
+    env = dict(os.environ if environ is None else environ)
+    if not shadow_enabled(env):
+        return {
+            "migration": RETAINED_CONVERSATION_LEDGER_BACKFILL,
+            "phase": "disabled",
+            "completed": False,
+            "counts": {},
+        }
+    ensure_memory_ledger_schema(conn)
+    columns = _conversation_projection_columns(conn)
+    required = {
+        "id",
+        "guild_id",
+        "user_id",
+        "role",
+        "content",
+        "channel_policy",
+    }
+    if not required.issubset(columns):
+        return {
+            "migration": RETAINED_CONVERSATION_LEDGER_BACKFILL,
+            "phase": "source_unavailable",
+            "completed": False,
+            "counts": {"retained_source_unavailable": 1},
+        }
+    safe_batch = max(1, min(int(batch_size or 1000), 2000))
+    state = conn.execute(
+        """
+        SELECT phase,cursor_value,completed,counts_json
+        FROM memory_ledger_knowledge_backfill
+        WHERE migration_key=?
+        """,
+        (RETAINED_CONVERSATION_LEDGER_BACKFILL,),
+    ).fetchone()
+    if state:
+        phase = str(state[0] or "conversations")
+        cursor = int(state[1] or 0)
+        completed = bool(state[2])
+        try:
+            counts = {
+                str(key): int(value or 0)
+                for key, value in json.loads(str(state[3] or "{}")).items()
+            }
+        except (TypeError, ValueError, json.JSONDecodeError):
+            counts = {}
+    else:
+        phase, cursor, completed, counts = "conversations", 0, False, {}
+        conn.execute(
+            """
+            INSERT INTO memory_ledger_knowledge_backfill(
+              migration_key,phase,cursor_value,completed,counts_json,updated_at
+            ) VALUES(?,?,?,?,?,?)
+            """,
+            (
+                RETAINED_CONVERSATION_LEDGER_BACKFILL,
+                phase,
+                "",
+                0,
+                "{}",
+                _now(),
+            ),
+        )
+    if completed:
+        return {
+            "migration": RETAINED_CONVERSATION_LEDGER_BACKFILL,
+            "phase": phase,
+            "completed": True,
+            "counts": counts,
+        }
+
+    optional = {
+        "user_name": "''",
+        "channel_name": "''",
+        "channel_id": "0",
+        "message_id": "NULL",
+        "timestamp": "''",
+    }
+    select = [
+        "c.id",
+        "c.user_id",
+        (
+            "c.user_name"
+            if "user_name" in columns
+            else "%s AS user_name" % optional["user_name"]
+        ),
+        "c.guild_id",
+        "c.content",
+        (
+            "c.channel_name"
+            if "channel_name" in columns
+            else "%s AS channel_name" % optional["channel_name"]
+        ),
+        "c.channel_policy",
+        (
+            "c.channel_id"
+            if "channel_id" in columns
+            else "%s AS channel_id" % optional["channel_id"]
+        ),
+        (
+            "c.message_id"
+            if "message_id" in columns
+            else "%s AS message_id" % optional["message_id"]
+        ),
+        (
+            "c.timestamp"
+            if "timestamp" in columns
+            else "%s AS timestamp" % optional["timestamp"]
+        ),
+    ]
+    cursor_filter = "AND c.id<?" if cursor > 0 else ""
+    parameters: tuple[Any, ...] = (
+        (cursor, safe_batch + 1)
+        if cursor > 0
+        else (safe_batch + 1,)
+    )
+    rows = conn.execute(
+        """
+        SELECT %s
+        FROM conversations c
+        LEFT JOIN memory_ledger_entries entry
+          ON entry.guild_id=c.guild_id
+         AND entry.source_table='conversations'
+         AND entry.source_row_id=CAST(c.id AS TEXT)
+         AND entry.source_role='user'
+        WHERE c.role='user'
+          AND c.guild_id>0 AND c.user_id>0
+          AND TRIM(c.content)<>''
+          AND c.channel_policy IN (
+            'public_home','public_context','public_selective'
+          )
+          AND entry.entry_id IS NULL
+          %s
+        ORDER BY c.id DESC
+        LIMIT ?
+        """
+        % (",".join(select), cursor_filter),
+        parameters,
+    ).fetchall()
+    batch = rows[:safe_batch]
+    keys = (
+        "id",
+        "user_id",
+        "user_name",
+        "guild_id",
+        "content",
+        "channel_name",
+        "channel_policy",
+        "channel_id",
+        "message_id",
+        "timestamp",
+    )
+    projection_env = dict(env)
+    projection_env[CONVERSATION_MOTIF_FORMATION_ENV] = "false"
+    for raw in reversed(batch):
+        row = dict(zip(keys, raw))
+        result = shadow_conversation_row(
+            conn,
+            row_id=int(row.get("id") or 0),
+            user_id=int(row.get("user_id") or 0),
+            user_name=str(row.get("user_name") or "")[:120],
+            guild_id=int(row.get("guild_id") or 0),
+            role="user",
+            content=str(row.get("content") or "")[:1000],
+            channel_name=str(row.get("channel_name") or "")[:80],
+            channel_policy=str(row.get("channel_policy") or ""),
+            channel_id=int(row.get("channel_id") or 0),
+            message_id=(int(row.get("message_id") or 0) or None),
+            route_mode="conversation_continuity",
+            observed_at=str(row.get("timestamp") or ""),
+            source_sequence=(
+                int(row.get("message_id") or 0)
+                or int(row.get("id") or 0)
+            ),
+            environ=projection_env,
+        )
+        _merge_backfill_count(counts, result.outcome)
+    counts["rows_scanned"] = int(counts.get("rows_scanned", 0) or 0) + len(
+        batch
+    )
+    if batch:
+        cursor = int(batch[-1][0] or 0)
+    completed = len(rows) <= safe_batch
+    if completed:
+        phase, cursor = "complete", 0
+    conn.execute(
+        """
+        UPDATE memory_ledger_knowledge_backfill
+        SET phase=?,cursor_value=?,completed=?,counts_json=?,updated_at=?
+        WHERE migration_key=?
+        """,
+        (
+            phase,
+            str(cursor or ""),
+            1 if completed else 0,
+            json.dumps(counts, sort_keys=True),
+            _now(),
+            RETAINED_CONVERSATION_LEDGER_BACKFILL,
+        ),
+    )
+    return {
+        "migration": RETAINED_CONVERSATION_LEDGER_BACKFILL,
+        "phase": phase,
+        "completed": completed,
+        "counts": counts,
+    }
 
 
 def backfill_atomic_knowledge_candidates(

--- a/bnl_memory_preview.py
+++ b/bnl_memory_preview.py
@@ -121,6 +121,8 @@ class MemoryPreviewDiagnostics:
     assessment_pool_selected_count: int = 0
     root_collapse_suppression_count: int = 0
     shared_root_projection_count: int = 0
+    canon_identity_status: str = "not_evaluated"
+    canon_identity_stable_row_count: int = 0
     profile_status: str = "not_applicable"
     profile_satisfied: bool = False
     profile_required_point_count: int = 0
@@ -756,6 +758,7 @@ def _packet_request(
         subject_user_id=int(request.subject_user_id or 0),
         route_mode=SIMULATED_ROUTE_MODE,
         conversation_surface=SIMULATED_CONVERSATION_SURFACE,
+        subject_display_name=str(request.subject_display_name or "")[:120],
         channel_id=int(request.simulated_channel_id or 0),
         channel_name=SIMULATED_CHANNEL_NAME,
         channel_policy=SIMULATED_CHANNEL_POLICY,
@@ -1014,6 +1017,16 @@ def _diagnostics(
         ),
         shared_root_projection_count=(
             int(packet.diagnostics.shared_root_projection_count or 0)
+            if packet is not None
+            else 0
+        ),
+        canon_identity_status=(
+            str(packet.diagnostics.canon_identity_status or "not_evaluated")
+            if packet is not None
+            else "not_evaluated"
+        ),
+        canon_identity_stable_row_count=(
+            int(packet.diagnostics.canon_identity_stable_row_count or 0)
             if packet is not None
             else 0
         ),
@@ -1583,6 +1596,11 @@ def render_content_free_diagnostics(
         % (
             diag.assessment_pool_eligible_count,
             diag.assessment_pool_selected_count,
+        ),
+        "- canon_identity_signal: `status=%s stable_public_rows=%s`"
+        % (
+            diag.canon_identity_status,
+            diag.canon_identity_stable_row_count,
         ),
         "- rendered_packet_lanes: `%s` project_canon_required=`%s`"
         % (

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -245,6 +245,11 @@ _PACKET_FACTUAL_OWNER_REPLACEMENT = (
     "Use only the selected evidence block below for stored member facts, "
     "observations, episodes, and unresolved threads."
 )
+_HONEST_EMPTY_PROFILE_RESPONSE = (
+    "I do not have enough reliable public history to summarize you without "
+    "guessing. I can respond to what you say here, but the longer-term "
+    "signal is still too thin for a grounded profile."
+)
 _PROFILE_PROJECT_SCOPE_RE = re.compile(
     r"\b(?:barcode(?:\s+(?:network|radio))?|project|collective|broadcast)\b",
     re.I,
@@ -538,6 +543,8 @@ class SharedBrainSynthesisBasis:
     profile_required_point_count: int = 0
     profile_required_detail_count: int = 0
     profile_requires_canon: bool = False
+    profile_recognized_canon_identity: bool = False
+    honest_empty_profile_fallback: bool = False
 
 
 @dataclass(frozen=True)
@@ -963,6 +970,94 @@ def _profile_sufficiency_usable(
     )
 
 
+def _empty_profile_usable(
+    packet: UnifiedIntelligencePacket | None,
+    assessment: UnifiedResponseAssessment | None,
+) -> bool:
+    if (
+        packet is None
+        or not isinstance(assessment, UnifiedResponseAssessment)
+    ):
+        return False
+    profile = getattr(packet, "profile_sufficiency", None)
+    return bool(
+        str(getattr(profile, "status", "") or "").strip().lower()
+        == "empty"
+        and not bool(getattr(profile, "satisfied", False))
+        and int(getattr(profile, "required_point_count", 0) or 0) == 0
+        and int(getattr(profile, "selected_point_count", 0) or 0) == 0
+        and int(getattr(profile, "independent_root_count", 0) or 0) == 0
+        and int(
+            getattr(profile, "independent_occurrence_count", 0) or 0
+        )
+        == 0
+        and assessment.profile_sufficiency_status == "empty"
+        and not assessment.profile_sufficiency_met
+        and assessment.profile_required_point_count == 0
+        and assessment.profile_selected_point_count == 0
+        and assessment.profile_independent_root_count == 0
+        and assessment.profile_independent_occurrence_count == 0
+    )
+
+
+def honest_empty_profile_response() -> str:
+    return _HONEST_EMPTY_PROFILE_RESPONSE
+
+
+def _empty_profile_fallback_scope_enabled(
+    *,
+    guild_id: int,
+    user_id: int,
+    channel_id: int,
+    route_mode: str,
+    channel_policy: str,
+    current_direct: bool,
+    user_text: str,
+    packet: UnifiedIntelligencePacket | None,
+    assessment: UnifiedResponseAssessment | None,
+    has_media: bool = False,
+    exact_quote_requested: bool = False,
+    third_party_attribution_requested: bool = False,
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    env = os.environ if environ is None else environ
+    return bool(
+        route_scope_enabled(
+            guild_id=guild_id,
+            user_id=user_id,
+            channel_id=channel_id,
+            route_mode=route_mode,
+            channel_policy=channel_policy,
+            current_direct=current_direct,
+            user_text=user_text,
+            has_media=has_media,
+            exact_quote_requested=exact_quote_requested,
+            third_party_attribution_requested=(
+                third_party_attribution_requested
+            ),
+            environ=env,
+        )
+        and _packet_usable(packet)
+        and _empty_profile_usable(packet, assessment)
+        and isinstance(assessment, UnifiedResponseAssessment)
+        and not (
+            set(assessment.selected_lanes)
+            & _NON_PACKET_FACTUAL_OWNER_LANES
+        )
+        and packet.request.guild_id == int(guild_id or 0)
+        and packet.request.subject_user_id == int(user_id or 0)
+        and packet.request.channel_id == int(channel_id or 0)
+        and packet.request.route_mode == _ROUTE_MODE
+        and packet.request.channel_policy
+        == str(channel_policy or "").strip().lower()
+        and packet.request.direct_state == "direct"
+        and assessment.guild_id == int(guild_id or 0)
+        and assessment.route_mode == _ROUTE_MODE
+        and assessment.channel_policy
+        == str(channel_policy or "").strip().lower()
+    )
+
+
 def scope_enabled(
     *,
     guild_id: int,
@@ -1087,12 +1182,33 @@ def _profile_requires_canon(
     packet: UnifiedIntelligencePacket,
 ) -> bool:
     return bool(
-        _PROFILE_PROJECT_SCOPE_RE.search(
-            str(packet.request.user_text or "")
+        _profile_recognized_canon_identity(packet)
+        or (
+            _PROFILE_PROJECT_SCOPE_RE.search(
+                str(packet.request.user_text or "")
+            )
+            and any(
+                item.lane == "canon"
+                and _canon_relevant_to_profile_request(packet, item)
+                for item in packet.items
+            )
         )
+    )
+
+
+def _profile_recognized_canon_identity(
+    packet: UnifiedIntelligencePacket,
+) -> bool:
+    return bool(
+        str(
+            getattr(packet.profile_sufficiency, "status", "") or ""
+        ).strip().lower()
+        == "sparse"
         and any(
             item.lane == "canon"
-            and _canon_relevant_to_profile_request(packet, item)
+            and item.source_type == "recognized_canon_fact"
+            and item.subject_key
+            == subject_key_for_user(packet.request.subject_user_id)
             for item in packet.items
         )
     )
@@ -1361,13 +1477,22 @@ def render_packet_context(
         )
     else:
         profile_rule = ""
+    recognized_identity = _profile_recognized_canon_identity(packet)
     project_rule = (
-        "- The request explicitly asks for BARCODE/project context. Use one "
-        "concise context anchor after the member assessment; canon may "
-        "clarify why the observed priorities fit BARCODE, but it must not "
-        "become the answer's organizing frame.\n"
-        if _profile_requires_canon(packet)
-        else ""
+        "- A unique, historically stable same-platform name signal matches "
+        "one approved BARCODE identity. State that approved identity "
+        "directly, then give exactly one narrow public observation. Treat "
+        "the match as recognition for this response, never as a permanent "
+        "account merge or proof of private identity.\n"
+        if recognized_identity
+        else (
+            "- The request explicitly asks for BARCODE/project context. Use "
+            "one concise context anchor after the member assessment; canon "
+            "may clarify why the observed priorities fit BARCODE, but it "
+            "must not become the answer's organizing frame.\n"
+            if _profile_requires_canon(packet)
+            else ""
+        )
     )
     request_angle_rule = (
         "- This request asks how the member works and makes decisions. State "
@@ -1384,10 +1509,16 @@ def render_packet_context(
         + "\nResponse rules:\n"
         "- Answer the current user naturally in BNL's established voice; do "
         "not recite this evidence as a database report.\n"
-        "- Lead with member-specific substance. Relevant BARCODE canon may "
-        "add one concise context anchor afterward, but can never substitute "
-        "for the public assessment or become its governing frame.\n"
-        "- Look across the selected observations for a useful throughline. "
+        + (
+            "- Lead with the approved recognized identity, then immediately "
+            "ground the rest in the single selected public observation.\n"
+            if recognized_identity
+            else "- Lead with member-specific substance. Relevant BARCODE "
+            "canon may add one concise context anchor afterward, but can "
+            "never substitute for the public assessment or become its "
+            "governing frame.\n"
+        )
+        + "- Look across the selected observations for a useful throughline. "
         "Separate what is directly known, what BNL has observed, and BNL's "
         "revisable opinion. Frame interpretation naturally as a read or "
         "impression instead of presenting it as a stored fact.\n"
@@ -1457,7 +1588,7 @@ def build_basis(
     environ: Mapping[str, str] | None = None,
 ) -> SharedBrainSynthesisBasis | None:
     env = os.environ if environ is None else environ
-    if not scope_enabled(
+    grounded_scope = scope_enabled(
         guild_id=guild_id,
         user_id=user_id,
         channel_id=channel_id,
@@ -1473,17 +1604,52 @@ def build_basis(
             third_party_attribution_requested
         ),
         environ=env,
+    )
+    empty_fallback_scope = bool(
+        not grounded_scope
+        and _empty_profile_fallback_scope_enabled(
+            guild_id=guild_id,
+            user_id=user_id,
+            channel_id=channel_id,
+            route_mode=route_mode,
+            channel_policy=channel_policy,
+            current_direct=current_direct,
+            user_text=user_text,
+            packet=packet,
+            assessment=assessment,
+            has_media=has_media,
+            exact_quote_requested=exact_quote_requested,
+            third_party_attribution_requested=(
+                third_party_attribution_requested
+            ),
+            environ=env,
+        )
+    )
+    if (
+        not grounded_scope
+        and not empty_fallback_scope
+    ):
+        return None
+    if packet is None or not isinstance(
+        assessment,
+        UnifiedResponseAssessment,
     ):
         return None
     authority_mode = str(configuration(env)["authority_mode"])
-    (
-        rendered,
-        lane_counts,
-        item_count,
-        source_digests,
-    ) = render_packet_context(packet)
-    if not rendered or not item_count:
-        return None
+    if empty_fallback_scope:
+        rendered = ""
+        lane_counts = ()
+        item_count = 0
+        source_digests = ()
+    else:
+        (
+            rendered,
+            lane_counts,
+            item_count,
+            source_digests,
+        ) = render_packet_context(packet)
+        if not rendered or not item_count:
+            return None
     factual_contexts = tuple(
         dict.fromkeys(
             str(value or "")
@@ -1529,6 +1695,10 @@ def build_basis(
             packet
         ),
         profile_requires_canon=_profile_requires_canon(packet),
+        profile_recognized_canon_identity=(
+            _profile_recognized_canon_identity(packet)
+        ),
+        honest_empty_profile_fallback=empty_fallback_scope,
     )
 
 
@@ -1599,9 +1769,18 @@ def revalidate_basis(
         != basis.profile_required_detail_count
         or _profile_requires_canon(basis.packet)
         != basis.profile_requires_canon
-        or not _profile_sufficiency_usable(
-            basis.packet,
-            basis.assessment,
+        or _profile_recognized_canon_identity(basis.packet)
+        != basis.profile_recognized_canon_identity
+        or (
+            not _empty_profile_usable(
+                basis.packet,
+                basis.assessment,
+            )
+            if basis.honest_empty_profile_fallback
+            else not _profile_sufficiency_usable(
+                basis.packet,
+                basis.assessment,
+            )
         )
     ):
         return False, "scope_or_basis_changed"
@@ -1622,6 +1801,12 @@ def build_packet_owned_prompt(
     """
 
     updated = str(prompt or "")
+    if basis.honest_empty_profile_fallback:
+        return PacketOwnedPrompt(
+            prompt=updated,
+            ready=False,
+            reason="profile_sufficiency_empty",
+        )
     if not updated.strip():
         return PacketOwnedPrompt(
             prompt=updated,
@@ -1765,10 +1950,14 @@ def build_profile_candidate_repair_prompt(
             "request. The claim audit below is controlling for the old draft."
         ),
         (
-            "Begin immediately with a concrete member-specific detail from a "
-            "KEEP_SUPPORTED unit or evidence line. A creative assessment may "
-            "share that opening sentence when it is explicitly tied to those "
-            "details; do not begin with an unframed broad label."
+            "Begin with the one approved recognized identity, then immediately "
+            "give the single concrete KEEP_SUPPORTED public observation. Do "
+            "not describe the match as a permanent account merge."
+            if basis.profile_recognized_canon_identity
+            else "Begin immediately with a concrete member-specific detail "
+            "from a KEEP_SUPPORTED unit or evidence line. A creative "
+            "assessment may share that opening sentence when it is explicitly "
+            "tied to those details; do not begin with an unframed broad label."
         ),
         (
             "Use at least %s materially distinct supported member points."
@@ -1790,9 +1979,12 @@ def build_profile_candidate_repair_prompt(
             else "Keep every personal claim within the supported evidence."
         ),
         (
-            "After the member assessment, use one concise relevant approved "
-            "BARCODE canon point as context. Do not organize the answer "
-            "around canon or let it displace public member evidence."
+            "Use the one approved recognized identity and exactly one public "
+            "observation; neither licenses a broader personality profile."
+            if basis.profile_recognized_canon_identity
+            else "After the member assessment, use one concise relevant "
+            "approved BARCODE canon point as context. Do not organize the "
+            "answer around canon or let it displace public member evidence."
             if basis.profile_requires_canon
             else "Use BARCODE canon only when it helps answer the request; it "
             "is not a required ingredient and must not become the answer's "
@@ -2523,7 +2715,10 @@ def candidate_profile_coverage(
     lore_dominant = bool(
         canon_only_claims
         and (
-            not member_first
+            (
+                not member_first
+                and not basis.profile_recognized_canon_identity
+            )
             or canon_only_claims > member_supported_claims
         )
     )

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -19,10 +19,15 @@ import uuid
 from typing import Any, Mapping, Sequence
 
 from bnl_canon_source_contract import (
+    AUTOMATIC_CANON_SIGNAL_IDENTITIES,
     CANON_FACTS,
+    CANON_MEMBER_IDENTITIES,
     CANON_SOURCE_CONTRACT_VERSION,
     Confidence,
     SourceClass,
+    SubjectIdentity,
+    matching_canon_member_identities,
+    normalize_canon_identity_label,
 )
 from bnl_memory_governance import (
     APPROVED_MEMBER_SCALAR_PREDICATES,
@@ -123,15 +128,27 @@ _BROAD_PROFILE_LANE_CAPS = {
     "canon": 1,
     "source_file": 1,
 }
-_PROFILE_MEMBER_EVIDENCE_LANES = frozenset(
+_PROFILE_DURABLE_MEMBER_EVIDENCE_LANES = frozenset(
     {"approved_fact", "atomic_knowledge", "moment"}
+)
+_PROFILE_MEMBER_EVIDENCE_LANES = (
+    _PROFILE_DURABLE_MEMBER_EVIDENCE_LANES
+    | {"assessment_observation"}
 )
 _PROFILE_CANON_MATCH_LANES = (
     _PROFILE_MEMBER_EVIDENCE_LANES
-    | {"assessment_observation", "conversation_context"}
+    | {"conversation_context"}
 )
 _ROOT_COLLAPSE_MEMBER_LANES = (
-    _PROFILE_MEMBER_EVIDENCE_LANES | {"conversation_context"}
+    _PROFILE_DURABLE_MEMBER_EVIDENCE_LANES
+    | {"conversation_context"}
+)
+_CANON_IDENTITY_MIN_STABLE_ROWS = 2
+_AUTOMATIC_CANON_SIGNAL_SUBJECT_KEYS = frozenset(
+    subject.key for subject in AUTOMATIC_CANON_SIGNAL_IDENTITIES
+)
+_CANON_MEMBER_SUBJECT_KEYS = frozenset(
+    subject.key for subject in CANON_MEMBER_IDENTITIES
 )
 _PROFILE_PROJECT_SCOPE_RE = re.compile(
     r"\b(?:barcode(?:\s+(?:network|radio))?|"
@@ -254,6 +271,7 @@ class IntelligencePacketRequest:
     subject_user_id: int
     route_mode: str
     conversation_surface: str
+    subject_display_name: str = ""
     channel_id: int = 0
     channel_name: str = ""
     channel_policy: str = "unknown"
@@ -317,6 +335,8 @@ class IntelligencePacketDiagnostics:
     duplicate_suppression: int = 0
     root_collapse_suppression: int = 0
     shared_root_projection_count: int = 0
+    canon_identity_status: str = "not_evaluated"
+    canon_identity_stable_row_count: int = 0
     processing_errors: list[str] = field(default_factory=list)
     invalid_invariants: list[str] = field(default_factory=list)
     revalidation_status: str = "not_evaluated"
@@ -345,6 +365,22 @@ class ProfileSufficiency:
     independent_root_count: int = 0
     independent_occurrence_count: int = 0
     reason_codes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class _CanonIdentitySignal:
+    status: str
+    subject: SubjectIdentity | None = None
+    stable_row_count: int = 0
+    evidence_digest: str = ""
+
+    @property
+    def recognized(self) -> bool:
+        return bool(
+            self.status == "recognized"
+            and self.subject is not None
+            and self.evidence_digest
+        )
 
 
 @dataclass(frozen=True)
@@ -501,6 +537,153 @@ def _stable_json(value: Any) -> str:
 def _digest(*values: Any) -> str:
     payload = "\x1f".join(_stable_json(value) for value in values)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _table_columns(
+    conn: sqlite3.Connection,
+    table_name: str,
+) -> set[str]:
+    if not conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (str(table_name or ""),),
+    ).fetchone():
+        return set()
+    return {
+        str(row[1] or "")
+        for row in conn.execute(
+            "PRAGMA table_info(%s)" % str(table_name or "")
+        ).fetchall()
+        if len(row) > 1 and str(row[1] or "")
+    }
+
+
+def _canon_identity_signal(
+    conn: sqlite3.Connection,
+    request: IntelligencePacketRequest,
+) -> _CanonIdentitySignal:
+    """Recognize one reversible same-platform canon signal.
+
+    This is deliberately not an account merge. A current exact approved label
+    must agree with at least two active public Ledger roots carrying that same
+    Discord label, and every current label must resolve unambiguously.
+    """
+
+    if (
+        int(request.guild_id or 0) <= 0
+        or int(request.subject_user_id or 0) <= 0
+    ):
+        return _CanonIdentitySignal("invalid_subject_scope")
+    labels = [str(request.subject_display_name or "")]
+    profile_columns = _table_columns(conn, "user_profiles")
+    if {
+        "guild_id",
+        "user_id",
+    }.issubset(profile_columns):
+        selected = tuple(
+            column
+            for column in ("display_name", "preferred_name")
+            if column in profile_columns
+        )
+        if selected:
+            row = conn.execute(
+                "SELECT %s FROM user_profiles WHERE guild_id=? AND user_id=?"
+                % ",".join(selected),
+                (
+                    int(request.guild_id or 0),
+                    int(request.subject_user_id or 0),
+                ),
+            ).fetchone()
+            if row:
+                labels.extend(str(value or "") for value in row)
+    current_labels = tuple(
+        dict.fromkeys(
+            normalized
+            for normalized in (
+                normalize_canon_identity_label(label) for label in labels
+            )
+            if normalized
+        )
+    )
+    if not current_labels:
+        return _CanonIdentitySignal("current_label_unavailable")
+    matches = tuple(
+        subject
+        for subject in matching_canon_member_identities(current_labels)
+        if subject.key in _AUTOMATIC_CANON_SIGNAL_SUBJECT_KEYS
+    )
+    if not matches:
+        return _CanonIdentitySignal("no_exact_canon_label")
+    if len(matches) != 1:
+        return _CanonIdentitySignal("ambiguous_canon_label")
+    subject = matches[0]
+    subject_key = subject_key_for_user(request.subject_user_id)
+    ledger_columns = _table_columns(conn, "memory_ledger_entries")
+    required_ledger_columns = {
+        "entry_id",
+        "guild_id",
+        "subject_key",
+        "subject_display_name",
+        "source_table",
+        "source_role",
+        "channel_policy",
+        "visibility",
+        "public_usable",
+        "derived",
+        "projection",
+        "lifecycle_status",
+    }
+    if not required_ledger_columns.issubset(ledger_columns):
+        return _CanonIdentitySignal("stable_history_unavailable")
+    history_rows = conn.execute(
+        """
+        SELECT entry_id,subject_display_name
+        FROM memory_ledger_entries
+        WHERE guild_id=? AND subject_key=?
+          AND source_table='conversations' AND source_role='user'
+          AND channel_policy IN (
+            'public_home','public_context','public_selective'
+          )
+          AND visibility IN ('public','public_safe')
+          AND public_usable=1 AND derived=0 AND projection=0
+          AND lifecycle_status='active'
+        ORDER BY observed_at DESC,source_sequence DESC,entry_id DESC
+        LIMIT 256
+        """,
+        (int(request.guild_id or 0), subject_key),
+    ).fetchall()
+    stable_rows = []
+    for entry_id, display_name in history_rows:
+        row_matches = matching_canon_member_identities((display_name,))
+        if len(row_matches) != 1 or row_matches[0].key != subject.key:
+            continue
+        stable_rows.append(
+            (
+                str(entry_id or ""),
+                normalize_canon_identity_label(display_name),
+            )
+        )
+    stable_rows = list(dict.fromkeys(stable_rows))
+    if len(stable_rows) < _CANON_IDENTITY_MIN_STABLE_ROWS:
+        return _CanonIdentitySignal(
+            "stable_history_insufficient",
+            subject=subject,
+            stable_row_count=len(stable_rows),
+        )
+    evidence_digest = _digest(
+        "same_platform_canon_signal_v1",
+        CANON_SOURCE_CONTRACT_VERSION,
+        int(request.guild_id or 0),
+        subject_key,
+        subject.key,
+        current_labels,
+        tuple(sorted(stable_rows)),
+    )
+    return _CanonIdentitySignal(
+        "recognized",
+        subject=subject,
+        stable_row_count=len(stable_rows),
+        evidence_digest=evidence_digest,
+    )
 
 
 def _terms(value: Any) -> set[str]:
@@ -667,12 +850,23 @@ def _profile_canon_anchor(
 ) -> IntelligencePacketItem | None:
     """Choose one canon point that best contextualizes selected public work."""
 
-    if (
-        not _broad_profile_request(request.user_text)
-        or not _profile_project_request(request.user_text)
-    ):
+    if not _broad_profile_request(request.user_text):
         return None
     subject = subject_key_for_user(request.subject_user_id)
+    recognized = tuple(
+        item
+        for item in candidates
+        if item.lane == "canon"
+        and item.source_type == "recognized_canon_fact"
+        and item.subject_key == subject
+    )
+    if recognized:
+        return sorted(
+            recognized,
+            key=lambda item: (-item.score, item.source_ref),
+        )[0]
+    if not _profile_project_request(request.user_text):
+        return None
     member_terms: set[str] = set()
     for item in candidates:
         if (
@@ -1982,7 +2176,21 @@ def _canon_digest(fact: Any) -> str:
     )
 
 
+def _recognized_canon_digest(
+    fact: Any,
+    signal: _CanonIdentitySignal,
+    subject_key: str,
+) -> str:
+    return _digest(
+        "recognized_canon_fact_v1",
+        _canon_digest(fact),
+        signal.evidence_digest,
+        str(subject_key or ""),
+    )
+
+
 def _canon_items(
+    conn: sqlite3.Connection,
     request: IntelligencePacketRequest,
     diagnostics: IntelligencePacketDiagnostics,
     exclusions: list[IntelligencePacketExclusion],
@@ -1991,7 +2199,78 @@ def _canon_items(
 ) -> list[IntelligencePacketItem]:
     items: list[IntelligencePacketItem] = []
     lowered = str(request.user_text or "").lower()
+    broad = _broad_profile_request(request.user_text)
+    subject_key = subject_key_for_user(request.subject_user_id)
+    signal = _canon_identity_signal(conn, request)
+    diagnostics.canon_identity_status = signal.status
+    diagnostics.canon_identity_stable_row_count = int(
+        signal.stable_row_count or 0
+    )
+    recognized_fact_keys = set()
+    if broad and signal.recognized and signal.subject is not None:
+        for fact in CANON_FACTS:
+            if fact.subject.key != signal.subject.key:
+                continue
+            recognized_fact_keys.add((fact.subject.key, fact.predicate))
+            value = _canon_value(fact.value)
+            fact_text = "%s %s: %s" % (
+                fact.subject.name,
+                fact.predicate.replace("_", " "),
+                value,
+            )
+            diagnostics.candidates_by_lane["canon"] = (
+                diagnostics.candidates_by_lane.get("canon", 0) + 1
+            )
+            source_digest = _recognized_canon_digest(
+                fact,
+                signal,
+                subject_key,
+            )
+            item = IntelligencePacketItem(
+                lane="canon",
+                source_class=fact.source_class.value,
+                source_type="recognized_canon_fact",
+                source_ref=(
+                    "canon_signal:%s:%s:%s"
+                    % (
+                        CANON_SOURCE_CONTRACT_VERSION,
+                        fact.subject.key,
+                        fact.predicate,
+                    )
+                ),
+                source_digest=source_digest,
+                subject_key=subject_key,
+                predicate_key=fact.predicate,
+                text=fact_text[:1000],
+                visibility=fact.visibility.value,
+                confidence=fact.confidence.value,
+                lifecycle="approved",
+                authority=_AUTHORITY_RANK[fact.source_class.value],
+                participants=(subject_key,),
+                observed_at="",
+                usage="content",
+                score=(
+                    120.0
+                    if fact.predicate == "primary_identity"
+                    else 104.0
+                ),
+                revalidation_kind="recognized_canon",
+                revalidation_key=source_digest,
+            )
+            if not _route_allows_item(request, item):
+                diagnostics.visibility_exclusions += 1
+                _add_exclusion(
+                    diagnostics,
+                    exclusions,
+                    lane="canon",
+                    reason="canon_visibility",
+                    source_class=item.source_class,
+                )
+                continue
+            items.append(item)
     for fact in CANON_FACTS:
+        if (fact.subject.key, fact.predicate) in recognized_fact_keys:
+            continue
         value = _canon_value(fact.value)
         fact_text = "%s %s: %s" % (
             fact.subject.name,
@@ -2004,6 +2283,11 @@ def _canon_items(
             for alias in aliases
             if alias
         )
+        if (
+            fact.subject.key in _CANON_MEMBER_SUBJECT_KEYS
+            and not alias_relevant
+        ):
+            continue
         if not alias_relevant and not (
             request_terms
             & (
@@ -2338,6 +2622,21 @@ def _select_items(
         exclusions,
     )
     canon_anchor = _profile_canon_anchor(request, candidates)
+    subject_key = subject_key_for_user(request.subject_user_id)
+    recognized_canon_signal = any(
+        item.lane == "canon"
+        and item.source_type == "recognized_canon_fact"
+        and item.subject_key == subject_key
+        for item in candidates
+    )
+    durable_member_candidate = any(
+        item.lane in _PROFILE_DURABLE_MEMBER_EVIDENCE_LANES
+        and item.subject_key == subject_key
+        and item.point_identity
+        and item.root_identities
+        and item.occurrence_identities
+        for item in candidates
+    )
     profile_candidates: list[IntelligencePacketItem] = []
     broad_lane_priority = {
         "current_intent": 0,
@@ -2376,7 +2675,14 @@ def _select_items(
     lane_counts: Counter[str] = Counter()
     used = 0
     budget = min(max(int(request.budget_chars or 2400), 400), 6000)
-    lane_caps = _BROAD_PROFILE_LANE_CAPS if broad else _LANE_CAPS
+    lane_caps = dict(
+        _BROAD_PROFILE_LANE_CAPS if broad else _LANE_CAPS
+    )
+    if broad and recognized_canon_signal and not durable_member_candidate:
+        # One stable canon-name signal may unlock one cautious historical
+        # example. It must never turn several isolated examples into a rich
+        # or durable personality profile.
+        lane_caps["assessment_observation"] = 1
     for item in ordered:
         item_roots = set(item.root_identities)
         if broad and _root_bearing_member_item(request, item) and item_roots:
@@ -2497,12 +2803,51 @@ def _profile_sufficiency(
             satisfied=True,
             reason_codes=("not_broad_profile",),
         )
-    candidate_items = tuple(
-        item for item in candidates if _profile_member_item(request, item)
+    durable_candidate_items = tuple(
+        item
+        for item in candidates
+        if _profile_member_item(request, item)
+        and item.lane in _PROFILE_DURABLE_MEMBER_EVIDENCE_LANES
     )
-    selected_items = tuple(
-        item for item in selected if _profile_member_item(request, item)
+    durable_selected_items = tuple(
+        item
+        for item in selected
+        if _profile_member_item(request, item)
+        and item.lane in _PROFILE_DURABLE_MEMBER_EVIDENCE_LANES
     )
+    recognized_canon_signal = any(
+        item.lane == "canon"
+        and item.source_type == "recognized_canon_fact"
+        and item.subject_key
+        == subject_key_for_user(request.subject_user_id)
+        for item in selected
+    )
+    observational_candidate_items = tuple(
+        item
+        for item in candidates
+        if _profile_member_item(request, item)
+        and item.lane == "assessment_observation"
+    )
+    observational_selected_items = tuple(
+        item
+        for item in selected
+        if _profile_member_item(request, item)
+        and item.lane == "assessment_observation"
+    )
+    observation_only = bool(
+        not durable_candidate_items
+        and recognized_canon_signal
+        and observational_candidate_items
+    )
+    if durable_candidate_items:
+        candidate_items = durable_candidate_items
+        selected_items = durable_selected_items
+    elif observation_only:
+        candidate_items = observational_candidate_items
+        selected_items = observational_selected_items
+    else:
+        candidate_items = ()
+        selected_items = ()
     candidate_points = {
         item.point_identity for item in candidate_items if item.point_identity
     }
@@ -2529,7 +2874,9 @@ def _profile_sufficiency(
     }
     candidate_point_count = len(candidate_points)
     required_points = (
-        2
+        1
+        if observation_only
+        else 2
         if candidate_point_count >= 2
         and len(candidate_occurrences) >= 2
         else 1
@@ -2541,7 +2888,11 @@ def _profile_sufficiency(
     if required_points == 0:
         status = "empty"
         satisfied = False
-        reasons.append("no_supported_member_evidence")
+        reasons.append(
+            "recognized_canon_without_supported_observation"
+            if recognized_canon_signal
+            else "no_supported_member_evidence"
+        )
     elif required_points == 1:
         satisfied = bool(
             len(selected_points) >= 1
@@ -2549,11 +2900,18 @@ def _profile_sufficiency(
             and len(selected_occurrences) >= 1
         )
         status = "sparse" if satisfied else "insufficient"
-        reasons.append(
-            "sparse_supported_member_evidence"
-            if satisfied
-            else "sparse_member_evidence_not_selected"
-        )
+        if observation_only:
+            reasons.append(
+                "recognized_canon_sparse_public_observation"
+                if satisfied
+                else "recognized_canon_observation_not_selected"
+            )
+        else:
+            reasons.append(
+                "sparse_supported_member_evidence"
+                if satisfied
+                else "sparse_member_evidence_not_selected"
+            )
     else:
         enough_points = len(selected_points) >= 2
         enough_roots = len(selected_roots) >= 2
@@ -2623,6 +2981,41 @@ def _canon_version(item: IntelligencePacketItem) -> str:
     return ""
 
 
+def _recognized_canon_version(
+    conn: sqlite3.Connection,
+    packet: UnifiedIntelligencePacket,
+    item: IntelligencePacketItem,
+) -> str:
+    signal = _canon_identity_signal(conn, packet.request)
+    if not signal.recognized or signal.subject is None:
+        return ""
+    parts = str(item.source_ref or "").split(":", 3)
+    if (
+        len(parts) != 4
+        or parts[0] != "canon_signal"
+        or parts[1] != CANON_SOURCE_CONTRACT_VERSION
+        or parts[2] != signal.subject.key
+    ):
+        return ""
+    predicate = parts[3]
+    fact = next(
+        (
+            candidate
+            for candidate in CANON_FACTS
+            if candidate.subject.key == signal.subject.key
+            and candidate.predicate == predicate
+        ),
+        None,
+    )
+    if fact is None:
+        return ""
+    return _recognized_canon_digest(
+        fact,
+        signal,
+        subject_key_for_user(packet.request.subject_user_id),
+    )
+
+
 def _relationship_version(
     conn: sqlite3.Connection,
     packet: UnifiedIntelligencePacket,
@@ -2665,6 +3058,12 @@ def revalidate_packet(
                 current = _atomic_candidate_digest(conn, item.revalidation_key)
             elif item.revalidation_kind == "canon":
                 current = _canon_version(item)
+            elif item.revalidation_kind == "recognized_canon":
+                current = _recognized_canon_version(
+                    conn,
+                    packet,
+                    item,
+                )
             elif item.revalidation_kind == "relationship":
                 current = _relationship_version(
                     conn,
@@ -2726,6 +3125,13 @@ def _packet_invariants(
             "provisional",
         }:
             invalid.append("atomic_state_violation")
+        if item.revalidation_kind == "recognized_canon" and not (
+            item.lane == "canon"
+            and item.source_type == "recognized_canon_fact"
+            and item.subject_key == subject
+            and item.source_class == SourceClass.APPROVED_CANON.value
+        ):
+            invalid.append("recognized_canon_scope_violation")
         if (
             item.revalidation_kind == "atomic"
             and item.source_class == SourceClass.LEGACY_SOURCE_BLIND.value
@@ -2812,6 +3218,7 @@ def build_packet(
         )
         candidates.extend(
             _canon_items(
+                conn,
                 request,
                 diagnostics,
                 exclusions,

--- a/docs/BNL01_PUBLIC_HOME_BROAD_RECALL_OWNER.md
+++ b/docs/BNL01_PUBLIC_HOME_BROAD_RECALL_OWNER.md
@@ -36,6 +36,42 @@ or when the packet and response-assessment shadows are unavailable.
 - Every candidate is revalidated before send; any failure returns to the
   established response.
 
+## Same-platform canon recognition
+
+Mac Modem, Cache Back, and DJ Floppydisc now have standalone facts in the
+structured canon contract. A broad self-profile may connect one of those
+identities to the requesting Discord account only when all of these conditions
+hold:
+
+- the member's current Discord display name is an exact, unambiguous approved
+  canon name or alias;
+- at least two active, public-safe conversation Ledger roots for that same
+  Discord user carry the same approved name; and
+- the signal still matches during send-time packet revalidation.
+
+The result is a reversible response-time recognition signal, not a persistent
+account merge or cross-platform identity claim. Near matches, ambiguous names,
+one-row names, private rows, and non-public routes do not qualify. The existing
+6 Bit owner path is unchanged.
+
+When the recognized member has no durable motif but does have public
+conversation evidence, the packet may select exactly one assessment
+observation and require cautious wording. That observation does not become a
+trait, Moment, or atomic-memory candidate. Stronger claims still require the
+existing independent-root and independent-occurrence thresholds.
+
+If a broad profile remains empty, the enabled owner route returns a fixed
+thin-record response rather than asking the model to improvise a biography.
+
+## Retained-conversation catch-up
+
+Startup runs one bounded, resumable pass through public retained user
+conversations that predate their Ledger projection. It uses the existing
+Ledger writer, excludes internal/sealed and model rows, and is idempotent.
+Motif formation is explicitly disabled during this pass, so catch-up alone
+cannot create or promote durable memory. Later restarts resume an unfinished
+slice from the recorded cursor.
+
 ## Diagnostics and rollback
 
 Content-free synthesis receipts record `authority_mode` as either

--- a/tests/test_canon_source_contract.py
+++ b/tests/test_canon_source_contract.py
@@ -73,6 +73,29 @@ class CanonSourceContractTests(unittest.TestCase):
         self.assertIn("GALAKNOISE is BARCODE's music producer", prompt_canon)
         self.assertNotIn("6 Bit is an artist, producer", prompt_canon)
 
+    def test_core_members_have_structured_canon_and_exact_aliases(self):
+        facts = {
+            (fact.subject.key, fact.predicate): str(fact.value)
+            for fact in c.CANON_FACTS
+        }
+        for subject in (c.DJ_FLOPPYDISC, c.CACHE_BACK, c.MAC_MODEM):
+            self.assertIn((subject.key, "primary_identity"), facts)
+            self.assertIn((subject.key, "behavior"), facts)
+            self.assertIn((subject.key, "typical_involvement"), facts)
+        self.assertEqual(
+            c.matching_canon_member_identities(("  mac modem!  ",)),
+            (c.MAC_MODEM,),
+        )
+        self.assertEqual(
+            c.matching_canon_member_identities(("Mac Modem Fan",)),
+            (),
+        )
+        prompt_block = c.render_key_personnel_canon_block()
+        self.assertIn("Mac Modem", prompt_block)
+        self.assertIn("DJ Floppydisc", prompt_block)
+        self.assertIn("Cache Back", prompt_block)
+        self.assertIn(prompt_block, BNL01_SYSTEM_PROMPT)
+
     def test_schedule_distinguishes_intake_show_first_track(self):
         self.assertEqual(c.FRIDAY_PUBLIC_SCHEDULE.intake_begins, "6:40 PM Pacific")
         self.assertEqual(c.FRIDAY_PUBLIC_SCHEDULE.show_begins, "7:00 PM Pacific")

--- a/tests/test_memory_preview_bot_path.py
+++ b/tests/test_memory_preview_bot_path.py
@@ -212,6 +212,45 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             "\n".join(result.diagnostics),
         )
 
+    async def test_empty_profile_skips_model_and_uses_honest_fallback(self):
+        generator = mock.AsyncMock(
+            return_value="Invented generic member biography."
+        )
+        guard = mock.AsyncMock(
+            side_effect=lambda response, _prompt: (
+                response,
+                {"suppressed": False, "suppression_reason": ""},
+            )
+        )
+
+        result = await bnl01_bot.execute_bnl_memory_preview(
+            source_db_path=self.db_path,
+            guild_id=1,
+            subject_user_id=8,
+            subject_display_name="Empty Member",
+            simulated_channel_id=10,
+            wording="BNL-01, what am I all about?",
+            generator=generator,
+            guard=guard,
+        )
+
+        generator.assert_not_awaited()
+        guard.assert_awaited_once()
+        self.assertFalse(result.candidate_selected)
+        self.assertEqual(
+            result.proposed_response,
+            bnl01_bot.honest_empty_profile_response(),
+        )
+        self.assertEqual(
+            result.established_response,
+            bnl01_bot.honest_empty_profile_response(),
+        )
+        self.assertEqual(result.fallback_reason, "profile_sufficiency_empty")
+        self.assertEqual(
+            result.final_selection,
+            "honest_empty_profile_fallback",
+        )
+
     async def test_rich_preview_repairs_one_category_only_draft(self):
         with sqlite3.connect(self.db_path) as conn:
             self._add_message(

--- a/tests/test_production_shaped_broad_recall_acceptance.py
+++ b/tests/test_production_shaped_broad_recall_acceptance.py
@@ -891,6 +891,121 @@ class ProductionShapedBroadRecallAcceptanceTests(unittest.TestCase):
         finally:
             prepared.close()
 
+    def test_stable_exact_canon_name_unlocks_one_cautious_observation(self):
+        self.add_raw_message(
+            user_id=111,
+            user_name="Mac Modem",
+            content=(
+                "I patched the signal meter so the interface stops "
+                "flickering."
+            ),
+            observed_at="2026-07-20T18:00:00+00:00",
+        )
+        self.add_raw_message(
+            user_id=111,
+            user_name="Mac Modem",
+            content=(
+                "Old modem tones could shape a short interlude in the "
+                "broadcast."
+            ),
+            observed_at="2026-07-22T18:00:00+00:00",
+        )
+        prepared = prepare_memory_preview(
+            self.request(
+                user_id=111,
+                user_name="Mac Modem",
+                wording="BNL, what am I all about?",
+            )
+        )
+        try:
+            self.assertTrue(prepared.ready)
+            self.assertEqual(prepared.diagnostics.profile_status, "sparse")
+            self.assertEqual(
+                prepared.diagnostics.canon_identity_status,
+                "recognized",
+            )
+            self.assertEqual(
+                prepared.diagnostics.canon_identity_stable_row_count,
+                2,
+            )
+            selected_observations = tuple(
+                item
+                for item in prepared.packet.items
+                if item.lane == "assessment_observation"
+            )
+            self.assertEqual(len(selected_observations), 1)
+            self.assertEqual(
+                {
+                    item.source_type
+                    for item in prepared.packet.items
+                    if item.lane == "canon"
+                },
+                {"recognized_canon_fact"},
+            )
+            self.assertFalse(
+                any(
+                    item.lane in {"atomic_knowledge", "moment"}
+                    for item in prepared.packet.items
+                )
+            )
+            evaluation = evaluate_memory_preview(
+                prepared,
+                baseline_response="The record is still thin.",
+                candidate_response=(
+                    "I recognize your signal as Mac Modem, a founding "
+                    "BARCODE member and chaotic tech entity. From your "
+                    "public appearances, I noticed you considering old "
+                    "modem tones for a short broadcast interlude."
+                ),
+            )
+            self.assertTrue(
+                evaluation.candidate_selected,
+                evaluation.fallback_reason,
+            )
+            self.assertEqual(evaluation.candidate_member_point_count, 1)
+            self.assertGreaterEqual(evaluation.candidate_canon_count, 1)
+        finally:
+            prepared.close()
+
+    def test_near_or_unstable_canon_name_does_not_resolve(self):
+        cases = (
+            (112, "Mac Modem Fan", "no_exact_canon_label"),
+            (113, "Mac Modem", "stable_history_insufficient"),
+        )
+        for user_id, user_name, expected_status in cases:
+            with self.subTest(user_name=user_name):
+                self.add_raw_message(
+                    user_id=user_id,
+                    user_name=user_name,
+                    content="I mentioned one isolated topic in passing.",
+                    observed_at="2026-07-22T18:00:00+00:00",
+                )
+                prepared = prepare_memory_preview(
+                    self.request(
+                        user_id=user_id,
+                        user_name=user_name,
+                        wording="BNL, what am I all about?",
+                    )
+                )
+                try:
+                    self.assertFalse(prepared.ready)
+                    self.assertEqual(
+                        prepared.diagnostics.profile_status,
+                        "empty",
+                    )
+                    self.assertEqual(
+                        prepared.diagnostics.canon_identity_status,
+                        expected_status,
+                    )
+                    self.assertFalse(
+                        any(
+                            item.source_type == "recognized_canon_fact"
+                            for item in prepared.packet.items
+                        )
+                    )
+                finally:
+                    prepared.close()
+
     def test_sparse_empty_and_ambiguous_profiles_do_not_invent_breadth(self):
         self.add_recurring_topic(
             user_id=106,

--- a/tests/test_production_shaped_memory_formation.py
+++ b/tests/test_production_shaped_memory_formation.py
@@ -1237,6 +1237,91 @@ class ProductionShapedMemoryFormationTests(unittest.TestCase):
             ],
         )
 
+    def test_retained_conversation_backfill_is_resumable_and_nonpromoting(self):
+        self.conn.execute(
+            """
+            CREATE TABLE conversations (
+              id INTEGER PRIMARY KEY,
+              guild_id INTEGER NOT NULL,
+              user_id INTEGER NOT NULL,
+              user_name TEXT,
+              role TEXT NOT NULL,
+              content TEXT NOT NULL,
+              channel_name TEXT,
+              channel_policy TEXT,
+              channel_id INTEGER,
+              message_id INTEGER,
+              timestamp TEXT
+            )
+            """
+        )
+        self.conn.executemany(
+            """
+            INSERT INTO conversations(
+              id,guild_id,user_id,user_name,role,content,channel_name,
+              channel_policy,channel_id,message_id,timestamp
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                (
+                    1, 1, 7, "Mac Modem", "user",
+                    "I adjusted a signal meter in the interface.",
+                    "barcode-bot", "public_home", 10, 7001,
+                    "2026-07-20T10:00:00+00:00",
+                ),
+                (
+                    2, 1, 7, "Mac Modem", "user",
+                    "Old modem tones could shape a short interlude.",
+                    "barcode-bot", "public_home", 10, 7002,
+                    "2026-07-22T10:00:00+00:00",
+                ),
+                (
+                    3, 1, 7, "Mac Modem", "user",
+                    "Internal planning must remain internal.",
+                    "operations", "internal_controlled", 12, 7003,
+                    "2026-07-23T10:00:00+00:00",
+                ),
+            ),
+        )
+
+        first = ledger.backfill_retained_conversation_ledger_entries(
+            self.conn,
+            batch_size=1,
+            environ=self.env,
+        )
+        second = ledger.backfill_retained_conversation_ledger_entries(
+            self.conn,
+            batch_size=1,
+            environ=self.env,
+        )
+        third = ledger.backfill_retained_conversation_ledger_entries(
+            self.conn,
+            batch_size=1,
+            environ=self.env,
+        )
+
+        self.assertFalse(first["completed"])
+        self.assertTrue(second["completed"])
+        self.assertEqual(second, third)
+        self.assertEqual(second["counts"]["rows_scanned"], 2)
+        self.assertEqual(second["counts"]["inserted"], 2)
+        projected = self.conn.execute(
+            """
+            SELECT source_row_id,subject_key,channel_policy
+            FROM memory_ledger_entries
+            WHERE source_table='conversations'
+            ORDER BY source_row_id
+            """
+        ).fetchall()
+        self.assertEqual(
+            projected,
+            [
+                ("1", "discord_user:7", "public_home"),
+                ("2", "discord_user:7", "public_home"),
+            ],
+        )
+        self.assertEqual(self.candidate_rows(), [])
+
     def test_motif_scan_reaches_supported_history_beyond_240_rows(self):
         started = datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc)
         self.add_conversation(

--- a/tests/test_shared_brain_synthesis_canary.py
+++ b/tests/test_shared_brain_synthesis_canary.py
@@ -1147,7 +1147,7 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
                     ),
                 )
 
-    def test_empty_or_canon_only_profile_cannot_enter_synthesis(self):
+    def test_empty_profile_uses_non_generative_honest_fallback_basis(self):
         self.conn.execute(
             """
             UPDATE memory_ledger_entries
@@ -1160,20 +1160,24 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
         self.assertEqual(packet.profile_sufficiency.status, "empty")
         self.assertFalse(packet.profile_sufficiency.satisfied)
         assessment = self._build_assessment(packet)
-        self.assertIsNone(
-            build_basis(
-                guild_id=1,
-                user_id=7,
-                channel_id=10,
-                route_mode="normal_chat",
-                channel_policy="public_context",
-                current_direct=True,
-                user_text=packet.request.user_text,
-                packet=packet,
-                assessment=assessment,
-                environ=self.flags,
-            )
+        basis = build_basis(
+            guild_id=1,
+            user_id=7,
+            channel_id=10,
+            route_mode="normal_chat",
+            channel_policy="public_context",
+            current_direct=True,
+            user_text=packet.request.user_text,
+            packet=packet,
+            assessment=assessment,
+            environ=self.flags,
         )
+        self.assertIsNotNone(basis)
+        self.assertTrue(basis.honest_empty_profile_fallback)
+        self.assertEqual(basis.rendered_context, "")
+        owned = build_packet_owned_prompt("Baseline prompt.", basis)
+        self.assertFalse(owned.ready)
+        self.assertEqual(owned.reason, "profile_sufficiency_empty")
 
     def test_malformed_profile_status_count_pairs_cannot_enter_synthesis(self):
         def basis_for(packet, assessment):


### PR DESCRIPTION
## Summary

- move Mac Modem, Cache Back, and DJ Floppydisc shorthand into the structured canon contract
- recognize an exact, unambiguous same-platform canon name only after two matching active public Ledger roots, without persisting an account merge
- let that recognized identity plus one public assessment observation form a cautious sparse profile while leaving durable recurrence thresholds unchanged
- replace empty broad-profile model improvisation with a fixed thin-record response
- run a bounded, resumable, public-only retained-conversation Ledger catch-up with motif formation disabled

## Safety boundaries

- the public-home broad-recall owner remains default-off and is not activated by this PR
- no deployment or production configuration changes
- no cross-platform identity binding, private identity projection, Relationship v2, Active Engagement, queue, Journal, Relay, or website changes
- near matches, ambiguous labels, one-row labels, internal/sealed rows, and stale send-time signals fail closed
- historical projection alone cannot create or promote an atomic-memory candidate

## Verification

- focused canon/Ledger/packet/synthesis/preview acceptance: 149 tests passed
- full repository check: 1,826 tests passed
- default-off verification: `requested=false`, `effective=false`, `authority_mode=none`
- local tested tree and GitHub tree: `b0638cf2d85208731bdb8a3b356e957459820c5b`
- verified parent: `951c928a7abcedb2ef1921d73d45267823f45cab`

## Post-merge acceptance

Deploy normally with the owner route still off. Verify the startup catch-up receipt, then run one owner-only non-persistent Mac Modem preview in `#bnl-testing`. No repeated public Discord canary is required. Activation remains a separate owner decision after that preview is grounded.