### PR TITLE
Add hybrid canon claim contract

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -18,6 +18,7 @@ from typing import Any, Awaitable, Callable, Mapping, Union
 
 from bnl_canon_source_contract import (
     CANON_SOURCE_CONTRACT_VERSION,
+    build_claim_contract_inventory,
     diagnostics as canon_source_diagnostics,
     queue_usability,
     render_concise_public_schedule,
@@ -36652,9 +36653,23 @@ def _collect_bnl_memory_diagnostic_data(
         get_member_activity_event_counts(guild_id)
     )
     shadow_acceptance = None
+    claim_contract_inventory = {
+        "claimContractVersion": "unavailable",
+        "mutationCount": 0,
+    }
     try:
         diagnostic_conn = sqlite3.connect(DB_FILE)
         try:
+            try:
+                claim_contract_inventory = build_claim_contract_inventory(
+                    diagnostic_conn,
+                    guild_id=guild_id,
+                )
+            except Exception as exc:
+                logging.debug(
+                    "hybrid_claim_inventory_failed error=%s",
+                    exc,
+                )
             shadow_acceptance = build_v2_shadow_acceptance_snapshot(
                 diagnostic_conn,
                 guild_id=guild_id,
@@ -36698,6 +36713,7 @@ def _collect_bnl_memory_diagnostic_data(
         recent_member_events_count_7d,
         shadow_acceptance,
         ledger_diag,
+        claim_contract_inventory,
     )
 
 
@@ -37543,6 +37559,7 @@ async def bnl_memory_check(interaction: discord.Interaction):
             recent_member_events_count_7d,
             shadow_acceptance,
             ledger_diag,
+            claim_contract_inventory,
         ) = await asyncio.to_thread(
             _collect_bnl_memory_diagnostic_data,
             guild_id=guild.id,
@@ -37575,6 +37592,24 @@ async def bnl_memory_check(interaction: discord.Interaction):
         f"- read_model_cache_age_seconds: `{read_model_diag.get('cache_age_seconds') if read_model_diag.get('cache_age_seconds') is not None else 'none'}`",
         f"- read_model_last_section_counts: `{read_model_diag.get('last_section_counts') or {}}`",
         f"- canon_source_contract: `{(read_model_diag.get('canon_source_contract') or {}).get('contractVersion')}`",
+        f"- hybrid_claim_contract: `{claim_contract_inventory.get('claimContractVersion')}`",
+        f"- hybrid_claim_source_rows: `{claim_contract_inventory.get('sourceRows') or {}}`",
+        f"- hybrid_claim_inspected_rows: `{claim_contract_inventory.get('inspectedRows') or {}}`",
+        f"- hybrid_claim_adapted_rows: `{claim_contract_inventory.get('adaptedRows') or {}}`",
+        f"- hybrid_claim_review_only: `{claim_contract_inventory.get('reviewOnlyCount', 0)}`",
+        f"- hybrid_claim_reasons: `{claim_contract_inventory.get('reasonCounts') or {}}`",
+        f"- hybrid_claim_identity_label_collisions: `{claim_contract_inventory.get('identityLabelCollisionCount', 0)}`",
+        f"- hybrid_claim_account_binding_collisions: `{claim_contract_inventory.get('identityBindingCollisionCount', 0)}`",
+        f"- hybrid_claim_callem_cache_collisions: `{claim_contract_inventory.get('callemCacheIdentityCollisionCount', 0)}`",
+        f"- hybrid_claim_id_collisions: `{claim_contract_inventory.get('claimIdCollisionCount', 0)}`",
+        f"- hybrid_claim_revision_collisions: `{claim_contract_inventory.get('revisionIdCollisionCount', 0)}`",
+        f"- hybrid_claim_revision_digest_mismatches: `{claim_contract_inventory.get('revisionDigestMismatchCount', 0)}`",
+        f"- hybrid_claim_nonopaque_authority_actors: `{claim_contract_inventory.get('nonOpaqueAuthorityActorCount', 0)}`",
+        f"- hybrid_claim_nonopaque_binding_actors: `{claim_contract_inventory.get('nonOpaqueBindingActorCount', 0)}`",
+        f"- hybrid_claim_truncated_sources: `{claim_contract_inventory.get('truncatedSources') or ()}`",
+        f"- hybrid_claim_reconciliation_status: `{claim_contract_inventory.get('sourceReconciliationStatus')}`",
+        f"- hybrid_claim_source_reconciled: `{'yes' if claim_contract_inventory.get('sourceAdaptedReconciled') else 'no'}`",
+        f"- hybrid_claim_mutation_count: `{claim_contract_inventory.get('mutationCount', 0)}`",
         f"- conversation_context_contract: `{LAST_CONVERSATION_CONTEXT_V2_DIAGNOSTICS.get('contract_version')}`",
         f"- conversation_context_enabled: `{'yes' if conversation_context_v2_enabled() else 'no'}`",
         f"- conversation_context_last_route_mode: `{LAST_CONVERSATION_CONTEXT_V2_DIAGNOSTICS.get('route_mode')}`",

--- a/bnl_canon_source_contract.py
+++ b/bnl_canon_source_contract.py
@@ -1,14 +1,67 @@
 """Versioned in-world canon/source contract for BNL compatibility callers."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections import Counter
+from dataclasses import asdict, dataclass, is_dataclass, replace
 from enum import Enum
 from datetime import datetime, timezone, timedelta
+import hashlib
+import json
 import re
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping, Sequence
 import unicodedata
 
 CANON_SOURCE_CONTRACT_VERSION = "canon_source_contract_v1"
+HYBRID_CANON_CLAIM_CONTRACT_VERSION = "hybrid_canon_claim_v1"
+CANON_CLAIM_ID_NAMESPACE = "bnl_canon_claim_identity_v1"
+LEGACY_CANON_ADAPTER_VERSION = "legacy_canon_adapter_v1"
+BROADCAST_CANON_ADAPTER_VERSION = "broadcast_declared_adapter_v1"
+LIVING_CANON_ADAPTER_VERSION = "living_canon_adapter_v1"
+OPEN_SIGNAL_ADAPTER_VERSION = "open_signal_adapter_v1"
+WEBSITE_LORE_ADAPTER_VERSION = "website_lore_review_adapter_v1"
+LIVING_CANON_RECURRENCE_VERSION = "living_canon_recurrence_v1"
+PUBLIC_ASSESSMENT_EVIDENCE_VERSION = "public_assessment_evidence_v1"
+ENTITY_ACCOUNT_BINDING_CONTRACT_VERSION = "canon_entity_account_binding_v1"
+
+
+class CanonStatus(str, Enum):
+    LEGACY = "legacy"
+    DECLARED = "declared"
+    LIVING = "living"
+    OPEN_SIGNAL = "open_signal"
+
+
+class CanonDomain(str, Enum):
+    REAL_COMMUNITY = "real_community"
+    BROADCAST_HISTORY = "broadcast_history"
+    OPERATIONAL = "operational"
+    LORE = "lore"
+    HYBRID = "hybrid"
+
+
+class ClaimKind(str, Enum):
+    IDENTITY = "identity"
+    ROLE = "role"
+    STANDING = "standing"
+    RELATIONSHIP = "relationship"
+    CONTRIBUTION = "contribution"
+    EVENT = "event"
+    CURRENT_STATE = "current_state"
+    BEHAVIOR_PATTERN = "behavior_pattern"
+    TRADITION_OR_JOKE = "tradition_or_joke"
+    WORLD_RULE = "world_rule"
+    OTHER = "other"
+
+
+class ClaimLifecycle(str, Enum):
+    CANDIDATE = "candidate"
+    PROVISIONAL = "provisional"
+    ESTABLISHED = "established"
+    CONTESTED = "contested"
+    SUPERSEDED = "superseded"
+    RETIRED = "retired"
+    RESOLVED = "resolved"
+    REVIEW_ONLY = "review_only"
 
 class SourceClass(str, Enum):
     OWNER_CORRECTION = "owner_correction"
@@ -82,6 +135,84 @@ class SourceClaim:
     projection: bool = False
     current_time_capable: bool = False
 
+
+@dataclass(frozen=True)
+class EntityAccountBinding:
+    """One explicit same-platform account binding.
+
+    Display names stay presentation hints.  The immutable platform account ID
+    is the only value that can bind an account to an established entity.
+    """
+
+    entity_id: str
+    platform: str
+    account_id: str
+    authority_receipt: str
+    authority_actor: str
+    binding_version: str = ENTITY_ACCOUNT_BINDING_CONTRACT_VERSION
+    authority_verified: bool = False
+    active: bool = True
+
+
+@dataclass(frozen=True)
+class EntityResolution:
+    status: str
+    subject: SubjectIdentity | None = None
+    method: str = ""
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class CanonClaim:
+    """Normalized read-model revision shared by every canon source adapter.
+
+    This is deliberately a logical contract, not a new storage owner.  Source
+    systems retain their own rows and mutation authority; this immutable view
+    only makes authority, lineage, visibility, and lifecycle comparable before
+    the unified packet performs selection.
+    """
+
+    claim_id: str
+    revision_id: str
+    subject_id: str
+    predicate: str
+    value: Any
+    canon_status: CanonStatus
+    domain: CanonDomain
+    claim_kind: ClaimKind
+    source_system: str
+    adapter_version: str
+    source_class: SourceClass
+    source_refs: tuple[str, ...]
+    root_ids: tuple[str, ...]
+    occurrence_ids: tuple[str, ...]
+    visibility: Visibility
+    lifecycle: ClaimLifecycle
+    confidence: Confidence
+    source_revision: str = ""
+    authority_actor: str = ""
+    authority_receipt: str = ""
+    eligible_routes: tuple[str, ...] = ()
+    valid_from: str = ""
+    valid_until: str = ""
+    supersedes: tuple[str, ...] = ()
+    correction_of: tuple[str, ...] = ()
+    recurrence_contract_version: str = ""
+    projection_state: str = "shadow"
+    projection_version: str = HYBRID_CANON_CLAIM_CONTRACT_VERSION
+
+
+@dataclass(frozen=True)
+class CanonAdapterResult:
+    claim: CanonClaim | None
+    reason: str
+    live_eligible: bool = False
+
+    @property
+    def contract_valid(self) -> bool:
+        return self.claim is not None
+
+
 @dataclass(frozen=True)
 class Resolution:
     usable: bool
@@ -101,8 +232,14 @@ DJ_FLOPPYDISC = SubjectIdentity(
 CACHE_BACK = SubjectIdentity(
     "cache_back",
     "Cache Back",
-    ("Call'em Bini", "Call’em Bini"),
 )
+CALL_EM_BINI = SubjectIdentity(
+    "call_em_bini",
+    "Call'em Bini",
+    ("Call’em Bini",),
+)
+# Compatibility spelling for early hybrid-contract callers.
+CALLEM_BINI = CALL_EM_BINI
 MAC_MODEM = SubjectIdentity(
     "mac_modem",
     "Mac Modem",
@@ -110,12 +247,25 @@ MAC_MODEM = SubjectIdentity(
 )
 GALAKNOISE = SubjectIdentity("galaknoise", "GALAKNOISE")
 BNL01 = SubjectIdentity("bnl_01", "BNL-01", ("BNL", "BARCODE Network Liaison Entity"))
+SHEILA = SubjectIdentity("sheila", "Sheila")
+CLIFF = SubjectIdentity("cliff", "Cliff")
 
 CANON_MEMBER_IDENTITIES = (
     SIX_BIT,
     DJ_FLOPPYDISC,
     CACHE_BACK,
     MAC_MODEM,
+)
+CANON_ENTITY_IDENTITIES = (
+    BARCODE,
+    BARCODE_NETWORK,
+    BARCODE_RADIO,
+    *CANON_MEMBER_IDENTITIES,
+    CALL_EM_BINI,
+    GALAKNOISE,
+    BNL01,
+    SHEILA,
+    CLIFF,
 )
 AUTOMATIC_CANON_SIGNAL_IDENTITIES = (
     DJ_FLOPPYDISC,
@@ -152,6 +302,878 @@ CANON_FACTS = (
     CanonFact(BNL01, "in_world_boundary", "BNL remains fully in-world; lore is his native operating language, not decorative flavor."),
     CanonFact(BARCODE_NETWORK, "website_information_architecture", "Reality first. Meaning second. Mythology deeper. This governs public website information architecture, not BNL's speaking order."),
 )
+
+BROADCAST_DECLARED_TYPE_DEFAULTS: dict[
+    str, tuple[CanonDomain, ClaimKind]
+] = {
+    "episode_arc": (CanonDomain.BROADCAST_HISTORY, ClaimKind.EVENT),
+    "notable_moment": (CanonDomain.BROADCAST_HISTORY, ClaimKind.EVENT),
+    "running_joke": (CanonDomain.HYBRID, ClaimKind.TRADITION_OR_JOKE),
+    "technical_issue": (CanonDomain.OPERATIONAL, ClaimKind.EVENT),
+    "moderation_context": (CanonDomain.REAL_COMMUNITY, ClaimKind.EVENT),
+    "show_state_override": (CanonDomain.OPERATIONAL, ClaimKind.CURRENT_STATE),
+}
+
+LEGACY_WEBSITE_LORE_RELATIONSHIP_CANDIDATES: tuple[
+    Mapping[str, str], ...
+] = (
+    {
+        "source_ref": "website:src/content.ts:cache_back:origin",
+        "source_revision": "9baac033",
+        "subject_id": CACHE_BACK.key,
+        "object_id": CALL_EM_BINI.key,
+        "text": (
+            "Built from a cache of data left behind by legendary artist "
+            "Call'em Bini."
+        ),
+    },
+)
+
+_BINDING_RECEIPT_PREFIXES = (
+    "binding_receipt:",
+    "owner_command:",
+    "service_receipt:",
+)
+_DECLARATION_RECEIPT_PREFIXES = (
+    "owner_command:",
+    "service_receipt:",
+)
+
+
+def _stable_contract_digest(*values: Any) -> str:
+    encoded = json.dumps(
+        values,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _stable_claim_id(
+    source_system: str,
+    source_identity: str,
+) -> str:
+    """Return source-owned identity stable across corrected revisions."""
+
+    return "clm_" + _stable_contract_digest(
+        CANON_CLAIM_ID_NAMESPACE,
+        source_system,
+        source_identity,
+    )[:32]
+
+
+def _claim_revision_payload(
+    claim: CanonClaim,
+) -> tuple[Any, ...]:
+    """Return every normalized field that makes one immutable revision."""
+
+    return (
+        HYBRID_CANON_CLAIM_CONTRACT_VERSION,
+        claim.source_revision,
+        claim.claim_id,
+        claim.subject_id,
+        claim.predicate,
+        claim.value,
+        claim.canon_status.value,
+        claim.domain.value,
+        claim.claim_kind.value,
+        claim.source_system,
+        claim.adapter_version,
+        claim.source_class.value,
+        claim.source_refs,
+        claim.root_ids,
+        claim.occurrence_ids,
+        claim.visibility.value,
+        claim.lifecycle.value,
+        claim.confidence.value,
+        claim.authority_actor,
+        claim.authority_receipt,
+        claim.eligible_routes,
+        claim.valid_from,
+        claim.valid_until,
+        claim.supersedes,
+        claim.correction_of,
+        claim.recurrence_contract_version,
+        claim.projection_state,
+        claim.projection_version,
+    )
+
+
+def _finalize_claim_revision(
+    claim: CanonClaim,
+) -> str:
+    """Bind an exact normalized revision while preserving stable claim ID."""
+
+    return "rev_" + _stable_contract_digest(
+        *_claim_revision_payload(claim)
+    )[:32]
+
+
+def _with_final_revision(
+    claim: CanonClaim,
+    *,
+    source_revision: str,
+) -> CanonClaim:
+    sourced_claim = replace(claim, source_revision=str(source_revision or ""))
+    revision_id = _finalize_claim_revision(sourced_claim)
+    return replace(sourced_claim, revision_id=revision_id)
+
+
+def strict_contract_bool(value: Any) -> bool:
+    """Coerce only explicit true values; malformed and absent data fail shut."""
+
+    if value is True:
+        return True
+    if value is False or value is None:
+        return False
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value == 1
+    if isinstance(value, str):
+        return value.strip().casefold() in {"1", "true", "yes", "on"}
+    return False
+
+
+def _explicit_contract_false(value: Any) -> bool:
+    if value is False:
+        return True
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value == 0
+    if isinstance(value, str):
+        return value.strip().casefold() in {"0", "false", "no", "off"}
+    return False
+
+
+def _opaque_actor_valid(actor: Any) -> bool:
+    normalized_actor = str(actor or "").strip()
+    return bool(
+        re.fullmatch(r"discord_user:[0-9]+", normalized_actor)
+        or re.fullmatch(
+            r"(?:owner_ref|service_actor):[a-z0-9][a-z0-9_.:-]{0,127}",
+            normalized_actor,
+        )
+    )
+
+
+def _opaque_authority_valid(
+    actor: Any,
+    receipt: Any,
+    *,
+    receipt_prefixes: tuple[str, ...],
+) -> bool:
+    normalized_receipt = str(receipt or "").strip()
+    return bool(
+        _opaque_actor_valid(actor)
+        and any(
+            normalized_receipt.startswith(prefix)
+            and re.fullmatch(
+                re.escape(prefix) + r"[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,191}",
+                normalized_receipt,
+            )
+            for prefix in receipt_prefixes
+        )
+    )
+
+
+def _binding_authority_valid(binding: EntityAccountBinding) -> bool:
+    return bool(
+        str(binding.binding_version or "").strip()
+        == ENTITY_ACCOUNT_BINDING_CONTRACT_VERSION
+        and strict_contract_bool(binding.authority_verified)
+        and _opaque_authority_valid(
+            binding.authority_actor,
+            binding.authority_receipt,
+            receipt_prefixes=_BINDING_RECEIPT_PREFIXES,
+        )
+    )
+
+
+def _platform_account_id_valid(platform: Any, account_id: Any) -> bool:
+    normalized_platform = str(platform or "").strip().casefold()
+    normalized_account = str(account_id or "").strip()
+    if normalized_platform == "discord":
+        return bool(re.fullmatch(r"[1-9][0-9]{0,24}", normalized_account))
+    return bool(
+        normalized_platform
+        and re.fullmatch(
+            r"[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,191}",
+            normalized_account,
+        )
+    )
+
+
+def _legacy_fact_shape(fact: CanonFact) -> tuple[CanonDomain, ClaimKind]:
+    predicate = str(fact.predicate or "")
+    if fact.subject.key == BARCODE_RADIO.key:
+        return CanonDomain.BROADCAST_HISTORY, (
+            ClaimKind.EVENT
+            if predicate in {"friday_public_schedule", "public_nature"}
+            else ClaimKind.OTHER
+        )
+    if predicate in {"primary_identity", "identity", "founding_members"}:
+        return CanonDomain.REAL_COMMUNITY, ClaimKind.IDENTITY
+    if predicate in {"primary_role", "roles", "typical_involvement"}:
+        return CanonDomain.REAL_COMMUNITY, ClaimKind.ROLE
+    if predicate == "behavior":
+        return CanonDomain.HYBRID, ClaimKind.BEHAVIOR_PATTERN
+    if predicate in {
+        "origin",
+        "in_world_boundary",
+        "website_information_architecture",
+    }:
+        return CanonDomain.HYBRID, ClaimKind.WORLD_RULE
+    return CanonDomain.REAL_COMMUNITY, ClaimKind.OTHER
+
+
+def adapt_legacy_canon_fact(fact: CanonFact) -> CanonClaim:
+    """Project one static registry fact without creating a database owner."""
+
+    domain, claim_kind = _legacy_fact_shape(fact)
+    source_ref = "canon_registry:%s:%s" % (
+        fact.subject.key,
+        fact.predicate,
+    )
+    claim_id = _stable_claim_id(
+        "legacy_canon_registry",
+        source_ref,
+    )
+    claim = CanonClaim(
+        claim_id=claim_id,
+        revision_id="",
+        subject_id=fact.subject.key,
+        predicate=fact.predicate,
+        value=fact.value,
+        canon_status=CanonStatus.LEGACY,
+        domain=domain,
+        claim_kind=claim_kind,
+        source_system="legacy_canon_registry",
+        adapter_version=LEGACY_CANON_ADAPTER_VERSION,
+        source_class=fact.source_class,
+        source_refs=(source_ref,),
+        root_ids=(source_ref,),
+        occurrence_ids=(source_ref,),
+        visibility=fact.visibility,
+        lifecycle=ClaimLifecycle.ESTABLISHED,
+        confidence=fact.confidence,
+        authority_actor="owner_ref:legacy_registry",
+        authority_receipt=(
+            "code_revision:%s" % CANON_SOURCE_CONTRACT_VERSION
+        ),
+        eligible_routes=(
+            ("reference_canon", "public_home")
+            if fact.visibility
+            in {
+                Visibility.PUBLIC,
+                Visibility.PUBLIC_SAFE,
+                Visibility.REFERENCE_CANON,
+            }
+            else ("reference_canon",)
+        ),
+        projection_state="shadow",
+        projection_version=LEGACY_CANON_ADAPTER_VERSION,
+    )
+    return _with_final_revision(
+        claim,
+        source_revision=CANON_SOURCE_CONTRACT_VERSION,
+    )
+
+
+def _mapping_text(row: Mapping[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = row.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def adapt_broadcast_memory_claim(
+    row: Mapping[str, Any],
+    *,
+    owner_authorized: bool = False,
+    authority_actor: str = "",
+    authority_receipt: str = "",
+) -> CanonAdapterResult:
+    """Build a read-only Declared projection from one Broadcast source row.
+
+    Historical or unauthenticated rows intentionally remain review-only.  PR 2
+    owns mutation APIs and the full Declared lifecycle; this adapter only
+    freezes the common shape and prevents legacy type coercion.
+    """
+
+    row_id = _mapping_text(row, "id", "row_id")
+    entry_type = _mapping_text(row, "entry_type", "type")
+    cleaned_value = _mapping_text(row, "cleaned_summary", "summary")
+    raw_value = _mapping_text(row, "raw_note")
+    value = cleaned_value or raw_value
+    if not row_id or not entry_type or not value:
+        return CanonAdapterResult(None, "missing_broadcast_source_identity")
+    subject_id = _mapping_text(row, "subject_id", "subject_key") or BARCODE_RADIO.key
+    defaults = BROADCAST_DECLARED_TYPE_DEFAULTS.get(entry_type)
+    status = (_mapping_text(row, "status") or "active").casefold()
+    recognized = defaults is not None
+    if defaults is None:
+        domain, claim_kind = CanonDomain.BROADCAST_HISTORY, ClaimKind.OTHER
+    else:
+        domain, claim_kind = defaults
+    if status == "superseded":
+        lifecycle = ClaimLifecycle.SUPERSEDED
+    elif status == "resolved":
+        lifecycle = ClaimLifecycle.RESOLVED
+    else:
+        lifecycle = ClaimLifecycle.REVIEW_ONLY
+    source_ref = "broadcast_memory:%s" % row_id
+    claim_id = _stable_claim_id(
+        "broadcast_memory",
+        source_ref,
+    )
+    source_revision = _mapping_text(
+        row,
+        "revision_id",
+        "updated_at",
+        "created_at",
+    ) or row_id
+    owner_authorized = strict_contract_bool(owner_authorized)
+    authority_verified = bool(
+        owner_authorized
+        and _opaque_authority_valid(
+            authority_actor,
+            authority_receipt,
+            receipt_prefixes=_DECLARATION_RECEIPT_PREFIXES,
+        )
+    )
+    public_safe = strict_contract_bool(row.get("public_safe"))
+    usage_scope = {
+        token.strip().casefold()
+        for token in _mapping_text(row, "usage_scope").split(",")
+        if token.strip()
+    }
+    public_route_scope = bool(
+        "internal" not in usage_scope
+        and entry_type != "moderation_context"
+        and bool(
+            usage_scope.intersection(
+                {
+                    "ambient",
+                    "direct",
+                    "public",
+                    "public_context",
+                    "relay",
+                    "show_status",
+                }
+            )
+        )
+    )
+    public_projection = bool(
+        authority_verified
+        and cleaned_value
+        and public_safe
+        and public_route_scope
+        and status == "active"
+    )
+    supersedes = _mapping_text(row, "supersedes_id")
+    correction_of = _mapping_text(row, "correction_of")
+    claim = CanonClaim(
+        claim_id=claim_id,
+        revision_id="",
+        subject_id=subject_id,
+        predicate=entry_type,
+        value=value,
+        canon_status=(
+            CanonStatus.DECLARED
+            if authority_verified
+            else CanonStatus.OPEN_SIGNAL
+        ),
+        domain=domain,
+        claim_kind=claim_kind,
+        source_system="broadcast_memory",
+        adapter_version=BROADCAST_CANON_ADAPTER_VERSION,
+        source_class=SourceClass.FIRST_PARTY_RECORD,
+        source_refs=(source_ref,),
+        root_ids=(source_ref,),
+        occurrence_ids=(source_ref,),
+        visibility=(
+            Visibility.PUBLIC_SAFE
+            if public_projection
+            else Visibility.INTERNAL
+        ),
+        lifecycle=lifecycle,
+        confidence=(Confidence.HIGH if authority_verified else Confidence.LOW),
+        authority_actor=(authority_actor if authority_verified else ""),
+        authority_receipt=(authority_receipt if authority_verified else ""),
+        eligible_routes=(
+            ("broadcast_memory", "public_home")
+            if public_projection
+            else ("broadcast_memory",)
+        ),
+        valid_from=_mapping_text(row, "valid_from", "created_at"),
+        valid_until=_mapping_text(row, "valid_until"),
+        supersedes=(("broadcast_memory:%s" % supersedes,) if supersedes else ()),
+        correction_of=(("broadcast_memory:%s" % correction_of,) if correction_of else ()),
+        projection_state="review_only" if lifecycle == ClaimLifecycle.REVIEW_ONLY else "shadow",
+        projection_version=BROADCAST_CANON_ADAPTER_VERSION,
+    )
+    claim = _with_final_revision(
+        claim,
+        source_revision=source_revision,
+    )
+    return CanonAdapterResult(
+        claim,
+        (
+            "superseded_or_resolved"
+            if lifecycle
+            in {ClaimLifecycle.SUPERSEDED, ClaimLifecycle.RESOLVED}
+            else "legacy_type_review_only"
+            if not recognized
+            else "owner_verified_review_only"
+            if authority_verified
+            else "owner_authority_review_only"
+        ),
+    )
+
+
+def _normalized_identity_tuple(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        values: Iterable[Any] = (value,)
+    elif isinstance(value, Iterable):
+        values = value
+    else:
+        values = ()
+    return tuple(
+        dict.fromkeys(
+            str(item).strip() for item in values if str(item).strip()
+        )
+    )
+
+
+def _strict_nonnegative_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return 0
+    return max(0, parsed)
+
+
+def _review_only_source_claim(
+    *,
+    source_system: str,
+    source_identity: str,
+    source_revision: str,
+    subject_id: str,
+    predicate: str,
+    value: Any,
+    root_ids: tuple[str, ...],
+    occurrence_ids: tuple[str, ...],
+    domain: CanonDomain,
+    claim_kind: ClaimKind,
+) -> CanonClaim:
+    source_ref = "%s:%s" % (source_system, source_identity)
+    claim = CanonClaim(
+        claim_id=_stable_claim_id(source_system, source_identity),
+        revision_id="",
+        subject_id=subject_id,
+        predicate=predicate,
+        value=value,
+        canon_status=CanonStatus.OPEN_SIGNAL,
+        domain=domain,
+        claim_kind=claim_kind,
+        source_system=source_system,
+        adapter_version=LIVING_CANON_ADAPTER_VERSION,
+        source_class=SourceClass.EVIDENCE_PROJECTION,
+        source_refs=(source_ref,),
+        root_ids=root_ids,
+        occurrence_ids=occurrence_ids,
+        visibility=Visibility.INTERNAL,
+        lifecycle=ClaimLifecycle.REVIEW_ONLY,
+        confidence=Confidence.LOW,
+        eligible_routes=(),
+        projection_state="review_only",
+        projection_version=LIVING_CANON_ADAPTER_VERSION,
+    )
+    return _with_final_revision(claim, source_revision=source_revision)
+
+
+def _adapt_living_pattern_claim(
+    row: Mapping[str, Any],
+    *,
+    source_system: str,
+    source_identity_key: str,
+) -> CanonAdapterResult:
+    candidate_type = _mapping_text(row, "candidate_type")
+    candidate_state = _mapping_text(row, "candidate_state", "lifecycle")
+    subject_id = _mapping_text(row, "subject_key", "subject_id")
+    predicate = _mapping_text(row, "predicate_key", "predicate")
+    value = _mapping_text(row, "meaning", "value")
+    root_ids = _normalized_identity_tuple(
+        row.get("root_ids") or row.get("root_entry_ids") or ()
+    )
+    occurrence_ids = _normalized_identity_tuple(
+        row.get("occurrence_ids") or row.get("occurrence_identities") or ()
+    )
+    source_identity = _mapping_text(row, source_identity_key)
+    if not source_identity:
+        return CanonAdapterResult(None, "living_source_identity_missing")
+    if candidate_state != ClaimLifecycle.ESTABLISHED.value:
+        return CanonAdapterResult(None, "living_lifecycle_ineligible")
+    if not subject_id or not predicate or not value:
+        return CanonAdapterResult(None, "living_source_lineage_missing")
+    source_revision = (
+        _mapping_text(row, "updated_at", "last_seen_at") or source_identity
+    )
+    try:
+        review_domain_hint = CanonDomain(_mapping_text(row, "domain"))
+    except ValueError:
+        review_domain_hint = CanonDomain.REAL_COMMUNITY
+    try:
+        review_kind_hint = ClaimKind(_mapping_text(row, "claim_kind"))
+    except ValueError:
+        review_kind_hint = (
+            ClaimKind.BEHAVIOR_PATTERN
+            if candidate_type == "topic_or_motif"
+            else ClaimKind.OTHER
+        )
+
+    def review(
+        reason: str,
+        *,
+        review_domain: CanonDomain | None = None,
+        review_kind: ClaimKind | None = None,
+    ) -> CanonAdapterResult:
+        return CanonAdapterResult(
+            _review_only_source_claim(
+                source_system=source_system,
+                source_identity=source_identity,
+                source_revision=source_revision,
+                subject_id=subject_id,
+                predicate=predicate,
+                value=value,
+                root_ids=root_ids,
+                occurrence_ids=occurrence_ids,
+                domain=review_domain or review_domain_hint,
+                claim_kind=review_kind or review_kind_hint,
+            ),
+            reason,
+        )
+
+    if candidate_type != "topic_or_motif":
+        return review(
+            "living_claim_kind_ineligible",
+            review_kind=ClaimKind.OTHER,
+        )
+    if not root_ids:
+        return review("living_source_lineage_missing")
+    if (
+        _mapping_text(row, "recurrence_contract_version")
+        != LIVING_CANON_RECURRENCE_VERSION
+    ):
+        return review("living_recurrence_unverified")
+    try:
+        domain = CanonDomain(_mapping_text(row, "domain"))
+        claim_kind = ClaimKind(_mapping_text(row, "claim_kind"))
+    except ValueError:
+        return review("living_domain_unverified")
+    if domain not in {
+        CanonDomain.REAL_COMMUNITY,
+        CanonDomain.LORE,
+        CanonDomain.HYBRID,
+    } or claim_kind not in {
+        ClaimKind.BEHAVIOR_PATTERN,
+        ClaimKind.TRADITION_OR_JOKE,
+    }:
+        return review(
+            "living_domain_ineligible",
+            review_domain=domain,
+            review_kind=claim_kind,
+        )
+    required_proofs = (
+        "candidate_eligible",
+        "source_eligible",
+        "roots_valid",
+        "occurrence_bounded",
+        "correction_fence_clear",
+        "contradiction_clear",
+    )
+    if not all(strict_contract_bool(row.get(key)) for key in required_proofs):
+        return review(
+            "living_recurrence_unverified",
+            review_domain=domain,
+            review_kind=claim_kind,
+        )
+    independent_roots = _strict_nonnegative_int(
+        row.get("independent_root_count")
+    )
+    independent_occurrences = _strict_nonnegative_int(
+        row.get("independent_occurrence_count")
+    )
+    if (
+        independent_roots < 2
+        or independent_occurrences < 2
+        or len(root_ids) < 2
+        or len(occurrence_ids) < 2
+    ):
+        return review(
+            "living_recurrence_insufficient",
+            review_domain=domain,
+            review_kind=claim_kind,
+        )
+    source_ref = "%s:%s" % (source_system, source_identity)
+    claim_id = _stable_claim_id(
+        source_system,
+        source_identity,
+    )
+    visibility = (
+        Visibility.PUBLIC_SAFE
+        if _mapping_text(row, "visibility") in {"public", "public_safe"}
+        and strict_contract_bool(row.get("public_usable"))
+        else Visibility.INTERNAL
+    )
+    claim = CanonClaim(
+        claim_id=claim_id,
+        revision_id="",
+        subject_id=subject_id,
+        predicate=predicate,
+        value=value,
+        canon_status=CanonStatus.LIVING,
+        domain=domain,
+        claim_kind=claim_kind,
+        source_system=source_system,
+        adapter_version=LIVING_CANON_ADAPTER_VERSION,
+        source_class=SourceClass.EVIDENCE_PROJECTION,
+        source_refs=(source_ref,),
+        root_ids=root_ids,
+        occurrence_ids=occurrence_ids,
+        visibility=visibility,
+        lifecycle=ClaimLifecycle.ESTABLISHED,
+        confidence=Confidence.MEDIUM,
+        eligible_routes=(
+            ("public_home",)
+            if visibility == Visibility.PUBLIC_SAFE
+            else ()
+        ),
+        recurrence_contract_version=LIVING_CANON_RECURRENCE_VERSION,
+        projection_state="shadow",
+        projection_version=LIVING_CANON_ADAPTER_VERSION,
+    )
+    return CanonAdapterResult(
+        _with_final_revision(
+            claim,
+            source_revision=source_revision,
+        ),
+        "eligible_living",
+    )
+
+
+def adapt_living_atomic_claim(row: Mapping[str, Any]) -> CanonAdapterResult:
+    """Normalize only an independently recurrence-verified atomic motif."""
+
+    return _adapt_living_pattern_claim(
+        row,
+        source_system="atomic_knowledge",
+        source_identity_key="candidate_id",
+    )
+
+
+def adapt_living_moment_claim(row: Mapping[str, Any]) -> CanonAdapterResult:
+    """Normalize Moment material only after cross-occurrence proof exists."""
+
+    normalized = dict(row)
+    moment_id = _mapping_text(normalized, "moment_id")
+    normalized.setdefault("candidate_type", "topic_or_motif")
+    if _mapping_text(normalized, "lifecycle_status") == "finalized":
+        normalized.setdefault("candidate_state", "established")
+    normalized.setdefault(
+        "meaning",
+        _mapping_text(normalized, "contribution_gist", "summary"),
+    )
+    normalized.setdefault(
+        "predicate_key",
+        _mapping_text(normalized, "topic_key") or "community_moment_pattern",
+    )
+    normalized.setdefault("domain", CanonDomain.REAL_COMMUNITY.value)
+    if not _mapping_text(normalized, "subject_key", "subject_id") and moment_id:
+        normalized["subject_key"] = "moment:%s" % moment_id
+        normalized.setdefault("claim_kind", ClaimKind.EVENT.value)
+    else:
+        normalized.setdefault(
+            "claim_kind",
+            ClaimKind.BEHAVIOR_PATTERN.value,
+        )
+    return _adapt_living_pattern_claim(
+        normalized,
+        source_system="memory_moment",
+        source_identity_key="moment_id",
+    )
+
+
+def adapt_open_signal_claim(row: Any) -> CanonAdapterResult:
+    """Normalize one already-governed question-scoped public observation."""
+
+    if not isinstance(row, Mapping):
+        if is_dataclass(row):
+            row = asdict(row)
+        else:
+            return CanonAdapterResult(None, "open_signal_contract_shape_invalid")
+
+    subject_id = _mapping_text(row, "subject_key", "subject_id")
+    entry_id = _mapping_text(row, "entry_id", "source_ref")
+    value = _mapping_text(row, "text", "value")
+    occurrence_id = _mapping_text(row, "occurrence_identity")
+    if not subject_id or not entry_id or not value or not occurrence_id:
+        return CanonAdapterResult(None, "open_signal_source_lineage_missing")
+    if (
+        _mapping_text(row, "assessment_contract_version")
+        != PUBLIC_ASSESSMENT_EVIDENCE_VERSION
+        or _mapping_text(row, "source_system")
+        != "memory_ledger_public_assessment"
+    ):
+        return CanonAdapterResult(None, "open_signal_governance_unverified")
+    if (
+        _mapping_text(row, "source_role").casefold() != "user"
+        or _mapping_text(row, "source_class").casefold()
+        != SourceClass.PUBLIC_OBSERVATION.value
+        or _mapping_text(row, "lifecycle_status").casefold() != "active"
+        or _mapping_text(row, "visibility").casefold()
+        not in {Visibility.PUBLIC.value, Visibility.PUBLIC_SAFE.value}
+        or _mapping_text(row, "channel_policy").casefold()
+        not in {"public_home", "public_context", "public_selective"}
+        or not strict_contract_bool(row.get("public_usable"))
+        or not strict_contract_bool(row.get("subject_authored"))
+        or not strict_contract_bool(row.get("selector_eligible"))
+        or not _explicit_contract_false(row.get("derived"))
+        or not _explicit_contract_false(row.get("projection"))
+    ):
+        return CanonAdapterResult(None, "open_signal_source_ineligible")
+    source_ref = (
+        entry_id if entry_id.startswith("memory_ledger:") else "memory_ledger:%s" % entry_id
+    )
+    predicate = _mapping_text(row, "predicate", "predicate_key") or "public_observation"
+    claim_id = _stable_claim_id(
+        "public_assessment_observation",
+        source_ref,
+    )
+    source_revision = (
+        _mapping_text(row, "source_digest", "observed_at") or entry_id
+    )
+    claim = CanonClaim(
+        claim_id=claim_id,
+        revision_id="",
+        subject_id=subject_id,
+        predicate=predicate,
+        value=value,
+        canon_status=CanonStatus.OPEN_SIGNAL,
+        domain=CanonDomain.REAL_COMMUNITY,
+        claim_kind=ClaimKind.BEHAVIOR_PATTERN,
+        source_system="public_assessment_observation",
+        adapter_version=OPEN_SIGNAL_ADAPTER_VERSION,
+        source_class=SourceClass.PUBLIC_OBSERVATION,
+        source_refs=(source_ref,),
+        root_ids=(source_ref,),
+        occurrence_ids=(occurrence_id,),
+        visibility=Visibility.PUBLIC_SAFE,
+        lifecycle=ClaimLifecycle.CANDIDATE,
+        confidence=Confidence.LOW,
+        eligible_routes=("public_home",),
+        projection_state="ephemeral",
+        projection_version=OPEN_SIGNAL_ADAPTER_VERSION,
+    )
+    return CanonAdapterResult(
+        _with_final_revision(
+            claim,
+            source_revision=source_revision,
+        ),
+        "eligible_open_signal",
+    )
+
+
+def adapt_website_lore_relationship_candidate(
+    row: Mapping[str, Any],
+) -> CanonAdapterResult:
+    """Preserve legacy site lore as nonfactual, internal review material."""
+
+    source_ref = _mapping_text(row, "source_ref")
+    subject_id = _mapping_text(row, "subject_id")
+    object_id = _mapping_text(row, "object_id")
+    value = _mapping_text(row, "text", "value")
+    if not source_ref or not subject_id or not object_id or not value:
+        return CanonAdapterResult(None, "website_lore_source_lineage_missing")
+    if subject_id == object_id:
+        return CanonAdapterResult(None, "website_lore_identity_merge_rejected")
+    predicate = "legacy_lore_origin_relationship_candidate"
+    claim_id = _stable_claim_id(
+        "website_legacy_lore",
+        source_ref,
+    )
+    claim = CanonClaim(
+        claim_id=claim_id,
+        revision_id="",
+        subject_id=subject_id,
+        predicate=predicate,
+        value={"object_id": object_id, "text": value},
+        canon_status=CanonStatus.OPEN_SIGNAL,
+        domain=CanonDomain.LORE,
+        claim_kind=ClaimKind.RELATIONSHIP,
+        source_system="website_legacy_lore",
+        adapter_version=WEBSITE_LORE_ADAPTER_VERSION,
+        source_class=SourceClass.DOSSIER_PROJECTION,
+        source_refs=(source_ref,),
+        root_ids=(source_ref,),
+        occurrence_ids=(source_ref,),
+        visibility=Visibility.INTERNAL,
+        lifecycle=ClaimLifecycle.REVIEW_ONLY,
+        confidence=Confidence.UNKNOWN,
+        eligible_routes=(),
+        projection_state="review_only",
+        projection_version=WEBSITE_LORE_ADAPTER_VERSION,
+    )
+    return CanonAdapterResult(
+        _with_final_revision(
+            claim,
+            source_revision=_mapping_text(row, "source_revision") or source_ref,
+        ),
+        "website_lore_review_only",
+    )
+
+
+def _parse_contract_time(value: Any) -> datetime | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def claim_within_validity_window(
+    claim: CanonClaim,
+    *,
+    at: datetime | str | None = None,
+) -> bool:
+    """Evaluate time applicability without changing status or lifecycle."""
+
+    if isinstance(at, datetime):
+        current = at
+        if current.tzinfo is None:
+            current = current.replace(tzinfo=timezone.utc)
+        current = current.astimezone(timezone.utc)
+    elif at is None:
+        current = datetime.now(timezone.utc)
+    else:
+        current = _parse_contract_time(at)
+        if current is None:
+            return False
+    start = _parse_contract_time(claim.valid_from)
+    end = _parse_contract_time(claim.valid_until)
+    if claim.valid_from and start is None:
+        return False
+    if claim.valid_until and end is None:
+        return False
+    return not ((start is not None and current < start) or (end is not None and current > end))
 
 _SOURCE_RANK = {c: i for i, c in enumerate((SourceClass.LEGACY_SOURCE_BLIND, SourceClass.DERIVED_SUMMARY, SourceClass.ENTITY_EVIDENCE_PROJECTION, SourceClass.DOSSIER_PROJECTION, SourceClass.SOURCE_FILE_PROJECTION, SourceClass.EVIDENCE_PROJECTION, SourceClass.PUBLIC_OBSERVATION, SourceClass.RUNTIME_OBSERVATION, SourceClass.FIRST_PARTY_RECORD, SourceClass.APPROVED_CANON, SourceClass.OWNER_CORRECTION), start=1)}
 _CONFIDENCE_RANK = {Confidence.UNKNOWN: 0, Confidence.LOW: 1, Confidence.MEDIUM: 2, Confidence.HIGH: 3, Confidence.APPROVED: 4}
@@ -253,6 +1275,621 @@ def matching_canon_member_identities(
     return tuple(matches)
 
 
+def matching_canon_entity_identities(
+    labels: Iterable[Any],
+) -> tuple[SubjectIdentity, ...]:
+    """Return exact presentation matches without binding an account."""
+
+    normalized = {
+        label
+        for label in (
+            normalize_canon_identity_label(value) for value in labels
+        )
+        if label
+    }
+    if not normalized:
+        return ()
+    matches = []
+    for subject in CANON_ENTITY_IDENTITIES:
+        subject_labels = {
+            label
+            for label in (
+                normalize_canon_identity_label(value)
+                for value in (subject.name, *subject.aliases)
+            )
+            if label
+        }
+        if normalized.intersection(subject_labels):
+            matches.append(subject)
+    return tuple(matches)
+
+
+def resolve_entity_identity(
+    *,
+    platform: str,
+    account_id: str,
+    labels: Iterable[Any] = (),
+    bindings: Sequence[EntityAccountBinding] = (),
+) -> EntityResolution:
+    """Resolve an entity with immutable account bindings taking precedence.
+
+    Exact names can produce a reversible presentation hint, but only an
+    explicit active binding returns the `account_binding` method.  Ambiguous
+    bindings or labels fail closed.
+    """
+
+    normalized_platform = str(platform or "").strip().casefold()
+    normalized_account = str(account_id or "").strip()
+    candidates = tuple(
+        binding
+        for binding in bindings
+        if _platform_account_id_valid(
+            normalized_platform,
+            normalized_account,
+        )
+        and strict_contract_bool(binding.active)
+        and _binding_authority_valid(binding)
+        and str(binding.platform or "").strip().casefold()
+        == normalized_platform
+        and str(binding.account_id or "").strip() == normalized_account
+    )
+    subjects_by_id = {
+        subject.key: subject for subject in CANON_ENTITY_IDENTITIES
+    }
+    bound_ids = {
+        str(binding.entity_id or "").strip() for binding in candidates
+    }
+    if len(bound_ids) > 1:
+        return EntityResolution(
+            "ambiguous",
+            method="account_binding",
+            reason="account_binding_collision",
+        )
+    if len(bound_ids) == 1:
+        entity_id = next(iter(bound_ids))
+        subject = subjects_by_id.get(entity_id)
+        if subject is None:
+            return EntityResolution(
+                "unresolved",
+                method="account_binding",
+                reason="bound_entity_unknown",
+            )
+        return EntityResolution(
+            "resolved",
+            subject=subject,
+            method="account_binding",
+            reason="stable_account_binding",
+        )
+    label_matches = matching_canon_entity_identities(labels)
+    if len(label_matches) > 1:
+        return EntityResolution(
+            "ambiguous",
+            method="exact_label_hint",
+            reason="identity_label_collision",
+        )
+    if len(label_matches) == 1:
+        return EntityResolution(
+            "hint_only",
+            subject=label_matches[0],
+            method="exact_label_hint",
+            reason="display_label_not_account_binding",
+        )
+    return EntityResolution(
+        "unresolved",
+        method="none",
+        reason="no_identity_evidence",
+    )
+
+
+def canon_claim_inventory_diagnostics(
+    claims: Iterable[CanonClaim],
+    *,
+    bindings: Sequence[EntityAccountBinding] = (),
+) -> dict[str, Any]:
+    """Return content-free collision and contract diagnostics."""
+
+    normalized_claims = tuple(claims)
+    claim_scopes: dict[str, set[str]] = {}
+    revision_payloads: dict[str, set[str]] = {}
+    for claim in normalized_claims:
+        claim_scopes.setdefault(claim.claim_id, set()).add(
+            _stable_contract_digest(
+                claim.source_system,
+                claim.source_refs,
+            )
+        )
+        revision_payloads.setdefault(claim.revision_id, set()).add(
+            _stable_contract_digest(*_claim_revision_payload(claim))
+        )
+    account_entities: dict[tuple[str, str], set[str]] = {}
+    for binding in bindings:
+        if not strict_contract_bool(binding.active) or not _binding_authority_valid(
+            binding
+        ):
+            continue
+        key = (
+            str(binding.platform or "").strip().casefold(),
+            str(binding.account_id or "").strip(),
+        )
+        account_entities.setdefault(key, set()).add(
+            str(binding.entity_id or "").strip()
+        )
+    label_entities: dict[str, set[str]] = {}
+    for subject in CANON_ENTITY_IDENTITIES:
+        for raw_label in (subject.name, *subject.aliases):
+            label = normalize_canon_identity_label(raw_label)
+            if label:
+                label_entities.setdefault(label, set()).add(subject.key)
+    cache_labels = {
+        normalize_canon_identity_label(value)
+        for value in (CACHE_BACK.name, *CACHE_BACK.aliases)
+        if normalize_canon_identity_label(value)
+    }
+    callem_labels = {
+        normalize_canon_identity_label(value)
+        for value in (CALLEM_BINI.name, *CALLEM_BINI.aliases)
+        if normalize_canon_identity_label(value)
+    }
+    return {
+        "claimContractVersion": HYBRID_CANON_CLAIM_CONTRACT_VERSION,
+        "claimCount": len(normalized_claims),
+        "claimIdCollisionCount": sum(
+            1 for scopes in claim_scopes.values() if len(scopes) > 1
+        ),
+        "revisionIdCollisionCount": sum(
+            1 for payloads in revision_payloads.values() if len(payloads) > 1
+        ),
+        "revisionDigestMismatchCount": sum(
+            1
+            for claim in normalized_claims
+            if claim.revision_id != _finalize_claim_revision(claim)
+        ),
+        "identityBindingCollisionCount": sum(
+            1 for entity_ids in account_entities.values() if len(entity_ids) > 1
+        ),
+        "identityLabelCollisionCount": sum(
+            1 for entity_ids in label_entities.values() if len(entity_ids) > 1
+        ),
+        "callemCacheIdentityCollisionCount": int(
+            bool(cache_labels.intersection(callem_labels))
+        ),
+        "nonOpaqueAuthorityActorCount": sum(
+            1
+            for claim in normalized_claims
+            if claim.authority_actor
+            and not _opaque_actor_valid(claim.authority_actor)
+        ),
+        "nonOpaqueBindingActorCount": sum(
+            1
+            for binding in bindings
+            if binding.authority_actor
+            and not _opaque_actor_valid(binding.authority_actor)
+        ),
+        "sourceSystems": tuple(
+            sorted({claim.source_system for claim in normalized_claims})
+        ),
+        "statuses": {
+            status.value: sum(
+                1
+                for claim in normalized_claims
+                if claim.canon_status == status
+            )
+            for status in CanonStatus
+        },
+    }
+
+
+def _sqlite_table_columns(conn: Any, table_name: str) -> tuple[str, ...]:
+    if not conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (str(table_name or ""),),
+    ).fetchone():
+        return ()
+    return tuple(
+        str(row[1] or "")
+        for row in conn.execute(
+            "PRAGMA table_info(%s)" % str(table_name or "")
+        ).fetchall()
+        if len(row) > 1 and str(row[1] or "")
+    )
+
+
+def _inventory_table_rows(
+    conn: Any,
+    *,
+    table_name: str,
+    wanted_columns: Sequence[str],
+    guild_id: int | None,
+    limit: int,
+) -> tuple[int, tuple[dict[str, Any], ...], bool]:
+    columns = _sqlite_table_columns(conn, table_name)
+    selected = tuple(column for column in wanted_columns if column in columns)
+    if not columns:
+        return 0, (), False
+    scope_unavailable = bool(
+        guild_id is not None and "guild_id" not in columns
+    )
+    where = ""
+    params: list[Any] = []
+    if guild_id is not None and "guild_id" in columns:
+        where = " WHERE guild_id=?"
+        params.append(int(guild_id or 0))
+    total = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM %s%s" % (table_name, where),
+            tuple(params),
+        ).fetchone()[0]
+        or 0
+    )
+    if not selected:
+        return total, (), True
+    order_column = next(
+        (
+            column
+            for column in (
+                "id",
+                "candidate_id",
+                "moment_id",
+                "entity_id",
+            )
+            if column in selected
+        ),
+        selected[0],
+    )
+    rows = conn.execute(
+        "SELECT %s FROM %s%s ORDER BY %s LIMIT ?"
+        % (",".join(selected), table_name, where, order_column),
+        (*params, max(1, min(int(limit or 1), 2000))),
+    ).fetchall()
+    return (
+        total,
+        tuple(
+            {column: row[index] for index, column in enumerate(selected)}
+            for row in rows
+        ),
+        bool(total > len(rows) or scope_unavailable),
+    )
+
+
+def _inventory_scoped_lineage_map(
+    conn: Any,
+    *,
+    table_name: str,
+    owner_column: str,
+    root_column: str,
+    owner_ids: Sequence[str],
+    guild_id: int | None,
+    independent_only: bool = False,
+) -> dict[str, list[str]]:
+    """Load roots only for the bounded owners already selected for inventory."""
+
+    columns = _sqlite_table_columns(conn, table_name)
+    required = {owner_column, root_column}
+    normalized_ids = tuple(
+        dict.fromkeys(str(value or "").strip() for value in owner_ids)
+    )
+    normalized_ids = tuple(value for value in normalized_ids if value)
+    if not required.issubset(columns) or not normalized_ids:
+        return {}
+    result: dict[str, list[str]] = {}
+    for start in range(0, len(normalized_ids), 400):
+        chunk = normalized_ids[start : start + 400]
+        where = [
+            "%s IN (%s)" % (owner_column, ",".join("?" for _ in chunk))
+        ]
+        params: list[Any] = list(chunk)
+        if guild_id is not None and "guild_id" in columns:
+            where.append("guild_id=?")
+            params.append(int(guild_id or 0))
+        if independent_only and "is_independent" in columns:
+            where.append("is_independent=1")
+        query = (
+            "SELECT %s,%s FROM %s WHERE %s ORDER BY %s,%s"
+            % (
+                owner_column,
+                root_column,
+                table_name,
+                " AND ".join(where),
+                owner_column,
+                root_column,
+            )
+        )
+        for owner_id, root_id in conn.execute(query, tuple(params)).fetchall():
+            if owner_id and root_id:
+                result.setdefault(str(owner_id), []).append(str(root_id))
+    return result
+
+
+def build_claim_contract_inventory(
+    conn: Any,
+    *,
+    guild_id: int | None = None,
+    max_rows_per_source: int = 2000,
+) -> dict[str, Any]:
+    """Build a bounded, content-free, zero-write adapter inventory.
+
+    This function intentionally performs no `ensure_*_schema` call.  Missing
+    sources remain absent, and every adapted/rejected count reconciles to the
+    exact bounded rows inspected without exposing names, text, account IDs, or
+    row identifiers.
+    """
+
+    before_changes = int(getattr(conn, "total_changes", 0) or 0)
+    claims: list[CanonClaim] = [
+        adapt_legacy_canon_fact(fact) for fact in CANON_FACTS
+    ]
+    source_rows: Counter[str] = Counter(
+        {"legacy_canon_registry": len(CANON_FACTS)}
+    )
+    inspected_rows: Counter[str] = Counter(
+        {"legacy_canon_registry": len(CANON_FACTS)}
+    )
+    adapted_rows: Counter[str] = Counter(
+        {"legacy_canon_registry": len(CANON_FACTS)}
+    )
+    rejected_rows: Counter[str] = Counter()
+    reason_counts: Counter[str] = Counter(
+        {"eligible_legacy": len(CANON_FACTS)}
+    )
+    truncated_sources: list[str] = []
+
+    source_rows["website_legacy_lore"] = len(
+        LEGACY_WEBSITE_LORE_RELATIONSHIP_CANDIDATES
+    )
+    inspected_rows["website_legacy_lore"] = len(
+        LEGACY_WEBSITE_LORE_RELATIONSHIP_CANDIDATES
+    )
+    for row in LEGACY_WEBSITE_LORE_RELATIONSHIP_CANDIDATES:
+        result = adapt_website_lore_relationship_candidate(row)
+        reason_counts[result.reason] += 1
+        if result.claim is not None:
+            claims.append(result.claim)
+            adapted_rows["website_legacy_lore"] += 1
+        else:
+            rejected_rows["website_legacy_lore"] += 1
+
+    broadcast_total, broadcast_rows, broadcast_truncated = (
+        _inventory_table_rows(
+            conn,
+            table_name="broadcast_memory",
+            wanted_columns=(
+                "id",
+                "guild_id",
+                "entry_type",
+                "raw_note",
+                "cleaned_summary",
+                "summary",
+                "status",
+                "public_safe",
+                "usage_scope",
+                "subject_id",
+                "subject_key",
+                "revision_id",
+                "updated_at",
+                "created_at",
+                "valid_from",
+                "valid_until",
+                "supersedes_id",
+                "correction_of",
+            ),
+            guild_id=guild_id,
+            limit=max_rows_per_source,
+        )
+    )
+    source_rows["broadcast_memory"] = broadcast_total
+    inspected_rows["broadcast_memory"] = len(broadcast_rows)
+    if broadcast_truncated:
+        truncated_sources.append("broadcast_memory")
+    for row in broadcast_rows:
+        result = adapt_broadcast_memory_claim(row)
+        reason_counts[result.reason] += 1
+        if result.claim is not None:
+            claims.append(result.claim)
+            adapted_rows["broadcast_memory"] += 1
+        else:
+            rejected_rows["broadcast_memory"] += 1
+
+    atomic_total, atomic_rows, atomic_truncated = _inventory_table_rows(
+        conn,
+        table_name="memory_ledger_knowledge_candidates",
+        wanted_columns=(
+            "candidate_id",
+            "candidate_type",
+            "candidate_state",
+            "subject_key",
+            "predicate_key",
+            "normalized_value",
+            "visibility",
+            "public_usable",
+            "candidate_eligible",
+            "independent_root_count",
+            "updated_at",
+            "last_seen_at",
+        ),
+        guild_id=guild_id,
+        limit=max_rows_per_source,
+    )
+    source_rows["atomic_knowledge"] = atomic_total
+    inspected_rows["atomic_knowledge"] = len(atomic_rows)
+    if atomic_truncated:
+        truncated_sources.append("atomic_knowledge")
+    root_map = _inventory_scoped_lineage_map(
+        conn,
+        table_name="memory_ledger_knowledge_roots",
+        owner_column="candidate_id",
+        root_column="root_entry_id",
+        owner_ids=tuple(
+            str(row.get("candidate_id") or "") for row in atomic_rows
+        ),
+        guild_id=guild_id,
+        independent_only=True,
+    )
+    for row in atomic_rows:
+        normalized = dict(row)
+        normalized["meaning"] = normalized.get("normalized_value")
+        normalized["root_ids"] = tuple(
+            root_map.get(str(normalized.get("candidate_id") or ""), ())
+        )
+        result = adapt_living_atomic_claim(normalized)
+        reason_counts[result.reason] += 1
+        if result.claim is not None:
+            claims.append(result.claim)
+            adapted_rows["atomic_knowledge"] += 1
+        else:
+            rejected_rows["atomic_knowledge"] += 1
+
+    moment_total, moment_rows, moment_truncated = _inventory_table_rows(
+        conn,
+        table_name="memory_moment_windows",
+        wanted_columns=(
+            "moment_id",
+            "guild_id",
+            "lifecycle_status",
+            "summary",
+            "topic_key",
+            "visibility",
+            "public_usable",
+            "updated_at",
+            "last_activity_at",
+        ),
+        guild_id=guild_id,
+        limit=max_rows_per_source,
+    )
+    source_rows["memory_moment"] = moment_total
+    inspected_rows["memory_moment"] = len(moment_rows)
+    if moment_truncated:
+        truncated_sources.append("memory_moment")
+    moment_root_map = _inventory_scoped_lineage_map(
+        conn,
+        table_name="memory_moment_members",
+        owner_column="moment_id",
+        root_column="ledger_entry_id",
+        owner_ids=tuple(
+            str(row.get("moment_id") or "") for row in moment_rows
+        ),
+        guild_id=None,
+    )
+    for row in moment_rows:
+        normalized = dict(row)
+        moment_id = str(normalized.get("moment_id") or "")
+        normalized["root_ids"] = tuple(moment_root_map.get(moment_id, ()))
+        normalized["occurrence_ids"] = ((moment_id,) if moment_id else ())
+        result = adapt_living_moment_claim(normalized)
+        reason_counts[result.reason] += 1
+        if result.claim is not None:
+            claims.append(result.claim)
+            adapted_rows["memory_moment"] += 1
+        else:
+            rejected_rows["memory_moment"] += 1
+
+    bindings: list[EntityAccountBinding] = []
+    binding_total, binding_rows, binding_truncated = _inventory_table_rows(
+        conn,
+        table_name="canon_entity_account_bindings",
+        wanted_columns=(
+            "guild_id",
+            "entity_id",
+            "platform",
+            "account_id",
+            "authority_receipt",
+            "authority_actor",
+            "binding_version",
+            "authority_verified",
+            "active",
+        ),
+        guild_id=guild_id,
+        limit=max_rows_per_source,
+    )
+    source_rows["entity_account_bindings"] = binding_total
+    inspected_rows["entity_account_bindings"] = len(binding_rows)
+    if binding_truncated:
+        truncated_sources.append("entity_account_bindings")
+    known_entity_ids = {
+        subject.key for subject in CANON_ENTITY_IDENTITIES
+    }
+    for row in binding_rows:
+        binding = EntityAccountBinding(
+            entity_id=_mapping_text(row, "entity_id"),
+            platform=_mapping_text(row, "platform").casefold(),
+            account_id=_mapping_text(row, "account_id"),
+            authority_receipt=_mapping_text(
+                row,
+                "authority_receipt",
+            ),
+            authority_actor=_mapping_text(row, "authority_actor"),
+            binding_version=(
+                _mapping_text(row, "binding_version")
+                or "unversioned"
+            ),
+            authority_verified=strict_contract_bool(
+                row.get("authority_verified")
+            ),
+            active=strict_contract_bool(row.get("active")),
+        )
+        if (
+            not binding.entity_id
+            or binding.entity_id not in known_entity_ids
+            or not _platform_account_id_valid(
+                binding.platform,
+                binding.account_id,
+            )
+            or not _binding_authority_valid(binding)
+        ):
+            rejected_rows["entity_account_bindings"] += 1
+            reason_counts["invalid_account_binding"] += 1
+            continue
+        bindings.append(binding)
+        adapted_rows["entity_account_bindings"] += 1
+        reason_counts[
+            "eligible_account_binding"
+            if binding.active
+            else "inactive_account_binding"
+        ] += 1
+
+    diagnostics = canon_claim_inventory_diagnostics(
+        claims,
+        bindings=tuple(bindings),
+    )
+    after_changes = int(getattr(conn, "total_changes", 0) or 0)
+    reconciled_sources = tuple(sorted(source_rows))
+    bounded_rows_reconciled = all(
+        int(inspected_rows.get(source, 0) or 0)
+        == int(adapted_rows.get(source, 0) or 0)
+        + int(rejected_rows.get(source, 0) or 0)
+        for source in reconciled_sources
+    )
+    complete_source_reconciliation = bool(
+        bounded_rows_reconciled and not truncated_sources
+    )
+    reconciliation_status = (
+        "complete"
+        if complete_source_reconciliation
+        else "partial_truncated"
+        if bounded_rows_reconciled and truncated_sources
+        else "mismatch"
+    )
+    diagnostics.update(
+        {
+            "sourceRows": dict(sorted(source_rows.items())),
+            "inspectedRows": dict(sorted(inspected_rows.items())),
+            "adaptedRows": dict(sorted(adapted_rows.items())),
+            "rejectedRows": dict(sorted(rejected_rows.items())),
+            "reasonCounts": dict(sorted(reason_counts.items())),
+            "reviewOnlyCount": sum(
+                1
+                for claim in claims
+                if claim.lifecycle == ClaimLifecycle.REVIEW_ONLY
+            ),
+            "truncatedSources": tuple(sorted(truncated_sources)),
+            "boundedRowsReconciled": bounded_rows_reconciled,
+            "sourceAdaptedReconciled": complete_source_reconciliation,
+            "sourceReconciliationStatus": reconciliation_status,
+            "mutationCount": max(0, after_changes - before_changes),
+        }
+    )
+    return diagnostics
+
+
 def canon_facts_for_subject(
     subject: SubjectIdentity,
 ) -> tuple[CanonFact, ...]:
@@ -307,6 +1944,32 @@ def render_prompt_canon_block() -> str:
 
 def map_route_source_label(label: str) -> SourceClass:
     return _ROUTE_SOURCE_MAP.get((label or "").strip(), SourceClass.LEGACY_SOURCE_BLIND)
+
+
+def map_system_source_label(source_system: str, label: str) -> SourceClass:
+    """Map a label only inside its owning system's authority boundary."""
+
+    system = str(source_system or "").strip().casefold()
+    normalized_label = str(label or "").strip()
+    if system == "legacy_canon_registry":
+        return (
+            SourceClass.APPROVED_CANON
+            if normalized_label in {"approved_canon", "canon"}
+            else SourceClass.LEGACY_SOURCE_BLIND
+        )
+    if system in {"website_relay", "website_public_projection"}:
+        return SourceClass.EVIDENCE_PROJECTION
+    if system in {"website_dossier", "website_source_file"}:
+        return (
+            SourceClass.DOSSIER_PROJECTION
+            if system == "website_dossier"
+            else SourceClass.SOURCE_FILE_PROJECTION
+        )
+    if system == "broadcast_memory":
+        return SourceClass.FIRST_PARTY_RECORD
+    if system == "public_assessment_observation":
+        return SourceClass.PUBLIC_OBSERVATION
+    return SourceClass.LEGACY_SOURCE_BLIND
 
 def has_explicit_route_source_mapping(label: str) -> bool:
     return (label or "").strip() in _ROUTE_SOURCE_MAP

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -18,6 +18,7 @@ from typing import Any, Iterable
 
 from bnl_canon_source_contract import (
     Confidence,
+    PUBLIC_ASSESSMENT_EVIDENCE_VERSION,
     SourceClass,
     SourceClaim,
     SubjectIdentity,
@@ -715,6 +716,18 @@ class PublicAssessmentEvidence:
     occurrence_identity: str
     score: float
     request_relevant: bool = False
+    subject_key: str = ""
+    assessment_contract_version: str = PUBLIC_ASSESSMENT_EVIDENCE_VERSION
+    source_system: str = "memory_ledger_public_assessment"
+    source_role: str = "user"
+    source_class: str = SourceClass.PUBLIC_OBSERVATION.value
+    lifecycle_status: str = ACTIVE_LIFECYCLE
+    channel_policy: str = "unknown"
+    public_usable: bool = False
+    subject_authored: bool = False
+    selector_eligible: bool = False
+    derived: bool = True
+    projection: bool = True
 
 
 @dataclass(frozen=True)
@@ -5222,7 +5235,7 @@ def _conversation_motif_history(
 ) -> list[dict[str, Any]]:
     rows = conn.execute(
         """
-        SELECT entry_id,subject_display_name,normalized_value,observed_at,
+        SELECT entry_id,subject_key,subject_display_name,normalized_value,observed_at,
                channel_id,channel_policy,source_table,source_row_id,
                source_role,source_class,visibility,public_usable,
                derived,projection,lifecycle_status
@@ -5261,6 +5274,7 @@ def _conversation_motif_history(
     ).fetchall()
     keys = (
         "entry_id",
+        "subject_key",
         "subject_display_name",
         "normalized_value",
         "observed_at",
@@ -5546,6 +5560,23 @@ def select_public_conversation_assessment_evidence(
             occurrence_identity=str(candidate["occurrence"]),
             score=float(candidate["base_score"]),
             request_relevant=bool(candidate["request_relevant"]),
+            subject_key=str(subject_key or ""),
+            source_role=str(candidate["entry"].get("source_role") or ""),
+            source_class=str(candidate["entry"].get("source_class") or ""),
+            lifecycle_status=str(
+                candidate["entry"].get("lifecycle_status") or ""
+            ),
+            channel_policy=str(
+                candidate["entry"].get("channel_policy") or "unknown"
+            ),
+            public_usable=bool(candidate["entry"].get("public_usable")),
+            subject_authored=bool(
+                str(candidate["entry"].get("subject_key") or "")
+                == str(subject_key or "")
+            ),
+            selector_eligible=True,
+            derived=bool(candidate["entry"].get("derived")),
+            projection=bool(candidate["entry"].get("projection")),
         )
         for candidate in selected
         if str(candidate["entry"].get("entry_id") or "")
@@ -7551,10 +7582,64 @@ def shadow_broadcast_status_event(conn: sqlite3.Connection, *, row_id: int, guil
     return result
 
 
-def shadow_canon_reference(conn: sqlite3.Connection, *, guild_id: int, canon_id: str, subject_key: str, subject_display_name: str, predicate_key: str, value: str, observed_at: str = "") -> LedgerWriteResult:
+def shadow_canon_reference(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    canon_id: str,
+    subject_key: str,
+    subject_display_name: str,
+    predicate_key: str,
+    value: str,
+    observed_at: str = "",
+    revision_id: str = "",
+    root_entry_ids: tuple[str, ...] = (),
+) -> LedgerWriteResult:
+    """Project an approved canon revision without becoming its authority.
+
+    The canon registry/declaration remains the source of truth.  This Ledger
+    row is explicitly derived and projected so it can support governed packet
+    lookup while never independently corroborating or re-canonizing itself.
+    """
     if not canon_id or not subject_key or not predicate_key:
-        return skipped_result(guild_id=guild_id, source_table="approved_canon", source_row_id=canon_id or "", reason_code="missing_canon_source_identity")
-    return insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="approved_canon", source_row_id=canon_id, source_revision=str(canon_id), source_role="approved_canon", entry_type="canon_reference", subject_key=subject_key, subject_display_name=subject_display_name, predicate_key=predicate_key, value=(value or "")[:500], source_class=SourceClass.APPROVED_CANON, route_mode="approved_canon", channel_policy="reference_canon", visibility=Visibility.REFERENCE_CANON, confidence=Confidence.APPROVED, public_usable=True, observed_at=observed_at or _now(), lifecycle_status=ACTIVE_LIFECYCLE))
+        return skipped_result(guild_id=guild_id, source_table="canon_claim_projection", source_row_id=canon_id or "", reason_code="missing_canon_source_identity")
+    roots = tuple(
+        sorted(
+            {
+                str(entry_id or "").strip()
+                for entry_id in root_entry_ids
+                if str(entry_id or "").strip()
+            }
+        )
+    )
+    revision = str(revision_id or canon_id)
+    return insert_ledger_entry(
+        conn,
+        LedgerEntry(
+            guild_id=guild_id,
+            source_table="canon_claim_projection",
+            source_row_id=canon_id,
+            source_revision=revision,
+            source_event_key="revision:%s" % revision,
+            source_role="canon_projection",
+            entry_type="canon_reference",
+            subject_key=subject_key,
+            subject_display_name=subject_display_name,
+            predicate_key=predicate_key,
+            value=(value or "")[:500],
+            source_class=SourceClass.APPROVED_CANON,
+            route_mode="approved_canon",
+            channel_policy="reference_canon",
+            visibility=Visibility.REFERENCE_CANON,
+            confidence=Confidence.APPROVED,
+            public_usable=True,
+            derived=True,
+            projection=True,
+            observed_at=observed_at or _now(),
+            lifecycle_status=ACTIVE_LIFECYCLE,
+            lineage=tuple(("derived_from", entry_id) for entry_id in roots),
+        ),
+    )
 
 
 def build_memory_ledger_evaluation(

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -25,10 +25,13 @@ from bnl_canon_source_contract import (
     CANON_MEMBER_IDENTITIES,
     CANON_SOURCE_CONTRACT_VERSION,
     Confidence,
+    EntityAccountBinding,
     SourceClass,
     SubjectIdentity,
     matching_canon_member_identities,
     normalize_canon_identity_label,
+    resolve_entity_identity,
+    strict_contract_bool,
 )
 from bnl_memory_governance import (
     APPROVED_MEMBER_SCALAR_PREDICATES,
@@ -588,6 +591,90 @@ def _table_columns(
     }
 
 
+def _explicit_canon_binding_signal(
+    conn: sqlite3.Connection,
+    request: IntelligencePacketRequest,
+) -> _CanonIdentitySignal | None:
+    """Prefer a versioned, boundary-verified immutable account binding."""
+
+    columns = _table_columns(conn, "canon_entity_account_bindings")
+    required = {
+        "guild_id",
+        "platform",
+        "account_id",
+        "entity_id",
+        "authority_receipt",
+        "authority_actor",
+        "binding_version",
+        "authority_verified",
+        "active",
+    }
+    if not required.issubset(columns):
+        return None
+    rows = conn.execute(
+        """
+        SELECT entity_id,platform,account_id,authority_receipt,
+               authority_actor,binding_version,authority_verified,active
+        FROM canon_entity_account_bindings
+        WHERE guild_id=?
+          AND lower(trim(platform))='discord'
+          AND trim(CAST(account_id AS TEXT))=?
+        ORDER BY entity_id,authority_receipt
+        """,
+        (
+            int(request.guild_id or 0),
+            str(int(request.subject_user_id or 0)),
+        ),
+    ).fetchall()
+    if not rows:
+        return None
+    bindings = tuple(
+        EntityAccountBinding(
+            entity_id=str(row[0] or ""),
+            platform=str(row[1] or ""),
+            account_id=str(row[2] or ""),
+            authority_receipt=str(row[3] or ""),
+            authority_actor=str(row[4] or ""),
+            binding_version=str(row[5] or ""),
+            authority_verified=strict_contract_bool(row[6]),
+            active=strict_contract_bool(row[7]),
+        )
+        for row in rows
+    )
+    resolution = resolve_entity_identity(
+        platform="discord",
+        account_id=str(int(request.subject_user_id or 0)),
+        bindings=bindings,
+    )
+    if resolution.status == "ambiguous":
+        return _CanonIdentitySignal("ambiguous_account_binding")
+    if resolution.status != "resolved" or resolution.subject is None:
+        return _CanonIdentitySignal("invalid_account_binding")
+    if resolution.subject.key not in _AUTOMATIC_CANON_SIGNAL_SUBJECT_KEYS:
+        return _CanonIdentitySignal(
+            "bound_non_signal_identity",
+            subject=resolution.subject,
+        )
+    return _CanonIdentitySignal(
+        "recognized",
+        subject=resolution.subject,
+        stable_row_count=1,
+        evidence_digest=_digest(
+            "same_platform_account_binding_v1",
+            CANON_SOURCE_CONTRACT_VERSION,
+            int(request.guild_id or 0),
+            int(request.subject_user_id or 0),
+            resolution.subject.key,
+            tuple(
+                sorted(
+                    _digest(*row)
+                    for row in rows
+                )
+            ),
+        ),
+    )
+
+
 def _canon_identity_signal(
     conn: sqlite3.Connection,
     request: IntelligencePacketRequest,
@@ -604,6 +691,9 @@ def _canon_identity_signal(
         or int(request.subject_user_id or 0) <= 0
     ):
         return _CanonIdentitySignal("invalid_subject_scope")
+    explicit_binding = _explicit_canon_binding_signal(conn, request)
+    if explicit_binding is not None:
+        return explicit_binding
     labels = [str(request.subject_display_name or "")]
     profile_columns = _table_columns(conn, "user_profiles")
     if {

--- a/docs/hybrid_canon_claim_contract_v1.md
+++ b/docs/hybrid_canon_claim_contract_v1.md
@@ -1,0 +1,88 @@
+# Hybrid Canon Claim Contract v1
+
+`hybrid_canon_claim_v1` is the read-model contract that lets BNL compare
+curated canon, owner declarations, learned community patterns, and immediate
+public observations without replacing their existing source owners.
+
+## Two independent dimensions
+
+- Establishment: `legacy`, `declared`, `living`, or `open_signal`.
+- Domain: `real_community`, `broadcast_history`, `operational`, `lore`, or
+  `hybrid`.
+
+Lifecycle, visibility, validity, confidence, and projection state remain
+independent. A Declared row may be internal, an expired operational claim may
+remain historical, and an established atomic row is not Living Canon unless it
+is a domain-qualified community `topic_or_motif` with at least two eligible
+independent roots across two bounded occurrence identities under
+`living_canon_recurrence_v1`. A finalized Moment alone is one occurrence, not
+proof of recurrence.
+
+## Source ownership
+
+- `CANON_FACTS` remains the Legacy source.
+- `broadcast_memory` remains the Broadcast source. Only rows carrying verified
+  owner authority normalize as Declared; historical rows without that proof
+  stay internal, review-only Open Signal.
+- Ledger, Moments, and atomic lifecycle remain the Living source machinery.
+  Current established atomic and finalized Moment rows normalize as internal,
+  review-only Open Signal until the recurrence contract is proved; they are not
+  silently promoted to Living Canon.
+- Public assessment observations remain ephemeral Open Signal.
+- The unified intelligence packet remains the only broad-profile factual
+  selection owner.
+
+Adapters produce immutable `CanonClaim` revisions. They do not copy, mutate,
+promote, or publish source rows. Every revision keeps a stable claim ID, exact
+revision ID, source revision, subject, predicate, source system, adapter
+version, source refs, root and occurrence IDs, authority receipt, visibility,
+validity, lifecycle, and correction lineage. Claim IDs use the permanent
+`bnl_canon_claim_identity_v1` namespace, so a contract-version change creates a
+new revision without changing the logical claim identity.
+
+Broadcast normalization uses `cleaned_summary` for any public-safe projection.
+`raw_note`, an internal usage scope, an inactive lifecycle, or an ambiguous
+boolean always fails closed to internal review metadata. Question-scoped Open
+Signal normalization likewise requires explicit active, public, subject-
+authored, human-source, nonderived assessment proof.
+
+`shadow_canon_reference()` is a derived Ledger projection. It is never an
+independent canon root and cannot corroborate or promote itself.
+
+## Identity
+
+Same-platform identity begins with an explicit immutable account binding.
+Display names are reversible hints only. Entities may exist without accounts
+and later receive a binding without duplication.
+
+A binding is usable only with `canon_entity_account_binding_v1`, an opaque
+authority actor, an explicit boundary-verification bit, a versioned mutation
+receipt, and an immutable platform-ID shape (Discord IDs are numeric). A label
+such as `owner_confirmed`, a display name in an account-ID field, a malformed
+boolean, or an unversioned lookalike row is not authority.
+
+The existing live packet prefers a fully versioned, boundary-verified binding
+when an approved binding table and row are already present. An invalid or
+ambiguous row fails closed rather than falling back to a conflicting display
+label. PR 1 creates no binding table or row and performs no data mutation;
+creating or approving binding data remains a separately authorized operation.
+Without an approved row, the existing label-compatibility path remains, except
+for removal of the false alias.
+
+Call'em Bini and Cache Back are distinct entities. Any relationship between
+them requires a separately typed, sourced claim; neither name is an alias or
+account-binding shortcut for the other. The existing website origin sentence
+is retained as an internal, review-only lore relationship candidate and has no
+fact or identity authority.
+
+The content-free inventory distinguishes complete source reconciliation from
+a bounded partial scan. Any truncated source forces
+`sourceAdaptedReconciled=false` and reports the affected source names; no
+source text, display label, account ID, or row ID is emitted.
+
+## Mutation boundary
+
+This version is shadow/read-only. Declared mutation, historical Broadcast
+classification, claim-content use in the live packet, website projection, and
+delegated authority are not enabled by this contract. The packet's binding
+lookup is read-only and effective only for already-approved binding rows.

--- a/tests/test_atomic_knowledge_candidates.py
+++ b/tests/test_atomic_knowledge_candidates.py
@@ -170,16 +170,21 @@ class AtomicKnowledgeCandidateTests(unittest.TestCase):
             source_class=SourceClass.PUBLIC_OBSERVATION,
             source_role="user",
         )
-        bnl_role_root = ledger.shadow_canon_reference(
-            self.conn,
-            canon_id="b001",
-            guild_id=1,
+        bnl_role_root = self.add_root(
+            90,
             subject_key=ledger.BNL_SUBJECT_KEY,
-            subject_display_name="BNL-01",
+            entry_type="canon_reference",
             predicate_key="roles",
             value="BNL-01 is the Network's memory and continuity layer.",
-            observed_at="2026-07-25T00:00:05+00:00",
-        ).entry_id
+            source_class=SourceClass.APPROVED_CANON,
+            source_role="approved_canon_source",
+            route_mode="approved_canon",
+            channel_policy="reference_canon",
+            visibility=Visibility.REFERENCE_CANON,
+            confidence=Confidence.APPROVED,
+            participants=(),
+            source_table="approved_canon_registry",
+        )
 
         results = [
             ledger.form_atomic_candidate_from_ledger_entry(

--- a/tests/test_atomic_knowledge_lifecycle.py
+++ b/tests/test_atomic_knowledge_lifecycle.py
@@ -240,16 +240,22 @@ class AtomicKnowledgeLifecycleTests(unittest.TestCase):
         self.assertTrue(first)
 
     def test_authority_can_establish_but_confidence_cannot_create_authority(self):
-        approved_root = ledger.shadow_canon_reference(
-            self.conn,
-            canon_id="lifecycle-canon",
-            guild_id=1,
+        approved_root = self.add_root(
+            90,
             subject_key=ledger.BNL_SUBJECT_KEY,
-            subject_display_name="BNL-01",
+            entry_type="canon_reference",
             predicate_key="roles",
             value="BNL is the Network continuity layer.",
+            source_class=SourceClass.APPROVED_CANON,
+            source_role="approved_canon_source",
+            visibility=Visibility.REFERENCE_CANON,
+            confidence=Confidence.APPROVED,
+            route_mode="approved_canon",
+            channel_policy="reference_canon",
+            participants=(),
+            source_table="approved_canon_registry",
             observed_at="2026-07-25T00:00:05+00:00",
-        ).entry_id
+        )
         approved = ledger.form_atomic_candidate_from_ledger_entry(
             self.conn,
             approved_root,

--- a/tests/test_canon_source_contract.py
+++ b/tests/test_canon_source_contract.py
@@ -90,6 +90,15 @@ class CanonSourceContractTests(unittest.TestCase):
             c.matching_canon_member_identities(("Mac Modem Fan",)),
             (),
         )
+        self.assertEqual(
+            c.matching_canon_member_identities(("Call'em Bini",)),
+            (),
+        )
+        self.assertEqual(
+            c.matching_canon_entity_identities(("Call'em Bini",)),
+            (c.CALLEM_BINI,),
+        )
+        self.assertNotIn("Call'em Bini", c.CACHE_BACK.aliases)
         prompt_block = c.render_key_personnel_canon_block()
         self.assertIn("Mac Modem", prompt_block)
         self.assertIn("DJ Floppydisc", prompt_block)

--- a/tests/test_hybrid_canon_claim_contract.py
+++ b/tests/test_hybrid_canon_claim_contract.py
@@ -1,0 +1,1225 @@
+import sqlite3
+import unittest
+from dataclasses import replace
+from unittest import mock
+
+import bnl_canon_source_contract as canon
+import bnl_memory_ledger as ledger
+import bnl_moment_engine as moments
+import bnl_unified_intelligence_packet as packet
+
+
+class HybridCanonClaimContractTests(unittest.TestCase):
+    def test_contract_separates_status_domain_and_lifecycle(self):
+        fact = next(
+            item
+            for item in canon.CANON_FACTS
+            if item.subject == canon.MAC_MODEM
+            and item.predicate == "behavior"
+        )
+        claim = canon.adapt_legacy_canon_fact(fact)
+
+        self.assertEqual(
+            canon.HYBRID_CANON_CLAIM_CONTRACT_VERSION,
+            "hybrid_canon_claim_v1",
+        )
+        self.assertEqual(claim.canon_status, canon.CanonStatus.LEGACY)
+        self.assertEqual(claim.domain, canon.CanonDomain.HYBRID)
+        self.assertEqual(
+            claim.claim_kind,
+            canon.ClaimKind.BEHAVIOR_PATTERN,
+        )
+        self.assertEqual(
+            claim.lifecycle,
+            canon.ClaimLifecycle.ESTABLISHED,
+        )
+        self.assertEqual(claim.source_system, "legacy_canon_registry")
+        self.assertTrue(claim.claim_id.startswith("clm_"))
+        self.assertTrue(claim.revision_id.startswith("rev_"))
+        self.assertEqual(claim.root_ids, claim.source_refs)
+
+    def test_legacy_claim_ids_are_stable_and_revisions_are_content_bound(self):
+        original = canon.CanonFact(
+            canon.CLIFF,
+            "primary_identity",
+            "A quiet signal witness.",
+        )
+        replacement = canon.CanonFact(
+            canon.CLIFF,
+            "primary_identity",
+            "A quiet signal witness with a new revision.",
+        )
+
+        first = canon.adapt_legacy_canon_fact(original)
+        replay = canon.adapt_legacy_canon_fact(original)
+        changed = canon.adapt_legacy_canon_fact(replacement)
+
+        self.assertEqual(first.claim_id, replay.claim_id)
+        self.assertEqual(first.revision_id, replay.revision_id)
+        self.assertEqual(first.claim_id, changed.claim_id)
+        self.assertNotEqual(first.revision_id, changed.revision_id)
+
+        with mock.patch.object(
+            canon,
+            "HYBRID_CANON_CLAIM_CONTRACT_VERSION",
+            "hybrid_canon_claim_v2_test",
+        ):
+            upgraded = canon.adapt_legacy_canon_fact(original)
+        self.assertEqual(first.claim_id, upgraded.claim_id)
+        self.assertNotEqual(first.revision_id, upgraded.revision_id)
+
+    def test_revision_id_binds_every_normalized_contract_dimension(self):
+        first = canon.adapt_legacy_canon_fact(canon.CANON_FACTS[0])
+        changed = replace(
+            first,
+            revision_id="",
+            visibility=canon.Visibility.INTERNAL,
+            eligible_routes=(),
+        )
+        changed = canon._with_final_revision(
+            changed,
+            source_revision=first.source_revision,
+        )
+
+        self.assertEqual(first.claim_id, changed.claim_id)
+        self.assertNotEqual(first.revision_id, changed.revision_id)
+
+        internal_fact = canon.CanonFact(
+            canon.CLIFF,
+            "private_working_note",
+            "Internal fixture.",
+            visibility=canon.Visibility.INTERNAL,
+        )
+        internal = canon.adapt_legacy_canon_fact(internal_fact)
+        self.assertEqual(internal.visibility, canon.Visibility.INTERNAL)
+        self.assertNotIn("public_home", internal.eligible_routes)
+
+    def test_source_owned_claim_id_survives_subject_or_predicate_correction(self):
+        base = {
+            "id": 81,
+            "entry_type": "notable_moment",
+            "cleaned_summary": "An owner-reviewed moment.",
+            "status": "active",
+            "subject_id": "barcode_radio",
+        }
+        original = canon.adapt_broadcast_memory_claim(base).claim
+        corrected = canon.adapt_broadcast_memory_claim(
+            {
+                **base,
+                "entry_type": "technical_issue",
+                "subject_id": "mac_modem",
+            }
+        ).claim
+        self.assertEqual(original.claim_id, corrected.claim_id)
+        self.assertNotEqual(original.revision_id, corrected.revision_id)
+
+    def test_same_label_cannot_inherit_authority_across_source_systems(self):
+        self.assertEqual(
+            canon.map_system_source_label(
+                "legacy_canon_registry",
+                "approved_canon",
+            ),
+            canon.SourceClass.APPROVED_CANON,
+        )
+        self.assertEqual(
+            canon.map_system_source_label(
+                "website_relay",
+                "approved_canon",
+            ),
+            canon.SourceClass.EVIDENCE_PROJECTION,
+        )
+        self.assertEqual(
+            canon.map_system_source_label(
+                "website_dossier",
+                "owner_confirmed",
+            ),
+            canon.SourceClass.DOSSIER_PROJECTION,
+        )
+
+    def test_callem_bini_and_cache_back_are_distinct(self):
+        self.assertNotIn("Call'em Bini", canon.CACHE_BACK.aliases)
+        self.assertEqual(
+            canon.matching_canon_entity_identities(("Call'em Bini",)),
+            (canon.CALLEM_BINI,),
+        )
+        self.assertEqual(
+            canon.matching_canon_member_identities(("Call'em Bini",)),
+            (),
+        )
+        self.assertEqual(
+            canon.matching_canon_member_identities(("Cache Back",)),
+            (canon.CACHE_BACK,),
+        )
+
+    def test_account_binding_beats_display_label_and_collisions_fail_closed(self):
+        binding = canon.EntityAccountBinding(
+            entity_id=canon.MAC_MODEM.key,
+            platform="Discord",
+            account_id="4242",
+            authority_receipt="binding_receipt:1",
+            authority_actor="discord_user:1",
+            authority_verified=True,
+        )
+        resolved = canon.resolve_entity_identity(
+            platform="discord",
+            account_id="4242",
+            labels=("Cache Back",),
+            bindings=(binding,),
+        )
+        self.assertEqual(resolved.status, "resolved")
+        self.assertEqual(resolved.method, "account_binding")
+        self.assertEqual(resolved.subject, canon.MAC_MODEM)
+
+        collision = canon.resolve_entity_identity(
+            platform="discord",
+            account_id="4242",
+            bindings=(
+                binding,
+                canon.EntityAccountBinding(
+                    entity_id=canon.CACHE_BACK.key,
+                    platform="discord",
+                    account_id="4242",
+                    authority_receipt="binding_receipt:2",
+                    authority_actor="discord_user:1",
+                    authority_verified=True,
+                ),
+            ),
+        )
+        self.assertEqual(collision.status, "ambiguous")
+        self.assertEqual(collision.reason, "account_binding_collision")
+
+        inactive = canon.resolve_entity_identity(
+            platform="discord",
+            account_id="4242",
+            labels=("Cache Back",),
+            bindings=(replace(binding, active="false"),),
+        )
+        self.assertEqual(inactive.status, "hint_only")
+        self.assertEqual(inactive.subject, canon.CACHE_BACK)
+
+        descriptive_only = canon.resolve_entity_identity(
+            platform="discord",
+            account_id="4242",
+            labels=("Cache Back",),
+            bindings=(
+                replace(
+                    binding,
+                    authority_receipt="owner_confirmed",
+                ),
+            ),
+        )
+        self.assertEqual(descriptive_only.status, "hint_only")
+        self.assertEqual(descriptive_only.subject, canon.CACHE_BACK)
+
+        name_shaped_actor = canon.resolve_entity_identity(
+            platform="discord",
+            account_id="4242",
+            labels=("Cache Back",),
+            bindings=(
+                replace(
+                    binding,
+                    authority_actor="discord_user:Jane Doe",
+                ),
+            ),
+        )
+        self.assertEqual(name_shaped_actor.status, "hint_only")
+        self.assertEqual(name_shaped_actor.subject, canon.CACHE_BACK)
+
+        empty_scope = canon.resolve_entity_identity(
+            platform="",
+            account_id="",
+            bindings=(
+                replace(binding, platform="", account_id=""),
+            ),
+        )
+        self.assertEqual(empty_scope.status, "unresolved")
+
+        name_shaped_account = canon.resolve_entity_identity(
+            platform="discord",
+            account_id="Jane Doe",
+            labels=("Cache Back",),
+            bindings=(
+                replace(binding, account_id="Jane Doe"),
+            ),
+        )
+        self.assertEqual(name_shaped_account.status, "hint_only")
+        self.assertEqual(name_shaped_account.subject, canon.CACHE_BACK)
+
+    def test_label_only_resolution_is_reversible_hint_not_account_binding(self):
+        resolution = canon.resolve_entity_identity(
+            platform="discord",
+            account_id="9999",
+            labels=("Sheila",),
+        )
+        self.assertEqual(resolution.status, "hint_only")
+        self.assertEqual(resolution.subject, canon.SHEILA)
+        self.assertEqual(resolution.method, "exact_label_hint")
+
+        bound = canon.resolve_entity_identity(
+            platform="discord",
+            account_id="9001",
+            labels=("Someone Else",),
+            bindings=(
+                canon.EntityAccountBinding(
+                    entity_id=canon.SHEILA.key,
+                    platform="DISCORD",
+                    account_id="9001",
+                    authority_receipt="binding_receipt:sheila",
+                    authority_actor="owner_ref:binding_owner",
+                    authority_verified=True,
+                ),
+            ),
+        )
+        self.assertEqual(bound.status, "resolved")
+        self.assertEqual(bound.subject, canon.SHEILA)
+        self.assertEqual(bound.method, "account_binding")
+
+        cliff = canon.resolve_entity_identity(
+            platform="discord",
+            account_id="9002",
+            labels=(),
+            bindings=(
+                canon.EntityAccountBinding(
+                    entity_id=canon.CLIFF.key,
+                    platform="discord",
+                    account_id="9002",
+                    authority_receipt="binding_receipt:cliff",
+                    authority_actor="owner_ref:binding_owner",
+                    authority_verified=True,
+                ),
+            ),
+        )
+        self.assertEqual(cliff.status, "resolved")
+        self.assertEqual(cliff.subject, canon.CLIFF)
+
+    def test_packet_prefers_a_fully_approved_account_binding(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.execute(
+                """
+                CREATE TABLE canon_entity_account_bindings(
+                  guild_id INTEGER NOT NULL,
+                  platform TEXT NOT NULL,
+                  account_id TEXT NOT NULL,
+                  entity_id TEXT NOT NULL,
+                  authority_receipt TEXT NOT NULL,
+                  authority_actor TEXT NOT NULL,
+                  binding_version TEXT NOT NULL,
+                  authority_verified INTEGER NOT NULL,
+                  active INTEGER NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "INSERT INTO canon_entity_account_bindings VALUES(?,?,?,?,?,?,?,?,?)",
+                (
+                    1,
+                    "Discord",
+                    "42",
+                    "mac_modem",
+                    "binding_receipt:42",
+                    "discord_user:1",
+                    "canon_entity_account_binding_v1",
+                    1,
+                    1,
+                ),
+            )
+            request = packet.IntelligencePacketRequest(
+                guild_id=1,
+                channel_id=10,
+                channel_policy="public_home",
+                route_mode="normal_chat",
+                conversation_surface="public_home",
+                subject_user_id=42,
+                subject_display_name="Cache Back",
+                user_text="BNL, what am I all about?",
+            )
+            signal = packet._canon_identity_signal(conn, request)
+            self.assertTrue(signal.recognized)
+            self.assertEqual(signal.subject, canon.MAC_MODEM)
+            self.assertEqual(signal.stable_row_count, 1)
+            conn.execute(
+                "UPDATE canon_entity_account_bindings SET active=?",
+                ("false",),
+            )
+            invalid = packet._canon_identity_signal(conn, request)
+            self.assertFalse(invalid.recognized)
+            self.assertEqual(invalid.status, "invalid_account_binding")
+        finally:
+            conn.close()
+
+    def test_broadcast_adapter_preserves_legacy_types_as_review_only(self):
+        legacy = canon.adapt_broadcast_memory_claim(
+            {
+                "id": 9,
+                "entry_type": "continuity_backreference",
+                "raw_note": "A prior episode still matters.",
+                "status": "active",
+                "public_safe": 1,
+            },
+            owner_authorized=True,
+            authority_actor="discord_user:1",
+            authority_receipt="owner_command:9",
+        )
+        self.assertIsNotNone(legacy.claim)
+        self.assertEqual(legacy.reason, "legacy_type_review_only")
+        self.assertEqual(
+            legacy.claim.lifecycle,
+            canon.ClaimLifecycle.REVIEW_ONLY,
+        )
+        self.assertEqual(
+            legacy.claim.predicate,
+            "continuity_backreference",
+        )
+        self.assertEqual(legacy.claim.visibility, canon.Visibility.INTERNAL)
+        self.assertEqual(legacy.claim.eligible_routes, ("broadcast_memory",))
+
+    def test_broadcast_adapter_stays_review_only_in_pr1(self):
+        row = {
+            "id": 4,
+            "entry_type": "notable_moment",
+            "raw_note": "Private operator wording.",
+            "cleaned_summary": "The signal held through the final track.",
+            "status": "active",
+            "public_safe": 1,
+            "usage_scope": "ambient,direct",
+            "subject_id": "barcode_radio",
+            "updated_at": "2026-08-01T00:00:00+00:00",
+        }
+        review = canon.adapt_broadcast_memory_claim(row)
+        declared = canon.adapt_broadcast_memory_claim(
+            row,
+            owner_authorized=True,
+            authority_actor="discord_user:1",
+            authority_receipt="owner_command:4",
+        )
+        self.assertEqual(
+            review.claim.lifecycle,
+            canon.ClaimLifecycle.REVIEW_ONLY,
+        )
+        self.assertEqual(
+            review.claim.canon_status,
+            canon.CanonStatus.OPEN_SIGNAL,
+        )
+        self.assertEqual(review.claim.visibility, canon.Visibility.INTERNAL)
+        self.assertNotIn("public_home", review.claim.eligible_routes)
+        self.assertEqual(
+            declared.claim.lifecycle,
+            canon.ClaimLifecycle.REVIEW_ONLY,
+        )
+        self.assertFalse(declared.live_eligible)
+        self.assertEqual(declared.reason, "owner_verified_review_only")
+        self.assertEqual(
+            declared.claim.canon_status,
+            canon.CanonStatus.DECLARED,
+        )
+        self.assertEqual(
+            declared.claim.domain,
+            canon.CanonDomain.BROADCAST_HISTORY,
+        )
+        self.assertEqual(declared.claim.visibility, canon.Visibility.PUBLIC_SAFE)
+        self.assertNotIn("Private operator wording", declared.claim.value)
+
+    def test_broadcast_adapter_fails_closed_on_scope_and_boolean_strings(self):
+        cases = (
+            ({"public_safe": "false", "usage_scope": "direct"},),
+            ({"public_safe": "1", "usage_scope": "internal"},),
+        )
+        for (overrides,) in cases:
+            with self.subTest(overrides=overrides):
+                result = canon.adapt_broadcast_memory_claim(
+                    {
+                        "id": 12,
+                        "entry_type": "notable_moment",
+                        "raw_note": "Private operator wording.",
+                        "cleaned_summary": "Safe summary.",
+                        "status": "active",
+                        **overrides,
+                    }
+                )
+                self.assertEqual(result.claim.visibility, canon.Visibility.INTERNAL)
+                self.assertEqual(
+                    result.claim.eligible_routes,
+                    ("broadcast_memory",),
+                )
+
+        raw_only = canon.adapt_broadcast_memory_claim(
+            {
+                "id": 13,
+                "entry_type": "notable_moment",
+                "raw_note": "Private operator wording.",
+                "status": "active",
+                "public_safe": "true",
+                "usage_scope": "direct",
+            }
+        )
+        self.assertEqual(raw_only.claim.visibility, canon.Visibility.INTERNAL)
+        self.assertNotIn("public_home", raw_only.claim.eligible_routes)
+
+        forged = canon.adapt_broadcast_memory_claim(
+            {
+                "id": 14,
+                "entry_type": "notable_moment",
+                "cleaned_summary": "A safe summary.",
+                "status": "active",
+            },
+            owner_authorized=True,
+            authority_actor="Personal Human Name",
+            authority_receipt="owner_confirmed",
+        )
+        self.assertEqual(forged.reason, "owner_authority_review_only")
+        self.assertEqual(forged.claim.authority_actor, "")
+        self.assertEqual(forged.claim.authority_receipt, "")
+        self.assertEqual(forged.claim.confidence, canon.Confidence.LOW)
+
+        mixed_internal = canon.adapt_broadcast_memory_claim(
+            {
+                "id": 15,
+                "entry_type": "moderation_context",
+                "cleaned_summary": "A moderation fixture.",
+                "status": "active",
+                "public_safe": True,
+                "usage_scope": "internal,direct",
+            }
+        )
+        self.assertEqual(
+            mixed_internal.claim.visibility,
+            canon.Visibility.INTERNAL,
+        )
+        self.assertNotIn("public_home", mixed_internal.claim.eligible_routes)
+
+    def test_living_adapter_rejects_heterogeneous_or_unestablished_rows(self):
+        role = canon.adapt_living_atomic_claim(
+            {
+                "candidate_id": "role-candidate",
+                "candidate_type": "person_role_fact",
+                "candidate_state": "established",
+                "subject_key": "discord_user:7",
+                "predicate_key": "role",
+                "meaning": "A role claim.",
+                "root_ids": ("root-1", "root-2"),
+            }
+        )
+        provisional = canon.adapt_living_atomic_claim(
+            {
+                "candidate_id": "provisional-candidate",
+                "candidate_type": "topic_or_motif",
+                "candidate_state": "provisional",
+                "subject_key": "discord_user:7",
+                "predicate_key": "topic",
+                "meaning": "A motif.",
+                "root_ids": ("root-1", "root-2"),
+            }
+        )
+        self.assertEqual(role.reason, "living_claim_kind_ineligible")
+        self.assertEqual(
+            provisional.reason,
+            "living_lifecycle_ineligible",
+        )
+
+    def test_established_atomic_or_finalized_moment_needs_recurrence_proof(self):
+        established = canon.adapt_living_atomic_claim(
+            {
+                "candidate_id": "candidate-1",
+                "candidate_type": "topic_or_motif",
+                "candidate_state": "established",
+                "subject_key": "discord_user:7",
+                "predicate_key": "topic",
+                "meaning": "A motif.",
+                "root_ids": ("root-1", "root-2"),
+            }
+        )
+        moment = canon.adapt_living_moment_claim(
+            {
+                "moment_id": "moment-1",
+                "lifecycle_status": "finalized",
+                "topic_key": "unseen-topic",
+                "summary": "Several rows in one finalized Moment.",
+                "root_ids": ("root-1", "root-2", "root-3"),
+                "occurrence_ids": ("moment-1",),
+            }
+        )
+        self.assertEqual(established.reason, "living_recurrence_unverified")
+        self.assertIsNotNone(established.claim)
+        self.assertEqual(
+            established.claim.canon_status,
+            canon.CanonStatus.OPEN_SIGNAL,
+        )
+        self.assertEqual(
+            established.claim.lifecycle,
+            canon.ClaimLifecycle.REVIEW_ONLY,
+        )
+        self.assertEqual(moment.reason, "living_recurrence_unverified")
+        self.assertIsNotNone(moment.claim)
+        self.assertEqual(moment.claim.claim_kind, canon.ClaimKind.EVENT)
+        self.assertEqual(moment.claim.lifecycle, canon.ClaimLifecycle.REVIEW_ONLY)
+
+    def test_living_adapter_accepts_only_explicit_cross_occurrence_proof(self):
+        adapted = canon.adapt_living_atomic_claim(
+            {
+                "candidate_id": "candidate-2",
+                "candidate_type": "topic_or_motif",
+                "candidate_state": "established",
+                "subject_key": "discord_user:7",
+                "predicate_key": "unseen_topic_pattern",
+                "meaning": "They repeatedly compare unusual antenna materials.",
+                "root_ids": ("root-1", "root-2"),
+                "occurrence_ids": ("exchange-1", "exchange-2"),
+                "recurrence_contract_version": "living_canon_recurrence_v1",
+                "domain": "real_community",
+                "claim_kind": "behavior_pattern",
+                "candidate_eligible": True,
+                "source_eligible": True,
+                "roots_valid": True,
+                "occurrence_bounded": True,
+                "correction_fence_clear": True,
+                "contradiction_clear": True,
+                "independent_root_count": 2,
+                "independent_occurrence_count": 2,
+                "visibility": "public_safe",
+                "public_usable": True,
+            }
+        )
+        self.assertEqual(adapted.reason, "eligible_living")
+        self.assertEqual(adapted.claim.canon_status, canon.CanonStatus.LIVING)
+        self.assertEqual(
+            adapted.claim.recurrence_contract_version,
+            canon.LIVING_CANON_RECURRENCE_VERSION,
+        )
+        self.assertFalse(adapted.live_eligible)
+
+        missing_identity = canon.adapt_living_atomic_claim(
+            {
+                "candidate_type": "topic_or_motif",
+                "candidate_state": "established",
+                "subject_key": "discord_user:7",
+                "predicate_key": "unseen_topic_pattern",
+                "meaning": "A repeated pattern.",
+                "root_ids": ("root-1", "root-2"),
+                "occurrence_ids": ("exchange-1", "exchange-2"),
+                "recurrence_contract_version": "living_canon_recurrence_v1",
+                "domain": "real_community",
+                "claim_kind": "behavior_pattern",
+                "candidate_eligible": True,
+                "source_eligible": True,
+                "roots_valid": True,
+                "occurrence_bounded": True,
+                "correction_fence_clear": True,
+                "contradiction_clear": True,
+                "independent_root_count": 2,
+                "independent_occurrence_count": 2,
+            }
+        )
+        self.assertIsNone(missing_identity.claim)
+        self.assertEqual(
+            missing_identity.reason,
+            "living_source_identity_missing",
+        )
+
+    def test_open_signal_is_ephemeral_and_source_linked(self):
+        adapted = canon.adapt_open_signal_claim(
+            {
+                "subject_key": "discord_user:7",
+                "entry_id": "entry-7",
+                "text": "They keep returning to unusual signal routing.",
+                "occurrence_identity": "occurrence-7",
+                "observed_at": "2026-08-01T00:00:00+00:00",
+                "assessment_contract_version": "public_assessment_evidence_v1",
+                "source_system": "memory_ledger_public_assessment",
+                "source_role": "user",
+                "source_class": "public_observation",
+                "lifecycle_status": "active",
+                "visibility": "public_safe",
+                "channel_policy": "public_home",
+                "public_usable": True,
+                "subject_authored": True,
+                "request_relevant": True,
+                "selector_eligible": True,
+                "derived": False,
+                "projection": False,
+            }
+        )
+        self.assertEqual(adapted.reason, "eligible_open_signal")
+        self.assertEqual(
+            adapted.claim.canon_status,
+            canon.CanonStatus.OPEN_SIGNAL,
+        )
+        self.assertEqual(
+            adapted.claim.lifecycle,
+            canon.ClaimLifecycle.CANDIDATE,
+        )
+        self.assertEqual(adapted.claim.projection_state, "ephemeral")
+        self.assertEqual(
+            adapted.claim.root_ids,
+            ("memory_ledger:entry-7",),
+        )
+        self.assertEqual(adapted.claim.occurrence_ids, ("occurrence-7",))
+
+    def test_open_signal_rejects_private_deleted_or_model_derived_rows(self):
+        base = {
+            "subject_key": "discord_user:7",
+            "entry_id": "entry-7",
+            "text": "A bounded observation.",
+            "occurrence_identity": "occurrence-7",
+            "assessment_contract_version": "public_assessment_evidence_v1",
+            "source_system": "memory_ledger_public_assessment",
+            "source_role": "user",
+            "source_class": "public_observation",
+            "lifecycle_status": "active",
+            "visibility": "public_safe",
+            "channel_policy": "public_home",
+            "public_usable": True,
+            "subject_authored": True,
+            "request_relevant": True,
+            "selector_eligible": True,
+            "derived": False,
+            "projection": False,
+        }
+        for overrides in (
+            {"visibility": "private"},
+            {"lifecycle_status": "deleted"},
+            {"source_role": "model", "derived": True},
+            {"public_usable": "false"},
+            {"subject_authored": False},
+        ):
+            with self.subTest(overrides=overrides):
+                result = canon.adapt_open_signal_claim({**base, **overrides})
+                self.assertIsNone(result.claim)
+                self.assertEqual(result.reason, "open_signal_source_ineligible")
+
+    def test_real_public_assessment_output_normalizes_directly(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            ledger.ensure_memory_ledger_schema(conn)
+            inserted = ledger.shadow_conversation_row(
+                conn,
+                row_id=701,
+                user_id=7,
+                user_name="Crow",
+                guild_id=1,
+                role="user",
+                content="I keep testing unusual antenna materials for the signal.",
+                channel_name="barcode-bot",
+                channel_policy="public_home",
+                channel_id=10,
+                route_mode="normal_chat",
+                observed_at="2026-08-01T00:00:00+00:00",
+            )
+            self.assertEqual(inserted.outcome, "inserted")
+            selected = ledger.select_public_conversation_assessment_evidence(
+                conn,
+                guild_id=1,
+                subject_key="discord_user:7",
+                request_text="What am I all about?",
+            )
+            self.assertEqual(len(selected.items), 1)
+            adapted = canon.adapt_open_signal_claim(selected.items[0])
+            self.assertEqual(adapted.reason, "eligible_open_signal")
+            self.assertEqual(
+                adapted.claim.subject_id,
+                "discord_user:7",
+            )
+            self.assertEqual(
+                adapted.claim.canon_status,
+                canon.CanonStatus.OPEN_SIGNAL,
+            )
+        finally:
+            conn.close()
+
+    def test_website_lore_origin_stays_review_only_and_nonidentifying(self):
+        result = canon.adapt_website_lore_relationship_candidate(
+            canon.LEGACY_WEBSITE_LORE_RELATIONSHIP_CANDIDATES[0]
+        )
+        self.assertEqual(result.reason, "website_lore_review_only")
+        self.assertEqual(result.claim.lifecycle, canon.ClaimLifecycle.REVIEW_ONLY)
+        self.assertEqual(result.claim.domain, canon.CanonDomain.LORE)
+        self.assertEqual(result.claim.claim_kind, canon.ClaimKind.RELATIONSHIP)
+        self.assertEqual(result.claim.visibility, canon.Visibility.INTERNAL)
+        self.assertFalse(result.live_eligible)
+        self.assertEqual(result.claim.subject_id, canon.CACHE_BACK.key)
+        self.assertEqual(
+            result.claim.value["object_id"],
+            canon.CALL_EM_BINI.key,
+        )
+        self.assertEqual(
+            canon.matching_canon_member_identities(("Call'em Bini",)),
+            (),
+        )
+
+    def test_validity_is_orthogonal_to_status_visibility_and_lifecycle(self):
+        row = {
+            "id": 40,
+            "entry_type": "show_state_override",
+            "cleaned_summary": "A temporary show state.",
+            "status": "active",
+            "public_safe": False,
+            "usage_scope": "internal",
+            "valid_from": "2026-08-01T00:00:00+00:00",
+            "valid_until": "2026-08-02T00:00:00+00:00",
+        }
+        claim = canon.adapt_broadcast_memory_claim(
+            row,
+            owner_authorized=True,
+            authority_actor="discord_user:1",
+            authority_receipt="owner_command:40",
+        ).claim
+        self.assertEqual(claim.canon_status, canon.CanonStatus.DECLARED)
+        self.assertEqual(claim.visibility, canon.Visibility.INTERNAL)
+        self.assertEqual(claim.lifecycle, canon.ClaimLifecycle.REVIEW_ONLY)
+        self.assertTrue(
+            canon.claim_within_validity_window(
+                claim,
+                at="2026-08-01T12:00:00+00:00",
+            )
+        )
+        self.assertFalse(
+            canon.claim_within_validity_window(
+                claim,
+                at="2026-08-03T00:00:00+00:00",
+            )
+        )
+        self.assertEqual(claim.canon_status, canon.CanonStatus.DECLARED)
+        self.assertEqual(claim.lifecycle, canon.ClaimLifecycle.REVIEW_ONLY)
+
+    def test_inventory_reports_contract_and_content_free_collisions(self):
+        claims = tuple(
+            canon.adapt_legacy_canon_fact(fact)
+            for fact in canon.CANON_FACTS
+        )
+        diagnostics = canon.canon_claim_inventory_diagnostics(claims)
+        self.assertEqual(
+            diagnostics["claimContractVersion"],
+            canon.HYBRID_CANON_CLAIM_CONTRACT_VERSION,
+        )
+        self.assertEqual(diagnostics["claimCount"], len(claims))
+        self.assertEqual(diagnostics["claimIdCollisionCount"], 0)
+        self.assertEqual(diagnostics["revisionIdCollisionCount"], 0)
+        self.assertEqual(diagnostics["revisionDigestMismatchCount"], 0)
+        self.assertEqual(diagnostics["identityBindingCollisionCount"], 0)
+        self.assertEqual(diagnostics["nonOpaqueAuthorityActorCount"], 0)
+
+        repeated = canon.canon_claim_inventory_diagnostics(
+            (claims[0], claims[0])
+        )
+        self.assertEqual(repeated["claimIdCollisionCount"], 0)
+        self.assertEqual(repeated["revisionIdCollisionCount"], 0)
+
+        hostile_claim = replace(
+            claims[0],
+            authority_actor="discord_user:Jane Doe",
+        )
+        hostile = canon.canon_claim_inventory_diagnostics(
+            (hostile_claim,),
+            bindings=(
+                canon.EntityAccountBinding(
+                    entity_id=canon.MAC_MODEM.key,
+                    platform="discord",
+                    account_id="7",
+                    authority_receipt="binding_receipt:hostile",
+                    authority_actor="discord_user:Jane Doe",
+                    authority_verified=True,
+                ),
+            ),
+        )
+        self.assertEqual(hostile["nonOpaqueAuthorityActorCount"], 1)
+        self.assertEqual(hostile["nonOpaqueBindingActorCount"], 1)
+
+    def test_database_inventory_reconciles_and_performs_zero_writes(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.execute(
+                """
+                CREATE TABLE broadcast_memory(
+                  id INTEGER PRIMARY KEY,
+                  guild_id INTEGER,
+                  entry_type TEXT,
+                  raw_note TEXT,
+                  status TEXT,
+                  public_safe INTEGER,
+                  created_at TEXT
+                )
+                """
+            )
+            conn.executemany(
+                "INSERT INTO broadcast_memory VALUES(?,?,?,?,?,?,?)",
+                (
+                    (
+                        1,
+                        1,
+                        "notable_moment",
+                        "Private fixture text must not enter diagnostics.",
+                        "active",
+                        1,
+                        "2026-08-01T00:00:00+00:00",
+                    ),
+                    (
+                        2,
+                        1,
+                        "recap",
+                        "Another private fixture value.",
+                        "active",
+                        0,
+                        "2026-08-01T01:00:00+00:00",
+                    ),
+                ),
+            )
+            before = conn.total_changes
+            inventory = canon.build_claim_contract_inventory(
+                conn,
+                guild_id=1,
+            )
+            self.assertEqual(conn.total_changes, before)
+            self.assertEqual(inventory["mutationCount"], 0)
+            self.assertEqual(inventory["sourceRows"]["broadcast_memory"], 2)
+            self.assertEqual(inventory["adaptedRows"]["broadcast_memory"], 2)
+            self.assertTrue(inventory["sourceAdaptedReconciled"])
+            self.assertEqual(inventory["sourceReconciliationStatus"], "complete")
+            self.assertEqual(inventory["truncatedSources"], ())
+            self.assertEqual(inventory["callemCacheIdentityCollisionCount"], 0)
+            rendered = repr(inventory)
+            self.assertNotIn("Private fixture", rendered)
+            self.assertNotIn("Another private", rendered)
+        finally:
+            conn.close()
+
+    def test_current_atomic_source_row_normalizes_as_review_only(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            ledger.ensure_memory_ledger_schema(conn)
+            roots = []
+            for row_id, observed_at, text in (
+                (
+                    801,
+                    "2026-07-24T20:00:00+00:00",
+                    "I keep fixing the bot code and memory system.",
+                ),
+                (
+                    802,
+                    "2026-07-25T20:00:00+00:00",
+                    "The website code needs another careful test.",
+                ),
+            ):
+                roots.append(
+                    ledger.insert_ledger_entry(
+                        conn,
+                        ledger.LedgerEntry(
+                            guild_id=1,
+                            source_table="conversations",
+                            source_row_id=row_id,
+                            source_revision=str(row_id),
+                            source_role="user",
+                            entry_type="observation",
+                            subject_key="discord_user:7",
+                            subject_display_name="Crow",
+                            predicate_key="conversation",
+                            value=text,
+                            source_class=canon.SourceClass.PUBLIC_OBSERVATION,
+                            route_mode="normal_chat",
+                            channel_id=10,
+                            channel_name="barcode-bot",
+                            channel_policy="public_home",
+                            visibility=canon.Visibility.PUBLIC,
+                            confidence=canon.Confidence.MEDIUM,
+                            public_usable=True,
+                            observed_at=observed_at,
+                            source_sequence=row_id,
+                            participants=(
+                                ledger.LedgerParticipant(
+                                    "discord_user:7",
+                                    "Crow",
+                                    "author",
+                                    0,
+                                ),
+                            ),
+                        ),
+                    ).entry_id
+                )
+            formed = ledger.form_atomic_candidates_from_recurring_conversation(
+                conn,
+                trigger_entry_id=roots[-1],
+                environ={
+                    ledger.MEMORY_LEDGER_SHADOW_ENV: "true",
+                    ledger.CONVERSATION_MOTIF_FORMATION_ENV: "true",
+                },
+            )
+            self.assertEqual(len(formed), 1)
+            inventory = canon.build_claim_contract_inventory(conn, guild_id=1)
+            self.assertEqual(inventory["sourceRows"]["atomic_knowledge"], 1)
+            self.assertEqual(inventory["adaptedRows"]["atomic_knowledge"], 1)
+            self.assertEqual(inventory["rejectedRows"].get("atomic_knowledge", 0), 0)
+            self.assertGreaterEqual(
+                inventory["reasonCounts"].get(
+                    "living_recurrence_unverified",
+                    0,
+                ),
+                1,
+            )
+        finally:
+            conn.close()
+
+    def test_current_finalized_moment_normalizes_as_review_only(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            ledger.ensure_memory_ledger_schema(conn)
+            moments.ensure_moment_schema(conn)
+            with mock.patch.dict(
+                "os.environ",
+                {
+                    ledger.MEMORY_LEDGER_SHADOW_ENV: "true",
+                    moments.MOMENT_ENGINE_SHADOW_ENV: "true",
+                },
+            ):
+                for row_id, user_id, name, text in (
+                    (901, 7, "Crow", "The synth patch should open the chorus."),
+                    (902, 8, "Moth", "The drums can answer that synth chorus."),
+                    (903, 7, "Crow", "The modular patch and drums resolve together."),
+                ):
+                    written = ledger.shadow_conversation_row(
+                        conn,
+                        row_id=row_id,
+                        user_id=user_id,
+                        user_name=name,
+                        guild_id=1,
+                        role="user",
+                        content=text,
+                        channel_name="barcode-bot",
+                        channel_policy="public_home",
+                        channel_id=10,
+                        route_mode="normal_chat",
+                        observed_at=(
+                            "2026-08-01T00:%02d:00+00:00" % (row_id - 901)
+                        ),
+                    )
+                    moments.observe_ledger_entry(conn, written.entry_id)
+                moments.sweep_expired_windows(
+                    conn,
+                    now="2026-08-01T00:10:00+00:00",
+                )
+            finalized = conn.execute(
+                """
+                SELECT COUNT(*) FROM memory_moment_windows
+                WHERE lifecycle_status='finalized'
+                """
+            ).fetchone()[0]
+            self.assertGreaterEqual(finalized, 1)
+            inventory = canon.build_claim_contract_inventory(conn, guild_id=1)
+            self.assertGreaterEqual(inventory["sourceRows"]["memory_moment"], 1)
+            self.assertGreaterEqual(inventory["adaptedRows"]["memory_moment"], 1)
+        finally:
+            conn.close()
+
+    def test_inventory_discloses_truncation_instead_of_overclaiming(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.execute(
+                """
+                CREATE TABLE broadcast_memory(
+                  id INTEGER PRIMARY KEY,
+                  guild_id INTEGER,
+                  entry_type TEXT,
+                  cleaned_summary TEXT,
+                  status TEXT
+                )
+                """
+            )
+            conn.executemany(
+                "INSERT INTO broadcast_memory VALUES(?,?,?,?,?)",
+                (
+                    (1, 1, "notable_moment", "One.", "active"),
+                    (2, 1, "notable_moment", "Two.", "active"),
+                ),
+            )
+            inventory = canon.build_claim_contract_inventory(
+                conn,
+                guild_id=1,
+                max_rows_per_source=1,
+            )
+            self.assertTrue(inventory["boundedRowsReconciled"])
+            self.assertFalse(inventory["sourceAdaptedReconciled"])
+            self.assertEqual(
+                inventory["sourceReconciliationStatus"],
+                "partial_truncated",
+            )
+            self.assertIn("broadcast_memory", inventory["truncatedSources"])
+        finally:
+            conn.close()
+
+    def test_inventory_fails_closed_on_source_schema_drift(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.execute("CREATE TABLE broadcast_memory(foo TEXT)")
+            conn.execute("INSERT INTO broadcast_memory VALUES(?)", ("row",))
+            inventory = canon.build_claim_contract_inventory(
+                conn,
+                guild_id=1,
+            )
+            self.assertEqual(inventory["sourceRows"]["broadcast_memory"], 1)
+            self.assertEqual(
+                inventory["inspectedRows"]["broadcast_memory"],
+                0,
+            )
+            self.assertFalse(inventory["sourceAdaptedReconciled"])
+            self.assertEqual(
+                inventory["sourceReconciliationStatus"],
+                "partial_truncated",
+            )
+            self.assertIn("broadcast_memory", inventory["truncatedSources"])
+        finally:
+            conn.close()
+
+    def test_inventory_lineage_lookup_is_candidate_and_guild_scoped(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.execute(
+                """
+                CREATE TABLE memory_ledger_knowledge_roots(
+                  candidate_id TEXT,
+                  guild_id INTEGER,
+                  root_entry_id TEXT,
+                  is_independent INTEGER
+                )
+                """
+            )
+            conn.executemany(
+                "INSERT INTO memory_ledger_knowledge_roots VALUES(?,?,?,?)",
+                (
+                    ("candidate-1", 1, "guild-1-root", 1),
+                    ("candidate-1", 2, "guild-2-root", 1),
+                    ("candidate-2", 1, "other-candidate-root", 1),
+                ),
+            )
+            roots = canon._inventory_scoped_lineage_map(
+                conn,
+                table_name="memory_ledger_knowledge_roots",
+                owner_column="candidate_id",
+                root_column="root_entry_id",
+                owner_ids=("candidate-1",),
+                guild_id=1,
+                independent_only=True,
+            )
+            self.assertEqual(roots, {"candidate-1": ["guild-1-root"]})
+        finally:
+            conn.close()
+
+    def test_callem_bini_cannot_unlock_cache_back_in_broad_packet(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            ledger.ensure_memory_ledger_schema(conn)
+            for row_id, observed_at, text in (
+                (
+                    1,
+                    "2026-08-01T00:00:00+00:00",
+                    "I keep returning to distorted tape transitions.",
+                ),
+                (
+                    2,
+                    "2026-08-01T01:00:00+00:00",
+                    "I tested another transition for the live set.",
+                ),
+            ):
+                result = ledger.shadow_conversation_row(
+                    conn,
+                    row_id=row_id,
+                    user_id=42,
+                    user_name="Call'em Bini",
+                    guild_id=1,
+                    role="user",
+                    content=text,
+                    channel_name="barcode-bot",
+                    channel_policy="public_home",
+                    channel_id=10,
+                    route_mode="normal_chat",
+                    observed_at=observed_at,
+                )
+                self.assertEqual(result.outcome, "inserted")
+            request = packet.IntelligencePacketRequest(
+                guild_id=1,
+                channel_id=10,
+                channel_policy="public_home",
+                route_mode="normal_chat",
+                conversation_surface="mention_or_reply",
+                subject_user_id=42,
+                subject_display_name="Call'em Bini",
+                user_text="BNL, what am I all about?",
+                now="2026-08-01T02:00:00+00:00",
+            )
+            built = packet.build_packet(
+                conn,
+                request,
+                persist=False,
+                environ={
+                    "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED": "true",
+                    "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+                    "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+                    "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+                    "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+                    "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
+                    "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
+                    "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+                },
+            )
+            self.assertIsNotNone(built)
+            self.assertEqual(
+                built.diagnostics.canon_identity_status,
+                "no_exact_canon_label",
+            )
+            self.assertFalse(
+                any(
+                    item.source_type == "recognized_canon_fact"
+                    for item in (*built.items, *built.validation_items)
+                )
+            )
+            self.assertFalse(
+                any("Cache Back" in item.text for item in built.items)
+            )
+            self.assertEqual(built.profile_sufficiency.status, "empty")
+        finally:
+            conn.close()
+
+    def test_shadow_canon_reference_is_projection_not_independent_authority(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            ledger.ensure_memory_ledger_schema(conn)
+            result = ledger.shadow_canon_reference(
+                conn,
+                canon_id="claim-1",
+                revision_id="revision-1",
+                guild_id=1,
+                subject_key=ledger.BNL_SUBJECT_KEY,
+                subject_display_name="BNL-01",
+                predicate_key="roles",
+                value="BNL is the continuity layer.",
+            )
+            row = conn.execute(
+                """
+                SELECT source_table,source_revision,source_role,derived,
+                       projection
+                FROM memory_ledger_entries WHERE entry_id=?
+                """,
+                (result.entry_id,),
+            ).fetchone()
+            self.assertEqual(
+                row,
+                (
+                    "canon_claim_projection",
+                    "revision-1",
+                    "canon_projection",
+                    1,
+                    1,
+                ),
+            )
+            attempted = ledger.form_atomic_candidate_from_ledger_entry(
+                conn,
+                result.entry_id,
+            )
+            self.assertEqual(attempted.outcome, "rejected")
+            self.assertEqual(
+                attempted.reason_code,
+                "derivative_misclassified_as_independent",
+            )
+        finally:
+            conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_diagnostic_command.py
+++ b/tests/test_memory_diagnostic_command.py
@@ -61,6 +61,26 @@ def diagnostic_data():
             "schemaVersion": "memory_ledger_v1",
             "insertedLedgerEntries": 0,
         },
+        {
+            "claimContractVersion": "hybrid_canon_claim_v1",
+            "sourceRows": {"legacy_canon_registry": 19},
+            "inspectedRows": {"legacy_canon_registry": 19},
+            "adaptedRows": {"legacy_canon_registry": 19},
+            "reviewOnlyCount": 0,
+            "reasonCounts": {"eligible_legacy": 19},
+            "identityLabelCollisionCount": 0,
+            "identityBindingCollisionCount": 0,
+            "callemCacheIdentityCollisionCount": 0,
+            "claimIdCollisionCount": 0,
+            "revisionIdCollisionCount": 0,
+            "revisionDigestMismatchCount": 0,
+            "nonOpaqueAuthorityActorCount": 0,
+            "nonOpaqueBindingActorCount": 0,
+            "truncatedSources": (),
+            "sourceReconciliationStatus": "complete",
+            "sourceAdaptedReconciled": True,
+            "mutationCount": 0,
+        },
     )
 
 
@@ -107,6 +127,19 @@ class MemoryDiagnosticCommandTests(unittest.IsolatedAsyncioTestCase):
             self.assertIn("BNL Memory Diagnostic", text)
             self.assertIn(
                 "- conversation_motif_formation_shadow_enabled: `yes`",
+                text,
+            )
+            self.assertIn(
+                "- hybrid_claim_contract: `hybrid_canon_claim_v1`",
+                text,
+            )
+            self.assertIn("- hybrid_claim_mutation_count: `0`", text)
+            self.assertIn(
+                "- hybrid_claim_reconciliation_status: `complete`",
+                text,
+            )
+            self.assertIn(
+                "- hybrid_claim_truncated_sources: `()`",
                 text,
             )
             self.assertEqual(limit, 1700)


### PR DESCRIPTION
## Hybrid Shared-Brain Convergence — PR 1/5

Implements the versioned hybrid canon claim and identity-integrity contract from the 2026-08-01 REV2 alignment pack.

### Scope

- normalizes Legacy, owner-verified Broadcast, current Atomic/Moment, and question-scoped public assessment evidence into one immutable claim contract
- keeps current unverified Broadcast and current recurrence-unproved Atomic/Moment material internal and review-only
- separates Call'em Bini from Cache Back while preserving the existing site-origin prose as an internal review candidate
- adds stable entity/account binding resolution; an already-approved exact binding outranks display labels, while invalid or ambiguous rows fail closed
- makes canon Ledger references explicit derived projections rather than independent roots
- adds content-free, zero-write inventory and collision diagnostics

### Safety boundaries

- creates no binding table or binding row
- migrates, copies, deletes, promotes, or publishes no source data
- changes no environment gate or deployment state
- enables no new shared-brain claim-content response behavior
- owner-verified Broadcast remains review-only in this PR
- live behavior is unchanged unless an already-approved binding source exists; otherwise label compatibility remains apart from the false alias removal

### Verification

- 146 focused dependency-free regression tests passed locally
- independent architecture review: MERGE-READY, 119 focused tests
- independent security/fail-closed review: MERGE-READY, 59 focused tests and hostile probes
- compileall and git diff --check passed
- full dependency-installed repository CI is required on this exact commit before merge

Remote tree: `2979a8551bff83326ce7b96869fb33c4418400b6`
Base: `e831f79b7ab429442e8beb8b7d810277646aa59a`

No deployment, database, configuration, binding-data, or live acceptance action is part of this PR.