### PR TITLE
Preserve supported profile coverage in broad recall

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -33221,12 +33221,15 @@ async def maybe_generate_shared_brain_synthesis_canary(
     if basis is None:
         return None
     if basis.honest_empty_profile_fallback:
-        honest_response = honest_empty_profile_response()
+        fallback_response = (
+            str(baseline_response or "").strip()
+            or honest_empty_profile_response()
+        )
         try:
             run = await asyncio.to_thread(
                 _begin_shared_brain_synthesis_receipt,
                 basis,
-                honest_response,
+                fallback_response,
                 candidate_prompt_ready=False,
                 candidate_prompt_failure_reason=(
                     "profile_sufficiency_empty"
@@ -33241,7 +33244,7 @@ async def maybe_generate_shared_brain_synthesis_canary(
             return None
         decision = SynthesisCanaryDecision(
             run=run,
-            response=honest_response,
+            response=fallback_response,
             candidate_selected=False,
             fallback_reason=(
                 run.fallback_reason
@@ -33255,7 +33258,7 @@ async def maybe_generate_shared_brain_synthesis_canary(
         )
         return SharedBrainSynthesisExecution(
             decision=decision,
-            response=honest_response,
+            response=fallback_response,
             prompt=prompt,
             prompt_source_bases=prompt_source_bases,
             candidate_active=False,
@@ -36918,21 +36921,22 @@ async def execute_bnl_memory_preview(
             and initial.basis.honest_empty_profile_fallback
         )
         baseline_response = (
-            honest_empty_profile_response()
-            if honest_empty_profile
-            else (
-                await generate(
-                    initial.request.baseline_prompt,
-                    "bnl_memory_preview_baseline",
-                )
-                or ""
-            ).strip()
-        )
-        if not baseline_response:
-            baseline_response = (
-                "I do not have enough eligible public-safe memory to give "
-                "you a grounded profile without guessing."
+            await generate(
+                initial.request.baseline_prompt,
+                "bnl_memory_preview_baseline",
             )
+            or ""
+        ).strip()
+        used_honest_empty_fallback = False
+        if not baseline_response:
+            if honest_empty_profile:
+                baseline_response = honest_empty_profile_response()
+                used_honest_empty_fallback = True
+            else:
+                baseline_response = (
+                    "I do not have enough eligible public-safe memory to "
+                    "give you a grounded profile without guessing."
+                )
 
         candidate_response = ""
         candidate_prompt = (
@@ -37272,7 +37276,7 @@ async def execute_bnl_memory_preview(
             "suppressed"
             if not proposed_response
             else "honest_empty_profile_fallback"
-            if honest_empty_profile
+            if used_honest_empty_fallback
             else "cleanup_salvage"
             if evaluation.candidate_selected and cleanup_salvage_applied
             else "cleanup_attempt"

--- a/bnl_memory_preview.py
+++ b/bnl_memory_preview.py
@@ -49,7 +49,7 @@ from bnl_unified_response_assessment import (
 )
 
 
-PREVIEW_SCHEMA_VERSION = "bnl_memory_preview_v1"
+PREVIEW_SCHEMA_VERSION = "bnl_memory_preview_v2"
 SIMULATED_ROUTE_MODE = "normal_chat"
 SIMULATED_CHANNEL_POLICY = "public_home"
 SIMULATED_CHANNEL_NAME = "barcode-bot"
@@ -114,6 +114,7 @@ class MemoryPreviewDiagnostics:
     lifecycle_candidates: int = 0
     lifecycle_state_changes: int = 0
     packet_lane_counts: tuple[tuple[str, int], ...] = ()
+    validation_support_lane_counts: tuple[tuple[str, int], ...] = ()
     packet_exclusion_reason_counts: tuple[tuple[str, int], ...] = ()
     packet_missing_lanes: tuple[str, ...] = ()
     packet_revalidation_status: str = "not_evaluated"
@@ -182,7 +183,11 @@ class MemoryPreviewEvaluation:
     response: str
     candidate_selected: bool
     fallback_reason: str
+    baseline_member_point_count: int = 0
+    baseline_member_detail_count: int = 0
+    baseline_canon_count: int = 0
     candidate_member_point_count: int = 0
+    candidate_member_detail_count: int = 0
     candidate_member_root_count: int = 0
     candidate_member_occurrence_count: int = 0
     candidate_canon_count: int = 0
@@ -193,6 +198,7 @@ class MemoryPreviewEvaluation:
     candidate_connective_claim_count: int = 0
     candidate_unsupported_factual_claim_count: int = 0
     candidate_claim_classifications: tuple[str, ...] = ()
+    supported_coverage_regressed: bool = False
 
 
 @dataclass(frozen=True)
@@ -981,6 +987,15 @@ def _diagnostics(
             if packet is not None
             else ()
         ),
+        validation_support_lane_counts=(
+            tuple(
+                sorted(
+                    packet.diagnostics.validation_support_by_lane.items()
+                )
+            )
+            if packet is not None
+            else ()
+        ),
         packet_exclusion_reason_counts=exclusion_counts,
         packet_missing_lanes=missing_lanes,
         packet_revalidation_status=(
@@ -1337,8 +1352,18 @@ def evaluate_memory_preview(
         response=decision.response,
         candidate_selected=decision.candidate_selected,
         fallback_reason=decision.fallback_reason,
+        baseline_member_point_count=(
+            decision.baseline_member_point_coverage_count
+        ),
+        baseline_member_detail_count=(
+            decision.baseline_member_detail_coverage_count
+        ),
+        baseline_canon_count=decision.baseline_canon_coverage_count,
         candidate_member_point_count=(
             decision.candidate_member_point_coverage_count
+        ),
+        candidate_member_detail_count=(
+            decision.candidate_member_detail_coverage_count
         ),
         candidate_member_root_count=(
             decision.candidate_member_root_coverage_count
@@ -1368,6 +1393,9 @@ def evaluate_memory_preview(
         candidate_claim_classifications=(
             decision.candidate_claim_classifications
         ),
+        supported_coverage_regressed=(
+            decision.supported_coverage_regressed
+        ),
     )
 
 
@@ -1386,8 +1414,18 @@ def fallback_memory_preview(
             response=evaluation.response,
             candidate_selected=False,
             fallback_reason=str(reason or "preview_fallback"),
+            baseline_member_point_count=(
+                evaluation.baseline_member_point_count
+            ),
+            baseline_member_detail_count=(
+                evaluation.baseline_member_detail_count
+            ),
+            baseline_canon_count=evaluation.baseline_canon_count,
             candidate_member_point_count=(
                 evaluation.candidate_member_point_count
+            ),
+            candidate_member_detail_count=(
+                evaluation.candidate_member_detail_count
             ),
             candidate_member_root_count=(
                 evaluation.candidate_member_root_count
@@ -1417,6 +1455,9 @@ def fallback_memory_preview(
             candidate_claim_classifications=(
                 evaluation.candidate_claim_classifications
             ),
+            supported_coverage_regressed=(
+                evaluation.supported_coverage_regressed
+            ),
         )
     decision = record_fallback(
         prepared.connection,
@@ -1429,8 +1470,18 @@ def fallback_memory_preview(
         response=decision.response,
         candidate_selected=False,
         fallback_reason=decision.fallback_reason,
+        baseline_member_point_count=(
+            decision.baseline_member_point_coverage_count
+        ),
+        baseline_member_detail_count=(
+            decision.baseline_member_detail_coverage_count
+        ),
+        baseline_canon_count=decision.baseline_canon_coverage_count,
         candidate_member_point_count=(
             decision.candidate_member_point_coverage_count
+        ),
+        candidate_member_detail_count=(
+            decision.candidate_member_detail_coverage_count
         ),
         candidate_member_root_count=(
             decision.candidate_member_root_coverage_count
@@ -1459,6 +1510,9 @@ def fallback_memory_preview(
         ),
         candidate_claim_classifications=(
             decision.candidate_claim_classifications
+        ),
+        supported_coverage_regressed=(
+            decision.supported_coverage_regressed
         ),
     )
 
@@ -1495,8 +1549,18 @@ def reevaluate_memory_preview(
         response=decision.response,
         candidate_selected=decision.candidate_selected,
         fallback_reason=decision.fallback_reason,
+        baseline_member_point_count=(
+            decision.baseline_member_point_coverage_count
+        ),
+        baseline_member_detail_count=(
+            decision.baseline_member_detail_coverage_count
+        ),
+        baseline_canon_count=decision.baseline_canon_coverage_count,
         candidate_member_point_count=(
             decision.candidate_member_point_coverage_count
+        ),
+        candidate_member_detail_count=(
+            decision.candidate_member_detail_coverage_count
         ),
         candidate_member_root_count=(
             decision.candidate_member_root_coverage_count
@@ -1525,6 +1589,9 @@ def reevaluate_memory_preview(
         ),
         candidate_claim_classifications=(
             decision.candidate_claim_classifications
+        ),
+        supported_coverage_regressed=(
+            decision.supported_coverage_regressed
         ),
     )
 
@@ -1592,6 +1659,8 @@ def render_content_free_diagnostics(
             diag.lifecycle_state_changes,
         ),
         "- packet_lanes: `%s`" % dict(diag.packet_lane_counts),
+        "- validation_support_lanes: `%s`"
+        % dict(diag.validation_support_lane_counts),
         "- public_assessment_pool: `eligible=%s selected=%s`"
         % (
             diag.assessment_pool_eligible_count,
@@ -1644,16 +1713,23 @@ def render_content_free_diagnostics(
             diag.replaced_factual_context_count,
             diag.prompt_owner_reason or "none",
         ),
-        "- candidate_gate: `selected=%s fallback=%s points=%s "
-        "roots=%s occurrences=%s canon=%s member_claims=%s "
-        "canon_claims=%s opinions=%s connective=%s unsupported=%s`"
+        "- candidate_gate: `selected=%s fallback=%s baseline_points=%s "
+        "candidate_points=%s baseline_details=%s candidate_details=%s "
+        "roots=%s occurrences=%s baseline_canon=%s candidate_canon=%s "
+        "coverage_regressed=%s member_claims=%s canon_claims=%s "
+        "opinions=%s connective=%s unsupported=%s`"
         % (
             str(evaluation.candidate_selected).lower(),
             evaluation.fallback_reason or "none",
+            evaluation.baseline_member_point_count,
             evaluation.candidate_member_point_count,
+            evaluation.baseline_member_detail_count,
+            evaluation.candidate_member_detail_count,
             evaluation.candidate_member_root_count,
             evaluation.candidate_member_occurrence_count,
+            evaluation.baseline_canon_count,
             evaluation.candidate_canon_count,
+            str(evaluation.supported_coverage_regressed).lower(),
             evaluation.candidate_member_supported_claim_count,
             evaluation.candidate_canon_supported_claim_count,
             evaluation.candidate_opinion_claim_count,

--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -759,9 +759,11 @@ def _read_intelligence_packet_report(
         return _report_error(
             {
                 "tablePresent": False,
-                "schemaVersion": "unified_intelligence_packet_v2",
+                "schemaVersion": "unified_intelligence_packet_v3",
                 "runs": 0,
                 "itemTotal": 0,
+                "validationItemTotal": 0,
+                "validationByLane": {},
                 "selectedByLane": {},
                 "selectedBySourceClass": {},
                 "selectedAtomicStates": {},
@@ -798,7 +800,7 @@ def _read_shared_brain_synthesis_report(
         return _report_error(
             {
                 "tablePresent": False,
-                "schemaVersion": "shared_brain_synthesis_v4",
+                "schemaVersion": "shared_brain_synthesis_v5",
                 "runs": 0,
                 "promptAppliedRuns": 0,
                 "liveAppliedRuns": 0,
@@ -809,7 +811,12 @@ def _read_shared_brain_synthesis_report(
                 "baselineCoherenceStatusCounts": {},
                 "candidateCoherenceStatusCounts": {},
                 "candidateEvidenceCoverageTotal": 0,
+                "validationItemTotal": 0,
+                "baselineMemberPointCoverageTotal": 0,
+                "baselineMemberDetailCoverageTotal": 0,
+                "baselineCanonCoverageTotal": 0,
                 "candidateMemberPointCoverageTotal": 0,
+                "candidateMemberDetailCoverageTotal": 0,
                 "candidateMemberRootCoverageTotal": 0,
                 "candidateMemberOccurrenceCoverageTotal": 0,
                 "candidateCanonCoverageTotal": 0,
@@ -818,6 +825,7 @@ def _read_shared_brain_synthesis_report(
                 "candidateCanonSupportedClaimTotal": 0,
                 "candidateOpinionClaimTotal": 0,
                 "candidateConnectiveClaimTotal": 0,
+                "supportedCoverageRegressionRuns": 0,
                 "candidateUnsupportedFactualClaimTotal": 0,
                 "promptFactualOwnerRuns": 0,
                 "promptOwnershipFailureRuns": 0,
@@ -837,6 +845,7 @@ def _read_shared_brain_synthesis_report(
                 "liveInsufficientMemberCoverageRuns": 0,
                 "liveLoreDominantRuns": 0,
                 "liveUnsupportedFactualClaimRuns": 0,
+                "liveSupportedCoverageRegressionRuns": 0,
                 "livePromptOwnershipViolationRuns": 0,
                 "relationshipPostureAppliedRuns": 0,
                 "contentFieldsPresent": [],
@@ -1172,6 +1181,7 @@ def build_v2_shadow_acceptance_snapshot(
         "liveUngroundedRuns",
         "liveInsufficientMemberCoverageRuns",
         "liveUnsupportedFactualClaimRuns",
+        "liveSupportedCoverageRegressionRuns",
         "livePromptOwnershipViolationRuns",
         "relationshipPostureAppliedRuns",
     ):
@@ -1901,7 +1911,7 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             ),
         ),
         "- relationship_legacy_v2_comparison: `%s`" % relationship.get("legacy_v2_comparison", "not_collected"),
-        "- unified_intelligence_packet: status=`%s` requested=`%s` effective=`%s` reason=`%s` schema=`%s` runs=`%s` items=`%s` lanes=`%s` sources=`%s` atomic_states=`%s` missing=`%s` conflicts=`%s` revalidation=`%s` source_changes=`%s` errors=`%s` invalid_invariants=`%s` prompt_applied=`%s` live_applied=`%s` content_fields=`%s` window_last=`%s`" % (
+        "- unified_intelligence_packet: status=`%s` requested=`%s` effective=`%s` reason=`%s` schema=`%s` runs=`%s` items=`%s` validation_items=`%s` lanes=`%s` validation_lanes=`%s` sources=`%s` atomic_states=`%s` missing=`%s` conflicts=`%s` revalidation=`%s` source_changes=`%s` errors=`%s` invalid_invariants=`%s` prompt_applied=`%s` live_applied=`%s` content_fields=`%s` window_last=`%s`" % (
             intelligence_packet_state.get(
                 "status",
                 "unknown",
@@ -1911,12 +1921,17 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             intelligence_packet_state.get("reason", "disabled"),
             intelligence_packet.get(
                 "schemaVersion",
-                "unified_intelligence_packet_v2",
+                "unified_intelligence_packet_v3",
             ),
             intelligence_packet.get("runs", 0),
             intelligence_packet.get("itemTotal", 0),
+            intelligence_packet.get("validationItemTotal", 0),
             json.dumps(
                 intelligence_packet.get("selectedByLane", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                intelligence_packet.get("validationByLane", {}),
                 sort_keys=True,
             ),
             json.dumps(
@@ -1974,7 +1989,7 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
                 "none",
             ),
         ),
-        "- shared_brain_synthesis_canary: status=`%s` requested=`%s` effective=`%s` reason=`%s` fully_scoped=`%s` schema=`%s` runs=`%s` route_families=`%s` authority_modes=`%s` prompt_applied=`%s` candidate_selected=`%s` live_applied=`%s` responses_sent=`%s` fallbacks=`%s` fallback_reasons=`%s` comparison=`%s` baseline_coherence=`%s` candidate_coherence=`%s` evidence_coverage=`%s` member_points=`%s` member_roots=`%s` member_occurrences=`%s` canon_coverage=`%s` member_supported_claims=`%s` canon_supported_claims=`%s` opinion_claims=`%s` connective_claims=`%s` unsupported_factual_claims=`%s` prompt_factual_owner=`%s` prompt_owner_failures=`%s` candidate_latency_ms=`%s` revalidation=`%s` control_leaks=`%s` errors=`%s` invalid_scope=`%s` invalid_revalidation_live=`%s` ungrounded_live=`%s` insufficient_member_live=`%s` unsupported_factual_live=`%s` prompt_owner_violation_live=`%s` relationship_posture_applied=`%s` content_fields=`%s` window_last=`%s`" % (
+        "- shared_brain_synthesis_canary: status=`%s` requested=`%s` effective=`%s` reason=`%s` fully_scoped=`%s` schema=`%s` runs=`%s` route_families=`%s` authority_modes=`%s` prompt_applied=`%s` candidate_selected=`%s` live_applied=`%s` responses_sent=`%s` fallbacks=`%s` fallback_reasons=`%s` comparison=`%s` baseline_coherence=`%s` candidate_coherence=`%s` evidence_coverage=`%s` validation_items=`%s` baseline_points=`%s` baseline_details=`%s` baseline_canon=`%s` member_points=`%s` member_details=`%s` member_roots=`%s` member_occurrences=`%s` canon_coverage=`%s` coverage_regressions=`%s` member_supported_claims=`%s` canon_supported_claims=`%s` opinion_claims=`%s` connective_claims=`%s` unsupported_factual_claims=`%s` prompt_factual_owner=`%s` prompt_owner_failures=`%s` candidate_latency_ms=`%s` revalidation=`%s` control_leaks=`%s` errors=`%s` invalid_scope=`%s` invalid_revalidation_live=`%s` ungrounded_live=`%s` insufficient_member_live=`%s` unsupported_factual_live=`%s` coverage_regression_live=`%s` prompt_owner_violation_live=`%s` relationship_posture_applied=`%s` content_fields=`%s` window_last=`%s`" % (
             shared_brain_synthesis_state.get("status", "unknown"),
             _on(shared_brain_synthesis_state.get("requested")),
             _on(shared_brain_synthesis_state.get("effective")),
@@ -1982,7 +1997,7 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             _on(shared_brain_synthesis_state.get("fullyScoped")),
             shared_brain_synthesis.get(
                 "schemaVersion",
-                "shared_brain_synthesis_v4",
+                "shared_brain_synthesis_v5",
             ),
             shared_brain_synthesis.get("runs", 0),
             json.dumps(
@@ -2027,8 +2042,25 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
                 "candidateEvidenceCoverageTotal",
                 0,
             ),
+            shared_brain_synthesis.get("validationItemTotal", 0),
+            shared_brain_synthesis.get(
+                "baselineMemberPointCoverageTotal",
+                0,
+            ),
+            shared_brain_synthesis.get(
+                "baselineMemberDetailCoverageTotal",
+                0,
+            ),
+            shared_brain_synthesis.get(
+                "baselineCanonCoverageTotal",
+                0,
+            ),
             shared_brain_synthesis.get(
                 "candidateMemberPointCoverageTotal",
+                0,
+            ),
+            shared_brain_synthesis.get(
+                "candidateMemberDetailCoverageTotal",
                 0,
             ),
             shared_brain_synthesis.get(
@@ -2041,6 +2073,10 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             ),
             shared_brain_synthesis.get(
                 "candidateCanonCoverageTotal",
+                0,
+            ),
+            shared_brain_synthesis.get(
+                "supportedCoverageRegressionRuns",
                 0,
             ),
             shared_brain_synthesis.get(
@@ -2096,6 +2132,10 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             ),
             shared_brain_synthesis.get(
                 "liveUnsupportedFactualClaimRuns",
+                0,
+            ),
+            shared_brain_synthesis.get(
+                "liveSupportedCoverageRegressionRuns",
                 0,
             ),
             shared_brain_synthesis.get(

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -37,7 +37,7 @@ from bnl_unified_response_assessment import (
 )
 
 
-SCHEMA_VERSION = "shared_brain_synthesis_v4"
+SCHEMA_VERSION = "shared_brain_synthesis_v5"
 TABLE_NAME = "memory_governance_shared_brain_synthesis_runs"
 ENABLED_ENV = "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_ENABLED"
 GUILD_IDS_ENV = "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_GUILD_IDS"
@@ -568,7 +568,11 @@ class SynthesisCanaryDecision:
     candidate_evidence_coverage_count: int
     revalidation_status: str
     candidate_generation_latency_ms: int = 0
+    baseline_member_point_coverage_count: int = 0
+    baseline_member_detail_coverage_count: int = 0
+    baseline_canon_coverage_count: int = 0
     candidate_member_point_coverage_count: int = 0
+    candidate_member_detail_coverage_count: int = 0
     candidate_member_root_coverage_count: int = 0
     candidate_member_occurrence_coverage_count: int = 0
     candidate_canon_coverage_count: int = 0
@@ -579,6 +583,7 @@ class SynthesisCanaryDecision:
     candidate_connective_claim_count: int = 0
     candidate_unsupported_factual_claim_count: int = 0
     candidate_claim_classifications: tuple[str, ...] = ()
+    supported_coverage_regressed: bool = False
 
 
 @dataclass(frozen=True)
@@ -616,6 +621,9 @@ class CandidateProfileCoverage:
     connective_claim_count: int = 0
     unsupported_factual_claim_count: int = 0
     claim_classifications: tuple[str, ...] = ()
+    covered_member_point_identities: tuple[str, ...] = ()
+    covered_member_detail_point_identities: tuple[str, ...] = ()
+    covered_canon_source_digests: tuple[str, ...] = ()
 
 
 def _flag(value: Any) -> bool:
@@ -2582,14 +2590,12 @@ def candidate_profile_coverage(
     if not _candidate_claim_units(response):
         return CandidateProfileCoverage()
     response_terms = _semantic_terms(_factual_candidate_text(response))
-    rendered_items = tuple(
-        item
-        for item in basis.packet.items
-        if item.source_digest in basis.rendered_source_digests
+    validation_items = tuple(
+        getattr(basis.packet, "validation_items", ()) or basis.packet.items
     )
     member_items = tuple(
         item
-        for item in rendered_items
+        for item in validation_items
         if item.lane in _PROFILE_MEMBER_LANES
         and item.point_identity
     )
@@ -2642,7 +2648,7 @@ def candidate_profile_coverage(
 
     covered_items = tuple(
         item
-        for item in rendered_items
+        for item in validation_items
         if response_terms & _semantic_terms(_item_evidence_text(item))
     )
     covered_member_items = tuple(
@@ -2682,16 +2688,16 @@ def candidate_profile_coverage(
     }
     covered_canon = tuple(
         item
-        for item in rendered_items
+        for item in validation_items
         if item.lane == "canon"
-        and response_terms & _item_profile_terms(item)
+        and len(response_terms & _item_profile_terms(item)) >= 2
     )
     canon_items = tuple(
-        item for item in rendered_items if item.lane == "canon"
+        item for item in validation_items if item.lane == "canon"
     )
     claim_member_items = tuple(
         item
-        for item in rendered_items
+        for item in validation_items
         if item.lane in _CLAIM_MEMBER_LANES
     )
     (
@@ -2739,6 +2745,13 @@ def candidate_profile_coverage(
         connective_claim_count=connective_claims,
         unsupported_factual_claim_count=unsupported_factual_claims,
         claim_classifications=claim_classifications,
+        covered_member_point_identities=tuple(sorted(covered_points)),
+        covered_member_detail_point_identities=tuple(
+            sorted(covered_detail_points)
+        ),
+        covered_canon_source_digests=tuple(
+            sorted(item.source_digest for item in covered_canon)
+        ),
     )
 
 
@@ -2747,6 +2760,25 @@ def candidate_evidence_coverage(
     response: str,
 ) -> int:
     return candidate_profile_coverage(basis, response).total_item_count
+
+
+def _supported_profile_coverage_regressed(
+    baseline: CandidateProfileCoverage,
+    candidate: CandidateProfileCoverage,
+) -> bool:
+    """Return whether a candidate drops exact safe support used by baseline."""
+
+    return bool(
+        not set(baseline.covered_member_point_identities).issubset(
+            candidate.covered_member_point_identities
+        )
+        or not set(
+            baseline.covered_member_detail_point_identities
+        ).issubset(candidate.covered_member_detail_point_identities)
+        or not set(baseline.covered_canon_source_digests).issubset(
+            candidate.covered_canon_source_digests
+        )
+    )
 
 
 def ensure_schema(conn: sqlite3.Connection) -> None:
@@ -2765,6 +2797,7 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             route_mode TEXT NOT NULL,
             channel_policy TEXT NOT NULL,
             packet_item_count INTEGER NOT NULL DEFAULT 0,
+            validation_item_count INTEGER NOT NULL DEFAULT 0,
             rendered_item_count INTEGER NOT NULL DEFAULT 0,
             rendered_lane_counts_json TEXT NOT NULL DEFAULT '{}',
             packet_digest TEXT NOT NULL,
@@ -2782,7 +2815,11 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             baseline_coherence_status TEXT NOT NULL DEFAULT 'not_evaluated',
             candidate_coherence_status TEXT NOT NULL DEFAULT 'not_evaluated',
             candidate_evidence_coverage_count INTEGER NOT NULL DEFAULT 0,
+            baseline_member_point_coverage_count INTEGER NOT NULL DEFAULT 0,
+            baseline_member_detail_coverage_count INTEGER NOT NULL DEFAULT 0,
+            baseline_canon_coverage_count INTEGER NOT NULL DEFAULT 0,
             candidate_member_point_coverage_count INTEGER NOT NULL DEFAULT 0,
+            candidate_member_detail_coverage_count INTEGER NOT NULL DEFAULT 0,
             candidate_member_root_coverage_count INTEGER NOT NULL DEFAULT 0,
             candidate_member_occurrence_coverage_count INTEGER NOT NULL DEFAULT 0,
             candidate_canon_coverage_count INTEGER NOT NULL DEFAULT 0,
@@ -2793,6 +2830,7 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             candidate_connective_claim_count INTEGER NOT NULL DEFAULT 0,
             candidate_unsupported_factual_claim_count INTEGER NOT NULL DEFAULT 0,
             candidate_claim_classification_counts_json TEXT NOT NULL DEFAULT '{}',
+            supported_coverage_regressed INTEGER NOT NULL DEFAULT 0,
             candidate_output_leak INTEGER NOT NULL DEFAULT 0,
             profile_sufficiency_status TEXT NOT NULL DEFAULT 'not_applicable',
             profile_required_point_count INTEGER NOT NULL DEFAULT 0,
@@ -2840,8 +2878,25 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             """
         )
     for column, definition in (
+        ("validation_item_count", "INTEGER NOT NULL DEFAULT 0"),
+        (
+            "baseline_member_point_coverage_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "baseline_member_detail_coverage_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "baseline_canon_coverage_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
         (
             "candidate_member_point_coverage_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "candidate_member_detail_coverage_count",
             "INTEGER NOT NULL DEFAULT 0",
         ),
         (
@@ -2881,6 +2936,7 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             "candidate_claim_classification_counts_json",
             "TEXT NOT NULL DEFAULT '{}'",
         ),
+        ("supported_coverage_regressed", "INTEGER NOT NULL DEFAULT 0"),
         (
             "profile_sufficiency_status",
             "TEXT NOT NULL DEFAULT 'not_applicable'",
@@ -2960,7 +3016,17 @@ def begin_run(
         fallback_reason = "packet_receipt_update_failed"
         processing_errors = 1
     source_ref_digest = _digest(
-        tuple(sorted(item.source_ref for item in basis.packet.items))
+        tuple(
+            sorted(
+                {
+                    item.source_ref
+                    for item in (
+                        *basis.packet.items,
+                        *getattr(basis.packet, "validation_items", ()),
+                    )
+                }
+            )
+        )
     )
     timestamp = created_at or _now()
     conn.execute(
@@ -3012,6 +3078,17 @@ def begin_run(
     )
     conn.execute(
         """
+        UPDATE memory_governance_shared_brain_synthesis_runs
+        SET validation_item_count=?
+        WHERE run_id=?
+        """,
+        (
+            len(getattr(basis.packet, "validation_items", ())),
+            run_id,
+        ),
+    )
+    conn.execute(
+        """
         DELETE FROM memory_governance_shared_brain_synthesis_runs
         WHERE guild_id=? AND run_id NOT IN (
           SELECT run_id
@@ -3055,9 +3132,17 @@ def evaluate_candidate(
         run.basis.assessment,
         candidate,
     )
+    baseline_coverage = candidate_profile_coverage(
+        run.basis,
+        baseline,
+    )
     profile_coverage = candidate_profile_coverage(
         run.basis,
         candidate,
+    )
+    supported_coverage_regressed = _supported_profile_coverage_regressed(
+        baseline_coverage,
+        profile_coverage,
     )
     evidence_coverage = profile_coverage.total_item_count
     output_leak = response_exposes_controls(candidate)
@@ -3122,6 +3207,8 @@ def evaluate_candidate(
         fallback_reason = "candidate_request_angle_missed"
     elif profile_coverage.unsupported_factual_claim_count > 0:
         fallback_reason = "candidate_claims_ungrounded"
+    elif supported_coverage_regressed:
+        fallback_reason = "candidate_supported_coverage_regressed"
     elif coherence_rank.get(candidate_coherence.status, 0) < coherence_rank.get(
         baseline_coherence.status,
         0,
@@ -3139,7 +3226,11 @@ def evaluate_candidate(
             ),comparison_status=?,
             baseline_coherence_status=?,candidate_coherence_status=?,
             candidate_evidence_coverage_count=?,candidate_output_leak=?,
+            baseline_member_point_coverage_count=?,
+            baseline_member_detail_coverage_count=?,
+            baseline_canon_coverage_count=?,
             candidate_member_point_coverage_count=?,
+            candidate_member_detail_coverage_count=?,
             candidate_member_root_coverage_count=?,
             candidate_member_occurrence_coverage_count=?,
             candidate_canon_coverage_count=?,candidate_lore_dominant=?,
@@ -3149,6 +3240,7 @@ def evaluate_candidate(
             candidate_connective_claim_count=?,
             candidate_unsupported_factual_claim_count=?,
             candidate_claim_classification_counts_json=?,
+            supported_coverage_regressed=?,
             revalidation_status=?,
             candidate_selected=?,fallback_reason=?,
             processing_error_count=processing_error_count+?,
@@ -3169,7 +3261,11 @@ def evaluate_candidate(
             candidate_coherence.status,
             evidence_coverage,
             int(output_leak),
+            baseline_coverage.member_point_count,
+            baseline_coverage.member_detail_point_count,
+            baseline_coverage.canon_item_count,
             profile_coverage.member_point_count,
+            profile_coverage.member_detail_point_count,
             profile_coverage.member_root_count,
             profile_coverage.member_occurrence_count,
             profile_coverage.canon_item_count,
@@ -3183,6 +3279,7 @@ def evaluate_candidate(
                 dict(Counter(profile_coverage.claim_classifications)),
                 sort_keys=True,
             ),
+            int(supported_coverage_regressed),
             revalidation_status,
             int(candidate_selected),
             fallback_reason,
@@ -3213,8 +3310,18 @@ def evaluate_candidate(
         candidate_evidence_coverage_count=evidence_coverage,
         revalidation_status=revalidation_status,
         candidate_generation_latency_ms=stored_latency,
+        baseline_member_point_coverage_count=(
+            baseline_coverage.member_point_count
+        ),
+        baseline_member_detail_coverage_count=(
+            baseline_coverage.member_detail_point_count
+        ),
+        baseline_canon_coverage_count=baseline_coverage.canon_item_count,
         candidate_member_point_coverage_count=(
             profile_coverage.member_point_count
+        ),
+        candidate_member_detail_coverage_count=(
+            profile_coverage.member_detail_point_count
         ),
         candidate_member_root_coverage_count=(
             profile_coverage.member_root_count
@@ -3242,6 +3349,7 @@ def evaluate_candidate(
         candidate_claim_classifications=(
             profile_coverage.claim_classifications
         ),
+        supported_coverage_regressed=supported_coverage_regressed,
     )
 
 
@@ -3289,8 +3397,20 @@ def record_fallback(
         candidate_generation_latency_ms=(
             decision.candidate_generation_latency_ms
         ),
+        baseline_member_point_coverage_count=(
+            decision.baseline_member_point_coverage_count
+        ),
+        baseline_member_detail_coverage_count=(
+            decision.baseline_member_detail_coverage_count
+        ),
+        baseline_canon_coverage_count=(
+            decision.baseline_canon_coverage_count
+        ),
         candidate_member_point_coverage_count=(
             decision.candidate_member_point_coverage_count
+        ),
+        candidate_member_detail_coverage_count=(
+            decision.candidate_member_detail_coverage_count
         ),
         candidate_member_root_coverage_count=(
             decision.candidate_member_root_coverage_count
@@ -3319,6 +3439,9 @@ def record_fallback(
         ),
         candidate_claim_classifications=(
             decision.candidate_claim_classifications
+        ),
+        supported_coverage_regressed=(
+            decision.supported_coverage_regressed
         ),
     )
 
@@ -3384,7 +3507,12 @@ def _empty_report() -> dict[str, Any]:
         "baselineCoherenceStatusCounts": {},
         "candidateCoherenceStatusCounts": {},
         "candidateEvidenceCoverageTotal": 0,
+        "validationItemTotal": 0,
+        "baselineMemberPointCoverageTotal": 0,
+        "baselineMemberDetailCoverageTotal": 0,
+        "baselineCanonCoverageTotal": 0,
         "candidateMemberPointCoverageTotal": 0,
+        "candidateMemberDetailCoverageTotal": 0,
         "candidateMemberRootCoverageTotal": 0,
         "candidateMemberOccurrenceCoverageTotal": 0,
         "candidateCanonCoverageTotal": 0,
@@ -3394,6 +3522,7 @@ def _empty_report() -> dict[str, Any]:
         "candidateOpinionClaimTotal": 0,
         "candidateConnectiveClaimTotal": 0,
         "candidateUnsupportedFactualClaimTotal": 0,
+        "supportedCoverageRegressionRuns": 0,
         "promptFactualOwnerRuns": 0,
         "promptOwnershipFailureRuns": 0,
         "routeFamilyCounts": {},
@@ -3413,6 +3542,7 @@ def _empty_report() -> dict[str, Any]:
         "liveInsufficientMemberCoverageRuns": 0,
         "liveLoreDominantRuns": 0,
         "liveUnsupportedFactualClaimRuns": 0,
+        "liveSupportedCoverageRegressionRuns": 0,
         "livePromptOwnershipViolationRuns": 0,
         "relationshipPostureAppliedRuns": 0,
         "contentFieldsPresent": [],
@@ -3465,6 +3595,26 @@ def build_evaluation_report(
         if "candidate_generation_latency_ms" in columns
         else "0"
     )
+    validation_item_expr = (
+        "validation_item_count"
+        if "validation_item_count" in columns
+        else "0"
+    )
+    baseline_member_point_expr = (
+        "baseline_member_point_coverage_count"
+        if "baseline_member_point_coverage_count" in columns
+        else "0"
+    )
+    baseline_member_detail_expr = (
+        "baseline_member_detail_coverage_count"
+        if "baseline_member_detail_coverage_count" in columns
+        else "0"
+    )
+    baseline_canon_expr = (
+        "baseline_canon_coverage_count"
+        if "baseline_canon_coverage_count" in columns
+        else "0"
+    )
     member_point_expr = (
         "candidate_member_point_coverage_count"
         if "candidate_member_point_coverage_count" in columns
@@ -3473,6 +3623,11 @@ def build_evaluation_report(
     member_root_expr = (
         "candidate_member_root_coverage_count"
         if "candidate_member_root_coverage_count" in columns
+        else "0"
+    )
+    member_detail_expr = (
+        "candidate_member_detail_coverage_count"
+        if "candidate_member_detail_coverage_count" in columns
         else "0"
     )
     member_occurrence_expr = (
@@ -3513,6 +3668,11 @@ def build_evaluation_report(
     unsupported_factual_claim_expr = (
         "candidate_unsupported_factual_claim_count"
         if "candidate_unsupported_factual_claim_count" in columns
+        else "0"
+    )
+    supported_coverage_regressed_expr = (
+        "supported_coverage_regressed"
+        if "supported_coverage_regressed" in columns
         else "0"
     )
     profile_status_expr = (
@@ -3638,6 +3798,22 @@ def build_evaluation_report(
         ).fetchone()[0]
         or 0
     )
+    live_supported_coverage_regressions = int(
+        conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM memory_governance_shared_brain_synthesis_runs
+            WHERE guild_id=? AND live_applied=1
+              AND {supported_coverage_regressed_expr}=1
+            """.format(
+                supported_coverage_regressed_expr=(
+                    supported_coverage_regressed_expr
+                )
+            ),
+            (int(guild_id or 0),),
+        ).fetchone()[0]
+        or 0
+    )
     live_prompt_ownership_violations = int(
         conn.execute(
             """
@@ -3704,12 +3880,16 @@ def build_evaluation_report(
                candidate_output_leak,
                processing_error_count,response_sent,
                {route_family_expr},{authority_mode_expr},{latency_expr},
-               {member_point_expr},{member_root_expr},
+               {validation_item_expr},
+               {baseline_member_point_expr},
+               {baseline_member_detail_expr},{baseline_canon_expr},
+               {member_point_expr},{member_detail_expr},{member_root_expr},
                {member_occurrence_expr},{canon_coverage_expr},
                {lore_dominant_expr},
                {member_supported_claim_expr},
                {canon_supported_claim_expr},{opinion_claim_expr},
                {connective_claim_expr},{unsupported_factual_claim_expr},
+               {supported_coverage_regressed_expr},
                created_at
         FROM memory_governance_shared_brain_synthesis_runs
         WHERE guild_id=?
@@ -3719,7 +3899,12 @@ def build_evaluation_report(
             route_family_expr=route_family_expr,
             authority_mode_expr=authority_mode_expr,
             latency_expr=latency_expr,
+            validation_item_expr=validation_item_expr,
+            baseline_member_point_expr=baseline_member_point_expr,
+            baseline_member_detail_expr=baseline_member_detail_expr,
+            baseline_canon_expr=baseline_canon_expr,
             member_point_expr=member_point_expr,
+            member_detail_expr=member_detail_expr,
             member_root_expr=member_root_expr,
             member_occurrence_expr=member_occurrence_expr,
             canon_coverage_expr=canon_coverage_expr,
@@ -3729,6 +3914,9 @@ def build_evaluation_report(
             opinion_claim_expr=opinion_claim_expr,
             connective_claim_expr=connective_claim_expr,
             unsupported_factual_claim_expr=unsupported_factual_claim_expr,
+            supported_coverage_regressed_expr=(
+                supported_coverage_regressed_expr
+            ),
         ),
         (int(guild_id or 0), max(1, min(int(limit or 500), 2000))),
     ).fetchall()
@@ -3741,10 +3929,14 @@ def build_evaluation_report(
     authority_modes: Counter[str] = Counter()
     latency_values: list[int] = []
     prompt = live = selected = coverage = leaks = errors = sent = 0
-    member_points = member_roots = member_occurrences = canon_coverage = 0
+    validation_items = 0
+    baseline_points = baseline_details = baseline_canon = 0
+    member_points = member_details = member_roots = 0
+    member_occurrences = canon_coverage = 0
     lore_dominant_runs = 0
     member_supported_claims = canon_supported_claims = 0
     opinion_claims = connective_claims = unsupported_factual_claims = 0
+    supported_coverage_regressions = 0
     for row in rows:
         (
             _schema,
@@ -3763,7 +3955,12 @@ def build_evaluation_report(
             route_family,
             authority_mode,
             candidate_latency_ms,
+            validation_item_count,
+            baseline_member_points,
+            baseline_member_details,
+            baseline_canon_coverage,
             candidate_member_points,
+            candidate_member_details,
             candidate_member_roots,
             candidate_member_occurrences,
             candidate_canon_coverage,
@@ -3773,6 +3970,7 @@ def build_evaluation_report(
             candidate_opinion_claims,
             candidate_connective_claims,
             candidate_unsupported_factual_claims,
+            supported_coverage_regressed,
             _created_at,
         ) = row
         prompt += int(bool(prompt_applied))
@@ -3784,7 +3982,12 @@ def build_evaluation_report(
         baseline_coherence[str(baseline_status or "unknown")] += 1
         candidate_coherence[str(candidate_status or "unknown")] += 1
         coverage += int(evidence_coverage or 0)
+        validation_items += int(validation_item_count or 0)
+        baseline_points += int(baseline_member_points or 0)
+        baseline_details += int(baseline_member_details or 0)
+        baseline_canon += int(baseline_canon_coverage or 0)
         member_points += int(candidate_member_points or 0)
+        member_details += int(candidate_member_details or 0)
         member_roots += int(candidate_member_roots or 0)
         member_occurrences += int(candidate_member_occurrences or 0)
         canon_coverage += int(candidate_canon_coverage or 0)
@@ -3795,6 +3998,9 @@ def build_evaluation_report(
         connective_claims += int(candidate_connective_claims or 0)
         unsupported_factual_claims += int(
             candidate_unsupported_factual_claims or 0
+        )
+        supported_coverage_regressions += int(
+            bool(supported_coverage_regressed)
         )
         revalidation[str(revalidation_status or "unknown")] += 1
         leaks += int(bool(output_leak))
@@ -3826,7 +4032,12 @@ def build_evaluation_report(
             sorted(candidate_coherence.items())
         ),
         "candidateEvidenceCoverageTotal": coverage,
+        "validationItemTotal": validation_items,
+        "baselineMemberPointCoverageTotal": baseline_points,
+        "baselineMemberDetailCoverageTotal": baseline_details,
+        "baselineCanonCoverageTotal": baseline_canon,
         "candidateMemberPointCoverageTotal": member_points,
+        "candidateMemberDetailCoverageTotal": member_details,
         "candidateMemberRootCoverageTotal": member_roots,
         "candidateMemberOccurrenceCoverageTotal": member_occurrences,
         "candidateCanonCoverageTotal": canon_coverage,
@@ -3837,6 +4048,9 @@ def build_evaluation_report(
         "candidateConnectiveClaimTotal": connective_claims,
         "candidateUnsupportedFactualClaimTotal": (
             unsupported_factual_claims
+        ),
+        "supportedCoverageRegressionRuns": (
+            supported_coverage_regressions
         ),
         "promptFactualOwnerRuns": prompt_factual_owner_runs,
         "promptOwnershipFailureRuns": prompt_ownership_failures,
@@ -3864,6 +4078,9 @@ def build_evaluation_report(
         "liveLoreDominantRuns": live_lore_dominant,
         "liveUnsupportedFactualClaimRuns": (
             live_unsupported_factual_claims
+        ),
+        "liveSupportedCoverageRegressionRuns": (
+            live_supported_coverage_regressions
         ),
         "livePromptOwnershipViolationRuns": (
             live_prompt_ownership_violations

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -3,7 +3,8 @@
 This module owns no facts.  It coordinates references selected by the existing
 Conversation Context, Memory Governance, Ledger, Moment, Relationship, canon,
 and Source File owners into one bounded comparison packet.  The packet is never
-rendered into a live prompt in this stage.
+rendered into a live prompt in this stage. Prompt items remain bounded
+separately from the route-safe factual support retained for validation.
 """
 from __future__ import annotations
 
@@ -49,7 +50,7 @@ from bnl_moment_engine import select_public_participant_moment_gists
 from bnl_relationship_engine import shadow_packet_posture
 
 
-SCHEMA_VERSION = "unified_intelligence_packet_v2"
+SCHEMA_VERSION = "unified_intelligence_packet_v3"
 TABLE_NAME = "memory_governance_intelligence_packet_runs"
 SHADOW_ENV = "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED"
 _SHADOW_PREREQUISITES = (
@@ -128,6 +129,28 @@ _BROAD_PROFILE_LANE_CAPS = {
     "canon": 1,
     "source_file": 1,
 }
+_VALIDATION_SUPPORT_ASSESSMENT_LIMIT = 8
+_VALIDATION_SUPPORT_LANES = frozenset(
+    {
+        "conversation_context",
+        "assessment_observation",
+        "approved_fact",
+        "moment",
+        "atomic_knowledge",
+        "open_loop",
+        "canon",
+        "source_file",
+    }
+)
+_CLAIM_SUBJECT_SCOPED_LANES = frozenset(
+    {
+        "assessment_observation",
+        "approved_fact",
+        "moment",
+        "atomic_knowledge",
+        "open_loop",
+    }
+)
 _PROFILE_DURABLE_MEMBER_EVIDENCE_LANES = frozenset(
     {"approved_fact", "atomic_knowledge", "moment"}
 )
@@ -327,6 +350,7 @@ class IntelligencePacketDiagnostics:
     selected_by_lane: dict[str, int] = field(default_factory=dict)
     selected_by_source_class: dict[str, int] = field(default_factory=dict)
     selected_atomic_states: dict[str, int] = field(default_factory=dict)
+    validation_support_by_lane: dict[str, int] = field(default_factory=dict)
     excluded_by_reason: dict[str, int] = field(default_factory=dict)
     missing_lanes: list[str] = field(default_factory=list)
     conflict_reasons: list[str] = field(default_factory=list)
@@ -392,10 +416,17 @@ class UnifiedIntelligencePacket:
     exclusions: tuple[IntelligencePacketExclusion, ...]
     diagnostics: IntelligencePacketDiagnostics
     profile_sufficiency: ProfileSufficiency = ProfileSufficiency()
+    validation_items: tuple[IntelligencePacketItem, ...] = ()
 
     @property
     def detailed_lanes(self) -> tuple[str, ...]:
         return tuple(dict.fromkeys(item.lane for item in self.items))
+
+    @property
+    def validation_lanes(self) -> tuple[str, ...]:
+        return tuple(
+            dict.fromkeys(item.lane for item in self.validation_items)
+        )
 
     @property
     def assessment_lanes(self) -> tuple[str, ...]:
@@ -1000,6 +1031,8 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             channel_policy TEXT NOT NULL,
             visibility_allowance TEXT NOT NULL,
             item_count INTEGER NOT NULL DEFAULT 0,
+            validation_item_count INTEGER NOT NULL DEFAULT 0,
+            validation_lane_counts_json TEXT NOT NULL DEFAULT '{}',
             selected_lane_counts_json TEXT NOT NULL DEFAULT '{}',
             source_class_counts_json TEXT NOT NULL DEFAULT '{}',
             atomic_state_counts_json TEXT NOT NULL DEFAULT '{}',
@@ -1022,6 +1055,11 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         """
     )
     for column, definition in (
+        ("validation_item_count", "INTEGER NOT NULL DEFAULT 0"),
+        (
+            "validation_lane_counts_json",
+            "TEXT NOT NULL DEFAULT '{}'",
+        ),
         ("root_collapse_suppression_count", "INTEGER NOT NULL DEFAULT 0"),
         ("shared_root_projection_count", "INTEGER NOT NULL DEFAULT 0"),
         (
@@ -1332,7 +1370,7 @@ def _assessment_observation_items(
         guild_id=int(request.guild_id or 0),
         subject_key=subject,
         request_text=str(request.user_text or ""),
-        max_results=_BROAD_PROFILE_LANE_CAPS["assessment_observation"],
+        max_results=_VALIDATION_SUPPORT_ASSESSMENT_LIMIT,
     )
     diagnostics.candidates_by_lane["assessment_observation"] = int(
         selection.eligible_count or 0
@@ -2594,6 +2632,7 @@ def _select_items(
 ) -> tuple[
     tuple[IntelligencePacketItem, ...],
     tuple[IntelligencePacketItem, ...],
+    tuple[IntelligencePacketItem, ...],
 ]:
     broad = _broad_profile_request(request.user_text)
     if request.immediate_recap:
@@ -2788,7 +2827,45 @@ def _select_items(
     diagnostics.missing_lanes = list(
         dict.fromkeys(diagnostics.missing_lanes)
     )
-    return tuple(selected), tuple(profile_candidates)
+    validation_items: list[IntelligencePacketItem] = []
+    seen_validation_sources: set[tuple[str, str, str]] = set()
+    validation_canon = tuple(
+        candidate
+        for candidate in ordered
+        if candidate.lane == "canon"
+        and (
+            (
+                recognized_canon_signal
+                and candidate.source_type == "recognized_canon_fact"
+                and candidate.subject_key == subject_key
+            )
+            or (
+                not recognized_canon_signal
+                and canon_anchor is not None
+                and candidate.subject_key == canon_anchor.subject_key
+            )
+        )
+    )
+    for item in (
+        *(item for item in selected if item.lane != "canon"),
+        *profile_candidates,
+        *validation_canon,
+    ):
+        if item.lane not in _VALIDATION_SUPPORT_LANES:
+            continue
+        source_key = (item.lane, item.source_ref, item.source_digest)
+        if source_key in seen_validation_sources:
+            continue
+        seen_validation_sources.add(source_key)
+        validation_items.append(item)
+        diagnostics.validation_support_by_lane[item.lane] = (
+            diagnostics.validation_support_by_lane.get(item.lane, 0) + 1
+        )
+    return (
+        tuple(selected),
+        tuple(profile_candidates),
+        tuple(validation_items),
+    )
 
 
 def _profile_sufficiency(
@@ -3045,7 +3122,13 @@ def revalidate_packet(
     """Re-read every durable source without applying packet content live."""
     changed = 0
     errors = 0
-    for item in packet.items:
+    revalidation_items = tuple(
+        {
+            (item.lane, item.source_ref, item.source_digest): item
+            for item in (*packet.items, *packet.validation_items)
+        }.values()
+    )
+    for item in revalidation_items:
         try:
             if item.revalidation_kind == "conversation":
                 row = _conversation_row(conn, int(item.revalidation_key or 0))
@@ -3083,7 +3166,10 @@ def revalidate_packet(
         status = "processing_error"
     elif changed:
         status = "source_changed"
-    elif any(item.revalidation_kind == "snapshot" for item in packet.items):
+    elif any(
+        item.revalidation_kind == "snapshot"
+        for item in revalidation_items
+    ):
         status = "passed_with_provider_snapshot"
     else:
         status = "passed"
@@ -3165,6 +3251,46 @@ def _packet_invariants(
             and item.subject_key == subject
         ):
             invalid.append("supporting_observation_scope_violation")
+    validation_keys = {
+        (item.lane, item.source_ref, item.source_digest)
+        for item in packet.validation_items
+    }
+    for item in packet.validation_items:
+        if item.lane not in _VALIDATION_SUPPORT_LANES:
+            invalid.append("validation_support_lane_violation")
+        if not _route_allows_item(packet.request, item):
+            invalid.append("validation_support_visibility_violation")
+        if (
+            item.lane in _CLAIM_SUBJECT_SCOPED_LANES
+            and int(packet.request.subject_user_id or 0) > 0
+            and item.subject_key != subject
+        ):
+            invalid.append("validation_support_subject_violation")
+        if (
+            broad
+            and item.lane in _PROFILE_MEMBER_EVIDENCE_LANES
+            and (
+                not item.root_identities
+                or not item.occurrence_identities
+                or not item.point_identity
+            )
+        ):
+            invalid.append("validation_support_root_lineage_violation")
+        if item.revalidation_kind == "recognized_canon" and not (
+            item.lane == "canon"
+            and item.source_type == "recognized_canon_fact"
+            and item.subject_key == subject
+            and item.source_class == SourceClass.APPROVED_CANON.value
+        ):
+            invalid.append("validation_support_canon_scope_violation")
+    for item in packet.items:
+        if (
+            item.lane in _VALIDATION_SUPPORT_LANES
+            and item.lane != "canon"
+            and (item.lane, item.source_ref, item.source_digest)
+            not in validation_keys
+        ):
+            invalid.append("selected_factual_item_missing_validation_support")
     return tuple(dict.fromkeys(invalid))
 
 
@@ -3238,7 +3364,7 @@ def build_packet(
         )
     except (sqlite3.DatabaseError, TypeError, ValueError) as exc:
         diagnostics.processing_errors.append(type(exc).__name__)
-    selected, profile_candidates = _select_items(
+    selected, profile_candidates, validation_items = _select_items(
         request,
         candidates,
         diagnostics,
@@ -3249,7 +3375,7 @@ def build_packet(
         selected=selected,
         candidates=profile_candidates,
     )
-    digest_payload = tuple(
+    prompt_digest_payload = tuple(
         (
             item.lane,
             item.source_class,
@@ -3263,9 +3389,24 @@ def build_packet(
         )
         for item in selected
     )
+    validation_digest_payload = tuple(
+        (
+            item.lane,
+            item.source_class,
+            item.source_ref,
+            item.source_digest,
+            item.lifecycle,
+            item.usage,
+            item.root_identities,
+            item.occurrence_identities,
+            item.point_identity,
+        )
+        for item in validation_items
+    )
     diagnostics.packet_digest = _digest(
         SCHEMA_VERSION,
-        digest_payload,
+        prompt_digest_payload,
+        validation_digest_payload,
         profile_sufficiency,
     )
     packet_id = "uip_" + _digest(
@@ -3284,6 +3425,7 @@ def build_packet(
         exclusions=tuple(exclusions),
         diagnostics=diagnostics,
         profile_sufficiency=profile_sufficiency,
+        validation_items=validation_items,
     )
     invalid = _packet_invariants(packet)
     if invalid:
@@ -3324,7 +3466,14 @@ def persist_packet_run(
     ensure_schema(conn)
     run_id = "uipr_" + uuid.uuid4().hex
     source_ref_digest = _digest(
-        tuple(sorted(item.source_ref for item in packet.items))
+        tuple(
+            sorted(
+                {
+                    item.source_ref
+                    for item in (*packet.items, *packet.validation_items)
+                }
+            )
+        )
     )
     conn.execute(
         """
@@ -3414,6 +3563,21 @@ def persist_packet_run(
             int(packet.request.guild_id or 0),
         ),
     )
+    conn.execute(
+        """
+        UPDATE memory_governance_intelligence_packet_runs
+        SET validation_item_count=?,validation_lane_counts_json=?
+        WHERE run_id=?
+        """,
+        (
+            len(packet.validation_items),
+            json.dumps(
+                packet.diagnostics.validation_support_by_lane,
+                sort_keys=True,
+            ),
+            run_id,
+        ),
+    )
     return run_id
 
 
@@ -3483,6 +3647,8 @@ def _empty_report() -> dict[str, Any]:
         "schemaVersion": SCHEMA_VERSION,
         "runs": 0,
         "itemTotal": 0,
+        "validationItemTotal": 0,
+        "validationByLane": {},
         "selectedByLane": {},
         "selectedBySourceClass": {},
         "selectedAtomicStates": {},
@@ -3546,7 +3712,7 @@ def build_evaluation_report(
 
     rows = conn.execute(
         """
-        SELECT schema_version,item_count,selected_lane_counts_json,
+        SELECT schema_version,item_count,%s,%s,selected_lane_counts_json,
                source_class_counts_json,atomic_state_counts_json,
                excluded_by_reason_json,missing_lanes_json,conflict_count,
                visibility_exclusion_count,budget_exclusion_count,
@@ -3562,6 +3728,8 @@ def build_evaluation_report(
         LIMIT ?
         """
         % (
+            column("validation_item_count", "0"),
+            column("validation_lane_counts_json", "'{}'"),
             column("root_collapse_suppression_count", "0"),
             column("shared_root_projection_count", "0"),
             column(
@@ -3578,6 +3746,7 @@ def build_evaluation_report(
         (int(guild_id or 0), max(1, min(int(limit or 1000), 5000))),
     ).fetchall()
     selected_lanes: Counter[str] = Counter()
+    validation_lanes: Counter[str] = Counter()
     source_classes: Counter[str] = Counter()
     atomic_states: Counter[str] = Counter()
     exclusions: Counter[str] = Counter()
@@ -3585,7 +3754,8 @@ def build_evaluation_report(
     revalidation: Counter[str] = Counter()
     profile_statuses: Counter[str] = Counter()
     profile_reasons: Counter[str] = Counter()
-    item_total = conflicts = visibility = budget = duplicates = 0
+    item_total = validation_item_total = 0
+    conflicts = visibility = budget = duplicates = 0
     root_collapses = shared_roots = profile_met = 0
     profile_points = profile_roots = profile_occurrences = 0
     errors = invalid = changed = prompt = live = 0
@@ -3593,6 +3763,8 @@ def build_evaluation_report(
         (
             _schema,
             item_count,
+            validation_item_count,
+            validation_lane_json,
             lane_json,
             source_json,
             atomic_json,
@@ -3620,8 +3792,10 @@ def build_evaluation_report(
             _created_at,
         ) = row
         item_total += int(item_count or 0)
+        validation_item_total += int(validation_item_count or 0)
         for counter, raw in (
             (selected_lanes, lane_json),
+            (validation_lanes, validation_lane_json),
             (source_classes, source_json),
             (atomic_states, atomic_json),
             (exclusions, exclusion_json),
@@ -3670,6 +3844,8 @@ def build_evaluation_report(
         "schemaVersion": str(rows[0][0]) if rows else SCHEMA_VERSION,
         "runs": len(rows),
         "itemTotal": item_total,
+        "validationItemTotal": validation_item_total,
+        "validationByLane": dict(sorted(validation_lanes.items())),
         "selectedByLane": dict(sorted(selected_lanes.items())),
         "selectedBySourceClass": dict(sorted(source_classes.items())),
         "selectedAtomicStates": dict(sorted(atomic_states.items())),

--- a/docs/BNL01_PUBLIC_HOME_BROAD_RECALL_OWNER.md
+++ b/docs/BNL01_PUBLIC_HOME_BROAD_RECALL_OWNER.md
@@ -28,6 +28,9 @@ or when the packet and response-assessment shadows are unavailable.
 
 - The governed packet is the only stored factual prompt owner for this route.
 - Competing legacy factual context is replaced before the candidate call.
+- Prompt selection stays bounded, while claim validation uses a separate
+  route-safe support set from the same existing source owners. Lane and prompt
+  budget exclusions do not make otherwise eligible support "unsupported."
 - Current-turn and exact-reply authority remain ahead of stored memory.
 - The subject is always the requesting member; cross-member facts remain
   ineligible.
@@ -35,6 +38,11 @@ or when the packet and response-assessment shadows are unavailable.
 - BNL-authored derivatives cannot corroborate themselves.
 - Every candidate is revalidated before send; any failure returns to the
   established response.
+- A candidate may replace the established response only when it retains every
+  exact, question-relevant member point, concrete detail, and approved canon
+  item that the established response used from that support set. A shorter or
+  differently framed candidate is allowed; loss of supported substance is not.
+- Unsupported baseline language does not gain authority from this comparison.
 
 ## Same-platform canon recognition
 
@@ -60,8 +68,9 @@ observation and require cautious wording. That observation does not become a
 trait, Moment, or atomic-memory candidate. Stronger claims still require the
 existing independent-root and independent-occurrence thresholds.
 
-If a broad profile remains empty, the enabled owner route returns a fixed
-thin-record response rather than asking the model to improvise a biography.
+An empty packet never suppresses a nonempty established response. The fixed
+thin-record response is used only when both the packet route and the already
+generated established path are empty.
 
 ## Retained-conversation catch-up
 
@@ -78,7 +87,8 @@ Content-free synthesis receipts record `authority_mode` as either
 `scoped_canary` or `public_home_broad_recall_owner`. Owner diagnostics report
 the requested/effective state, authority mode, scope status, kill switch,
 route counts, selection/fallback totals, revalidation, prompt ownership, guard
-outcomes, and live applications.
+outcomes, validation-support lane counts, baseline/candidate supported
+coverage, supported-coverage regressions, and live applications.
 
 Rollback is the independent kill switch:
 

--- a/tests/test_memory_preview_bot_path.py
+++ b/tests/test_memory_preview_bot_path.py
@@ -212,9 +212,9 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             "\n".join(result.diagnostics),
         )
 
-    async def test_empty_profile_skips_model_and_uses_honest_fallback(self):
+    async def test_empty_packet_preserves_established_response(self):
         generator = mock.AsyncMock(
-            return_value="Invented generic member biography."
+            return_value="The established path still recognizes your signal."
         )
         guard = mock.AsyncMock(
             side_effect=lambda response, _prompt: (
@@ -234,18 +234,47 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             guard=guard,
         )
 
-        generator.assert_not_awaited()
+        generator.assert_awaited_once()
+        self.assertTrue(
+            generator.await_args.args[1].endswith("baseline")
+        )
         guard.assert_awaited_once()
+        self.assertFalse(result.candidate_selected)
+        self.assertEqual(
+            result.proposed_response,
+            "The established path still recognizes your signal.",
+        )
+        self.assertEqual(
+            result.established_response,
+            "The established path still recognizes your signal.",
+        )
+        self.assertEqual(result.fallback_reason, "profile_sufficiency_empty")
+        self.assertEqual(result.final_selection, "established_path")
+
+    async def test_empty_packet_uses_honest_response_only_if_baseline_fails(
+        self,
+    ):
+        result = await bnl01_bot.execute_bnl_memory_preview(
+            source_db_path=self.db_path,
+            guild_id=1,
+            subject_user_id=8,
+            subject_display_name="Empty Member",
+            simulated_channel_id=10,
+            wording="BNL-01, what am I all about?",
+            generator=mock.AsyncMock(return_value=""),
+            guard=mock.AsyncMock(
+                side_effect=lambda response, _prompt: (
+                    response,
+                    {"suppressed": False, "suppression_reason": ""},
+                )
+            ),
+        )
+
         self.assertFalse(result.candidate_selected)
         self.assertEqual(
             result.proposed_response,
             bnl01_bot.honest_empty_profile_response(),
         )
-        self.assertEqual(
-            result.established_response,
-            bnl01_bot.honest_empty_profile_response(),
-        )
-        self.assertEqual(result.fallback_reason, "profile_sufficiency_empty")
         self.assertEqual(
             result.final_selection,
             "honest_empty_profile_fallback",
@@ -890,6 +919,12 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_preview_compares_real_established_memory_to_packet(self):
         with sqlite3.connect(self.db_path) as conn:
+            self._add_message(
+                conn,
+                3,
+                "I build pocket synthesizers.",
+                "2026-07-26T19:00:00+00:00",
+            )
             conn.execute(
                 """
                 CREATE TABLE memory_tiers (
@@ -935,7 +970,7 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
         async def generator(prompt, route):
             calls.append((route, prompt))
             if route.endswith("baseline"):
-                return "I remember your pocket-synthesizer work."
+                return "I remember that you build pocket synthesizers."
             return (
                 "You keep returning to software and technical "
                 "systems."
@@ -964,9 +999,19 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("Derived memory summaries", packet_prompt)
         self.assertEqual(
             result.established_response,
-            "I remember your pocket-synthesizer work.",
+            "I remember that you build pocket synthesizers.",
         )
         self.assertTrue(result.packet_candidate_response)
+        self.assertFalse(result.candidate_selected)
+        self.assertEqual(
+            result.fallback_reason,
+            "candidate_supported_coverage_regressed",
+        )
+        self.assertEqual(result.final_selection, "established_path")
+        self.assertEqual(
+            result.proposed_response,
+            "I remember that you build pocket synthesizers.",
+        )
 
     async def test_preview_never_calls_conversation_or_model_savers(self):
         async def generator(_prompt, route):

--- a/tests/test_production_shaped_broad_recall_acceptance.py
+++ b/tests/test_production_shaped_broad_recall_acceptance.py
@@ -933,7 +933,13 @@ class ProductionShapedBroadRecallAcceptanceTests(unittest.TestCase):
                 for item in prepared.packet.items
                 if item.lane == "assessment_observation"
             )
+            validation_observations = tuple(
+                item
+                for item in prepared.packet.validation_items
+                if item.lane == "assessment_observation"
+            )
             self.assertEqual(len(selected_observations), 1)
+            self.assertEqual(len(validation_observations), 2)
             self.assertEqual(
                 {
                     item.source_type
@@ -964,6 +970,46 @@ class ProductionShapedBroadRecallAcceptanceTests(unittest.TestCase):
             )
             self.assertEqual(evaluation.candidate_member_point_count, 1)
             self.assertGreaterEqual(evaluation.candidate_canon_count, 1)
+
+            selected_point = selected_observations[0].point_identity
+            unrendered_observation = next(
+                item
+                for item in validation_observations
+                if item.point_identity != selected_point
+            )
+            unrendered_evaluation = evaluate_memory_preview(
+                prepared,
+                baseline_response="The record is still thin.",
+                candidate_response=(
+                    "I recognize your signal as Mac Modem, a founding "
+                    "BARCODE member and chaotic tech entity. From your "
+                    "public appearances, I noticed that "
+                    + unrendered_observation.text
+                ),
+            )
+            self.assertTrue(
+                unrendered_evaluation.candidate_selected,
+                unrendered_evaluation.fallback_reason,
+            )
+
+            coverage_regression = evaluate_memory_preview(
+                prepared,
+                baseline_response=selected_observations[0].text,
+                candidate_response=(
+                    "I recognize your signal as Mac Modem, a founding "
+                    "BARCODE member and chaotic tech entity. From your "
+                    "public appearances, I noticed that "
+                    + unrendered_observation.text
+                ),
+            )
+            self.assertFalse(coverage_regression.candidate_selected)
+            self.assertTrue(
+                coverage_regression.supported_coverage_regressed
+            )
+            self.assertEqual(
+                coverage_regression.fallback_reason,
+                "candidate_supported_coverage_regressed",
+            )
         finally:
             prepared.close()
 

--- a/tests/test_shared_brain_synthesis_bot_path.py
+++ b/tests/test_shared_brain_synthesis_bot_path.py
@@ -153,6 +153,52 @@ class SharedBrainSynthesisBotPathTests(
             ),
         )
 
+    async def test_empty_packet_keeps_nonempty_established_response(self):
+        basis = replace(
+            self.synthesis_basis("Legacy factual profile block."),
+            honest_empty_profile_fallback=True,
+        )
+        run = SimpleNamespace(
+            prompt_applied=False,
+            fallback_reason="candidate_prompt_profile_sufficiency_empty",
+            revalidation_status="passed",
+        )
+        generation = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "_begin_shared_brain_synthesis_receipt",
+                return_value=run,
+            ) as begin,
+            mock.patch.object(
+                bnl01_bot,
+                "get_gemini_response_with_optional_typing",
+                new=generation,
+            ),
+        ):
+            execution = await (
+                bnl01_bot.maybe_generate_shared_brain_synthesis_canary(
+                    channel=FakeChannel(),
+                    baseline_response="Established useful response.",
+                    prompt="Baseline prompt.",
+                    prompt_source_bases=("existing-basis",),
+                    basis=basis,
+                    user_id=7,
+                    guild_id=1,
+                    user_display_name="Crow",
+                    source_context_available=True,
+                )
+            )
+
+        self.assertIsNotNone(execution)
+        self.assertEqual(execution.response, "Established useful response.")
+        self.assertFalse(execution.candidate_active)
+        generation.assert_not_awaited()
+        self.assertEqual(
+            begin.call_args.args[1],
+            "Established useful response.",
+        )
+
     async def test_candidate_call_uses_packet_as_only_factual_owner(self):
         legacy_context = (
             "Relationship state: stage=familiar, stance=warm.\n"

--- a/tests/test_shared_brain_synthesis_canary.py
+++ b/tests/test_shared_brain_synthesis_canary.py
@@ -2000,6 +2000,7 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             UPDATE memory_governance_shared_brain_synthesis_runs
             SET candidate_member_root_coverage_count=0,
                 candidate_unsupported_factual_claim_count=1,
+                supported_coverage_regressed=1,
                 competing_factual_context_count=1,
                 replaced_factual_context_count=0
             WHERE run_id=?
@@ -2016,6 +2017,10 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
             1,
         )
         self.assertEqual(
+            report["liveSupportedCoverageRegressionRuns"],
+            1,
+        )
+        self.assertEqual(
             report["livePromptOwnershipViolationRuns"],
             1,
         )
@@ -2027,6 +2032,7 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
         for key in (
             "liveInsufficientMemberCoverageRuns",
             "liveUnsupportedFactualClaimRuns",
+            "liveSupportedCoverageRegressionRuns",
             "livePromptOwnershipViolationRuns",
         ):
             self.assertIn(

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -757,6 +757,11 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
             for item in packet.items
             if item.lane == "assessment_observation"
         )
+        validation_observations = tuple(
+            item
+            for item in packet.validation_items
+            if item.lane == "assessment_observation"
+        )
 
         self.assertEqual(
             packet.diagnostics.candidates_by_lane[
@@ -765,6 +770,13 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
             6,
         )
         self.assertEqual(len(assessment_items), 4)
+        self.assertEqual(len(validation_observations), 6)
+        self.assertEqual(
+            packet.diagnostics.validation_support_by_lane.get(
+                "assessment_observation"
+            ),
+            6,
+        )
         self.assertGreaterEqual(
             sum(
                 any(


### PR DESCRIPTION
## What changed

- Separate the small prompt-rendered packet from the complete route-safe support set used for factual validation.
- Track exact supported member points, detail points, and canon used by both the established response and packet candidate.
- Prevent a packet candidate from replacing the established response when it drops supported, question-relevant coverage.
- Preserve a useful established response when the packet is empty; use the honest thin-record response only when both paths are genuinely empty.
- Add preview, canary, acceptance, and operational diagnostics for validation support and coverage regression.

## Root cause

Packet lane caps were serving two different jobs: limiting prompt context and defining the validator's entire evidence universe. Safe authorized facts omitted from the small rendered packet were therefore treated as unsupported, and a technically grounded but narrower candidate could replace a richer valid established response.

## Impact

Broad member-profile recall can remain bounded and privacy-safe without stripping legitimate supported substance. Unsupported claims still fail closed, while valid established behavior remains the comparison baseline. This is a general coverage invariant, not a Mac Modem- or DJ Floppydisc-specific wording patch.

No production gate, activation default, queue, website, Relationship, Journal, Relay, or stored-memory authority is changed. Public-home ownership remains off pending separate approval and post-deploy evidence.

## Validation

- `PYTHONPATH=/tmp/bnl01-test-deps make check`
- 1,828 tests passed; 36 skipped
- `git diff --check`
- Remote commit is one commit ahead of `b7a80681f6cd5e04965df99c50a318cc5e4ae748`
- Remote tree `87fad989fa3d153fc8665cc706af1bcd02245f5b` matches the locally tested tree exactly
