### PR TITLE
Add Declared Canon lifecycle and Broadcast adapter

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -62,6 +62,7 @@ from bnl_memory_ledger import (
     record_bnl_self_name_decision,
     subject_key_for_user,
     shadow_broadcast_memory_row,
+    shadow_declared_canon_projection,
     shadow_conversation_row,
     record_shadow_receipt,
     shadow_broadcast_status_event,
@@ -208,6 +209,19 @@ from bnl_journal_source_store import (
     record_source_event as record_journal_source_event,
     sanitize_summary as sanitize_journal_source_summary,
     timestamp_to_epoch_ms as journal_timestamp_to_epoch_ms,
+)
+from bnl_declared_canon import (
+    BROADCAST_MEMORY_SOURCE as DECLARED_BROADCAST_MEMORY_SOURCE,
+    DeclaredCanonError,
+    add_declared_canon,
+    change_declared_canon_status,
+    classify_broadcast_memory,
+    correct_declared_canon,
+    ensure_declared_canon_schema,
+    preview_declared_canon,
+    preview_historical_broadcast_memory,
+    retire_declared_canon,
+    supersede_declared_canon,
 )
 from bnl_journal_automation import (
     automation_status as journal_automation_status,
@@ -5304,6 +5318,7 @@ def init_db():
     from bnl_entity_evidence import ensure_entity_evidence_schema
     evidence_conn = sqlite3.connect(DB_FILE)
     try:
+        ensure_declared_canon_schema(evidence_conn)
         ensure_entity_evidence_schema(evidence_conn)
         ensure_memory_ledger_schema(evidence_conn)
         ensure_relationship_v2_schema(evidence_conn)
@@ -6665,6 +6680,27 @@ def configured_owner_control_denial_reason(user: discord.abc.User) -> str:
     if not is_owner_operator(user):
         return "configured_owner_required"
     return ""
+
+
+def require_configured_owner_mutation_actor(
+    actor_user_id: int,
+    guild_id: int,
+) -> int:
+    """Enforce configured owner and primary-guild mutation boundaries."""
+
+    configured = int(BNL_OWNER_USER_ID or 0)
+    actor = int(actor_user_id or 0)
+    primary_guild = int(BNL_PRIMARY_GUILD_ID or 0)
+    target_guild = int(guild_id or 0)
+    if configured <= 0:
+        raise PermissionError("owner_user_id_not_configured")
+    if actor <= 0 or actor != configured:
+        raise PermissionError("configured_owner_required")
+    if primary_guild <= 0:
+        raise PermissionError("primary_guild_id_not_configured")
+    if target_guild <= 0 or target_guild != primary_guild:
+        raise PermissionError("configured_primary_guild_required")
+    return actor
 
 
 def has_mod_role(member: discord.Member) -> bool:
@@ -9716,6 +9752,462 @@ async def maybe_handle_provider_status_command(message: discord.Message, clean_c
     ]
     await message.reply("\n".join(lines))
     return True
+
+
+_DECLARED_CANON_COMMON_FIELDS = frozenset(
+    {
+        "subject_type",
+        "subject_id",
+        "object_subject_type",
+        "object_subject_id",
+        "predicate",
+        "value",
+        "raw_declaration",
+        "cleaned_summary",
+        "domain",
+        "claim_kind",
+        "visibility",
+        "eligible_routes",
+        "valid_from",
+        "valid_until",
+    }
+)
+
+
+def _declared_canon_command_nonce(message: discord.Message, suffix: str) -> str:
+    message_id = int(getattr(message, "id", 0) or 0)
+    if message_id <= 0:
+        raise DeclaredCanonError("discord_message_id_required")
+    normalized_suffix = re.sub(r"[^A-Za-z0-9._-]+", "-", suffix or "command")
+    return (f"discord-{message_id}-{normalized_suffix}")[:128]
+
+
+def _declared_canon_json_payload(raw: str, *, required: bool) -> dict:
+    text = str(raw or "").strip()
+    if not text:
+        if required:
+            raise DeclaredCanonError("declared_command_json_required")
+        return {}
+    try:
+        payload = json.loads(text)
+    except (TypeError, json.JSONDecodeError):
+        raise DeclaredCanonError("declared_command_json_invalid")
+    if not isinstance(payload, dict):
+        raise DeclaredCanonError("declared_command_object_required")
+    return payload
+
+
+def _declared_canon_validate_command_fields(
+    payload: dict,
+    *,
+    allowed: set[str] | frozenset[str],
+    required: set[str] | frozenset[str] = frozenset(),
+) -> None:
+    if set(payload) - set(allowed):
+        raise DeclaredCanonError("declared_command_unexpected_field")
+    if set(required) - set(payload):
+        raise DeclaredCanonError("declared_command_missing_field")
+    if "eligible_routes" in payload and not isinstance(
+        payload.get("eligible_routes"), (list, tuple)
+    ):
+        raise DeclaredCanonError("declared_command_routes_list_required")
+
+
+def _declared_canon_claim_kwargs(payload: dict) -> dict:
+    return {
+        "subject_type": payload.get("subject_type", ""),
+        "subject_id": payload.get("subject_id", ""),
+        "object_subject_type": payload.get("object_subject_type", ""),
+        "object_subject_id": payload.get("object_subject_id", ""),
+        "predicate": payload.get("predicate", ""),
+        "value": payload.get("value"),
+        "raw_declaration": payload.get("raw_declaration", ""),
+        "cleaned_summary": payload.get("cleaned_summary", ""),
+        "domain": payload.get("domain", ""),
+        "claim_kind": payload.get("claim_kind", ""),
+        "visibility": payload.get("visibility", "internal"),
+        "eligible_routes": tuple(payload.get("eligible_routes") or ()),
+        "valid_from": payload.get("valid_from", ""),
+        "valid_until": payload.get("valid_until", ""),
+    }
+
+
+def _shadow_declared_revision_after_owner_command(
+    message: discord.Message,
+    revision,
+    *,
+    projection_index: int,
+) -> str:
+    if not memory_ledger_shadow_enabled():
+        return "disabled"
+
+    guild_id = int(getattr(getattr(message, "guild", None), "id", 0) or 0)
+    actor_id = int(getattr(getattr(message, "author", None), "id", 0) or 0)
+    nonce = _declared_canon_command_nonce(
+        message, f"declared-projection-{projection_index}"
+    )
+
+    def project(ledger_conn):
+        roots = ()
+        if (
+            revision.source_system == DECLARED_BROADCAST_MEMORY_SOURCE
+            and revision.lifecycle_status == "established"
+        ):
+            rows = ledger_conn.execute(
+                """
+                SELECT entry_id
+                FROM memory_ledger_entries
+                WHERE guild_id=? AND source_table='broadcast_memory'
+                  AND source_row_id=? AND source_role='broadcast_memory'
+                  AND lifecycle_status='active'
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM memory_ledger_lineage AS edge
+                      WHERE edge.guild_id=memory_ledger_entries.guild_id
+                        AND edge.target_entry_id=memory_ledger_entries.entry_id
+                        AND edge.lineage_type IN ('supersedes','retracts')
+                  )
+                ORDER BY created_at DESC
+                """,
+                (guild_id, revision.source_row_id),
+            ).fetchall()
+            if len(rows) == 1:
+                roots = (str(rows[0][0]),)
+        return shadow_declared_canon_projection(
+            ledger_conn,
+            guild_id=guild_id,
+            declaration_id=revision.declaration_id,
+            revision_id=revision.revision_id,
+            actor_user_id=actor_id,
+            authority_nonce=nonce,
+            expected_source_fingerprint=revision.source_fingerprint,
+            expected_lifecycle_status=revision.lifecycle_status,
+            root_entry_ids=roots,
+        )
+
+    result = _shadow_memory_ledger_write(
+        "declared_canon_projection",
+        project,
+        guild_id=guild_id,
+        source_table="declared_canon_revisions",
+        source_row_id=revision.declaration_id,
+        source_revision=revision.revision_id,
+        source_event_key=f"revision:{revision.revision_id}",
+    )
+    if result is None:
+        return "error:shadow_exception"
+    return f"{result.outcome}:{result.reason_code}"
+
+
+def _declared_canon_mutation_summary(result, projection_states: list[str]) -> str:
+    revisions = ", ".join(
+        f"{item.declaration_id}/{item.revision_id} [{item.lifecycle_status}]"
+        for item in result.revisions
+    )
+    return (
+        f"Declared Canon operation committed: {result.operation_id}. "
+        f"Revisions: {revisions}. Shadow projections: {', '.join(projection_states)}."
+    )
+
+
+async def maybe_handle_declared_canon_command(
+    message: discord.Message,
+    clean_content: str,
+) -> bool:
+    """Handle strict owner-only Declared Canon JSON controls in R&D."""
+
+    match = re.match(
+        r"^!bnl\s+canon(?:\s+(.*))?$",
+        str(clean_content or "").strip(),
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    if not match:
+        return False
+    if not is_research_and_development_channel(message):
+        await message.reply(
+            "Declared Canon controls are restricted to #research-and-development."
+        )
+        return True
+    denial_reason = configured_owner_control_denial_reason(
+        getattr(message, "author", None)
+    )
+    if denial_reason:
+        await message.reply(f"Declared Canon control denied: {denial_reason}.")
+        return True
+    guild_id = int(getattr(getattr(message, "guild", None), "id", 0) or 0)
+    if not BNL_PRIMARY_GUILD_ID:
+        await message.reply(
+            "Declared Canon control denied: primary_guild_id_not_configured."
+        )
+        return True
+    if guild_id != int(BNL_PRIMARY_GUILD_ID):
+        await message.reply(
+            "Declared Canon control denied: configured_primary_guild_required."
+        )
+        return True
+    command = str(match.group(1) or "").strip()
+    action, _, raw_payload = command.partition(" ")
+    action = action.strip().casefold()
+    if not action:
+        await message.reply(
+            "Declared Canon action required: preview, broadcast-preview, add, "
+            "correct, retire, status, supersede, or broadcast-classify."
+        )
+        return True
+    actor_id = int(getattr(getattr(message, "author", None), "id", 0) or 0)
+    nonce = _declared_canon_command_nonce(message, action)
+    try:
+        payload = _declared_canon_json_payload(
+            raw_payload,
+            required=action
+            not in {"preview", "broadcast-preview"},
+        )
+        if action == "preview":
+            _declared_canon_validate_command_fields(
+                payload,
+                allowed={"source_system", "limit"},
+            )
+            with journal_release_privacy_fence(DB_FILE):
+                with sqlite3.connect(DB_FILE, timeout=30) as conn:
+                    preview = preview_declared_canon(
+                        conn,
+                        actor_user_id=actor_id,
+                        authority_nonce=nonce,
+                        guild_id=guild_id,
+                        source_system=payload.get("source_system", ""),
+                        limit=int(payload.get("limit", 100) or 100),
+                    )
+            if preview.mutation_count:
+                raise DeclaredCanonError("declared_preview_mutated_state")
+            counts = {}
+            for item in preview.items:
+                key = f"{item.source_system}:{item.lifecycle_status}"
+                counts[key] = counts.get(key, 0) + 1
+            await message.reply(
+                "Declared Canon preview (content-free): "
+                f"rows={preview.total_rows}, returned={len(preview.items)}, "
+                f"truncated={int(preview.truncated)}, counts={json.dumps(counts, sort_keys=True)}."
+            )
+            return True
+        if action == "broadcast-preview":
+            _declared_canon_validate_command_fields(
+                payload,
+                allowed={"limit", "offset"},
+            )
+            with journal_release_privacy_fence(DB_FILE):
+                with sqlite3.connect(DB_FILE, timeout=30) as conn:
+                    preview = preview_historical_broadcast_memory(
+                        conn,
+                        actor_user_id=actor_id,
+                        authority_nonce=nonce,
+                        guild_id=guild_id,
+                        limit=int(payload.get("limit", 200) or 200),
+                        offset=int(payload.get("offset", 0) or 0),
+                    )
+            if preview.mutation_count:
+                raise DeclaredCanonError("broadcast_preview_mutated_state")
+            await message.reply(
+                "Broadcast → Declared preview (content-free): "
+                f"rows={preview.total_rows}, returned={len(preview.items)}, "
+                f"truncated={int(preview.truncated)}, "
+                f"counts_scope={preview.counts_scope}, "
+                f"types={json.dumps(dict(preview.type_counts), sort_keys=True)}, "
+                f"eras={json.dumps(dict(preview.era_counts), sort_keys=True)}, "
+                f"dispositions={json.dumps(dict(preview.disposition_counts), sort_keys=True)}."
+            )
+            return True
+
+        result = None
+        with journal_release_privacy_fence(DB_FILE):
+            with sqlite3.connect(DB_FILE, timeout=30) as conn:
+                if action == "add":
+                    required = {
+                        "subject_type",
+                        "subject_id",
+                        "predicate",
+                        "value",
+                        "raw_declaration",
+                        "domain",
+                        "claim_kind",
+                    }
+                    _declared_canon_validate_command_fields(
+                        payload,
+                        allowed=_DECLARED_CANON_COMMON_FIELDS,
+                        required=required,
+                    )
+                    result = add_declared_canon(
+                        conn,
+                        actor_user_id=actor_id,
+                        authority_nonce=nonce,
+                        guild_id=guild_id,
+                        **_declared_canon_claim_kwargs(payload),
+                    )
+                elif action == "correct":
+                    required = {
+                        "declaration_id",
+                        "expected_revision_id",
+                        "subject_type",
+                        "subject_id",
+                        "predicate",
+                        "value",
+                        "raw_declaration",
+                        "domain",
+                        "claim_kind",
+                    }
+                    _declared_canon_validate_command_fields(
+                        payload,
+                        allowed=_DECLARED_CANON_COMMON_FIELDS
+                        | {"declaration_id", "expected_revision_id", "reason"},
+                        required=required,
+                    )
+                    result = correct_declared_canon(
+                        conn,
+                        actor_user_id=actor_id,
+                        authority_nonce=nonce,
+                        guild_id=guild_id,
+                        declaration_id=payload["declaration_id"],
+                        expected_revision_id=payload["expected_revision_id"],
+                        reason=payload.get("reason", ""),
+                        **_declared_canon_claim_kwargs(payload),
+                    )
+                elif action == "retire":
+                    _declared_canon_validate_command_fields(
+                        payload,
+                        allowed={"declaration_id", "expected_revision_id", "reason"},
+                        required={"declaration_id", "expected_revision_id"},
+                    )
+                    result = retire_declared_canon(
+                        conn,
+                        actor_user_id=actor_id,
+                        authority_nonce=nonce,
+                        guild_id=guild_id,
+                        declaration_id=payload["declaration_id"],
+                        expected_revision_id=payload["expected_revision_id"],
+                        reason=payload.get("reason", ""),
+                    )
+                elif action == "status":
+                    _declared_canon_validate_command_fields(
+                        payload,
+                        allowed={
+                            "declaration_id",
+                            "expected_revision_id",
+                            "lifecycle_status",
+                            "reason",
+                        },
+                        required={
+                            "declaration_id",
+                            "expected_revision_id",
+                            "lifecycle_status",
+                        },
+                    )
+                    result = change_declared_canon_status(
+                        conn,
+                        actor_user_id=actor_id,
+                        authority_nonce=nonce,
+                        guild_id=guild_id,
+                        declaration_id=payload["declaration_id"],
+                        expected_revision_id=payload["expected_revision_id"],
+                        lifecycle_status=payload["lifecycle_status"],
+                        reason=payload.get("reason", ""),
+                    )
+                elif action == "supersede":
+                    _declared_canon_validate_command_fields(
+                        payload,
+                        allowed={
+                            "declaration_id",
+                            "expected_revision_id",
+                            "replacement_declaration_id",
+                            "expected_replacement_revision_id",
+                            "reason",
+                        },
+                        required={
+                            "declaration_id",
+                            "expected_revision_id",
+                            "replacement_declaration_id",
+                            "expected_replacement_revision_id",
+                        },
+                    )
+                    result = supersede_declared_canon(
+                        conn,
+                        actor_user_id=actor_id,
+                        authority_nonce=nonce,
+                        guild_id=guild_id,
+                        declaration_id=payload["declaration_id"],
+                        expected_revision_id=payload["expected_revision_id"],
+                        replacement_declaration_id=payload[
+                            "replacement_declaration_id"
+                        ],
+                        expected_replacement_revision_id=payload[
+                            "expected_replacement_revision_id"
+                        ],
+                        reason=payload.get("reason", ""),
+                    )
+                elif action == "broadcast-classify":
+                    allowed = {
+                        "broadcast_row_id",
+                        "expected_source_fingerprint",
+                        "expected_revision_id",
+                        "subject_type",
+                        "subject_id",
+                        "object_subject_type",
+                        "object_subject_id",
+                        "predicate",
+                        "domain",
+                        "claim_kind",
+                        "visibility",
+                        "eligible_routes",
+                        "reason",
+                    }
+                    required = {
+                        "broadcast_row_id",
+                        "expected_source_fingerprint",
+                        "subject_type",
+                        "subject_id",
+                    }
+                    _declared_canon_validate_command_fields(
+                        payload, allowed=allowed, required=required
+                    )
+                    result = classify_broadcast_memory(
+                        conn,
+                        actor_user_id=actor_id,
+                        authority_nonce=nonce,
+                        guild_id=guild_id,
+                        broadcast_row_id=int(payload["broadcast_row_id"]),
+                        expected_source_fingerprint=payload[
+                            "expected_source_fingerprint"
+                        ],
+                        expected_revision_id=payload.get("expected_revision_id", ""),
+                        subject_type=payload["subject_type"],
+                        subject_id=payload["subject_id"],
+                        object_subject_type=payload.get("object_subject_type", ""),
+                        object_subject_id=payload.get("object_subject_id", ""),
+                        predicate=payload.get("predicate", ""),
+                        domain=payload.get("domain", ""),
+                        claim_kind=payload.get("claim_kind", ""),
+                        visibility=payload.get("visibility", "internal"),
+                        eligible_routes=tuple(payload.get("eligible_routes") or ()),
+                        reason=payload.get("reason", ""),
+                    )
+                else:
+                    raise DeclaredCanonError("declared_command_action_unknown")
+        projection_states = [
+            _shadow_declared_revision_after_owner_command(
+                message,
+                revision,
+                projection_index=index,
+            )
+            for index, revision in enumerate(result.revisions, start=1)
+        ]
+        await message.reply(
+            _declared_canon_mutation_summary(result, projection_states)
+        )
+        return True
+    except (DeclaredCanonError, ValueError, TypeError) as exc:
+        reason = str(exc or "declared_command_rejected")
+        if not re.fullmatch(r"[a-z0-9_.:-]{1,120}", reason):
+            reason = "declared_command_rejected"
+        await message.reply(f"Declared Canon operation not applied: {reason}.")
+        return True
 
 
 async def maybe_handle_debug_last_route_command(message: discord.Message, clean_content: str) -> bool:
@@ -16222,9 +16714,18 @@ def format_member_activity_summary(events: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def add_broadcast_memory_entry(guild_id: int, message: discord.Message, processed: dict):
-    now = datetime.now(PACIFIC_TZ).isoformat()
-    conn = sqlite3.connect(DB_FILE)
+def _insert_broadcast_memory_row(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    actor_id: int,
+    actor_name: str,
+    raw_content: str,
+    processed: dict,
+    now: str,
+    supersedes_id: int = 0,
+) -> tuple[int, tuple]:
+    require_configured_owner_mutation_actor(actor_id, guild_id)
     cursor = conn.cursor()
     cursor.execute(
         """
@@ -16232,15 +16733,16 @@ def add_broadcast_memory_entry(guild_id: int, message: discord.Message, processe
             guild_id, episode_date, submitted_by_user_id, submitted_by_name, raw_note,
             cleaned_summary, entry_type, importance, public_safe, affects_next_show,
             usage_scope, target_show_date, valid_until, override_span_count, needs_clarification,
-            status, created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)
+            status, created_at, updated_at, corrected_by_user_id, corrected_by_name,
+            correction_reason, supersedes_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, ?)
         """,
         (
-            guild_id,
-            processed.get("episode_date") or _recent_friday_pacific_for_note(message.content),
-            getattr(getattr(message, "author", None), "id", None),
-            getattr(getattr(message, "author", None), "display_name", "system"),
-            _truncate_raw_note(getattr(message, "content", "")),
+            int(guild_id),
+            processed.get("episode_date") or _recent_friday_pacific_for_note(raw_content),
+            actor_id,
+            actor_name,
+            _truncate_raw_note(raw_content),
             processed.get("cleaned_summary", ""),
             processed.get("entry_type", "notable_moment"),
             processed.get("importance", "medium"),
@@ -16253,27 +16755,285 @@ def add_broadcast_memory_entry(guild_id: int, message: discord.Message, processe
             1 if processed.get("needs_clarification") else 0,
             now,
             now,
+            actor_id if supersedes_id else None,
+            actor_name if supersedes_id else None,
+            "explicit correction/replace request" if supersedes_id else None,
+            int(supersedes_id) if supersedes_id else None,
         ),
     )
-    new_id = cursor.lastrowid
-    if processed.get("supersedes_id"):
-        cursor.execute("UPDATE broadcast_memory SET supersedes_id=?, corrected_by_user_id=?, corrected_by_name=?, correction_reason=?, updated_at=? WHERE id=?", (int(processed.get("supersedes_id") or 0), getattr(getattr(message, "author", None), "id", None), getattr(getattr(message, "author", None), "display_name", "system"), "replacement", now, new_id))
-    committed = cursor.execute("SELECT cleaned_summary, entry_type, public_safe, status, usage_scope, submitted_by_user_id, submitted_by_name, created_at, updated_at, supersedes_id FROM broadcast_memory WHERE id=?", (new_id,)).fetchone()
-    conn.commit()
-    conn.close()
-    if committed:
-        committed_updated_at = committed[8] or committed[7] or now
-        _shadow_memory_ledger_write(
-            "broadcast_memory",
-            lambda ledger_conn: shadow_broadcast_memory_row(
-                ledger_conn, row_id=int(new_id or 0), guild_id=guild_id, cleaned_summary=committed[0] or "",
-                entry_type=committed[1] or "notable_moment", public_safe=bool(committed[2]),
-                status=committed[3] or "active", usage_scope=committed[4] or "internal",
-                submitted_by_user_id=committed[5], submitted_by_name=committed[6] or "system",
-                created_at=committed[7] or committed_updated_at, updated_at=committed_updated_at, supersedes_id=committed[9],
-            ),
-            guild_id=guild_id, source_table="broadcast_memory", source_row_id=int(new_id or 0), source_revision=f"rev:{int(new_id or 0)}:{committed_updated_at.lower()}",
+    new_id = int(cursor.lastrowid or 0)
+    committed = cursor.execute(
+        """
+        SELECT cleaned_summary, entry_type, public_safe, status, usage_scope,
+               submitted_by_user_id, submitted_by_name, created_at, updated_at,
+               supersedes_id
+        FROM broadcast_memory
+        WHERE guild_id=? AND id=?
+        """,
+        (int(guild_id), new_id),
+    ).fetchone()
+    if not committed:
+        raise RuntimeError("broadcast_memory_insert_missing")
+    return new_id, committed
+
+
+def _broadcast_primary_projection_ids(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    row_id: int,
+) -> tuple[str, ...]:
+    if not conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='memory_ledger_entries'"
+    ).fetchone():
+        return ()
+    return tuple(
+        str(row[0])
+        for row in conn.execute(
+            """
+            SELECT entry_id
+            FROM memory_ledger_entries
+            WHERE guild_id=? AND source_table='broadcast_memory'
+              AND source_row_id=? AND source_role='broadcast_memory'
+              AND NOT EXISTS (
+                  SELECT 1 FROM memory_ledger_lineage l
+                  WHERE l.guild_id=memory_ledger_entries.guild_id
+                    AND l.target_entry_id=memory_ledger_entries.entry_id
+                    AND l.lineage_type IN ('supersedes','retracts')
+              )
+            ORDER BY entry_id
+            """,
+            (int(guild_id), str(int(row_id))),
+        ).fetchall()
+    )
+
+
+def _finalize_required_broadcast_shadow_in_transaction(
+    conn: sqlite3.Connection,
+    *,
+    writer: str,
+    result: LedgerWriteResult,
+) -> LedgerWriteResult:
+    """Record one exact new shadow row without weakening source atomicity."""
+
+    if not conn.in_transaction:
+        raise RuntimeError("broadcast_shadow_transaction_required")
+    if not isinstance(result, LedgerWriteResult):
+        raise RuntimeError("broadcast_shadow_result_required")
+    # Every caller below performs a single-use source mutation. A dedup here
+    # means a row with the same identity predated this source transaction and
+    # must be treated as a conflicting snapshot, not silently accepted.
+    if result.outcome != "inserted" or not result.entry_id:
+        raise RuntimeError(
+            "broadcast_shadow_write_required:%s:%s"
+            % (result.outcome, result.reason_code)
         )
+    try:
+        record_shadow_receipt(
+            conn,
+            guild_id=result.guild_id,
+            writer=writer,
+            source_table=result.source_table,
+            source_row_id=result.source_row_id,
+            source_revision=result.source_revision,
+            source_event_key=result.source_event_key,
+            outcome=result.outcome,
+            reason_code=result.reason_code,
+            entry_id=result.entry_id,
+        )
+    except Exception as receipt_exc:
+        logging.debug(
+            "broadcast_shadow_receipt_failed writer=%s error_type=%s",
+            writer,
+            type(receipt_exc).__name__,
+        )
+    try:
+        form_atomic_candidate_from_ledger_entry(conn, result.entry_id)
+    except Exception as knowledge_exc:
+        logging.debug(
+            "broadcast_atomic_shadow_failed writer=%s error_type=%s",
+            writer,
+            type(knowledge_exc).__name__,
+        )
+        try:
+            record_atomic_knowledge_processing_error(
+                conn,
+                guild_id=result.guild_id,
+                reason_code=(
+                    "broadcast_shadow_" + type(knowledge_exc).__name__
+                )[:120],
+                root_entry_ids=(result.entry_id,),
+            )
+        except Exception as diagnostic_exc:
+            logging.debug(
+                "broadcast_atomic_shadow_diagnostic_failed "
+                "writer=%s error_type=%s",
+                writer,
+                type(diagnostic_exc).__name__,
+            )
+    return result
+
+
+def _write_new_broadcast_primary_shadow_in_transaction(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    row_id: int,
+    actor_id: int,
+    expected_updated_at: str,
+    required_for_existing_lineage: bool = False,
+) -> LedgerWriteResult | None:
+    """Project an exact just-inserted source row inside its source transaction."""
+
+    require_configured_owner_mutation_actor(actor_id, guild_id)
+    if not conn.in_transaction:
+        raise RuntimeError("broadcast_shadow_transaction_required")
+    if (
+        not memory_ledger_shadow_enabled()
+        and not required_for_existing_lineage
+    ):
+        return None
+    row = conn.execute(
+        """
+        SELECT cleaned_summary,entry_type,public_safe,status,usage_scope,
+               submitted_by_user_id,submitted_by_name,created_at,updated_at,
+               supersedes_id
+        FROM broadcast_memory
+        WHERE guild_id=? AND id=?
+        """,
+        (int(guild_id), int(row_id)),
+    ).fetchone()
+    if not row:
+        raise RuntimeError("broadcast_shadow_source_missing")
+    if int(row[5] or 0) != int(actor_id):
+        raise PermissionError("broadcast_shadow_source_actor_mismatch")
+    if str(row[8] or "") != str(expected_updated_at or ""):
+        raise RuntimeError("broadcast_shadow_source_snapshot_mismatch")
+    if str(row[3] or "").strip().casefold() != "active":
+        raise RuntimeError("broadcast_shadow_new_source_not_active")
+    if _broadcast_primary_projection_ids(
+        conn,
+        guild_id=int(guild_id),
+        row_id=int(row_id),
+    ):
+        raise RuntimeError("broadcast_shadow_new_primary_conflict")
+    result = shadow_broadcast_memory_row(
+        conn,
+        row_id=int(row_id),
+        guild_id=int(guild_id),
+        cleaned_summary=str(row[0] or ""),
+        entry_type=str(row[1] or "notable_moment"),
+        public_safe=bool(row[2]),
+        status=str(row[3] or "active"),
+        usage_scope=str(row[4] or "internal"),
+        submitted_by_user_id=int(row[5] or 0),
+        submitted_by_name=str(row[6] or "system"),
+        created_at=str(row[7] or row[8] or ""),
+        updated_at=str(row[8] or ""),
+        supersedes_id=row[9],
+    )
+    finalized = _finalize_required_broadcast_shadow_in_transaction(
+        conn,
+        writer="broadcast_memory",
+        result=result,
+    )
+    if _broadcast_primary_projection_ids(
+        conn,
+        guild_id=int(guild_id),
+        row_id=int(row_id),
+    ) != (result.entry_id,):
+        raise RuntimeError("broadcast_shadow_new_primary_mismatch")
+    return finalized
+
+
+def _write_broadcast_status_shadow_in_transaction(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    row_id: int,
+    status: str,
+    updated_at: str,
+    actor_id: int,
+    actor_name: str,
+    superseded_by_id: int | None = None,
+    required_for_source_transition: bool = False,
+) -> LedgerWriteResult | None:
+    """Atomically retract an existing Broadcast primary when source changes."""
+
+    require_configured_owner_mutation_actor(actor_id, guild_id)
+    if not conn.in_transaction:
+        raise RuntimeError("broadcast_shadow_transaction_required")
+    primary_ids = _broadcast_primary_projection_ids(
+        conn,
+        guild_id=int(guild_id),
+        row_id=int(row_id),
+    )
+    # With no primary Ledger representation there is no stale evidence to
+    # retract. The authoritative source transition may safely commit; a later
+    # backfill will observe its terminal source state.
+    if not primary_ids and not required_for_source_transition:
+        return None
+    result = shadow_broadcast_status_event(
+        conn,
+        row_id=int(row_id),
+        guild_id=int(guild_id),
+        status=str(status or ""),
+        updated_at=str(updated_at or ""),
+        actor_id=int(actor_id),
+        actor_name=str(actor_name or ""),
+        superseded_by_id=superseded_by_id,
+    )
+    _finalize_required_broadcast_shadow_in_transaction(
+        conn,
+        writer="broadcast_memory_status",
+        result=result,
+    )
+    if primary_ids:
+        retracted_ids = {
+            str(row[0])
+            for row in conn.execute(
+                """
+                SELECT target_entry_id
+                FROM memory_ledger_lineage
+                WHERE entry_id=? AND lineage_type='retracts'
+                """,
+                (result.entry_id,),
+            ).fetchall()
+        }
+        if retracted_ids != set(primary_ids):
+            raise RuntimeError("broadcast_shadow_retraction_required")
+    return result
+
+
+def add_broadcast_memory_entry(guild_id: int, message: discord.Message, processed: dict):
+    actor_id = require_configured_owner_mutation_actor(
+        getattr(getattr(message, "author", None), "id", 0),
+        guild_id,
+    )
+    if int(guild_id or 0) <= 0:
+        raise ValueError("broadcast_memory_guild_required")
+    if int(processed.get("supersedes_id") or 0):
+        raise ValueError("broadcast_replacement_requires_atomic_helper")
+    now = datetime.now(PACIFIC_TZ).isoformat()
+    actor_name = getattr(getattr(message, "author", None), "display_name", "system")
+    with journal_release_privacy_fence(DB_FILE):
+        with sqlite3.connect(DB_FILE, timeout=30) as conn:
+            new_id, committed = _insert_broadcast_memory_row(
+                conn,
+                guild_id=int(guild_id),
+                actor_id=actor_id,
+                actor_name=actor_name,
+                raw_content=getattr(message, "content", ""),
+                processed=processed,
+                now=now,
+            )
+            _write_new_broadcast_primary_shadow_in_transaction(
+                conn,
+                guild_id=int(guild_id),
+                row_id=new_id,
+                actor_id=actor_id,
+                expected_updated_at=str(committed[8] or now),
+            )
     return int(new_id or 0)
 
 
@@ -16695,19 +17455,58 @@ def get_active_show_state_override(guild_id: int, show_date: str = None):
     return row
 
 
-def clear_active_show_state_overrides(guild_id: int):
+def clear_active_show_state_overrides(guild_id: int, actor_id: int):
+    require_configured_owner_mutation_actor(actor_id, guild_id)
+    if int(guild_id or 0) <= 0:
+        raise ValueError("broadcast_memory_guild_required")
     now_iso = datetime.now(PACIFIC_TZ).isoformat()
+    actor_name = "configured_owner"
+    correction_reason = "owner restored normal show state"
     with journal_release_privacy_fence(DB_FILE):
         with sqlite3.connect(DB_FILE, timeout=30) as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            rows = conn.execute(
+                """
+                SELECT id
+                FROM broadcast_memory
+                WHERE guild_id=? AND status='active'
+                  AND superseded_by_id IS NULL
+                  AND entry_type='show_state_override'
+                ORDER BY id
+                """,
+                (int(guild_id),),
+            ).fetchall()
             cursor = conn.execute(
                 """
                 UPDATE broadcast_memory
-                SET status='resolved', updated_at=?
-                WHERE guild_id=? AND status='active' AND entry_type='show_state_override'
+                SET status='resolved', updated_at=?,
+                    corrected_by_user_id=?, corrected_by_name=?,
+                    correction_reason=?
+                WHERE guild_id=? AND status='active'
+                  AND superseded_by_id IS NULL
+                  AND entry_type='show_state_override'
                 """,
-                (now_iso, guild_id),
+                (
+                    now_iso,
+                    int(actor_id),
+                    actor_name,
+                    correction_reason,
+                    int(guild_id),
+                ),
             )
             changed = cursor.rowcount
+            if int(changed or 0) != len(rows):
+                raise RuntimeError("broadcast_override_transition_race")
+            for (memory_id,) in rows:
+                _write_broadcast_status_shadow_in_transaction(
+                    conn,
+                    guild_id=int(guild_id),
+                    row_id=int(memory_id),
+                    status="resolved",
+                    updated_at=now_iso,
+                    actor_id=int(actor_id),
+                    actor_name=actor_name,
+                )
     return int(changed or 0)
 
 def _summary_snippet(text: str, limit: int = 70) -> str:
@@ -16764,7 +17563,20 @@ def _find_active_broadcast_memory_by_id(guild_id: int, memory_id: int):
     return row
 
 
-def _set_broadcast_memory_status(memory_id: int, status: str, actor_id: int, actor_name: str, reason: str = ""):
+def _set_broadcast_memory_status(
+    guild_id: int,
+    memory_id: int,
+    status: str,
+    actor_id: int,
+    actor_name: str,
+    reason: str = "",
+):
+    require_configured_owner_mutation_actor(actor_id, guild_id)
+    if int(guild_id or 0) <= 0:
+        raise ValueError("broadcast_memory_guild_required")
+    normalized_status = str(status or "").strip().casefold()
+    if normalized_status != "resolved":
+        raise ValueError("broadcast_status_transition_not_allowed")
     now_iso = datetime.now(PACIFIC_TZ).isoformat()
     with journal_release_privacy_fence(DB_FILE):
         with sqlite3.connect(DB_FILE, timeout=30) as conn:
@@ -16772,48 +17584,128 @@ def _set_broadcast_memory_status(memory_id: int, status: str, actor_id: int, act
                 """
                 UPDATE broadcast_memory
                 SET status=?, updated_at=?, corrected_by_user_id=?, corrected_by_name=?, correction_reason=?
-                WHERE id=?
+                WHERE guild_id=? AND id=?
+                  AND status='active' AND superseded_by_id IS NULL
                 """,
-                (status, now_iso, actor_id, actor_name, reason[:200], memory_id),
+                (
+                    normalized_status,
+                    now_iso,
+                    actor_id,
+                    actor_name,
+                    reason[:200],
+                    int(guild_id),
+                    memory_id,
+                ),
             )
             changed = cursor.rowcount
             row = conn.execute(
-                "SELECT guild_id, superseded_by_id FROM broadcast_memory WHERE id=?",
-                (memory_id,),
+                "SELECT guild_id, superseded_by_id FROM broadcast_memory WHERE guild_id=? AND id=?",
+                (int(guild_id), memory_id),
             ).fetchone()
-    if changed and row and not (str(status or "").lower() == "superseded" and not row[1]):
-        _shadow_memory_ledger_write(
-            "broadcast_memory_status",
-            lambda ledger_conn: shadow_broadcast_status_event(ledger_conn, row_id=memory_id, guild_id=int(row[0] or 0), status=status, updated_at=now_iso, actor_id=actor_id, actor_name=actor_name, superseded_by_id=row[1]),
-            guild_id=int(row[0] or 0), source_table="broadcast_memory", source_row_id=memory_id, source_revision=f"event:status:{status}:{now_iso.lower()}", source_event_key=f"status:{status}",
-        )
+            if changed and row:
+                _write_broadcast_status_shadow_in_transaction(
+                    conn,
+                    guild_id=int(row[0] or 0),
+                    row_id=int(memory_id),
+                    status=normalized_status,
+                    updated_at=now_iso,
+                    actor_id=int(actor_id),
+                    actor_name=actor_name,
+                    superseded_by_id=row[1],
+                )
     return int(changed or 0)
 
 
-def _supersede_broadcast_memory(
+def _replace_broadcast_memory_entry(
+    guild_id: int,
     memory_id: int,
-    replacement_id: int,
-    actor_id: int,
-    actor_name: str,
-    updated_at: str,
+    message: discord.Message,
+    processed: dict,
 ) -> int:
-    """Make an established-memory row ineligible behind the Journal fence."""
+    """Atomically insert a replacement and supersede its active source row."""
+
+    actor_id = require_configured_owner_mutation_actor(
+        getattr(getattr(message, "author", None), "id", 0),
+        guild_id,
+    )
+    guild_id = int(guild_id or 0)
+    memory_id = int(memory_id or 0)
+    if guild_id <= 0:
+        raise ValueError("broadcast_memory_guild_required")
+    if memory_id <= 0:
+        raise ValueError("broadcast_supersession_target_required")
+    now = datetime.now(PACIFIC_TZ).isoformat()
+    actor_name = getattr(getattr(message, "author", None), "display_name", "system")
+    prepared = dict(processed or {})
+    prepared.pop("supersedes_id", None)
     with journal_release_privacy_fence(DB_FILE):
         with sqlite3.connect(DB_FILE, timeout=30) as conn:
+            target = conn.execute(
+                """
+                SELECT 1
+                FROM broadcast_memory
+                WHERE guild_id=? AND id=? AND status='active'
+                  AND superseded_by_id IS NULL
+                """,
+                (guild_id, memory_id),
+            ).fetchone()
+            if not target:
+                return 0
+            new_id, committed = _insert_broadcast_memory_row(
+                conn,
+                guild_id=guild_id,
+                actor_id=actor_id,
+                actor_name=actor_name,
+                raw_content=getattr(message, "content", ""),
+                processed=prepared,
+                now=now,
+                supersedes_id=memory_id,
+            )
             changed = conn.execute(
-                "UPDATE broadcast_memory SET status='superseded', superseded_by_id=?, "
-                "updated_at=?, corrected_by_user_id=?, corrected_by_name=?, correction_reason=? "
-                "WHERE id=?",
+                """
+                UPDATE broadcast_memory
+                SET status='superseded', superseded_by_id=?, updated_at=?,
+                    corrected_by_user_id=?, corrected_by_name=?, correction_reason=?
+                WHERE guild_id=? AND id=? AND status='active'
+                  AND superseded_by_id IS NULL
+                """,
                 (
-                    int(replacement_id),
-                    updated_at,
-                    int(actor_id),
+                    new_id,
+                    now,
+                    actor_id,
                     actor_name,
                     "explicit correction/replace request",
-                    int(memory_id),
+                    guild_id,
+                    memory_id,
                 ),
             ).rowcount
-    return int(changed or 0)
+            if int(changed or 0) != 1:
+                raise RuntimeError("broadcast_replacement_lost_target")
+            existing_primary_ids = _broadcast_primary_projection_ids(
+                conn,
+                guild_id=guild_id,
+                row_id=memory_id,
+            )
+            _write_new_broadcast_primary_shadow_in_transaction(
+                conn,
+                guild_id=guild_id,
+                row_id=new_id,
+                actor_id=actor_id,
+                expected_updated_at=str(committed[8] or now),
+                required_for_existing_lineage=bool(existing_primary_ids),
+            )
+            _write_broadcast_status_shadow_in_transaction(
+                conn,
+                guild_id=guild_id,
+                row_id=memory_id,
+                status="superseded",
+                updated_at=now,
+                actor_id=actor_id,
+                actor_name=actor_name,
+                superseded_by_id=new_id,
+                required_for_source_transition=bool(existing_primary_ids),
+            )
+    return new_id
 
 async def process_broadcast_memory_note(message) -> dict:
     raw_content = (message.content or "").strip()
@@ -30724,10 +31616,19 @@ async def maybe_reject_unauthorized_official_broadcast_memory(
     message: discord.Message,
     clean_content: str,
 ) -> bool:
-    """Reject official broadcast-memory mutations unless the configured owner acts."""
+    """Reject Broadcast mutations outside the exact owner/primary-guild scope."""
     denial_reason = configured_owner_control_denial_reason(
         getattr(message, "author", None)
     )
+    if not denial_reason:
+        configured_guild = int(BNL_PRIMARY_GUILD_ID or 0)
+        message_guild = int(
+            getattr(getattr(message, "guild", None), "id", 0) or 0
+        )
+        if configured_guild <= 0:
+            denial_reason = "primary_guild_id_not_configured"
+        elif message_guild != configured_guild:
+            denial_reason = "configured_primary_guild_required"
     if not denial_reason:
         return False
     logging.info(
@@ -30754,6 +31655,16 @@ async def maybe_reject_unauthorized_official_broadcast_memory(
                 reply = (
                     "Not stored. Official broadcast-memory controls are disabled "
                     "because `BNL_OWNER_USER_ID` is not configured."
+                )
+            elif denial_reason == "primary_guild_id_not_configured":
+                reply = (
+                    "Not stored. Official broadcast-memory controls are disabled "
+                    "because `BNL_PRIMARY_GUILD_ID` is not configured."
+                )
+            elif denial_reason == "configured_primary_guild_required":
+                reply = (
+                    "Not stored. Official broadcast memory is restricted to the "
+                    "configured primary guild."
                 )
             else:
                 reply = (
@@ -34099,11 +35010,19 @@ async def on_message(message: discord.Message):
         return
     if getattr(message.author, "bot", False):
         return
-
-    direct_conversation_ingress = _register_direct_conversation_ingress(message)
-
     if message.content.startswith("/"):
         return
+
+    # Declared Canon controls may contain owner-authored raw authority text.
+    # Dispatch the original Discord payload before *any* conversational state
+    # or normalization.  Mention/whitespace rewriting would otherwise mutate
+    # JSON string values, and even denied or malformed controls must never
+    # enter promptable room/batch/context stores.  The handler owns all scope,
+    # authentication, payload validation, and denial/error replies.
+    if await maybe_handle_declared_canon_command(message, message.content):
+        return
+
+    direct_conversation_ingress = _register_direct_conversation_ingress(message)
 
     active_channel_id = get_guild_config(message.guild.id)
 
@@ -34359,6 +35278,7 @@ async def on_message(message: discord.Message):
             if resolve_last_intent or resolve_by_topic or resolve_by_id:
                 changed = await asyncio.to_thread(
                     _set_broadcast_memory_status,
+                    message.guild.id,
                     target_id,
                     "resolved",
                     message.author.id,
@@ -34387,6 +35307,7 @@ async def on_message(message: discord.Message):
             if processed.get("entry_type") == "show_state_resume":
                 await asyncio.to_thread(
                     _set_broadcast_memory_status,
+                    message.guild.id,
                     target_id,
                     "resolved",
                     message.author.id,
@@ -34396,6 +35317,7 @@ async def on_message(message: discord.Message):
                 cleared = await asyncio.to_thread(
                     clear_active_show_state_overrides,
                     message.guild.id,
+                    message.author.id,
                 )
                 await message.reply(f"Logged. Normal schedule restored; resolved overrides: {cleared}.")
                 return
@@ -34411,22 +35333,16 @@ async def on_message(message: discord.Message):
                 }
             processed["episode_date"] = _extract_exact_episode_date(correction_text) or target_date
             processed["entry_type"] = processed.get("entry_type") or target_type
-            processed["supersedes_id"] = target_id
-            new_id = add_broadcast_memory_entry(message.guild.id, faux_message, processed)
-            updated_at = datetime.now(PACIFIC_TZ).isoformat()
-            await asyncio.to_thread(
-                _supersede_broadcast_memory,
+            new_id = await asyncio.to_thread(
+                _replace_broadcast_memory_entry,
+                message.guild.id,
                 target_id,
-                new_id,
-                message.author.id,
-                message.author.display_name,
-                updated_at,
+                faux_message,
+                processed,
             )
-            _shadow_memory_ledger_write(
-                "broadcast_memory_status",
-                lambda ledger_conn: shadow_broadcast_status_event(ledger_conn, row_id=target_id, guild_id=message.guild.id, status="superseded", updated_at=updated_at, actor_id=message.author.id, actor_name=message.author.display_name, superseded_by_id=new_id),
-                guild_id=message.guild.id, source_table="broadcast_memory", source_row_id=target_id, source_revision=f"event:status:superseded:{updated_at.lower()}", source_event_key="status:superseded",
-            )
+            if not new_id:
+                await message.reply("Correction not applied. The active broadcast-memory entry changed before the replacement could be committed.")
+                return
             await message.reply(f"Corrected broadcast memory: resolved/superseded id {target_id} and added replacement id {new_id} for {processed.get('episode_date')}.")
             return
         processed_entries = await process_broadcast_memory_notes(message)
@@ -34435,6 +35351,7 @@ async def on_message(message: discord.Message):
             cleared = await asyncio.to_thread(
                 clear_active_show_state_overrides,
                 message.guild.id,
+                message.author.id,
             )
             await message.reply(f"Logged. Normal schedule restored; resolved overrides: {cleared}.")
             return

--- a/bnl_canon_source_contract.py
+++ b/bnl_canon_source_contract.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections import Counter
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, is_dataclass, replace
 from enum import Enum
 from datetime import datetime, timezone, timedelta
@@ -15,6 +16,7 @@ CANON_SOURCE_CONTRACT_VERSION = "canon_source_contract_v1"
 HYBRID_CANON_CLAIM_CONTRACT_VERSION = "hybrid_canon_claim_v1"
 CANON_CLAIM_ID_NAMESPACE = "bnl_canon_claim_identity_v1"
 LEGACY_CANON_ADAPTER_VERSION = "legacy_canon_adapter_v1"
+DECLARED_CANON_ADAPTER_VERSION = "declared_canon_adapter_v1"
 BROADCAST_CANON_ADAPTER_VERSION = "broadcast_declared_adapter_v1"
 LIVING_CANON_ADAPTER_VERSION = "living_canon_adapter_v1"
 OPEN_SIGNAL_ADAPTER_VERSION = "open_signal_adapter_v1"
@@ -200,6 +202,9 @@ class CanonClaim:
     recurrence_contract_version: str = ""
     projection_state: str = "shadow"
     projection_version: str = HYBRID_CANON_CLAIM_CONTRACT_VERSION
+    subject_type: str = ""
+    object_subject_type: str = ""
+    object_subject_id: str = ""
 
 
 @dataclass(frozen=True)
@@ -334,9 +339,10 @@ _BINDING_RECEIPT_PREFIXES = (
     "owner_command:",
     "service_receipt:",
 )
-_DECLARATION_RECEIPT_PREFIXES = (
-    "owner_command:",
-    "service_receipt:",
+_TRUSTED_SERVICE_ACTOR_REFS = frozenset(
+    {
+        "service_actor:legacy_canon_registry_v1",
+    }
 )
 
 
@@ -369,7 +375,7 @@ def _claim_revision_payload(
 ) -> tuple[Any, ...]:
     """Return every normalized field that makes one immutable revision."""
 
-    return (
+    payload = (
         HYBRID_CANON_CLAIM_CONTRACT_VERSION,
         claim.source_revision,
         claim.claim_id,
@@ -399,6 +405,16 @@ def _claim_revision_payload(
         claim.projection_state,
         claim.projection_version,
     )
+    typed_identity = (
+        str(claim.subject_type or ""),
+        str(claim.object_subject_type or ""),
+        str(claim.object_subject_id or ""),
+    )
+    # Preserve existing revision IDs for adapters that predate typed subjects;
+    # a Declared claim opts into the extension by carrying at least one field.
+    if any(typed_identity):
+        payload += ("typed_subject_contract_v1", *typed_identity)
+    return payload
 
 
 def _finalize_claim_revision(
@@ -448,11 +464,8 @@ def _explicit_contract_false(value: Any) -> bool:
 def _opaque_actor_valid(actor: Any) -> bool:
     normalized_actor = str(actor or "").strip()
     return bool(
-        re.fullmatch(r"discord_user:[0-9]+", normalized_actor)
-        or re.fullmatch(
-            r"(?:owner_ref|service_actor):[a-z0-9][a-z0-9_.:-]{0,127}",
-            normalized_actor,
-        )
+        re.fullmatch(r"discord_user:[1-9][0-9]{0,24}", normalized_actor)
+        or normalized_actor in _TRUSTED_SERVICE_ACTOR_REFS
     )
 
 
@@ -556,7 +569,7 @@ def adapt_legacy_canon_fact(fact: CanonFact) -> CanonClaim:
         visibility=fact.visibility,
         lifecycle=ClaimLifecycle.ESTABLISHED,
         confidence=fact.confidence,
-        authority_actor="owner_ref:legacy_registry",
+        authority_actor="service_actor:legacy_canon_registry_v1",
         authority_receipt=(
             "code_revision:%s" % CANON_SOURCE_CONTRACT_VERSION
         ),
@@ -587,6 +600,27 @@ def _mapping_text(row: Mapping[str, Any], *keys: str) -> str:
     return ""
 
 
+@contextmanager
+def _read_snapshot(conn: Any):
+    """Reuse a caller transaction or own one read-only SQLite snapshot."""
+
+    owns_snapshot = not bool(getattr(conn, "in_transaction", False))
+    before_changes = int(getattr(conn, "total_changes", 0) or 0)
+    if owns_snapshot:
+        conn.execute("BEGIN")
+    try:
+        yield
+        if int(getattr(conn, "total_changes", 0) or 0) != before_changes:
+            raise RuntimeError("read_snapshot_mutated_state")
+    except Exception:
+        if owns_snapshot and bool(getattr(conn, "in_transaction", False)):
+            conn.rollback()
+        raise
+    else:
+        if owns_snapshot and bool(getattr(conn, "in_transaction", False)):
+            conn.commit()
+
+
 def adapt_broadcast_memory_claim(
     row: Mapping[str, Any],
     *,
@@ -594,11 +628,13 @@ def adapt_broadcast_memory_claim(
     authority_actor: str = "",
     authority_receipt: str = "",
 ) -> CanonAdapterResult:
-    """Build a read-only Declared projection from one Broadcast source row.
+    """Build the raw Broadcast compatibility view.
 
-    Historical or unauthenticated rows intentionally remain review-only.  PR 2
-    owns mutation APIs and the full Declared lifecycle; this adapter only
-    freezes the common shape and prevents legacy type coercion.
+    A ``broadcast_memory`` row is first-party source material, not proof that
+    the owner declared it canon.  The legacy caller authority parameters are
+    retained only for source compatibility and are intentionally ignored.  An
+    exact, current ``declared_canon_revisions`` join is the only path to the
+    Declared read model (see :func:`adapt_declared_canon_revision`).
     """
 
     row_id = _mapping_text(row, "id", "row_id")
@@ -610,18 +646,11 @@ def adapt_broadcast_memory_claim(
         return CanonAdapterResult(None, "missing_broadcast_source_identity")
     subject_id = _mapping_text(row, "subject_id", "subject_key") or BARCODE_RADIO.key
     defaults = BROADCAST_DECLARED_TYPE_DEFAULTS.get(entry_type)
-    status = (_mapping_text(row, "status") or "active").casefold()
     recognized = defaults is not None
     if defaults is None:
         domain, claim_kind = CanonDomain.BROADCAST_HISTORY, ClaimKind.OTHER
     else:
         domain, claim_kind = defaults
-    if status == "superseded":
-        lifecycle = ClaimLifecycle.SUPERSEDED
-    elif status == "resolved":
-        lifecycle = ClaimLifecycle.RESOLVED
-    else:
-        lifecycle = ClaimLifecycle.REVIEW_ONLY
     source_ref = "broadcast_memory:%s" % row_id
     claim_id = _stable_claim_id(
         "broadcast_memory",
@@ -633,44 +662,9 @@ def adapt_broadcast_memory_claim(
         "updated_at",
         "created_at",
     ) or row_id
-    owner_authorized = strict_contract_bool(owner_authorized)
-    authority_verified = bool(
-        owner_authorized
-        and _opaque_authority_valid(
-            authority_actor,
-            authority_receipt,
-            receipt_prefixes=_DECLARATION_RECEIPT_PREFIXES,
-        )
-    )
-    public_safe = strict_contract_bool(row.get("public_safe"))
-    usage_scope = {
-        token.strip().casefold()
-        for token in _mapping_text(row, "usage_scope").split(",")
-        if token.strip()
-    }
-    public_route_scope = bool(
-        "internal" not in usage_scope
-        and entry_type != "moderation_context"
-        and bool(
-            usage_scope.intersection(
-                {
-                    "ambient",
-                    "direct",
-                    "public",
-                    "public_context",
-                    "relay",
-                    "show_status",
-                }
-            )
-        )
-    )
-    public_projection = bool(
-        authority_verified
-        and cleaned_value
-        and public_safe
-        and public_route_scope
-        and status == "active"
-    )
+    # Do not remove these compatibility parameters until all external callers
+    # have migrated.  Reading them would recreate the pre-PR2 authority bug.
+    _ = (owner_authorized, authority_actor, authority_receipt)
     supersedes = _mapping_text(row, "supersedes_id")
     correction_of = _mapping_text(row, "correction_of")
     claim = CanonClaim(
@@ -679,11 +673,7 @@ def adapt_broadcast_memory_claim(
         subject_id=subject_id,
         predicate=entry_type,
         value=value,
-        canon_status=(
-            CanonStatus.DECLARED
-            if authority_verified
-            else CanonStatus.OPEN_SIGNAL
-        ),
+        canon_status=CanonStatus.OPEN_SIGNAL,
         domain=domain,
         claim_kind=claim_kind,
         source_system="broadcast_memory",
@@ -692,25 +682,17 @@ def adapt_broadcast_memory_claim(
         source_refs=(source_ref,),
         root_ids=(source_ref,),
         occurrence_ids=(source_ref,),
-        visibility=(
-            Visibility.PUBLIC_SAFE
-            if public_projection
-            else Visibility.INTERNAL
-        ),
-        lifecycle=lifecycle,
-        confidence=(Confidence.HIGH if authority_verified else Confidence.LOW),
-        authority_actor=(authority_actor if authority_verified else ""),
-        authority_receipt=(authority_receipt if authority_verified else ""),
-        eligible_routes=(
-            ("broadcast_memory", "public_home")
-            if public_projection
-            else ("broadcast_memory",)
-        ),
+        visibility=Visibility.INTERNAL,
+        lifecycle=ClaimLifecycle.REVIEW_ONLY,
+        confidence=Confidence.LOW,
+        authority_actor="",
+        authority_receipt="",
+        eligible_routes=("broadcast_memory",),
         valid_from=_mapping_text(row, "valid_from", "created_at"),
         valid_until=_mapping_text(row, "valid_until"),
         supersedes=(("broadcast_memory:%s" % supersedes,) if supersedes else ()),
         correction_of=(("broadcast_memory:%s" % correction_of,) if correction_of else ()),
-        projection_state="review_only" if lifecycle == ClaimLifecycle.REVIEW_ONLY else "shadow",
+        projection_state="review_only",
         projection_version=BROADCAST_CANON_ADAPTER_VERSION,
     )
     claim = _with_final_revision(
@@ -720,16 +702,235 @@ def adapt_broadcast_memory_claim(
     return CanonAdapterResult(
         claim,
         (
-            "superseded_or_resolved"
-            if lifecycle
-            in {ClaimLifecycle.SUPERSEDED, ClaimLifecycle.RESOLVED}
-            else "legacy_type_review_only"
+            "legacy_type_review_only"
             if not recognized
-            else "owner_verified_review_only"
-            if authority_verified
-            else "owner_authority_review_only"
+            else "broadcast_source_review_only"
         ),
     )
+
+
+def _declared_revision_claim(
+    revision: Any,
+    *,
+    broadcast_row: Mapping[str, Any] | None = None,
+) -> CanonClaim:
+    """Normalize one already-validated PR2 revision without adding authority."""
+
+    from bnl_declared_canon import (
+        BROADCAST_MEMORY_SOURCE,
+        GENERAL_DECLARATION_SOURCE,
+    )
+
+    routes = tuple(json.loads(str(revision.eligible_routes_json or "[]")))
+    domain = CanonDomain(str(revision.domain))
+    claim_kind = ClaimKind(str(revision.claim_kind))
+    visibility = Visibility(str(revision.visibility))
+    lifecycle = ClaimLifecycle(str(revision.lifecycle_status))
+    declaration_ref = "declared_canon:%s" % revision.declaration_id
+    revision_ref = "declared_canon_revision:%s" % revision.revision_id
+    correction_of = (
+        ("declared_canon_revision:%s" % revision.correction_of_revision_id,)
+        if revision.correction_of_revision_id
+        else ()
+    )
+    supersedes = (
+        ("declared_canon:%s" % revision.supersedes_declaration_id,)
+        if revision.supersedes_declaration_id
+        else ()
+    )
+    if revision.source_system == BROADCAST_MEMORY_SOURCE:
+        if broadcast_row is None:
+            raise ValueError("broadcast_source_required")
+        source_ref = "broadcast_memory:%s" % revision.source_row_id
+        value: Any = _mapping_text(broadcast_row, "cleaned_summary")
+        if not value:
+            raise ValueError("broadcast_cleaned_summary_required")
+        source_supersedes = _mapping_text(broadcast_row, "supersedes_id")
+        if source_supersedes:
+            supersedes = tuple(
+                dict.fromkeys(
+                    (*supersedes, "broadcast_memory:%s" % source_supersedes)
+                )
+            )
+        claim_id = _stable_claim_id("broadcast_memory", source_ref)
+        source_system = "broadcast_memory"
+        source_refs = (source_ref, revision_ref)
+        root_ids = (source_ref,)
+        source_class = SourceClass.FIRST_PARTY_RECORD
+    elif revision.source_system == GENERAL_DECLARATION_SOURCE:
+        source_ref = declaration_ref
+        value = json.loads(str(revision.value_json))
+        claim_id = _stable_claim_id("declared_canon", declaration_ref)
+        source_system = "declared_canon"
+        source_refs = (declaration_ref, revision_ref)
+        root_ids = (declaration_ref,)
+        source_class = (
+            SourceClass.OWNER_CORRECTION
+            if str(revision.operation) == "correct"
+            else SourceClass.APPROVED_CANON
+        )
+    else:
+        raise ValueError("declared_source_system_invalid")
+    if claim_kind == ClaimKind.RELATIONSHIP:
+        value = {
+            "value": value,
+            "object_subject_type": str(revision.object_subject_type),
+            "object_subject_id": str(revision.object_subject_id),
+        }
+    adapter_version = (
+        BROADCAST_CANON_ADAPTER_VERSION
+        if revision.source_system == BROADCAST_MEMORY_SOURCE
+        else DECLARED_CANON_ADAPTER_VERSION
+    )
+    claim = CanonClaim(
+        claim_id=claim_id,
+        revision_id="",
+        subject_id=str(revision.subject_id),
+        predicate=str(revision.predicate),
+        value=value,
+        canon_status=CanonStatus.DECLARED,
+        domain=domain,
+        claim_kind=claim_kind,
+        source_system=source_system,
+        adapter_version=adapter_version,
+        source_class=source_class,
+        source_refs=source_refs,
+        root_ids=root_ids,
+        occurrence_ids=root_ids,
+        visibility=visibility,
+        lifecycle=lifecycle,
+        confidence=Confidence.APPROVED,
+        authority_actor=str(revision.authority_actor),
+        authority_receipt=str(revision.authority_receipt),
+        eligible_routes=routes,
+        valid_from=str(revision.valid_from or ""),
+        valid_until=str(revision.valid_until or ""),
+        supersedes=supersedes,
+        correction_of=correction_of,
+        projection_state="shadow",
+        projection_version=adapter_version,
+        subject_type=str(revision.subject_type),
+        object_subject_type=str(revision.object_subject_type or ""),
+        object_subject_id=str(revision.object_subject_id or ""),
+    )
+    return _with_final_revision(
+        claim,
+        source_revision=str(revision.revision_id),
+    )
+
+
+def _adapt_declared_canon_revision_in_snapshot(
+    conn: Any,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    declaration_id: str,
+    expected_revision_id: str,
+    expected_source_fingerprint: str,
+    now: str = "",
+) -> CanonAdapterResult:
+    """Adapt an exact current PR2 revision through its owner read boundary.
+
+    The lifecycle module revalidates stored authority, latest-revision state,
+    validity, and the authoritative source.  Broadcast content is then read a
+    second time and fingerprinted as the exact value snapshot returned here.
+    No schema is created and the result remains shadow-only/non-live.
+    """
+
+    from bnl_declared_canon import (
+        BROADCAST_MEMORY_SOURCE,
+        DECLARED_CANON_CONTRACT_VERSION,
+        DeclaredCanonError,
+        _digest,
+        validate_current_declared_canon_revision,
+    )
+
+    before = int(getattr(conn, "total_changes", 0) or 0)
+    try:
+        revision = validate_current_declared_canon_revision(
+            conn,
+            actor_user_id=int(actor_user_id or 0),
+            authority_nonce=str(authority_nonce or ""),
+            guild_id=int(guild_id or 0),
+            declaration_id=str(declaration_id or ""),
+            expected_revision_id=str(expected_revision_id or ""),
+            expected_source_fingerprint=str(expected_source_fingerprint or ""),
+            now=str(now or ""),
+        )
+        if revision.source_system == BROADCAST_MEMORY_SOURCE:
+            expected_declaration_id = "dcl_" + _digest(
+                DECLARED_CANON_CONTRACT_VERSION,
+                int(guild_id or 0),
+                BROADCAST_MEMORY_SOURCE,
+                int(revision.source_row_id),
+            )[:32]
+            if revision.declaration_id != expected_declaration_id:
+                return CanonAdapterResult(
+                    None, "declared_broadcast_identity_invalid"
+                )
+            duplicate_authorities = int(
+                conn.execute(
+                    """
+                    SELECT COUNT(DISTINCT declaration_id)
+                    FROM main.declared_canon_revisions
+                    WHERE guild_id=? AND source_system='broadcast_memory'
+                      AND source_row_id=?
+                    """,
+                    (int(guild_id or 0), str(revision.source_row_id)),
+                ).fetchone()[0]
+                or 0
+            )
+            if duplicate_authorities != 1:
+                return CanonAdapterResult(
+                    None, "declared_broadcast_duplicate_authority"
+                )
+        evaluation_now = (
+            _parse_contract_time(now)
+            if str(now or "").strip()
+            else datetime.now(timezone.utc)
+        )
+        if evaluation_now is None:
+            return CanonAdapterResult(None, "declared_validation_now_invalid")
+        claim, internal_reason = _inventory_current_declared_claim(
+            conn,
+            revision,
+            now=evaluation_now,
+        )
+        if claim is None:
+            return CanonAdapterResult(None, internal_reason)
+    except (DeclaredCanonError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        code = getattr(exc, "code", "") or str(exc or "invalid")
+        return CanonAdapterResult(None, "declared_%s" % code)
+    if int(getattr(conn, "total_changes", 0) or 0) != before:
+        return CanonAdapterResult(None, "declared_adapter_mutated_state")
+    return CanonAdapterResult(claim, "declared_shadow_current", False)
+
+
+def adapt_declared_canon_revision(
+    conn: Any,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    declaration_id: str,
+    expected_revision_id: str,
+    expected_source_fingerprint: str,
+    now: str = "",
+) -> CanonAdapterResult:
+    """Return one exact current Declared claim from one read snapshot."""
+
+    with _read_snapshot(conn):
+        return _adapt_declared_canon_revision_in_snapshot(
+            conn,
+            actor_user_id=actor_user_id,
+            authority_nonce=authority_nonce,
+            guild_id=guild_id,
+            declaration_id=declaration_id,
+            expected_revision_id=expected_revision_id,
+            expected_source_fingerprint=expected_source_fingerprint,
+            now=now,
+        )
 
 
 def _normalized_identity_tuple(value: Any) -> tuple[str, ...]:
@@ -1391,6 +1592,9 @@ def canon_claim_inventory_diagnostics(
     normalized_claims = tuple(claims)
     claim_scopes: dict[str, set[str]] = {}
     revision_payloads: dict[str, set[str]] = {}
+    current_source_claims: dict[tuple[str, str], set[str]] = {}
+    declared_root_authorities: dict[str, set[str]] = {}
+    declared_subject_types: dict[str, set[str]] = {}
     for claim in normalized_claims:
         claim_scopes.setdefault(claim.claim_id, set()).add(
             _stable_contract_digest(
@@ -1401,6 +1605,20 @@ def canon_claim_inventory_diagnostics(
         revision_payloads.setdefault(claim.revision_id, set()).add(
             _stable_contract_digest(*_claim_revision_payload(claim))
         )
+        primary_source_ref = claim.source_refs[0] if claim.source_refs else ""
+        if primary_source_ref:
+            current_source_claims.setdefault(
+                (claim.source_system, primary_source_ref), set()
+            ).add(claim.revision_id)
+        if claim.canon_status == CanonStatus.DECLARED:
+            if claim.subject_id and claim.subject_type:
+                declared_subject_types.setdefault(claim.subject_id, set()).add(
+                    claim.subject_type
+                )
+            for root_id in set(claim.root_ids):
+                declared_root_authorities.setdefault(root_id, set()).add(
+                    str(claim.authority_receipt or "")
+                )
     account_entities: dict[tuple[str, str], set[str]] = {}
     for binding in bindings:
         if not strict_contract_bool(binding.active) or not _binding_authority_valid(
@@ -1444,6 +1662,43 @@ def canon_claim_inventory_diagnostics(
             for claim in normalized_claims
             if claim.revision_id != _finalize_claim_revision(claim)
         ),
+        "duplicateCurrentSourceClaimCount": sum(
+            1
+            for revision_ids in current_source_claims.values()
+            if len(revision_ids) > 1
+        ),
+        "duplicateRootWithinClaimCount": sum(
+            1
+            for claim in normalized_claims
+            if len(claim.root_ids) != len(set(claim.root_ids))
+        ),
+        "duplicateDeclaredRootAuthorityCount": sum(
+            1
+            for receipts in declared_root_authorities.values()
+            if len(receipts) > 1
+        ),
+        "declaredTypedSubjectCount": sum(
+            1
+            for claim in normalized_claims
+            if claim.canon_status == CanonStatus.DECLARED and claim.subject_type
+        ),
+        "declaredUntypedSubjectCount": sum(
+            1
+            for claim in normalized_claims
+            if claim.canon_status == CanonStatus.DECLARED and not claim.subject_type
+        ),
+        "declaredRelationshipEndpointMissingCount": sum(
+            1
+            for claim in normalized_claims
+            if claim.canon_status == CanonStatus.DECLARED
+            and claim.claim_kind == ClaimKind.RELATIONSHIP
+            and (not claim.object_subject_type or not claim.object_subject_id)
+        ),
+        "declaredSubjectIdMultiTypeCount": sum(
+            1
+            for subject_types in declared_subject_types.values()
+            if len(subject_types) > 1
+        ),
         "identityBindingCollisionCount": sum(
             1 for entity_ids in account_entities.values() if len(entity_ids) > 1
         ),
@@ -1480,15 +1735,18 @@ def canon_claim_inventory_diagnostics(
 
 
 def _sqlite_table_columns(conn: Any, table_name: str) -> tuple[str, ...]:
+    normalized_table = str(table_name or "").strip()
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", normalized_table):
+        raise ValueError("sqlite_table_name_invalid")
     if not conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
-        (str(table_name or ""),),
+        "SELECT 1 FROM main.sqlite_master WHERE type='table' AND name=?",
+        (normalized_table,),
     ).fetchone():
         return ()
     return tuple(
         str(row[1] or "")
         for row in conn.execute(
-            "PRAGMA table_info(%s)" % str(table_name or "")
+            "PRAGMA main.table_info(%s)" % normalized_table
         ).fetchall()
         if len(row) > 1 and str(row[1] or "")
     )
@@ -1502,6 +1760,7 @@ def _inventory_table_rows(
     guild_id: int | None,
     limit: int,
 ) -> tuple[int, tuple[dict[str, Any], ...], bool]:
+    normalized_table = str(table_name or "").strip()
     columns = _sqlite_table_columns(conn, table_name)
     selected = tuple(column for column in wanted_columns if column in columns)
     if not columns:
@@ -1516,7 +1775,7 @@ def _inventory_table_rows(
         params.append(int(guild_id or 0))
     total = int(
         conn.execute(
-            "SELECT COUNT(*) FROM %s%s" % (table_name, where),
+            "SELECT COUNT(*) FROM main.%s%s" % (normalized_table, where),
             tuple(params),
         ).fetchone()[0]
         or 0
@@ -1538,7 +1797,12 @@ def _inventory_table_rows(
     )
     rows = conn.execute(
         "SELECT %s FROM %s%s ORDER BY %s LIMIT ?"
-        % (",".join(selected), table_name, where, order_column),
+        % (
+            ",".join(selected),
+            "main.%s" % normalized_table,
+            where,
+            order_column,
+        ),
         (*params, max(1, min(int(limit or 1), 2000))),
     ).fetchall()
     return (
@@ -1563,7 +1827,8 @@ def _inventory_scoped_lineage_map(
 ) -> dict[str, list[str]]:
     """Load roots only for the bounded owners already selected for inventory."""
 
-    columns = _sqlite_table_columns(conn, table_name)
+    normalized_table = str(table_name or "").strip()
+    columns = _sqlite_table_columns(conn, normalized_table)
     required = {owner_column, root_column}
     normalized_ids = tuple(
         dict.fromkeys(str(value or "").strip() for value in owner_ids)
@@ -1588,7 +1853,7 @@ def _inventory_scoped_lineage_map(
             % (
                 owner_column,
                 root_column,
-                table_name,
+                "main.%s" % normalized_table,
                 " AND ".join(where),
                 owner_column,
                 root_column,
@@ -1600,11 +1865,353 @@ def _inventory_scoped_lineage_map(
     return result
 
 
-def build_claim_contract_inventory(
+def _inventory_current_declared_claim(
+    conn: Any,
+    revision: Any,
+    *,
+    now: datetime,
+) -> tuple[CanonClaim | None, str]:
+    """Validate one latest sidecar revision for content-free inventory use.
+
+    Unlike the value-returning public adapter, inventory does not impersonate
+    an authenticated owner request.  It validates stored authority directly,
+    constructs a claim only in memory, and emits counts rather than content.
+    """
+
+    from bnl_declared_canon import (
+        BROADCAST_MEMORY_SOURCE,
+        BROADCAST_TYPE_DEFAULTS,
+        BROADCAST_USAGE_SCOPES,
+        GENERAL_DECLARATION_SOURCE,
+        PUBLIC_VISIBILITIES,
+        _broadcast_lifecycle,
+        _broadcast_row,
+        _general_fingerprint,
+        _require_revision_contract,
+        _scope_tokens,
+        _stored_authority_valid,
+        _validate_broadcast_public_routes,
+        _validity_window_state,
+        broadcast_source_fingerprint,
+    )
+
+    try:
+        if not _stored_authority_valid(revision):
+            return None, "declared_stored_authority_invalid"
+        _require_revision_contract(revision)
+        if str(revision.lifecycle_status) != "established":
+            return None, "declared_latest_historical"
+        if _validity_window_state(
+            revision.valid_from,
+            revision.valid_until,
+            now,
+        ) not in {"unbounded", "current"}:
+            return None, "declared_validity_not_current"
+        broadcast_row = None
+        if revision.source_system == GENERAL_DECLARATION_SOURCE:
+            if revision.source_row_id != revision.declaration_id:
+                return None, "declared_general_identity_invalid"
+            fields = {
+                "raw_declaration": revision.raw_declaration,
+                "cleaned_summary": revision.cleaned_summary,
+                "subject_type": revision.subject_type,
+                "subject_id": revision.subject_id,
+                "object_subject_type": revision.object_subject_type,
+                "object_subject_id": revision.object_subject_id,
+                "predicate": revision.predicate,
+                "value_json": revision.value_json,
+                "domain": revision.domain,
+                "claim_kind": revision.claim_kind,
+                "visibility": revision.visibility,
+                "eligible_routes_json": revision.eligible_routes_json,
+                "valid_from": revision.valid_from,
+                "valid_until": revision.valid_until,
+            }
+            if _general_fingerprint(fields) != revision.source_fingerprint:
+                return None, "declared_general_fingerprint_invalid"
+        elif revision.source_system == BROADCAST_MEMORY_SOURCE:
+            try:
+                source_row_id = int(str(revision.source_row_id))
+            except (TypeError, ValueError):
+                return None, "declared_broadcast_identity_invalid"
+            broadcast_row = _broadcast_row(
+                conn,
+                guild_id=int(revision.guild_id),
+                row_id=source_row_id,
+            )
+            if broadcast_row is None:
+                return None, "declared_broadcast_source_missing"
+            if (
+                broadcast_source_fingerprint(broadcast_row)
+                != str(revision.source_fingerprint)
+            ):
+                return None, "declared_broadcast_fingerprint_stale"
+            if _broadcast_lifecycle(broadcast_row, now) != "established":
+                return None, "declared_broadcast_source_not_current"
+            entry_type = str(broadcast_row.get("entry_type") or "")
+            recognized = entry_type in BROADCAST_TYPE_DEFAULTS
+            classification_mode = str(revision.classification_mode)
+            legacy_mode = classification_mode == "owner_explicit_legacy_mapping"
+            if recognized == legacy_mode:
+                return None, "declared_broadcast_mapping_invalid"
+            if classification_mode == "owner_explicit_default_mapping":
+                default_domain, default_kind = BROADCAST_TYPE_DEFAULTS[entry_type]
+                if (
+                    str(revision.domain) != default_domain
+                    or str(revision.claim_kind) != default_kind
+                    or str(revision.predicate) != entry_type
+                ):
+                    return None, "declared_broadcast_default_mapping_invalid"
+            scopes = _scope_tokens(broadcast_row.get("usage_scope"))
+            if scopes.difference(BROADCAST_USAGE_SCOPES):
+                return None, "declared_broadcast_scope_unrecognized"
+            if revision.visibility in PUBLIC_VISIBILITIES:
+                if (
+                    not strict_contract_bool(broadcast_row.get("public_safe"))
+                    or "internal" in scopes
+                    or entry_type == "moderation_context"
+                ):
+                    return None, "declared_broadcast_public_intersection_invalid"
+                _validate_broadcast_public_routes(
+                    routes_json=revision.eligible_routes_json,
+                    source_scopes=scopes,
+                )
+        else:
+            return None, "declared_source_system_invalid"
+        return (
+            _declared_revision_claim(
+                revision,
+                broadcast_row=broadcast_row,
+            ),
+            "declared_shadow_current",
+        )
+    except (ValueError, TypeError, json.JSONDecodeError) as exc:
+        return None, "declared_%s" % (str(exc or "invalid"))
+
+
+def _inventory_declared_canon_claims(
+    conn: Any,
+    *,
+    guild_id: int | None,
+    broadcast_rows: Sequence[Mapping[str, Any]],
+    limit: int,
+    now: datetime,
+) -> tuple[tuple[CanonClaim, ...], dict[str, CanonClaim], dict[str, int], bool]:
+    """Load latest PR2 sidecars without exposing source or revision IDs."""
+
+    from bnl_declared_canon import (
+        BROADCAST_MEMORY_SOURCE,
+        DECLARED_CANON_TABLE,
+        GENERAL_DECLARATION_SOURCE,
+        _REVISION_COLUMNS,
+        _digest,
+        _row_to_revision,
+        DECLARED_CANON_CONTRACT_VERSION,
+    )
+
+    stats = Counter(
+        {
+            "declaredRevisionCount": 0,
+            "declaredHistoricalRevisionCount": 0,
+            "declaredCurrentClaimCount": 0,
+            "declaredInvalidLatestCount": 0,
+            "broadcastDeclaredCurrentCount": 0,
+            "broadcastOpenReviewCount": len(broadcast_rows),
+            "broadcastStaleSidecarCount": 0,
+            "broadcastDuplicateAuthorityCount": 0,
+            "declaredOrphanBroadcastSourceCount": 0,
+        }
+    )
+    columns = set(_sqlite_table_columns(conn, DECLARED_CANON_TABLE))
+    if not columns:
+        return (), {}, dict(stats), False
+    if not set(_REVISION_COLUMNS).issubset(columns) or guild_id is None:
+        return (), {}, dict(stats), True
+    safe_limit = max(1, min(int(limit or 1), 2000))
+    scoped_guild = int(guild_id or 0)
+    total_revisions, total_declarations = conn.execute(
+        """
+        SELECT COUNT(*),COUNT(DISTINCT declaration_id)
+        FROM main.declared_canon_revisions WHERE guild_id=?
+        """,
+        (scoped_guild,),
+    ).fetchone()
+    stats["declaredRevisionCount"] = int(total_revisions or 0)
+    stats["declaredHistoricalRevisionCount"] = max(
+        0, int(total_revisions or 0) - int(total_declarations or 0)
+    )
+    general_count = int(
+        conn.execute(
+            """
+            SELECT COUNT(DISTINCT declaration_id)
+            FROM main.declared_canon_revisions
+            WHERE guild_id=? AND source_system=?
+            """,
+            (scoped_guild, GENERAL_DECLARATION_SOURCE),
+        ).fetchone()[0]
+        or 0
+    )
+    general_rows = conn.execute(
+        """
+        SELECT %s
+        FROM main.declared_canon_revisions d
+        JOIN (
+          SELECT declaration_id,MAX(revision_number) AS max_revision
+          FROM main.declared_canon_revisions
+          WHERE guild_id=? AND source_system=?
+          GROUP BY declaration_id
+        ) latest
+          ON latest.declaration_id=d.declaration_id
+         AND latest.max_revision=d.revision_number
+        WHERE d.guild_id=? AND d.source_system=?
+        ORDER BY d.declaration_id LIMIT ?
+        """ % ",".join("d.%s" % column for column in _REVISION_COLUMNS),
+        (
+            scoped_guild,
+            GENERAL_DECLARATION_SOURCE,
+            scoped_guild,
+            GENERAL_DECLARATION_SOURCE,
+            safe_limit,
+        ),
+    ).fetchall()
+    general_claims: list[CanonClaim] = []
+    for raw_revision in general_rows:
+        claim, _reason = _inventory_current_declared_claim(
+            conn,
+            _row_to_revision(raw_revision),
+            now=now,
+        )
+        if claim is None:
+            stats["declaredInvalidLatestCount"] += 1
+        else:
+            general_claims.append(claim)
+            stats["declaredCurrentClaimCount"] += 1
+
+    broadcast_ids = tuple(
+        dict.fromkeys(
+            _mapping_text(row, "id", "row_id") for row in broadcast_rows
+        )
+    )
+    broadcast_ids = tuple(value for value in broadcast_ids if value)
+    sidecar_counts: dict[str, int] = {}
+    expected_declarations: dict[str, str] = {
+        source_id: "dcl_"
+        + _digest(
+            DECLARED_CANON_CONTRACT_VERSION,
+            scoped_guild,
+            BROADCAST_MEMORY_SOURCE,
+            int(source_id),
+        )[:32]
+        for source_id in broadcast_ids
+        if str(source_id).isdigit()
+    }
+    if broadcast_ids:
+        for start in range(0, len(broadcast_ids), 400):
+            chunk = broadcast_ids[start : start + 400]
+            placeholders = ",".join("?" for _ in chunk)
+            for source_id, declaration_count in conn.execute(
+                """
+                SELECT source_row_id,COUNT(DISTINCT declaration_id)
+                FROM main.declared_canon_revisions
+                WHERE guild_id=? AND source_system=?
+                  AND source_row_id IN (%s)
+                GROUP BY source_row_id
+                """ % placeholders,
+                (scoped_guild, BROADCAST_MEMORY_SOURCE, *chunk),
+            ).fetchall():
+                sidecar_counts[str(source_id)] = int(declaration_count or 0)
+    latest_by_source: dict[str, Any] = {}
+    expected_ids = tuple(expected_declarations.values())
+    for start in range(0, len(expected_ids), 400):
+        chunk = expected_ids[start : start + 400]
+        if not chunk:
+            continue
+        placeholders = ",".join("?" for _ in chunk)
+        rows = conn.execute(
+            """
+            SELECT %s
+            FROM main.declared_canon_revisions d
+            JOIN (
+              SELECT declaration_id,MAX(revision_number) AS max_revision
+              FROM main.declared_canon_revisions
+              WHERE guild_id=? AND declaration_id IN (%s)
+              GROUP BY declaration_id
+            ) latest
+              ON latest.declaration_id=d.declaration_id
+             AND latest.max_revision=d.revision_number
+            WHERE d.guild_id=? AND d.source_system=?
+            """ % (
+                ",".join("d.%s" % column for column in _REVISION_COLUMNS),
+                placeholders,
+            ),
+            (
+                scoped_guild,
+                *chunk,
+                scoped_guild,
+                BROADCAST_MEMORY_SOURCE,
+            ),
+        ).fetchall()
+        for raw_revision in rows:
+            revision = _row_to_revision(raw_revision)
+            latest_by_source[str(revision.source_row_id)] = revision
+    broadcast_claims: dict[str, CanonClaim] = {}
+    for source_id in broadcast_ids:
+        declaration_count = sidecar_counts.get(source_id, 0)
+        if declaration_count == 0:
+            continue
+        if declaration_count != 1:
+            stats["broadcastDuplicateAuthorityCount"] += 1
+            stats["broadcastStaleSidecarCount"] += 1
+            continue
+        revision = latest_by_source.get(source_id)
+        if revision is None:
+            stats["broadcastStaleSidecarCount"] += 1
+            continue
+        claim, _reason = _inventory_current_declared_claim(
+            conn,
+            revision,
+            now=now,
+        )
+        if claim is None:
+            stats["broadcastStaleSidecarCount"] += 1
+            continue
+        broadcast_claims[source_id] = claim
+        stats["broadcastDeclaredCurrentCount"] += 1
+        stats["broadcastOpenReviewCount"] -= 1
+        stats["declaredCurrentClaimCount"] += 1
+
+    stats["declaredOrphanBroadcastSourceCount"] = int(
+        conn.execute(
+            """
+            SELECT COUNT(*) FROM (
+              SELECT d.source_row_id
+              FROM main.declared_canon_revisions d
+              LEFT JOIN main.broadcast_memory b
+                ON b.guild_id=d.guild_id
+               AND CAST(b.id AS TEXT)=d.source_row_id
+              WHERE d.guild_id=? AND d.source_system=? AND b.id IS NULL
+              GROUP BY d.source_row_id
+            )
+            """,
+            (scoped_guild, BROADCAST_MEMORY_SOURCE),
+        ).fetchone()[0]
+        or 0
+    ) if _sqlite_table_columns(conn, "broadcast_memory") else 0
+    truncated = bool(general_count > len(general_rows))
+    return (
+        tuple(general_claims),
+        broadcast_claims,
+        dict(stats),
+        truncated,
+    )
+
+
+def _build_claim_contract_inventory_in_snapshot(
     conn: Any,
     *,
     guild_id: int | None = None,
     max_rows_per_source: int = 2000,
+    now: datetime | str | None = None,
 ) -> dict[str, Any]:
     """Build a bounded, content-free, zero-write adapter inventory.
 
@@ -1615,6 +2222,17 @@ def build_claim_contract_inventory(
     """
 
     before_changes = int(getattr(conn, "total_changes", 0) or 0)
+    if isinstance(now, datetime):
+        inventory_now = now
+        if inventory_now.tzinfo is None:
+            inventory_now = inventory_now.replace(tzinfo=timezone.utc)
+        inventory_now = inventory_now.astimezone(timezone.utc)
+    elif now is None or not str(now or "").strip():
+        inventory_now = datetime.now(timezone.utc)
+    else:
+        inventory_now = _parse_contract_time(now)
+        if inventory_now is None:
+            inventory_now = datetime.min.replace(tzinfo=timezone.utc)
     claims: list[CanonClaim] = [
         adapt_legacy_canon_fact(fact) for fact in CANON_FACTS
     ]
@@ -1680,8 +2298,34 @@ def build_claim_contract_inventory(
     inspected_rows["broadcast_memory"] = len(broadcast_rows)
     if broadcast_truncated:
         truncated_sources.append("broadcast_memory")
+    (
+        general_declared_claims,
+        broadcast_declared_claims,
+        declared_inventory_stats,
+        declared_inventory_truncated,
+    ) = _inventory_declared_canon_claims(
+        conn,
+        guild_id=guild_id,
+        broadcast_rows=broadcast_rows,
+        limit=max_rows_per_source,
+        now=inventory_now,
+    )
+    claims.extend(general_declared_claims)
+    reason_counts["declared_shadow_current"] += len(general_declared_claims)
+    if declared_inventory_truncated:
+        truncated_sources.append("declared_canon_revisions")
     for row in broadcast_rows:
-        result = adapt_broadcast_memory_claim(row)
+        source_id = _mapping_text(row, "id", "row_id")
+        declared_claim = broadcast_declared_claims.get(source_id)
+        result = (
+            CanonAdapterResult(
+                declared_claim,
+                "declared_shadow_current",
+                False,
+            )
+            if declared_claim is not None
+            else adapt_broadcast_memory_claim(row)
+        )
         reason_counts[result.reason] += 1
         if result.claim is not None:
             claims.append(result.claim)
@@ -1885,9 +2529,28 @@ def build_claim_contract_inventory(
             "sourceAdaptedReconciled": complete_source_reconciliation,
             "sourceReconciliationStatus": reconciliation_status,
             "mutationCount": max(0, after_changes - before_changes),
+            **declared_inventory_stats,
         }
     )
     return diagnostics
+
+
+def build_claim_contract_inventory(
+    conn: Any,
+    *,
+    guild_id: int | None = None,
+    max_rows_per_source: int = 2000,
+    now: datetime | str | None = None,
+) -> dict[str, Any]:
+    """Build the bounded content-free inventory from one read snapshot."""
+
+    with _read_snapshot(conn):
+        return _build_claim_contract_inventory_in_snapshot(
+            conn,
+            guild_id=guild_id,
+            max_rows_per_source=max_rows_per_source,
+            now=now,
+        )
 
 
 def canon_facts_for_subject(

--- a/bnl_declared_canon.py
+++ b/bnl_declared_canon.py
@@ -1,0 +1,2854 @@
+"""Dependency-free Declared Canon lifecycle and Broadcast classification core.
+
+This module owns no response route, projection, model call, or deployment gate.
+It stores append-only owner declarations and typed metadata for rows whose
+authoritative content remains in ``broadcast_memory``.
+
+Trust boundary: ``actor_user_id`` must come from an authenticated Discord
+message/interaction object.  This dependency-free core cannot authenticate a
+network principal; it independently rechecks that opaque ID and the exact guild
+against ``BNL_OWNER_USER_ID`` and ``BNL_PRIMARY_GUILD_ID`` on every public read
+or mutation.  It accepts neither caller-built authority objects nor receipts.
+Receipts are deterministic integrity labels bound to the complete request and
+stored revision. They add no runtime secret or deployment prerequisite.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+import re
+import sqlite3
+from typing import Any, Iterable, Mapping, Sequence
+
+
+DECLARED_CANON_CONTRACT_VERSION = "declared_canon_lifecycle_v1"
+DECLARED_CANON_TABLE = "declared_canon_revisions"
+GENERAL_DECLARATION_SOURCE = "general_declaration"
+BROADCAST_MEMORY_SOURCE = "broadcast_memory"
+BROADCAST_DECLARED_CANON_OWNER_ERA_CUTOFF = "2026-07-23T19:16:22+00:00"
+BROADCAST_SOURCE_FINGERPRINT_VERSION = "broadcast_memory_complete_row_v2"
+INTERNAL_AUTHORITY_RECEIPT_VERSION = "declared_canon_internal_receipt_v1"
+STORED_AUTHORITY_BINDING_VERSION = "declared_canon_stored_payload_v1"
+# These fields are the minimum recognized Broadcast schema, not a fingerprint
+# allowlist.  Every column returned by the authoritative source row, including
+# unknown/future columns, is included in the v2 fingerprint.  Adding a column
+# therefore invalidates prior review until the owner explicitly reclassifies it.
+_BROADCAST_SOURCE_REQUIRED_FIELDS = (
+    "id",
+    "guild_id",
+    "episode_date",
+    "submitted_by_user_id",
+    "submitted_by_name",
+    "raw_note",
+    "cleaned_summary",
+    "entry_type",
+    "importance",
+    "public_safe",
+    "affects_next_show",
+    "usage_scope",
+    "target_show_date",
+    "valid_until",
+    "override_span_count",
+    "needs_clarification",
+    "status",
+    "created_at",
+    "updated_at",
+    "corrected_by_user_id",
+    "corrected_by_name",
+    "correction_reason",
+    "supersedes_id",
+    "superseded_by_id",
+)
+
+GENERAL_SUBJECT_TYPES = frozenset(
+    {
+        "entity",
+        "person",
+        "character",
+        "project",
+        "relationship",
+        "broadcast",
+        "event",
+        "organization",
+    }
+)
+CANON_DOMAINS = frozenset(
+    {"real_community", "broadcast_history", "operational", "lore", "hybrid"}
+)
+CLAIM_KINDS = frozenset(
+    {
+        "identity",
+        "role",
+        "standing",
+        "relationship",
+        "contribution",
+        "event",
+        "current_state",
+        "behavior_pattern",
+        "tradition_or_joke",
+        "world_rule",
+        "other",
+    }
+)
+VISIBILITIES = frozenset(
+    {
+        "public",
+        "public_safe",
+        "reference_canon",
+        "internal",
+        "private",
+        "mod",
+        "protected",
+    }
+)
+PUBLIC_VISIBILITIES = frozenset({"public", "public_safe", "reference_canon"})
+PUBLIC_ROUTES = frozenset(
+    {
+        "public_home",
+        "public_context",
+        "public_selective",
+        "relay",
+        "journal",
+        "website",
+    }
+)
+ALLOWED_ELIGIBLE_ROUTES = PUBLIC_ROUTES | frozenset(
+    {
+        "broadcast_memory",
+        "declared_canon_review",
+        "internal_controlled",
+        "protected_system",
+        "reference_canon",
+        "sealed_test",
+    }
+)
+GENERAL_LIFECYCLES = frozenset(
+    {
+        "established",
+        "contested",
+        "review_only",
+        "resolved",
+        "retired",
+        "superseded",
+    }
+)
+TERMINAL_LIFECYCLES = frozenset({"retired", "superseded"})
+
+BROADCAST_TYPE_DEFAULTS = {
+    "episode_arc": ("broadcast_history", "event"),
+    "notable_moment": ("broadcast_history", "event"),
+    "running_joke": ("hybrid", "tradition_or_joke"),
+    "technical_issue": ("operational", "event"),
+    "moderation_context": ("real_community", "event"),
+    "show_state_override": ("operational", "current_state"),
+}
+BROADCAST_USAGE_SCOPES = frozenset(
+    {"direct", "ambient", "show_status", "relay", "internal"}
+)
+
+_SOURCE_SYSTEMS = frozenset({GENERAL_DECLARATION_SOURCE, BROADCAST_MEMORY_SOURCE})
+_MUTATION_OPERATIONS = frozenset(
+    {"add", "correct", "supersede", "retire", "status", "classify_broadcast"}
+)
+_PREVIEW_OPERATIONS = frozenset({"preview_declared", "preview_broadcast"})
+_AUTHORITY_NONCE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$")
+_STABLE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_.:-]{1,119}$")
+_PREDICATE_RE = re.compile(r"^[a-z][a-z0-9_.:-]{1,119}$")
+_ROUTE_RE = re.compile(r"^[a-z][a-z0-9_.:-]{1,79}$")
+
+BROADCAST_PUBLIC_ROUTE_SCOPES = {
+    "public_home": frozenset({"ambient", "direct"}),
+    "public_context": frozenset({"ambient", "direct"}),
+    "public_selective": frozenset({"ambient", "direct"}),
+    "relay": frozenset({"relay"}),
+    "journal": frozenset({"ambient"}),
+    "website": frozenset({"relay"}),
+}
+
+
+class DeclaredCanonError(ValueError):
+    """Fail-closed Declared Canon contract error with a stable reason code."""
+
+    def __init__(self, code: str):
+        self.code = str(code or "declared_canon_error")
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True)
+class _VerifiedAuthority:
+    actor_user_id: int
+    guild_id: int
+    operation: str
+    request_fingerprint: str
+    operation_id: str
+    authority_actor: str
+    authority_receipt: str
+
+
+@dataclass(frozen=True)
+class DeclaredCanonRevision:
+    revision_id: str
+    declaration_id: str
+    revision_number: int
+    guild_id: int
+    source_system: str
+    source_row_id: str
+    source_fingerprint: str
+    operation: str
+    operation_id: str
+    operation_reason: str
+    classification_mode: str
+    raw_declaration: str
+    cleaned_summary: str
+    subject_type: str
+    subject_id: str
+    object_subject_type: str
+    object_subject_id: str
+    predicate: str
+    value_json: str
+    domain: str
+    claim_kind: str
+    visibility: str
+    eligible_routes_json: str
+    valid_from: str
+    valid_until: str
+    lifecycle_status: str
+    previous_revision_id: str
+    correction_of_revision_id: str
+    supersedes_declaration_id: str
+    superseded_by_declaration_id: str
+    derived_from_source_ref: str
+    authority_request_fingerprint: str
+    authority_actor: str
+    authority_receipt: str
+    authority_verified: bool
+    contract_version: str
+    created_at: str
+
+    @property
+    def eligible_routes(self) -> tuple[str, ...]:
+        try:
+            values = json.loads(self.eligible_routes_json or "[]")
+        except (TypeError, json.JSONDecodeError):
+            return ()
+        if not isinstance(values, list):
+            return ()
+        return tuple(str(value) for value in values if str(value or ""))
+
+
+@dataclass(frozen=True)
+class MutationResult:
+    operation_id: str
+    revisions: tuple[DeclaredCanonRevision, ...]
+
+    @property
+    def primary(self) -> DeclaredCanonRevision:
+        return self.revisions[0]
+
+
+@dataclass(frozen=True)
+class DeclaredPreviewItem:
+    declaration_id: str
+    revision_id: str
+    revision_number: int
+    source_system: str
+    domain: str
+    claim_kind: str
+    visibility: str
+    lifecycle_status: str
+    classification_mode: str
+    current_revision: bool
+
+
+@dataclass(frozen=True)
+class DeclaredPreview:
+    contract_version: str
+    guild_id: int
+    authority_actor_ref: str
+    authority_receipt_id: str
+    items: tuple[DeclaredPreviewItem, ...]
+    total_rows: int
+    truncated: bool
+    mutation_count: int
+
+
+@dataclass(frozen=True)
+class BroadcastPreviewItem:
+    preview_item: str
+    source_era: str
+    entry_type: str
+    status: str
+    usage_scope: str
+    public_safe: bool
+    submitter_state: str
+    validity_state: str
+    derivation_state: str
+    subject_link_state: str
+    source_fingerprint_state: str
+    classification_state: str
+    disposition: str
+    reason_codes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BroadcastHistoryPreview:
+    contract_version: str
+    guild_id: int
+    authority_actor_ref: str
+    authority_receipt_id: str
+    owner_era_cutoff: str
+    items: tuple[BroadcastPreviewItem, ...]
+    total_rows: int
+    truncated: bool
+    counts_scope: str
+    type_counts: Mapping[str, int]
+    era_counts: Mapping[str, int]
+    disposition_counts: Mapping[str, int]
+    mutation_count: int
+
+
+_REVISION_COLUMNS = (
+    "revision_id",
+    "declaration_id",
+    "revision_number",
+    "guild_id",
+    "source_system",
+    "source_row_id",
+    "source_fingerprint",
+    "operation",
+    "operation_id",
+    "operation_reason",
+    "classification_mode",
+    "raw_declaration",
+    "cleaned_summary",
+    "subject_type",
+    "subject_id",
+    "object_subject_type",
+    "object_subject_id",
+    "predicate",
+    "value_json",
+    "domain",
+    "claim_kind",
+    "visibility",
+    "eligible_routes_json",
+    "valid_from",
+    "valid_until",
+    "lifecycle_status",
+    "previous_revision_id",
+    "correction_of_revision_id",
+    "supersedes_declaration_id",
+    "superseded_by_declaration_id",
+    "derived_from_source_ref",
+    "authority_request_fingerprint",
+    "authority_actor",
+    "authority_receipt",
+    "authority_verified",
+    "contract_version",
+    "created_at",
+)
+
+
+def _utc_now() -> str:
+    # Broadcast intake stores microseconds. Keep equal precision so an
+    # immediately classified row cannot appear fractionally future-dated.
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _digest(*values: Any) -> str:
+    payload = json.dumps(
+        values,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _strict_bool(value: Any) -> bool:
+    if value is True:
+        return True
+    if value is False or value is None:
+        return False
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value == 1
+    return False
+
+
+def _configured_owner_user_id() -> int:
+    """Read trusted runtime configuration for every public operation."""
+
+    try:
+        return int(os.getenv("BNL_OWNER_USER_ID", "0") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _configured_primary_guild_id() -> int:
+    try:
+        return int(os.getenv("BNL_PRIMARY_GUILD_ID", "0") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _require_configured_owner_actor(*, actor_user_id: int, guild_id: int) -> int:
+    configured = _configured_owner_user_id()
+    actor = int(actor_user_id or 0)
+    target_guild = int(guild_id or 0)
+    if configured <= 0:
+        raise DeclaredCanonError("owner_user_id_not_configured")
+    if actor <= 0 or actor != configured:
+        raise DeclaredCanonError("configured_owner_required")
+    configured_guild = _configured_primary_guild_id()
+    if configured_guild <= 0:
+        raise DeclaredCanonError("primary_guild_id_not_configured")
+    if target_guild <= 0 or target_guild != configured_guild:
+        raise DeclaredCanonError("configured_primary_guild_required")
+    return actor
+
+
+def _authorize_request(
+    *,
+    actor_user_id: int,
+    guild_id: int,
+    operation: str,
+    authority_nonce: str,
+    binding: Mapping[str, Any],
+) -> _VerifiedAuthority:
+    """Issue an internal receipt bound to the exact normalized request.
+
+    Callers cannot supply a configured-owner value or a prebuilt receipt.  The
+    actor is compared with ``BNL_OWNER_USER_ID`` at this boundary on every call.
+    No secret or caller-supplied receipt participates. The internally computed,
+    visibly versioned receipt commits to the operation, guild, actor, nonce,
+    target, expected revision/source fingerprint, and normalized payload.
+    """
+
+    normalized_operation = str(operation or "").strip().casefold()
+    if normalized_operation not in _MUTATION_OPERATIONS | _PREVIEW_OPERATIONS:
+        raise DeclaredCanonError("invalid_authority_operation")
+    actor = _require_configured_owner_actor(
+        actor_user_id=actor_user_id, guild_id=guild_id
+    )
+    nonce = str(authority_nonce or "").strip()
+    if not _AUTHORITY_NONCE_RE.fullmatch(nonce):
+        raise DeclaredCanonError("invalid_authority_nonce")
+    request_fingerprint = "req_" + _digest(
+        DECLARED_CANON_CONTRACT_VERSION,
+        normalized_operation,
+        int(guild_id),
+        actor,
+        binding,
+    )[:48]
+    operation_id = "op_" + _digest(
+        DECLARED_CANON_CONTRACT_VERSION,
+        int(guild_id),
+        actor,
+        nonce,
+    )[:32]
+    receipt_digest = _digest(
+        INTERNAL_AUTHORITY_RECEIPT_VERSION,
+        "request_authority",
+        DECLARED_CANON_CONTRACT_VERSION,
+        normalized_operation,
+        int(guild_id),
+        actor,
+        nonce,
+        operation_id,
+        request_fingerprint,
+    )
+    return _VerifiedAuthority(
+        actor_user_id=actor,
+        guild_id=int(guild_id),
+        operation=normalized_operation,
+        request_fingerprint=request_fingerprint,
+        operation_id=operation_id,
+        authority_actor="discord_user:%s" % actor,
+        authority_receipt=(
+            "owner_command:%s:%s:%s:%s"
+            % (
+                DECLARED_CANON_CONTRACT_VERSION,
+                INTERNAL_AUTHORITY_RECEIPT_VERSION,
+                normalized_operation,
+                receipt_digest,
+            )
+        ),
+    )
+
+
+def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    return bool(
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+            (str(table_name or ""),),
+        ).fetchone()
+    )
+
+
+def _table_columns(conn: sqlite3.Connection, table_name: str) -> tuple[str, ...]:
+    if not _table_exists(conn, table_name):
+        return ()
+    return tuple(str(row[1]) for row in conn.execute("PRAGMA table_info(%s)" % table_name))
+
+
+@contextmanager
+def _immediate_transaction(conn: sqlite3.Connection):
+    if conn.in_transaction:
+        raise DeclaredCanonError("transaction_already_active")
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        yield
+    except Exception:
+        conn.rollback()
+        raise
+    else:
+        conn.commit()
+
+
+@contextmanager
+def _read_snapshot(conn: sqlite3.Connection):
+    """Hold one coherent read snapshot without taking caller transaction ownership."""
+
+    owns_transaction = not conn.in_transaction
+    before = int(conn.total_changes or 0)
+    if owns_transaction:
+        conn.execute("BEGIN")
+        # BEGIN is deferred in SQLite. This read pins the snapshot before any
+        # validator query so a WAL writer cannot splice a newer revision/source
+        # row into the remainder of the validation sequence.
+        conn.execute("SELECT 1 FROM sqlite_schema LIMIT 1").fetchone()
+    try:
+        yield
+        if int(conn.total_changes or 0) != before:
+            raise DeclaredCanonError("read_validator_mutated_state")
+    except Exception:
+        if owns_transaction:
+            conn.rollback()
+        raise
+    else:
+        if owns_transaction:
+            conn.commit()
+
+
+def ensure_declared_canon_schema(conn: sqlite3.Connection) -> None:
+    """Create the one additive revision table and append-only guards."""
+
+    with _immediate_transaction(conn):
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS declared_canon_revisions (
+                revision_id TEXT PRIMARY KEY,
+                declaration_id TEXT NOT NULL,
+                revision_number INTEGER NOT NULL CHECK(revision_number > 0),
+                guild_id INTEGER NOT NULL CHECK(guild_id > 0),
+                source_system TEXT NOT NULL,
+                source_row_id TEXT NOT NULL,
+                source_fingerprint TEXT NOT NULL,
+                operation TEXT NOT NULL,
+                operation_id TEXT NOT NULL,
+                operation_reason TEXT NOT NULL DEFAULT '',
+                classification_mode TEXT NOT NULL,
+                raw_declaration TEXT NOT NULL DEFAULT '',
+                cleaned_summary TEXT NOT NULL DEFAULT '',
+                subject_type TEXT NOT NULL,
+                subject_id TEXT NOT NULL,
+                object_subject_type TEXT NOT NULL DEFAULT '',
+                object_subject_id TEXT NOT NULL DEFAULT '',
+                predicate TEXT NOT NULL,
+                value_json TEXT NOT NULL DEFAULT '',
+                domain TEXT NOT NULL,
+                claim_kind TEXT NOT NULL,
+                visibility TEXT NOT NULL,
+                eligible_routes_json TEXT NOT NULL DEFAULT '[]',
+                valid_from TEXT NOT NULL DEFAULT '',
+                valid_until TEXT NOT NULL DEFAULT '',
+                lifecycle_status TEXT NOT NULL,
+                previous_revision_id TEXT NOT NULL DEFAULT '',
+                correction_of_revision_id TEXT NOT NULL DEFAULT '',
+                supersedes_declaration_id TEXT NOT NULL DEFAULT '',
+                superseded_by_declaration_id TEXT NOT NULL DEFAULT '',
+                derived_from_source_ref TEXT NOT NULL DEFAULT '',
+                authority_request_fingerprint TEXT NOT NULL,
+                authority_actor TEXT NOT NULL,
+                authority_receipt TEXT NOT NULL,
+                authority_verified INTEGER NOT NULL CHECK(authority_verified IN (0,1)),
+                contract_version TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                UNIQUE(guild_id, declaration_id, revision_number),
+                UNIQUE(guild_id, declaration_id, operation_id)
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_declared_canon_source
+            ON declared_canon_revisions(
+                guild_id, source_system, source_row_id, revision_number
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_declared_canon_subject
+            ON declared_canon_revisions(
+                guild_id, subject_type, subject_id, lifecycle_status
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS trg_declared_canon_revisions_no_conflicting_insert
+            BEFORE INSERT ON declared_canon_revisions
+            WHEN EXISTS(
+                SELECT 1 FROM declared_canon_revisions existing
+                WHERE existing.revision_id=NEW.revision_id
+                   OR (
+                       existing.guild_id=NEW.guild_id
+                       AND existing.declaration_id=NEW.declaration_id
+                       AND existing.revision_number=NEW.revision_number
+                   )
+                   OR (
+                       existing.guild_id=NEW.guild_id
+                       AND existing.declaration_id=NEW.declaration_id
+                       AND existing.operation_id=NEW.operation_id
+                   )
+            )
+            BEGIN
+                SELECT RAISE(ABORT, 'declared_canon_append_only_conflict');
+            END
+            """
+        )
+        conn.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS trg_declared_canon_revisions_no_update
+            BEFORE UPDATE ON declared_canon_revisions
+            BEGIN
+                SELECT RAISE(ABORT, 'declared_canon_append_only_update');
+            END
+            """
+        )
+        conn.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS trg_declared_canon_revisions_no_delete
+            BEFORE DELETE ON declared_canon_revisions
+            BEGIN
+                SELECT RAISE(ABORT, 'declared_canon_append_only_delete');
+            END
+            """
+        )
+
+
+def _require_schema(conn: sqlite3.Connection) -> None:
+    columns = set(_table_columns(conn, DECLARED_CANON_TABLE))
+    if not set(_REVISION_COLUMNS).issubset(columns):
+        raise DeclaredCanonError("declared_canon_schema_unavailable")
+
+
+def _bounded_text(value: Any, *, field: str, maximum: int, required: bool = True) -> str:
+    text = str(value or "").strip()
+    if required and not text:
+        raise DeclaredCanonError("missing_%s" % field)
+    if len(text) > maximum:
+        raise DeclaredCanonError("%s_too_long" % field)
+    return text
+
+
+def _validate_stable_token(value: Any, *, field: str, pattern: re.Pattern[str]) -> str:
+    token = str(value or "").strip()
+    if not pattern.fullmatch(token):
+        raise DeclaredCanonError("invalid_%s" % field)
+    return token
+
+
+def _canonical_value_json(value: Any) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError):
+        raise DeclaredCanonError("invalid_typed_value")
+    if len(encoded) > 4000:
+        raise DeclaredCanonError("typed_value_too_long")
+    return encoded
+
+
+def _canonical_routes(routes: Iterable[str], visibility: str) -> str:
+    normalized = tuple(
+        sorted(
+            {
+                str(route or "").strip().casefold()
+                for route in routes
+                if str(route or "").strip()
+            }
+        )
+    )
+    if any(not _ROUTE_RE.fullmatch(route) for route in normalized):
+        raise DeclaredCanonError("invalid_eligible_route")
+    if any(route not in ALLOWED_ELIGIBLE_ROUTES for route in normalized):
+        raise DeclaredCanonError("unknown_eligible_route")
+    if visibility not in PUBLIC_VISIBILITIES and PUBLIC_ROUTES.intersection(normalized):
+        raise DeclaredCanonError("internal_visibility_public_route")
+    return json.dumps(normalized, separators=(",", ":"))
+
+
+def _parse_validity(value: Any, *, field: str) -> tuple[str, datetime | None]:
+    text = str(value or "").strip()
+    if not text:
+        return "", None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        raise DeclaredCanonError("invalid_%s" % field)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return text, parsed.astimezone(timezone.utc)
+
+
+def _validated_claim_fields(
+    *,
+    subject_type: Any,
+    subject_id: Any,
+    object_subject_type: Any,
+    object_subject_id: Any,
+    predicate: Any,
+    value: Any,
+    raw_declaration: Any,
+    cleaned_summary: Any,
+    domain: Any,
+    claim_kind: Any,
+    visibility: Any,
+    eligible_routes: Iterable[str],
+    valid_from: Any,
+    valid_until: Any,
+) -> dict[str, str]:
+    normalized_subject_type = str(subject_type or "").strip().casefold()
+    if normalized_subject_type not in GENERAL_SUBJECT_TYPES:
+        raise DeclaredCanonError("invalid_subject_type")
+    normalized_subject_id = _validate_stable_token(
+        subject_id, field="subject_id", pattern=_STABLE_ID_RE
+    )
+    normalized_predicate = _validate_stable_token(
+        predicate, field="predicate", pattern=_PREDICATE_RE
+    )
+    normalized_domain = str(domain or "").strip().casefold()
+    if normalized_domain not in CANON_DOMAINS:
+        raise DeclaredCanonError("invalid_domain")
+    normalized_claim_kind = str(claim_kind or "").strip().casefold()
+    if normalized_claim_kind not in CLAIM_KINDS:
+        raise DeclaredCanonError("invalid_claim_kind")
+    normalized_object_type = str(object_subject_type or "").strip().casefold()
+    normalized_object_id = str(object_subject_id or "").strip()
+    if normalized_claim_kind == "relationship":
+        if normalized_object_type not in GENERAL_SUBJECT_TYPES:
+            raise DeclaredCanonError("relationship_object_subject_type_required")
+        normalized_object_id = _validate_stable_token(
+            normalized_object_id,
+            field="object_subject_id",
+            pattern=_STABLE_ID_RE,
+        )
+    elif normalized_object_type or normalized_object_id:
+        raise DeclaredCanonError("relationship_object_not_allowed")
+    if normalized_subject_type == "relationship" and normalized_claim_kind != "relationship":
+        raise DeclaredCanonError("relationship_claim_kind_required")
+    normalized_visibility = str(visibility or "").strip().casefold()
+    if normalized_visibility not in VISIBILITIES:
+        raise DeclaredCanonError("invalid_visibility")
+    normalized_valid_from, parsed_from = _parse_validity(
+        valid_from, field="valid_from"
+    )
+    normalized_valid_until, parsed_until = _parse_validity(
+        valid_until, field="valid_until"
+    )
+    if parsed_from and parsed_until and parsed_until < parsed_from:
+        raise DeclaredCanonError("invalid_validity_window")
+    return {
+        "subject_type": normalized_subject_type,
+        "subject_id": normalized_subject_id,
+        "object_subject_type": normalized_object_type,
+        "object_subject_id": normalized_object_id,
+        "predicate": normalized_predicate,
+        "value_json": _canonical_value_json(value),
+        "raw_declaration": _bounded_text(
+            raw_declaration, field="raw_declaration", maximum=4000
+        ),
+        "cleaned_summary": _bounded_text(
+            cleaned_summary,
+            field="cleaned_summary",
+            maximum=1000,
+            required=False,
+        ),
+        "domain": normalized_domain,
+        "claim_kind": normalized_claim_kind,
+        "visibility": normalized_visibility,
+        "eligible_routes_json": _canonical_routes(
+            eligible_routes, normalized_visibility
+        ),
+        "valid_from": normalized_valid_from,
+        "valid_until": normalized_valid_until,
+    }
+
+
+def _operation_id(authority: _VerifiedAuthority) -> str:
+    return authority.operation_id
+
+
+def _opaque_actor_ref(authority: _VerifiedAuthority) -> str:
+    return "actor_" + _digest(
+        DECLARED_CANON_CONTRACT_VERSION,
+        authority.guild_id,
+        authority.actor_user_id,
+    )[:20]
+
+
+def _receipt_id(authority: _VerifiedAuthority) -> str:
+    return "receipt_" + _digest(authority.authority_receipt)[:24]
+
+
+def _general_fingerprint(fields: Mapping[str, str]) -> str:
+    return "src_" + _digest(
+        DECLARED_CANON_CONTRACT_VERSION,
+        GENERAL_DECLARATION_SOURCE,
+        fields.get("raw_declaration", ""),
+        fields.get("cleaned_summary", ""),
+        fields.get("subject_type", ""),
+        fields.get("subject_id", ""),
+        fields.get("object_subject_type", ""),
+        fields.get("object_subject_id", ""),
+        fields.get("predicate", ""),
+        fields.get("value_json", ""),
+        fields.get("domain", ""),
+        fields.get("claim_kind", ""),
+        fields.get("visibility", ""),
+        fields.get("eligible_routes_json", ""),
+        fields.get("valid_from", ""),
+        fields.get("valid_until", ""),
+    )[:40]
+
+
+def _stored_authority_receipt(payload: Mapping[str, Any]) -> str:
+    operation = str(payload.get("operation") or "")
+    digest = _digest(
+        INTERNAL_AUTHORITY_RECEIPT_VERSION,
+        STORED_AUTHORITY_BINDING_VERSION,
+        *(payload.get(column) for column in _REVISION_COLUMNS
+          if column not in {"revision_id", "authority_receipt"}),
+    )
+    return "owner_command:%s:%s:%s:%s" % (
+        DECLARED_CANON_CONTRACT_VERSION,
+        INTERNAL_AUTHORITY_RECEIPT_VERSION,
+        operation,
+        digest,
+    )
+
+
+def _revision_payload(
+    *,
+    declaration_id: str,
+    revision_number: int,
+    guild_id: int,
+    source_system: str,
+    source_row_id: str,
+    source_fingerprint: str,
+    operation: str,
+    operation_id: str,
+    operation_reason: str,
+    classification_mode: str,
+    raw_declaration: str,
+    cleaned_summary: str,
+    subject_type: str,
+    subject_id: str,
+    object_subject_type: str,
+    object_subject_id: str,
+    predicate: str,
+    value_json: str,
+    domain: str,
+    claim_kind: str,
+    visibility: str,
+    eligible_routes_json: str,
+    valid_from: str,
+    valid_until: str,
+    lifecycle_status: str,
+    previous_revision_id: str,
+    correction_of_revision_id: str,
+    supersedes_declaration_id: str,
+    superseded_by_declaration_id: str,
+    derived_from_source_ref: str,
+    authority_request_fingerprint: str,
+    authority_actor: str,
+    created_at: str,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "revision_id": "",
+        "declaration_id": declaration_id,
+        "revision_number": int(revision_number),
+        "guild_id": int(guild_id),
+        "source_system": source_system,
+        "source_row_id": source_row_id,
+        "source_fingerprint": source_fingerprint,
+        "operation": operation,
+        "operation_id": operation_id,
+        "operation_reason": operation_reason,
+        "classification_mode": classification_mode,
+        "raw_declaration": raw_declaration,
+        "cleaned_summary": cleaned_summary,
+        "subject_type": subject_type,
+        "subject_id": subject_id,
+        "object_subject_type": object_subject_type,
+        "object_subject_id": object_subject_id,
+        "predicate": predicate,
+        "value_json": value_json,
+        "domain": domain,
+        "claim_kind": claim_kind,
+        "visibility": visibility,
+        "eligible_routes_json": eligible_routes_json,
+        "valid_from": valid_from,
+        "valid_until": valid_until,
+        "lifecycle_status": lifecycle_status,
+        "previous_revision_id": previous_revision_id,
+        "correction_of_revision_id": correction_of_revision_id,
+        "supersedes_declaration_id": supersedes_declaration_id,
+        "superseded_by_declaration_id": superseded_by_declaration_id,
+        "derived_from_source_ref": derived_from_source_ref,
+        "authority_request_fingerprint": authority_request_fingerprint,
+        "authority_actor": authority_actor,
+        "authority_receipt": "",
+        "authority_verified": 1,
+        "contract_version": DECLARED_CANON_CONTRACT_VERSION,
+        "created_at": created_at,
+    }
+    if not re.fullmatch(
+        r"req_[0-9a-f]{48}",
+        str(payload["authority_request_fingerprint"] or ""),
+    ):
+        raise DeclaredCanonError("authority_request_fingerprint_invalid")
+    payload["authority_receipt"] = _stored_authority_receipt(payload)
+    payload["revision_id"] = "drev_" + _digest(
+        *(payload[column] for column in _REVISION_COLUMNS if column != "revision_id")
+    )[:40]
+    return payload
+
+
+def _copy_revision_payload(
+    prior: DeclaredCanonRevision,
+    *,
+    operation: str,
+    operation_id: str,
+    operation_reason: str,
+    authority: _VerifiedAuthority,
+    created_at: str,
+    lifecycle_status: str | None = None,
+    supersedes_declaration_id: str | None = None,
+    superseded_by_declaration_id: str | None = None,
+) -> dict[str, Any]:
+    return _revision_payload(
+        declaration_id=prior.declaration_id,
+        revision_number=prior.revision_number + 1,
+        guild_id=prior.guild_id,
+        source_system=prior.source_system,
+        source_row_id=prior.source_row_id,
+        source_fingerprint=prior.source_fingerprint,
+        operation=operation,
+        operation_id=operation_id,
+        operation_reason=operation_reason,
+        classification_mode=prior.classification_mode,
+        raw_declaration=prior.raw_declaration,
+        cleaned_summary=prior.cleaned_summary,
+        subject_type=prior.subject_type,
+        subject_id=prior.subject_id,
+        object_subject_type=prior.object_subject_type,
+        object_subject_id=prior.object_subject_id,
+        predicate=prior.predicate,
+        value_json=prior.value_json,
+        domain=prior.domain,
+        claim_kind=prior.claim_kind,
+        visibility=prior.visibility,
+        eligible_routes_json=prior.eligible_routes_json,
+        valid_from=prior.valid_from,
+        valid_until=prior.valid_until,
+        lifecycle_status=(
+            lifecycle_status
+            if lifecycle_status is not None
+            else prior.lifecycle_status
+        ),
+        previous_revision_id=prior.revision_id,
+        correction_of_revision_id="",
+        supersedes_declaration_id=(
+            supersedes_declaration_id
+            if supersedes_declaration_id is not None
+            else prior.supersedes_declaration_id
+        ),
+        superseded_by_declaration_id=(
+            superseded_by_declaration_id
+            if superseded_by_declaration_id is not None
+            else prior.superseded_by_declaration_id
+        ),
+        derived_from_source_ref=prior.derived_from_source_ref,
+        authority_request_fingerprint=authority.request_fingerprint,
+        authority_actor=authority.authority_actor,
+        created_at=created_at,
+    )
+
+
+def _insert_revision(conn: sqlite3.Connection, payload: Mapping[str, Any]) -> None:
+    conn.execute(
+        "INSERT INTO declared_canon_revisions (%s) VALUES (%s)"
+        % (",".join(_REVISION_COLUMNS), ",".join("?" for _ in _REVISION_COLUMNS)),
+        tuple(payload[column] for column in _REVISION_COLUMNS),
+    )
+
+
+def _row_to_revision(row: Sequence[Any]) -> DeclaredCanonRevision:
+    values = dict(zip(_REVISION_COLUMNS, row))
+    values["authority_verified"] = _strict_bool(values["authority_verified"])
+    return DeclaredCanonRevision(**values)
+
+
+def _latest_revision(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    declaration_id: str,
+) -> DeclaredCanonRevision | None:
+    row = conn.execute(
+        "SELECT %s FROM declared_canon_revisions "
+        "WHERE guild_id=? AND declaration_id=? "
+        "ORDER BY revision_number DESC LIMIT 1" % ",".join(_REVISION_COLUMNS),
+        (int(guild_id), str(declaration_id or "")),
+    ).fetchone()
+    return _row_to_revision(row) if row else None
+
+
+def _existing_operation(
+    conn: sqlite3.Connection,
+    *,
+    authority: _VerifiedAuthority,
+) -> tuple[DeclaredCanonRevision, ...] | None:
+    rows = conn.execute(
+        "SELECT %s FROM declared_canon_revisions "
+        "WHERE guild_id=? AND operation_id=? ORDER BY rowid"
+        % ",".join(_REVISION_COLUMNS),
+        (authority.guild_id, authority.operation_id),
+    ).fetchall()
+    if not rows:
+        return None
+    revisions = tuple(_row_to_revision(row) for row in rows)
+    if any(
+        revision.operation != authority.operation
+        or revision.authority_actor != authority.authority_actor
+        or revision.authority_request_fingerprint
+        != authority.request_fingerprint
+        for revision in revisions
+    ):
+        raise DeclaredCanonError("authority_nonce_replay_mismatch")
+    for revision in revisions:
+        _require_trusted_stored_revision(revision)
+    return revisions
+
+
+def _requested_and_created_at(now: str) -> tuple[str, str]:
+    requested = ""
+    if str(now or "").strip():
+        requested = _parse_validity(now, field="created_at")[0]
+    return requested, requested or _utc_now()
+
+
+def _require_general_latest(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    declaration_id: str,
+    allow_terminal: bool = False,
+) -> DeclaredCanonRevision:
+    normalized_id = _validate_stable_token(
+        declaration_id, field="declaration_id", pattern=_STABLE_ID_RE
+    )
+    latest = _latest_revision(
+        conn, guild_id=int(guild_id), declaration_id=normalized_id
+    )
+    if latest is None or latest.source_system != GENERAL_DECLARATION_SOURCE:
+        raise DeclaredCanonError("general_declaration_not_found")
+    _require_trusted_stored_revision(latest)
+    if not allow_terminal and latest.lifecycle_status in TERMINAL_LIFECYCLES:
+        raise DeclaredCanonError("declaration_terminal")
+    return latest
+
+
+def add_declared_canon(
+    conn: sqlite3.Connection,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    subject_type: str,
+    subject_id: str,
+    object_subject_type: str = "",
+    object_subject_id: str = "",
+    predicate: str,
+    value: Any,
+    raw_declaration: str,
+    cleaned_summary: str = "",
+    domain: str,
+    claim_kind: str,
+    visibility: str = "internal",
+    eligible_routes: Iterable[str] = (),
+    valid_from: str = "",
+    valid_until: str = "",
+    now: str = "",
+) -> MutationResult:
+    _require_configured_owner_actor(
+        actor_user_id=actor_user_id, guild_id=guild_id
+    )
+    _require_schema(conn)
+    fields = _validated_claim_fields(
+        subject_type=subject_type,
+        subject_id=subject_id,
+        object_subject_type=object_subject_type,
+        object_subject_id=object_subject_id,
+        predicate=predicate,
+        value=value,
+        raw_declaration=raw_declaration,
+        cleaned_summary=cleaned_summary,
+        domain=domain,
+        claim_kind=claim_kind,
+        visibility=visibility,
+        eligible_routes=eligible_routes,
+        valid_from=valid_from,
+        valid_until=valid_until,
+    )
+    requested_now, created_at = _requested_and_created_at(now)
+    authority = _authorize_request(
+        actor_user_id=actor_user_id,
+        guild_id=guild_id,
+        operation="add",
+        authority_nonce=authority_nonce,
+        binding={"new_declaration": fields, "requested_now": requested_now},
+    )
+    operation_id = _operation_id(authority)
+    declaration_id = "dcl_" + _digest(
+        DECLARED_CANON_CONTRACT_VERSION,
+        int(guild_id),
+        authority.request_fingerprint,
+        authority.authority_receipt,
+    )[:32]
+    payload = _revision_payload(
+        declaration_id=declaration_id,
+        revision_number=1,
+        guild_id=int(guild_id),
+        source_system=GENERAL_DECLARATION_SOURCE,
+        source_row_id=declaration_id,
+        source_fingerprint=_general_fingerprint(fields),
+        operation="add",
+        operation_id=operation_id,
+        operation_reason="",
+        classification_mode="owner_explicit",
+        lifecycle_status="established",
+        previous_revision_id="",
+        correction_of_revision_id="",
+        supersedes_declaration_id="",
+        superseded_by_declaration_id="",
+        derived_from_source_ref="",
+        authority_request_fingerprint=authority.request_fingerprint,
+        authority_actor=authority.authority_actor,
+        created_at=created_at,
+        **fields,
+    )
+    with _immediate_transaction(conn):
+        existing = _existing_operation(conn, authority=authority)
+        if existing is not None:
+            return MutationResult(operation_id, existing)
+        _insert_revision(conn, payload)
+    return MutationResult(operation_id, (_row_to_revision(tuple(payload[c] for c in _REVISION_COLUMNS)),))
+
+
+def correct_declared_canon(
+    conn: sqlite3.Connection,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    declaration_id: str,
+    expected_revision_id: str,
+    subject_type: str,
+    subject_id: str,
+    object_subject_type: str = "",
+    object_subject_id: str = "",
+    predicate: str,
+    value: Any,
+    raw_declaration: str,
+    cleaned_summary: str = "",
+    domain: str,
+    claim_kind: str,
+    visibility: str = "internal",
+    eligible_routes: Iterable[str] = (),
+    valid_from: str = "",
+    valid_until: str = "",
+    reason: str = "",
+    now: str = "",
+) -> MutationResult:
+    _require_configured_owner_actor(
+        actor_user_id=actor_user_id, guild_id=guild_id
+    )
+    _require_schema(conn)
+    fields = _validated_claim_fields(
+        subject_type=subject_type,
+        subject_id=subject_id,
+        object_subject_type=object_subject_type,
+        object_subject_id=object_subject_id,
+        predicate=predicate,
+        value=value,
+        raw_declaration=raw_declaration,
+        cleaned_summary=cleaned_summary,
+        domain=domain,
+        claim_kind=claim_kind,
+        visibility=visibility,
+        eligible_routes=eligible_routes,
+        valid_from=valid_from,
+        valid_until=valid_until,
+    )
+    operation_reason = _bounded_text(
+        reason, field="operation_reason", maximum=500, required=False
+    )
+    expected_revision = _validate_stable_token(
+        expected_revision_id,
+        field="expected_revision_id",
+        pattern=_STABLE_ID_RE,
+    )
+    requested_now, created_at = _requested_and_created_at(now)
+    authority = _authorize_request(
+        actor_user_id=actor_user_id,
+        guild_id=guild_id,
+        operation="correct",
+        authority_nonce=authority_nonce,
+        binding={
+            "declaration_id": str(declaration_id or ""),
+            "expected_revision_id": expected_revision,
+            "replacement": fields,
+            "reason": operation_reason,
+            "requested_now": requested_now,
+        },
+    )
+    operation_id = _operation_id(authority)
+    with _immediate_transaction(conn):
+        existing = _existing_operation(conn, authority=authority)
+        if existing is not None:
+            return MutationResult(operation_id, existing)
+        prior = _require_general_latest(
+            conn, guild_id=guild_id, declaration_id=declaration_id
+        )
+        if prior.revision_id != expected_revision:
+            raise DeclaredCanonError("expected_revision_mismatch")
+        payload = _revision_payload(
+            declaration_id=prior.declaration_id,
+            revision_number=prior.revision_number + 1,
+            guild_id=int(guild_id),
+            source_system=GENERAL_DECLARATION_SOURCE,
+            source_row_id=prior.source_row_id,
+            source_fingerprint=_general_fingerprint(fields),
+            operation="correct",
+            operation_id=operation_id,
+            operation_reason=operation_reason,
+            classification_mode="owner_explicit",
+            lifecycle_status=prior.lifecycle_status,
+            previous_revision_id=prior.revision_id,
+            correction_of_revision_id=prior.revision_id,
+            supersedes_declaration_id=prior.supersedes_declaration_id,
+            superseded_by_declaration_id=prior.superseded_by_declaration_id,
+            derived_from_source_ref=prior.derived_from_source_ref,
+            authority_request_fingerprint=authority.request_fingerprint,
+            authority_actor=authority.authority_actor,
+            created_at=created_at,
+            **fields,
+        )
+        _insert_revision(conn, payload)
+    return MutationResult(operation_id, (_row_to_revision(tuple(payload[c] for c in _REVISION_COLUMNS)),))
+
+
+def retire_declared_canon(
+    conn: sqlite3.Connection,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    declaration_id: str,
+    expected_revision_id: str,
+    reason: str = "",
+    now: str = "",
+) -> MutationResult:
+    _require_configured_owner_actor(
+        actor_user_id=actor_user_id, guild_id=guild_id
+    )
+    _require_schema(conn)
+    expected_revision = _validate_stable_token(
+        expected_revision_id,
+        field="expected_revision_id",
+        pattern=_STABLE_ID_RE,
+    )
+    requested_now, created_at = _requested_and_created_at(now)
+    operation_reason = _bounded_text(
+        reason, field="operation_reason", maximum=500, required=False
+    )
+    authority = _authorize_request(
+        actor_user_id=actor_user_id,
+        guild_id=guild_id,
+        operation="retire",
+        authority_nonce=authority_nonce,
+        binding={
+            "declaration_id": str(declaration_id or ""),
+            "expected_revision_id": expected_revision,
+            "reason": operation_reason,
+            "requested_now": requested_now,
+        },
+    )
+    operation_id = _operation_id(authority)
+    with _immediate_transaction(conn):
+        existing = _existing_operation(conn, authority=authority)
+        if existing is not None:
+            return MutationResult(operation_id, existing)
+        prior = _require_general_latest(
+            conn, guild_id=guild_id, declaration_id=declaration_id
+        )
+        if prior.revision_id != expected_revision:
+            raise DeclaredCanonError("expected_revision_mismatch")
+        payload = _copy_revision_payload(
+            prior,
+            operation="retire",
+            operation_id=operation_id,
+            operation_reason=operation_reason,
+            authority=authority,
+            created_at=created_at,
+            lifecycle_status="retired",
+        )
+        _insert_revision(conn, payload)
+    return MutationResult(operation_id, (_row_to_revision(tuple(payload[c] for c in _REVISION_COLUMNS)),))
+
+
+def change_declared_canon_status(
+    conn: sqlite3.Connection,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    declaration_id: str,
+    expected_revision_id: str,
+    lifecycle_status: str,
+    reason: str = "",
+    now: str = "",
+) -> MutationResult:
+    _require_configured_owner_actor(
+        actor_user_id=actor_user_id, guild_id=guild_id
+    )
+    _require_schema(conn)
+    normalized_status = str(lifecycle_status or "").strip().casefold()
+    if normalized_status not in {"established", "contested", "resolved"}:
+        raise DeclaredCanonError("invalid_status_change")
+    expected_revision = _validate_stable_token(
+        expected_revision_id,
+        field="expected_revision_id",
+        pattern=_STABLE_ID_RE,
+    )
+    requested_now, created_at = _requested_and_created_at(now)
+    operation_reason = _bounded_text(
+        reason, field="operation_reason", maximum=500, required=False
+    )
+    authority = _authorize_request(
+        actor_user_id=actor_user_id,
+        guild_id=guild_id,
+        operation="status",
+        authority_nonce=authority_nonce,
+        binding={
+            "declaration_id": str(declaration_id or ""),
+            "expected_revision_id": expected_revision,
+            "lifecycle_status": normalized_status,
+            "reason": operation_reason,
+            "requested_now": requested_now,
+        },
+    )
+    operation_id = _operation_id(authority)
+    with _immediate_transaction(conn):
+        existing = _existing_operation(conn, authority=authority)
+        if existing is not None:
+            return MutationResult(operation_id, existing)
+        prior = _require_general_latest(
+            conn, guild_id=guild_id, declaration_id=declaration_id
+        )
+        if prior.revision_id != expected_revision:
+            raise DeclaredCanonError("expected_revision_mismatch")
+        if prior.lifecycle_status == normalized_status:
+            raise DeclaredCanonError("status_unchanged")
+        payload = _copy_revision_payload(
+            prior,
+            operation="status",
+            operation_id=operation_id,
+            operation_reason=operation_reason,
+            authority=authority,
+            created_at=created_at,
+            lifecycle_status=normalized_status,
+        )
+        _insert_revision(conn, payload)
+    return MutationResult(operation_id, (_row_to_revision(tuple(payload[c] for c in _REVISION_COLUMNS)),))
+
+
+def supersede_declared_canon(
+    conn: sqlite3.Connection,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    declaration_id: str,
+    expected_revision_id: str,
+    replacement_declaration_id: str,
+    expected_replacement_revision_id: str,
+    reason: str = "",
+    now: str = "",
+) -> MutationResult:
+    """Atomically mark one declaration superseded and link its replacement."""
+
+    _require_configured_owner_actor(
+        actor_user_id=actor_user_id, guild_id=guild_id
+    )
+    _require_schema(conn)
+    normalized_declaration_id = _validate_stable_token(
+        declaration_id, field="declaration_id", pattern=_STABLE_ID_RE
+    )
+    normalized_replacement_id = _validate_stable_token(
+        replacement_declaration_id,
+        field="replacement_declaration_id",
+        pattern=_STABLE_ID_RE,
+    )
+    if normalized_declaration_id == normalized_replacement_id:
+        raise DeclaredCanonError("self_supersession")
+    expected_revision = _validate_stable_token(
+        expected_revision_id,
+        field="expected_revision_id",
+        pattern=_STABLE_ID_RE,
+    )
+    expected_replacement_revision = _validate_stable_token(
+        expected_replacement_revision_id,
+        field="expected_replacement_revision_id",
+        pattern=_STABLE_ID_RE,
+    )
+    requested_now, created_at = _requested_and_created_at(now)
+    operation_reason = _bounded_text(
+        reason, field="operation_reason", maximum=500, required=False
+    )
+    authority = _authorize_request(
+        actor_user_id=actor_user_id,
+        guild_id=guild_id,
+        operation="supersede",
+        authority_nonce=authority_nonce,
+        binding={
+            "declaration_id": normalized_declaration_id,
+            "expected_revision_id": expected_revision,
+            "replacement_declaration_id": normalized_replacement_id,
+            "expected_replacement_revision_id": expected_replacement_revision,
+            "reason": operation_reason,
+            "requested_now": requested_now,
+        },
+    )
+    operation_id = _operation_id(authority)
+    with _immediate_transaction(conn):
+        existing = _existing_operation(conn, authority=authority)
+        if existing is not None:
+            by_declaration = {item.declaration_id: item for item in existing}
+            return MutationResult(
+                operation_id,
+                (
+                    by_declaration[normalized_declaration_id],
+                    by_declaration[normalized_replacement_id],
+                ),
+            )
+        prior = _require_general_latest(
+            conn, guild_id=guild_id, declaration_id=normalized_declaration_id
+        )
+        replacement = _require_general_latest(
+            conn, guild_id=guild_id, declaration_id=normalized_replacement_id
+        )
+        if prior.revision_id != expected_revision:
+            raise DeclaredCanonError("expected_revision_mismatch")
+        if replacement.revision_id != expected_replacement_revision:
+            raise DeclaredCanonError("expected_replacement_revision_mismatch")
+        replacement_payload = _copy_revision_payload(
+            replacement,
+            operation="supersede",
+            operation_id=operation_id,
+            operation_reason=operation_reason,
+            authority=authority,
+            created_at=created_at,
+            supersedes_declaration_id=prior.declaration_id,
+        )
+        prior_payload = _copy_revision_payload(
+            prior,
+            operation="supersede",
+            operation_id=operation_id,
+            operation_reason=operation_reason,
+            authority=authority,
+            created_at=created_at,
+            lifecycle_status="superseded",
+            superseded_by_declaration_id=replacement.declaration_id,
+        )
+        _insert_revision(conn, replacement_payload)
+        _insert_revision(conn, prior_payload)
+    return MutationResult(
+        operation_id,
+        (
+            _row_to_revision(tuple(prior_payload[c] for c in _REVISION_COLUMNS)),
+            _row_to_revision(tuple(replacement_payload[c] for c in _REVISION_COLUMNS)),
+        ),
+    )
+
+
+def _broadcast_row(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    row_id: int,
+) -> dict[str, Any] | None:
+    columns = _table_columns(conn, BROADCAST_MEMORY_SOURCE)
+    required = set(_BROADCAST_SOURCE_REQUIRED_FIELDS)
+    if not required.issubset(set(columns)):
+        return None
+    cursor = conn.execute(
+        "SELECT * FROM broadcast_memory WHERE guild_id=? AND id=? LIMIT 1",
+        (int(guild_id), int(row_id)),
+    )
+    row = cursor.fetchone()
+    returned_columns = tuple(
+        str(item[0] or "") for item in (cursor.description or ())
+    )
+    return dict(zip(returned_columns, row)) if row else None
+
+
+def _canonical_broadcast_source_value(value: Any) -> tuple[str, Any]:
+    """Give each SQLite scalar a deterministic, type-explicit encoding."""
+
+    if value is None:
+        return ("null", None)
+    if isinstance(value, bool):
+        return ("bool", bool(value))
+    if isinstance(value, int):
+        return ("int", str(value))
+    if isinstance(value, float):
+        return ("float", value.hex())
+    if isinstance(value, str):
+        return ("text", value)
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return ("blob", bytes(value).hex())
+    raise DeclaredCanonError("broadcast_source_value_unversioned")
+
+
+def broadcast_source_fingerprint(row: Mapping[str, Any]) -> str:
+    """Bind classification to the complete versioned Broadcast source row.
+
+    The minimum known schema must be present, but it is not an allowlist. Every
+    returned column is sorted by name and included with a type-explicit scalar
+    encoding. Unknown/future columns therefore stale an existing approval even
+    when their current value is NULL or appears operationally unrelated.
+    The sidecar stores only the hash; Broadcast remains the content authority.
+    """
+
+    required = _BROADCAST_SOURCE_REQUIRED_FIELDS
+    if any(field not in row for field in required):
+        raise DeclaredCanonError("broadcast_source_unversioned")
+    normalized: list[tuple[str, tuple[str, Any]]] = []
+    seen: set[str] = set()
+    for raw_name in row:
+        if not isinstance(raw_name, str) or not raw_name:
+            raise DeclaredCanonError("broadcast_source_column_unversioned")
+        name = str(raw_name)
+        if name in seen:
+            raise DeclaredCanonError("broadcast_source_column_ambiguous")
+        seen.add(name)
+        normalized.append((name, _canonical_broadcast_source_value(row[raw_name])))
+    canonical_row = tuple(sorted(normalized, key=lambda item: item[0]))
+    return "bsrc_" + _digest(
+        DECLARED_CANON_CONTRACT_VERSION,
+        BROADCAST_SOURCE_FINGERPRINT_VERSION,
+        BROADCAST_MEMORY_SOURCE,
+        canonical_row,
+    )[:40]
+
+
+def _scope_tokens(value: Any) -> frozenset[str]:
+    return frozenset(
+        token.strip().casefold().replace("-", "_")
+        for token in re.split(r"[,/;\s]+", str(value or ""))
+        if token.strip()
+    )
+
+
+def _validate_broadcast_public_routes(
+    *, routes_json: str, source_scopes: frozenset[str]
+) -> None:
+    if source_scopes.difference(BROADCAST_USAGE_SCOPES):
+        raise DeclaredCanonError("broadcast_usage_scope_unrecognized")
+    try:
+        decoded = json.loads(routes_json or "[]")
+    except (TypeError, json.JSONDecodeError):
+        raise DeclaredCanonError("invalid_eligible_routes_json")
+    if not isinstance(decoded, list):
+        raise DeclaredCanonError("invalid_eligible_routes_json")
+    routes = tuple(str(route) for route in decoded)
+    if any(route not in ALLOWED_ELIGIBLE_ROUTES for route in routes):
+        raise DeclaredCanonError("unknown_eligible_route")
+    for route in routes:
+        required_scopes = BROADCAST_PUBLIC_ROUTE_SCOPES.get(str(route))
+        if required_scopes is not None and not required_scopes.intersection(
+            source_scopes
+        ):
+            raise DeclaredCanonError("broadcast_route_scope_widening")
+
+
+def _broadcast_validity_state(row: Mapping[str, Any], now: datetime) -> str:
+    return _validity_window_state(
+        row.get("created_at"), row.get("valid_until"), now
+    )
+
+
+def _broadcast_lifecycle(row: Mapping[str, Any], now: datetime) -> str:
+    status = str(row.get("status") or "").strip().casefold()
+    if status not in {"active", "resolved", "superseded"}:
+        raise DeclaredCanonError("broadcast_source_status_unrecognized")
+    if row.get("superseded_by_id") and status != "superseded":
+        raise DeclaredCanonError("broadcast_source_supersession_inconsistent")
+    if status == "superseded":
+        return "superseded"
+    if status == "resolved":
+        return "resolved"
+    validity = _broadcast_validity_state(row, now)
+    if validity == "invalid":
+        raise DeclaredCanonError("broadcast_source_validity_invalid")
+    return "established"
+
+
+def classify_broadcast_memory(
+    conn: sqlite3.Connection,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    broadcast_row_id: int,
+    expected_source_fingerprint: str,
+    expected_revision_id: str = "",
+    subject_type: str,
+    subject_id: str,
+    object_subject_type: str = "",
+    object_subject_id: str = "",
+    predicate: str = "",
+    domain: str = "",
+    claim_kind: str = "",
+    visibility: str = "internal",
+    eligible_routes: Iterable[str] = (),
+    reason: str = "",
+    now: str = "",
+) -> MutationResult:
+    """Append typed owner metadata for one Broadcast row without copying it.
+
+    The six current parser types may use versioned defaults.  An exact legacy
+    type remains zero-write review-only unless the owner supplies an explicit
+    domain and claim kind; it is never coerced into a current type.
+    """
+
+    _require_configured_owner_actor(
+        actor_user_id=actor_user_id, guild_id=guild_id
+    )
+    _require_schema(conn)
+    normalized_subject_type = str(subject_type or "").strip().casefold()
+    if normalized_subject_type not in GENERAL_SUBJECT_TYPES:
+        raise DeclaredCanonError("invalid_subject_type")
+    normalized_subject_id = _validate_stable_token(
+        subject_id, field="subject_id", pattern=_STABLE_ID_RE
+    )
+    expected_fingerprint = str(expected_source_fingerprint or "").strip()
+    if not re.fullmatch(r"bsrc_[0-9a-f]{40}", expected_fingerprint):
+        raise DeclaredCanonError("expected_source_fingerprint_required")
+    expected_revision = str(expected_revision_id or "").strip()
+    if expected_revision:
+        expected_revision = _validate_stable_token(
+            expected_revision,
+            field="expected_revision_id",
+            pattern=_STABLE_ID_RE,
+        )
+    normalized_visibility = str(visibility or "").strip().casefold()
+    if normalized_visibility not in VISIBILITIES:
+        raise DeclaredCanonError("invalid_visibility")
+    routes_json = _canonical_routes(eligible_routes, normalized_visibility)
+    requested_domain = str(domain or "").strip().casefold()
+    if requested_domain and requested_domain not in CANON_DOMAINS:
+        raise DeclaredCanonError("invalid_domain")
+    requested_claim_kind = str(claim_kind or "").strip().casefold()
+    if requested_claim_kind and requested_claim_kind not in CLAIM_KINDS:
+        raise DeclaredCanonError("invalid_claim_kind")
+    operation_reason = _bounded_text(
+        reason, field="operation_reason", maximum=500, required=False
+    )
+    requested_now, created_at = _requested_and_created_at(now)
+    parsed_now = _parse_validity(created_at, field="created_at")[1]
+    assert parsed_now is not None
+    request_binding = {
+        "broadcast_row_id": int(broadcast_row_id or 0),
+        "expected_source_fingerprint": expected_fingerprint,
+        "expected_revision_id": expected_revision,
+        "subject_type": normalized_subject_type,
+        "subject_id": normalized_subject_id,
+        "object_subject_type": str(object_subject_type or "").strip().casefold(),
+        "object_subject_id": str(object_subject_id or "").strip(),
+        "predicate": str(predicate or "").strip().casefold(),
+        "requested_domain": requested_domain,
+        "requested_claim_kind": requested_claim_kind,
+        "visibility": normalized_visibility,
+        "eligible_routes_json": routes_json,
+        "reason": operation_reason,
+        "requested_now": requested_now,
+    }
+    authority = _authorize_request(
+        actor_user_id=actor_user_id,
+        guild_id=guild_id,
+        operation="classify_broadcast",
+        authority_nonce=authority_nonce,
+        binding=request_binding,
+    )
+    operation_id = _operation_id(authority)
+    with _immediate_transaction(conn):
+        existing = _existing_operation(conn, authority=authority)
+        if existing is not None:
+            return MutationResult(operation_id, existing)
+        source = _broadcast_row(
+            conn, guild_id=int(guild_id), row_id=int(broadcast_row_id or 0)
+        )
+        if source is None:
+            raise DeclaredCanonError("broadcast_source_not_found")
+        source_fingerprint = broadcast_source_fingerprint(source)
+        if source_fingerprint != expected_fingerprint:
+            raise DeclaredCanonError("expected_source_fingerprint_mismatch")
+        entry_type = str(source.get("entry_type") or "").strip()
+        defaults = BROADCAST_TYPE_DEFAULTS.get(entry_type)
+        if defaults is None:
+            if not requested_domain or not requested_claim_kind:
+                raise DeclaredCanonError("legacy_type_review_only")
+            default_domain, default_claim_kind = (
+                requested_domain,
+                requested_claim_kind,
+            )
+        else:
+            default_domain, default_claim_kind = defaults
+        normalized_domain = requested_domain or default_domain
+        normalized_claim_kind = requested_claim_kind or default_claim_kind
+        normalized_predicate = str(predicate or entry_type).strip().casefold()
+        normalized_predicate = _validate_stable_token(
+            normalized_predicate, field="predicate", pattern=_PREDICATE_RE
+        )
+        normalized_object_type = str(object_subject_type or "").strip().casefold()
+        normalized_object_id = str(object_subject_id or "").strip()
+        if normalized_claim_kind == "relationship":
+            if not predicate:
+                raise DeclaredCanonError("relationship_predicate_required")
+            if normalized_object_type not in GENERAL_SUBJECT_TYPES:
+                raise DeclaredCanonError(
+                    "relationship_object_subject_type_required"
+                )
+            normalized_object_id = _validate_stable_token(
+                normalized_object_id,
+                field="object_subject_id",
+                pattern=_STABLE_ID_RE,
+            )
+        elif normalized_object_type or normalized_object_id:
+            raise DeclaredCanonError("relationship_object_not_allowed")
+        if normalized_subject_type == "relationship" and normalized_claim_kind != "relationship":
+            raise DeclaredCanonError("relationship_claim_kind_required")
+        scopes = _scope_tokens(source.get("usage_scope"))
+        lifecycle = _broadcast_lifecycle(source, parsed_now)
+        if entry_type == "moderation_context" and normalized_visibility in PUBLIC_VISIBILITIES:
+            raise DeclaredCanonError("moderation_context_internal_only")
+        if normalized_visibility in PUBLIC_VISIBILITIES:
+            if lifecycle != "established" or _broadcast_validity_state(
+                source, parsed_now
+            ) not in {"unbounded", "current"}:
+                raise DeclaredCanonError("broadcast_source_not_current_for_public")
+            if not _strict_bool(source.get("public_safe")):
+                raise DeclaredCanonError("broadcast_source_not_public_safe")
+            if "internal" in scopes:
+                raise DeclaredCanonError("broadcast_internal_scope_veto")
+            _validate_broadcast_public_routes(
+                routes_json=routes_json, source_scopes=scopes
+            )
+        declaration_id = "dcl_" + _digest(
+            DECLARED_CANON_CONTRACT_VERSION,
+            int(guild_id),
+            BROADCAST_MEMORY_SOURCE,
+            int(broadcast_row_id),
+        )[:32]
+        prior = _latest_revision(
+            conn, guild_id=int(guild_id), declaration_id=declaration_id
+        )
+        if prior and (
+            prior.source_system != BROADCAST_MEMORY_SOURCE
+            or prior.source_row_id != str(int(broadcast_row_id))
+        ):
+            raise DeclaredCanonError("broadcast_declaration_identity_collision")
+        if prior is not None:
+            _require_trusted_stored_revision(prior)
+        if prior is None and expected_revision:
+            raise DeclaredCanonError("expected_revision_mismatch")
+        if prior is not None and prior.revision_id != expected_revision:
+            raise DeclaredCanonError("expected_revision_mismatch")
+        valid_from = str(source.get("created_at") or "")
+        valid_until = str(source.get("valid_until") or "")
+        if valid_from:
+            _parse_validity(valid_from, field="valid_from")
+        if valid_until:
+            _parse_validity(valid_until, field="valid_until")
+        payload = _revision_payload(
+            declaration_id=declaration_id,
+            revision_number=(prior.revision_number + 1 if prior else 1),
+            guild_id=int(guild_id),
+            source_system=BROADCAST_MEMORY_SOURCE,
+            source_row_id=str(int(broadcast_row_id)),
+            source_fingerprint=source_fingerprint,
+            operation="classify_broadcast",
+            operation_id=operation_id,
+            operation_reason=operation_reason,
+            classification_mode=(
+                "owner_explicit_legacy_mapping"
+                if defaults is None
+                else "owner_explicit_mapping_override"
+                if requested_domain or requested_claim_kind or predicate
+                else "owner_explicit_default_mapping"
+            ),
+            raw_declaration="",
+            cleaned_summary="",
+            subject_type=normalized_subject_type,
+            subject_id=normalized_subject_id,
+            object_subject_type=normalized_object_type,
+            object_subject_id=normalized_object_id,
+            predicate=normalized_predicate,
+            value_json="",
+            domain=normalized_domain,
+            claim_kind=normalized_claim_kind,
+            visibility=normalized_visibility,
+            eligible_routes_json=routes_json,
+            valid_from=valid_from,
+            valid_until=valid_until,
+            lifecycle_status=lifecycle,
+            previous_revision_id=(prior.revision_id if prior else ""),
+            correction_of_revision_id=(prior.revision_id if prior else ""),
+            supersedes_declaration_id="",
+            superseded_by_declaration_id="",
+            derived_from_source_ref="",
+            authority_request_fingerprint=authority.request_fingerprint,
+            authority_actor=authority.authority_actor,
+            created_at=created_at,
+        )
+        _insert_revision(conn, payload)
+    return MutationResult(operation_id, (_row_to_revision(tuple(payload[c] for c in _REVISION_COLUMNS)),))
+
+
+def _stored_authority_valid(revision: DeclaredCanonRevision) -> bool:
+    try:
+        payload = {
+            column: getattr(revision, column)
+            for column in _REVISION_COLUMNS
+        }
+        # SQLite stores the verification bit as integer 0/1; normalize the
+        # dataclass bool back to that canonical storage representation before
+        # recomputing either immutable digest.
+        payload["authority_verified"] = (
+            1 if _strict_bool(revision.authority_verified) else 0
+        )
+        operation = str(revision.operation or "")
+        prefix = "owner_command:%s:%s:%s:" % (
+            DECLARED_CANON_CONTRACT_VERSION,
+            INTERNAL_AUTHORITY_RECEIPT_VERSION,
+            operation,
+        )
+        if not (
+            _strict_bool(revision.authority_verified)
+            and str(revision.contract_version or "")
+            == DECLARED_CANON_CONTRACT_VERSION
+            and operation in _MUTATION_OPERATIONS
+            and str(revision.operation_id or "").startswith("op_")
+            and re.fullmatch(r"op_[0-9a-f]{32}", revision.operation_id or "")
+            and re.fullmatch(
+                r"req_[0-9a-f]{48}",
+                revision.authority_request_fingerprint or "",
+            )
+            and str(revision.authority_actor or "")
+            == "discord_user:%s" % _configured_owner_user_id()
+            and str(revision.authority_receipt or "").startswith(prefix)
+        ):
+            return False
+        expected_receipt = _stored_authority_receipt(payload)
+        if str(revision.authority_receipt or "") != expected_receipt:
+            return False
+        expected_revision_id = "drev_" + _digest(
+            *(payload[column] for column in _REVISION_COLUMNS
+              if column != "revision_id")
+        )[:40]
+        return str(revision.revision_id or "") == expected_revision_id
+    except (DeclaredCanonError, AttributeError, TypeError, ValueError):
+        return False
+
+
+def _revision_subject_shape_valid(revision: DeclaredCanonRevision) -> bool:
+    if (
+        revision.subject_type not in GENERAL_SUBJECT_TYPES
+        or not _STABLE_ID_RE.fullmatch(revision.subject_id)
+        or not _PREDICATE_RE.fullmatch(revision.predicate)
+    ):
+        return False
+    if revision.claim_kind == "relationship":
+        return bool(
+            revision.object_subject_type in GENERAL_SUBJECT_TYPES
+            and _STABLE_ID_RE.fullmatch(revision.object_subject_id)
+        )
+    return not revision.object_subject_type and not revision.object_subject_id
+
+
+def _require_revision_contract(revision: DeclaredCanonRevision) -> None:
+    if revision.source_system not in _SOURCE_SYSTEMS:
+        raise DeclaredCanonError("invalid_source_system")
+    if revision.domain not in CANON_DOMAINS:
+        raise DeclaredCanonError("invalid_domain")
+    if revision.claim_kind not in CLAIM_KINDS:
+        raise DeclaredCanonError("invalid_claim_kind")
+    if revision.visibility not in VISIBILITIES:
+        raise DeclaredCanonError("invalid_visibility")
+    if revision.lifecycle_status not in GENERAL_LIFECYCLES:
+        raise DeclaredCanonError("invalid_lifecycle_status")
+    if not _revision_subject_shape_valid(revision):
+        raise DeclaredCanonError("classification_subject_link_invalid")
+    try:
+        routes = json.loads(revision.eligible_routes_json or "[]")
+    except (TypeError, json.JSONDecodeError):
+        raise DeclaredCanonError("invalid_eligible_routes_json")
+    if not isinstance(routes, list):
+        raise DeclaredCanonError("invalid_eligible_routes_json")
+    if _canonical_routes(routes, revision.visibility) != revision.eligible_routes_json:
+        raise DeclaredCanonError("noncanonical_eligible_routes")
+    _parse_validity(revision.valid_from, field="valid_from")
+    _parse_validity(revision.valid_until, field="valid_until")
+    if revision.source_system == GENERAL_DECLARATION_SOURCE:
+        if revision.classification_mode != "owner_explicit":
+            raise DeclaredCanonError("general_classification_mode_invalid")
+        try:
+            json.loads(revision.value_json)
+        except (TypeError, json.JSONDecodeError):
+            raise DeclaredCanonError("invalid_typed_value")
+    else:
+        if revision.classification_mode not in {
+            "owner_explicit_default_mapping",
+            "owner_explicit_mapping_override",
+            "owner_explicit_legacy_mapping",
+        }:
+            raise DeclaredCanonError("broadcast_classification_mode_invalid")
+        if (
+            revision.raw_declaration
+            or revision.cleaned_summary
+            or revision.value_json
+            or revision.derived_from_source_ref
+        ):
+            raise DeclaredCanonError("broadcast_sidecar_content_or_projection_invalid")
+
+
+def _require_trusted_stored_revision(
+    revision: DeclaredCanonRevision,
+) -> None:
+    """Reject any prior row that cannot safely anchor a new revision."""
+
+    if not _stored_authority_valid(revision):
+        raise DeclaredCanonError("stored_authority_invalid")
+    _require_revision_contract(revision)
+    if revision.source_system == GENERAL_DECLARATION_SOURCE:
+        if revision.source_row_id != revision.declaration_id:
+            raise DeclaredCanonError("general_source_identity_invalid")
+        fields = {
+            "raw_declaration": revision.raw_declaration,
+            "cleaned_summary": revision.cleaned_summary,
+            "subject_type": revision.subject_type,
+            "subject_id": revision.subject_id,
+            "object_subject_type": revision.object_subject_type,
+            "object_subject_id": revision.object_subject_id,
+            "predicate": revision.predicate,
+            "value_json": revision.value_json,
+            "domain": revision.domain,
+            "claim_kind": revision.claim_kind,
+            "visibility": revision.visibility,
+            "eligible_routes_json": revision.eligible_routes_json,
+            "valid_from": revision.valid_from,
+            "valid_until": revision.valid_until,
+        }
+        if _general_fingerprint(fields) != revision.source_fingerprint:
+            raise DeclaredCanonError("declared_source_fingerprint_invalid")
+        return
+    if revision.source_system == BROADCAST_MEMORY_SOURCE:
+        try:
+            source_row_id = int(revision.source_row_id)
+        except (TypeError, ValueError):
+            raise DeclaredCanonError("broadcast_source_identity_invalid")
+        expected_declaration_id = "dcl_" + _digest(
+            DECLARED_CANON_CONTRACT_VERSION,
+            int(revision.guild_id),
+            BROADCAST_MEMORY_SOURCE,
+            source_row_id,
+        )[:32]
+        if revision.declaration_id != expected_declaration_id:
+            raise DeclaredCanonError("broadcast_source_identity_invalid")
+        if not re.fullmatch(
+            r"bsrc_[0-9a-f]{40}",
+            str(revision.source_fingerprint or ""),
+        ):
+            raise DeclaredCanonError("broadcast_source_fingerprint_invalid")
+        return
+    raise DeclaredCanonError("invalid_source_system")
+
+
+def validate_current_declared_canon_revision(
+    conn: sqlite3.Connection,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    declaration_id: str,
+    expected_revision_id: str,
+    expected_source_fingerprint: str,
+    now: str = "",
+) -> DeclaredCanonRevision:
+    """Validate one exact current revision inside a coherent read snapshot."""
+
+    with _read_snapshot(conn):
+        return _validate_current_declared_canon_revision(
+            conn,
+            actor_user_id=actor_user_id,
+            authority_nonce=authority_nonce,
+            guild_id=guild_id,
+            declaration_id=declaration_id,
+            expected_revision_id=expected_revision_id,
+            expected_source_fingerprint=expected_source_fingerprint,
+            now=now,
+        )
+
+
+def _validate_current_declared_canon_revision(
+    conn: sqlite3.Connection,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    declaration_id: str,
+    expected_revision_id: str,
+    expected_source_fingerprint: str,
+    now: str = "",
+) -> DeclaredCanonRevision:
+    """Read-only foundation validator for a later Ledger integration.
+
+    This function does not project or write anything.  The caller must be an
+    already-authenticated Discord command boundary and must present the exact
+    owner-reviewed revision and source fingerprint.  Only a current,
+    source-intersecting ``established`` revision is returned.
+    """
+
+    _require_configured_owner_actor(
+        actor_user_id=actor_user_id, guild_id=guild_id
+    )
+    before = int(conn.total_changes or 0)
+    _require_schema(conn)
+    normalized_declaration_id = _validate_stable_token(
+        declaration_id, field="declaration_id", pattern=_STABLE_ID_RE
+    )
+    normalized_revision_id = _validate_stable_token(
+        expected_revision_id,
+        field="expected_revision_id",
+        pattern=_STABLE_ID_RE,
+    )
+    normalized_fingerprint = str(expected_source_fingerprint or "").strip()
+    if not re.fullmatch(r"(?:src|bsrc)_[0-9a-f]{40}", normalized_fingerprint):
+        raise DeclaredCanonError("expected_source_fingerprint_required")
+    requested_now, evaluation_now = _requested_and_created_at(now)
+    parsed_now = _parse_validity(evaluation_now, field="validation_now")[1]
+    assert parsed_now is not None
+    _authorize_request(
+        actor_user_id=actor_user_id,
+        guild_id=guild_id,
+        operation="preview_declared",
+        authority_nonce=authority_nonce,
+        binding={
+            "validation": "current_established_revision",
+            "declaration_id": normalized_declaration_id,
+            "expected_revision_id": normalized_revision_id,
+            "expected_source_fingerprint": normalized_fingerprint,
+            "requested_now": requested_now,
+        },
+    )
+    revision = _latest_revision(
+        conn,
+        guild_id=int(guild_id),
+        declaration_id=normalized_declaration_id,
+    )
+    if revision is None or revision.revision_id != normalized_revision_id:
+        raise DeclaredCanonError("expected_revision_mismatch")
+    if revision.source_fingerprint != normalized_fingerprint:
+        raise DeclaredCanonError("expected_source_fingerprint_mismatch")
+    if not _stored_authority_valid(revision):
+        raise DeclaredCanonError("stored_authority_invalid")
+    if revision.lifecycle_status != "established":
+        raise DeclaredCanonError("declared_revision_not_established")
+    _require_revision_contract(revision)
+    if _validity_window_state(
+        revision.valid_from, revision.valid_until, parsed_now
+    ) not in {"unbounded", "current"}:
+        raise DeclaredCanonError("declared_revision_not_current")
+    if revision.source_system == GENERAL_DECLARATION_SOURCE:
+        if revision.source_row_id != revision.declaration_id:
+            raise DeclaredCanonError("general_source_identity_invalid")
+        fields = {
+            "raw_declaration": revision.raw_declaration,
+            "cleaned_summary": revision.cleaned_summary,
+            "subject_type": revision.subject_type,
+            "subject_id": revision.subject_id,
+            "object_subject_type": revision.object_subject_type,
+            "object_subject_id": revision.object_subject_id,
+            "predicate": revision.predicate,
+            "value_json": revision.value_json,
+            "domain": revision.domain,
+            "claim_kind": revision.claim_kind,
+            "visibility": revision.visibility,
+            "eligible_routes_json": revision.eligible_routes_json,
+            "valid_from": revision.valid_from,
+            "valid_until": revision.valid_until,
+        }
+        if _general_fingerprint(fields) != normalized_fingerprint:
+            raise DeclaredCanonError("declared_source_fingerprint_invalid")
+    elif revision.source_system == BROADCAST_MEMORY_SOURCE:
+        try:
+            source_row_id = int(revision.source_row_id)
+        except (TypeError, ValueError):
+            raise DeclaredCanonError("broadcast_source_identity_invalid")
+        source = _broadcast_row(
+            conn, guild_id=int(guild_id), row_id=source_row_id
+        )
+        if source is None:
+            raise DeclaredCanonError("broadcast_source_not_found")
+        if broadcast_source_fingerprint(source) != normalized_fingerprint:
+            raise DeclaredCanonError("expected_source_fingerprint_mismatch")
+        if _broadcast_lifecycle(source, parsed_now) != "established" or (
+            _broadcast_validity_state(source, parsed_now)
+            not in {"unbounded", "current"}
+        ):
+            raise DeclaredCanonError("broadcast_source_not_current")
+        entry_type = str(source.get("entry_type") or "")
+        if entry_type not in BROADCAST_TYPE_DEFAULTS and (
+            revision.classification_mode != "owner_explicit_legacy_mapping"
+        ):
+            raise DeclaredCanonError("legacy_type_review_only")
+        if revision.visibility in PUBLIC_VISIBILITIES:
+            scopes = _scope_tokens(source.get("usage_scope"))
+            if (
+                not _strict_bool(source.get("public_safe"))
+                or "internal" in scopes
+                or entry_type == "moderation_context"
+            ):
+                raise DeclaredCanonError("broadcast_public_eligibility_invalid")
+            _validate_broadcast_public_routes(
+                routes_json=revision.eligible_routes_json,
+                source_scopes=scopes,
+            )
+    else:
+        raise DeclaredCanonError("invalid_source_system")
+    if int(conn.total_changes or 0) != before:
+        raise DeclaredCanonError("read_validator_mutated_state")
+    return revision
+
+
+def validate_latest_declared_canon_revision(
+    conn: sqlite3.Connection,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    declaration_id: str,
+    expected_revision_id: str,
+    expected_source_fingerprint: str,
+    expected_lifecycle_status: str,
+    now: str = "",
+) -> DeclaredCanonRevision:
+    """Validate one exact terminal revision inside a coherent read snapshot."""
+
+    with _read_snapshot(conn):
+        return _validate_latest_declared_canon_revision(
+            conn,
+            actor_user_id=actor_user_id,
+            authority_nonce=authority_nonce,
+            guild_id=guild_id,
+            declaration_id=declaration_id,
+            expected_revision_id=expected_revision_id,
+            expected_source_fingerprint=expected_source_fingerprint,
+            expected_lifecycle_status=expected_lifecycle_status,
+            now=now,
+        )
+
+
+def _validate_latest_declared_canon_revision(
+    conn: sqlite3.Connection,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    declaration_id: str,
+    expected_revision_id: str,
+    expected_source_fingerprint: str,
+    expected_lifecycle_status: str,
+    now: str = "",
+) -> DeclaredCanonRevision:
+    """Validate an exact latest revision, including historical/terminal state.
+
+    This read-only API exists so a later Ledger adapter can project an explicit
+    retraction/supersession instead of leaving an older established projection
+    effective.  It does not call terminal records current and does not write.
+    """
+
+    _require_configured_owner_actor(
+        actor_user_id=actor_user_id, guild_id=guild_id
+    )
+    before = int(conn.total_changes or 0)
+    _require_schema(conn)
+    normalized_declaration_id = _validate_stable_token(
+        declaration_id, field="declaration_id", pattern=_STABLE_ID_RE
+    )
+    normalized_revision_id = _validate_stable_token(
+        expected_revision_id,
+        field="expected_revision_id",
+        pattern=_STABLE_ID_RE,
+    )
+    normalized_fingerprint = str(expected_source_fingerprint or "").strip()
+    if not re.fullmatch(r"(?:src|bsrc)_[0-9a-f]{40}", normalized_fingerprint):
+        raise DeclaredCanonError("expected_source_fingerprint_required")
+    normalized_lifecycle = str(expected_lifecycle_status or "").strip().casefold()
+    if normalized_lifecycle not in GENERAL_LIFECYCLES:
+        raise DeclaredCanonError("expected_lifecycle_status_invalid")
+    if normalized_lifecycle == "established":
+        raise DeclaredCanonError("latest_validator_requires_noncurrent_lifecycle")
+    requested_now, evaluation_now = _requested_and_created_at(now)
+    parsed_now = _parse_validity(evaluation_now, field="validation_now")[1]
+    assert parsed_now is not None
+    _authorize_request(
+        actor_user_id=actor_user_id,
+        guild_id=guild_id,
+        operation="preview_declared",
+        authority_nonce=authority_nonce,
+        binding={
+            "validation": "exact_latest_revision",
+            "declaration_id": normalized_declaration_id,
+            "expected_revision_id": normalized_revision_id,
+            "expected_source_fingerprint": normalized_fingerprint,
+            "expected_lifecycle_status": normalized_lifecycle,
+            "requested_now": requested_now,
+        },
+    )
+    revision = _latest_revision(
+        conn,
+        guild_id=int(guild_id),
+        declaration_id=normalized_declaration_id,
+    )
+    if revision is None or revision.revision_id != normalized_revision_id:
+        raise DeclaredCanonError("expected_revision_mismatch")
+    if revision.source_fingerprint != normalized_fingerprint:
+        raise DeclaredCanonError("expected_source_fingerprint_mismatch")
+    if revision.lifecycle_status != normalized_lifecycle:
+        raise DeclaredCanonError("expected_lifecycle_status_mismatch")
+    if not _stored_authority_valid(revision):
+        raise DeclaredCanonError("stored_authority_invalid")
+    _require_revision_contract(revision)
+    if revision.source_system == GENERAL_DECLARATION_SOURCE:
+        if revision.source_row_id != revision.declaration_id:
+            raise DeclaredCanonError("general_source_identity_invalid")
+        fields = {
+            "raw_declaration": revision.raw_declaration,
+            "cleaned_summary": revision.cleaned_summary,
+            "subject_type": revision.subject_type,
+            "subject_id": revision.subject_id,
+            "object_subject_type": revision.object_subject_type,
+            "object_subject_id": revision.object_subject_id,
+            "predicate": revision.predicate,
+            "value_json": revision.value_json,
+            "domain": revision.domain,
+            "claim_kind": revision.claim_kind,
+            "visibility": revision.visibility,
+            "eligible_routes_json": revision.eligible_routes_json,
+            "valid_from": revision.valid_from,
+            "valid_until": revision.valid_until,
+        }
+        if _general_fingerprint(fields) != normalized_fingerprint:
+            raise DeclaredCanonError("declared_source_fingerprint_invalid")
+    elif revision.source_system == BROADCAST_MEMORY_SOURCE:
+        try:
+            source_row_id = int(revision.source_row_id)
+        except (TypeError, ValueError):
+            raise DeclaredCanonError("broadcast_source_identity_invalid")
+        source = _broadcast_row(
+            conn, guild_id=int(guild_id), row_id=source_row_id
+        )
+        if source is None:
+            raise DeclaredCanonError("broadcast_source_not_found")
+        if broadcast_source_fingerprint(source) != normalized_fingerprint:
+            raise DeclaredCanonError("expected_source_fingerprint_mismatch")
+        if _broadcast_lifecycle(source, parsed_now) != normalized_lifecycle:
+            raise DeclaredCanonError("broadcast_lifecycle_intersection_mismatch")
+        entry_type = str(source.get("entry_type") or "")
+        if entry_type not in BROADCAST_TYPE_DEFAULTS and (
+            revision.classification_mode != "owner_explicit_legacy_mapping"
+        ):
+            raise DeclaredCanonError("legacy_type_review_only")
+        if (
+            normalized_lifecycle == "established"
+            and revision.visibility in PUBLIC_VISIBILITIES
+        ):
+            scopes = _scope_tokens(source.get("usage_scope"))
+            if (
+                not _strict_bool(source.get("public_safe"))
+                or "internal" in scopes
+                or entry_type == "moderation_context"
+            ):
+                raise DeclaredCanonError("broadcast_public_eligibility_invalid")
+            _validate_broadcast_public_routes(
+                routes_json=revision.eligible_routes_json,
+                source_scopes=scopes,
+            )
+    else:
+        raise DeclaredCanonError("invalid_source_system")
+    if int(conn.total_changes or 0) != before:
+        raise DeclaredCanonError("read_validator_mutated_state")
+    return revision
+
+
+def preview_declared_canon(
+    conn: sqlite3.Connection,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    source_system: str = "",
+    limit: int = 100,
+) -> DeclaredPreview:
+    """Return content-free revision metadata without creating schema or rows."""
+
+    before = int(conn.total_changes or 0)
+    normalized_source = str(source_system or "").strip().casefold()
+    if normalized_source and normalized_source not in _SOURCE_SYSTEMS:
+        raise DeclaredCanonError("invalid_source_system")
+    safe_limit = max(1, min(int(limit or 100), 500))
+    authority = _authorize_request(
+        actor_user_id=actor_user_id,
+        guild_id=guild_id,
+        operation="preview_declared",
+        authority_nonce=authority_nonce,
+        binding={"source_system": normalized_source, "limit": safe_limit},
+    )
+    if not _table_exists(conn, DECLARED_CANON_TABLE):
+        return DeclaredPreview(
+            DECLARED_CANON_CONTRACT_VERSION,
+            int(guild_id),
+            _opaque_actor_ref(authority),
+            _receipt_id(authority),
+            (),
+            0,
+            False,
+            int(conn.total_changes or 0) - before,
+        )
+    where = ["guild_id=?"]
+    params: list[Any] = [int(guild_id)]
+    if normalized_source:
+        where.append("source_system=?")
+        params.append(normalized_source)
+    total = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM declared_canon_revisions WHERE %s"
+            % " AND ".join(where),
+            tuple(params),
+        ).fetchone()[0]
+        or 0
+    )
+    rows = conn.execute(
+        """
+        SELECT declaration_id,revision_id,revision_number,source_system,
+               domain,claim_kind,visibility,lifecycle_status,classification_mode,
+               CASE WHEN revision_number=(
+                   SELECT MAX(r2.revision_number)
+                   FROM declared_canon_revisions r2
+                   WHERE r2.guild_id=declared_canon_revisions.guild_id
+                     AND r2.declaration_id=declared_canon_revisions.declaration_id
+               ) THEN 1 ELSE 0 END
+        FROM declared_canon_revisions
+        WHERE %s
+        ORDER BY declaration_id,revision_number DESC
+        LIMIT ?
+        """ % " AND ".join(where),
+        (*params, safe_limit),
+    ).fetchall()
+    after = int(conn.total_changes or 0)
+    return DeclaredPreview(
+        DECLARED_CANON_CONTRACT_VERSION,
+        int(guild_id),
+        _opaque_actor_ref(authority),
+        _receipt_id(authority),
+        tuple(
+            DeclaredPreviewItem(
+                declaration_id=str(row[0]),
+                revision_id=str(row[1]),
+                revision_number=int(row[2]),
+                source_system=str(row[3]),
+                domain=str(row[4]),
+                claim_kind=str(row[5]),
+                visibility=str(row[6]),
+                lifecycle_status=str(row[7]),
+                classification_mode=str(row[8]),
+                current_revision=bool(row[9]),
+            )
+            for row in rows
+        ),
+        total,
+        total > len(rows),
+        after - before,
+    )
+
+
+def _preview_validity_state(value: Any, now: datetime) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return "unbounded"
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return "invalid"
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return "expired" if parsed.astimezone(timezone.utc) < now else "current"
+
+
+def _validity_window_state(
+    valid_from: Any, valid_until: Any, now: datetime
+) -> str:
+    raw_from = str(valid_from or "").strip()
+    raw_until = str(valid_until or "").strip()
+    try:
+        parsed_from = _parse_validity(raw_from, field="valid_from")[1]
+        parsed_until = _parse_validity(raw_until, field="valid_until")[1]
+    except DeclaredCanonError:
+        return "invalid"
+    if parsed_from and parsed_until and parsed_until < parsed_from:
+        return "invalid"
+    if parsed_from and parsed_from > now:
+        return "not_started"
+    if parsed_until and parsed_until < now:
+        return "expired"
+    if not raw_from and not raw_until:
+        return "unbounded"
+    return "current"
+
+
+def preview_historical_broadcast_memory(
+    conn: sqlite3.Connection,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    limit: int = 200,
+    offset: int = 0,
+    now: str = "",
+) -> BroadcastHistoryPreview:
+    """Build a zero-write, content-free classification preview.
+
+    Raw/clean content, source row IDs, stable source tokens, names, and account
+    IDs are never returned.  Item keys are derived from this preview receipt and
+    therefore cannot correlate rows across previews.  Era is review grouping,
+    never authority.
+    """
+
+    before = int(conn.total_changes or 0)
+    safe_limit = max(1, min(int(limit or 200), 500))
+    safe_offset = max(0, int(offset or 0))
+    cutoff_text, cutoff_value = _parse_validity(
+        BROADCAST_DECLARED_CANON_OWNER_ERA_CUTOFF,
+        field="owner_era_cutoff",
+    )
+    if cutoff_value is None:
+        raise DeclaredCanonError("owner_era_cutoff_required")
+    now_text, now_value = _parse_validity(now or _utc_now(), field="preview_now")
+    assert now_value is not None
+    authority = _authorize_request(
+        actor_user_id=actor_user_id,
+        guild_id=guild_id,
+        operation="preview_broadcast",
+        authority_nonce=authority_nonce,
+        binding={
+            "limit": safe_limit,
+            "offset": safe_offset,
+            "owner_era_cutoff": cutoff_text,
+            "preview_now": now_text,
+        },
+    )
+    receipt_id = _receipt_id(authority)
+    columns = _table_columns(conn, BROADCAST_MEMORY_SOURCE)
+    required = {"id", "guild_id", "entry_type", "status", "created_at"}
+    if not required.issubset(set(columns)):
+        return BroadcastHistoryPreview(
+            contract_version=DECLARED_CANON_CONTRACT_VERSION,
+            guild_id=int(guild_id),
+            authority_actor_ref=_opaque_actor_ref(authority),
+            authority_receipt_id=receipt_id,
+            owner_era_cutoff=cutoff_text,
+            items=(),
+            total_rows=0,
+            truncated=False,
+            counts_scope="returned_page",
+            type_counts={},
+            era_counts={},
+            disposition_counts={},
+            mutation_count=int(conn.total_changes or 0) - before,
+        )
+    total = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM broadcast_memory WHERE guild_id=?",
+            (int(guild_id),),
+        ).fetchone()[0]
+        or 0
+    )
+    source_cursor = conn.execute(
+        "SELECT * FROM broadcast_memory WHERE guild_id=? ORDER BY id LIMIT ? OFFSET ?",
+        (int(guild_id), safe_limit, safe_offset),
+    )
+    returned_columns = tuple(
+        str(item[0] or "") for item in (source_cursor.description or ())
+    )
+    raw_rows = source_cursor.fetchall()
+    rows = tuple(dict(zip(returned_columns, row)) for row in raw_rows)
+    classification_rows: dict[str, dict[str, str]] = {}
+    if _table_exists(conn, DECLARED_CANON_TABLE):
+        source_ids = tuple(str(row.get("id")) for row in rows)
+        if source_ids:
+            placeholders = ",".join("?" for _ in source_ids)
+            selected = ",".join(
+                "d.%s" % column for column in _REVISION_COLUMNS
+            )
+            for classified_row in conn.execute(
+                """
+                SELECT %s
+                FROM declared_canon_revisions d
+                JOIN (
+                    SELECT declaration_id,MAX(revision_number) AS max_revision
+                    FROM declared_canon_revisions
+                    WHERE guild_id=? AND source_system='broadcast_memory'
+                      AND source_row_id IN (%s)
+                    GROUP BY declaration_id
+                ) latest
+                  ON latest.declaration_id=d.declaration_id
+                 AND latest.max_revision=d.revision_number
+                WHERE d.guild_id=? AND d.source_system='broadcast_memory'
+                """ % (selected, placeholders),
+                (int(guild_id), *source_ids, int(guild_id)),
+            ).fetchall():
+                item = dict(zip(_REVISION_COLUMNS, classified_row))
+                item["_validated_revision"] = _row_to_revision(classified_row)
+                classification_rows[str(item["source_row_id"])] = item
+    items: list[BroadcastPreviewItem] = []
+    type_counts: dict[str, int] = {}
+    era_counts: dict[str, int] = {}
+    disposition_counts: dict[str, int] = {}
+    for position, row in enumerate(rows, start=1):
+        row_id = int(row.get("id") or 0)
+        entry_type = str(row.get("entry_type") or "")
+        preview_entry_type = (
+            entry_type
+            if entry_type in BROADCAST_TYPE_DEFAULTS
+            else "legacy_or_unrecognized"
+        )
+        status = str(row.get("status") or "").strip().casefold()
+        preview_status = (
+            status
+            if status in {"active", "resolved", "superseded"}
+            else "unrecognized"
+        )
+        scopes = _scope_tokens(row.get("usage_scope"))
+        safe_scopes = scopes.intersection(BROADCAST_USAGE_SCOPES)
+        unknown_scopes = scopes.difference(BROADCAST_USAGE_SCOPES)
+        public_safe = _strict_bool(row.get("public_safe"))
+        raw_submitter = row.get("submitted_by_user_id")
+        submitter_malformed = False
+        try:
+            submitter_id = int(raw_submitter or 0)
+        except (TypeError, ValueError, OverflowError):
+            submitter_id = 0
+            submitter_malformed = bool(str(raw_submitter or "").strip())
+        submitter_matches = submitter_id == int(authority.actor_user_id)
+        recognized = entry_type in BROADCAST_TYPE_DEFAULTS
+        classified = classification_rows.get(str(row_id))
+        legacy_explicit = bool(
+            classified
+            and classified.get("classification_mode")
+            == "owner_explicit_legacy_mapping"
+        )
+        reasons: list[str] = []
+        try:
+            source_created = _parse_validity(
+                row.get("created_at"), field="broadcast_created_at"
+            )[1]
+        except DeclaredCanonError:
+            source_created = None
+        if source_created is None:
+            source_era = "unknown_era"
+        elif source_created < cutoff_value:
+            source_era = "pre_declared_canon_owner_era"
+        else:
+            source_era = "post_declared_canon_owner_era"
+        reasons.append(source_era)
+        if not recognized and not legacy_explicit:
+            reasons.append("legacy_type_review_only")
+        elif not recognized:
+            reasons.append("legacy_type_explicitly_classified")
+        if submitter_malformed:
+            reasons.append("submitter_identity_malformed")
+        if not submitter_matches:
+            reasons.append("owner_authorship_unverified")
+        if status not in {"active", "resolved", "superseded"}:
+            reasons.append("status_unrecognized")
+        if status in {"resolved", "superseded"}:
+            reasons.append("historical_not_current")
+        if "internal" in scopes:
+            reasons.append("internal_scope")
+        if unknown_scopes:
+            reasons.append("usage_scope_unrecognized")
+        validity_state = _broadcast_validity_state(row, now_value)
+        if validity_state in {"expired", "invalid", "not_started"}:
+            reasons.append("validity_%s" % validity_state)
+        linked = bool(row.get("supersedes_id") or row.get("superseded_by_id"))
+        if entry_type == "continuity_backreference":
+            reasons.append("derived_relationship_ambiguous")
+        try:
+            current_source_fingerprint = broadcast_source_fingerprint(row)
+            source_versioned = True
+        except DeclaredCanonError:
+            current_source_fingerprint = ""
+            source_versioned = False
+            reasons.append("broadcast_source_unversioned")
+        classification_valid = False
+        if not classified:
+            classification_state = "unclassified"
+            fingerprint_state = "unclassified"
+            subject_link_state = "unclassified"
+        else:
+            stored_fingerprint = str(classified.get("source_fingerprint") or "")
+            fingerprint_state = (
+                "current"
+                if source_versioned
+                and stored_fingerprint == current_source_fingerprint
+                else "stale_or_unversioned"
+            )
+            if fingerprint_state != "current":
+                reasons.append("classification_source_stale")
+            subject_type = str(classified.get("subject_type") or "")
+            subject_id = str(classified.get("subject_id") or "")
+            claim_kind = str(classified.get("claim_kind") or "")
+            predicate = str(classified.get("predicate") or "")
+            domain = str(classified.get("domain") or "")
+            visibility = str(classified.get("visibility") or "")
+            object_type = str(classified.get("object_subject_type") or "")
+            object_id = str(classified.get("object_subject_id") or "")
+            subject_valid = bool(
+                subject_type in GENERAL_SUBJECT_TYPES
+                and _STABLE_ID_RE.fullmatch(subject_id)
+                and _PREDICATE_RE.fullmatch(predicate)
+                and domain in CANON_DOMAINS
+                and claim_kind in CLAIM_KINDS
+                and visibility in VISIBILITIES
+            )
+            if claim_kind == "relationship":
+                subject_valid = bool(
+                    subject_valid
+                    and object_type in GENERAL_SUBJECT_TYPES
+                    and _STABLE_ID_RE.fullmatch(object_id)
+                )
+            elif object_type or object_id:
+                subject_valid = False
+            if classified.get("derived_from_source_ref"):
+                subject_link_state = "derived_projection_not_authoritative"
+                subject_valid = False
+                reasons.append("derived_projection_not_supported")
+            else:
+                subject_link_state = (
+                    "explicit_typed" if subject_valid else "invalid_or_missing"
+                )
+            if not subject_valid:
+                reasons.append("classification_subject_link_invalid")
+            authority_valid = _stored_authority_valid(
+                classified.get("_validated_revision")
+            )
+            if not authority_valid:
+                reasons.append("classification_authority_invalid")
+            metadata_valid = True
+            try:
+                mode = str(classified.get("classification_mode") or "")
+                if mode not in {
+                    "owner_explicit_default_mapping",
+                    "owner_explicit_mapping_override",
+                    "owner_explicit_legacy_mapping",
+                }:
+                    raise DeclaredCanonError("broadcast_classification_mode_invalid")
+                if recognized and mode == "owner_explicit_legacy_mapping":
+                    raise DeclaredCanonError("broadcast_classification_mode_invalid")
+                if not recognized and mode != "owner_explicit_legacy_mapping":
+                    raise DeclaredCanonError("legacy_type_review_only")
+                decoded_routes = json.loads(
+                    str(classified.get("eligible_routes_json") or "[]")
+                )
+                if not isinstance(decoded_routes, list):
+                    raise DeclaredCanonError("invalid_eligible_routes_json")
+                if (
+                    _canonical_routes(decoded_routes, visibility)
+                    != str(classified.get("eligible_routes_json") or "[]")
+                ):
+                    raise DeclaredCanonError("noncanonical_eligible_routes")
+            except (DeclaredCanonError, json.JSONDecodeError, TypeError):
+                metadata_valid = False
+                reasons.append("classification_metadata_invalid")
+            lifecycle = str(classified.get("lifecycle_status") or "")
+            lifecycle_intersects = (
+                lifecycle == "established"
+                and status == "active"
+                and not row.get("superseded_by_id")
+                and validity_state in {"unbounded", "current"}
+            ) or (
+                lifecycle in {"resolved", "superseded"}
+                and status == lifecycle
+            )
+            if not lifecycle_intersects:
+                reasons.append("classification_lifecycle_stale")
+            public_intersects = True
+            if visibility in PUBLIC_VISIBILITIES:
+                if (
+                    not public_safe
+                    or "internal" in scopes
+                    or entry_type == "moderation_context"
+                    or lifecycle != "established"
+                ):
+                    public_intersects = False
+                try:
+                    _validate_broadcast_public_routes(
+                        routes_json=str(
+                            classified.get("eligible_routes_json") or "[]"
+                        ),
+                        source_scopes=scopes,
+                    )
+                except (DeclaredCanonError, json.JSONDecodeError, TypeError):
+                    public_intersects = False
+                if not public_intersects:
+                    reasons.append("classification_public_eligibility_stale")
+            classification_valid = bool(
+                fingerprint_state == "current"
+                and subject_valid
+                and authority_valid
+                and metadata_valid
+                and lifecycle_intersects
+                and public_intersects
+                and (recognized or legacy_explicit)
+            )
+            classification_state = "%s:%s:%s" % (
+                "current" if classification_valid else "not_current",
+                lifecycle if lifecycle in GENERAL_LIFECYCLES else "invalid",
+                str(classified.get("classification_mode") or "")
+                if str(classified.get("classification_mode") or "")
+                in {
+                    "owner_explicit_default_mapping",
+                    "owner_explicit_mapping_override",
+                    "owner_explicit_legacy_mapping",
+                }
+                else "invalid",
+            )
+        if classification_valid and str(classified.get("lifecycle_status")) == "established":
+            disposition = "declared_classification_current"
+        elif classification_valid:
+            disposition = "declared_classification_historical"
+        elif classified:
+            disposition = "stale_classification_review"
+        else:
+            disposition = "needs_owner_review"
+        type_counts[preview_entry_type] = type_counts.get(preview_entry_type, 0) + 1
+        era_counts[source_era] = era_counts.get(source_era, 0) + 1
+        disposition_counts[disposition] = disposition_counts.get(disposition, 0) + 1
+        items.append(
+            BroadcastPreviewItem(
+                preview_item="item_" + _digest(receipt_id, position)[:16],
+                source_era=source_era,
+                entry_type=preview_entry_type,
+                status=preview_status,
+                usage_scope=",".join(
+                    (*sorted(safe_scopes),)
+                    + (("unknown_scope_present",) if unknown_scopes else ())
+                ),
+                public_safe=public_safe,
+                submitter_state=(
+                    "configured_owner" if submitter_matches else "unverified"
+                ),
+                validity_state=validity_state,
+                derivation_state="source_lineage_linked" if linked else "primary",
+                subject_link_state=subject_link_state,
+                source_fingerprint_state=fingerprint_state,
+                classification_state=classification_state,
+                disposition=disposition,
+                reason_codes=tuple(sorted(set(reasons))),
+            )
+        )
+    after = int(conn.total_changes or 0)
+    return BroadcastHistoryPreview(
+        contract_version=DECLARED_CANON_CONTRACT_VERSION,
+        guild_id=int(guild_id),
+        authority_actor_ref=_opaque_actor_ref(authority),
+        authority_receipt_id=receipt_id,
+        owner_era_cutoff=cutoff_text,
+        items=tuple(items),
+        total_rows=total,
+        truncated=safe_offset + len(rows) < total,
+        counts_scope="returned_page",
+        type_counts=dict(sorted(type_counts.items())),
+        era_counts=dict(sorted(era_counts.items())),
+        disposition_counts=dict(sorted(disposition_counts.items())),
+        mutation_count=after - before,
+    )
+
+
+__all__ = [
+    "ALLOWED_ELIGIBLE_ROUTES",
+    "BROADCAST_DECLARED_CANON_OWNER_ERA_CUTOFF",
+    "BROADCAST_MEMORY_SOURCE",
+    "BROADCAST_PUBLIC_ROUTE_SCOPES",
+    "BROADCAST_SOURCE_FINGERPRINT_VERSION",
+    "BROADCAST_TYPE_DEFAULTS",
+    "BroadcastHistoryPreview",
+    "BroadcastPreviewItem",
+    "DECLARED_CANON_CONTRACT_VERSION",
+    "DECLARED_CANON_TABLE",
+    "DeclaredCanonError",
+    "DeclaredCanonRevision",
+    "DeclaredPreview",
+    "DeclaredPreviewItem",
+    "GENERAL_DECLARATION_SOURCE",
+    "INTERNAL_AUTHORITY_RECEIPT_VERSION",
+    "MutationResult",
+    "add_declared_canon",
+    "broadcast_source_fingerprint",
+    "change_declared_canon_status",
+    "classify_broadcast_memory",
+    "correct_declared_canon",
+    "ensure_declared_canon_schema",
+    "preview_declared_canon",
+    "preview_historical_broadcast_memory",
+    "retire_declared_canon",
+    "supersede_declared_canon",
+    "validate_current_declared_canon_revision",
+    "validate_latest_declared_canon_revision",
+]

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -7,6 +7,7 @@ adapters may consume only revalidated, route-safe projections.
 from __future__ import annotations
 
 from collections import Counter
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 import hashlib
@@ -7555,31 +7556,597 @@ def shadow_broadcast_memory_row(conn: sqlite3.Connection, *, row_id: int, guild_
 
 
 def _unique_broadcast_primary_entry(conn: sqlite3.Connection, *, guild_id: int, source_row_id: int | str) -> str:
+    entries = _effective_broadcast_primary_entries(
+        conn,
+        guild_id=guild_id,
+        source_row_id=source_row_id,
+    )
+    return entries[0] if len(entries) == 1 else ""
+
+
+@dataclass(frozen=True)
+class BroadcastEffectiveRepresentations:
+    """Every unretracted Ledger representation of one Broadcast source row."""
+
+    primary_entry_ids: tuple[str, ...] = ()
+    declared_projection_entry_ids: tuple[str, ...] = ()
+
+    @property
+    def all_entry_ids(self) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                set(self.primary_entry_ids)
+                | set(self.declared_projection_entry_ids)
+            )
+        )
+
+
+def _entry_is_unretracted_sql(alias: str) -> str:
+    return """
+        NOT EXISTS (
+            SELECT 1 FROM memory_ledger_lineage AS incoming
+            WHERE incoming.guild_id={alias}.guild_id
+              AND incoming.target_entry_id={alias}.entry_id
+              AND incoming.lineage_type IN ('supersedes','retracts')
+        )
+    """.format(alias=alias)
+
+
+def _effective_broadcast_representations(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    source_row_id: int | str,
+) -> BroadcastEffectiveRepresentations:
+    """Return all effective roots and Declared shadows for one Broadcast row.
+
+    A projection may still be effective after its primary root was already
+    retracted or even removed.  Root lineage therefore discovers ordinary
+    projections from *all* matching roots, while the authoritative Declared
+    sidecar mapping catches an orphan whose root/edge is missing.  Multiplicity
+    is preserved for invalidation; this helper never elects one row as truth.
+    """
+
     ensure_memory_ledger_schema(conn)
-    rows = conn.execute(
-        "SELECT entry_id FROM memory_ledger_entries WHERE guild_id=? AND source_table='broadcast_memory' AND source_row_id=? AND source_role='broadcast_memory' ORDER BY created_at DESC",
-        (guild_id, str(source_row_id)),
+    normalized_guild_id = int(guild_id or 0)
+    normalized_source_row_id = str(source_row_id)
+    effective_clause = _entry_is_unretracted_sql("entry")
+    primary_rows = conn.execute(
+        """
+        SELECT entry.entry_id
+        FROM memory_ledger_entries AS entry
+        WHERE entry.guild_id=?
+          AND entry.source_table='broadcast_memory'
+          AND entry.source_row_id=?
+          AND entry.source_role='broadcast_memory'
+          AND %s
+        ORDER BY entry.created_at,entry.entry_id
+        """ % effective_clause,
+        (normalized_guild_id, normalized_source_row_id),
     ).fetchall()
-    return rows[0][0] if len(rows) == 1 else ""
+    primary_ids = {
+        str(row[0]) for row in primary_rows if str(row[0] or "")
+    }
+
+    projection_clause = _entry_is_unretracted_sql("projection_row")
+    derived_projection_rows = conn.execute(
+        """
+        SELECT DISTINCT projection_row.entry_id
+        FROM memory_ledger_entries AS projection_row
+        JOIN memory_ledger_lineage AS source_edge
+          ON source_edge.guild_id=projection_row.guild_id
+         AND source_edge.entry_id=projection_row.entry_id
+         AND source_edge.lineage_type='derived_from'
+        JOIN memory_ledger_entries AS source_root
+          ON source_root.guild_id=source_edge.guild_id
+         AND source_root.entry_id=source_edge.target_entry_id
+        WHERE projection_row.guild_id=?
+          AND projection_row.source_table='declared_canon_projection'
+          AND projection_row.source_role='declared_canon_projection'
+          AND source_root.source_table='broadcast_memory'
+          AND source_root.source_row_id=?
+          AND source_root.source_role='broadcast_memory'
+          AND %s
+        ORDER BY projection_row.entry_id
+        """ % projection_clause,
+        (normalized_guild_id, normalized_source_row_id),
+    ).fetchall()
+    projection_ids = {
+        str(row[0])
+        for row in derived_projection_rows
+        if str(row[0] or "")
+    }
+
+    declared_columns = {
+        str(row[1] or "")
+        for row in conn.execute("PRAGMA table_info(declared_canon_revisions)")
+    }
+    if {
+        "revision_id",
+        "declaration_id",
+        "guild_id",
+        "source_system",
+        "source_row_id",
+        "lifecycle_status",
+    }.issubset(declared_columns):
+        orphan_rows = conn.execute(
+            """
+            SELECT DISTINCT projection_row.entry_id
+            FROM memory_ledger_entries AS projection_row
+            JOIN declared_canon_revisions AS revision
+              ON revision.guild_id=projection_row.guild_id
+             AND revision.declaration_id=projection_row.source_row_id
+             AND revision.revision_id=projection_row.source_revision
+            WHERE projection_row.guild_id=?
+              AND projection_row.source_table='declared_canon_projection'
+              AND projection_row.source_role='declared_canon_projection'
+              AND revision.source_system='broadcast_memory'
+              AND revision.source_row_id=?
+              AND revision.lifecycle_status='established'
+              AND %s
+            ORDER BY projection_row.entry_id
+            """ % projection_clause,
+            (normalized_guild_id, normalized_source_row_id),
+        ).fetchall()
+        projection_ids.update(
+            str(row[0]) for row in orphan_rows if str(row[0] or "")
+        )
+
+    return BroadcastEffectiveRepresentations(
+        primary_entry_ids=tuple(sorted(primary_ids)),
+        declared_projection_entry_ids=tuple(sorted(projection_ids)),
+    )
 
 
-def shadow_broadcast_status_event(conn: sqlite3.Connection, *, row_id: int, guild_id: int, status: str, updated_at: str, actor_id: int | None = None, actor_name: str = "", superseded_by_id: int | None = None) -> LedgerWriteResult:
-    rev = source_revision_for(row_id, updated_at, event=f"status:{status}:{updated_at}")
-    lineage = ()
-    reason_override = "ok"
-    if status == "superseded" and superseded_by_id:
-        old_entry = _unique_broadcast_primary_entry(conn, guild_id=guild_id, source_row_id=row_id)
-        replacement_entry = _unique_broadcast_primary_entry(conn, guild_id=guild_id, source_row_id=superseded_by_id)
-        if old_entry and replacement_entry:
-            lineage = (("derived_from", old_entry), ("derived_from", replacement_entry))
-        else:
-            reason_override = "unresolved_broadcast_status_lineage"
-    lifecycle = RESOLVED_LIFECYCLE if status == "resolved" else REVIEW_ONLY_LIFECYCLE
-    predicate = f"broadcast_status:{status or 'unknown'}"
-    result = insert_ledger_entry(conn, LedgerEntry(guild_id=guild_id, source_table="broadcast_memory", source_row_id=row_id, source_revision=rev, source_event_key=f"status:{status}", source_role="broadcast_memory_status", entry_type="event", subject_key="barcode_radio", subject_display_name="BARCODE Radio", predicate_key=predicate, value=status or "unknown", source_class=SourceClass.FIRST_PARTY_RECORD, visibility=Visibility.INTERNAL, confidence=Confidence.HIGH, public_usable=False, observed_at=updated_at or _now(), source_sequence=int(row_id or 0), lifecycle_status=lifecycle, participants=tuple([LedgerParticipant(f"discord_user:{actor_id}", actor_name or "", "correction_actor", 0)] if actor_id else ()), lineage=lineage))
-    if reason_override != "ok" and result.outcome == "inserted":
-        return LedgerWriteResult(result.entry_id, result.outcome, reason_override, result.source_table, result.source_row_id, result.source_revision, result.source_event_key, result.guild_id)
-    return result
+def _effective_broadcast_primary_entries(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    source_row_id: int | str,
+) -> tuple[str, ...]:
+    """Return every unretracted primary root for one Broadcast source row."""
+
+    return _effective_broadcast_representations(
+        conn,
+        guild_id=guild_id,
+        source_row_id=source_row_id,
+    ).primary_entry_ids
+
+
+@contextmanager
+def _ledger_atomic_projection_transaction(conn: sqlite3.Connection):
+    """Hold one snapshot/write transaction without owning a caller's commit."""
+
+    owns_transaction = not conn.in_transaction
+    if owns_transaction:
+        conn.execute("BEGIN IMMEDIATE")
+    try:
+        yield
+    except Exception:
+        if owns_transaction:
+            conn.rollback()
+        raise
+    else:
+        if owns_transaction:
+            conn.commit()
+
+
+def _configured_owner_and_guild() -> tuple[int, int]:
+    try:
+        owner_id = int(os.getenv("BNL_OWNER_USER_ID", "0") or 0)
+    except (TypeError, ValueError):
+        owner_id = 0
+    try:
+        primary_guild_id = int(os.getenv("BNL_PRIMARY_GUILD_ID", "0") or 0)
+    except (TypeError, ValueError):
+        primary_guild_id = 0
+    return owner_id, primary_guild_id
+
+
+def _stored_ledger_entry_matches(
+    conn: sqlite3.Connection,
+    entry: LedgerEntry,
+) -> bool:
+    """Prove a deduplicated identity is the exact row we intended to extend."""
+
+    stored = conn.execute(
+        """
+        SELECT schema_version,guild_id,subject_key,subject_display_name,
+               entry_type,predicate_key,normalized_value,source_class,
+               source_table,source_row_id,source_revision,source_event_key,
+               source_role,route_mode,channel_id,channel_name,channel_policy,
+               source_message_id,visibility,confidence,public_usable,derived,
+               projection,salience,observed_at,source_sequence,valid_from,
+               valid_until,freshness,lifecycle_status
+        FROM memory_ledger_entries WHERE entry_id=?
+        """,
+        (entry.entry_id,),
+    ).fetchone()
+    expected = (
+        MEMORY_LEDGER_SCHEMA_VERSION,
+        int(entry.guild_id or 0),
+        entry.subject_key,
+        entry.subject_display_name,
+        entry.entry_type,
+        entry.predicate_key,
+        entry.value[:1000],
+        entry.source_class.value,
+        entry.source_table,
+        str(entry.source_row_id),
+        entry.source_revision,
+        entry.source_event_key,
+        entry.source_role,
+        entry.route_mode,
+        int(entry.channel_id or 0),
+        entry.channel_name[:120],
+        entry.channel_policy[:80],
+        entry.source_message_id,
+        entry.visibility.value,
+        entry.confidence.value,
+        1 if entry.public_usable else 0,
+        1 if entry.derived else 0,
+        1 if entry.projection else 0,
+        float(entry.salience or 0.0),
+        entry.observed_at,
+        entry.source_sequence,
+        entry.valid_from,
+        entry.valid_until,
+        entry.freshness,
+        entry.lifecycle_status,
+    )
+    if stored != expected:
+        return False
+    expected_participants = {
+        (
+            participant.participant_key,
+            participant.display_name[:120],
+            participant.role[:40],
+            index,
+        )
+        for index, participant in enumerate(
+            sorted(
+                entry.participants,
+                key=lambda item: (item.order_index, item.participant_key),
+            )
+        )
+    }
+    stored_participants = {
+        (str(row[0]), str(row[1] or ""), str(row[2] or ""), int(row[3] or 0))
+        for row in conn.execute(
+            """
+            SELECT participant_key,display_name,participant_role,order_index
+            FROM memory_ledger_participants WHERE entry_id=?
+            """,
+            (entry.entry_id,),
+        ).fetchall()
+    }
+    return stored_participants == expected_participants
+
+
+def _insert_or_reconcile_ledger_lineage(
+    conn: sqlite3.Connection,
+    entry: LedgerEntry,
+    *,
+    conflict_reason: str,
+) -> LedgerWriteResult:
+    """Insert an entry or safely append missing edges to an exact duplicate.
+
+    Generic Ledger deduplication intentionally does not accept new caller-
+    supplied lineage.  Terminal invalidation is the narrow exception: after
+    revalidating the complete stored row and participant set, a retry may add
+    newly discovered retraction edges with ``INSERT OR IGNORE``.
+    """
+
+    result = insert_ledger_entry(conn, entry)
+    if result.outcome != "deduplicated":
+        return result
+    if not _stored_ledger_entry_matches(conn, entry):
+        return LedgerWriteResult(
+            entry_id=entry.entry_id,
+            outcome="error",
+            reason_code=conflict_reason,
+            source_table=entry.source_table,
+            source_row_id=str(entry.source_row_id),
+            source_revision=entry.source_revision,
+            source_event_key=entry.source_event_key,
+            guild_id=int(entry.guild_id or 0),
+        )
+    now = _now()
+    for lineage_type, target in entry.lineage:
+        if lineage_type not in LINEAGE_TYPES or not str(target or ""):
+            continue
+        target_row = conn.execute(
+            """
+            SELECT 1 FROM memory_ledger_entries
+            WHERE guild_id=? AND entry_id=?
+            """,
+            (int(entry.guild_id or 0), str(target)),
+        ).fetchone()
+        if target_row is None:
+            return LedgerWriteResult(
+                entry_id=entry.entry_id,
+                outcome="error",
+                reason_code="%s_target_missing" % conflict_reason,
+                source_table=entry.source_table,
+                source_row_id=str(entry.source_row_id),
+                source_revision=entry.source_revision,
+                source_event_key=entry.source_event_key,
+                guild_id=int(entry.guild_id or 0),
+            )
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO memory_ledger_lineage
+              (entry_id,guild_id,lineage_type,target_entry_id,created_at)
+            VALUES(?,?,?,?,?)
+            """,
+            (
+                entry.entry_id,
+                int(entry.guild_id or 0),
+                lineage_type,
+                str(target),
+                now,
+            ),
+        )
+    return LedgerWriteResult(
+        entry_id=entry.entry_id,
+        outcome="deduplicated",
+        reason_code="exact_source_duplicate_lineage_reconciled",
+        source_table=entry.source_table,
+        source_row_id=str(entry.source_row_id),
+        source_revision=entry.source_revision,
+        source_event_key=entry.source_event_key,
+        guild_id=int(entry.guild_id or 0),
+    )
+
+
+def shadow_broadcast_status_event(
+    conn: sqlite3.Connection,
+    *,
+    row_id: int,
+    guild_id: int,
+    status: str,
+    updated_at: str,
+    actor_id: int | None = None,
+    actor_name: str = "",
+    superseded_by_id: int | None = None,
+) -> LedgerWriteResult:
+    """Project an authenticated, already-applied Broadcast transition.
+
+    The authoritative ``broadcast_memory`` row is re-read in the same SQLite
+    snapshot/write transaction as the retraction insert.  Callers that already
+    hold the source mutation transaction keep ownership of its commit; direct
+    callers receive a local ``BEGIN IMMEDIATE`` boundary.
+    """
+
+    try:
+        normalized_row_id = int(row_id or 0)
+    except (TypeError, ValueError):
+        normalized_row_id = 0
+    try:
+        normalized_guild_id = int(guild_id or 0)
+    except (TypeError, ValueError):
+        normalized_guild_id = 0
+    try:
+        normalized_actor_id = int(actor_id or 0)
+    except (TypeError, ValueError):
+        normalized_actor_id = 0
+    normalized_status = str(status or "").strip().casefold()
+    normalized_updated_at = str(updated_at or "").strip()
+    rev = source_revision_for(
+        normalized_row_id,
+        normalized_updated_at,
+        event="status:%s:%s" % (normalized_status, normalized_updated_at),
+    )
+
+    owner_id, primary_guild_id = _configured_owner_and_guild()
+    if owner_id <= 0:
+        return skipped_result(
+            guild_id=normalized_guild_id,
+            source_table="broadcast_memory",
+            source_row_id=normalized_row_id,
+            source_revision=rev,
+            source_event_key="status:%s" % normalized_status,
+            reason_code="broadcast_status_owner_not_configured",
+        )
+    if primary_guild_id <= 0:
+        return skipped_result(
+            guild_id=normalized_guild_id,
+            source_table="broadcast_memory",
+            source_row_id=normalized_row_id,
+            source_revision=rev,
+            source_event_key="status:%s" % normalized_status,
+            reason_code="broadcast_status_primary_guild_not_configured",
+        )
+    if normalized_actor_id != owner_id:
+        return skipped_result(
+            guild_id=normalized_guild_id,
+            source_table="broadcast_memory",
+            source_row_id=normalized_row_id,
+            source_revision=rev,
+            source_event_key="status:%s" % normalized_status,
+            reason_code="broadcast_status_configured_owner_required",
+        )
+    if normalized_guild_id != primary_guild_id:
+        return skipped_result(
+            guild_id=normalized_guild_id,
+            source_table="broadcast_memory",
+            source_row_id=normalized_row_id,
+            source_revision=rev,
+            source_event_key="status:%s" % normalized_status,
+            reason_code="broadcast_status_primary_guild_required",
+        )
+    if (
+        normalized_row_id <= 0
+        or normalized_status not in {"resolved", "superseded"}
+        or not normalized_updated_at
+    ):
+        return skipped_result(
+            guild_id=normalized_guild_id,
+            source_table="broadcast_memory",
+            source_row_id=normalized_row_id,
+            source_revision=rev,
+            source_event_key="status:%s" % normalized_status,
+            reason_code="broadcast_status_snapshot_invalid",
+        )
+
+    invalid_superseded_by = False
+    if superseded_by_id is None:
+        expected_superseded_by = None
+    else:
+        try:
+            expected_superseded_by = int(superseded_by_id)
+        except (TypeError, ValueError):
+            expected_superseded_by = None
+            invalid_superseded_by = True
+    if invalid_superseded_by:
+        return skipped_result(
+            guild_id=normalized_guild_id,
+            source_table="broadcast_memory",
+            source_row_id=normalized_row_id,
+            source_revision=rev,
+            source_event_key="status:%s" % normalized_status,
+            reason_code="broadcast_status_snapshot_invalid",
+        )
+    if normalized_status == "superseded":
+        if expected_superseded_by is None or expected_superseded_by <= 0:
+            return skipped_result(
+                guild_id=normalized_guild_id,
+                source_table="broadcast_memory",
+                source_row_id=normalized_row_id,
+                source_revision=rev,
+                source_event_key="status:%s" % normalized_status,
+                reason_code="broadcast_status_snapshot_invalid",
+            )
+    elif expected_superseded_by is not None:
+        return skipped_result(
+            guild_id=normalized_guild_id,
+            source_table="broadcast_memory",
+            source_row_id=normalized_row_id,
+            source_revision=rev,
+            source_event_key="status:%s" % normalized_status,
+            reason_code="broadcast_status_snapshot_invalid",
+        )
+
+    with _ledger_atomic_projection_transaction(conn):
+        columns = {
+            str(row[1] or "")
+            for row in conn.execute("PRAGMA table_info(broadcast_memory)")
+        }
+        required_columns = {
+            "id",
+            "guild_id",
+            "status",
+            "updated_at",
+            "corrected_by_user_id",
+            "corrected_by_name",
+            "superseded_by_id",
+        }
+        if not required_columns.issubset(columns):
+            return skipped_result(
+                guild_id=normalized_guild_id,
+                source_table="broadcast_memory",
+                source_row_id=normalized_row_id,
+                source_revision=rev,
+                source_event_key="status:%s" % normalized_status,
+                reason_code="broadcast_status_source_schema_invalid",
+            )
+        source_row = conn.execute(
+            """
+            SELECT guild_id,status,updated_at,corrected_by_user_id,
+                   corrected_by_name,superseded_by_id
+            FROM broadcast_memory
+            WHERE guild_id=? AND id=?
+            LIMIT 1
+            """,
+            (normalized_guild_id, normalized_row_id),
+        ).fetchone()
+        if source_row is None:
+            return skipped_result(
+                guild_id=normalized_guild_id,
+                source_table="broadcast_memory",
+                source_row_id=normalized_row_id,
+                source_revision=rev,
+                source_event_key="status:%s" % normalized_status,
+                reason_code="broadcast_status_source_not_found",
+            )
+        try:
+            source_superseded_by = (
+                int(source_row[5]) if source_row[5] is not None else None
+            )
+        except (TypeError, ValueError):
+            source_superseded_by = "invalid"
+        if (
+            int(source_row[0] or 0) != normalized_guild_id
+            or str(source_row[1] or "").strip().casefold() != normalized_status
+            or str(source_row[2] or "").strip() != normalized_updated_at
+            or int(source_row[3] or 0) != normalized_actor_id
+            or source_superseded_by != expected_superseded_by
+        ):
+            return skipped_result(
+                guild_id=normalized_guild_id,
+                source_table="broadcast_memory",
+                source_row_id=normalized_row_id,
+                source_revision=rev,
+                source_event_key="status:%s" % normalized_status,
+                reason_code="broadcast_status_source_snapshot_mismatch",
+            )
+
+        old_entries = _effective_broadcast_primary_entries(
+            conn,
+            guild_id=normalized_guild_id,
+            source_row_id=normalized_row_id,
+        )
+        lineage_items = [
+            ("retracts", old_entry) for old_entry in old_entries
+        ]
+        if normalized_status == "superseded":
+            replacement_entries = _effective_broadcast_primary_entries(
+                conn,
+                guild_id=normalized_guild_id,
+                source_row_id=expected_superseded_by,
+            )
+            lineage_items.extend(
+                ("derived_from", entry_id)
+                for entry_id in (*old_entries, *replacement_entries)
+            )
+
+        lifecycle = (
+            RESOLVED_LIFECYCLE
+            if normalized_status == "resolved"
+            else REVIEW_ONLY_LIFECYCLE
+        )
+        return insert_ledger_entry(
+            conn,
+            LedgerEntry(
+                guild_id=normalized_guild_id,
+                source_table="broadcast_memory",
+                source_row_id=normalized_row_id,
+                source_revision=rev,
+                source_event_key="status:%s" % normalized_status,
+                source_role="broadcast_memory_status",
+                entry_type="event",
+                subject_key="barcode_radio",
+                subject_display_name="BARCODE Radio",
+                predicate_key="broadcast_status:%s" % normalized_status,
+                value=normalized_status,
+                source_class=SourceClass.FIRST_PARTY_RECORD,
+                visibility=Visibility.INTERNAL,
+                confidence=Confidence.HIGH,
+                public_usable=False,
+                observed_at=normalized_updated_at,
+                source_sequence=normalized_row_id,
+                lifecycle_status=lifecycle,
+                participants=(
+                    LedgerParticipant(
+                        "discord_user:%s" % normalized_actor_id,
+                        str(source_row[4] or ""),
+                        "correction_actor",
+                        0,
+                    ),
+                ),
+                lineage=tuple(lineage_items),
+            ),
+        )
 
 
 def shadow_canon_reference(
@@ -7640,6 +8207,397 @@ def shadow_canon_reference(
             lineage=tuple(("derived_from", entry_id) for entry_id in roots),
         ),
     )
+
+
+def _declared_projection_subject_key(subject_type: str, subject_id: str) -> str:
+    return "%s:%s" % (
+        str(subject_type or "").strip().casefold(),
+        str(subject_id or "").strip(),
+    )
+
+
+def shadow_declared_canon_projection(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    declaration_id: str,
+    revision_id: str,
+    actor_user_id: int,
+    authority_nonce: str,
+    expected_source_fingerprint: str,
+    expected_lifecycle_status: str,
+    root_entry_ids: tuple[str, ...] = (),
+) -> LedgerWriteResult:
+    """Project one Declared revision without making it live evidence.
+
+    The append-only declaration or Broadcast row remains authoritative.  PR 2
+    deliberately keeps this projection internal, derived, review-only, and
+    non-public so existing packet, Journal, Relay, dossier, and site readers
+    cannot consume a second representation before final convergence.
+    """
+
+    from bnl_declared_canon import (
+        BROADCAST_MEMORY_SOURCE,
+        DeclaredCanonError,
+        validate_current_declared_canon_revision,
+        validate_latest_declared_canon_revision,
+    )
+
+    declaration_id = str(declaration_id or "").strip()
+    revision_id = str(revision_id or "").strip()
+    expected_source_fingerprint = str(expected_source_fingerprint or "").strip()
+    if not declaration_id or not revision_id or not expected_source_fingerprint:
+        return skipped_result(
+            guild_id=guild_id,
+            source_table="declared_canon_projection",
+            source_row_id=declaration_id,
+            source_revision=revision_id,
+            reason_code="missing_declared_projection_identity",
+        )
+    normalized_guild_id = int(guild_id or 0)
+    normalized_lifecycle = str(expected_lifecycle_status or "").strip().casefold()
+    provided_roots = tuple(
+        str(entry_id or "").strip()
+        for entry_id in root_entry_ids
+        if str(entry_id or "").strip()
+    )
+    roots = tuple(sorted(set(provided_roots)))
+
+    with _ledger_atomic_projection_transaction(conn):
+        try:
+            if normalized_lifecycle == "established":
+                revision = validate_current_declared_canon_revision(
+                    conn,
+                    actor_user_id=int(actor_user_id or 0),
+                    authority_nonce=authority_nonce,
+                    guild_id=normalized_guild_id,
+                    declaration_id=declaration_id,
+                    expected_revision_id=revision_id,
+                    expected_source_fingerprint=expected_source_fingerprint,
+                )
+            else:
+                revision = validate_latest_declared_canon_revision(
+                    conn,
+                    actor_user_id=int(actor_user_id or 0),
+                    authority_nonce=authority_nonce,
+                    guild_id=normalized_guild_id,
+                    declaration_id=declaration_id,
+                    expected_revision_id=revision_id,
+                    expected_source_fingerprint=expected_source_fingerprint,
+                    expected_lifecycle_status=normalized_lifecycle,
+                )
+        except DeclaredCanonError as exc:
+            return skipped_result(
+                guild_id=normalized_guild_id,
+                source_table="declared_canon_projection",
+                source_row_id=declaration_id,
+                source_revision=revision_id,
+                reason_code=(
+                    "declared_projection_%s" % str(exc or "invalid")
+                )[:120],
+            )
+
+        terminal = revision.lifecycle_status in {
+            "contested",
+            "resolved",
+            "retired",
+            "superseded",
+        }
+
+        if revision.source_system == BROADCAST_MEMORY_SOURCE:
+            if terminal:
+                if provided_roots:
+                    return skipped_result(
+                        guild_id=normalized_guild_id,
+                        source_table="declared_canon_projection",
+                        source_row_id=declaration_id,
+                        source_revision=revision_id,
+                        reason_code=(
+                            "declared_projection_broadcast_terminal_roots_forbidden"
+                        ),
+                    )
+                # A terminal sidecar carries no Broadcast content.  Its sole
+                # purpose is to retract the prior Declared projection after
+                # validate_latest_declared_canon_revision has re-intersected
+                # the exact terminal source row in this transaction.
+                value = revision.lifecycle_status
+            elif len(provided_roots) != 1 or len(roots) != 1:
+                return skipped_result(
+                    guild_id=normalized_guild_id,
+                    source_table="declared_canon_projection",
+                    source_row_id=declaration_id,
+                    source_revision=revision_id,
+                    reason_code="declared_projection_broadcast_root_required",
+                )
+            else:
+                source_row = conn.execute(
+                    """
+                    SELECT cleaned_summary,updated_at,status
+                    FROM broadcast_memory
+                    WHERE guild_id=? AND id=?
+                    """,
+                    (normalized_guild_id, int(revision.source_row_id)),
+                ).fetchone()
+                if (
+                    not source_row
+                    or not str(source_row[0] or "").strip()
+                    or not str(source_row[1] or "").strip()
+                    or str(source_row[2] or "").strip().casefold() != "active"
+                ):
+                    return skipped_result(
+                        guild_id=normalized_guild_id,
+                        source_table="declared_canon_projection",
+                        source_row_id=declaration_id,
+                        source_revision=revision_id,
+                        reason_code="declared_projection_broadcast_value_missing",
+                    )
+                value = str(source_row[0])
+                expected_root_revision = source_revision_for(
+                    revision.source_row_id,
+                    str(source_row[1]),
+                )
+                root_row = conn.execute(
+                    """
+                    SELECT guild_id,source_table,source_row_id,source_role,
+                           source_revision,normalized_value,lifecycle_status
+                    FROM memory_ledger_entries
+                    WHERE entry_id=?
+                    """,
+                    (roots[0],),
+                ).fetchone()
+                if root_row is None or int(root_row[0] or 0) != normalized_guild_id:
+                    return skipped_result(
+                        guild_id=normalized_guild_id,
+                        source_table="declared_canon_projection",
+                        source_row_id=declaration_id,
+                        source_revision=revision_id,
+                        reason_code="declared_projection_root_scope_invalid",
+                    )
+                if (
+                    str(root_row[1] or "") != "broadcast_memory"
+                    or str(root_row[2] or "") != revision.source_row_id
+                    or str(root_row[3] or "") != "broadcast_memory"
+                ):
+                    return skipped_result(
+                        guild_id=normalized_guild_id,
+                        source_table="declared_canon_projection",
+                        source_row_id=declaration_id,
+                        source_revision=revision_id,
+                        reason_code="declared_projection_broadcast_root_required",
+                    )
+                if (
+                    str(root_row[4] or "") != expected_root_revision
+                    or str(root_row[5] or "") != value[:500]
+                    or str(root_row[6] or "") != ACTIVE_LIFECYCLE
+                    or conn.execute(
+                        """
+                        SELECT 1
+                        FROM memory_ledger_lineage
+                        WHERE guild_id=? AND target_entry_id=?
+                          AND lineage_type IN ('supersedes','retracts')
+                        LIMIT 1
+                        """,
+                        (normalized_guild_id, roots[0]),
+                    ).fetchone()
+                ):
+                    return skipped_result(
+                        guild_id=normalized_guild_id,
+                        source_table="declared_canon_projection",
+                        source_row_id=declaration_id,
+                        source_revision=revision_id,
+                        reason_code="declared_projection_broadcast_root_stale",
+                    )
+                current_primary_count = conn.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM memory_ledger_entries AS root
+                    WHERE root.guild_id=?
+                      AND root.source_table='broadcast_memory'
+                      AND root.source_row_id=?
+                      AND root.source_role='broadcast_memory'
+                      AND root.lifecycle_status='active'
+                      AND NOT EXISTS (
+                        SELECT 1
+                        FROM memory_ledger_lineage AS edge
+                        WHERE edge.guild_id=root.guild_id
+                          AND edge.target_entry_id=root.entry_id
+                          AND edge.lineage_type IN ('supersedes','retracts')
+                    )
+                    """,
+                    (normalized_guild_id, revision.source_row_id),
+                ).fetchone()[0]
+                if int(current_primary_count or 0) != 1:
+                    return skipped_result(
+                        guild_id=normalized_guild_id,
+                        source_table="declared_canon_projection",
+                        source_row_id=declaration_id,
+                        source_revision=revision_id,
+                        reason_code="declared_projection_broadcast_root_ambiguous",
+                    )
+        else:
+            if provided_roots:
+                return skipped_result(
+                    guild_id=normalized_guild_id,
+                    source_table="declared_canon_projection",
+                    source_row_id=declaration_id,
+                    source_revision=revision_id,
+                    reason_code="declared_projection_general_roots_forbidden",
+                )
+            value = revision.cleaned_summary or revision.value_json
+
+        previous: tuple[str, ...] = ()
+        if revision.previous_revision_id:
+            prior_rows = conn.execute(
+                """
+                SELECT entry_id
+                FROM memory_ledger_entries
+                WHERE guild_id=?
+                  AND source_table='declared_canon_projection'
+                  AND source_row_id=?
+                  AND source_revision=?
+                ORDER BY created_at DESC
+                """,
+                (
+                    normalized_guild_id,
+                    declaration_id,
+                    revision.previous_revision_id,
+                ),
+            ).fetchall()
+            if len(prior_rows) != 1:
+                return skipped_result(
+                    guild_id=normalized_guild_id,
+                    source_table="declared_canon_projection",
+                    source_row_id=declaration_id,
+                    source_revision=revision_id,
+                    reason_code="declared_projection_previous_revision_missing",
+                )
+            previous = (str(prior_rows[0][0]),)
+
+        cross_declaration_previous: tuple[str, ...] = ()
+        if revision.supersedes_declaration_id:
+            superseded_latest = conn.execute(
+                """
+                SELECT previous_revision_id,lifecycle_status,
+                       superseded_by_declaration_id
+                FROM declared_canon_revisions
+                WHERE guild_id=? AND declaration_id=?
+                ORDER BY revision_number DESC
+                LIMIT 1
+                """,
+                (
+                    normalized_guild_id,
+                    revision.supersedes_declaration_id,
+                ),
+            ).fetchone()
+            if (
+                superseded_latest is None
+                or str(superseded_latest[1] or "") != "superseded"
+                or str(superseded_latest[2] or "") != declaration_id
+                or not str(superseded_latest[0] or "")
+            ):
+                return skipped_result(
+                    guild_id=normalized_guild_id,
+                    source_table="declared_canon_projection",
+                    source_row_id=declaration_id,
+                    source_revision=revision_id,
+                    reason_code=(
+                        "declared_projection_cross_supersession_invalid"
+                    ),
+                )
+            superseded_projection_rows = conn.execute(
+                """
+                SELECT entry_id
+                FROM memory_ledger_entries
+                WHERE guild_id=?
+                  AND source_table='declared_canon_projection'
+                  AND source_row_id=?
+                  AND source_revision=?
+                ORDER BY created_at DESC
+                """,
+                (
+                    normalized_guild_id,
+                    revision.supersedes_declaration_id,
+                    str(superseded_latest[0]),
+                ),
+            ).fetchall()
+            if len(superseded_projection_rows) != 1:
+                return skipped_result(
+                    guild_id=normalized_guild_id,
+                    source_table="declared_canon_projection",
+                    source_row_id=declaration_id,
+                    source_revision=revision_id,
+                    reason_code=(
+                        "declared_projection_superseded_source_projection_missing"
+                    ),
+                )
+            cross_declaration_previous = (
+                str(superseded_projection_rows[0][0]),
+            )
+
+        lineage_items = [("derived_from", entry_id) for entry_id in roots]
+        lineage_items.extend(
+            ("retracts" if terminal else "supersedes", entry_id)
+            for entry_id in previous
+        )
+        lineage_items.extend(
+            ("supersedes", entry_id)
+            for entry_id in cross_declaration_previous
+        )
+        lineage = tuple(dict.fromkeys(lineage_items))
+
+        subject_key = _declared_projection_subject_key(
+            revision.subject_type,
+            revision.subject_id,
+        )
+        participants = [
+            LedgerParticipant(subject_key, "", "subject", 0),
+        ]
+        if revision.claim_kind == "relationship":
+            participants.append(
+                LedgerParticipant(
+                    _declared_projection_subject_key(
+                        revision.object_subject_type,
+                        revision.object_subject_id,
+                    ),
+                    "",
+                    "relationship_object",
+                    1,
+                )
+            )
+
+        return insert_ledger_entry(
+            conn,
+            LedgerEntry(
+                guild_id=normalized_guild_id,
+                source_table="declared_canon_projection",
+                source_row_id=declaration_id,
+                source_revision=revision_id,
+                source_event_key="revision:%s" % revision_id,
+                source_role="declared_canon_projection",
+                entry_type="canon_reference",
+                subject_key=subject_key,
+                subject_display_name="",
+                predicate_key=revision.predicate,
+                value=(value or "")[:500],
+                source_class=SourceClass.EVIDENCE_PROJECTION,
+                route_mode="declared_canon_review",
+                channel_policy="declared_canon_review",
+                visibility=Visibility.INTERNAL,
+                confidence=Confidence.LOW,
+                public_usable=False,
+                derived=True,
+                projection=True,
+                observed_at=revision.created_at or _now(),
+                lifecycle_status=(
+                    RESOLVED_LIFECYCLE
+                    if revision.lifecycle_status
+                    in {"resolved", "retired", "superseded"}
+                    else REVIEW_ONLY_LIFECYCLE
+                ),
+                participants=tuple(participants),
+                lineage=lineage,
+            ),
+        )
 
 
 def build_memory_ledger_evaluation(

--- a/docs/BNL01_DECLARED_CANON_LIFECYCLE_V1.md
+++ b/docs/BNL01_DECLARED_CANON_LIFECYCLE_V1.md
@@ -1,0 +1,167 @@
+# Declared Canon Lifecycle v1
+
+`declared_canon_lifecycle_v1` adds an owner-controlled, append-only lifecycle
+for explicit BARCODE declarations without creating another database, retriever,
+or response owner.
+
+## Source ownership
+
+- General declarations use one additive `declared_canon_revisions` table in the
+  existing bot database. The owner's raw declaration and each immutable
+  revision remain in that table.
+- Broadcast declarations keep `broadcast_memory` as the authority-bearing
+  content source. A declaration revision stores only typed classification,
+  subject, lifecycle, authority, and an exact source fingerprint; it does not
+  copy the raw note or cleaned summary.
+- Cleaned summaries are projections. They never become independent authority
+  or corroborate their raw parent.
+- Legacy Canon remains versioned in code. Living Canon and Open Signal retain
+  their existing owners.
+
+## Append-only operations
+
+Every add, correction, supersession, retirement, or status change appends an
+immutable revision. The stable declaration ID survives correction; revision
+IDs and revision numbers do not. Prior revisions are never deleted or silently
+rewritten.
+
+All preview and mutation APIs independently require:
+
+- a configured owner ID;
+- an exact actor/owner match;
+- the configured primary guild and an exact target-guild match;
+- an opaque `discord_user:<id>` actor; and
+- an internally issued, versioned receipt bound to the exact operation,
+  target, expected snapshot, payload, and Discord-message nonce.
+
+No Declared Canon signing key or secret environment variable exists. Under the
+trusted application-and-database threat model, the core deterministically
+issues the receipt itself after authenticating the configured owner and guild;
+no public API accepts a caller-built authority or receipt. The visible receipt
+version commits to actor, guild, operation, nonce, normalized request, and the
+complete immutable stored revision. Validators recompute both that receipt and
+the revision ID before admitting a row. This detects accidental or partial row
+tampering but does not claim to defend against an attacker who can both rewrite
+the trusted database and execute trusted application code.
+
+The Discord route is a first boundary, not the only boundary. A direct helper
+call with missing, mismatched, cross-guild, malformed, or stale authority fails
+before writing.
+
+Mutations also use optimistic concurrency. General declarations require the
+exact current revision ID. Broadcast classifications require both the exact
+current declaration revision (when reclassifying) and a fingerprint of the
+approved source snapshot. Operation nonces are idempotent only for an exact
+request; reusing one with a changed binding fails closed.
+
+Exported current/latest validators hold one coherent SQLite read snapshot for
+their complete revision-and-source validation sequence. They open and close a
+read transaction only when the caller has none; an existing caller transaction
+is reused and left open. WAL writers may commit concurrently, but a validator
+cannot mix a revision from one database state with a Broadcast row from another.
+The validators remain zero-write, and a later call observes the newer commit.
+
+## Broadcast classification
+
+Only the six current parser types have default mappings:
+
+- `episode_arc`
+- `notable_moment`
+- `running_joke`
+- `technical_issue`
+- `moderation_context`
+- `show_state_override`
+
+The mapping supplies a proposed domain and claim kind, not a subject. Every
+classification requires an explicit typed subject. Submitter identity is
+provenance and never becomes the subject automatically.
+
+Historical or out-of-contract values—including `continuity_backreference`,
+`show_note`, `recap`, and arbitrary legacy strings—retain their exact source
+type and stay review-only until an explicit owner classification. A timestamp,
+public-safe flag, active status, or post-PR-362 creation date is not owner
+authority by itself.
+
+The `broadcast_memory_complete_row_v2` fingerprint hashes the complete source
+row returned by SQLite, not a field allowlist. Column names are sorted and every
+value is encoded with an explicit scalar type before hashing. This covers
+content, provenance, scope/visibility inputs, validity, lifecycle, correction
+data, supersession links, source timestamps, and every unknown/future column.
+Adding any source column therefore stales existing approval—even when its value
+is NULL—until the owner explicitly reviews and reclassifies the row.
+
+## Historical preview
+
+The historical preview is bounded, content-free, and zero-write. It reports
+counts by owner-era boundary, submitter class, source type, lifecycle, scope,
+visibility, validity, derivation, subject-link state, and review disposition.
+It never returns raw notes, cleaned summaries, names, account IDs, or proposed
+mutation payloads. An owner-only review may use a turn-scoped opaque source
+token to identify an exact row for a later, separately approved action; the
+token itself carries no authority and is not stable evidence.
+
+`total_rows` describes the full guild-scoped source query. The count mappings
+are explicitly labeled `counts_scope=returned_page`; they never pretend a
+bounded page is a global aggregate. Malformed historical timestamps or
+submitter identifiers remain reviewable as reason-coded, unknown provenance
+instead of aborting the preview.
+
+Applying any historical classification or subject link remains a separate
+owner-approved data operation. PR 2 creates no backfill and runs no such write.
+
+## Broadcast source/lineage atomicity
+
+New Broadcast primary projections are derived from an exact source row inside
+the source write transaction. Resolve, clear, and replacement transitions
+re-read the exact owner/guild/status/update/supersession snapshot and retract
+every still-effective Ledger primary for that exact source row in the same
+transaction. A missing primary is safe because there is no Ledger
+representation to invalidate. If an older defect left duplicate primaries,
+the status event must retract the complete pre-write set or the source
+transition rolls back; it never chooses one as more authoritative. New primary
+creation remains strict at exactly one. A disabled shadow flag therefore
+cannot strand an already-written active primary, and a skipped, conflicting,
+or failed required projection rolls back the Broadcast source transition.
+
+## Non-live boundary
+
+Declared claim adapters remain read models. New Ledger projections are always:
+
+- derived and projected;
+- internal;
+- review-only; and
+- `public_usable=0`.
+
+Their route and channel labels are both `declared_canon_review`, so no existing
+approved-canon or public-route selector can mistake the PR 2 shadow for live
+canon evidence. Corrections emit
+supersession lineage; contested, resolved, retired, and superseded revisions
+emit retraction lineage against the exact prior projection.
+
+Existing Broadcast readers continue to use the mature `broadcast_memory`
+compatibility lane in PR 2. The new declaration view does not feed the unified
+packet, Journal, Relay, dossiers, website projections, or public responses.
+Final one-packet selection and duplicate-source collapse belong to the later
+convergence PR.
+
+## Owner command surface
+
+The first owner surface is an exact `!bnl canon <action> <JSON>` command in
+`#research-and-development`. It supports content-free `preview` and
+`broadcast-preview`, plus `add`, `correct`, `status`, `retire`, `supersede`,
+and `broadcast-classify`. The parser rejects unknown fields and never guesses
+from natural language. Mutation replies contain only operation/declaration/
+revision IDs, lifecycle state, and shadow outcome; they never echo the raw
+declaration or Broadcast content.
+
+Control-shaped messages are dispatched from the original Discord payload
+before mention/whitespace normalization, direct-conversation ingress, room
+context, batching, or other conversational sinks. This preserves exact JSON
+string values (including mention tokens and intentional spacing) and keeps
+authorized, denied, wrong-channel, and malformed control attempts out of later
+prompts.
+
+No environment gate, deployment state, website authority, delegated steward
+power, historical classification, or live response behavior is changed by
+this lifecycle contract. It introduces no credential, environment variable,
+or deployment prerequisite.

--- a/docs/hybrid_canon_claim_contract_v1.md
+++ b/docs/hybrid_canon_claim_contract_v1.md
@@ -21,9 +21,10 @@ proof of recurrence.
 ## Source ownership
 
 - `CANON_FACTS` remains the Legacy source.
-- `broadcast_memory` remains the Broadcast source. Only rows carrying verified
-  owner authority normalize as Declared; historical rows without that proof
-  stay internal, review-only Open Signal.
+- `broadcast_memory` remains the Broadcast content source. A raw row alone is
+  always internal, review-only Open Signal. Only an exact current join to an
+  owner-verified `declared_canon_revisions` sidecar can normalize it as a
+  Declared shadow; stale or absent sidecars fall back to the raw Open view.
 - Ledger, Moments, and atomic lifecycle remain the Living source machinery.
   Current established atomic and finalized Moment rows normalize as internal,
   review-only Open Signal until the recurrence contract is proved; they are not
@@ -46,8 +47,10 @@ boolean always fails closed to internal review metadata. Question-scoped Open
 Signal normalization likewise requires explicit active, public, subject-
 authored, human-source, nonderived assessment proof.
 
-`shadow_canon_reference()` is a derived Ledger projection. It is never an
-independent canon root and cannot corroborate or promote itself.
+`shadow_canon_reference()` and `shadow_declared_canon_projection()` are derived
+Ledger projections. They are never independent canon roots and cannot
+corroborate or promote themselves. The Declared projection revalidates the
+exact latest authority/source revision and same-guild roots before insertion.
 
 ## Identity
 
@@ -82,7 +85,33 @@ source text, display label, account ID, or row ID is emitted.
 
 ## Mutation boundary
 
-This version is shadow/read-only. Declared mutation, historical Broadcast
-classification, claim-content use in the live packet, website projection, and
-delegated authority are not enabled by this contract. The packet's binding
-lookup is read-only and effective only for already-approved binding rows.
+PR 2 adds the owner-only, append-only `declared_canon_lifecycle_v1` mutation
+contract described in `BNL01_DECLARED_CANON_LIFECYCLE_V1.md`. General
+declarations live in its revision table; Broadcast content remains in
+`broadcast_memory`, with only typed classification metadata and a source
+fingerprint stored beside it. No historical classifications are written
+automatically.
+
+Every stored revision carries a request fingerprint and an internally issued,
+deterministic, versioned receipt. It requires no runtime signing secret and no
+public API accepts a caller-supplied authority or receipt. Under the trusted
+application-and-database threat model, read boundaries recompute the receipt
+over the exact actor, guild, operation, nonce/request bindings and complete
+immutable stored payload, then recompute the revision ID. A conflicting
+`INSERT OR REPLACE` is rejected before SQLite can replace history.
+
+Broadcast sidecars bind to `broadcast_memory_complete_row_v2`, which hashes the
+complete deterministically canonicalized source row including unknown/future
+columns. Any schema addition stales prior approval and requires explicit owner
+review; no column is silently treated as non-authoritative.
+
+Core current/latest validators own one coherent read snapshot when the caller
+has no transaction and reuse a caller-owned transaction otherwise. This keeps
+revision selection, stored-receipt validation, and authoritative source-row
+revalidation on one database state while remaining zero-write.
+
+Claim-content use in the live packet, website projection, and delegated
+authority remain disabled. New Declared Ledger projections are internal,
+derived, review-only, and nonpublic until final convergence. The packet's
+binding lookup remains read-only and effective only for already-approved
+binding rows.

--- a/tests/test_broadcast_declared_canon.py
+++ b/tests/test_broadcast_declared_canon.py
@@ -1,0 +1,850 @@
+from dataclasses import asdict
+from datetime import datetime, timezone
+import inspect
+import os
+import re
+import sqlite3
+import unittest
+from unittest import mock
+
+import bnl_declared_canon as declared
+
+
+class BroadcastDeclaredCanonTests(unittest.TestCase):
+    def setUp(self):
+        self.env = mock.patch.dict(
+            os.environ,
+            {
+                "BNL_OWNER_USER_ID": "61",
+                "BNL_PRIMARY_GUILD_ID": "7",
+            },
+        )
+        self.env.start()
+        self.conn = sqlite3.connect(":memory:")
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute(
+            """
+            CREATE TABLE broadcast_memory (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                guild_id INTEGER NOT NULL,
+                episode_date TEXT NOT NULL,
+                submitted_by_user_id INTEGER,
+                submitted_by_name TEXT,
+                raw_note TEXT,
+                cleaned_summary TEXT NOT NULL,
+                entry_type TEXT NOT NULL,
+                importance TEXT DEFAULT 'medium',
+                public_safe INTEGER DEFAULT 0,
+                affects_next_show INTEGER DEFAULT 0,
+                usage_scope TEXT DEFAULT 'internal',
+                target_show_date TEXT,
+                valid_until TEXT,
+                override_span_count INTEGER DEFAULT 1,
+                needs_clarification INTEGER DEFAULT 0,
+                status TEXT DEFAULT 'active',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                corrected_by_user_id INTEGER,
+                corrected_by_name TEXT,
+                correction_reason TEXT,
+                supersedes_id INTEGER,
+                superseded_by_id INTEGER
+            )
+            """
+        )
+        self.conn.commit()
+        declared.ensure_declared_canon_schema(self.conn)
+
+    def tearDown(self):
+        self.conn.close()
+        self.env.stop()
+
+    def insert_broadcast(
+        self,
+        entry_type="notable_moment",
+        *,
+        guild_id=7,
+        submitter=61,
+        raw="Owner raw broadcast declaration.",
+        cleaned="Public-safe broadcast summary.",
+        public_safe=1,
+        usage_scope="ambient,direct",
+        valid_until="",
+        status="active",
+        created_at="2026-08-01T01:00:00+00:00",
+        updated_at="2026-08-01T01:00:00+00:00",
+        supersedes_id=None,
+        superseded_by_id=None,
+    ):
+        cursor = self.conn.execute(
+            """
+            INSERT INTO broadcast_memory(
+                guild_id,episode_date,submitted_by_user_id,submitted_by_name,
+                raw_note,cleaned_summary,entry_type,importance,public_safe,
+                affects_next_show,usage_scope,target_show_date,valid_until,
+                override_span_count,needs_clarification,status,created_at,
+                updated_at,corrected_by_user_id,corrected_by_name,
+                correction_reason,supersedes_id,superseded_by_id
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                guild_id,
+                "2026-08-01",
+                submitter,
+                "6 Bit" if submitter == 61 else "Test Member",
+                raw,
+                cleaned,
+                entry_type,
+                "medium",
+                public_safe,
+                0,
+                usage_scope,
+                None,
+                valid_until,
+                1,
+                0,
+                status,
+                created_at,
+                updated_at,
+                None,
+                None,
+                None,
+                supersedes_id,
+                superseded_by_id,
+            ),
+        )
+        self.conn.commit()
+        return int(cursor.lastrowid)
+
+    def source(self, row_id):
+        row = self.conn.execute(
+            "SELECT * FROM broadcast_memory WHERE id=?", (row_id,)
+        ).fetchone()
+        return dict(row)
+
+    def classify(
+        self,
+        row_id,
+        nonce="classify-0001",
+        *,
+        expected_fingerprint=None,
+        expected_revision_id="",
+        actor=61,
+        **overrides,
+    ):
+        values = {
+            "guild_id": 7,
+            "broadcast_row_id": row_id,
+            "expected_source_fingerprint": (
+                expected_fingerprint
+                if expected_fingerprint is not None
+                else declared.broadcast_source_fingerprint(self.source(row_id))
+            ),
+            "expected_revision_id": expected_revision_id,
+            "subject_type": "broadcast",
+            "subject_id": "barcode_radio",
+            "visibility": "internal",
+            "eligible_routes": ("broadcast_memory",),
+            "now": "2026-08-01T02:00:00+00:00",
+        }
+        values.update(overrides)
+        return declared.classify_broadcast_memory(
+            self.conn,
+            actor_user_id=actor,
+            authority_nonce=nonce,
+            **values,
+        )
+
+    def test_six_exact_current_types_receive_only_versioned_defaults(self):
+        for index, (entry_type, expected) in enumerate(
+            declared.BROADCAST_TYPE_DEFAULTS.items(), start=1
+        ):
+            row_id = self.insert_broadcast(entry_type)
+            revision = self.classify(
+                row_id, nonce="classify-%04d" % index
+            ).primary
+            self.assertEqual((revision.domain, revision.claim_kind), expected)
+            self.assertEqual(revision.predicate, entry_type)
+            self.assertEqual(revision.lifecycle_status, "established")
+            self.assertEqual(revision.classification_mode, "owner_explicit_default_mapping")
+
+    def test_owner_can_override_default_mapping_without_changing_source_type(self):
+        row_id = self.insert_broadcast("notable_moment")
+        revision = self.classify(
+            row_id,
+            domain="lore",
+            claim_kind="other",
+        ).primary
+        self.assertEqual((revision.domain, revision.claim_kind), ("lore", "other"))
+        self.assertEqual(revision.predicate, "notable_moment")
+        self.assertEqual(revision.classification_mode, "owner_explicit_mapping_override")
+        self.assertEqual(self.source(row_id)["entry_type"], "notable_moment")
+
+    def test_broadcast_sidecar_copies_no_source_content(self):
+        raw = "Private owner wording remains only in Broadcast Memory."
+        cleaned = "Clean public wording remains only in Broadcast Memory."
+        row_id = self.insert_broadcast(raw=raw, cleaned=cleaned)
+        revision = self.classify(row_id).primary
+        stored = self.conn.execute(
+            "SELECT raw_declaration,cleaned_summary,value_json "
+            "FROM declared_canon_revisions WHERE revision_id=?",
+            (revision.revision_id,),
+        ).fetchone()
+        self.assertEqual(tuple(stored), ("", "", ""))
+        table_dump = repr(
+            self.conn.execute(
+                "SELECT raw_declaration,cleaned_summary,value_json "
+                "FROM declared_canon_revisions"
+            ).fetchall()
+        )
+        self.assertNotIn(raw, table_dump)
+        self.assertNotIn(cleaned, table_dump)
+
+    def test_legacy_exact_type_is_zero_write_until_explicit_owner_mapping(self):
+        legacy_types = (
+            "continuity_backreference",
+            "show_note",
+            "recap",
+            "arbitrary_low_level_value",
+            "Notable_Moment",
+        )
+        for index, entry_type in enumerate(legacy_types, start=1):
+            row_id = self.insert_broadcast(entry_type)
+            before = self.conn.total_changes
+            with self.assertRaisesRegex(
+                declared.DeclaredCanonError, "legacy_type_review_only"
+            ):
+                self.classify(row_id, nonce="legacy-%04d" % index)
+            self.assertEqual(self.conn.total_changes, before)
+
+        row_id = self.insert_broadcast("continuity_backreference")
+        revision = self.classify(
+            row_id,
+            nonce="legacy-explicit1",
+            domain="broadcast_history",
+            claim_kind="event",
+        ).primary
+        self.assertEqual(revision.predicate, "continuity_backreference")
+        self.assertEqual(revision.classification_mode, "owner_explicit_legacy_mapping")
+        self.assertEqual(self.source(row_id)["entry_type"], "continuity_backreference")
+        preview = declared.preview_historical_broadcast_memory(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="legacy-preview1",
+            guild_id=7,
+            now="2026-08-01T04:00:00+00:00",
+        )
+        explicit_item = preview.items[-1]
+        self.assertEqual(explicit_item.entry_type, "legacy_or_unrecognized")
+        self.assertEqual(explicit_item.disposition, "declared_classification_current")
+        self.assertIn("legacy_type_explicitly_classified", explicit_item.reason_codes)
+
+    def test_typed_subject_is_explicit_and_submitter_is_provenance_only(self):
+        row_id = self.insert_broadcast(submitter=62)
+        revision = self.classify(
+            row_id,
+            subject_type="person",
+            subject_id="test_member",
+        ).primary
+        self.assertEqual(revision.subject_id, "test_member")
+        self.assertNotEqual(revision.subject_id, "discord_user:62")
+
+    def test_relationship_mapping_requires_typed_counterpart_and_predicate(self):
+        row_id = self.insert_broadcast()
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "relationship_predicate_required"
+        ):
+            self.classify(
+                row_id,
+                claim_kind="relationship",
+                object_subject_type="organization",
+                object_subject_id="barcode_network",
+            )
+        relation = self.classify(
+            row_id,
+            nonce="relation-map01",
+            claim_kind="relationship",
+            predicate="broadcasts_for",
+            object_subject_type="organization",
+            object_subject_id="barcode_network",
+        ).primary
+        self.assertEqual(relation.object_subject_type, "organization")
+        self.assertEqual(relation.object_subject_id, "barcode_network")
+
+    def test_public_classification_requires_safe_current_source_and_scope(self):
+        good = self.insert_broadcast(public_safe=1, usage_scope="ambient,direct")
+        revision = self.classify(
+            good,
+            visibility="public_safe",
+            eligible_routes=("public_home", "public_selective"),
+        ).primary
+        self.assertEqual(revision.visibility, "public_safe")
+
+        false_source = self.insert_broadcast(public_safe=0)
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "broadcast_source_not_public_safe"
+        ):
+            self.classify(
+                false_source,
+                nonce="public-false1",
+                visibility="public_safe",
+                eligible_routes=("public_home",),
+            )
+        string_true = self.insert_broadcast(public_safe="true")
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "broadcast_source_not_public_safe"
+        ):
+            self.classify(
+                string_true,
+                nonce="public-string1",
+                visibility="public_safe",
+                eligible_routes=("public_home",),
+            )
+        internal_scope = self.insert_broadcast(public_safe=1, usage_scope="internal,direct")
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "broadcast_internal_scope_veto"
+        ):
+            self.classify(
+                internal_scope,
+                nonce="public-intern1",
+                visibility="public_safe",
+                eligible_routes=("public_home",),
+            )
+        no_relay_scope = self.insert_broadcast(public_safe=1, usage_scope="ambient,direct")
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "broadcast_route_scope_widening"
+        ):
+            self.classify(
+                no_relay_scope,
+                nonce="route-widen-01",
+                visibility="public_safe",
+                eligible_routes=("relay",),
+            )
+        resolved = self.insert_broadcast(status="resolved")
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "broadcast_source_not_current_for_public"
+        ):
+            self.classify(
+                resolved,
+                nonce="public-resolved",
+                visibility="public_safe",
+                eligible_routes=("public_home",),
+            )
+
+    def test_moderation_context_is_internal_even_if_source_says_safe(self):
+        row_id = self.insert_broadcast("moderation_context", public_safe=1)
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "moderation_context_internal_only"
+        ):
+            self.classify(
+                row_id,
+                visibility="public_safe",
+                eligible_routes=("public_home",),
+            )
+        internal = self.classify(
+            row_id, nonce="moderation-002", visibility="internal"
+        ).primary
+        self.assertEqual(internal.visibility, "internal")
+
+    def test_fingerprint_binds_every_known_and_future_source_column(self):
+        row_id = self.insert_broadcast()
+        original_row = self.source(row_id)
+        original = declared.broadcast_source_fingerprint(original_row)
+        mutations = {
+            "cleaned_summary": "changed",
+            "updated_at": "2026-08-01T03:00:00+00:00",
+            "status": "resolved",
+            "public_safe": 0,
+            "usage_scope": "internal",
+            "valid_until": "2026-07-01T00:00:00+00:00",
+            "submitted_by_user_id": 62,
+            "corrected_by_user_id": 62,
+            "correction_reason": "changed provenance",
+            "supersedes_id": 99,
+            "superseded_by_id": 100,
+        }
+        for column, value in mutations.items():
+            changed = dict(original_row)
+            changed[column] = value
+            self.assertNotEqual(
+                declared.broadcast_source_fingerprint(changed),
+                original,
+                column,
+            )
+        unrelated_future_column = dict(original_row)
+        unrelated_future_column["future_display_hint"] = None
+        self.assertNotEqual(
+            declared.broadcast_source_fingerprint(unrelated_future_column),
+            original,
+        )
+        changed_future_column = dict(unrelated_future_column)
+        changed_future_column["future_display_hint"] = "now populated"
+        self.assertNotEqual(
+            declared.broadcast_source_fingerprint(changed_future_column),
+            declared.broadcast_source_fingerprint(unrelated_future_column),
+        )
+        self.assertEqual(
+            declared.broadcast_source_fingerprint(
+                dict(reversed(tuple(unrelated_future_column.items())))
+            ),
+            declared.broadcast_source_fingerprint(unrelated_future_column),
+        )
+
+    def test_source_schema_addition_stales_existing_approval_even_when_null(self):
+        row_id = self.insert_broadcast()
+        revision = self.classify(row_id, nonce="schema-stale-add1").primary
+        self.conn.execute(
+            "ALTER TABLE broadcast_memory ADD COLUMN future_display_hint TEXT"
+        )
+        self.conn.commit()
+        preview = declared.preview_historical_broadcast_memory(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="schema-stale-preview1",
+            guild_id=7,
+            now="2026-08-01T04:00:00+00:00",
+        )
+        self.assertEqual(preview.items[0].source_fingerprint_state, "stale_or_unversioned")
+        self.assertIn("classification_source_stale", preview.items[0].reason_codes)
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "expected_source_fingerprint_mismatch"
+        ):
+            declared.validate_current_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="schema-stale-read01",
+                guild_id=7,
+                declaration_id=revision.declaration_id,
+                expected_revision_id=revision.revision_id,
+                expected_source_fingerprint=revision.source_fingerprint,
+                now="2026-08-01T04:00:00+00:00",
+            )
+
+    def test_stale_owner_snapshot_rejects_before_write(self):
+        row_id = self.insert_broadcast()
+        approved = declared.broadcast_source_fingerprint(self.source(row_id))
+        self.conn.execute(
+            "UPDATE broadcast_memory SET public_safe=0,usage_scope='internal',updated_at=? WHERE id=?",
+            ("2026-08-01T03:00:00+00:00", row_id),
+        )
+        self.conn.commit()
+        before = self.conn.total_changes
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "expected_source_fingerprint_mismatch"
+        ):
+            self.classify(
+                row_id,
+                expected_fingerprint=approved,
+                nonce="stale-source01",
+            )
+        self.assertEqual(self.conn.total_changes, before)
+
+    def test_classification_exact_retry_and_nonce_replay_are_fail_closed(self):
+        row_one = self.insert_broadcast()
+        first = self.classify(row_one, nonce="class-replay01")
+        before = self.conn.total_changes
+        retry = self.classify(row_one, nonce="class-replay01")
+        self.assertEqual(retry.primary.revision_id, first.primary.revision_id)
+        self.assertEqual(self.conn.total_changes, before)
+        row_two = self.insert_broadcast()
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "authority_nonce_replay_mismatch"
+        ):
+            self.classify(row_two, nonce="class-replay01")
+
+    def test_reclassification_cannot_launder_forged_prior_sidecar(self):
+        row_id = self.insert_broadcast()
+        created = self.classify(row_id, nonce="forge-sidecar01").primary
+        forged = asdict(created)
+        forged["revision_number"] = 2
+        forged["previous_revision_id"] = created.revision_id
+        forged["correction_of_revision_id"] = created.revision_id
+        forged["operation_id"] = "op_" + "6" * 32
+        forged["authority_request_fingerprint"] = "req_" + "7" * 48
+        forged["authority_verified"] = 1
+        forged["authority_receipt"] = (
+            "owner_command:declared_canon_lifecycle_v1:"
+            "declared_canon_internal_receipt_v1:classify_broadcast:"
+            + "8" * 64
+        )
+        forged["revision_id"] = "drev_" + declared._digest(
+            *(forged[column] for column in declared._REVISION_COLUMNS
+              if column != "revision_id")
+        )[:40]
+        self.conn.execute(
+            "INSERT INTO declared_canon_revisions (%s) VALUES (%s)"
+            % (
+                ",".join(declared._REVISION_COLUMNS),
+                ",".join("?" for _ in declared._REVISION_COLUMNS),
+            ),
+            tuple(forged[column] for column in declared._REVISION_COLUMNS),
+        )
+        self.conn.commit()
+        before = self.conn.total_changes
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "stored_authority_invalid"
+        ):
+            self.classify(
+                row_id,
+                nonce="forge-sidecar02",
+                expected_revision_id=forged["revision_id"],
+            )
+        self.assertEqual(self.conn.total_changes, before)
+
+    def test_reclassification_requires_expected_revision_and_appends(self):
+        row_id = self.insert_broadcast()
+        original = self.classify(row_id).primary
+        self.conn.execute(
+            "UPDATE broadcast_memory SET cleaned_summary=?,updated_at=? WHERE id=?",
+            ("Corrected source summary.", "2026-08-01T03:00:00+00:00", row_id),
+        )
+        self.conn.commit()
+        current_fingerprint = declared.broadcast_source_fingerprint(self.source(row_id))
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "expected_revision_mismatch"
+        ):
+            self.classify(
+                row_id,
+                nonce="reclass-stale1",
+                expected_fingerprint=current_fingerprint,
+            )
+        corrected = self.classify(
+            row_id,
+            nonce="reclass-good01",
+            expected_fingerprint=current_fingerprint,
+            expected_revision_id=original.revision_id,
+        ).primary
+        self.assertEqual(corrected.revision_number, 2)
+        self.assertEqual(corrected.previous_revision_id, original.revision_id)
+        self.assertNotEqual(corrected.source_fingerprint, original.source_fingerprint)
+
+    def test_classification_owner_and_primary_guild_boundaries(self):
+        row_id = self.insert_broadcast()
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "configured_owner_required"
+        ):
+            self.classify(row_id, actor=62)
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "configured_primary_guild_required"
+        ):
+            self.classify(row_id, guild_id=8)
+
+    def test_historical_preview_is_zero_write_content_free_and_fixed_era_grouped(self):
+        pre_id = self.insert_broadcast(
+            created_at="2026-07-22T12:00:00+00:00",
+            updated_at="2026-07-22T12:00:00+00:00",
+            raw="Pre-boundary raw content.",
+            cleaned="Pre-boundary clean content.",
+        )
+        post_id = self.insert_broadcast(
+            "continuity_backreference",
+            created_at="2026-07-24T12:00:00+00:00",
+            updated_at="2026-07-24T12:00:00+00:00",
+            raw="Post-boundary raw content.",
+            cleaned="Post-boundary clean content.",
+            submitter=62,
+            supersedes_id=pre_id,
+        )
+        before = self.conn.total_changes
+        preview = declared.preview_historical_broadcast_memory(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="preview-bcast1",
+            guild_id=7,
+            now="2026-08-01T04:00:00+00:00",
+        )
+        self.assertEqual(preview.mutation_count, 0)
+        self.assertEqual(self.conn.total_changes, before)
+        self.assertEqual(
+            preview.owner_era_cutoff,
+            declared.BROADCAST_DECLARED_CANON_OWNER_ERA_CUTOFF,
+        )
+        self.assertEqual(
+            tuple(item.source_era for item in preview.items),
+            ("pre_declared_canon_owner_era", "post_declared_canon_owner_era"),
+        )
+        self.assertEqual(
+            tuple(item.disposition for item in preview.items),
+            ("needs_owner_review", "needs_owner_review"),
+        )
+        self.assertRegex(preview.authority_actor_ref, r"^actor_[0-9a-f]{20}$")
+        self.assertRegex(preview.authority_receipt_id, r"^receipt_[0-9a-f]{24}$")
+        for item in preview.items:
+            fields = asdict(item)
+            self.assertNotIn("source_row_id", fields)
+            self.assertNotIn("source_token", fields)
+            self.assertRegex(item.preview_item, r"^item_[0-9a-f]{16}$")
+        self.assertNotIn("Pre-boundary raw content.", repr(preview))
+        self.assertNotIn("Post-boundary clean content.", repr(preview))
+        self.assertNotIn("submitted_by_user_id", repr(preview))
+        self.assertNotIn("owner_era_cutoff", inspect.signature(
+            declared.preview_historical_broadcast_memory
+        ).parameters)
+        second = declared.preview_historical_broadcast_memory(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="preview-bcast2",
+            guild_id=7,
+            now="2026-08-01T04:00:00+00:00",
+        )
+        self.assertNotEqual(preview.items[0].preview_item, second.items[0].preview_item)
+        paged = declared.preview_historical_broadcast_memory(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="preview-page01",
+            guild_id=7,
+            limit=1,
+            now="2026-08-01T04:00:00+00:00",
+        )
+        self.assertEqual(paged.total_rows, 2)
+        self.assertTrue(paged.truncated)
+        self.assertEqual(paged.counts_scope, "returned_page")
+        self.assertEqual(sum(paged.type_counts.values()), 1)
+        self.assertEqual(sum(paged.era_counts.values()), 1)
+        self.assertEqual(sum(paged.disposition_counts.values()), 1)
+        self.assertEqual(pre_id + 1, post_id)
+
+    def test_historical_preview_reason_codes_malformed_provenance(self):
+        self.insert_broadcast(
+            submitter="not-a-user-id",
+            created_at="not-a-timestamp",
+            updated_at="2026-08-01T01:00:00+00:00",
+        )
+        preview = declared.preview_historical_broadcast_memory(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="malformed-prev1",
+            guild_id=7,
+            now="2026-08-01T04:00:00+00:00",
+        )
+        self.assertEqual(len(preview.items), 1)
+        item = preview.items[0]
+        self.assertEqual(item.source_era, "unknown_era")
+        self.assertEqual(item.submitter_state, "unverified")
+        self.assertIn("submitter_identity_malformed", item.reason_codes)
+        self.assertIn("owner_authorship_unverified", item.reason_codes)
+
+    def test_historical_preview_buckets_hostile_legacy_metadata(self):
+        secret_type = "person_email_alice@example.com"
+        secret_scope = "internal,secret_account_12345"
+        secret_status = "active_private_secret"
+        self.insert_broadcast(
+            secret_type,
+            usage_scope=secret_scope,
+            status=secret_status,
+            created_at="2026-07-22T12:00:00+00:00",
+            updated_at="2026-07-22T12:00:00+00:00",
+        )
+        preview = declared.preview_historical_broadcast_memory(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="hostile-preview1",
+            guild_id=7,
+            now="2026-08-01T04:00:00+00:00",
+        )
+        rendered = repr(preview)
+        self.assertNotIn(secret_type, rendered)
+        self.assertNotIn("secret_account_12345", rendered)
+        self.assertNotIn(secret_status, rendered)
+        self.assertEqual(preview.items[0].entry_type, "legacy_or_unrecognized")
+        self.assertEqual(preview.items[0].status, "unrecognized")
+        self.assertEqual(
+            preview.items[0].usage_scope, "internal,unknown_scope_present"
+        )
+        self.assertEqual(
+            preview.type_counts, {"legacy_or_unrecognized": 1}
+        )
+
+    def test_preview_recomputes_fingerprint_and_never_calls_stale_public_current(self):
+        row_id = self.insert_broadcast(public_safe=1, usage_scope="ambient,direct")
+        revision = self.classify(
+            row_id,
+            visibility="public_safe",
+            eligible_routes=("public_home",),
+        ).primary
+        current = declared.preview_historical_broadcast_memory(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="preview-current",
+            guild_id=7,
+            now="2026-08-01T04:00:00+00:00",
+        )
+        self.assertEqual(current.items[0].source_fingerprint_state, "current")
+        self.assertEqual(current.items[0].disposition, "declared_classification_current")
+
+        self.conn.execute(
+            "UPDATE broadcast_memory SET status='resolved',public_safe=0,"
+            "usage_scope='internal',valid_until=?,updated_at=? WHERE id=?",
+            (
+                "2026-07-01T00:00:00+00:00",
+                "2026-08-01T05:00:00+00:00",
+                row_id,
+            ),
+        )
+        self.conn.commit()
+        stale = declared.preview_historical_broadcast_memory(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="preview-stale01",
+            guild_id=7,
+            now="2026-08-01T06:00:00+00:00",
+        )
+        item = stale.items[0]
+        self.assertEqual(item.source_fingerprint_state, "stale_or_unversioned")
+        self.assertEqual(item.disposition, "stale_classification_review")
+        self.assertIn("classification_source_stale", item.reason_codes)
+        self.assertTrue(item.classification_state.startswith("not_current:"))
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "expected_source_fingerprint_mismatch"
+        ):
+            declared.validate_current_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="validate-stale1",
+                guild_id=7,
+                declaration_id=revision.declaration_id,
+                expected_revision_id=revision.revision_id,
+                expected_source_fingerprint=revision.source_fingerprint,
+                now="2026-08-01T06:00:00+00:00",
+            )
+
+    def test_read_validator_accepts_only_current_source_intersection_zero_write(self):
+        row_id = self.insert_broadcast(public_safe=1, usage_scope="ambient,direct")
+        revision = self.classify(
+            row_id,
+            visibility="public_safe",
+            eligible_routes=("public_home",),
+        ).primary
+        before = self.conn.total_changes
+        result = declared.validate_current_declared_canon_revision(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="validate-bcast1",
+            guild_id=7,
+            declaration_id=revision.declaration_id,
+            expected_revision_id=revision.revision_id,
+            expected_source_fingerprint=revision.source_fingerprint,
+            now="2026-08-01T04:00:00+00:00",
+        )
+        self.assertEqual(result.revision_id, revision.revision_id)
+        self.assertEqual(self.conn.total_changes, before)
+
+    def test_implicit_runtime_now_preserves_microseconds_for_immediate_validation(self):
+        source_now = datetime.now(timezone.utc).isoformat()
+        row_id = self.insert_broadcast(
+            created_at=source_now,
+            updated_at=source_now,
+        )
+        revision = self.classify(
+            row_id,
+            nonce="microsecond-add1",
+            now="",
+        ).primary
+        validated = declared.validate_current_declared_canon_revision(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="microsecond-read",
+            guild_id=7,
+            declaration_id=revision.declaration_id,
+            expected_revision_id=revision.revision_id,
+            expected_source_fingerprint=revision.source_fingerprint,
+        )
+        self.assertEqual(validated.revision_id, revision.revision_id)
+
+    def test_latest_validator_exposes_resolved_broadcast_for_retraction_only(self):
+        row_id = self.insert_broadcast(status="resolved", public_safe=0, usage_scope="internal")
+        revision = self.classify(row_id).primary
+        self.assertEqual(revision.lifecycle_status, "resolved")
+        before = self.conn.total_changes
+        latest = declared.validate_latest_declared_canon_revision(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="resolved-read01",
+            guild_id=7,
+            declaration_id=revision.declaration_id,
+            expected_revision_id=revision.revision_id,
+            expected_source_fingerprint=revision.source_fingerprint,
+            expected_lifecycle_status="resolved",
+            now="2026-08-01T04:00:00+00:00",
+        )
+        self.assertEqual(latest.lifecycle_status, "resolved")
+        self.assertEqual(self.conn.total_changes, before)
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "declared_revision_not_established"
+        ):
+            declared.validate_current_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="resolved-current",
+                guild_id=7,
+                declaration_id=revision.declaration_id,
+                expected_revision_id=revision.revision_id,
+                expected_source_fingerprint=revision.source_fingerprint,
+                now="2026-08-01T04:00:00+00:00",
+            )
+
+    def test_preview_and_validator_reject_forged_stored_authority(self):
+        row_id = self.insert_broadcast()
+        revision = self.classify(row_id).primary
+        self.conn.execute("DROP TRIGGER trg_declared_canon_revisions_no_update")
+        self.conn.execute(
+            "UPDATE declared_canon_revisions SET authority_receipt='owner_confirmed' "
+            "WHERE revision_id=?",
+            (revision.revision_id,),
+        )
+        self.conn.commit()
+        preview = declared.preview_historical_broadcast_memory(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="forged-preview1",
+            guild_id=7,
+            now="2026-08-01T04:00:00+00:00",
+        )
+        self.assertEqual(preview.items[0].disposition, "stale_classification_review")
+        self.assertIn(
+            "classification_authority_invalid", preview.items[0].reason_codes
+        )
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "stored_authority_invalid"
+        ):
+            declared.validate_current_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="forged-validate1",
+                guild_id=7,
+                declaration_id=revision.declaration_id,
+                expected_revision_id=revision.revision_id,
+                expected_source_fingerprint=revision.source_fingerprint,
+                now="2026-08-01T04:00:00+00:00",
+            )
+
+    def test_no_projection_or_derived_classification_api_exists(self):
+        signature = inspect.signature(declared.classify_broadcast_memory)
+        self.assertNotIn("derived_from_source_ref", signature.parameters)
+        self.assertFalse(any("project" in name for name in declared.__all__))
+
+    def test_missing_or_unversioned_broadcast_schema_fails_closed(self):
+        other = sqlite3.connect(":memory:")
+        try:
+            declared.ensure_declared_canon_schema(other)
+            before = other.total_changes
+            with self.assertRaisesRegex(
+                declared.DeclaredCanonError, "broadcast_source_not_found"
+            ):
+                declared.classify_broadcast_memory(
+                    other,
+                    actor_user_id=61,
+                    authority_nonce="missing-table1",
+                    guild_id=7,
+                    broadcast_row_id=1,
+                    expected_source_fingerprint="bsrc_" + "0" * 40,
+                    subject_type="broadcast",
+                    subject_id="barcode_radio",
+                )
+            self.assertEqual(other.total_changes, before)
+        finally:
+            other.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_declared_canon_bot_controls.py
+++ b/tests/test_declared_canon_bot_controls.py
@@ -1,0 +1,436 @@
+import asyncio
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from unittest import mock
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+import bnl_declared_canon as declared
+
+
+class _Author:
+    def __init__(self, user_id=61):
+        self.id = user_id
+        self.display_name = "Owner" if user_id == 61 else "Other"
+
+
+class _Guild:
+    def __init__(self, guild_id=7):
+        self.id = guild_id
+
+
+class _Channel:
+    id = 700
+    name = "research-and-development"
+
+
+class _Message:
+    def __init__(self, content, *, message_id=1001, user_id=61, guild_id=7):
+        self.content = content
+        self.id = message_id
+        self.author = _Author(user_id)
+        self.guild = _Guild(guild_id)
+        self.channel = _Channel()
+        self.replies = []
+
+    async def reply(self, text, **_kwargs):
+        self.replies.append(text)
+
+
+class DeclaredCanonBotControlTests(unittest.TestCase):
+    def setUp(self):
+        self.old_db = bnl01_bot.DB_FILE
+        self.old_owner = bnl01_bot.BNL_OWNER_USER_ID
+        self.old_guild = bnl01_bot.BNL_PRIMARY_GUILD_ID
+        self.tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.tmp.close()
+        bnl01_bot.DB_FILE = self.tmp.name
+        bnl01_bot.BNL_OWNER_USER_ID = 61
+        bnl01_bot.BNL_PRIMARY_GUILD_ID = 7
+        self.runtime = mock.patch.dict(
+            os.environ,
+            {
+                "BNL_OWNER_USER_ID": "61",
+                "BNL_PRIMARY_GUILD_ID": "7",
+                "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "1",
+            },
+            clear=False,
+        )
+        self.runtime.start()
+        bnl01_bot.init_db()
+        self.rd = mock.patch.object(
+            bnl01_bot,
+            "is_research_and_development_channel",
+            return_value=True,
+        )
+        self.rd.start()
+
+    def tearDown(self):
+        self.rd.stop()
+        self.runtime.stop()
+        bnl01_bot.DB_FILE = self.old_db
+        bnl01_bot.BNL_OWNER_USER_ID = self.old_owner
+        bnl01_bot.BNL_PRIMARY_GUILD_ID = self.old_guild
+        try:
+            os.unlink(self.tmp.name)
+        except OSError:
+            pass
+
+    def rows(self, sql, params=()):
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            return conn.execute(sql, params).fetchall()
+
+    def invoke(self, command, **message_kwargs):
+        message = _Message(command, **message_kwargs)
+        handled = asyncio.run(
+            bnl01_bot.maybe_handle_declared_canon_command(message, command)
+        )
+        self.assertTrue(handled)
+        self.assertTrue(message.replies)
+        return message
+
+    @staticmethod
+    def add_payload(summary="Owner-only role summary."):
+        return {
+            "subject_type": "project",
+            "subject_id": "barcode_radio",
+            "predicate": "current_role",
+            "value": {"summary": summary},
+            "raw_declaration": "PRIVATE RAW DECLARATION: " + summary,
+            "cleaned_summary": summary,
+            "domain": "real_community",
+            "claim_kind": "role",
+            "visibility": "internal",
+            "eligible_routes": ["declared_canon_review"],
+        }
+
+    def test_owner_add_is_idempotent_and_emits_only_nonlive_projection(self):
+        payload = self.add_payload()
+        command = "!bnl canon add " + json.dumps(payload, sort_keys=True)
+        first = self.invoke(command, message_id=1101)
+        self.assertNotIn("PRIVATE RAW DECLARATION", first.replies[0])
+        self.assertEqual(
+            self.rows("SELECT COUNT(*) FROM declared_canon_revisions")[0][0],
+            1,
+        )
+        self.assertEqual(
+            self.rows(
+                """
+                SELECT source_class,visibility,public_usable,derived,projection,
+                       lifecycle_status
+                FROM memory_ledger_entries
+                WHERE source_table='declared_canon_projection'
+                """
+            ),
+            [("evidence_projection", "internal", 0, 1, 1, "review_only")],
+        )
+        retry = self.invoke(command, message_id=1101)
+        self.assertIn("operation committed", retry.replies[0].lower())
+        self.assertEqual(
+            self.rows("SELECT COUNT(*) FROM declared_canon_revisions")[0][0],
+            1,
+        )
+        self.assertEqual(
+            self.rows(
+                "SELECT COUNT(*) FROM memory_ledger_entries WHERE source_table='declared_canon_projection'"
+            )[0][0],
+            1,
+        )
+
+    def test_owner_add_reports_projection_gate_disabled_exactly(self):
+        command = "!bnl canon add " + json.dumps(
+            self.add_payload("Disabled shadow summary."), sort_keys=True
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_MEMORY_LEDGER_SHADOW_ENABLED": "0"},
+            clear=False,
+        ):
+            reply = self.invoke(command, message_id=1111)
+
+        self.assertIn("Shadow projections: disabled.", reply.replies[0])
+        self.assertNotIn("error:shadow_exception", reply.replies[0])
+        self.assertEqual(
+            self.rows("SELECT COUNT(*) FROM declared_canon_revisions")[0][0],
+            1,
+        )
+        self.assertEqual(
+            self.rows(
+                "SELECT COUNT(*) FROM memory_ledger_entries "
+                "WHERE source_table='declared_canon_projection'"
+            )[0][0],
+            0,
+        )
+
+    def test_owner_add_reports_enabled_projection_exception_after_commit(self):
+        command = "!bnl canon add " + json.dumps(
+            self.add_payload("Projection exception summary."), sort_keys=True
+        )
+        with mock.patch.object(
+            bnl01_bot,
+            "shadow_declared_canon_projection",
+            side_effect=RuntimeError("forced declared projection failure"),
+        ):
+            reply = self.invoke(command, message_id=1112)
+
+        self.assertIn(
+            "Shadow projections: error:shadow_exception.", reply.replies[0]
+        )
+        self.assertNotIn("Shadow projections: disabled.", reply.replies[0])
+        self.assertEqual(
+            self.rows("SELECT COUNT(*) FROM declared_canon_revisions")[0][0],
+            1,
+        )
+        self.assertEqual(
+            self.rows(
+                "SELECT COUNT(*) FROM memory_ledger_entries "
+                "WHERE source_table='declared_canon_projection'"
+            )[0][0],
+            0,
+        )
+        self.assertEqual(
+            self.rows(
+                """
+                SELECT outcome,reason_code
+                FROM memory_ledger_shadow_receipts
+                WHERE writer='declared_canon_projection'
+                """
+            ),
+            [("error", "shadow_exception")],
+        )
+
+    def test_changed_nonce_reuse_and_stale_revision_fail_without_write(self):
+        original_command = "!bnl canon add " + json.dumps(
+            self.add_payload("Original summary."), sort_keys=True
+        )
+        self.invoke(original_command, message_id=1201)
+        changed_command = "!bnl canon add " + json.dumps(
+            self.add_payload("Changed under reused nonce."), sort_keys=True
+        )
+        changed = self.invoke(changed_command, message_id=1201)
+        self.assertIn("authority_nonce_replay_mismatch", changed.replies[0])
+        declaration_id, revision_id = self.rows(
+            "SELECT declaration_id,revision_id FROM declared_canon_revisions"
+        )[0]
+        correction = self.add_payload("Correction with stale expectation.")
+        correction.update(
+            {
+                "declaration_id": declaration_id,
+                "expected_revision_id": "drev_00000000000000000000000000000000",
+                "reason": "stale fixture",
+            }
+        )
+        stale = self.invoke(
+            "!bnl canon correct " + json.dumps(correction, sort_keys=True),
+            message_id=1202,
+        )
+        self.assertIn("expected_revision_mismatch", stale.replies[0])
+        self.assertEqual(
+            self.rows(
+                "SELECT declaration_id,revision_id FROM declared_canon_revisions"
+            ),
+            [(declaration_id, revision_id)],
+        )
+
+    def test_nonowner_and_cross_guild_controls_fail_before_write(self):
+        command = "!bnl canon add " + json.dumps(self.add_payload(), sort_keys=True)
+        denied = self.invoke(command, message_id=1301, user_id=62)
+        self.assertIn("configured_owner_required", denied.replies[0])
+        cross_guild = self.invoke(command, message_id=1302, guild_id=8)
+        self.assertIn("configured_primary_guild_required", cross_guild.replies[0])
+        self.assertEqual(
+            self.rows("SELECT COUNT(*) FROM declared_canon_revisions")[0][0],
+            0,
+        )
+
+    def test_broadcast_classification_keeps_content_in_source_and_projects_root(self):
+        source_message = _Message(
+            "PRIVATE RAW BROADCAST SOURCE",
+            message_id=1401,
+        )
+        row_id = bnl01_bot.add_broadcast_memory_entry(
+            7,
+            source_message,
+            {
+                "episode_date": "2026-08-01",
+                "cleaned_summary": "Clean Broadcast source summary.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            columns = [row[1] for row in conn.execute("PRAGMA table_info(broadcast_memory)")]
+            values = conn.execute(
+                "SELECT %s FROM broadcast_memory WHERE id=?" % ",".join(columns),
+                (row_id,),
+            ).fetchone()
+        fingerprint = declared.broadcast_source_fingerprint(dict(zip(columns, values)))
+        payload = {
+            "broadcast_row_id": row_id,
+            "expected_source_fingerprint": fingerprint,
+            "subject_type": "broadcast",
+            "subject_id": "barcode_radio",
+            "visibility": "internal",
+            "eligible_routes": ["broadcast_memory"],
+        }
+        reply = self.invoke(
+            "!bnl canon broadcast-classify " + json.dumps(payload, sort_keys=True),
+            message_id=1402,
+        )
+        self.assertNotIn("PRIVATE RAW", reply.replies[0])
+        self.assertEqual(
+            self.rows(
+                """
+                SELECT raw_declaration,cleaned_summary,value_json
+                FROM declared_canon_revisions
+                """
+            ),
+            [("", "", "")],
+        )
+        projection = self.rows(
+            """
+            SELECT entry_id,normalized_value,public_usable,lifecycle_status
+            FROM memory_ledger_entries
+            WHERE source_table='declared_canon_projection'
+            """
+        )
+        self.assertEqual(
+            projection[0][1:],
+            ("Clean Broadcast source summary.", 0, "review_only"),
+        )
+        root_lineage = self.rows(
+            "SELECT lineage_type FROM memory_ledger_lineage WHERE entry_id=?",
+            (projection[0][0],),
+        )
+        self.assertEqual(root_lineage, [("derived_from",)])
+
+    def test_previews_are_zero_write_and_do_not_echo_unrecognized_metadata(self):
+        bnl01_bot.add_broadcast_memory_entry(
+            7,
+            _Message("PRIVATE PREVIEW SOURCE", message_id=1501),
+            {
+                "episode_date": "2026-08-01",
+                "cleaned_summary": "Preview source summary.",
+                "entry_type": "person_123456789_private_label",
+                "public_safe": False,
+                "usage_scope": "account_987654321,internal",
+            },
+        )
+        before = self.rows("SELECT COUNT(*) FROM declared_canon_revisions")[0][0]
+        preview = self.invoke("!bnl canon broadcast-preview", message_id=1502)
+        rendered = preview.replies[0]
+        self.assertNotIn("person_123456789_private_label", rendered)
+        self.assertNotIn("account_987654321", rendered)
+        self.assertNotIn("PRIVATE PREVIEW SOURCE", rendered)
+        self.assertIn("legacy_or_unrecognized", rendered)
+        self.assertIn("counts_scope=returned_page", rendered)
+        self.assertEqual(
+            self.rows("SELECT COUNT(*) FROM declared_canon_revisions")[0][0],
+            before,
+        )
+
+    def test_on_message_preserves_raw_control_before_any_conversational_sink(self):
+        raw_declaration = "Owner keeps <@123>  and  exact spacing."
+        payload = self.add_payload()
+        payload["raw_declaration"] = raw_declaration
+        command = "!bnl canon add " + json.dumps(payload)
+        message = _Message(command, message_id=1601)
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "_register_direct_conversation_ingress",
+            ) as ingress,
+            mock.patch.object(bnl01_bot, "upsert_user_profile") as profile,
+            mock.patch.object(
+                bnl01_bot, "resolve_discord_user_mentions_for_conversation"
+            ) as normalize,
+            mock.patch.object(
+                bnl01_bot,
+                "resolve_discord_turn_addressing_async",
+                new=mock.AsyncMock(),
+            ) as addressing,
+            mock.patch.object(
+                bnl01_bot,
+                "record_recent_room_event_from_message",
+            ) as recent_room,
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_handle_provider_status_command",
+                new=mock.AsyncMock(),
+            ) as provider,
+        ):
+            asyncio.run(bnl01_bot.on_message(message))
+
+        self.assertEqual(
+            self.rows("SELECT raw_declaration FROM declared_canon_revisions"),
+            [(raw_declaration,)],
+        )
+        ingress.assert_not_called()
+        profile.assert_not_called()
+        normalize.assert_not_called()
+        addressing.assert_not_awaited()
+        recent_room.assert_not_called()
+        provider.assert_not_awaited()
+
+    def test_on_message_denied_wrong_channel_and_malformed_controls_never_sink(self):
+        cases = (
+            (_Message("!bnl canon preview", message_id=1611, user_id=62), True),
+            (_Message("!bnl canon preview", message_id=1612), False),
+            (_Message("!bnl canon add {broken-json", message_id=1613), True),
+        )
+        for message, rd_allowed in cases:
+            with self.subTest(message_id=message.id):
+                with (
+                    mock.patch.object(
+                        bnl01_bot,
+                        "is_research_and_development_channel",
+                        return_value=rd_allowed,
+                    ),
+                    mock.patch.object(
+                        bnl01_bot, "_register_direct_conversation_ingress"
+                    ) as ingress,
+                    mock.patch.object(
+                        bnl01_bot, "upsert_user_profile"
+                    ) as profile,
+                    mock.patch.object(
+                        bnl01_bot,
+                        "resolve_discord_user_mentions_for_conversation",
+                    ) as normalize,
+                    mock.patch.object(
+                        bnl01_bot,
+                        "resolve_discord_turn_addressing_async",
+                        new=mock.AsyncMock(),
+                    ) as addressing,
+                    mock.patch.object(
+                        bnl01_bot, "record_recent_room_event_from_message"
+                    ) as recent_room,
+                    mock.patch.object(
+                        bnl01_bot,
+                        "maybe_handle_provider_status_command",
+                        new=mock.AsyncMock(),
+                    ) as provider,
+                ):
+                    asyncio.run(bnl01_bot.on_message(message))
+
+                self.assertTrue(message.replies)
+                ingress.assert_not_called()
+                profile.assert_not_called()
+                normalize.assert_not_called()
+                addressing.assert_not_awaited()
+                recent_room.assert_not_called()
+                provider.assert_not_awaited()
+
+        self.assertEqual(
+            self.rows("SELECT COUNT(*) FROM declared_canon_revisions")[0][0],
+            0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_declared_canon_lifecycle.py
+++ b/tests/test_declared_canon_lifecycle.py
@@ -1,0 +1,878 @@
+from dataclasses import asdict
+import inspect
+import os
+import sqlite3
+import tempfile
+import unittest
+from unittest import mock
+
+import bnl_declared_canon as declared
+
+
+def add_kwargs(**overrides):
+    values = {
+        "guild_id": 7,
+        "subject_type": "person",
+        "subject_id": "test_member",
+        "predicate": "community_role",
+        "value": {"role": "signal keeper", "current": True},
+        "raw_declaration": "6 Bit declares Test Member the signal keeper.",
+        "cleaned_summary": "Test Member is the signal keeper.",
+        "domain": "real_community",
+        "claim_kind": "role",
+        "visibility": "internal",
+        "eligible_routes": ("declared_canon_review",),
+        "valid_from": "2026-08-01T00:00:00+00:00",
+    }
+    values.update(overrides)
+    return values
+
+
+class DeclaredCanonLifecycleTests(unittest.TestCase):
+    def setUp(self):
+        self.env = mock.patch.dict(
+            os.environ,
+            {
+                "BNL_OWNER_USER_ID": "61",
+                "BNL_PRIMARY_GUILD_ID": "7",
+            },
+        )
+        self.env.start()
+        self.conn = sqlite3.connect(":memory:")
+        declared.ensure_declared_canon_schema(self.conn)
+
+    def tearDown(self):
+        self.conn.close()
+        self.env.stop()
+
+    def rows(self, query, params=()):
+        return self.conn.execute(query, params).fetchall()
+
+    def add(self, nonce="add-case-0001", actor=61, **overrides):
+        return declared.add_declared_canon(
+            self.conn,
+            actor_user_id=actor,
+            authority_nonce=nonce,
+            **add_kwargs(**overrides),
+        )
+
+    def test_schema_is_idempotent_one_table_and_append_only(self):
+        declared.ensure_declared_canon_schema(self.conn)
+        tables = {
+            row[0]
+            for row in self.rows(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        self.assertEqual(tables, {declared.DECLARED_CANON_TABLE})
+        created = self.add().primary
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError, "declared_canon_append_only_update"
+        ):
+            self.conn.execute(
+                "UPDATE declared_canon_revisions SET lifecycle_status='retired' "
+                "WHERE revision_id=?",
+                (created.revision_id,),
+            )
+        self.conn.rollback()
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError, "declared_canon_append_only_delete"
+        ):
+            self.conn.execute(
+                "DELETE FROM declared_canon_revisions WHERE revision_id=?",
+                (created.revision_id,),
+            )
+        self.conn.rollback()
+
+        replacement = asdict(created)
+        replacement["cleaned_summary"] = "REPLACED HISTORY"
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError, "declared_canon_append_only_conflict"
+        ):
+            self.conn.execute(
+                "INSERT OR REPLACE INTO declared_canon_revisions (%s) VALUES (%s)"
+                % (
+                    ",".join(declared._REVISION_COLUMNS),
+                    ",".join("?" for _ in declared._REVISION_COLUMNS),
+                ),
+                tuple(replacement[column] for column in declared._REVISION_COLUMNS),
+            )
+        self.conn.rollback()
+        stored = self.rows(
+            "SELECT cleaned_summary FROM declared_canon_revisions WHERE revision_id=?",
+            (created.revision_id,),
+        )
+        self.assertEqual(stored, [(created.cleaned_summary,)])
+
+    def test_public_apis_accept_no_caller_built_owner_or_receipt(self):
+        signature = inspect.signature(declared.add_declared_canon)
+        self.assertNotIn("authority", signature.parameters)
+        self.assertNotIn("authority_receipt", signature.parameters)
+        self.assertNotIn("configured_owner_user_id", signature.parameters)
+        self.assertFalse(hasattr(declared, "OwnerAuthority"))
+        self.assertFalse(hasattr(declared, "build_owner_authority"))
+
+    def test_every_boundary_reads_trusted_owner_and_primary_guild(self):
+        with mock.patch.dict(os.environ, {"BNL_OWNER_USER_ID": ""}):
+            with self.assertRaisesRegex(
+                declared.DeclaredCanonError, "owner_user_id_not_configured"
+            ):
+                self.add()
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "configured_owner_required"
+        ):
+            self.add(actor=62)
+        with mock.patch.dict(os.environ, {"BNL_PRIMARY_GUILD_ID": ""}):
+            with self.assertRaisesRegex(
+                declared.DeclaredCanonError, "primary_guild_id_not_configured"
+            ):
+                self.add()
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "configured_primary_guild_required"
+        ):
+            self.add(guild_id=8)
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM declared_canon_revisions")[0][0], 0)
+
+        no_schema = sqlite3.connect(":memory:")
+        try:
+            with self.assertRaisesRegex(
+                declared.DeclaredCanonError, "configured_owner_required"
+            ):
+                declared.validate_current_declared_canon_revision(
+                    no_schema,
+                    actor_user_id=62,
+                    authority_nonce="no-schema-auth1",
+                    guild_id=7,
+                    declaration_id="dcl_" + "0" * 32,
+                    expected_revision_id="drev_" + "0" * 40,
+                    expected_source_fingerprint="src_" + "0" * 40,
+                )
+        finally:
+            no_schema.close()
+
+    def test_add_separates_content_and_stores_bound_versioned_receipt(self):
+        revision = self.add().primary
+        self.assertEqual(revision.revision_number, 1)
+        self.assertEqual(revision.lifecycle_status, "established")
+        self.assertEqual(revision.source_system, "general_declaration")
+        self.assertEqual(revision.authority_actor, "discord_user:61")
+        self.assertTrue(revision.authority_verified)
+        self.assertNotEqual(revision.raw_declaration, revision.cleaned_summary)
+        self.assertTrue(revision.source_fingerprint.startswith("src_"))
+        self.assertRegex(
+            revision.authority_receipt,
+            r"^owner_command:declared_canon_lifecycle_v1:"
+            r"declared_canon_internal_receipt_v1:add:[0-9a-f]{64}$",
+        )
+        self.assertRegex(
+            revision.authority_request_fingerprint,
+            r"^req_[0-9a-f]{48}$",
+        )
+
+    def test_well_formed_forged_receipt_and_recomputed_revision_id_fail(self):
+        created = self.add("forge-source01").primary
+        forged = asdict(created)
+        forged["declaration_id"] = "dcl_" + "2" * 32
+        forged["source_row_id"] = forged["declaration_id"]
+        forged["operation_id"] = "op_" + "3" * 32
+        forged["authority_request_fingerprint"] = "req_" + "4" * 48
+        forged["authority_verified"] = 1
+        forged["authority_receipt"] = (
+            "owner_command:declared_canon_lifecycle_v1:"
+            "declared_canon_internal_receipt_v1:add:" + "5" * 64
+        )
+        forged["revision_id"] = "drev_" + declared._digest(
+            *(forged[column] for column in declared._REVISION_COLUMNS
+              if column != "revision_id")
+        )[:40]
+        self.conn.execute(
+            "INSERT INTO declared_canon_revisions (%s) VALUES (%s)"
+            % (
+                ",".join(declared._REVISION_COLUMNS),
+                ",".join("?" for _ in declared._REVISION_COLUMNS),
+            ),
+            tuple(forged[column] for column in declared._REVISION_COLUMNS),
+        )
+        self.conn.commit()
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "stored_authority_invalid"
+        ):
+            declared.validate_current_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="forge-validate1",
+                guild_id=7,
+                declaration_id=forged["declaration_id"],
+                expected_revision_id=forged["revision_id"],
+                expected_source_fingerprint=forged["source_fingerprint"],
+                now="2026-08-01T12:00:00+00:00",
+            )
+
+    def test_mutation_cannot_launder_forged_latest_revision(self):
+        created = self.add("launder-source1").primary
+        forged = asdict(created)
+        forged["revision_number"] = 2
+        forged["previous_revision_id"] = created.revision_id
+        forged["operation_id"] = "op_" + "6" * 32
+        forged["authority_request_fingerprint"] = "req_" + "7" * 48
+        forged["authority_verified"] = 1
+        forged["raw_declaration"] = "Forged latest declaration."
+        forged["cleaned_summary"] = "Forged latest summary."
+        forged["source_fingerprint"] = declared._general_fingerprint(forged)
+        forged["authority_receipt"] = (
+            "owner_command:declared_canon_lifecycle_v1:"
+            "declared_canon_internal_receipt_v1:add:" + "8" * 64
+        )
+        forged["revision_id"] = "drev_" + declared._digest(
+            *(forged[column] for column in declared._REVISION_COLUMNS
+              if column != "revision_id")
+        )[:40]
+        self.conn.execute(
+            "INSERT INTO declared_canon_revisions (%s) VALUES (%s)"
+            % (
+                ",".join(declared._REVISION_COLUMNS),
+                ",".join("?" for _ in declared._REVISION_COLUMNS),
+            ),
+            tuple(forged[column] for column in declared._REVISION_COLUMNS),
+        )
+        self.conn.commit()
+        before = self.conn.total_changes
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "stored_authority_invalid"
+        ):
+            declared.change_declared_canon_status(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="launder-status1",
+                guild_id=7,
+                declaration_id=created.declaration_id,
+                expected_revision_id=forged["revision_id"],
+                lifecycle_status="contested",
+                now="2026-08-01T12:00:00+00:00",
+            )
+        self.assertEqual(self.conn.total_changes, before)
+        self.assertEqual(
+            self.rows(
+                "SELECT COUNT(*) FROM declared_canon_revisions WHERE declaration_id=?",
+                (created.declaration_id,),
+            )[0][0],
+            2,
+        )
+
+    def test_receipts_require_no_secret_configuration(self):
+        created = self.add("no-secret-source1").primary
+        changed = declared.change_declared_canon_status(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="no-secret-status1",
+            guild_id=7,
+            declaration_id=created.declaration_id,
+            expected_revision_id=created.revision_id,
+            lifecycle_status="contested",
+        ).primary
+        self.assertEqual(changed.lifecycle_status, "contested")
+        self.assertTrue(declared._stored_authority_valid(created))
+        self.assertTrue(declared._stored_authority_valid(changed))
+
+    def test_exact_retry_is_zero_write_and_changed_binding_rejects(self):
+        first = self.add("idempotent-0001")
+        before = self.conn.total_changes
+        retry = self.add("idempotent-0001")
+        self.assertEqual(retry.primary.revision_id, first.primary.revision_id)
+        self.assertEqual(retry.operation_id, first.operation_id)
+        self.assertEqual(self.conn.total_changes, before)
+        distinct_message = self.add("idempotent-0002")
+        self.assertNotEqual(
+            distinct_message.primary.declaration_id,
+            first.primary.declaration_id,
+        )
+        self.assertNotEqual(distinct_message.operation_id, first.operation_id)
+        self.assertNotEqual(
+            distinct_message.primary.authority_receipt,
+            first.primary.authority_receipt,
+        )
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "authority_nonce_replay_mismatch"
+        ):
+            self.add(
+                "idempotent-0001",
+                cleaned_summary="A changed payload cannot reuse the interaction.",
+            )
+
+    def test_same_nonce_cannot_cross_operations(self):
+        created = self.add("one-interaction1").primary
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "authority_nonce_replay_mismatch"
+        ):
+            declared.retire_declared_canon(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="one-interaction1",
+                guild_id=7,
+                declaration_id=created.declaration_id,
+                expected_revision_id=created.revision_id,
+            )
+
+    def test_content_free_preview_is_owner_only_opaque_and_zero_write(self):
+        created = self.add().primary
+        before = self.conn.total_changes
+        preview = declared.preview_declared_canon(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="preview-0001",
+            guild_id=7,
+        )
+        self.assertEqual(preview.mutation_count, 0)
+        self.assertEqual(self.conn.total_changes, before)
+        self.assertEqual(preview.total_rows, 1)
+        self.assertEqual(preview.items[0].declaration_id, created.declaration_id)
+        self.assertTrue(preview.items[0].current_revision)
+        self.assertRegex(preview.authority_actor_ref, r"^actor_[0-9a-f]{20}$")
+        self.assertRegex(preview.authority_receipt_id, r"^receipt_[0-9a-f]{24}$")
+        item_fields = asdict(preview.items[0])
+        self.assertNotIn("source_row_id", item_fields)
+        self.assertNotIn("subject_id", item_fields)
+        self.assertNotIn("predicate", item_fields)
+        self.assertNotIn(created.raw_declaration, repr(preview))
+        self.assertNotIn(created.cleaned_summary, repr(preview))
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "configured_owner_required"
+        ):
+            declared.preview_declared_canon(
+                self.conn,
+                actor_user_id=62,
+                authority_nonce="preview-wrong1",
+                guild_id=7,
+            )
+
+    def test_correction_requires_exact_revision_and_appends_lineage(self):
+        original = self.add().primary
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "expected_revision_mismatch"
+        ):
+            declared.correct_declared_canon(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="correct-stale1",
+                declaration_id=original.declaration_id,
+                expected_revision_id="drev_" + "0" * 40,
+                reason="stale",
+                **add_kwargs(),
+            )
+        corrected = declared.correct_declared_canon(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="correct-0001",
+            declaration_id=original.declaration_id,
+            expected_revision_id=original.revision_id,
+            reason="Role wording corrected.",
+            **add_kwargs(
+                value={"role": "signal archivist", "current": True},
+                raw_declaration="6 Bit corrects the role to signal archivist.",
+                cleaned_summary="Test Member is the signal archivist.",
+            ),
+        ).primary
+        self.assertEqual(corrected.declaration_id, original.declaration_id)
+        self.assertEqual(corrected.revision_number, 2)
+        self.assertEqual(corrected.previous_revision_id, original.revision_id)
+        self.assertEqual(corrected.correction_of_revision_id, original.revision_id)
+        self.assertNotEqual(corrected.source_fingerprint, original.source_fingerprint)
+
+    def test_status_retire_terminal_and_idempotent_retry(self):
+        original = self.add().primary
+        contested = declared.change_declared_canon_status(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="status-00001",
+            guild_id=7,
+            declaration_id=original.declaration_id,
+            expected_revision_id=original.revision_id,
+            lifecycle_status="contested",
+        ).primary
+        retired_result = declared.retire_declared_canon(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="retire-00001",
+            guild_id=7,
+            declaration_id=original.declaration_id,
+            expected_revision_id=contested.revision_id,
+        )
+        before = self.conn.total_changes
+        retry = declared.retire_declared_canon(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="retire-00001",
+            guild_id=7,
+            declaration_id=original.declaration_id,
+            expected_revision_id=contested.revision_id,
+        )
+        self.assertEqual(retry.primary.revision_id, retired_result.primary.revision_id)
+        self.assertEqual(self.conn.total_changes, before)
+        with self.assertRaisesRegex(declared.DeclaredCanonError, "declaration_terminal"):
+            declared.change_declared_canon_status(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="status-00002",
+                guild_id=7,
+                declaration_id=original.declaration_id,
+                expected_revision_id=retired_result.primary.revision_id,
+                lifecycle_status="established",
+            )
+
+    def test_supersession_is_atomic_bidirectional_and_idempotent(self):
+        old = self.add("add-old-0001", subject_id="old_role").primary
+        replacement = self.add(
+            "add-new-0001",
+            subject_id="new_role",
+            raw_declaration="6 Bit declares the replacement role.",
+        ).primary
+        kwargs = {
+            "actor_user_id": 61,
+            "authority_nonce": "supersede-001",
+            "guild_id": 7,
+            "declaration_id": old.declaration_id,
+            "expected_revision_id": old.revision_id,
+            "replacement_declaration_id": replacement.declaration_id,
+            "expected_replacement_revision_id": replacement.revision_id,
+            "reason": "Replacement is authoritative.",
+        }
+        result = declared.supersede_declared_canon(self.conn, **kwargs)
+        old_terminal, new_current = result.revisions
+        self.assertEqual(old_terminal.lifecycle_status, "superseded")
+        self.assertEqual(old_terminal.superseded_by_declaration_id, replacement.declaration_id)
+        self.assertEqual(new_current.supersedes_declaration_id, old.declaration_id)
+        before = self.conn.total_changes
+        retry = declared.supersede_declared_canon(self.conn, **kwargs)
+        self.assertEqual(
+            tuple(item.revision_id for item in retry.revisions),
+            tuple(item.revision_id for item in result.revisions),
+        )
+        self.assertEqual(self.conn.total_changes, before)
+
+    def test_replacement_status_and_correction_preserve_supersession_lineage(self):
+        old = self.add("lineage-old-01", subject_id="old_signal_role").primary
+        replacement = self.add(
+            "lineage-new-01",
+            subject_id="new_signal_role",
+            raw_declaration="6 Bit declares the new signal role.",
+        ).primary
+        _, linked_replacement = declared.supersede_declared_canon(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="lineage-link-01",
+            guild_id=7,
+            declaration_id=old.declaration_id,
+            expected_revision_id=old.revision_id,
+            replacement_declaration_id=replacement.declaration_id,
+            expected_replacement_revision_id=replacement.revision_id,
+        ).revisions
+        contested = declared.change_declared_canon_status(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="lineage-status1",
+            guild_id=7,
+            declaration_id=replacement.declaration_id,
+            expected_revision_id=linked_replacement.revision_id,
+            lifecycle_status="contested",
+        ).primary
+        self.assertEqual(contested.supersedes_declaration_id, old.declaration_id)
+
+        corrected = declared.correct_declared_canon(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="lineage-correct",
+            declaration_id=replacement.declaration_id,
+            expected_revision_id=contested.revision_id,
+            reason="Correct wording without erasing lifecycle or lineage.",
+            **add_kwargs(
+                subject_id="new_signal_role",
+                raw_declaration="6 Bit corrects the new signal role wording.",
+                cleaned_summary="The new signal role has corrected wording.",
+            ),
+        ).primary
+        self.assertEqual(corrected.lifecycle_status, "contested")
+        self.assertEqual(corrected.supersedes_declaration_id, old.declaration_id)
+        self.assertEqual(corrected.superseded_by_declaration_id, "")
+
+    def test_supersession_rolls_back_when_replacement_is_missing(self):
+        old = self.add("add-old-0002", subject_id="old_role_2").primary
+        before = self.conn.total_changes
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "general_declaration_not_found"
+        ):
+            declared.supersede_declared_canon(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="supersede-bad1",
+                guild_id=7,
+                declaration_id=old.declaration_id,
+                expected_revision_id=old.revision_id,
+                replacement_declaration_id="dcl_missing",
+                expected_replacement_revision_id="drev_" + "0" * 40,
+            )
+        self.assertEqual(self.conn.total_changes, before)
+
+    def test_supersession_rolls_back_first_insert_if_second_insert_aborts(self):
+        old = self.add("atomic-old-001", subject_id="atomic_old").primary
+        replacement = self.add(
+            "atomic-new-001", subject_id="atomic_new"
+        ).primary
+        self.conn.execute(
+            """
+            CREATE TRIGGER fail_old_supersede
+            BEFORE INSERT ON declared_canon_revisions
+            WHEN NEW.operation='supersede' AND NEW.declaration_id='%s'
+            BEGIN
+                SELECT RAISE(ABORT, 'forced_second_insert_failure');
+            END
+            """ % old.declaration_id
+        )
+        self.conn.commit()
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError, "forced_second_insert_failure"
+        ):
+            declared.supersede_declared_canon(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="atomic-super001",
+                guild_id=7,
+                declaration_id=old.declaration_id,
+                expected_revision_id=old.revision_id,
+                replacement_declaration_id=replacement.declaration_id,
+                expected_replacement_revision_id=replacement.revision_id,
+            )
+        rows = self.rows(
+            "SELECT declaration_id,revision_number,lifecycle_status "
+            "FROM declared_canon_revisions ORDER BY rowid"
+        )
+        self.assertEqual(
+            rows,
+            [
+                (old.declaration_id, 1, "established"),
+                (replacement.declaration_id, 1, "established"),
+            ],
+        )
+
+    def test_relationship_claim_requires_typed_counterpart(self):
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError,
+            "relationship_object_subject_type_required",
+        ):
+            self.add(claim_kind="relationship", predicate="works_with")
+        relation = self.add(
+            "relationship-01",
+            claim_kind="relationship",
+            predicate="works_with",
+            object_subject_type="organization",
+            object_subject_id="barcode_network",
+        ).primary
+        self.assertEqual(relation.object_subject_type, "organization")
+        self.assertEqual(relation.object_subject_id, "barcode_network")
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "relationship_object_not_allowed"
+        ):
+            self.add(
+                "bad-endpoint-01",
+                object_subject_type="organization",
+                object_subject_id="barcode_network",
+            )
+
+    def test_validation_and_closed_route_allowlist_fail_closed(self):
+        invalid_cases = (
+            {"subject_id": "Display Name"},
+            {"subject_type": "unknown"},
+            {"predicate": "Role Label"},
+            {"domain": "everything"},
+            {"claim_kind": "biography"},
+            {"visibility": "internal", "eligible_routes": ("public_selective",)},
+            {"eligible_routes": ("surprise_public_route",)},
+            {
+                "valid_from": "2026-08-02T00:00:00+00:00",
+                "valid_until": "2026-08-01T00:00:00+00:00",
+            },
+        )
+        for index, overrides in enumerate(invalid_cases):
+            with self.assertRaises(declared.DeclaredCanonError):
+                self.add("invalid-%04d" % index, **overrides)
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM declared_canon_revisions")[0][0], 0)
+
+    def test_read_validator_is_zero_write_and_rejects_stale_or_cross_guild(self):
+        revision = self.add().primary
+        before = self.conn.total_changes
+        validated = declared.validate_current_declared_canon_revision(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="validator-0001",
+            guild_id=7,
+            declaration_id=revision.declaration_id,
+            expected_revision_id=revision.revision_id,
+            expected_source_fingerprint=revision.source_fingerprint,
+            now="2026-08-01T01:00:00+00:00",
+        )
+        self.assertEqual(validated.revision_id, revision.revision_id)
+        self.assertEqual(self.conn.total_changes, before)
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "expected_source_fingerprint_mismatch"
+        ):
+            declared.validate_current_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="validator-0002",
+                guild_id=7,
+                declaration_id=revision.declaration_id,
+                expected_revision_id=revision.revision_id,
+                expected_source_fingerprint="src_" + "0" * 40,
+            )
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "configured_primary_guild_required"
+        ):
+            declared.validate_current_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="validator-0003",
+                guild_id=8,
+                declaration_id=revision.declaration_id,
+                expected_revision_id=revision.revision_id,
+                expected_source_fingerprint=revision.source_fingerprint,
+            )
+
+    def test_read_validator_honors_full_validity_window_and_lifecycle(self):
+        future = self.add(
+            "future-claim01",
+            valid_from="2026-09-01T00:00:00+00:00",
+        ).primary
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "declared_revision_not_current"
+        ):
+            declared.validate_current_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="future-check01",
+                guild_id=7,
+                declaration_id=future.declaration_id,
+                expected_revision_id=future.revision_id,
+                expected_source_fingerprint=future.source_fingerprint,
+                now="2026-08-15T00:00:00+00:00",
+            )
+        contested = declared.change_declared_canon_status(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="future-status1",
+            guild_id=7,
+            declaration_id=future.declaration_id,
+            expected_revision_id=future.revision_id,
+            lifecycle_status="contested",
+        ).primary
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "declared_revision_not_established"
+        ):
+            declared.validate_current_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="contested-check",
+                guild_id=7,
+                declaration_id=contested.declaration_id,
+                expected_revision_id=contested.revision_id,
+                expected_source_fingerprint=contested.source_fingerprint,
+                now="2026-09-02T00:00:00+00:00",
+            )
+
+    def test_latest_validator_returns_terminal_revision_without_calling_it_current(self):
+        original = self.add("terminal-source1").primary
+        retired = declared.retire_declared_canon(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="terminal-retire",
+            guild_id=7,
+            declaration_id=original.declaration_id,
+            expected_revision_id=original.revision_id,
+        ).primary
+        before = self.conn.total_changes
+        latest = declared.validate_latest_declared_canon_revision(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="terminal-read01",
+            guild_id=7,
+            declaration_id=retired.declaration_id,
+            expected_revision_id=retired.revision_id,
+            expected_source_fingerprint=retired.source_fingerprint,
+            expected_lifecycle_status="retired",
+        )
+        self.assertEqual(latest.lifecycle_status, "retired")
+        self.assertEqual(self.conn.total_changes, before)
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "declared_revision_not_established"
+        ):
+            declared.validate_current_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="terminal-current",
+                guild_id=7,
+                declaration_id=retired.declaration_id,
+                expected_revision_id=retired.revision_id,
+                expected_source_fingerprint=retired.source_fingerprint,
+            )
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError,
+            "latest_validator_requires_noncurrent_lifecycle",
+        ):
+            declared.validate_latest_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="terminal-wrong1",
+                guild_id=7,
+                declaration_id=retired.declaration_id,
+                expected_revision_id=retired.revision_id,
+                expected_source_fingerprint=retired.source_fingerprint,
+                expected_lifecycle_status="established",
+            )
+
+    def test_current_validator_owns_one_wal_snapshot_across_latest_append(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = os.path.join(temp_dir, "declared-current-snapshot.sqlite3")
+            writer = sqlite3.connect(database_path, timeout=5)
+            reader = sqlite3.connect(database_path, timeout=5)
+            try:
+                writer.execute("PRAGMA journal_mode=WAL")
+                declared.ensure_declared_canon_schema(writer)
+                original = declared.add_declared_canon(
+                    writer,
+                    actor_user_id=61,
+                    authority_nonce="wal-current-add1",
+                    **add_kwargs(),
+                ).primary
+                real_latest = declared._latest_revision
+                interleaved = {"revision": None}
+
+                def latest_then_append(conn, **kwargs):
+                    revision = real_latest(conn, **kwargs)
+                    if conn is reader and interleaved["revision"] is None:
+                        interleaved["revision"] = declared.change_declared_canon_status(
+                            writer,
+                            actor_user_id=61,
+                            authority_nonce="wal-current-status1",
+                            guild_id=7,
+                            declaration_id=original.declaration_id,
+                            expected_revision_id=original.revision_id,
+                            lifecycle_status="contested",
+                        ).primary
+                    return revision
+
+                before = reader.total_changes
+                with mock.patch.object(
+                    declared, "_latest_revision", side_effect=latest_then_append
+                ):
+                    validated = declared.validate_current_declared_canon_revision(
+                        reader,
+                        actor_user_id=61,
+                        authority_nonce="wal-current-read1",
+                        guild_id=7,
+                        declaration_id=original.declaration_id,
+                        expected_revision_id=original.revision_id,
+                        expected_source_fingerprint=original.source_fingerprint,
+                        now="2026-08-01T01:00:00+00:00",
+                    )
+                self.assertEqual(validated.revision_id, original.revision_id)
+                self.assertIsNotNone(interleaved["revision"])
+                self.assertEqual(reader.total_changes, before)
+                self.assertFalse(reader.in_transaction)
+                with self.assertRaisesRegex(
+                    declared.DeclaredCanonError, "expected_revision_mismatch"
+                ):
+                    declared.validate_current_declared_canon_revision(
+                        reader,
+                        actor_user_id=61,
+                        authority_nonce="wal-current-read2",
+                        guild_id=7,
+                        declaration_id=original.declaration_id,
+                        expected_revision_id=original.revision_id,
+                        expected_source_fingerprint=original.source_fingerprint,
+                    )
+            finally:
+                reader.close()
+                writer.close()
+
+    def test_latest_validator_reuses_caller_wal_snapshot_and_leaves_it_open(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = os.path.join(temp_dir, "declared-latest-snapshot.sqlite3")
+            writer = sqlite3.connect(database_path, timeout=5)
+            reader = sqlite3.connect(database_path, timeout=5)
+            try:
+                writer.execute("PRAGMA journal_mode=WAL")
+                declared.ensure_declared_canon_schema(writer)
+                original = declared.add_declared_canon(
+                    writer,
+                    actor_user_id=61,
+                    authority_nonce="wal-latest-add01",
+                    **add_kwargs(),
+                ).primary
+                contested = declared.change_declared_canon_status(
+                    writer,
+                    actor_user_id=61,
+                    authority_nonce="wal-latest-status1",
+                    guild_id=7,
+                    declaration_id=original.declaration_id,
+                    expected_revision_id=original.revision_id,
+                    lifecycle_status="contested",
+                ).primary
+
+                reader.execute("BEGIN")
+                reader.execute(
+                    "SELECT revision_id FROM declared_canon_revisions "
+                    "WHERE revision_id=?",
+                    (contested.revision_id,),
+                ).fetchone()
+                resolved = declared.change_declared_canon_status(
+                    writer,
+                    actor_user_id=61,
+                    authority_nonce="wal-latest-status2",
+                    guild_id=7,
+                    declaration_id=contested.declaration_id,
+                    expected_revision_id=contested.revision_id,
+                    lifecycle_status="resolved",
+                ).primary
+                before = reader.total_changes
+                validated = declared.validate_latest_declared_canon_revision(
+                    reader,
+                    actor_user_id=61,
+                    authority_nonce="wal-latest-read01",
+                    guild_id=7,
+                    declaration_id=contested.declaration_id,
+                    expected_revision_id=contested.revision_id,
+                    expected_source_fingerprint=contested.source_fingerprint,
+                    expected_lifecycle_status="contested",
+                )
+                self.assertEqual(validated.revision_id, contested.revision_id)
+                self.assertEqual(reader.total_changes, before)
+                self.assertTrue(reader.in_transaction)
+                reader.commit()
+                latest = declared.validate_latest_declared_canon_revision(
+                    reader,
+                    actor_user_id=61,
+                    authority_nonce="wal-latest-read02",
+                    guild_id=7,
+                    declaration_id=resolved.declaration_id,
+                    expected_revision_id=resolved.revision_id,
+                    expected_source_fingerprint=resolved.source_fingerprint,
+                    expected_lifecycle_status="resolved",
+                )
+                self.assertEqual(latest.revision_id, resolved.revision_id)
+                self.assertFalse(reader.in_transaction)
+            finally:
+                if reader.in_transaction:
+                    reader.rollback()
+                reader.close()
+                writer.close()
+
+    def test_mutation_refuses_caller_owned_transaction(self):
+        self.conn.execute("BEGIN")
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "transaction_already_active"
+        ):
+            self.add()
+        self.conn.rollback()
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM declared_canon_revisions")[0][0], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_declared_canon_projection.py
+++ b/tests/test_declared_canon_projection.py
@@ -1,0 +1,780 @@
+import os
+import sqlite3
+import tempfile
+import threading
+import unittest
+from unittest import mock
+
+import bnl_declared_canon as declared
+import bnl_memory_ledger as ledger
+
+
+def claim_fields(**overrides):
+    values = {
+        "guild_id": 7,
+        "subject_type": "project",
+        "subject_id": "barcode_radio",
+        "predicate": "current_role",
+        "value": {"role": "broadcast continuity"},
+        "raw_declaration": "6 Bit declares the broadcast continuity role.",
+        "cleaned_summary": "BARCODE Radio has a broadcast continuity role.",
+        "domain": "broadcast_history",
+        "claim_kind": "role",
+        "visibility": "internal",
+        "eligible_routes": ("declared_canon_review",),
+        "now": "2026-08-01T00:00:00+00:00",
+    }
+    values.update(overrides)
+    return values
+
+
+class DeclaredCanonProjectionTests(unittest.TestCase):
+    def setUp(self):
+        self.env = mock.patch.dict(
+            os.environ,
+            {
+                "BNL_OWNER_USER_ID": "61",
+                "BNL_PRIMARY_GUILD_ID": "7",
+            },
+        )
+        self.env.start()
+        self.conn = sqlite3.connect(":memory:")
+        ledger.ensure_memory_ledger_schema(self.conn)
+        declared.ensure_declared_canon_schema(self.conn)
+
+    def tearDown(self):
+        self.conn.close()
+        self.env.stop()
+
+    def add_claim(self, nonce="projection-add1", **overrides):
+        return declared.add_declared_canon(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce=nonce,
+            **claim_fields(**overrides),
+        ).primary
+
+    def project(self, revision, nonce, root_entry_ids=()):
+        return ledger.shadow_declared_canon_projection(
+            self.conn,
+            guild_id=7,
+            declaration_id=revision.declaration_id,
+            revision_id=revision.revision_id,
+            actor_user_id=61,
+            authority_nonce=nonce,
+            expected_source_fingerprint=revision.source_fingerprint,
+            expected_lifecycle_status=revision.lifecycle_status,
+            root_entry_ids=root_entry_ids,
+        )
+
+    @staticmethod
+    def create_broadcast_table(conn):
+        conn.execute(
+            """
+            CREATE TABLE broadcast_memory (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                guild_id INTEGER NOT NULL,
+                episode_date TEXT NOT NULL,
+                submitted_by_user_id INTEGER,
+                submitted_by_name TEXT,
+                raw_note TEXT,
+                cleaned_summary TEXT NOT NULL,
+                entry_type TEXT NOT NULL,
+                importance TEXT DEFAULT 'medium',
+                public_safe INTEGER DEFAULT 0,
+                affects_next_show INTEGER DEFAULT 0,
+                usage_scope TEXT DEFAULT 'internal',
+                target_show_date TEXT,
+                valid_until TEXT,
+                override_span_count INTEGER DEFAULT 1,
+                needs_clarification INTEGER DEFAULT 0,
+                status TEXT DEFAULT 'active',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                corrected_by_user_id INTEGER,
+                corrected_by_name TEXT,
+                correction_reason TEXT,
+                supersedes_id INTEGER,
+                superseded_by_id INTEGER
+            )
+            """
+        )
+        conn.commit()
+
+    @staticmethod
+    def insert_broadcast(conn, cleaned="Authoritative Broadcast summary."):
+        cursor = conn.execute(
+            """
+            INSERT INTO broadcast_memory(
+                guild_id,episode_date,submitted_by_user_id,submitted_by_name,
+                raw_note,cleaned_summary,entry_type,importance,public_safe,
+                affects_next_show,usage_scope,target_show_date,valid_until,
+                override_span_count,needs_clarification,status,created_at,
+                updated_at,corrected_by_user_id,corrected_by_name,
+                correction_reason,supersedes_id,superseded_by_id
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                7,
+                "2026-08-01",
+                61,
+                "6 Bit",
+                "Owner Broadcast note.",
+                cleaned,
+                "notable_moment",
+                "medium",
+                1,
+                0,
+                "ambient,direct",
+                None,
+                "",
+                1,
+                0,
+                "active",
+                "2026-08-01T00:00:00+00:00",
+                "2026-08-01T00:00:00+00:00",
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+        )
+        conn.commit()
+        return int(cursor.lastrowid)
+
+    @staticmethod
+    def broadcast_source(conn, row_id):
+        cursor = conn.execute(
+            "SELECT * FROM broadcast_memory WHERE id=?",
+            (int(row_id),),
+        )
+        row = cursor.fetchone()
+        return dict(zip((item[0] for item in cursor.description), row))
+
+    def classify_broadcast(self, conn, row_id, nonce="projection-classify1"):
+        fingerprint = declared.broadcast_source_fingerprint(
+            self.broadcast_source(conn, row_id)
+        )
+        revision = declared.classify_broadcast_memory(
+            conn,
+            actor_user_id=61,
+            authority_nonce=nonce,
+            guild_id=7,
+            broadcast_row_id=row_id,
+            expected_source_fingerprint=fingerprint,
+            subject_type="broadcast",
+            subject_id="barcode_radio",
+            visibility="internal",
+            eligible_routes=("broadcast_memory",),
+            now="2026-08-01T01:00:00+00:00",
+        ).primary
+        return revision
+
+    def test_projection_is_derived_internal_review_only_and_nonpublic(self):
+        revision = self.add_claim()
+        projected = self.project(revision, "projection-run1")
+
+        row = self.conn.execute(
+            """
+            SELECT source_table,source_revision,source_role,route_mode,
+                   channel_policy,visibility,public_usable,derived,projection,
+                   lifecycle_status
+            FROM memory_ledger_entries
+            WHERE entry_id=?
+            """,
+            (projected.entry_id,),
+        ).fetchone()
+        self.assertEqual(
+            row,
+            (
+                "declared_canon_projection",
+                revision.revision_id,
+                "declared_canon_projection",
+                "declared_canon_review",
+                "declared_canon_review",
+                "internal",
+                0,
+                1,
+                1,
+                "review_only",
+            ),
+        )
+        lineage = self.conn.execute(
+            """
+            SELECT lineage_type,target_entry_id
+            FROM memory_ledger_lineage
+            WHERE entry_id=?
+            ORDER BY lineage_type,target_entry_id
+            """,
+            (projected.entry_id,),
+        ).fetchall()
+        self.assertEqual(lineage, [])
+
+    def test_general_declaration_rejects_arbitrary_ledger_roots(self):
+        revision = self.add_claim("projection-no-root1")
+        arbitrary_root = ledger.shadow_broadcast_memory_row(
+            self.conn,
+            row_id=11,
+            guild_id=7,
+            cleaned_summary="An unrelated Ledger root.",
+            entry_type="notable_moment",
+            public_safe=True,
+            status="active",
+            usage_scope="ambient,direct",
+            updated_at="2026-08-01T00:00:00+00:00",
+        )
+        self.conn.commit()
+
+        projected = self.project(
+            revision,
+            "projection-no-root2",
+            root_entry_ids=(arbitrary_root.entry_id,),
+        )
+
+        self.assertEqual(projected.outcome, "skipped")
+        self.assertEqual(
+            projected.reason_code,
+            "declared_projection_general_roots_forbidden",
+        )
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT COUNT(*) FROM memory_ledger_entries
+                WHERE source_table='declared_canon_projection'
+                """
+            ).fetchone()[0],
+            0,
+        )
+
+    def test_broadcast_projection_requires_one_exact_broadcast_root(self):
+        self.create_broadcast_table(self.conn)
+        row_id = self.insert_broadcast(self.conn)
+        revision = self.classify_broadcast(self.conn, row_id)
+        root = ledger.shadow_broadcast_memory_row(
+            self.conn,
+            row_id=row_id,
+            guild_id=7,
+            cleaned_summary="Authoritative Broadcast summary.",
+            entry_type="notable_moment",
+            public_safe=True,
+            status="active",
+            usage_scope="ambient,direct",
+            created_at="2026-08-01T00:00:00+00:00",
+            updated_at="2026-08-01T00:00:00+00:00",
+        )
+        self.conn.commit()
+
+        missing = self.project(revision, "projection-root-missing1")
+        duplicate = self.project(
+            revision,
+            "projection-root-duplicate1",
+            root_entry_ids=(root.entry_id, root.entry_id),
+        )
+        projected = self.project(
+            revision,
+            "projection-root-exact1",
+            root_entry_ids=(root.entry_id,),
+        )
+
+        self.assertEqual(missing.outcome, "skipped")
+        self.assertEqual(duplicate.outcome, "skipped")
+        self.assertEqual(projected.outcome, "inserted")
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT lineage_type,target_entry_id
+                FROM memory_ledger_lineage
+                WHERE entry_id=?
+                """,
+                (projected.entry_id,),
+            ).fetchall(),
+            [("derived_from", root.entry_id)],
+        )
+
+    def test_broadcast_projection_rejects_stale_prior_root_revision(self):
+        self.create_broadcast_table(self.conn)
+        row_id = self.insert_broadcast(
+            self.conn,
+            cleaned="The earlier Broadcast value.",
+        )
+        stale_root = ledger.shadow_broadcast_memory_row(
+            self.conn,
+            row_id=row_id,
+            guild_id=7,
+            cleaned_summary="The earlier Broadcast value.",
+            entry_type="notable_moment",
+            public_safe=True,
+            status="active",
+            usage_scope="ambient,direct",
+            created_at="2026-08-01T00:00:00+00:00",
+            updated_at="2026-08-01T00:00:00+00:00",
+        )
+        self.conn.execute(
+            """
+            UPDATE broadcast_memory
+            SET cleaned_summary=?,updated_at=?
+            WHERE guild_id=? AND id=?
+            """,
+            (
+                "The current Broadcast value.",
+                "2026-08-01T00:01:00+00:00",
+                7,
+                row_id,
+            ),
+        )
+        self.conn.commit()
+        revision = self.classify_broadcast(
+            self.conn,
+            row_id,
+            nonce="projection-stale-classify1",
+        )
+
+        projected = self.project(
+            revision,
+            "projection-stale-root1",
+            root_entry_ids=(stale_root.entry_id,),
+        )
+
+        self.assertEqual(projected.outcome, "skipped")
+        self.assertEqual(
+            projected.reason_code,
+            "declared_projection_broadcast_root_stale",
+        )
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT COUNT(*) FROM memory_ledger_entries
+                WHERE source_table='declared_canon_projection'
+                """
+            ).fetchone()[0],
+            0,
+        )
+
+    def test_terminal_broadcast_projection_retracts_active_declared_projection(self):
+        self.create_broadcast_table(self.conn)
+        row_id = self.insert_broadcast(self.conn)
+        active_revision = self.classify_broadcast(
+            self.conn,
+            row_id,
+            nonce="projection-terminal-classify1",
+        )
+        root = ledger.shadow_broadcast_memory_row(
+            self.conn,
+            row_id=row_id,
+            guild_id=7,
+            cleaned_summary="Authoritative Broadcast summary.",
+            entry_type="notable_moment",
+            public_safe=True,
+            status="active",
+            usage_scope="ambient,direct",
+            created_at="2026-08-01T00:00:00+00:00",
+            updated_at="2026-08-01T00:00:00+00:00",
+        )
+        active_projection = self.project(
+            active_revision,
+            "projection-terminal-run1",
+            root_entry_ids=(root.entry_id,),
+        )
+        self.assertEqual(active_projection.outcome, "inserted")
+
+        self.conn.execute(
+            """
+            UPDATE broadcast_memory
+            SET status='resolved',updated_at=?,corrected_by_user_id=?,
+                corrected_by_name=?,correction_reason=?
+            WHERE guild_id=? AND id=?
+            """,
+            (
+                "2026-08-01T02:00:00+00:00",
+                61,
+                "6 Bit",
+                "Owner resolved the Broadcast memory.",
+                7,
+                row_id,
+            ),
+        )
+        self.conn.commit()
+        source = self.broadcast_source(self.conn, row_id)
+        terminal_revision = declared.classify_broadcast_memory(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="projection-terminal-classify2",
+            guild_id=7,
+            broadcast_row_id=row_id,
+            expected_source_fingerprint=declared.broadcast_source_fingerprint(source),
+            expected_revision_id=active_revision.revision_id,
+            subject_type="broadcast",
+            subject_id="barcode_radio",
+            visibility="internal",
+            eligible_routes=("broadcast_memory",),
+            now="2026-08-01T02:00:00+00:00",
+        ).primary
+
+        rejected = self.project(
+            terminal_revision,
+            "projection-terminal-root-rejected1",
+            root_entry_ids=(root.entry_id,),
+        )
+        terminal_projection = self.project(
+            terminal_revision,
+            "projection-terminal-run2",
+        )
+
+        self.assertEqual(rejected.outcome, "skipped")
+        self.assertEqual(
+            rejected.reason_code,
+            "declared_projection_broadcast_terminal_roots_forbidden",
+        )
+        self.assertEqual(terminal_projection.outcome, "inserted")
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT normalized_value,lifecycle_status,visibility,
+                       public_usable,derived,projection
+                FROM memory_ledger_entries WHERE entry_id=?
+                """,
+                (terminal_projection.entry_id,),
+            ).fetchone(),
+            ("resolved", "resolved", "internal", 0, 1, 1),
+        )
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT lineage_type,target_entry_id
+                FROM memory_ledger_lineage WHERE entry_id=?
+                """,
+                (terminal_projection.entry_id,),
+            ).fetchall(),
+            [("retracts", active_projection.entry_id)],
+        )
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM memory_ledger_entries AS projection_row
+                WHERE projection_row.entry_id=?
+                  AND NOT EXISTS (
+                      SELECT 1 FROM memory_ledger_lineage AS edge
+                      WHERE edge.guild_id=projection_row.guild_id
+                        AND edge.target_entry_id=projection_row.entry_id
+                        AND edge.lineage_type IN ('supersedes','retracts')
+                  )
+                """,
+                (active_projection.entry_id,),
+            ).fetchone()[0],
+            0,
+        )
+
+    def test_new_revision_supersedes_prior_projection_without_becoming_live(self):
+        first_revision = self.add_claim("projection-add2")
+        first = self.project(first_revision, "projection-run2")
+        self.conn.commit()
+        corrected_revision = declared.correct_declared_canon(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="projection-fix2",
+            declaration_id=first_revision.declaration_id,
+            expected_revision_id=first_revision.revision_id,
+            reason="Correct the role wording.",
+            **claim_fields(
+                value={"role": "broadcast memory continuity"},
+                raw_declaration="6 Bit corrects the broadcast continuity role.",
+                cleaned_summary="BARCODE Radio has a broadcast memory continuity role.",
+                now="2026-08-01T00:01:00+00:00",
+            ),
+        ).primary
+        second = self.project(corrected_revision, "projection-run3")
+
+        lineage = self.conn.execute(
+            """
+            SELECT lineage_type,target_entry_id
+            FROM memory_ledger_lineage
+            WHERE entry_id=?
+            """,
+            (second.entry_id,),
+        ).fetchall()
+        self.assertEqual(lineage, [("supersedes", first.entry_id)])
+        live_rows = self.conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM memory_ledger_entries
+            WHERE source_table='declared_canon_projection'
+              AND (public_usable=1 OR lifecycle_status!='review_only'
+                   OR visibility!='internal')
+            """
+        ).fetchone()[0]
+        self.assertEqual(live_rows, 0)
+
+    def test_typed_subject_keys_do_not_collapse_person_and_project(self):
+        person = self.add_claim(
+            "projection-person1",
+            subject_type="person",
+            subject_id="shared_identity",
+        )
+        project = self.add_claim(
+            "projection-project1",
+            subject_type="project",
+            subject_id="shared_identity",
+        )
+
+        person_projection = self.project(person, "projection-person2")
+        project_projection = self.project(project, "projection-project2")
+
+        self.assertNotEqual(person_projection.entry_id, project_projection.entry_id)
+        rows = self.conn.execute(
+            """
+            SELECT subject_key
+            FROM memory_ledger_entries
+            WHERE entry_id IN (?,?)
+            ORDER BY subject_key
+            """,
+            (person_projection.entry_id, project_projection.entry_id),
+        ).fetchall()
+        self.assertEqual(
+            rows,
+            [("person:shared_identity",), ("project:shared_identity",)],
+        )
+
+    def test_relationship_projection_preserves_both_typed_endpoints(self):
+        relation = self.add_claim(
+            "projection-relation1",
+            subject_type="person",
+            subject_id="six_bit",
+            object_subject_type="project",
+            object_subject_id="barcode_radio",
+            predicate="hosts",
+            claim_kind="relationship",
+            value={"relationship": "host"},
+            raw_declaration="6 Bit declares that 6 Bit hosts BARCODE Radio.",
+            cleaned_summary="6 Bit hosts BARCODE Radio.",
+        )
+
+        projected = self.project(relation, "projection-relation2")
+
+        self.assertEqual(projected.outcome, "inserted")
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT subject_key,predicate_key
+                FROM memory_ledger_entries WHERE entry_id=?
+                """,
+                (projected.entry_id,),
+            ).fetchone(),
+            ("person:six_bit", "hosts"),
+        )
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT participant_key,participant_role
+                FROM memory_ledger_participants
+                WHERE entry_id=?
+                ORDER BY order_index
+                """,
+                (projected.entry_id,),
+            ).fetchall(),
+            [
+                ("person:six_bit", "subject"),
+                ("project:barcode_radio", "relationship_object"),
+            ],
+        )
+
+    def test_cross_declaration_supersession_preserves_exact_lineage(self):
+        old_revision = self.add_claim(
+            "projection-old-add1",
+            subject_id="old_broadcast_role",
+            cleaned_summary="The old broadcast role is established.",
+        )
+        replacement_revision = self.add_claim(
+            "projection-new-add1",
+            subject_id="replacement_broadcast_role",
+            cleaned_summary="The replacement broadcast role is established.",
+        )
+        old_projection = self.project(old_revision, "projection-old-run1")
+        replacement_projection = self.project(
+            replacement_revision,
+            "projection-new-run1",
+        )
+
+        supersession = declared.supersede_declared_canon(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="projection-supersede1",
+            guild_id=7,
+            declaration_id=old_revision.declaration_id,
+            expected_revision_id=old_revision.revision_id,
+            replacement_declaration_id=replacement_revision.declaration_id,
+            expected_replacement_revision_id=replacement_revision.revision_id,
+            reason="Replace the old role declaration.",
+            now="2026-08-01T00:02:00+00:00",
+        )
+        by_declaration = {
+            revision.declaration_id: revision
+            for revision in supersession.revisions
+        }
+        old_terminal = by_declaration[old_revision.declaration_id]
+        replacement_current = by_declaration[replacement_revision.declaration_id]
+
+        replacement_current_projection = self.project(
+            replacement_current,
+            "projection-new-run2",
+        )
+        old_terminal_projection = self.project(
+            old_terminal,
+            "projection-old-run2",
+        )
+
+        replacement_edges = set(
+            self.conn.execute(
+                """
+                SELECT lineage_type,target_entry_id
+                FROM memory_ledger_lineage WHERE entry_id=?
+                """,
+                (replacement_current_projection.entry_id,),
+            ).fetchall()
+        )
+        old_terminal_edges = set(
+            self.conn.execute(
+                """
+                SELECT lineage_type,target_entry_id
+                FROM memory_ledger_lineage WHERE entry_id=?
+                """,
+                (old_terminal_projection.entry_id,),
+            ).fetchall()
+        )
+        self.assertEqual(
+            replacement_edges,
+            {
+                ("supersedes", replacement_projection.entry_id),
+                ("supersedes", old_projection.entry_id),
+            },
+        )
+        self.assertEqual(
+            old_terminal_edges,
+            {("retracts", old_projection.entry_id)},
+        )
+
+    def test_projection_holds_source_snapshot_until_insert(self):
+        handle = tempfile.NamedTemporaryFile(delete=False)
+        path = handle.name
+        handle.close()
+        writer = None
+        contender = None
+        thread = None
+        release_validation = threading.Event()
+        validation_complete = threading.Event()
+        outcome = {}
+        try:
+            writer = sqlite3.connect(
+                path,
+                timeout=1,
+                check_same_thread=False,
+            )
+            contender = sqlite3.connect(path, timeout=0.05)
+            contender.execute("PRAGMA busy_timeout=50")
+            ledger.ensure_memory_ledger_schema(writer)
+            declared.ensure_declared_canon_schema(writer)
+            self.create_broadcast_table(writer)
+            row_id = self.insert_broadcast(
+                writer,
+                cleaned="The source value held by the atomic snapshot.",
+            )
+            revision = self.classify_broadcast(
+                writer,
+                row_id,
+                nonce="projection-lock-classify1",
+            )
+            root = ledger.shadow_broadcast_memory_row(
+                writer,
+                row_id=row_id,
+                guild_id=7,
+                cleaned_summary="The source value held by the atomic snapshot.",
+                entry_type="notable_moment",
+                public_safe=True,
+                status="active",
+                usage_scope="ambient,direct",
+                created_at="2026-08-01T00:00:00+00:00",
+                updated_at="2026-08-01T00:00:00+00:00",
+            )
+            writer.commit()
+
+            real_validator = declared.validate_current_declared_canon_revision
+
+            def paused_validator(*args, **kwargs):
+                validated = real_validator(*args, **kwargs)
+                validation_complete.set()
+                if not release_validation.wait(5):
+                    raise RuntimeError("projection_test_release_timeout")
+                return validated
+
+            def run_projection():
+                try:
+                    outcome["result"] = ledger.shadow_declared_canon_projection(
+                        writer,
+                        guild_id=7,
+                        declaration_id=revision.declaration_id,
+                        revision_id=revision.revision_id,
+                        actor_user_id=61,
+                        authority_nonce="projection-lock-run1",
+                        expected_source_fingerprint=revision.source_fingerprint,
+                        expected_lifecycle_status=revision.lifecycle_status,
+                        root_entry_ids=(root.entry_id,),
+                    )
+                except Exception as exc:  # pragma: no cover - assertion below
+                    outcome["error"] = exc
+
+            with mock.patch.object(
+                declared,
+                "validate_current_declared_canon_revision",
+                side_effect=paused_validator,
+            ):
+                thread = threading.Thread(target=run_projection)
+                thread.start()
+                self.assertTrue(validation_complete.wait(5))
+                with self.assertRaisesRegex(sqlite3.OperationalError, "locked"):
+                    contender.execute(
+                        """
+                        UPDATE broadcast_memory
+                        SET cleaned_summary=?,updated_at=?
+                        WHERE guild_id=? AND id=?
+                        """,
+                        (
+                            "A racing source mutation.",
+                            "2026-08-01T00:00:01+00:00",
+                            7,
+                            row_id,
+                        ),
+                    )
+                contender.rollback()
+                release_validation.set()
+                thread.join(5)
+
+            self.assertFalse(thread.is_alive())
+            self.assertNotIn("error", outcome)
+            self.assertEqual(outcome["result"].outcome, "inserted")
+            self.assertEqual(
+                writer.execute(
+                    """
+                    SELECT normalized_value
+                    FROM memory_ledger_entries WHERE entry_id=?
+                    """,
+                    (outcome["result"].entry_id,),
+                ).fetchone()[0],
+                "The source value held by the atomic snapshot.",
+            )
+        finally:
+            release_validation.set()
+            if thread is not None and thread.is_alive():
+                thread.join(5)
+            if contender is not None:
+                contender.close()
+            if writer is not None:
+                writer.close()
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hybrid_canon_claim_contract.py
+++ b/tests/test_hybrid_canon_claim_contract.py
@@ -1,15 +1,140 @@
+import os
 import sqlite3
+import tempfile
 import unittest
 from dataclasses import replace
 from unittest import mock
 
 import bnl_canon_source_contract as canon
+import bnl_declared_canon as declared_canon
 import bnl_memory_ledger as ledger
 import bnl_moment_engine as moments
 import bnl_unified_intelligence_packet as packet
 
 
 class HybridCanonClaimContractTests(unittest.TestCase):
+    def create_pr2_broadcast_table(self, conn):
+        conn.execute(
+            """
+            CREATE TABLE broadcast_memory (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                guild_id INTEGER NOT NULL,
+                episode_date TEXT NOT NULL,
+                submitted_by_user_id INTEGER,
+                submitted_by_name TEXT,
+                raw_note TEXT,
+                cleaned_summary TEXT NOT NULL,
+                entry_type TEXT NOT NULL,
+                importance TEXT DEFAULT 'medium',
+                public_safe INTEGER DEFAULT 0,
+                affects_next_show INTEGER DEFAULT 0,
+                usage_scope TEXT DEFAULT 'internal',
+                target_show_date TEXT,
+                valid_until TEXT,
+                override_span_count INTEGER DEFAULT 1,
+                needs_clarification INTEGER DEFAULT 0,
+                status TEXT DEFAULT 'active',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                corrected_by_user_id INTEGER,
+                corrected_by_name TEXT,
+                correction_reason TEXT,
+                supersedes_id INTEGER,
+                superseded_by_id INTEGER
+            )
+            """
+        )
+        conn.commit()
+        declared_canon.ensure_declared_canon_schema(conn)
+
+    def insert_pr2_broadcast(
+        self,
+        conn,
+        *,
+        cleaned="A source-owned Broadcast summary.",
+        raw="Private operator wording.",
+        entry_type="notable_moment",
+        status="active",
+        public_safe=1,
+        usage_scope="ambient,direct",
+        created_at="2026-08-01T00:00:00+00:00",
+        valid_until="",
+    ):
+        cursor = conn.execute(
+            """
+            INSERT INTO broadcast_memory(
+                guild_id,episode_date,submitted_by_user_id,submitted_by_name,
+                raw_note,cleaned_summary,entry_type,importance,public_safe,
+                affects_next_show,usage_scope,target_show_date,valid_until,
+                override_span_count,needs_clarification,status,created_at,
+                updated_at,corrected_by_user_id,corrected_by_name,
+                correction_reason,supersedes_id,superseded_by_id
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                7,
+                "2026-08-01",
+                61,
+                "Owner Fixture",
+                raw,
+                cleaned,
+                entry_type,
+                "medium",
+                public_safe,
+                0,
+                usage_scope,
+                None,
+                valid_until,
+                1,
+                0,
+                status,
+                created_at,
+                created_at,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+        )
+        conn.commit()
+        return int(cursor.lastrowid)
+
+    def classify_pr2_broadcast(
+        self,
+        conn,
+        row_id,
+        *,
+        nonce="classify-contract-0001",
+        expected_revision_id="",
+        visibility="public_safe",
+        eligible_routes=("public_home",),
+    ):
+        columns = tuple(
+            row[1] for row in conn.execute("PRAGMA table_info(broadcast_memory)")
+        )
+        values = conn.execute(
+            "SELECT %s FROM broadcast_memory WHERE id=?" % ",".join(columns),
+            (row_id,),
+        ).fetchone()
+        fingerprint = declared_canon.broadcast_source_fingerprint(
+            dict(zip(columns, values))
+        )
+        return declared_canon.classify_broadcast_memory(
+            conn,
+            actor_user_id=61,
+            authority_nonce=nonce,
+            guild_id=7,
+            broadcast_row_id=row_id,
+            expected_source_fingerprint=fingerprint,
+            expected_revision_id=expected_revision_id,
+            subject_type="broadcast",
+            subject_id="barcode_radio",
+            visibility=visibility,
+            eligible_routes=eligible_routes,
+            now="2026-08-01T01:00:00+00:00",
+        ).primary
+
     def test_contract_separates_status_domain_and_lifecycle(self):
         fact = next(
             item
@@ -225,6 +350,20 @@ class HybridCanonClaimContractTests(unittest.TestCase):
         self.assertEqual(name_shaped_actor.status, "hint_only")
         self.assertEqual(name_shaped_actor.subject, canon.CACHE_BACK)
 
+        name_shaped_owner_ref = canon.resolve_entity_identity(
+            platform="discord",
+            account_id="4242",
+            labels=("Cache Back",),
+            bindings=(
+                replace(
+                    binding,
+                    authority_actor="owner_ref:first.last",
+                ),
+            ),
+        )
+        self.assertEqual(name_shaped_owner_ref.status, "hint_only")
+        self.assertEqual(name_shaped_owner_ref.subject, canon.CACHE_BACK)
+
         empty_scope = canon.resolve_entity_identity(
             platform="",
             account_id="",
@@ -265,7 +404,7 @@ class HybridCanonClaimContractTests(unittest.TestCase):
                     platform="DISCORD",
                     account_id="9001",
                     authority_receipt="binding_receipt:sheila",
-                    authority_actor="owner_ref:binding_owner",
+                    authority_actor="discord_user:1",
                     authority_verified=True,
                 ),
             ),
@@ -284,7 +423,7 @@ class HybridCanonClaimContractTests(unittest.TestCase):
                     platform="discord",
                     account_id="9002",
                     authority_receipt="binding_receipt:cliff",
-                    authority_actor="owner_ref:binding_owner",
+                    authority_actor="discord_user:1",
                     authority_verified=True,
                 ),
             ),
@@ -374,7 +513,7 @@ class HybridCanonClaimContractTests(unittest.TestCase):
         self.assertEqual(legacy.claim.visibility, canon.Visibility.INTERNAL)
         self.assertEqual(legacy.claim.eligible_routes, ("broadcast_memory",))
 
-    def test_broadcast_adapter_stays_review_only_in_pr1(self):
+    def test_raw_broadcast_adapter_ignores_legacy_caller_authority(self):
         row = {
             "id": 4,
             "entry_type": "notable_moment",
@@ -403,22 +542,21 @@ class HybridCanonClaimContractTests(unittest.TestCase):
         )
         self.assertEqual(review.claim.visibility, canon.Visibility.INTERNAL)
         self.assertNotIn("public_home", review.claim.eligible_routes)
-        self.assertEqual(
-            declared.claim.lifecycle,
-            canon.ClaimLifecycle.REVIEW_ONLY,
-        )
+        self.assertEqual(declared.claim.lifecycle, canon.ClaimLifecycle.REVIEW_ONLY)
         self.assertFalse(declared.live_eligible)
-        self.assertEqual(declared.reason, "owner_verified_review_only")
+        self.assertEqual(declared.reason, "broadcast_source_review_only")
         self.assertEqual(
             declared.claim.canon_status,
-            canon.CanonStatus.DECLARED,
+            canon.CanonStatus.OPEN_SIGNAL,
         )
         self.assertEqual(
             declared.claim.domain,
             canon.CanonDomain.BROADCAST_HISTORY,
         )
-        self.assertEqual(declared.claim.visibility, canon.Visibility.PUBLIC_SAFE)
-        self.assertNotIn("Private operator wording", declared.claim.value)
+        self.assertEqual(declared.claim.visibility, canon.Visibility.INTERNAL)
+        self.assertEqual(declared.claim.authority_actor, "")
+        self.assertEqual(declared.claim.authority_receipt, "")
+        self.assertFalse(declared.live_eligible)
 
     def test_broadcast_adapter_fails_closed_on_scope_and_boolean_strings(self):
         cases = (
@@ -467,7 +605,7 @@ class HybridCanonClaimContractTests(unittest.TestCase):
             authority_actor="Personal Human Name",
             authority_receipt="owner_confirmed",
         )
-        self.assertEqual(forged.reason, "owner_authority_review_only")
+        self.assertEqual(forged.reason, "broadcast_source_review_only")
         self.assertEqual(forged.claim.authority_actor, "")
         self.assertEqual(forged.claim.authority_receipt, "")
         self.assertEqual(forged.claim.confidence, canon.Confidence.LOW)
@@ -487,6 +625,524 @@ class HybridCanonClaimContractTests(unittest.TestCase):
             canon.Visibility.INTERNAL,
         )
         self.assertNotIn("public_home", mixed_internal.claim.eligible_routes)
+
+    def test_exact_current_sidecar_join_is_declared_shadow_and_rereads_source(self):
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_OWNER_USER_ID": "61", "BNL_PRIMARY_GUILD_ID": "7"},
+        ):
+            conn = sqlite3.connect(":memory:")
+            try:
+                self.create_pr2_broadcast_table(conn)
+                row_id = self.insert_pr2_broadcast(conn)
+                revision = self.classify_pr2_broadcast(conn, row_id)
+                before = conn.total_changes
+                result = canon.adapt_declared_canon_revision(
+                    conn,
+                    actor_user_id=61,
+                    authority_nonce="adapt-declared-0001",
+                    guild_id=7,
+                    declaration_id=revision.declaration_id,
+                    expected_revision_id=revision.revision_id,
+                    expected_source_fingerprint=revision.source_fingerprint,
+                    now="2026-08-01T02:00:00+00:00",
+                )
+                self.assertEqual(conn.total_changes, before)
+                self.assertEqual(result.reason, "declared_shadow_current")
+                self.assertFalse(result.live_eligible)
+                self.assertEqual(result.claim.canon_status, canon.CanonStatus.DECLARED)
+                self.assertEqual(result.claim.lifecycle, canon.ClaimLifecycle.ESTABLISHED)
+                self.assertEqual(result.claim.value, "A source-owned Broadcast summary.")
+                self.assertNotIn("Private operator wording", result.claim.value)
+                self.assertEqual(
+                    result.claim.root_ids,
+                    ("broadcast_memory:%s" % row_id,),
+                )
+                self.assertEqual(result.claim.occurrence_ids, result.claim.root_ids)
+                self.assertIn(
+                    "declared_canon_revision:%s" % revision.revision_id,
+                    result.claim.source_refs,
+                )
+                self.assertNotIn(
+                    "declared_canon_revision:%s" % revision.revision_id,
+                    result.claim.root_ids,
+                )
+                self.assertEqual(result.claim.eligible_routes, ("public_home",))
+                self.assertEqual(result.claim.authority_receipt, revision.authority_receipt)
+                raw = canon.adapt_broadcast_memory_claim(
+                    {
+                        "id": row_id,
+                        "entry_type": "notable_moment",
+                        "cleaned_summary": "A source-owned Broadcast summary.",
+                    }
+                ).claim
+                duplicate_view = canon.canon_claim_inventory_diagnostics(
+                    (raw, result.claim)
+                )
+                self.assertEqual(
+                    duplicate_view["duplicateCurrentSourceClaimCount"],
+                    1,
+                )
+                conn.execute("BEGIN")
+                nested = canon.adapt_declared_canon_revision(
+                    conn,
+                    actor_user_id=61,
+                    authority_nonce="adapt-caller-snapshot",
+                    guild_id=7,
+                    declaration_id=revision.declaration_id,
+                    expected_revision_id=revision.revision_id,
+                    expected_source_fingerprint=revision.source_fingerprint,
+                    now="2026-08-01T02:00:00+00:00",
+                )
+                self.assertEqual(nested.reason, "declared_shadow_current")
+                self.assertTrue(conn.in_transaction)
+                conn.rollback()
+                latest = self.classify_pr2_broadcast(
+                    conn,
+                    row_id,
+                    nonce="classify-contract-latest",
+                    expected_revision_id=revision.revision_id,
+                )
+                old = canon.adapt_declared_canon_revision(
+                    conn,
+                    actor_user_id=61,
+                    authority_nonce="adapt-declared-old1",
+                    guild_id=7,
+                    declaration_id=revision.declaration_id,
+                    expected_revision_id=revision.revision_id,
+                    expected_source_fingerprint=revision.source_fingerprint,
+                    now="2026-08-01T02:00:00+00:00",
+                )
+                self.assertIsNone(old.claim)
+                self.assertEqual(old.reason, "declared_expected_revision_mismatch")
+                self.assertNotEqual(latest.revision_id, revision.revision_id)
+            finally:
+                conn.close()
+
+    def test_declared_join_rejects_stale_source_and_duplicate_authority(self):
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_OWNER_USER_ID": "61", "BNL_PRIMARY_GUILD_ID": "7"},
+        ):
+            conn = sqlite3.connect(":memory:")
+            try:
+                self.create_pr2_broadcast_table(conn)
+                row_id = self.insert_pr2_broadcast(conn)
+                revision = self.classify_pr2_broadcast(conn, row_id)
+                conn.execute(
+                    """
+                    INSERT INTO declared_canon_revisions(%s)
+                    SELECT %s FROM declared_canon_revisions
+                    WHERE revision_id=?
+                    """ % (
+                        ",".join(declared_canon._REVISION_COLUMNS),
+                        ",".join(
+                            "?" if column in {"revision_id", "declaration_id"}
+                            else column
+                            for column in declared_canon._REVISION_COLUMNS
+                        ),
+                    ),
+                    (
+                        "dcr_" + "a" * 40,
+                        "dcl_" + "b" * 32,
+                        revision.revision_id,
+                    ),
+                )
+                conn.commit()
+                duplicate = canon.adapt_declared_canon_revision(
+                    conn,
+                    actor_user_id=61,
+                    authority_nonce="adapt-duplicate-0001",
+                    guild_id=7,
+                    declaration_id=revision.declaration_id,
+                    expected_revision_id=revision.revision_id,
+                    expected_source_fingerprint=revision.source_fingerprint,
+                    now="2026-08-01T02:00:00+00:00",
+                )
+                self.assertIsNone(duplicate.claim)
+                self.assertEqual(
+                    duplicate.reason,
+                    "declared_broadcast_duplicate_authority",
+                )
+            finally:
+                conn.close()
+
+            conn = sqlite3.connect(":memory:")
+            try:
+                self.create_pr2_broadcast_table(conn)
+                row_id = self.insert_pr2_broadcast(conn)
+                revision = self.classify_pr2_broadcast(conn, row_id)
+                conn.execute(
+                    """
+                    UPDATE broadcast_memory
+                    SET cleaned_summary=?,public_safe=0,usage_scope='internal',
+                        updated_at='2026-08-01T03:00:00+00:00'
+                    WHERE id=?
+                    """,
+                    ("Changed after classification.", row_id),
+                )
+                conn.commit()
+                stale = canon.adapt_declared_canon_revision(
+                    conn,
+                    actor_user_id=61,
+                    authority_nonce="adapt-stale-0001",
+                    guild_id=7,
+                    declaration_id=revision.declaration_id,
+                    expected_revision_id=revision.revision_id,
+                    expected_source_fingerprint=revision.source_fingerprint,
+                    now="2026-08-01T04:00:00+00:00",
+                )
+                self.assertIsNone(stale.claim)
+                self.assertEqual(
+                    stale.reason,
+                    "declared_expected_source_fingerprint_mismatch",
+                )
+            finally:
+                conn.close()
+
+            conn = sqlite3.connect(":memory:")
+            try:
+                self.create_pr2_broadcast_table(conn)
+                row_id = self.insert_pr2_broadcast(
+                    conn,
+                    public_safe=0,
+                    usage_scope="internal,unreviewed_scope",
+                )
+                revision = self.classify_pr2_broadcast(
+                    conn,
+                    row_id,
+                    nonce="classify-scope-0001",
+                    visibility="internal",
+                    eligible_routes=("broadcast_memory",),
+                )
+                invalid_scope = canon.adapt_declared_canon_revision(
+                    conn,
+                    actor_user_id=61,
+                    authority_nonce="adapt-scope-0001",
+                    guild_id=7,
+                    declaration_id=revision.declaration_id,
+                    expected_revision_id=revision.revision_id,
+                    expected_source_fingerprint=revision.source_fingerprint,
+                    now="2026-08-01T02:00:00+00:00",
+                )
+                self.assertIsNone(invalid_scope.claim)
+                self.assertEqual(
+                    invalid_scope.reason,
+                    "declared_broadcast_scope_unrecognized",
+                )
+            finally:
+                conn.close()
+
+    def test_general_declared_adapter_uses_latest_owner_revision_only(self):
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_OWNER_USER_ID": "61", "BNL_PRIMARY_GUILD_ID": "7"},
+        ):
+            conn = sqlite3.connect(":memory:")
+            try:
+                declared_canon.ensure_declared_canon_schema(conn)
+                revision = declared_canon.add_declared_canon(
+                    conn,
+                    actor_user_id=61,
+                    authority_nonce="general-declared-0001",
+                    guild_id=7,
+                    subject_type="project",
+                    subject_id="barcode_radio",
+                    predicate="official_role",
+                    value={"role": "weekly broadcast"},
+                    raw_declaration="BARCODE Radio is the weekly broadcast.",
+                    cleaned_summary="The weekly BARCODE broadcast.",
+                    domain="broadcast_history",
+                    claim_kind="role",
+                    visibility="internal",
+                    eligible_routes=("declared_canon_review",),
+                    now="2026-08-01T01:00:00+00:00",
+                ).primary
+                before = conn.total_changes
+                result = canon.adapt_declared_canon_revision(
+                    conn,
+                    actor_user_id=61,
+                    authority_nonce="adapt-general-0001",
+                    guild_id=7,
+                    declaration_id=revision.declaration_id,
+                    expected_revision_id=revision.revision_id,
+                    expected_source_fingerprint=revision.source_fingerprint,
+                    now="2026-08-01T02:00:00+00:00",
+                )
+                self.assertEqual(conn.total_changes, before)
+                self.assertEqual(result.reason, "declared_shadow_current")
+                self.assertEqual(result.claim.value, {"role": "weekly broadcast"})
+                self.assertEqual(result.claim.canon_status, canon.CanonStatus.DECLARED)
+                self.assertEqual(result.claim.root_ids, ("declared_canon:%s" % revision.declaration_id,))
+                self.assertFalse(result.live_eligible)
+            finally:
+                conn.close()
+
+    def test_declared_adapter_uses_one_snapshot_across_concurrent_source_change(self):
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_OWNER_USER_ID": "61", "BNL_PRIMARY_GUILD_ID": "7"},
+        ), tempfile.TemporaryDirectory() as temp_dir:
+            database_path = os.path.join(temp_dir, "declared_snapshot.sqlite3")
+            reader = sqlite3.connect(database_path, timeout=2)
+            writer = None
+            try:
+                reader.execute("PRAGMA journal_mode=WAL")
+                self.create_pr2_broadcast_table(reader)
+                row_id = self.insert_pr2_broadcast(
+                    reader,
+                    cleaned="Snapshot-old Broadcast value.",
+                )
+                revision = self.classify_pr2_broadcast(reader, row_id)
+                writer = sqlite3.connect(database_path, timeout=2)
+                original_validator = (
+                    declared_canon.validate_current_declared_canon_revision
+                )
+                interleaved = {"committed": False}
+
+                def validate_then_change(*args, **kwargs):
+                    validated = original_validator(*args, **kwargs)
+                    writer.execute(
+                        """
+                        UPDATE broadcast_memory
+                        SET cleaned_summary='Snapshot-new Broadcast value.',
+                            public_safe=0,usage_scope='internal',
+                            updated_at='2026-08-01T03:00:00+00:00'
+                        WHERE id=?
+                        """,
+                        (row_id,),
+                    )
+                    writer.commit()
+                    interleaved["committed"] = True
+                    return validated
+
+                before = reader.total_changes
+                with mock.patch.object(
+                    declared_canon,
+                    "validate_current_declared_canon_revision",
+                    side_effect=validate_then_change,
+                ):
+                    result = canon.adapt_declared_canon_revision(
+                        reader,
+                        actor_user_id=61,
+                        authority_nonce="adapt-snapshot-0001",
+                        guild_id=7,
+                        declaration_id=revision.declaration_id,
+                        expected_revision_id=revision.revision_id,
+                        expected_source_fingerprint=revision.source_fingerprint,
+                        now="2026-08-01T02:00:00+00:00",
+                    )
+                self.assertTrue(interleaved["committed"])
+                self.assertEqual(reader.total_changes, before)
+                self.assertFalse(reader.in_transaction)
+                self.assertEqual(result.reason, "declared_shadow_current")
+                self.assertEqual(result.claim.value, "Snapshot-old Broadcast value.")
+                self.assertNotEqual(
+                    result.claim.value,
+                    writer.execute(
+                        "SELECT cleaned_summary FROM broadcast_memory WHERE id=?",
+                        (row_id,),
+                    ).fetchone()[0],
+                )
+                self.assertFalse(result.live_eligible)
+            finally:
+                if writer is not None:
+                    writer.close()
+                reader.close()
+
+    def test_inventory_uses_one_snapshot_across_concurrent_source_change(self):
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_OWNER_USER_ID": "61", "BNL_PRIMARY_GUILD_ID": "7"},
+        ), tempfile.TemporaryDirectory() as temp_dir:
+            database_path = os.path.join(temp_dir, "inventory_snapshot.sqlite3")
+            reader = sqlite3.connect(database_path, timeout=2)
+            writer = None
+            try:
+                reader.execute("PRAGMA journal_mode=WAL")
+                self.create_pr2_broadcast_table(reader)
+                row_id = self.insert_pr2_broadcast(
+                    reader,
+                    cleaned="Inventory-old source value.",
+                )
+                self.classify_pr2_broadcast(reader, row_id)
+                writer = sqlite3.connect(database_path, timeout=2)
+                original_inventory_join = canon._inventory_declared_canon_claims
+                interleaved = {"committed": False}
+
+                def change_then_join(*args, **kwargs):
+                    writer.execute(
+                        """
+                        UPDATE broadcast_memory
+                        SET cleaned_summary='Inventory-new source value.',
+                            public_safe=0,usage_scope='internal',
+                            updated_at='2026-08-01T03:00:00+00:00'
+                        WHERE id=?
+                        """,
+                        (row_id,),
+                    )
+                    writer.commit()
+                    interleaved["committed"] = True
+                    return original_inventory_join(*args, **kwargs)
+
+                before = reader.total_changes
+                with mock.patch.object(
+                    canon,
+                    "_inventory_declared_canon_claims",
+                    side_effect=change_then_join,
+                ):
+                    inventory = canon.build_claim_contract_inventory(
+                        reader,
+                        guild_id=7,
+                        now="2026-08-01T02:00:00+00:00",
+                    )
+                self.assertTrue(interleaved["committed"])
+                self.assertEqual(reader.total_changes, before)
+                self.assertFalse(reader.in_transaction)
+                self.assertEqual(inventory["mutationCount"], 0)
+                self.assertEqual(inventory["broadcastDeclaredCurrentCount"], 1)
+                self.assertEqual(inventory["broadcastOpenReviewCount"], 0)
+                self.assertEqual(inventory["broadcastStaleSidecarCount"], 0)
+                self.assertNotIn("Inventory-old source value", repr(inventory))
+                self.assertNotIn("Inventory-new source value", repr(inventory))
+            finally:
+                if writer is not None:
+                    writer.close()
+                reader.close()
+
+    def test_declared_subject_type_distinguishes_same_id_across_entity_kinds(self):
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_OWNER_USER_ID": "61", "BNL_PRIMARY_GUILD_ID": "7"},
+        ):
+            conn = sqlite3.connect(":memory:")
+            try:
+                declared_canon.ensure_declared_canon_schema(conn)
+                claims = []
+                for subject_type, nonce in (
+                    ("person", "typed-person-0001"),
+                    ("project", "typed-project-0001"),
+                ):
+                    revision = declared_canon.add_declared_canon(
+                        conn,
+                        actor_user_id=61,
+                        authority_nonce=nonce,
+                        guild_id=7,
+                        subject_type=subject_type,
+                        subject_id="shared_signal_id",
+                        predicate="official_role",
+                        value={"role": "fixture"},
+                        raw_declaration="Typed subject fixture.",
+                        cleaned_summary="Typed subject fixture.",
+                        domain="real_community",
+                        claim_kind="role",
+                        visibility="internal",
+                        eligible_routes=("declared_canon_review",),
+                        now="2026-08-01T01:00:00+00:00",
+                    ).primary
+                    adapted = canon.adapt_declared_canon_revision(
+                        conn,
+                        actor_user_id=61,
+                        authority_nonce="adapt-%s" % nonce,
+                        guild_id=7,
+                        declaration_id=revision.declaration_id,
+                        expected_revision_id=revision.revision_id,
+                        expected_source_fingerprint=revision.source_fingerprint,
+                        now="2026-08-01T02:00:00+00:00",
+                    )
+                    self.assertFalse(adapted.live_eligible)
+                    claims.append(adapted.claim)
+                self.assertEqual(
+                    tuple(claim.subject_type for claim in claims),
+                    ("person", "project"),
+                )
+                self.assertEqual(claims[0].subject_id, claims[1].subject_id)
+                self.assertNotEqual(claims[0].claim_id, claims[1].claim_id)
+                retyped = canon._with_final_revision(
+                    replace(
+                        claims[0],
+                        revision_id="",
+                        subject_type="project",
+                    ),
+                    source_revision=claims[0].source_revision,
+                )
+                self.assertNotEqual(retyped.revision_id, claims[0].revision_id)
+                diagnostics = canon.canon_claim_inventory_diagnostics(claims)
+                self.assertEqual(diagnostics["declaredTypedSubjectCount"], 2)
+                self.assertEqual(diagnostics["declaredUntypedSubjectCount"], 0)
+                self.assertEqual(diagnostics["declaredSubjectIdMultiTypeCount"], 1)
+            finally:
+                conn.close()
+
+    def test_declared_relationship_preserves_typed_object_endpoint(self):
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_OWNER_USER_ID": "61", "BNL_PRIMARY_GUILD_ID": "7"},
+        ):
+            conn = sqlite3.connect(":memory:")
+            try:
+                declared_canon.ensure_declared_canon_schema(conn)
+                revision = declared_canon.add_declared_canon(
+                    conn,
+                    actor_user_id=61,
+                    authority_nonce="typed-relation-0001",
+                    guild_id=7,
+                    subject_type="person",
+                    subject_id="six_bit",
+                    object_subject_type="project",
+                    object_subject_id="barcode_radio",
+                    predicate="broadcasts_for",
+                    value={"role": "host"},
+                    raw_declaration="6 Bit hosts BARCODE Radio.",
+                    cleaned_summary="6 Bit hosts BARCODE Radio.",
+                    domain="real_community",
+                    claim_kind="relationship",
+                    visibility="internal",
+                    eligible_routes=("declared_canon_review",),
+                    now="2026-08-01T01:00:00+00:00",
+                ).primary
+                result = canon.adapt_declared_canon_revision(
+                    conn,
+                    actor_user_id=61,
+                    authority_nonce="adapt-relation-0001",
+                    guild_id=7,
+                    declaration_id=revision.declaration_id,
+                    expected_revision_id=revision.revision_id,
+                    expected_source_fingerprint=revision.source_fingerprint,
+                    now="2026-08-01T02:00:00+00:00",
+                )
+                self.assertEqual(result.claim.subject_type, "person")
+                self.assertEqual(result.claim.subject_id, "six_bit")
+                self.assertEqual(result.claim.object_subject_type, "project")
+                self.assertEqual(result.claim.object_subject_id, "barcode_radio")
+                self.assertEqual(
+                    result.claim.value["object_subject_id"],
+                    "barcode_radio",
+                )
+                self.assertFalse(result.live_eligible)
+                diagnostics = canon.canon_claim_inventory_diagnostics(
+                    (result.claim,)
+                )
+                self.assertEqual(
+                    diagnostics["declaredRelationshipEndpointMissingCount"],
+                    0,
+                )
+                malformed = replace(
+                    result.claim,
+                    object_subject_type="",
+                    object_subject_id="",
+                )
+                malformed_diagnostics = canon.canon_claim_inventory_diagnostics(
+                    (malformed,)
+                )
+                self.assertEqual(
+                    malformed_diagnostics[
+                        "declaredRelationshipEndpointMissingCount"
+                    ],
+                    1,
+                )
+            finally:
+                conn.close()
 
     def test_living_adapter_rejects_heterogeneous_or_unestablished_rows(self):
         role = canon.adapt_living_atomic_claim(
@@ -763,7 +1419,7 @@ class HybridCanonClaimContractTests(unittest.TestCase):
             authority_actor="discord_user:1",
             authority_receipt="owner_command:40",
         ).claim
-        self.assertEqual(claim.canon_status, canon.CanonStatus.DECLARED)
+        self.assertEqual(claim.canon_status, canon.CanonStatus.OPEN_SIGNAL)
         self.assertEqual(claim.visibility, canon.Visibility.INTERNAL)
         self.assertEqual(claim.lifecycle, canon.ClaimLifecycle.REVIEW_ONLY)
         self.assertTrue(
@@ -778,7 +1434,7 @@ class HybridCanonClaimContractTests(unittest.TestCase):
                 at="2026-08-03T00:00:00+00:00",
             )
         )
-        self.assertEqual(claim.canon_status, canon.CanonStatus.DECLARED)
+        self.assertEqual(claim.canon_status, canon.CanonStatus.OPEN_SIGNAL)
         self.assertEqual(claim.lifecycle, canon.ClaimLifecycle.REVIEW_ONLY)
 
     def test_inventory_reports_contract_and_content_free_collisions(self):
@@ -795,6 +1451,9 @@ class HybridCanonClaimContractTests(unittest.TestCase):
         self.assertEqual(diagnostics["claimIdCollisionCount"], 0)
         self.assertEqual(diagnostics["revisionIdCollisionCount"], 0)
         self.assertEqual(diagnostics["revisionDigestMismatchCount"], 0)
+        self.assertEqual(diagnostics["duplicateCurrentSourceClaimCount"], 0)
+        self.assertEqual(diagnostics["duplicateRootWithinClaimCount"], 0)
+        self.assertEqual(diagnostics["duplicateDeclaredRootAuthorityCount"], 0)
         self.assertEqual(diagnostics["identityBindingCollisionCount"], 0)
         self.assertEqual(diagnostics["nonOpaqueAuthorityActorCount"], 0)
 
@@ -806,7 +1465,7 @@ class HybridCanonClaimContractTests(unittest.TestCase):
 
         hostile_claim = replace(
             claims[0],
-            authority_actor="discord_user:Jane Doe",
+            authority_actor="owner_ref:first.last",
         )
         hostile = canon.canon_claim_inventory_diagnostics(
             (hostile_claim,),
@@ -816,7 +1475,7 @@ class HybridCanonClaimContractTests(unittest.TestCase):
                     platform="discord",
                     account_id="7",
                     authority_receipt="binding_receipt:hostile",
-                    authority_actor="discord_user:Jane Doe",
+                    authority_actor="owner_ref:first.last",
                     authority_verified=True,
                 ),
             ),
@@ -863,6 +1522,7 @@ class HybridCanonClaimContractTests(unittest.TestCase):
                     ),
                 ),
             )
+            conn.commit()
             before = conn.total_changes
             inventory = canon.build_claim_contract_inventory(
                 conn,
@@ -879,8 +1539,146 @@ class HybridCanonClaimContractTests(unittest.TestCase):
             rendered = repr(inventory)
             self.assertNotIn("Private fixture", rendered)
             self.assertNotIn("Another private", rendered)
+            conn.execute("BEGIN")
+            nested = canon.build_claim_contract_inventory(conn, guild_id=1)
+            self.assertEqual(nested["mutationCount"], 0)
+            self.assertTrue(conn.in_transaction)
+            conn.rollback()
         finally:
             conn.close()
+
+    def test_database_inventory_ignores_temp_source_shadow(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            source_schema = """
+                CREATE {scope} TABLE broadcast_memory(
+                  id INTEGER PRIMARY KEY,
+                  guild_id INTEGER,
+                  entry_type TEXT,
+                  raw_note TEXT,
+                  status TEXT,
+                  public_safe INTEGER,
+                  created_at TEXT
+                )
+            """
+            conn.execute(source_schema.format(scope=""))
+            conn.execute(
+                "INSERT INTO main.broadcast_memory VALUES(?,?,?,?,?,?,?)",
+                (
+                    1,
+                    1,
+                    "notable_moment",
+                    "Main source",
+                    "active",
+                    1,
+                    "2026-08-01T00:00:00+00:00",
+                ),
+            )
+            conn.execute(source_schema.format(scope="TEMP"))
+            conn.executemany(
+                "INSERT INTO temp.broadcast_memory VALUES(?,?,?,?,?,?,?)",
+                (
+                    (9, 1, "recap", "Temp one", "active", 1, "2025-01-01"),
+                    (10, 1, "recap", "Temp two", "active", 1, "2025-01-02"),
+                ),
+            )
+            conn.commit()
+
+            inventory = canon.build_claim_contract_inventory(conn, guild_id=1)
+
+            self.assertEqual(inventory["sourceRows"]["broadcast_memory"], 1)
+            self.assertEqual(inventory["adaptedRows"]["broadcast_memory"], 1)
+            self.assertNotIn("Temp one", repr(inventory))
+            self.assertNotIn("Temp two", repr(inventory))
+        finally:
+            conn.close()
+
+    def test_inventory_collapses_broadcast_sidecar_and_counts_old_revisions(self):
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_OWNER_USER_ID": "61", "BNL_PRIMARY_GUILD_ID": "7"},
+        ):
+            conn = sqlite3.connect(":memory:")
+            try:
+                self.create_pr2_broadcast_table(conn)
+                declared_row = self.insert_pr2_broadcast(
+                    conn,
+                    cleaned="Declared fixture content must stay out of diagnostics.",
+                )
+                self.insert_pr2_broadcast(
+                    conn,
+                    cleaned="Open fixture content must stay out of diagnostics.",
+                )
+                first = self.classify_pr2_broadcast(conn, declared_row)
+                second = self.classify_pr2_broadcast(
+                    conn,
+                    declared_row,
+                    nonce="classify-contract-0002",
+                    expected_revision_id=first.revision_id,
+                )
+                self.assertNotEqual(first.revision_id, second.revision_id)
+                before = conn.total_changes
+                inventory = canon.build_claim_contract_inventory(
+                    conn,
+                    guild_id=7,
+                    now="2026-08-01T02:00:00+00:00",
+                )
+                self.assertEqual(conn.total_changes, before)
+                self.assertEqual(inventory["mutationCount"], 0)
+                self.assertEqual(inventory["adaptedRows"]["broadcast_memory"], 2)
+                self.assertEqual(inventory["broadcastDeclaredCurrentCount"], 1)
+                self.assertEqual(inventory["broadcastOpenReviewCount"], 1)
+                self.assertEqual(inventory["broadcastStaleSidecarCount"], 0)
+                self.assertEqual(inventory["duplicateCurrentSourceClaimCount"], 0)
+                self.assertEqual(inventory["duplicateRootWithinClaimCount"], 0)
+                self.assertEqual(inventory["duplicateDeclaredRootAuthorityCount"], 0)
+                self.assertEqual(inventory["declaredHistoricalRevisionCount"], 1)
+                self.assertEqual(inventory["statuses"]["declared"], 1)
+                self.assertGreaterEqual(inventory["statuses"]["open_signal"], 1)
+                rendered = repr(inventory)
+                self.assertNotIn("Declared fixture content", rendered)
+                self.assertNotIn("Open fixture content", rendered)
+                self.assertNotIn(first.revision_id, rendered)
+                self.assertNotIn("broadcast_memory:%s" % declared_row, rendered)
+            finally:
+                conn.close()
+
+    def test_inventory_falls_back_to_one_open_claim_for_stale_or_duplicate_sidecar(self):
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_OWNER_USER_ID": "61", "BNL_PRIMARY_GUILD_ID": "7"},
+        ):
+            conn = sqlite3.connect(":memory:")
+            try:
+                self.create_pr2_broadcast_table(conn)
+                row_id = self.insert_pr2_broadcast(conn)
+                revision = self.classify_pr2_broadcast(conn, row_id)
+                conn.execute(
+                    """
+                    UPDATE broadcast_memory
+                    SET status='resolved',public_safe=0,usage_scope='internal',
+                        updated_at='2026-08-01T03:00:00+00:00'
+                    WHERE id=?
+                    """,
+                    (row_id,),
+                )
+                conn.commit()
+                before = conn.total_changes
+                inventory = canon.build_claim_contract_inventory(
+                    conn,
+                    guild_id=7,
+                    now="2026-08-01T04:00:00+00:00",
+                )
+                self.assertEqual(conn.total_changes, before)
+                self.assertEqual(inventory["broadcastDeclaredCurrentCount"], 0)
+                self.assertEqual(inventory["broadcastOpenReviewCount"], 1)
+                self.assertEqual(inventory["broadcastStaleSidecarCount"], 1)
+                self.assertEqual(inventory["statuses"]["declared"], 0)
+                self.assertGreaterEqual(inventory["statuses"]["open_signal"], 1)
+                self.assertEqual(inventory["adaptedRows"]["broadcast_memory"], 1)
+                self.assertNotIn(revision.revision_id, repr(inventory))
+            finally:
+                conn.close()
 
     def test_current_atomic_source_row_normalizes_as_review_only(self):
         conn = sqlite3.connect(":memory:")

--- a/tests/test_memory_ledger_bot_paths.py
+++ b/tests/test_memory_ledger_bot_paths.py
@@ -32,10 +32,21 @@ class _FailMessage(_Message):
 class MemoryLedgerBotPathTests(unittest.TestCase):
     def setUp(self):
         self.old_db = bnl01_bot.DB_FILE
+        self.old_owner_user_id = bnl01_bot.BNL_OWNER_USER_ID
+        self.old_primary_guild_id = bnl01_bot.BNL_PRIMARY_GUILD_ID
         self.tmp = tempfile.NamedTemporaryFile(delete=False)
         self.tmp.close()
         bnl01_bot.DB_FILE = self.tmp.name
-        self.env = mock.patch.dict(os.environ, {}, clear=False)
+        bnl01_bot.BNL_OWNER_USER_ID = 42
+        bnl01_bot.BNL_PRIMARY_GUILD_ID = 1
+        self.env = mock.patch.dict(
+            os.environ,
+            {
+                "BNL_OWNER_USER_ID": "42",
+                "BNL_PRIMARY_GUILD_ID": "1",
+            },
+            clear=False,
+        )
         self.env.start()
         os.environ.pop("BNL_MEMORY_LEDGER_SHADOW_ENABLED", None)
         bnl01_bot.init_db()
@@ -43,6 +54,8 @@ class MemoryLedgerBotPathTests(unittest.TestCase):
     def tearDown(self):
         self.env.stop()
         bnl01_bot.DB_FILE = self.old_db
+        bnl01_bot.BNL_OWNER_USER_ID = self.old_owner_user_id
+        bnl01_bot.BNL_PRIMARY_GUILD_ID = self.old_primary_guild_id
         try:
             os.unlink(self.tmp.name)
         except OSError:
@@ -702,6 +715,758 @@ class MemoryLedgerBotPathTests(unittest.TestCase):
         dump = str(self.rows("SELECT * FROM memory_ledger_shadow_receipts"))
         self.assertNotIn("RAW SECRET", dump)
 
+    def test_broadcast_low_level_mutations_require_configured_owner(self):
+        msg = _Message("RAW owner boundary note")
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 0):
+            with self.assertRaisesRegex(
+                PermissionError,
+                "owner_user_id_not_configured",
+            ):
+                bnl01_bot.add_broadcast_memory_entry(
+                    1,
+                    msg,
+                    {
+                        "cleaned_summary": "No write is allowed.",
+                        "entry_type": "notable_moment",
+                    },
+                )
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 999):
+            with self.assertRaisesRegex(
+                PermissionError,
+                "configured_owner_required",
+            ):
+                bnl01_bot.add_broadcast_memory_entry(
+                    1,
+                    msg,
+                    {
+                        "cleaned_summary": "Still no write is allowed.",
+                        "entry_type": "notable_moment",
+                    },
+                )
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM broadcast_memory")[0][0], 0)
+
+    def test_broadcast_low_level_mutations_require_configured_primary_guild(self):
+        msg = _Message("RAW primary guild boundary note")
+        with mock.patch.object(bnl01_bot, "BNL_PRIMARY_GUILD_ID", 0):
+            with self.assertRaisesRegex(
+                PermissionError,
+                "primary_guild_id_not_configured",
+            ):
+                bnl01_bot.add_broadcast_memory_entry(
+                    1,
+                    msg,
+                    {
+                        "cleaned_summary": "No write without configured scope.",
+                        "entry_type": "notable_moment",
+                    },
+                )
+        with self.assertRaisesRegex(
+            PermissionError,
+            "configured_primary_guild_required",
+        ):
+            bnl01_bot.add_broadcast_memory_entry(
+                2,
+                msg,
+                {
+                    "cleaned_summary": "No cross-guild owner write.",
+                    "entry_type": "notable_moment",
+                },
+            )
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM broadcast_memory")[0][0], 0)
+
+    def test_raw_broadcast_insert_helper_rechecks_owner_and_guild(self):
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 999):
+                with self.assertRaisesRegex(
+                    PermissionError,
+                    "configured_owner_required",
+                ):
+                    bnl01_bot._insert_broadcast_memory_row(
+                        conn,
+                        guild_id=1,
+                        actor_id=42,
+                        actor_name="forged",
+                        raw_content="RAW direct helper bypass",
+                        processed={
+                            "cleaned_summary": "Must not be inserted.",
+                            "entry_type": "notable_moment",
+                        },
+                        now="2026-08-01T00:00:00+00:00",
+                    )
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM broadcast_memory")[0][0], 0)
+
+    def test_broadcast_status_mutation_rejects_cross_guild_scope(self):
+        memory_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW scoped status note"),
+            {
+                "cleaned_summary": "Guild-scoped status fixture.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        with self.assertRaisesRegex(
+            PermissionError,
+            "configured_primary_guild_required",
+        ):
+            bnl01_bot._set_broadcast_memory_status(
+                2,
+                memory_id,
+                "resolved",
+                42,
+                "6 Bit",
+                "cross-guild hostile fixture",
+            )
+        self.assertEqual(
+            self.rows(
+                "SELECT status FROM broadcast_memory WHERE guild_id=1 AND id=?",
+                (memory_id,),
+            )[0][0],
+            "active",
+        )
+
+    def test_broadcast_status_helper_rejects_unowned_transition(self):
+        memory_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW status transition note"),
+            {
+                "cleaned_summary": "Status transition fixture.",
+                "entry_type": "notable_moment",
+            },
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "broadcast_status_transition_not_allowed",
+        ):
+            bnl01_bot._set_broadcast_memory_status(
+                1,
+                memory_id,
+                "active",
+                42,
+                "6 Bit",
+                "attempted reactivation",
+            )
+        self.assertEqual(
+            self.rows("SELECT status FROM broadcast_memory WHERE id=?", (memory_id,))[0][0],
+            "active",
+        )
+
+    def test_broadcast_status_cannot_rewrite_superseded_source(self):
+        original_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW original status fixture"),
+            {
+                "cleaned_summary": "Original status fixture.",
+                "entry_type": "notable_moment",
+            },
+        )
+        replacement_id = bnl01_bot._replace_broadcast_memory_entry(
+            1,
+            original_id,
+            _Message("RAW replacement status fixture"),
+            {
+                "cleaned_summary": "Replacement status fixture.",
+                "entry_type": "notable_moment",
+            },
+        )
+        self.assertEqual(
+            bnl01_bot._set_broadcast_memory_status(
+                1,
+                original_id,
+                "resolved",
+                42,
+                "6 Bit",
+                "hostile terminal rewrite",
+            ),
+            0,
+        )
+        self.assertEqual(
+            self.rows(
+                "SELECT status,superseded_by_id FROM broadcast_memory WHERE id=?",
+                (original_id,),
+            )[0],
+            ("superseded", replacement_id),
+        )
+
+    def test_broadcast_status_resolution_is_single_use_and_retracts_source(self):
+        self.enable()
+        memory_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW status resolution note"),
+            {
+                "cleaned_summary": "Status resolution fixture.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        self.assertEqual(
+            bnl01_bot._set_broadcast_memory_status(
+                1, memory_id, "resolved", 42, "6 Bit", "no longer current"
+            ),
+            1,
+        )
+        self.assertEqual(
+            bnl01_bot._set_broadcast_memory_status(
+                1, memory_id, "resolved", 42, "6 Bit", "replayed command"
+            ),
+            0,
+        )
+        source_entry = self.rows(
+            """
+            SELECT entry_id FROM memory_ledger_entries
+            WHERE source_table='broadcast_memory'
+              AND source_role='broadcast_memory' AND source_row_id=?
+            """,
+            (str(memory_id),),
+        )[0][0]
+        status_entry = self.rows(
+            """
+            SELECT entry_id FROM memory_ledger_entries
+            WHERE source_table='broadcast_memory'
+              AND source_role='broadcast_memory_status' AND source_row_id=?
+            """,
+            (str(memory_id),),
+        )[0][0]
+        self.assertEqual(
+            self.rows(
+                """
+                SELECT lineage_type,target_entry_id
+                FROM memory_ledger_lineage WHERE entry_id=?
+                """,
+                (status_entry,),
+            ),
+            [("retracts", source_entry)],
+        )
+
+    def test_broadcast_status_resolution_retracts_all_duplicate_primary_roots(self):
+        self.enable()
+        memory_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW duplicate primary resolution note"),
+            {
+                "cleaned_summary": "Duplicate primary resolution fixture.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            duplicate = ledger.shadow_broadcast_memory_row(
+                conn,
+                row_id=memory_id,
+                guild_id=1,
+                cleaned_summary="Duplicate primary resolution fixture.",
+                entry_type="notable_moment",
+                public_safe=True,
+                status="active",
+                usage_scope="ambient,direct",
+                updated_at="duplicate-effective-revision",
+            )
+            self.assertEqual(duplicate.outcome, "inserted")
+        primary_ids = {
+            row[0]
+            for row in self.rows(
+                """
+                SELECT entry_id FROM memory_ledger_entries
+                WHERE source_table='broadcast_memory'
+                  AND source_role='broadcast_memory' AND source_row_id=?
+                """,
+                (str(memory_id),),
+            )
+        }
+        self.assertEqual(len(primary_ids), 2)
+        self.assertEqual(
+            bnl01_bot._set_broadcast_memory_status(
+                1, memory_id, "resolved", 42, "6 Bit", "terminal correction"
+            ),
+            1,
+        )
+        status_entry = self.rows(
+            """
+            SELECT entry_id FROM memory_ledger_entries
+            WHERE source_table='broadcast_memory'
+              AND source_role='broadcast_memory_status' AND source_row_id=?
+            """,
+            (str(memory_id),),
+        )[0][0]
+        self.assertEqual(
+            {
+                row[0]
+                for row in self.rows(
+                    """
+                    SELECT target_entry_id FROM memory_ledger_lineage
+                    WHERE entry_id=? AND lineage_type='retracts'
+                    """,
+                    (status_entry,),
+                )
+            },
+            primary_ids,
+        )
+
+    def test_broadcast_status_resolution_cannot_rewrite_superseded_source(self):
+        self.enable()
+        original_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW original status source"),
+            {
+                "cleaned_summary": "Original source.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        replacement_id = bnl01_bot._replace_broadcast_memory_entry(
+            1,
+            original_id,
+            _Message("RAW replacement status source"),
+            {
+                "cleaned_summary": "Replacement source.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        before = self.rows(
+            """
+            SELECT status,superseded_by_id,corrected_by_user_id,correction_reason
+            FROM broadcast_memory WHERE id=?
+            """,
+            (original_id,),
+        )[0]
+        self.assertEqual(
+            bnl01_bot._set_broadcast_memory_status(
+                1, original_id, "resolved", 42, "6 Bit", "hostile replay"
+            ),
+            0,
+        )
+        self.assertEqual(
+            self.rows(
+                """
+                SELECT status,superseded_by_id,corrected_by_user_id,correction_reason
+                FROM broadcast_memory WHERE id=?
+                """,
+                (original_id,),
+            )[0],
+            before,
+        )
+        self.assertEqual(before[0:2], ("superseded", replacement_id))
+
+    def test_clear_show_state_low_level_helper_requires_owner(self):
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 999):
+            with self.assertRaisesRegex(
+                PermissionError,
+                "configured_owner_required",
+            ):
+                bnl01_bot.clear_active_show_state_overrides(1, 42)
+
+    def test_clear_show_state_records_each_resolved_lineage_event(self):
+        self.enable()
+        ids = [
+            bnl01_bot.add_broadcast_memory_entry(
+                1,
+                _Message(f"RAW show override {index}"),
+                {
+                    "cleaned_summary": f"Show override fixture {index}.",
+                    "entry_type": "show_state_override",
+                    "importance": "high",
+                    "public_safe": True,
+                    "usage_scope": "show_status,direct",
+                },
+            )
+            for index in (1, 2)
+        ]
+        self.assertEqual(bnl01_bot.clear_active_show_state_overrides(1, 42), 2)
+        self.assertEqual(
+            self.rows(
+                """
+                SELECT id,status,corrected_by_user_id,corrected_by_name,
+                       correction_reason
+                FROM broadcast_memory WHERE id IN (?,?) ORDER BY id
+                """,
+                tuple(ids),
+            ),
+            [
+                (
+                    ids[0],
+                    "resolved",
+                    42,
+                    "configured_owner",
+                    "owner restored normal show state",
+                ),
+                (
+                    ids[1],
+                    "resolved",
+                    42,
+                    "configured_owner",
+                    "owner restored normal show state",
+                ),
+            ],
+        )
+        self.assertEqual(
+            self.rows(
+                """
+                SELECT source_row_id,lifecycle_status
+                FROM memory_ledger_entries
+                WHERE source_table='broadcast_memory'
+                  AND source_role='broadcast_memory_status'
+                ORDER BY CAST(source_row_id AS INTEGER)
+                """
+            ),
+            [(str(ids[0]), "resolved"), (str(ids[1]), "resolved")],
+        )
+
+    def test_clear_show_state_rolls_back_before_shadow_on_update_failure(self):
+        self.enable()
+        memory_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW show override rollback"),
+            {
+                "cleaned_summary": "Show override rollback fixture.",
+                "entry_type": "show_state_override",
+                "importance": "high",
+            },
+        )
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            conn.execute(
+                """
+                CREATE TRIGGER reject_test_show_state_resolution
+                BEFORE UPDATE OF status ON broadcast_memory
+                WHEN NEW.status='resolved'
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced show-state failure');
+                END
+                """
+            )
+        with self.assertRaises(sqlite3.DatabaseError):
+            bnl01_bot.clear_active_show_state_overrides(1, 42)
+        self.assertEqual(
+            self.rows("SELECT status FROM broadcast_memory WHERE id=?", (memory_id,))[0][0],
+            "active",
+        )
+        self.assertEqual(
+            self.rows(
+                """
+                SELECT COUNT(*) FROM memory_ledger_entries
+                WHERE source_table='broadcast_memory'
+                  AND source_role='broadcast_memory_status'
+                  AND source_row_id=?
+                """,
+                (str(memory_id),),
+            )[0][0],
+            0,
+        )
+
+    def test_broadcast_add_rolls_back_when_required_primary_shadow_fails(self):
+        self.enable()
+        with mock.patch.object(
+            bnl01_bot,
+            "shadow_broadcast_memory_row",
+            side_effect=RuntimeError("forced primary shadow failure"),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "forced primary shadow failure",
+            ):
+                bnl01_bot.add_broadcast_memory_entry(
+                    1,
+                    _Message("RAW atomic add rollback"),
+                    {
+                        "cleaned_summary": "Atomic add rollback fixture.",
+                        "entry_type": "notable_moment",
+                        "public_safe": True,
+                        "usage_scope": "ambient,direct",
+                    },
+                )
+        self.assertEqual(
+            self.rows("SELECT COUNT(*) FROM broadcast_memory")[0][0],
+            0,
+        )
+        self.assertEqual(
+            self.rows(
+                "SELECT COUNT(*) FROM memory_ledger_entries "
+                "WHERE source_table='broadcast_memory'"
+            )[0][0],
+            0,
+        )
+
+    def test_broadcast_add_rejects_a_wrong_primary_deduplication(self):
+        self.enable()
+        hostile_dedup = ledger.LedgerWriteResult(
+            entry_id="mle_hostile_existing_snapshot",
+            outcome="deduplicated",
+            reason_code="exact_source_duplicate",
+            source_table="broadcast_memory",
+            source_row_id="1",
+            source_revision="rev:1:hostile",
+            guild_id=1,
+        )
+        with mock.patch.object(
+            bnl01_bot,
+            "shadow_broadcast_memory_row",
+            return_value=hostile_dedup,
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "broadcast_shadow_write_required:deduplicated",
+            ):
+                bnl01_bot.add_broadcast_memory_entry(
+                    1,
+                    _Message("RAW hostile dedup rollback"),
+                    {
+                        "cleaned_summary": "Hostile dedup rollback fixture.",
+                        "entry_type": "notable_moment",
+                        "public_safe": True,
+                        "usage_scope": "ambient,direct",
+                    },
+                )
+        self.assertEqual(
+            self.rows("SELECT COUNT(*) FROM broadcast_memory")[0][0],
+            0,
+        )
+
+    def test_broadcast_resolution_rolls_back_when_required_retraction_fails(self):
+        self.enable()
+        memory_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW atomic resolve rollback"),
+            {
+                "cleaned_summary": "Atomic resolve rollback fixture.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        with mock.patch.object(
+            bnl01_bot,
+            "shadow_broadcast_status_event",
+            side_effect=RuntimeError("forced status shadow failure"),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "forced status shadow failure",
+            ):
+                bnl01_bot._set_broadcast_memory_status(
+                    1,
+                    memory_id,
+                    "resolved",
+                    42,
+                    "6 Bit",
+                    "atomic rollback fixture",
+                )
+        self.assertEqual(
+            self.rows(
+                "SELECT status FROM broadcast_memory WHERE id=?",
+                (memory_id,),
+            )[0][0],
+            "active",
+        )
+        self.assertEqual(
+            self.rows(
+                """
+                SELECT COUNT(*) FROM memory_ledger_entries
+                WHERE source_table='broadcast_memory'
+                  AND source_role='broadcast_memory_status'
+                  AND source_row_id=?
+                """,
+                (str(memory_id),),
+            )[0][0],
+            0,
+        )
+
+    def test_disabled_shadow_still_retracts_an_existing_primary(self):
+        self.enable()
+        memory_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW disabled gate retraction"),
+            {
+                "cleaned_summary": "Existing public primary fixture.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        os.environ.pop("BNL_MEMORY_LEDGER_SHADOW_ENABLED", None)
+        self.assertEqual(
+            bnl01_bot._set_broadcast_memory_status(
+                1,
+                memory_id,
+                "resolved",
+                42,
+                "6 Bit",
+                "source no longer current",
+            ),
+            1,
+        )
+        primary_id = self.rows(
+            """
+            SELECT entry_id FROM memory_ledger_entries
+            WHERE source_table='broadcast_memory'
+              AND source_role='broadcast_memory' AND source_row_id=?
+            """,
+            (str(memory_id),),
+        )[0][0]
+        self.assertEqual(
+            self.rows(
+                """
+                SELECT l.lineage_type,l.target_entry_id
+                FROM memory_ledger_lineage l
+                JOIN memory_ledger_entries e ON e.entry_id=l.entry_id
+                WHERE e.source_table='broadcast_memory'
+                  AND e.source_role='broadcast_memory_status'
+                  AND e.source_row_id=?
+                """,
+                (str(memory_id),),
+            ),
+            [("retracts", primary_id)],
+        )
+
+    def test_disabled_shadow_replacement_without_primary_writes_no_ledger_rows(self):
+        memory_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW disabled replacement source"),
+            {
+                "cleaned_summary": "Disabled replacement source.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        self.assertEqual(
+            self.rows(
+                "SELECT COUNT(*) FROM memory_ledger_entries "
+                "WHERE source_table='broadcast_memory'"
+            )[0][0],
+            0,
+        )
+
+        replacement_id = bnl01_bot._replace_broadcast_memory_entry(
+            1,
+            memory_id,
+            _Message("RAW disabled replacement target"),
+            {
+                "cleaned_summary": "Disabled replacement target.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+
+        self.assertGreater(replacement_id, memory_id)
+        self.assertEqual(
+            self.rows(
+                "SELECT id,status,supersedes_id,superseded_by_id "
+                "FROM broadcast_memory ORDER BY id"
+            ),
+            [
+                (memory_id, "superseded", None, replacement_id),
+                (replacement_id, "active", memory_id, None),
+            ],
+        )
+        self.assertEqual(
+            self.rows(
+                "SELECT COUNT(*) FROM memory_ledger_entries "
+                "WHERE source_table='broadcast_memory'"
+            )[0][0],
+            0,
+        )
+
+    def test_replacement_retracts_all_duplicate_existing_primaries(self):
+        self.enable()
+        memory_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW ambiguous primary fixture"),
+            {
+                "cleaned_summary": "Ambiguous primary fixture.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            second = ledger.shadow_broadcast_memory_row(
+                conn,
+                row_id=memory_id,
+                guild_id=1,
+                cleaned_summary="Conflicting stale primary fixture.",
+                entry_type="notable_moment",
+                public_safe=True,
+                status="active",
+                usage_scope="ambient,direct",
+                submitted_by_user_id=42,
+                submitted_by_name="6 Bit",
+                created_at="2026-08-01T00:00:00+00:00",
+                updated_at="2026-08-01T00:01:00+00:00",
+            )
+            self.assertEqual(second.outcome, "inserted")
+        old_primary_ids = {
+            row[0]
+            for row in self.rows(
+                """
+                SELECT entry_id FROM memory_ledger_entries
+                WHERE source_table='broadcast_memory'
+                  AND source_role='broadcast_memory' AND source_row_id=?
+                """,
+                (str(memory_id),),
+            )
+        }
+        self.assertEqual(len(old_primary_ids), 2)
+        os.environ.pop("BNL_MEMORY_LEDGER_SHADOW_ENABLED", None)
+        replacement_id = bnl01_bot._replace_broadcast_memory_entry(
+            1,
+            memory_id,
+            _Message("RAW duplicate-root replacement"),
+            {
+                "cleaned_summary": "Replacement after duplicate roots.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        self.assertGreater(replacement_id, memory_id)
+        self.assertEqual(
+            self.rows(
+                "SELECT status,superseded_by_id FROM broadcast_memory WHERE id=?",
+                (memory_id,),
+            )[0],
+            ("superseded", replacement_id),
+        )
+        status_entry = self.rows(
+            """
+            SELECT entry_id FROM memory_ledger_entries
+            WHERE source_table='broadcast_memory'
+              AND source_role='broadcast_memory_status' AND source_row_id=?
+            """,
+            (str(memory_id),),
+        )[0][0]
+        self.assertEqual(
+            {
+                row[0]
+                for row in self.rows(
+                    """
+                    SELECT target_entry_id FROM memory_ledger_lineage
+                    WHERE entry_id=? AND lineage_type='retracts'
+                    """,
+                    (status_entry,),
+                )
+            },
+            old_primary_ids,
+        )
+        self.assertEqual(
+            len(
+                self.rows(
+                    """
+                    SELECT entry_id FROM memory_ledger_entries
+                    WHERE source_table='broadcast_memory'
+                      AND source_role='broadcast_memory' AND source_row_id=?
+                    """,
+                    (str(replacement_id),),
+                )
+            ),
+            1,
+        )
+
     def test_broadcast_replacement_has_one_revision_and_real_lineage(self):
         self.enable()
         original_id = bnl01_bot.add_broadcast_memory_entry(
@@ -714,41 +1479,23 @@ class MemoryLedgerBotPathTests(unittest.TestCase):
                 "usage_scope": "ambient,direct",
             },
         )
-        replacement_id = bnl01_bot.add_broadcast_memory_entry(
+        replacement_id = bnl01_bot._replace_broadcast_memory_entry(
             1,
+            original_id,
             _Message("RAW replacement"),
             {
                 "cleaned_summary": "Replacement safe summary.",
                 "entry_type": "show_note",
                 "public_safe": True,
                 "usage_scope": "ambient,direct",
-                "supersedes_id": original_id,
             },
         )
-        updated_at = "2026-07-16T00:00:00-07:00"
-        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
-            conn.execute(
-                "UPDATE broadcast_memory SET status='superseded', superseded_by_id=?, updated_at=? WHERE id=?",
-                (replacement_id, updated_at, original_id),
-            )
-            conn.commit()
-        bnl01_bot._shadow_memory_ledger_write(
-            "broadcast_memory_status",
-            lambda ledger_conn: ledger.shadow_broadcast_status_event(
-                ledger_conn,
-                row_id=original_id,
-                guild_id=1,
-                status="superseded",
-                updated_at=updated_at,
-                actor_id=42,
-                actor_name="Crow",
-                superseded_by_id=replacement_id,
-            ),
-            guild_id=1,
-            source_table="broadcast_memory",
-            source_row_id=original_id,
-            source_revision=f"event:status:superseded:{updated_at.lower()}",
-            source_event_key="status:superseded",
+        self.assertEqual(
+            self.rows(
+                "SELECT status,superseded_by_id FROM broadcast_memory WHERE id=?",
+                (original_id,),
+            )[0],
+            ("superseded", replacement_id),
         )
         primary_rows = self.rows(
             """
@@ -808,6 +1555,73 @@ class MemoryLedgerBotPathTests(unittest.TestCase):
             """
         )
         self.assertEqual(effective_active, [(replacement_entry,)])
+
+    def test_broadcast_replacement_requires_atomic_helper(self):
+        original_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW original"),
+            {
+                "cleaned_summary": "Original safe summary.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "broadcast_replacement_requires_atomic_helper",
+        ):
+            bnl01_bot.add_broadcast_memory_entry(
+                1,
+                _Message("RAW unsafe split replacement"),
+                {
+                    "cleaned_summary": "This must not be stored separately.",
+                    "entry_type": "notable_moment",
+                    "supersedes_id": original_id,
+                },
+            )
+        self.assertEqual(self.rows("SELECT COUNT(*) FROM broadcast_memory")[0][0], 1)
+
+    def test_broadcast_replacement_rolls_back_if_supersession_update_fails(self):
+        original_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW original"),
+            {
+                "cleaned_summary": "Original safe summary.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            conn.execute(
+                """
+                CREATE TRIGGER reject_test_broadcast_supersession
+                BEFORE UPDATE OF status ON broadcast_memory
+                WHEN NEW.status='superseded'
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced supersession failure');
+                END
+                """
+            )
+        with self.assertRaises(sqlite3.DatabaseError):
+            bnl01_bot._replace_broadcast_memory_entry(
+                1,
+                original_id,
+                _Message("RAW replacement"),
+                {
+                    "cleaned_summary": "Replacement must roll back.",
+                    "entry_type": "notable_moment",
+                    "public_safe": True,
+                    "usage_scope": "ambient,direct",
+                },
+            )
+        self.assertEqual(
+            self.rows(
+                "SELECT id,status,superseded_by_id FROM broadcast_memory ORDER BY id"
+            ),
+            [(original_id, "active", None)],
+        )
 
     def test_prune_purges_exact_raw_source_and_moment_before_transcript_delete(self):
         self.enable()

--- a/tests/test_memory_ledger_v1.py
+++ b/tests/test_memory_ledger_v1.py
@@ -8,11 +8,17 @@ import bnl_memory_ledger as ledger
 
 class MemoryLedgerV1Tests(unittest.TestCase):
     def setUp(self):
+        self.env = mock.patch.dict(
+            os.environ,
+            {"BNL_OWNER_USER_ID": "61", "BNL_PRIMARY_GUILD_ID": "1"},
+        )
+        self.env.start()
         self.conn = sqlite3.connect(":memory:")
         ledger.ensure_memory_ledger_schema(self.conn)
 
     def tearDown(self):
         self.conn.close()
+        self.env.stop()
 
     def count_entries(self):
         return self.conn.execute("SELECT COUNT(*) FROM memory_ledger_entries").fetchone()[0]
@@ -237,6 +243,237 @@ class MemoryLedgerV1Tests(unittest.TestCase):
             ledger.shadow_broadcast_memory_row(self.conn, row_id=idx, guild_id=1, cleaned_summary=f"Summary {idx}", entry_type="show_note", public_safe=(idx != 64), status="active", usage_scope=scope)
             row = self.conn.execute("SELECT public_usable, visibility FROM memory_ledger_entries WHERE source_row_id=?", (str(idx),)).fetchone()
             self.assertEqual(row, (expected_public, expected_visibility))
+
+    def test_broadcast_status_event_retracts_the_active_source_projection(self):
+        self.conn.execute(
+            """
+            CREATE TABLE broadcast_memory(
+                id INTEGER PRIMARY KEY,
+                guild_id INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                corrected_by_user_id INTEGER,
+                corrected_by_name TEXT,
+                superseded_by_id INTEGER
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            INSERT INTO broadcast_memory(
+                id,guild_id,status,updated_at,corrected_by_user_id,
+                corrected_by_name,superseded_by_id
+            ) VALUES(70,1,'active','2026-08-01T00:00:00+00:00',NULL,NULL,NULL)
+            """
+        )
+        original = ledger.shadow_broadcast_memory_row(
+            self.conn,
+            row_id=70,
+            guild_id=1,
+            cleaned_summary="A current Broadcast fact.",
+            entry_type="notable_moment",
+            public_safe=True,
+            status="active",
+            usage_scope="ambient,direct",
+            updated_at="2026-08-01T00:00:00+00:00",
+        )
+        self.conn.execute(
+            """
+            UPDATE broadcast_memory
+            SET status='resolved',updated_at=?,corrected_by_user_id=?,
+                corrected_by_name=?
+            WHERE guild_id=1 AND id=70
+            """,
+            ("2026-08-01T01:00:00+00:00", 61, "configured_owner"),
+        )
+        status = ledger.shadow_broadcast_status_event(
+            self.conn,
+            row_id=70,
+            guild_id=1,
+            status="resolved",
+            updated_at="2026-08-01T01:00:00+00:00",
+            actor_id=61,
+            actor_name="configured_owner",
+        )
+        self.assertEqual(status.outcome, "inserted")
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT lineage_type,target_entry_id
+                FROM memory_ledger_lineage WHERE entry_id=?
+                """,
+                (status.entry_id,),
+            ).fetchall(),
+            [("retracts", original.entry_id)],
+        )
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT COUNT(*) FROM memory_ledger_entries
+                WHERE source_table='broadcast_memory'
+                  AND source_role='broadcast_memory'
+                  AND lifecycle_status='active'
+                  AND entry_id NOT IN (
+                    SELECT target_entry_id FROM memory_ledger_lineage
+                    WHERE lineage_type IN ('supersedes','retracts')
+                  )
+                """
+            ).fetchone()[0],
+            0,
+        )
+
+    def test_broadcast_status_event_retracts_every_duplicate_effective_root(self):
+        self.conn.execute(
+            """
+            CREATE TABLE broadcast_memory(
+                id INTEGER PRIMARY KEY,
+                guild_id INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                corrected_by_user_id INTEGER,
+                corrected_by_name TEXT,
+                superseded_by_id INTEGER
+            )
+            """
+        )
+        self.conn.execute(
+            "INSERT INTO broadcast_memory VALUES(72,1,'active',?,NULL,NULL,NULL)",
+            ("2026-08-01T00:00:00+00:00",),
+        )
+        roots = tuple(
+            ledger.shadow_broadcast_memory_row(
+                self.conn,
+                row_id=72,
+                guild_id=1,
+                cleaned_summary="Duplicate effective Broadcast root.",
+                entry_type="notable_moment",
+                public_safe=True,
+                status="active",
+                usage_scope="ambient,direct",
+                updated_at=updated_at,
+            ).entry_id
+            for updated_at in (
+                "2026-08-01T00:00:00+00:00",
+                "2026-08-01T00:01:00+00:00",
+            )
+        )
+        self.assertEqual(len(set(roots)), 2)
+        self.conn.execute(
+            """
+            UPDATE broadcast_memory
+            SET status='resolved',updated_at=?,corrected_by_user_id=?,
+                corrected_by_name=? WHERE guild_id=1 AND id=72
+            """,
+            ("2026-08-01T01:00:00+00:00", 61, "configured_owner"),
+        )
+        status = ledger.shadow_broadcast_status_event(
+            self.conn,
+            row_id=72,
+            guild_id=1,
+            status="resolved",
+            updated_at="2026-08-01T01:00:00+00:00",
+            actor_id=61,
+            actor_name="configured_owner",
+        )
+        self.assertEqual(status.outcome, "inserted")
+        self.assertEqual(
+            {
+                row[0]
+                for row in self.conn.execute(
+                    """
+                    SELECT target_entry_id FROM memory_ledger_lineage
+                    WHERE entry_id=? AND lineage_type='retracts'
+                    """,
+                    (status.entry_id,),
+                ).fetchall()
+            },
+            set(roots),
+        )
+        self.assertEqual(
+            ledger._effective_broadcast_primary_entries(
+                self.conn, guild_id=1, source_row_id=72
+            ),
+            (),
+        )
+
+    def test_broadcast_status_event_fails_closed_on_actor_or_stale_snapshot(self):
+        self.conn.execute(
+            """
+            CREATE TABLE broadcast_memory(
+                id INTEGER PRIMARY KEY,
+                guild_id INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                corrected_by_user_id INTEGER,
+                corrected_by_name TEXT,
+                superseded_by_id INTEGER
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            INSERT INTO broadcast_memory VALUES(
+                71,1,'resolved','2026-08-01T01:00:00+00:00',
+                61,'configured_owner',NULL
+            )
+            """
+        )
+        original = ledger.shadow_broadcast_memory_row(
+            self.conn,
+            row_id=71,
+            guild_id=1,
+            cleaned_summary="A source that must not be retracted by stale input.",
+            entry_type="notable_moment",
+            public_safe=True,
+            status="active",
+            usage_scope="ambient,direct",
+            updated_at="2026-08-01T00:00:00+00:00",
+        )
+        before_entries = self.count_entries()
+
+        nonowner = ledger.shadow_broadcast_status_event(
+            self.conn,
+            row_id=71,
+            guild_id=1,
+            status="resolved",
+            updated_at="2026-08-01T01:00:00+00:00",
+            actor_id=62,
+            actor_name="forged",
+        )
+        stale = ledger.shadow_broadcast_status_event(
+            self.conn,
+            row_id=71,
+            guild_id=1,
+            status="resolved",
+            updated_at="2026-08-01T00:59:59+00:00",
+            actor_id=61,
+            actor_name="configured_owner",
+        )
+
+        self.assertEqual(nonowner.outcome, "skipped")
+        self.assertEqual(
+            nonowner.reason_code,
+            "broadcast_status_configured_owner_required",
+        )
+        self.assertEqual(stale.outcome, "skipped")
+        self.assertEqual(
+            stale.reason_code,
+            "broadcast_status_source_snapshot_mismatch",
+        )
+        self.assertEqual(self.count_entries(), before_entries)
+        self.assertEqual(
+            self.conn.execute(
+                "SELECT COUNT(*) FROM memory_ledger_lineage"
+            ).fetchone()[0],
+            0,
+        )
+        self.assertEqual(
+            self.conn.execute(
+                "SELECT lifecycle_status FROM memory_ledger_entries WHERE entry_id=?",
+                (original.entry_id,),
+            ).fetchone()[0],
+            "active",
+        )
 
     def test_evaluation_detects_missing_success_receipt_entry_and_dangling_lineage(self):
         ledger.record_shadow_receipt(self.conn, guild_id=1, writer="test", source_table="conversations", source_row_id=999, outcome="inserted", reason_code="ok", entry_id="missing")

--- a/tests/test_owner_only_controls.py
+++ b/tests/test_owner_only_controls.py
@@ -338,7 +338,8 @@ class OwnerOnlySurfaceTests(unittest.IsolatedAsyncioTestCase):
 
         bnl01_bot._broadcast_memory_denial_last_at.clear()
         non_owner_message.reply.reset_mock()
-        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 999):
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 999), \
+             mock.patch.object(bnl01_bot, "BNL_PRIMARY_GUILD_ID", 10):
             denied = await bnl01_bot.maybe_reject_unauthorized_official_broadcast_memory(
                 non_owner_message,
                 "Official show note.",
@@ -355,6 +356,34 @@ class OwnerOnlySurfaceTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertFalse(allowed)
         owner_message.reply.assert_not_awaited()
+
+        bnl01_bot._broadcast_memory_denial_last_at.clear()
+        owner_message.reply.reset_mock()
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 999), \
+             mock.patch.object(bnl01_bot, "BNL_PRIMARY_GUILD_ID", 0):
+            unconfigured = await bnl01_bot.maybe_reject_unauthorized_official_broadcast_memory(
+                owner_message,
+                "Official show note.",
+            )
+        self.assertTrue(unconfigured)
+        self.assertIn("BNL_PRIMARY_GUILD_ID", owner_message.reply.await_args.args[0])
+
+        bnl01_bot._broadcast_memory_denial_last_at.clear()
+        owner_message.reply.reset_mock()
+        cross_guild_message = SimpleNamespace(
+            guild=SimpleNamespace(id=11),
+            channel=channel,
+            author=SimpleNamespace(id=999),
+            reply=AsyncMock(),
+        )
+        with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 999), \
+             mock.patch.object(bnl01_bot, "BNL_PRIMARY_GUILD_ID", 10):
+            cross_guild = await bnl01_bot.maybe_reject_unauthorized_official_broadcast_memory(
+                cross_guild_message,
+                "Official show note.",
+            )
+        self.assertTrue(cross_guild)
+        self.assertIn("primary guild", cross_guild_message.reply.await_args.args[0])
 
     async def test_broadcast_memory_route_denies_admin_and_allows_owner_storage(self):
         admin = member(3, administrator=True)
@@ -388,6 +417,7 @@ class OwnerOnlySurfaceTests(unittest.IsolatedAsyncioTestCase):
         }]
 
         with mock.patch.object(bnl01_bot, "BNL_OWNER_USER_ID", 999), \
+             mock.patch.object(bnl01_bot, "BNL_PRIMARY_GUILD_ID", 10), \
              patched_broadcast_memory_route(processed) as (process, add):
             await bnl01_bot.on_message(denied_message)
             process.assert_not_awaited()

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 from bnl_canon_source_contract import Confidence, SourceClass, Visibility
 import bnl_memory_ledger as ledger
+import bnl_declared_canon as declared
 import bnl_moment_engine as moments
 import bnl_relationship_engine as relationships
 from bnl_shadow_acceptance import (
@@ -1609,6 +1610,58 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
         )
         self.assertFalse(internal.diagnostics.prompt_applied)
         self.assertFalse(internal.diagnostics.live_applied)
+
+    def test_declared_canon_shadow_projection_is_not_packet_evidence(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "BNL_OWNER_USER_ID": "61",
+                "BNL_PRIMARY_GUILD_ID": "1",
+            },
+            clear=False,
+        ):
+            self.conn.commit()
+            declared.ensure_declared_canon_schema(self.conn)
+            revision = declared.add_declared_canon(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="packet-declared-add-001",
+                guild_id=1,
+                subject_type="person",
+                subject_id="discord_user:7",
+                predicate="private_declared_fixture",
+                value={"fixture": "DECLARED PROJECTION SENTINEL"},
+                raw_declaration="DECLARED PROJECTION SENTINEL raw authority.",
+                cleaned_summary="DECLARED PROJECTION SENTINEL",
+                domain="real_community",
+                claim_kind="other",
+                visibility="internal",
+                eligible_routes=("declared_canon_review",),
+                now="2026-07-25T12:00:00+00:00",
+            ).primary
+            projected = ledger.shadow_declared_canon_projection(
+                self.conn,
+                guild_id=1,
+                declaration_id=revision.declaration_id,
+                revision_id=revision.revision_id,
+                actor_user_id=61,
+                authority_nonce="packet-declared-project-001",
+                expected_source_fingerprint=revision.source_fingerprint,
+                expected_lifecycle_status=revision.lifecycle_status,
+            )
+            self.assertEqual(projected.outcome, "inserted")
+            self.conn.commit()
+        packet = build_packet(
+            self.conn,
+            self.public_request(text="What do you know about me?"),
+            environ=self.flags,
+        )
+        rendered = render_packet_context(packet)
+        self.assertNotIn("DECLARED PROJECTION SENTINEL", rendered)
+        self.assertNotIn(
+            projected.entry_id,
+            {item.source_ref for item in packet.items},
+        )
 
     def test_gate_requires_all_shadows_and_rejects_live_authority(self):
         enabled = shadow_configuration(self.flags)


### PR DESCRIPTION
## Hybrid Shared-Brain Convergence — PR 2 of 5

Adds the non-live Declared Canon lifecycle and a review-preserving Broadcast Memory adapter on top of the hybrid claim contract from #413.

### What this adds
- append-only owner-controlled Declared Canon revisions with optimistic concurrency
- typed subjects, relationships, domains, claim kinds, visibility, validity, and lifecycle
- deterministic internally issued authority receipts bound to exact actor/guild/operation/nonce/request/stored payload
- exact owner and configured-primary-guild checks at every public lifecycle boundary
- complete-row `broadcast_memory_complete_row_v2` fingerprints, including unknown/future source columns
- bounded, content-free, zero-write historical Broadcast preview
- strict R&D-only `!bnl canon <action> <JSON>` controls dispatched before conversational normalization or storage
- nonpublic, review-only Ledger projections with correction/supersession/retraction lineage
- atomic Broadcast source transitions and exact retract-all handling for duplicate stale primaries

### Preserved boundaries
- Broadcast Memory remains the authoritative content owner; no source row is copied into a new memory store
- no historical row is classified, promoted, or backfilled
- no Declared claim is admitted to the live packet or public response
- no new runtime secret, environment flag, deployment prerequisite, or production configuration
- no website mutation, delegated steward authority, Relationship v2, Active Engagement, queue/payment authority, or VPS action

### Verification
- focused core/contract suite: 138 passed
- focused Discord/bot-control suite: 55 passed
- full repository suite: 1,959 passed
- independent read-only audit: all seven sensitive invariants present; no blockers
- GitHub tree SHA matches the exact locally tested tree: `891966634f81797d3e148daf84ef7953e2ade318`

Part of the frozen Hybrid Shared-Brain Repair alignment plan. This PR is not deployment or behavioral acceptance.