### PR TITLE
Harden Declared Canon authority and invalidation

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -55,6 +55,7 @@ from bnl_memory_ledger import (
     conversation_motif_formation_enabled,
     current_bnl_self_name_records,
     ensure_memory_ledger_schema,
+    effective_broadcast_representations,
     form_atomic_candidate_from_ledger_entry,
     form_atomic_candidates_from_recurring_conversation,
     normalize_bnl_self_name,
@@ -9853,26 +9854,13 @@ def _shadow_declared_revision_after_owner_command(
             revision.source_system == DECLARED_BROADCAST_MEMORY_SOURCE
             and revision.lifecycle_status == "established"
         ):
-            rows = ledger_conn.execute(
-                """
-                SELECT entry_id
-                FROM memory_ledger_entries
-                WHERE guild_id=? AND source_table='broadcast_memory'
-                  AND source_row_id=? AND source_role='broadcast_memory'
-                  AND lifecycle_status='active'
-                  AND NOT EXISTS (
-                      SELECT 1
-                      FROM memory_ledger_lineage AS edge
-                      WHERE edge.guild_id=memory_ledger_entries.guild_id
-                        AND edge.target_entry_id=memory_ledger_entries.entry_id
-                        AND edge.lineage_type IN ('supersedes','retracts')
-                  )
-                ORDER BY created_at DESC
-                """,
-                (guild_id, revision.source_row_id),
-            ).fetchall()
-            if len(rows) == 1:
-                roots = (str(rows[0][0]),)
+            primary_ids = effective_broadcast_representations(
+                ledger_conn,
+                guild_id=guild_id,
+                source_row_id=revision.source_row_id,
+            ).primary_entry_ids
+            if len(primary_ids) == 1:
+                roots = primary_ids
         return shadow_declared_canon_projection(
             ledger_conn,
             guild_id=guild_id,
@@ -16729,7 +16717,7 @@ def _insert_broadcast_memory_row(
     cursor = conn.cursor()
     cursor.execute(
         """
-        INSERT INTO broadcast_memory (
+        INSERT INTO main.broadcast_memory (
             guild_id, episode_date, submitted_by_user_id, submitted_by_name, raw_note,
             cleaned_summary, entry_type, importance, public_safe, affects_next_show,
             usage_scope, target_show_date, valid_until, override_span_count, needs_clarification,
@@ -16767,7 +16755,7 @@ def _insert_broadcast_memory_row(
         SELECT cleaned_summary, entry_type, public_safe, status, usage_scope,
                submitted_by_user_id, submitted_by_name, created_at, updated_at,
                supersedes_id
-        FROM broadcast_memory
+        FROM main.broadcast_memory
         WHERE guild_id=? AND id=?
         """,
         (int(guild_id), new_id),
@@ -16783,29 +16771,24 @@ def _broadcast_primary_projection_ids(
     guild_id: int,
     row_id: int,
 ) -> tuple[str, ...]:
-    if not conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='memory_ledger_entries'"
-    ).fetchone():
-        return ()
-    return tuple(
-        str(row[0])
-        for row in conn.execute(
-            """
-            SELECT entry_id
-            FROM memory_ledger_entries
-            WHERE guild_id=? AND source_table='broadcast_memory'
-              AND source_row_id=? AND source_role='broadcast_memory'
-              AND NOT EXISTS (
-                  SELECT 1 FROM memory_ledger_lineage l
-                  WHERE l.guild_id=memory_ledger_entries.guild_id
-                    AND l.target_entry_id=memory_ledger_entries.entry_id
-                    AND l.lineage_type IN ('supersedes','retracts')
-              )
-            ORDER BY entry_id
-            """,
-            (int(guild_id), str(int(row_id))),
-        ).fetchall()
-    )
+    return effective_broadcast_representations(
+        conn,
+        guild_id=int(guild_id),
+        source_row_id=int(row_id),
+    ).primary_entry_ids
+
+
+def _broadcast_effective_representation_ids(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    row_id: int,
+) -> tuple[str, ...]:
+    return effective_broadcast_representations(
+        conn,
+        guild_id=int(guild_id),
+        source_row_id=int(row_id),
+    ).all_entry_ids
 
 
 def _finalize_required_broadcast_shadow_in_transaction(
@@ -16898,7 +16881,7 @@ def _write_new_broadcast_primary_shadow_in_transaction(
         SELECT cleaned_summary,entry_type,public_safe,status,usage_scope,
                submitted_by_user_id,submitted_by_name,created_at,updated_at,
                supersedes_id
-        FROM broadcast_memory
+        FROM main.broadcast_memory
         WHERE guild_id=? AND id=?
         """,
         (int(guild_id), int(row_id)),
@@ -16963,15 +16946,15 @@ def _write_broadcast_status_shadow_in_transaction(
     require_configured_owner_mutation_actor(actor_id, guild_id)
     if not conn.in_transaction:
         raise RuntimeError("broadcast_shadow_transaction_required")
-    primary_ids = _broadcast_primary_projection_ids(
+    representation_ids = _broadcast_effective_representation_ids(
         conn,
         guild_id=int(guild_id),
         row_id=int(row_id),
     )
-    # With no primary Ledger representation there is no stale evidence to
+    # With no Ledger representation there is no stale evidence to
     # retract. The authoritative source transition may safely commit; a later
     # backfill will observe its terminal source state.
-    if not primary_ids and not required_for_source_transition:
+    if not representation_ids and not required_for_source_transition:
         return None
     result = shadow_broadcast_status_event(
         conn,
@@ -16988,20 +16971,12 @@ def _write_broadcast_status_shadow_in_transaction(
         writer="broadcast_memory_status",
         result=result,
     )
-    if primary_ids:
-        retracted_ids = {
-            str(row[0])
-            for row in conn.execute(
-                """
-                SELECT target_entry_id
-                FROM memory_ledger_lineage
-                WHERE entry_id=? AND lineage_type='retracts'
-                """,
-                (result.entry_id,),
-            ).fetchall()
-        }
-        if retracted_ids != set(primary_ids):
-            raise RuntimeError("broadcast_shadow_retraction_required")
+    if _broadcast_effective_representation_ids(
+        conn,
+        guild_id=int(guild_id),
+        row_id=int(row_id),
+    ):
+        raise RuntimeError("broadcast_shadow_retraction_required")
     return result
 
 
@@ -17468,7 +17443,7 @@ def clear_active_show_state_overrides(guild_id: int, actor_id: int):
             rows = conn.execute(
                 """
                 SELECT id
-                FROM broadcast_memory
+                FROM main.broadcast_memory
                 WHERE guild_id=? AND status='active'
                   AND superseded_by_id IS NULL
                   AND entry_type='show_state_override'
@@ -17478,7 +17453,7 @@ def clear_active_show_state_overrides(guild_id: int, actor_id: int):
             ).fetchall()
             cursor = conn.execute(
                 """
-                UPDATE broadcast_memory
+                UPDATE main.broadcast_memory
                 SET status='resolved', updated_at=?,
                     corrected_by_user_id=?, corrected_by_name=?,
                     correction_reason=?
@@ -17582,7 +17557,7 @@ def _set_broadcast_memory_status(
         with sqlite3.connect(DB_FILE, timeout=30) as conn:
             cursor = conn.execute(
                 """
-                UPDATE broadcast_memory
+                UPDATE main.broadcast_memory
                 SET status=?, updated_at=?, corrected_by_user_id=?, corrected_by_name=?, correction_reason=?
                 WHERE guild_id=? AND id=?
                   AND status='active' AND superseded_by_id IS NULL
@@ -17599,7 +17574,7 @@ def _set_broadcast_memory_status(
             )
             changed = cursor.rowcount
             row = conn.execute(
-                "SELECT guild_id, superseded_by_id FROM broadcast_memory WHERE guild_id=? AND id=?",
+                "SELECT guild_id, superseded_by_id FROM main.broadcast_memory WHERE guild_id=? AND id=?",
                 (int(guild_id), memory_id),
             ).fetchone()
             if changed and row:
@@ -17643,7 +17618,7 @@ def _replace_broadcast_memory_entry(
             target = conn.execute(
                 """
                 SELECT 1
-                FROM broadcast_memory
+                FROM main.broadcast_memory
                 WHERE guild_id=? AND id=? AND status='active'
                   AND superseded_by_id IS NULL
                 """,
@@ -17663,7 +17638,7 @@ def _replace_broadcast_memory_entry(
             )
             changed = conn.execute(
                 """
-                UPDATE broadcast_memory
+                UPDATE main.broadcast_memory
                 SET status='superseded', superseded_by_id=?, updated_at=?,
                     corrected_by_user_id=?, corrected_by_name=?, correction_reason=?
                 WHERE guild_id=? AND id=? AND status='active'
@@ -17681,7 +17656,7 @@ def _replace_broadcast_memory_entry(
             ).rowcount
             if int(changed or 0) != 1:
                 raise RuntimeError("broadcast_replacement_lost_target")
-            existing_primary_ids = _broadcast_primary_projection_ids(
+            existing_representation_ids = _broadcast_effective_representation_ids(
                 conn,
                 guild_id=guild_id,
                 row_id=memory_id,
@@ -17692,7 +17667,7 @@ def _replace_broadcast_memory_entry(
                 row_id=new_id,
                 actor_id=actor_id,
                 expected_updated_at=str(committed[8] or now),
-                required_for_existing_lineage=bool(existing_primary_ids),
+                required_for_existing_lineage=bool(existing_representation_ids),
             )
             _write_broadcast_status_shadow_in_transaction(
                 conn,
@@ -17703,7 +17678,7 @@ def _replace_broadcast_memory_entry(
                 actor_id=actor_id,
                 actor_name=actor_name,
                 superseded_by_id=new_id,
-                required_for_source_transition=bool(existing_primary_ids),
+                required_for_source_transition=bool(existing_representation_ids),
             )
     return new_id
 

--- a/bnl_canon_source_contract.py
+++ b/bnl_canon_source_contract.py
@@ -2002,11 +2002,11 @@ def _inventory_declared_canon_claims(
     from bnl_declared_canon import (
         BROADCAST_MEMORY_SOURCE,
         DECLARED_CANON_TABLE,
+        DeclaredCanonError,
         GENERAL_DECLARATION_SOURCE,
-        _REVISION_COLUMNS,
         _digest,
-        _row_to_revision,
         DECLARED_CANON_CONTRACT_VERSION,
+        validate_declared_canon_read_boundary,
     )
 
     stats = Counter(
@@ -2015,6 +2015,7 @@ def _inventory_declared_canon_claims(
             "declaredHistoricalRevisionCount": 0,
             "declaredCurrentClaimCount": 0,
             "declaredInvalidLatestCount": 0,
+            "declaredBoundaryRejectedCount": 0,
             "broadcastDeclaredCurrentCount": 0,
             "broadcastOpenReviewCount": len(broadcast_rows),
             "broadcastStaleSidecarCount": 0,
@@ -2022,13 +2023,21 @@ def _inventory_declared_canon_claims(
             "declaredOrphanBroadcastSourceCount": 0,
         }
     )
-    columns = set(_sqlite_table_columns(conn, DECLARED_CANON_TABLE))
+    columns = _sqlite_table_columns(conn, DECLARED_CANON_TABLE)
     if not columns:
         return (), {}, dict(stats), False
-    if not set(_REVISION_COLUMNS).issubset(columns) or guild_id is None:
+    if guild_id is None:
         return (), {}, dict(stats), True
     safe_limit = max(1, min(int(limit or 1), 2000))
     scoped_guild = int(guild_id or 0)
+    try:
+        latest_revisions = validate_declared_canon_read_boundary(
+            conn,
+            guild_id=scoped_guild,
+        )
+    except DeclaredCanonError:
+        stats["declaredBoundaryRejectedCount"] = 1
+        return (), {}, dict(stats), True
     total_revisions, total_declarations = conn.execute(
         """
         SELECT COUNT(*),COUNT(DISTINCT declaration_id)
@@ -2040,45 +2049,22 @@ def _inventory_declared_canon_claims(
     stats["declaredHistoricalRevisionCount"] = max(
         0, int(total_revisions or 0) - int(total_declarations or 0)
     )
-    general_count = int(
-        conn.execute(
-            """
-            SELECT COUNT(DISTINCT declaration_id)
-            FROM main.declared_canon_revisions
-            WHERE guild_id=? AND source_system=?
-            """,
-            (scoped_guild, GENERAL_DECLARATION_SOURCE),
-        ).fetchone()[0]
-        or 0
+    general_revisions = tuple(
+        sorted(
+            (
+                revision
+                for revision in latest_revisions
+                if revision.source_system == GENERAL_DECLARATION_SOURCE
+            ),
+            key=lambda revision: revision.declaration_id,
+        )
     )
-    general_rows = conn.execute(
-        """
-        SELECT %s
-        FROM main.declared_canon_revisions d
-        JOIN (
-          SELECT declaration_id,MAX(revision_number) AS max_revision
-          FROM main.declared_canon_revisions
-          WHERE guild_id=? AND source_system=?
-          GROUP BY declaration_id
-        ) latest
-          ON latest.declaration_id=d.declaration_id
-         AND latest.max_revision=d.revision_number
-        WHERE d.guild_id=? AND d.source_system=?
-        ORDER BY d.declaration_id LIMIT ?
-        """ % ",".join("d.%s" % column for column in _REVISION_COLUMNS),
-        (
-            scoped_guild,
-            GENERAL_DECLARATION_SOURCE,
-            scoped_guild,
-            GENERAL_DECLARATION_SOURCE,
-            safe_limit,
-        ),
-    ).fetchall()
+    general_count = len(general_revisions)
     general_claims: list[CanonClaim] = []
-    for raw_revision in general_rows:
+    for revision in general_revisions[:safe_limit]:
         claim, _reason = _inventory_current_declared_claim(
             conn,
-            _row_to_revision(raw_revision),
+            revision,
             now=now,
         )
         if claim is None:
@@ -2093,7 +2079,7 @@ def _inventory_declared_canon_claims(
         )
     )
     broadcast_ids = tuple(value for value in broadcast_ids if value)
-    sidecar_counts: dict[str, int] = {}
+    sidecar_declarations: dict[str, set[str]] = {}
     expected_declarations: dict[str, str] = {
         source_id: "dcl_"
         + _digest(
@@ -2105,58 +2091,19 @@ def _inventory_declared_canon_claims(
         for source_id in broadcast_ids
         if str(source_id).isdigit()
     }
-    if broadcast_ids:
-        for start in range(0, len(broadcast_ids), 400):
-            chunk = broadcast_ids[start : start + 400]
-            placeholders = ",".join("?" for _ in chunk)
-            for source_id, declaration_count in conn.execute(
-                """
-                SELECT source_row_id,COUNT(DISTINCT declaration_id)
-                FROM main.declared_canon_revisions
-                WHERE guild_id=? AND source_system=?
-                  AND source_row_id IN (%s)
-                GROUP BY source_row_id
-                """ % placeholders,
-                (scoped_guild, BROADCAST_MEMORY_SOURCE, *chunk),
-            ).fetchall():
-                sidecar_counts[str(source_id)] = int(declaration_count or 0)
     latest_by_source: dict[str, Any] = {}
-    expected_ids = tuple(expected_declarations.values())
-    for start in range(0, len(expected_ids), 400):
-        chunk = expected_ids[start : start + 400]
-        if not chunk:
+    for revision in latest_revisions:
+        if revision.source_system != BROADCAST_MEMORY_SOURCE:
             continue
-        placeholders = ",".join("?" for _ in chunk)
-        rows = conn.execute(
-            """
-            SELECT %s
-            FROM main.declared_canon_revisions d
-            JOIN (
-              SELECT declaration_id,MAX(revision_number) AS max_revision
-              FROM main.declared_canon_revisions
-              WHERE guild_id=? AND declaration_id IN (%s)
-              GROUP BY declaration_id
-            ) latest
-              ON latest.declaration_id=d.declaration_id
-             AND latest.max_revision=d.revision_number
-            WHERE d.guild_id=? AND d.source_system=?
-            """ % (
-                ",".join("d.%s" % column for column in _REVISION_COLUMNS),
-                placeholders,
-            ),
-            (
-                scoped_guild,
-                *chunk,
-                scoped_guild,
-                BROADCAST_MEMORY_SOURCE,
-            ),
-        ).fetchall()
-        for raw_revision in rows:
-            revision = _row_to_revision(raw_revision)
-            latest_by_source[str(revision.source_row_id)] = revision
+        source_id = str(revision.source_row_id)
+        sidecar_declarations.setdefault(source_id, set()).add(
+            str(revision.declaration_id)
+        )
+        if revision.declaration_id == expected_declarations.get(source_id):
+            latest_by_source[source_id] = revision
     broadcast_claims: dict[str, CanonClaim] = {}
     for source_id in broadcast_ids:
-        declaration_count = sidecar_counts.get(source_id, 0)
+        declaration_count = len(sidecar_declarations.get(source_id, set()))
         if declaration_count == 0:
             continue
         if declaration_count != 1:
@@ -2197,7 +2144,7 @@ def _inventory_declared_canon_claims(
         ).fetchone()[0]
         or 0
     ) if _sqlite_table_columns(conn, "broadcast_memory") else 0
-    truncated = bool(general_count > len(general_rows))
+    truncated = bool(general_count > safe_limit)
     return (
         tuple(general_claims),
         broadcast_claims,

--- a/bnl_declared_canon.py
+++ b/bnl_declared_canon.py
@@ -9,8 +9,8 @@ message/interaction object.  This dependency-free core cannot authenticate a
 network principal; it independently rechecks that opaque ID and the exact guild
 against ``BNL_OWNER_USER_ID`` and ``BNL_PRIMARY_GUILD_ID`` on every public read
 or mutation.  It accepts neither caller-built authority objects nor receipts.
-Receipts are deterministic integrity labels bound to the complete request and
-stored revision. They add no runtime secret or deployment prerequisite.
+Receipts are keyed integrity labels bound to the complete request and stored
+revision.  The signing secret is runtime configuration, never caller input.
 """
 from __future__ import annotations
 
@@ -18,6 +18,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import hashlib
+import hmac
 import json
 import os
 import re
@@ -33,6 +34,9 @@ BROADCAST_DECLARED_CANON_OWNER_ERA_CUTOFF = "2026-07-23T19:16:22+00:00"
 BROADCAST_SOURCE_FINGERPRINT_VERSION = "broadcast_memory_complete_row_v2"
 INTERNAL_AUTHORITY_RECEIPT_VERSION = "declared_canon_internal_receipt_v1"
 STORED_AUTHORITY_BINDING_VERSION = "declared_canon_stored_payload_v1"
+DECLARED_CANON_AUTHORITY_SECRET_ENV = "BNL_DECLARED_CANON_AUTHORITY_SECRET"
+DECLARED_CANON_AUTHORITY_SECRET_MIN_BYTES = 32
+
 # These fields are the minimum recognized Broadcast schema, not a fingerprint
 # allowlist.  Every column returned by the authoritative source row, including
 # unknown/future columns, is included in the v2 fingerprint.  Adding a column
@@ -351,6 +355,111 @@ _REVISION_COLUMNS = (
     "created_at",
 )
 
+_DECLARED_CANON_TABLE_DDL = """
+CREATE TABLE IF NOT EXISTS main.declared_canon_revisions (
+    revision_id TEXT PRIMARY KEY,
+    declaration_id TEXT NOT NULL,
+    revision_number INTEGER NOT NULL CHECK(revision_number > 0),
+    guild_id INTEGER NOT NULL CHECK(guild_id > 0),
+    source_system TEXT NOT NULL,
+    source_row_id TEXT NOT NULL,
+    source_fingerprint TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    operation_id TEXT NOT NULL,
+    operation_reason TEXT NOT NULL DEFAULT '',
+    classification_mode TEXT NOT NULL,
+    raw_declaration TEXT NOT NULL DEFAULT '',
+    cleaned_summary TEXT NOT NULL DEFAULT '',
+    subject_type TEXT NOT NULL,
+    subject_id TEXT NOT NULL,
+    object_subject_type TEXT NOT NULL DEFAULT '',
+    object_subject_id TEXT NOT NULL DEFAULT '',
+    predicate TEXT NOT NULL,
+    value_json TEXT NOT NULL DEFAULT '',
+    domain TEXT NOT NULL,
+    claim_kind TEXT NOT NULL,
+    visibility TEXT NOT NULL,
+    eligible_routes_json TEXT NOT NULL DEFAULT '[]',
+    valid_from TEXT NOT NULL DEFAULT '',
+    valid_until TEXT NOT NULL DEFAULT '',
+    lifecycle_status TEXT NOT NULL,
+    previous_revision_id TEXT NOT NULL DEFAULT '',
+    correction_of_revision_id TEXT NOT NULL DEFAULT '',
+    supersedes_declaration_id TEXT NOT NULL DEFAULT '',
+    superseded_by_declaration_id TEXT NOT NULL DEFAULT '',
+    derived_from_source_ref TEXT NOT NULL DEFAULT '',
+    authority_request_fingerprint TEXT NOT NULL,
+    authority_actor TEXT NOT NULL,
+    authority_receipt TEXT NOT NULL,
+    authority_verified INTEGER NOT NULL CHECK(authority_verified IN (0,1)),
+    contract_version TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE(guild_id, declaration_id, revision_number),
+    UNIQUE(guild_id, declaration_id, operation_id)
+)
+"""
+
+_DECLARED_CANON_INDEX_DDL = {
+    "idx_declared_canon_source": """
+        CREATE INDEX IF NOT EXISTS main.idx_declared_canon_source
+        ON declared_canon_revisions(
+            guild_id, source_system, source_row_id, revision_number
+        )
+    """,
+    "idx_declared_canon_subject": """
+        CREATE INDEX IF NOT EXISTS main.idx_declared_canon_subject
+        ON declared_canon_revisions(
+            guild_id, subject_type, subject_id, lifecycle_status
+        )
+    """,
+}
+
+_DECLARED_CANON_TRIGGER_DDL = {
+    "trg_declared_canon_revisions_no_conflicting_insert": """
+        CREATE TRIGGER IF NOT EXISTS main.trg_declared_canon_revisions_no_conflicting_insert
+        BEFORE INSERT ON declared_canon_revisions
+        WHEN EXISTS(
+            SELECT 1 FROM declared_canon_revisions existing
+            WHERE existing.revision_id=NEW.revision_id
+               OR (
+                   existing.guild_id=NEW.guild_id
+                   AND existing.declaration_id=NEW.declaration_id
+                   AND existing.revision_number=NEW.revision_number
+               )
+               OR (
+                   existing.guild_id=NEW.guild_id
+                   AND existing.declaration_id=NEW.declaration_id
+                   AND existing.operation_id=NEW.operation_id
+               )
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'declared_canon_append_only_conflict');
+        END
+    """,
+    "trg_declared_canon_revisions_no_update": """
+        CREATE TRIGGER IF NOT EXISTS main.trg_declared_canon_revisions_no_update
+        BEFORE UPDATE ON declared_canon_revisions
+        BEGIN
+            SELECT RAISE(ABORT, 'declared_canon_append_only_update');
+        END
+    """,
+    "trg_declared_canon_revisions_no_delete": """
+        CREATE TRIGGER IF NOT EXISTS main.trg_declared_canon_revisions_no_delete
+        BEFORE DELETE ON declared_canon_revisions
+        BEGIN
+            SELECT RAISE(ABORT, 'declared_canon_append_only_delete');
+        END
+    """,
+}
+
+_DECLARED_CANON_UNIQUE_COLUMN_SETS = frozenset(
+    {
+        ("revision_id",),
+        ("guild_id", "declaration_id", "revision_number"),
+        ("guild_id", "declaration_id", "operation_id"),
+    }
+)
+
 
 def _utc_now() -> str:
     # Broadcast intake stores microseconds. Keep equal precision so an
@@ -367,6 +476,29 @@ def _digest(*values: Any) -> str:
         default=str,
     ).encode("utf-8")
     return hashlib.sha256(payload).hexdigest()
+
+
+def _authority_secret() -> bytes:
+    """Load the dedicated authority key without accepting a caller override."""
+
+    raw = os.getenv(DECLARED_CANON_AUTHORITY_SECRET_ENV, "")
+    if not raw:
+        raise DeclaredCanonError("declared_canon_authority_secret_not_configured")
+    encoded = raw.encode("utf-8")
+    if len(encoded) < DECLARED_CANON_AUTHORITY_SECRET_MIN_BYTES:
+        raise DeclaredCanonError("declared_canon_authority_secret_invalid")
+    return encoded
+
+
+def _authority_hmac(*values: Any) -> str:
+    payload = json.dumps(
+        values,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hmac.new(_authority_secret(), payload, hashlib.sha256).hexdigest()
 
 
 def _strict_bool(value: Any) -> bool:
@@ -423,9 +555,9 @@ def _authorize_request(
 
     Callers cannot supply a configured-owner value or a prebuilt receipt.  The
     actor is compared with ``BNL_OWNER_USER_ID`` at this boundary on every call.
-    No secret or caller-supplied receipt participates. The internally computed,
-    visibly versioned receipt commits to the operation, guild, actor, nonce,
-    target, expected revision/source fingerprint, and normalized payload.
+    No caller-supplied secret or receipt participates. The internally computed,
+    keyed and visibly versioned receipt commits to the operation, guild, actor,
+    nonce, target, expected revision/source fingerprint, and normalized payload.
     """
 
     normalized_operation = str(operation or "").strip().casefold()
@@ -450,7 +582,7 @@ def _authorize_request(
         actor,
         nonce,
     )[:32]
-    receipt_digest = _digest(
+    receipt_digest = _authority_hmac(
         INTERNAL_AUTHORITY_RECEIPT_VERSION,
         "request_authority",
         DECLARED_CANON_CONTRACT_VERSION,
@@ -481,9 +613,11 @@ def _authorize_request(
 
 
 def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    if table_name not in {DECLARED_CANON_TABLE, BROADCAST_MEMORY_SOURCE}:
+        raise DeclaredCanonError("invalid_main_table_identifier")
     return bool(
         conn.execute(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+            "SELECT 1 FROM main.sqlite_master WHERE type='table' AND name=?",
             (str(table_name or ""),),
         ).fetchone()
     )
@@ -492,7 +626,38 @@ def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
 def _table_columns(conn: sqlite3.Connection, table_name: str) -> tuple[str, ...]:
     if not _table_exists(conn, table_name):
         return ()
-    return tuple(str(row[1]) for row in conn.execute("PRAGMA table_info(%s)" % table_name))
+    return tuple(
+        str(row[1])
+        for row in conn.execute("PRAGMA main.table_info(%s)" % table_name)
+    )
+
+
+def _normalized_schema_sql(value: Any) -> str:
+    normalized = " ".join(str(value or "").strip().casefold().split())
+    normalized = normalized.replace(" if not exists ", " ")
+    normalized = normalized.replace("main.", "")
+    return normalized.rstrip(";")
+
+
+def _main_schema_sql(
+    conn: sqlite3.Connection, *, object_type: str, name: str
+) -> str:
+    row = conn.execute(
+        "SELECT sql FROM main.sqlite_master WHERE type=? AND name=?",
+        (str(object_type), str(name)),
+    ).fetchone()
+    return str(row[0] or "") if row else ""
+
+
+def _main_index_columns(
+    conn: sqlite3.Connection, index_name: str
+) -> tuple[str, ...]:
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", str(index_name or "")):
+        raise DeclaredCanonError("declared_canon_schema_integrity_invalid")
+    return tuple(
+        str(row[2])
+        for row in conn.execute("PRAGMA main.index_info(%s)" % index_name)
+    )
 
 
 @contextmanager
@@ -520,7 +685,7 @@ def _read_snapshot(conn: sqlite3.Connection):
         # BEGIN is deferred in SQLite. This read pins the snapshot before any
         # validator query so a WAL writer cannot splice a newer revision/source
         # row into the remainder of the validation sequence.
-        conn.execute("SELECT 1 FROM sqlite_schema LIMIT 1").fetchone()
+        conn.execute("SELECT 1 FROM main.sqlite_schema LIMIT 1").fetchone()
     try:
         yield
         if int(conn.total_changes or 0) != before:
@@ -535,117 +700,80 @@ def _read_snapshot(conn: sqlite3.Connection):
 
 
 def ensure_declared_canon_schema(conn: sqlite3.Connection) -> None:
-    """Create the one additive revision table and append-only guards."""
+    """Create the exact schema once; never auto-heal an existing damaged one."""
 
     with _immediate_transaction(conn):
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS declared_canon_revisions (
-                revision_id TEXT PRIMARY KEY,
-                declaration_id TEXT NOT NULL,
-                revision_number INTEGER NOT NULL CHECK(revision_number > 0),
-                guild_id INTEGER NOT NULL CHECK(guild_id > 0),
-                source_system TEXT NOT NULL,
-                source_row_id TEXT NOT NULL,
-                source_fingerprint TEXT NOT NULL,
-                operation TEXT NOT NULL,
-                operation_id TEXT NOT NULL,
-                operation_reason TEXT NOT NULL DEFAULT '',
-                classification_mode TEXT NOT NULL,
-                raw_declaration TEXT NOT NULL DEFAULT '',
-                cleaned_summary TEXT NOT NULL DEFAULT '',
-                subject_type TEXT NOT NULL,
-                subject_id TEXT NOT NULL,
-                object_subject_type TEXT NOT NULL DEFAULT '',
-                object_subject_id TEXT NOT NULL DEFAULT '',
-                predicate TEXT NOT NULL,
-                value_json TEXT NOT NULL DEFAULT '',
-                domain TEXT NOT NULL,
-                claim_kind TEXT NOT NULL,
-                visibility TEXT NOT NULL,
-                eligible_routes_json TEXT NOT NULL DEFAULT '[]',
-                valid_from TEXT NOT NULL DEFAULT '',
-                valid_until TEXT NOT NULL DEFAULT '',
-                lifecycle_status TEXT NOT NULL,
-                previous_revision_id TEXT NOT NULL DEFAULT '',
-                correction_of_revision_id TEXT NOT NULL DEFAULT '',
-                supersedes_declaration_id TEXT NOT NULL DEFAULT '',
-                superseded_by_declaration_id TEXT NOT NULL DEFAULT '',
-                derived_from_source_ref TEXT NOT NULL DEFAULT '',
-                authority_request_fingerprint TEXT NOT NULL,
-                authority_actor TEXT NOT NULL,
-                authority_receipt TEXT NOT NULL,
-                authority_verified INTEGER NOT NULL CHECK(authority_verified IN (0,1)),
-                contract_version TEXT NOT NULL,
-                created_at TEXT NOT NULL,
-                UNIQUE(guild_id, declaration_id, revision_number),
-                UNIQUE(guild_id, declaration_id, operation_id)
-            )
-            """
-        )
-        conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_declared_canon_source
-            ON declared_canon_revisions(
-                guild_id, source_system, source_row_id, revision_number
-            )
-            """
-        )
-        conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_declared_canon_subject
-            ON declared_canon_revisions(
-                guild_id, subject_type, subject_id, lifecycle_status
-            )
-            """
-        )
-        conn.execute(
-            """
-            CREATE TRIGGER IF NOT EXISTS trg_declared_canon_revisions_no_conflicting_insert
-            BEFORE INSERT ON declared_canon_revisions
-            WHEN EXISTS(
-                SELECT 1 FROM declared_canon_revisions existing
-                WHERE existing.revision_id=NEW.revision_id
-                   OR (
-                       existing.guild_id=NEW.guild_id
-                       AND existing.declaration_id=NEW.declaration_id
-                       AND existing.revision_number=NEW.revision_number
-                   )
-                   OR (
-                       existing.guild_id=NEW.guild_id
-                       AND existing.declaration_id=NEW.declaration_id
-                       AND existing.operation_id=NEW.operation_id
-                   )
-            )
-            BEGIN
-                SELECT RAISE(ABORT, 'declared_canon_append_only_conflict');
-            END
-            """
-        )
-        conn.execute(
-            """
-            CREATE TRIGGER IF NOT EXISTS trg_declared_canon_revisions_no_update
-            BEFORE UPDATE ON declared_canon_revisions
-            BEGIN
-                SELECT RAISE(ABORT, 'declared_canon_append_only_update');
-            END
-            """
-        )
-        conn.execute(
-            """
-            CREATE TRIGGER IF NOT EXISTS trg_declared_canon_revisions_no_delete
-            BEFORE DELETE ON declared_canon_revisions
-            BEGIN
-                SELECT RAISE(ABORT, 'declared_canon_append_only_delete');
-            END
-            """
-        )
+        if _table_exists(conn, DECLARED_CANON_TABLE):
+            _require_schema(conn)
+            return
+        conn.execute(_DECLARED_CANON_TABLE_DDL)
+        for statement in _DECLARED_CANON_INDEX_DDL.values():
+            conn.execute(statement)
+        for statement in _DECLARED_CANON_TRIGGER_DDL.values():
+            conn.execute(statement)
+        _require_schema(conn)
 
 
 def _require_schema(conn: sqlite3.Connection) -> None:
-    columns = set(_table_columns(conn, DECLARED_CANON_TABLE))
-    if not set(_REVISION_COLUMNS).issubset(columns):
+    if not _table_exists(conn, DECLARED_CANON_TABLE):
         raise DeclaredCanonError("declared_canon_schema_unavailable")
+    if _table_columns(conn, DECLARED_CANON_TABLE) != _REVISION_COLUMNS:
+        raise DeclaredCanonError("declared_canon_schema_integrity_invalid")
+    actual_table_sql = _main_schema_sql(
+        conn, object_type="table", name=DECLARED_CANON_TABLE
+    )
+    if _normalized_schema_sql(actual_table_sql) != _normalized_schema_sql(
+        _DECLARED_CANON_TABLE_DDL
+    ):
+        raise DeclaredCanonError("declared_canon_schema_integrity_invalid")
+
+    index_rows = conn.execute(
+        "PRAGMA main.index_list(%s)" % DECLARED_CANON_TABLE
+    ).fetchall()
+    explicit_indexes = {
+        str(row[1]): (_strict_bool(row[2]), _main_index_columns(conn, str(row[1])))
+        for row in index_rows
+        if str(row[3] or "") == "c"
+    }
+    expected_explicit_indexes = {
+        "idx_declared_canon_source": (
+            False,
+            ("guild_id", "source_system", "source_row_id", "revision_number"),
+        ),
+        "idx_declared_canon_subject": (
+            False,
+            ("guild_id", "subject_type", "subject_id", "lifecycle_status"),
+        ),
+    }
+    if explicit_indexes != expected_explicit_indexes:
+        raise DeclaredCanonError("declared_canon_schema_integrity_invalid")
+    for name, expected_sql in _DECLARED_CANON_INDEX_DDL.items():
+        if _normalized_schema_sql(
+            _main_schema_sql(conn, object_type="index", name=name)
+        ) != _normalized_schema_sql(expected_sql):
+            raise DeclaredCanonError("declared_canon_schema_integrity_invalid")
+
+    unique_column_sets = frozenset(
+        _main_index_columns(conn, str(row[1]))
+        for row in index_rows
+        if _strict_bool(row[2])
+    )
+    if unique_column_sets != _DECLARED_CANON_UNIQUE_COLUMN_SETS:
+        raise DeclaredCanonError("declared_canon_schema_integrity_invalid")
+
+    trigger_rows = conn.execute(
+        "SELECT name,sql FROM main.sqlite_master "
+        "WHERE type='trigger' AND tbl_name=?",
+        (DECLARED_CANON_TABLE,),
+    ).fetchall()
+    actual_triggers = {str(row[0]): str(row[1] or "") for row in trigger_rows}
+    if set(actual_triggers) != set(_DECLARED_CANON_TRIGGER_DDL):
+        raise DeclaredCanonError("declared_canon_schema_integrity_invalid")
+    for name, expected_sql in _DECLARED_CANON_TRIGGER_DDL.items():
+        if _normalized_schema_sql(actual_triggers.get(name)) != _normalized_schema_sql(
+            expected_sql
+        ):
+            raise DeclaredCanonError("declared_canon_schema_integrity_invalid")
 
 
 def _bounded_text(value: Any, *, field: str, maximum: int, required: bool = True) -> str:
@@ -835,7 +963,7 @@ def _general_fingerprint(fields: Mapping[str, str]) -> str:
 
 def _stored_authority_receipt(payload: Mapping[str, Any]) -> str:
     operation = str(payload.get("operation") or "")
-    digest = _digest(
+    digest = _authority_hmac(
         INTERNAL_AUTHORITY_RECEIPT_VERSION,
         STORED_AUTHORITY_BINDING_VERSION,
         *(payload.get(column) for column in _REVISION_COLUMNS
@@ -999,7 +1127,7 @@ def _copy_revision_payload(
 
 def _insert_revision(conn: sqlite3.Connection, payload: Mapping[str, Any]) -> None:
     conn.execute(
-        "INSERT INTO declared_canon_revisions (%s) VALUES (%s)"
+        "INSERT INTO main.declared_canon_revisions (%s) VALUES (%s)"
         % (",".join(_REVISION_COLUMNS), ",".join("?" for _ in _REVISION_COLUMNS)),
         tuple(payload[column] for column in _REVISION_COLUMNS),
     )
@@ -1011,19 +1139,59 @@ def _row_to_revision(row: Sequence[Any]) -> DeclaredCanonRevision:
     return DeclaredCanonRevision(**values)
 
 
+def _validated_revision_chain(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    declaration_id: str,
+) -> tuple[DeclaredCanonRevision, ...]:
+    """Load and authenticate every revision before trusting the current head."""
+
+    rows = conn.execute(
+        "SELECT %s FROM main.declared_canon_revisions "
+        "WHERE guild_id=? AND declaration_id=? ORDER BY revision_number"
+        % ",".join(_REVISION_COLUMNS),
+        (int(guild_id), str(declaration_id or "")),
+    ).fetchall()
+    revisions = tuple(_row_to_revision(row) for row in rows)
+    prior: DeclaredCanonRevision | None = None
+    for expected_number, revision in enumerate(revisions, start=1):
+        if (
+            int(revision.guild_id) != int(guild_id)
+            or revision.declaration_id != str(declaration_id or "")
+            or int(revision.revision_number) != expected_number
+            or (
+                not prior
+                and bool(str(revision.previous_revision_id or ""))
+            )
+            or (
+                prior is not None
+                and revision.previous_revision_id != prior.revision_id
+            )
+            or (
+                prior is not None
+                and (
+                    revision.source_system != prior.source_system
+                    or revision.source_row_id != prior.source_row_id
+                )
+            )
+        ):
+            raise DeclaredCanonError("declared_canon_revision_chain_invalid")
+        _require_trusted_stored_revision(revision)
+        prior = revision
+    return revisions
+
+
 def _latest_revision(
     conn: sqlite3.Connection,
     *,
     guild_id: int,
     declaration_id: str,
 ) -> DeclaredCanonRevision | None:
-    row = conn.execute(
-        "SELECT %s FROM declared_canon_revisions "
-        "WHERE guild_id=? AND declaration_id=? "
-        "ORDER BY revision_number DESC LIMIT 1" % ",".join(_REVISION_COLUMNS),
-        (int(guild_id), str(declaration_id or "")),
-    ).fetchone()
-    return _row_to_revision(row) if row else None
+    chain = _validated_revision_chain(
+        conn, guild_id=int(guild_id), declaration_id=str(declaration_id or "")
+    )
+    return chain[-1] if chain else None
 
 
 def _existing_operation(
@@ -1032,7 +1200,7 @@ def _existing_operation(
     authority: _VerifiedAuthority,
 ) -> tuple[DeclaredCanonRevision, ...] | None:
     rows = conn.execute(
-        "SELECT %s FROM declared_canon_revisions "
+        "SELECT %s FROM main.declared_canon_revisions "
         "WHERE guild_id=? AND operation_id=? ORDER BY rowid"
         % ",".join(_REVISION_COLUMNS),
         (authority.guild_id, authority.operation_id),
@@ -1048,8 +1216,10 @@ def _existing_operation(
         for revision in revisions
     ):
         raise DeclaredCanonError("authority_nonce_replay_mismatch")
-    for revision in revisions:
-        _require_trusted_stored_revision(revision)
+    for declaration_id in {revision.declaration_id for revision in revisions}:
+        _validated_revision_chain(
+            conn, guild_id=authority.guild_id, declaration_id=declaration_id
+        )
     return revisions
 
 
@@ -1106,7 +1276,6 @@ def add_declared_canon(
     _require_configured_owner_actor(
         actor_user_id=actor_user_id, guild_id=guild_id
     )
-    _require_schema(conn)
     fields = _validated_claim_fields(
         subject_type=subject_type,
         subject_id=subject_id,
@@ -1161,6 +1330,7 @@ def add_declared_canon(
         **fields,
     )
     with _immediate_transaction(conn):
+        _require_schema(conn)
         existing = _existing_operation(conn, authority=authority)
         if existing is not None:
             return MutationResult(operation_id, existing)
@@ -1196,7 +1366,6 @@ def correct_declared_canon(
     _require_configured_owner_actor(
         actor_user_id=actor_user_id, guild_id=guild_id
     )
-    _require_schema(conn)
     fields = _validated_claim_fields(
         subject_type=subject_type,
         subject_id=subject_id,
@@ -1237,6 +1406,7 @@ def correct_declared_canon(
     )
     operation_id = _operation_id(authority)
     with _immediate_transaction(conn):
+        _require_schema(conn)
         existing = _existing_operation(conn, authority=authority)
         if existing is not None:
             return MutationResult(operation_id, existing)
@@ -1285,7 +1455,6 @@ def retire_declared_canon(
     _require_configured_owner_actor(
         actor_user_id=actor_user_id, guild_id=guild_id
     )
-    _require_schema(conn)
     expected_revision = _validate_stable_token(
         expected_revision_id,
         field="expected_revision_id",
@@ -1309,6 +1478,7 @@ def retire_declared_canon(
     )
     operation_id = _operation_id(authority)
     with _immediate_transaction(conn):
+        _require_schema(conn)
         existing = _existing_operation(conn, authority=authority)
         if existing is not None:
             return MutationResult(operation_id, existing)
@@ -1345,7 +1515,6 @@ def change_declared_canon_status(
     _require_configured_owner_actor(
         actor_user_id=actor_user_id, guild_id=guild_id
     )
-    _require_schema(conn)
     normalized_status = str(lifecycle_status or "").strip().casefold()
     if normalized_status not in {"established", "contested", "resolved"}:
         raise DeclaredCanonError("invalid_status_change")
@@ -1373,6 +1542,7 @@ def change_declared_canon_status(
     )
     operation_id = _operation_id(authority)
     with _immediate_transaction(conn):
+        _require_schema(conn)
         existing = _existing_operation(conn, authority=authority)
         if existing is not None:
             return MutationResult(operation_id, existing)
@@ -1414,7 +1584,6 @@ def supersede_declared_canon(
     _require_configured_owner_actor(
         actor_user_id=actor_user_id, guild_id=guild_id
     )
-    _require_schema(conn)
     normalized_declaration_id = _validate_stable_token(
         declaration_id, field="declaration_id", pattern=_STABLE_ID_RE
     )
@@ -1455,6 +1624,7 @@ def supersede_declared_canon(
     )
     operation_id = _operation_id(authority)
     with _immediate_transaction(conn):
+        _require_schema(conn)
         existing = _existing_operation(conn, authority=authority)
         if existing is not None:
             by_declaration = {item.declaration_id: item for item in existing}
@@ -1516,7 +1686,7 @@ def _broadcast_row(
     if not required.issubset(set(columns)):
         return None
     cursor = conn.execute(
-        "SELECT * FROM broadcast_memory WHERE guild_id=? AND id=? LIMIT 1",
+        "SELECT * FROM main.broadcast_memory WHERE guild_id=? AND id=? LIMIT 1",
         (int(guild_id), int(row_id)),
     )
     row = cursor.fetchone()
@@ -1659,7 +1829,6 @@ def classify_broadcast_memory(
     _require_configured_owner_actor(
         actor_user_id=actor_user_id, guild_id=guild_id
     )
-    _require_schema(conn)
     normalized_subject_type = str(subject_type or "").strip().casefold()
     if normalized_subject_type not in GENERAL_SUBJECT_TYPES:
         raise DeclaredCanonError("invalid_subject_type")
@@ -1717,6 +1886,7 @@ def classify_broadcast_memory(
     )
     operation_id = _operation_id(authority)
     with _immediate_transaction(conn):
+        _require_schema(conn)
         existing = _existing_operation(conn, authority=authority)
         if existing is not None:
             return MutationResult(operation_id, existing)
@@ -1868,10 +2038,15 @@ def _stored_authority_valid(revision: DeclaredCanonRevision) -> bool:
             INTERNAL_AUTHORITY_RECEIPT_VERSION,
             operation,
         )
+        configured_owner = _configured_owner_user_id()
+        configured_guild = _configured_primary_guild_id()
         if not (
-            _strict_bool(revision.authority_verified)
+            configured_owner > 0
+            and configured_guild > 0
+            and _strict_bool(revision.authority_verified)
             and str(revision.contract_version or "")
             == DECLARED_CANON_CONTRACT_VERSION
+            and int(revision.guild_id) == configured_guild
             and operation in _MUTATION_OPERATIONS
             and str(revision.operation_id or "").startswith("op_")
             and re.fullmatch(r"op_[0-9a-f]{32}", revision.operation_id or "")
@@ -1880,18 +2055,22 @@ def _stored_authority_valid(revision: DeclaredCanonRevision) -> bool:
                 revision.authority_request_fingerprint or "",
             )
             and str(revision.authority_actor or "")
-            == "discord_user:%s" % _configured_owner_user_id()
+            == "discord_user:%s" % configured_owner
             and str(revision.authority_receipt or "").startswith(prefix)
         ):
             return False
         expected_receipt = _stored_authority_receipt(payload)
-        if str(revision.authority_receipt or "") != expected_receipt:
+        if not hmac.compare_digest(
+            str(revision.authority_receipt or ""), expected_receipt
+        ):
             return False
         expected_revision_id = "drev_" + _digest(
             *(payload[column] for column in _REVISION_COLUMNS
               if column != "revision_id")
         )[:40]
-        return str(revision.revision_id or "") == expected_revision_id
+        return hmac.compare_digest(
+            str(revision.revision_id or ""), expected_revision_id
+        )
     except (DeclaredCanonError, AttributeError, TypeError, ValueError):
         return False
 
@@ -2007,6 +2186,48 @@ def _require_trusted_stored_revision(
             raise DeclaredCanonError("broadcast_source_fingerprint_invalid")
         return
     raise DeclaredCanonError("invalid_source_system")
+
+
+def validate_declared_canon_read_boundary(
+    conn: sqlite3.Connection, *, guild_id: int
+) -> tuple[DeclaredCanonRevision, ...]:
+    """Validate schema and every current chain inside a caller-owned snapshot.
+
+    Internal inventory adapters use this boundary after opening their own read
+    snapshot.  It authenticates stored authority without manufacturing a new
+    owner request, nonce, or receipt.
+    """
+
+    if not conn.in_transaction:
+        raise DeclaredCanonError("declared_canon_read_snapshot_required")
+    configured_owner = _configured_owner_user_id()
+    if configured_owner <= 0:
+        raise DeclaredCanonError("owner_user_id_not_configured")
+    configured_guild = _configured_primary_guild_id()
+    if configured_guild <= 0:
+        raise DeclaredCanonError("primary_guild_id_not_configured")
+    if int(guild_id or 0) != configured_guild:
+        raise DeclaredCanonError("configured_primary_guild_required")
+    _authority_secret()
+    _require_schema(conn)
+    declaration_ids = tuple(
+        str(row[0])
+        for row in conn.execute(
+            "SELECT DISTINCT declaration_id "
+            "FROM main.declared_canon_revisions WHERE guild_id=? "
+            "ORDER BY declaration_id",
+            (configured_guild,),
+        ).fetchall()
+    )
+    latest: list[DeclaredCanonRevision] = []
+    for declaration_id in declaration_ids:
+        chain = _validated_revision_chain(
+            conn, guild_id=configured_guild, declaration_id=declaration_id
+        )
+        if not chain:
+            raise DeclaredCanonError("declared_canon_revision_chain_invalid")
+        latest.append(chain[-1])
+    return tuple(latest)
 
 
 def validate_current_declared_canon_revision(
@@ -2336,6 +2557,28 @@ def preview_declared_canon(
     source_system: str = "",
     limit: int = 100,
 ) -> DeclaredPreview:
+    """Return content-free revision metadata from one coherent read snapshot."""
+
+    with _read_snapshot(conn):
+        return _preview_declared_canon(
+            conn,
+            actor_user_id=actor_user_id,
+            authority_nonce=authority_nonce,
+            guild_id=guild_id,
+            source_system=source_system,
+            limit=limit,
+        )
+
+
+def _preview_declared_canon(
+    conn: sqlite3.Connection,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    source_system: str = "",
+    limit: int = 100,
+) -> DeclaredPreview:
     """Return content-free revision metadata without creating schema or rows."""
 
     before = int(conn.total_changes or 0)
@@ -2361,6 +2604,7 @@ def preview_declared_canon(
             False,
             int(conn.total_changes or 0) - before,
         )
+    validate_declared_canon_read_boundary(conn, guild_id=int(guild_id))
     where = ["guild_id=?"]
     params: list[Any] = [int(guild_id)]
     if normalized_source:
@@ -2368,7 +2612,7 @@ def preview_declared_canon(
         params.append(normalized_source)
     total = int(
         conn.execute(
-            "SELECT COUNT(*) FROM declared_canon_revisions WHERE %s"
+            "SELECT COUNT(*) FROM main.declared_canon_revisions WHERE %s"
             % " AND ".join(where),
             tuple(params),
         ).fetchone()[0]
@@ -2376,15 +2620,15 @@ def preview_declared_canon(
     )
     rows = conn.execute(
         """
-        SELECT declaration_id,revision_id,revision_number,source_system,
+        SELECT d.declaration_id,d.revision_id,d.revision_number,d.source_system,
                domain,claim_kind,visibility,lifecycle_status,classification_mode,
                CASE WHEN revision_number=(
                    SELECT MAX(r2.revision_number)
-                   FROM declared_canon_revisions r2
-                   WHERE r2.guild_id=declared_canon_revisions.guild_id
-                     AND r2.declaration_id=declared_canon_revisions.declaration_id
+                   FROM main.declared_canon_revisions r2
+                   WHERE r2.guild_id=d.guild_id
+                     AND r2.declaration_id=d.declaration_id
                ) THEN 1 ELSE 0 END
-        FROM declared_canon_revisions
+        FROM main.declared_canon_revisions d
         WHERE %s
         ORDER BY declaration_id,revision_number DESC
         LIMIT ?
@@ -2462,6 +2706,30 @@ def preview_historical_broadcast_memory(
     offset: int = 0,
     now: str = "",
 ) -> BroadcastHistoryPreview:
+    """Build a zero-write preview from one coherent read snapshot."""
+
+    with _read_snapshot(conn):
+        return _preview_historical_broadcast_memory(
+            conn,
+            actor_user_id=actor_user_id,
+            authority_nonce=authority_nonce,
+            guild_id=guild_id,
+            limit=limit,
+            offset=offset,
+            now=now,
+        )
+
+
+def _preview_historical_broadcast_memory(
+    conn: sqlite3.Connection,
+    *,
+    actor_user_id: int,
+    authority_nonce: str,
+    guild_id: int,
+    limit: int = 200,
+    offset: int = 0,
+    now: str = "",
+) -> BroadcastHistoryPreview:
     """Build a zero-write, content-free classification preview.
 
     Raw/clean content, source row IDs, stable source tokens, names, and account
@@ -2514,13 +2782,13 @@ def preview_historical_broadcast_memory(
         )
     total = int(
         conn.execute(
-            "SELECT COUNT(*) FROM broadcast_memory WHERE guild_id=?",
+            "SELECT COUNT(*) FROM main.broadcast_memory WHERE guild_id=?",
             (int(guild_id),),
         ).fetchone()[0]
         or 0
     )
     source_cursor = conn.execute(
-        "SELECT * FROM broadcast_memory WHERE guild_id=? ORDER BY id LIMIT ? OFFSET ?",
+        "SELECT * FROM main.broadcast_memory WHERE guild_id=? ORDER BY id LIMIT ? OFFSET ?",
         (int(guild_id), safe_limit, safe_offset),
     )
     returned_columns = tuple(
@@ -2530,6 +2798,7 @@ def preview_historical_broadcast_memory(
     rows = tuple(dict(zip(returned_columns, row)) for row in raw_rows)
     classification_rows: dict[str, dict[str, str]] = {}
     if _table_exists(conn, DECLARED_CANON_TABLE):
+        validate_declared_canon_read_boundary(conn, guild_id=int(guild_id))
         source_ids = tuple(str(row.get("id")) for row in rows)
         if source_ids:
             placeholders = ",".join("?" for _ in source_ids)
@@ -2539,10 +2808,10 @@ def preview_historical_broadcast_memory(
             for classified_row in conn.execute(
                 """
                 SELECT %s
-                FROM declared_canon_revisions d
+                FROM main.declared_canon_revisions d
                 JOIN (
                     SELECT declaration_id,MAX(revision_number) AS max_revision
-                    FROM declared_canon_revisions
+                    FROM main.declared_canon_revisions
                     WHERE guild_id=? AND source_system='broadcast_memory'
                       AND source_row_id IN (%s)
                     GROUP BY declaration_id
@@ -2831,6 +3100,8 @@ __all__ = [
     "BroadcastHistoryPreview",
     "BroadcastPreviewItem",
     "DECLARED_CANON_CONTRACT_VERSION",
+    "DECLARED_CANON_AUTHORITY_SECRET_ENV",
+    "DECLARED_CANON_AUTHORITY_SECRET_MIN_BYTES",
     "DECLARED_CANON_TABLE",
     "DeclaredCanonError",
     "DeclaredCanonRevision",
@@ -2850,5 +3121,6 @@ __all__ = [
     "retire_declared_canon",
     "supersede_declared_canon",
     "validate_current_declared_canon_revision",
+    "validate_declared_canon_read_boundary",
     "validate_latest_declared_canon_revision",
 ]

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -7584,7 +7584,7 @@ class BroadcastEffectiveRepresentations:
 def _entry_is_unretracted_sql(alias: str) -> str:
     return """
         NOT EXISTS (
-            SELECT 1 FROM memory_ledger_lineage AS incoming
+            SELECT 1 FROM main.memory_ledger_lineage AS incoming
             WHERE incoming.guild_id={alias}.guild_id
               AND incoming.target_entry_id={alias}.entry_id
               AND incoming.lineage_type IN ('supersedes','retracts')
@@ -7592,7 +7592,7 @@ def _entry_is_unretracted_sql(alias: str) -> str:
     """.format(alias=alias)
 
 
-def _effective_broadcast_representations(
+def effective_broadcast_representations(
     conn: sqlite3.Connection,
     *,
     guild_id: int,
@@ -7614,7 +7614,7 @@ def _effective_broadcast_representations(
     primary_rows = conn.execute(
         """
         SELECT entry.entry_id
-        FROM memory_ledger_entries AS entry
+        FROM main.memory_ledger_entries AS entry
         WHERE entry.guild_id=?
           AND entry.source_table='broadcast_memory'
           AND entry.source_row_id=?
@@ -7632,12 +7632,12 @@ def _effective_broadcast_representations(
     derived_projection_rows = conn.execute(
         """
         SELECT DISTINCT projection_row.entry_id
-        FROM memory_ledger_entries AS projection_row
-        JOIN memory_ledger_lineage AS source_edge
+        FROM main.memory_ledger_entries AS projection_row
+        JOIN main.memory_ledger_lineage AS source_edge
           ON source_edge.guild_id=projection_row.guild_id
          AND source_edge.entry_id=projection_row.entry_id
          AND source_edge.lineage_type='derived_from'
-        JOIN memory_ledger_entries AS source_root
+        JOIN main.memory_ledger_entries AS source_root
           ON source_root.guild_id=source_edge.guild_id
          AND source_root.entry_id=source_edge.target_entry_id
         WHERE projection_row.guild_id=?
@@ -7659,7 +7659,9 @@ def _effective_broadcast_representations(
 
     declared_columns = {
         str(row[1] or "")
-        for row in conn.execute("PRAGMA table_info(declared_canon_revisions)")
+        for row in conn.execute(
+            "PRAGMA main.table_info(declared_canon_revisions)"
+        )
     }
     if {
         "revision_id",
@@ -7672,8 +7674,8 @@ def _effective_broadcast_representations(
         orphan_rows = conn.execute(
             """
             SELECT DISTINCT projection_row.entry_id
-            FROM memory_ledger_entries AS projection_row
-            JOIN declared_canon_revisions AS revision
+            FROM main.memory_ledger_entries AS projection_row
+            JOIN main.declared_canon_revisions AS revision
               ON revision.guild_id=projection_row.guild_id
              AND revision.declaration_id=projection_row.source_row_id
              AND revision.revision_id=projection_row.source_revision
@@ -7695,6 +7697,21 @@ def _effective_broadcast_representations(
     return BroadcastEffectiveRepresentations(
         primary_entry_ids=tuple(sorted(primary_ids)),
         declared_projection_entry_ids=tuple(sorted(projection_ids)),
+    )
+
+
+def _effective_broadcast_representations(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    source_row_id: int | str,
+) -> BroadcastEffectiveRepresentations:
+    """Compatibility alias for callers introduced before the public helper."""
+
+    return effective_broadcast_representations(
+        conn,
+        guild_id=guild_id,
+        source_row_id=source_row_id,
     )
 
 
@@ -7758,7 +7775,7 @@ def _stored_ledger_entry_matches(
                source_message_id,visibility,confidence,public_usable,derived,
                projection,salience,observed_at,source_sequence,valid_from,
                valid_until,freshness,lifecycle_status
-        FROM memory_ledger_entries WHERE entry_id=?
+        FROM main.memory_ledger_entries WHERE entry_id=?
         """,
         (entry.entry_id,),
     ).fetchone()
@@ -7815,7 +7832,7 @@ def _stored_ledger_entry_matches(
         for row in conn.execute(
             """
             SELECT participant_key,display_name,participant_role,order_index
-            FROM memory_ledger_participants WHERE entry_id=?
+            FROM main.memory_ledger_participants WHERE entry_id=?
             """,
             (entry.entry_id,),
         ).fetchall()
@@ -7857,7 +7874,7 @@ def _insert_or_reconcile_ledger_lineage(
             continue
         target_row = conn.execute(
             """
-            SELECT 1 FROM memory_ledger_entries
+            SELECT 1 FROM main.memory_ledger_entries
             WHERE guild_id=? AND entry_id=?
             """,
             (int(entry.guild_id or 0), str(target)),
@@ -7875,7 +7892,7 @@ def _insert_or_reconcile_ledger_lineage(
             )
         conn.execute(
             """
-            INSERT OR IGNORE INTO memory_ledger_lineage
+            INSERT OR IGNORE INTO main.memory_ledger_lineage
               (entry_id,guild_id,lineage_type,target_entry_id,created_at)
             VALUES(?,?,?,?,?)
             """,
@@ -8030,7 +8047,7 @@ def shadow_broadcast_status_event(
     with _ledger_atomic_projection_transaction(conn):
         columns = {
             str(row[1] or "")
-            for row in conn.execute("PRAGMA table_info(broadcast_memory)")
+            for row in conn.execute("PRAGMA main.table_info(broadcast_memory)")
         }
         required_columns = {
             "id",
@@ -8054,7 +8071,7 @@ def shadow_broadcast_status_event(
             """
             SELECT guild_id,status,updated_at,corrected_by_user_id,
                    corrected_by_name,superseded_by_id
-            FROM broadcast_memory
+            FROM main.broadcast_memory
             WHERE guild_id=? AND id=?
             LIMIT 1
             """,
@@ -8091,10 +8108,14 @@ def shadow_broadcast_status_event(
                 reason_code="broadcast_status_source_snapshot_mismatch",
             )
 
-        old_entries = _effective_broadcast_primary_entries(
+        old_representations = _effective_broadcast_representations(
             conn,
             guild_id=normalized_guild_id,
             source_row_id=normalized_row_id,
+        )
+        old_entries = old_representations.primary_entry_ids
+        old_declared_projections = (
+            old_representations.declared_projection_entry_ids
         )
         lineage_items = [
             ("retracts", old_entry) for old_entry in old_entries
@@ -8115,38 +8136,124 @@ def shadow_broadcast_status_event(
             if normalized_status == "resolved"
             else REVIEW_ONLY_LIFECYCLE
         )
-        return insert_ledger_entry(
+        participants = (
+            LedgerParticipant(
+                "discord_user:%s" % normalized_actor_id,
+                str(source_row[4] or ""),
+                "correction_actor",
+                0,
+            ),
+        )
+        status_entry = LedgerEntry(
+            guild_id=normalized_guild_id,
+            source_table="broadcast_memory",
+            source_row_id=normalized_row_id,
+            source_revision=rev,
+            source_event_key="status:%s" % normalized_status,
+            source_role="broadcast_memory_status",
+            entry_type="event",
+            subject_key="barcode_radio",
+            subject_display_name="BARCODE Radio",
+            predicate_key="broadcast_status:%s" % normalized_status,
+            value=normalized_status,
+            source_class=SourceClass.FIRST_PARTY_RECORD,
+            visibility=Visibility.INTERNAL,
+            confidence=Confidence.HIGH,
+            public_usable=False,
+            observed_at=normalized_updated_at,
+            source_sequence=normalized_row_id,
+            lifecycle_status=lifecycle,
+            participants=participants,
+            lineage=tuple(lineage_items),
+        )
+        status_result = _insert_or_reconcile_ledger_lineage(
             conn,
-            LedgerEntry(
+            status_entry,
+            conflict_reason="broadcast_status_identity_conflict",
+        )
+        if status_result.outcome not in {"inserted", "deduplicated"}:
+            raise RuntimeError(
+                "broadcast_status_lineage_write_failed:%s"
+                % status_result.reason_code
+            )
+
+        # Keep projection retractions on their own internal event so the
+        # established bot boundary can continue verifying the primary event's
+        # exact root set. Both events are nevertheless written and verified in
+        # this same source transaction.
+        if old_declared_projections:
+            projection_rev = source_revision_for(
+                normalized_row_id,
+                normalized_updated_at,
+                event=(
+                    "declared_projection_status_v1:%s:%s"
+                    % (normalized_status, normalized_updated_at)
+                ),
+            )
+            projection_entry = LedgerEntry(
                 guild_id=normalized_guild_id,
                 source_table="broadcast_memory",
                 source_row_id=normalized_row_id,
-                source_revision=rev,
-                source_event_key="status:%s" % normalized_status,
-                source_role="broadcast_memory_status",
+                source_revision=projection_rev,
+                source_event_key=(
+                    "declared_projection_status_v1:%s" % normalized_status
+                ),
+                source_role="broadcast_memory_projection_status",
                 entry_type="event",
                 subject_key="barcode_radio",
                 subject_display_name="BARCODE Radio",
-                predicate_key="broadcast_status:%s" % normalized_status,
+                predicate_key=(
+                    "broadcast_projection_status:%s" % normalized_status
+                ),
                 value=normalized_status,
                 source_class=SourceClass.FIRST_PARTY_RECORD,
                 visibility=Visibility.INTERNAL,
                 confidence=Confidence.HIGH,
                 public_usable=False,
+                derived=True,
+                projection=True,
                 observed_at=normalized_updated_at,
                 source_sequence=normalized_row_id,
                 lifecycle_status=lifecycle,
-                participants=(
-                    LedgerParticipant(
-                        "discord_user:%s" % normalized_actor_id,
-                        str(source_row[4] or ""),
-                        "correction_actor",
-                        0,
-                    ),
+                participants=participants,
+                lineage=tuple(
+                    ("retracts", entry_id)
+                    for entry_id in old_declared_projections
                 ),
-                lineage=tuple(lineage_items),
-            ),
+            )
+            projection_result = _insert_or_reconcile_ledger_lineage(
+                conn,
+                projection_entry,
+                conflict_reason=(
+                    "broadcast_projection_status_identity_conflict"
+                ),
+            )
+            if projection_result.outcome not in {"inserted", "deduplicated"}:
+                raise RuntimeError(
+                    "broadcast_projection_lineage_write_failed:%s"
+                    % projection_result.reason_code
+                )
+            record_shadow_receipt(
+                conn,
+                guild_id=normalized_guild_id,
+                writer="broadcast_memory_projection_status",
+                source_table=projection_result.source_table,
+                source_row_id=projection_result.source_row_id,
+                source_revision=projection_result.source_revision,
+                source_event_key=projection_result.source_event_key,
+                outcome=projection_result.outcome,
+                reason_code=projection_result.reason_code,
+                entry_id=projection_result.entry_id,
+            )
+
+        remaining = _effective_broadcast_representations(
+            conn,
+            guild_id=normalized_guild_id,
+            source_row_id=normalized_row_id,
         )
+        if remaining.all_entry_ids:
+            raise RuntimeError("broadcast_terminal_retraction_incomplete")
+        return status_result
 
 
 def shadow_canon_reference(
@@ -8213,6 +8320,53 @@ def _declared_projection_subject_key(subject_type: str, subject_id: str) -> str:
     return "%s:%s" % (
         str(subject_type or "").strip().casefold(),
         str(subject_id or "").strip(),
+    )
+
+
+def _effective_declared_projection_entries(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    declaration_id: str,
+    exclude_revision_id: str = "",
+) -> tuple[str, ...]:
+    """Return every unretracted projection for one Declared declaration.
+
+    The declaration revision store decides which revision is current.  This
+    helper deliberately preserves multiplicity in the Ledger so a validated
+    current/terminal projection can invalidate every stale representation
+    instead of electing one duplicate and leaving the others effective.
+    """
+
+    ensure_memory_ledger_schema(conn)
+    sql = """
+        SELECT projection_row.entry_id
+        FROM main.memory_ledger_entries AS projection_row
+        WHERE projection_row.guild_id=?
+          AND projection_row.source_table='declared_canon_projection'
+          AND projection_row.source_role='declared_canon_projection'
+          AND projection_row.source_row_id=?
+          AND NOT EXISTS (
+              SELECT 1 FROM main.memory_ledger_lineage AS incoming
+              WHERE incoming.guild_id=projection_row.guild_id
+                AND incoming.target_entry_id=projection_row.entry_id
+                AND incoming.lineage_type IN ('supersedes','retracts')
+          )
+    """
+    params: list[Any] = [int(guild_id or 0), str(declaration_id or "")]
+    normalized_exclusion = str(exclude_revision_id or "").strip()
+    if normalized_exclusion:
+        sql += " AND projection_row.source_revision!=?"
+        params.append(normalized_exclusion)
+    sql += " ORDER BY projection_row.created_at,projection_row.entry_id"
+    return tuple(
+        sorted(
+            {
+                str(row[0])
+                for row in conn.execute(sql, params).fetchall()
+                if str(row[0] or "")
+            }
+        )
     )
 
 
@@ -8333,7 +8487,7 @@ def shadow_declared_canon_projection(
                 source_row = conn.execute(
                     """
                     SELECT cleaned_summary,updated_at,status
-                    FROM broadcast_memory
+                    FROM main.broadcast_memory
                     WHERE guild_id=? AND id=?
                     """,
                     (normalized_guild_id, int(revision.source_row_id)),
@@ -8360,7 +8514,7 @@ def shadow_declared_canon_projection(
                     """
                     SELECT guild_id,source_table,source_row_id,source_role,
                            source_revision,normalized_value,lifecycle_status
-                    FROM memory_ledger_entries
+                    FROM main.memory_ledger_entries
                     WHERE entry_id=?
                     """,
                     (roots[0],),
@@ -8392,7 +8546,7 @@ def shadow_declared_canon_projection(
                     or conn.execute(
                         """
                         SELECT 1
-                        FROM memory_ledger_lineage
+                        FROM main.memory_ledger_lineage
                         WHERE guild_id=? AND target_entry_id=?
                           AND lineage_type IN ('supersedes','retracts')
                         LIMIT 1
@@ -8410,7 +8564,7 @@ def shadow_declared_canon_projection(
                 current_primary_count = conn.execute(
                     """
                     SELECT COUNT(*)
-                    FROM memory_ledger_entries AS root
+                    FROM main.memory_ledger_entries AS root
                     WHERE root.guild_id=?
                       AND root.source_table='broadcast_memory'
                       AND root.source_row_id=?
@@ -8418,7 +8572,7 @@ def shadow_declared_canon_projection(
                       AND root.lifecycle_status='active'
                       AND NOT EXISTS (
                         SELECT 1
-                        FROM memory_ledger_lineage AS edge
+                        FROM main.memory_ledger_lineage AS edge
                         WHERE edge.guild_id=root.guild_id
                           AND edge.target_entry_id=root.entry_id
                           AND edge.lineage_type IN ('supersedes','retracts')
@@ -8445,33 +8599,12 @@ def shadow_declared_canon_projection(
                 )
             value = revision.cleaned_summary or revision.value_json
 
-        previous: tuple[str, ...] = ()
-        if revision.previous_revision_id:
-            prior_rows = conn.execute(
-                """
-                SELECT entry_id
-                FROM memory_ledger_entries
-                WHERE guild_id=?
-                  AND source_table='declared_canon_projection'
-                  AND source_row_id=?
-                  AND source_revision=?
-                ORDER BY created_at DESC
-                """,
-                (
-                    normalized_guild_id,
-                    declaration_id,
-                    revision.previous_revision_id,
-                ),
-            ).fetchall()
-            if len(prior_rows) != 1:
-                return skipped_result(
-                    guild_id=normalized_guild_id,
-                    source_table="declared_canon_projection",
-                    source_row_id=declaration_id,
-                    source_revision=revision_id,
-                    reason_code="declared_projection_previous_revision_missing",
-                )
-            previous = (str(prior_rows[0][0]),)
+        previous = _effective_declared_projection_entries(
+            conn,
+            guild_id=normalized_guild_id,
+            declaration_id=declaration_id,
+            exclude_revision_id=revision_id,
+        )
 
         cross_declaration_previous: tuple[str, ...] = ()
         if revision.supersedes_declaration_id:
@@ -8479,7 +8612,7 @@ def shadow_declared_canon_projection(
                 """
                 SELECT previous_revision_id,lifecycle_status,
                        superseded_by_declaration_id
-                FROM declared_canon_revisions
+                FROM main.declared_canon_revisions
                 WHERE guild_id=? AND declaration_id=?
                 ORDER BY revision_number DESC
                 LIMIT 1
@@ -8504,34 +8637,10 @@ def shadow_declared_canon_projection(
                         "declared_projection_cross_supersession_invalid"
                     ),
                 )
-            superseded_projection_rows = conn.execute(
-                """
-                SELECT entry_id
-                FROM memory_ledger_entries
-                WHERE guild_id=?
-                  AND source_table='declared_canon_projection'
-                  AND source_row_id=?
-                  AND source_revision=?
-                ORDER BY created_at DESC
-                """,
-                (
-                    normalized_guild_id,
-                    revision.supersedes_declaration_id,
-                    str(superseded_latest[0]),
-                ),
-            ).fetchall()
-            if len(superseded_projection_rows) != 1:
-                return skipped_result(
-                    guild_id=normalized_guild_id,
-                    source_table="declared_canon_projection",
-                    source_row_id=declaration_id,
-                    source_revision=revision_id,
-                    reason_code=(
-                        "declared_projection_superseded_source_projection_missing"
-                    ),
-                )
-            cross_declaration_previous = (
-                str(superseded_projection_rows[0][0]),
+            cross_declaration_previous = _effective_declared_projection_entries(
+                conn,
+                guild_id=normalized_guild_id,
+                declaration_id=revision.supersedes_declaration_id,
             )
 
         lineage_items = [("derived_from", entry_id) for entry_id in roots]
@@ -8565,38 +8674,40 @@ def shadow_declared_canon_projection(
                 )
             )
 
-        return insert_ledger_entry(
-            conn,
-            LedgerEntry(
-                guild_id=normalized_guild_id,
-                source_table="declared_canon_projection",
-                source_row_id=declaration_id,
-                source_revision=revision_id,
-                source_event_key="revision:%s" % revision_id,
-                source_role="declared_canon_projection",
-                entry_type="canon_reference",
-                subject_key=subject_key,
-                subject_display_name="",
-                predicate_key=revision.predicate,
-                value=(value or "")[:500],
-                source_class=SourceClass.EVIDENCE_PROJECTION,
-                route_mode="declared_canon_review",
-                channel_policy="declared_canon_review",
-                visibility=Visibility.INTERNAL,
-                confidence=Confidence.LOW,
-                public_usable=False,
-                derived=True,
-                projection=True,
-                observed_at=revision.created_at or _now(),
-                lifecycle_status=(
-                    RESOLVED_LIFECYCLE
-                    if revision.lifecycle_status
-                    in {"resolved", "retired", "superseded"}
-                    else REVIEW_ONLY_LIFECYCLE
-                ),
-                participants=tuple(participants),
-                lineage=lineage,
+        projection_entry = LedgerEntry(
+            guild_id=normalized_guild_id,
+            source_table="declared_canon_projection",
+            source_row_id=declaration_id,
+            source_revision=revision_id,
+            source_event_key="revision:%s" % revision_id,
+            source_role="declared_canon_projection",
+            entry_type="canon_reference",
+            subject_key=subject_key,
+            subject_display_name="",
+            predicate_key=revision.predicate,
+            value=(value or "")[:500],
+            source_class=SourceClass.EVIDENCE_PROJECTION,
+            route_mode="declared_canon_review",
+            channel_policy="declared_canon_review",
+            visibility=Visibility.INTERNAL,
+            confidence=Confidence.LOW,
+            public_usable=False,
+            derived=True,
+            projection=True,
+            observed_at=revision.created_at or _now(),
+            lifecycle_status=(
+                RESOLVED_LIFECYCLE
+                if revision.lifecycle_status
+                in {"resolved", "retired", "superseded"}
+                else REVIEW_ONLY_LIFECYCLE
             ),
+            participants=tuple(participants),
+            lineage=lineage,
+        )
+        return _insert_or_reconcile_ledger_lineage(
+            conn,
+            projection_entry,
+            conflict_reason="declared_projection_identity_conflict",
         )
 
 

--- a/docs/BNL01_DECLARED_CANON_LIFECYCLE_V1.md
+++ b/docs/BNL01_DECLARED_CANON_LIFECYCLE_V1.md
@@ -34,15 +34,21 @@ All preview and mutation APIs independently require:
 - an internally issued, versioned receipt bound to the exact operation,
   target, expected snapshot, payload, and Discord-message nonce.
 
-No Declared Canon signing key or secret environment variable exists. Under the
-trusted application-and-database threat model, the core deterministically
-issues the receipt itself after authenticating the configured owner and guild;
-no public API accepts a caller-built authority or receipt. The visible receipt
-version commits to actor, guild, operation, nonce, normalized request, and the
-complete immutable stored revision. Validators recompute both that receipt and
-the revision ID before admitting a row. This detects accidental or partial row
-tampering but does not claim to defend against an attacker who can both rewrite
-the trusted database and execute trusted application code.
+`BNL_DECLARED_CANON_AUTHORITY_SECRET` is a dedicated signing secret and must
+contain at least 32 UTF-8 bytes. The core uses HMAC-SHA-256 to authenticate both
+the normalized owner request and the complete immutable stored revision. No
+public API accepts a caller-built authority, receipt, or signing key. A missing
+or short secret fails before a write; changing the secret makes every existing
+receipt invalid and blocks reads and mutations until an explicit, reviewed
+rotation/migration restores one coherent signing epoch. Rotation is never
+silently accepted as new authority.
+
+The visible receipt version commits to actor, primary guild, operation, nonce,
+normalized request, and every stored revision field except its self-referential
+receipt and revision ID. Validators recompute the HMAC and revision ID before
+admitting a row and compare the integrity values in constant time. Stored rows
+must still name the currently configured owner and current primary guild; a
+historically valid receipt from different runtime authority does not qualify.
 
 The Discord route is a first boundary, not the only boundary. A direct helper
 call with missing, mismatched, cross-guild, malformed, or stale authority fails
@@ -53,6 +59,39 @@ exact current revision ID. Broadcast classifications require both the exact
 current declaration revision (when reclassifying) and a fingerprint of the
 approved source snapshot. Operation nonces are idempotent only for an exact
 request; reusing one with a changed binding fails closed.
+
+## Schema and chain integrity
+
+All authoritative table lookups, reads, and writes are explicitly qualified to
+SQLite's `main` schema. A same-named TEMP table therefore cannot shadow an older
+Declared Canon head or an older Broadcast source row. Every write verifies the
+schema after `BEGIN IMMEDIATE` has acquired the write boundary; every exported
+read and preview verifies it inside one pinned read snapshot.
+
+Schema creation is one-time and exact. If `declared_canon_revisions` already
+exists, initialization validates the complete table definition, primary and
+unique constraints, named indexes, and the exact append-only triggers. A
+missing, extra, or same-name-but-altered trigger, weakened constraint, changed
+column, or unexpected index fails with a schema-integrity error. Initialization
+does not repair, recreate, or normalize a damaged existing authority schema.
+
+The insert-conflict, no-update, and no-delete triggers cover ordinary SQL and
+SQLite conflict forms including `REPLACE`, `INSERT OR REPLACE`,
+`UPDATE OR REPLACE`, and UPSERT against either the primary key or composite
+unique constraints. Each trusted head is also derived only after validating the
+complete ordered chain: revision numbers must be contiguous from one, every
+`previous_revision_id` must name the immediately prior authenticated revision,
+source identity must remain stable, and every row must pass its contract and
+HMAC checks. Internal inventory code may perform this check inside its existing
+read transaction without minting a synthetic owner request.
+
+This design cannot, by itself, prove that an attacker with arbitrary write and
+DDL access to the same SQLite file did not delete the newest signed rows and
+then restore the exact expected schema. Detecting that perfect whole-file
+rollback requires a trusted monotonic head or signed checkpoint stored outside
+the database. The lifecycle therefore detects damaged schema, row tampering,
+and broken/missing middle links, but does not claim external rollback
+attestation that PR 2 does not own.
 
 Exported current/latest validators hold one coherent SQLite read snapshot for
 their complete revision-and-source validation sequence. They open and close a
@@ -106,6 +145,10 @@ bounded page is a global aggregate. Malformed historical timestamps or
 submitter identifiers remain reviewable as reason-coded, unknown provenance
 instead of aborting the preview.
 
+If a Declared Canon table is present, the preview first authenticates its exact
+schema and every complete declaration chain. Corrupt sidecar authority aborts
+the preview rather than being displayed as a merely stale classification.
+
 Applying any historical classification or subject link remains a separate
 owner-approved data operation. PR 2 creates no backfill and runs no such write.
 
@@ -114,29 +157,38 @@ owner-approved data operation. PR 2 creates no backfill and runs no such write.
 New Broadcast primary projections are derived from an exact source row inside
 the source write transaction. Resolve, clear, and replacement transitions
 re-read the exact owner/guild/status/update/supersession snapshot and retract
-every still-effective Ledger primary for that exact source row in the same
-transaction. A missing primary is safe because there is no Ledger
-representation to invalidate. If an older defect left duplicate primaries,
-the status event must retract the complete pre-write set or the source
-transition rolls back; it never chooses one as more authoritative. New primary
-creation remains strict at exactly one. A disabled shadow flag therefore
-cannot strand an already-written active primary, and a skipped, conflicting,
-or failed required projection rolls back the Broadcast source transition.
+every still-effective Ledger representation for that source row in the same
+transaction: all primary roots, every Declared projection derived from those
+roots, and an orphaned Declared projection still linked by the authoritative
+sidecar. A missing primary is safe only when no other effective representation
+exists. If an older defect left duplicates, multiplicity is diagnostic rather
+than a reason to choose one or skip invalidation; the complete pre-write set
+must be retracted or the source transition rolls back. Exact terminal-event
+retries may add missing lineage only after the complete stored event and
+participant set match. New primary creation remains strict at exactly one. A
+disabled shadow flag therefore cannot strand an already-written
+representation, and a skipped, conflicting, or failed required projection
+rolls back the Broadcast source transition.
 
 ## Non-live boundary
 
-Declared claim adapters remain read models. New Ledger projections are always:
+Declared claim adapters remain read models. New Ledger projections always
+remain in the non-live review lane:
 
 - derived and projected;
 - internal;
-- review-only; and
 - `public_usable=0`.
+
+Established and contested projection rows use the `review_only` lifecycle.
+Resolved, retired, and superseded terminal projection rows retain the
+`resolved` lifecycle while remaining non-live.
 
 Their route and channel labels are both `declared_canon_review`, so no existing
 approved-canon or public-route selector can mistake the PR 2 shadow for live
-canon evidence. Corrections emit
-supersession lineage; contested, resolved, retired, and superseded revisions
-emit retraction lineage against the exact prior projection.
+canon evidence. Corrections supersede every effective older projection;
+contested, resolved, retired, and superseded revisions retract every effective
+older projection. Already-ineffective historical rows retain their existing
+lineage without a redundant edge.
 
 Existing Broadcast readers continue to use the mature `broadcast_memory`
 compatibility lane in PR 2. The new declaration view does not feed the unified
@@ -154,6 +206,15 @@ from natural language. Mutation replies contain only operation/declaration/
 revision IDs, lifecycle state, and shadow outcome; they never echo the raw
 declaration or Broadcast content.
 
+`broadcast-preview` is an aggregate, content-free diagnostic rather than an A5
+classification handoff. The dependency-free core computes per-row,
+receipt-scoped opaque `preview_item` values, but the Discord reply exposes only
+grouped counts and those values are intentionally neither stable nor resolvable
+back to a source row through the command surface. Any historical A5 write needs
+a later, separately owner-approved resolver or review manifest that binds an
+opaque selection to the exact row ID and source fingerprint inside one reviewed
+snapshot. PR 2 does not expose raw row IDs/fingerprints or create that workflow.
+
 Control-shaped messages are dispatched from the original Discord payload
 before mention/whitespace normalization, direct-conversation ingress, room
 context, batching, or other conversational sinks. This preserves exact JSON
@@ -163,5 +224,7 @@ prompts.
 
 No environment gate, deployment state, website authority, delegated steward
 power, historical classification, or live response behavior is changed by
-this lifecycle contract. It introduces no credential, environment variable,
-or deployment prerequisite.
+this lifecycle contract. The new authority secret is code-level configuration
+only in this PR: it is not generated, deployed, rotated, or written to any
+repository file. Provisioning it is a separate deployment operation that must
+occur before the owner command surface can be enabled.

--- a/docs/hybrid_canon_claim_contract_v1.md
+++ b/docs/hybrid_canon_claim_contract_v1.md
@@ -93,12 +93,23 @@ fingerprint stored beside it. No historical classifications are written
 automatically.
 
 Every stored revision carries a request fingerprint and an internally issued,
-deterministic, versioned receipt. It requires no runtime signing secret and no
-public API accepts a caller-supplied authority or receipt. Under the trusted
-application-and-database threat model, read boundaries recompute the receipt
-over the exact actor, guild, operation, nonce/request bindings and complete
-immutable stored payload, then recompute the revision ID. A conflicting
-`INSERT OR REPLACE` is rejected before SQLite can replace history.
+keyed, versioned receipt. `BNL_DECLARED_CANON_AUTHORITY_SECRET` must contain at
+least 32 bytes, and no public API accepts a caller-supplied authority or
+receipt. Read boundaries recompute the HMAC over the exact actor, guild,
+operation, nonce/request bindings and complete immutable stored payload, then
+recompute the revision ID. Missing, short, or rotated key material fails
+closed; rotation requires an explicit reviewed migration rather than silently
+re-signing history. A conflicting `INSERT OR REPLACE` is rejected before
+SQLite can replace history.
+
+The sidecar and source reads are pinned to SQLite's `main` schema, and every
+admission path verifies the exact table/constraint/trigger contract inside the
+same mutation transaction or read snapshot. These controls detect schema
+damage and ordinary rollback attempts within the active database. They do not
+claim protection against a privileged attacker who can restore both an older
+signed database state and the exact schema; a later live authority boundary
+would require an external signed head/checkpoint for that stronger threat
+model.
 
 Broadcast sidecars bind to `broadcast_memory_complete_row_v2`, which hashes the
 complete deterministically canonicalized source row including unknown/future
@@ -112,6 +123,8 @@ revalidation on one database state while remaining zero-write.
 
 Claim-content use in the live packet, website projection, and delegated
 authority remain disabled. New Declared Ledger projections are internal,
-derived, review-only, and nonpublic until final convergence. The packet's
-binding lookup remains read-only and effective only for already-approved
-binding rows.
+derived, nonpublic, and confined to the `declared_canon_review` lane until
+final convergence. Established and contested rows use the `review_only`
+lifecycle; resolved, retired, and superseded terminal rows retain the
+`resolved` lifecycle. The packet's binding lookup remains read-only and
+effective only for already-approved binding rows.

--- a/tests/test_broadcast_declared_canon.py
+++ b/tests/test_broadcast_declared_canon.py
@@ -17,6 +17,9 @@ class BroadcastDeclaredCanonTests(unittest.TestCase):
             {
                 "BNL_OWNER_USER_ID": "61",
                 "BNL_PRIMARY_GUILD_ID": "7",
+                "BNL_DECLARED_CANON_AUTHORITY_SECRET": (
+                    "declared-canon-test-signing-secret-0001"
+                ),
             },
         )
         self.env.start()
@@ -792,18 +795,23 @@ class BroadcastDeclaredCanonTests(unittest.TestCase):
             "WHERE revision_id=?",
             (revision.revision_id,),
         )
+        self.conn.execute(
+            declared._DECLARED_CANON_TRIGGER_DDL[
+                "trg_declared_canon_revisions_no_update"
+            ]
+        )
         self.conn.commit()
-        preview = declared.preview_historical_broadcast_memory(
-            self.conn,
-            actor_user_id=61,
-            authority_nonce="forged-preview1",
-            guild_id=7,
-            now="2026-08-01T04:00:00+00:00",
-        )
-        self.assertEqual(preview.items[0].disposition, "stale_classification_review")
-        self.assertIn(
-            "classification_authority_invalid", preview.items[0].reason_codes
-        )
+        declared._require_schema(self.conn)
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "stored_authority_invalid"
+        ):
+            declared.preview_historical_broadcast_memory(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="forged-preview1",
+                guild_id=7,
+                now="2026-08-01T04:00:00+00:00",
+            )
         with self.assertRaisesRegex(
             declared.DeclaredCanonError, "stored_authority_invalid"
         ):
@@ -817,6 +825,47 @@ class BroadcastDeclaredCanonTests(unittest.TestCase):
                 expected_source_fingerprint=revision.source_fingerprint,
                 now="2026-08-01T04:00:00+00:00",
             )
+
+    def test_temp_broadcast_table_cannot_shadow_terminal_main_source(self):
+        row_id = self.insert_broadcast(public_safe=1, usage_scope="ambient,direct")
+        revision = self.classify(
+            row_id,
+            nonce="temp-broadcast1",
+            visibility="public_safe",
+            eligible_routes=("public_home",),
+        ).primary
+        self.conn.execute(
+            "CREATE TEMP TABLE broadcast_memory AS "
+            "SELECT * FROM main.broadcast_memory WHERE id=?",
+            (row_id,),
+        )
+        self.conn.execute(
+            "UPDATE main.broadcast_memory SET status='resolved',public_safe=0,"
+            "usage_scope='internal',updated_at=? WHERE id=?",
+            ("2026-08-01T05:00:00+00:00", row_id),
+        )
+        self.conn.commit()
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "expected_source_fingerprint_mismatch"
+        ):
+            declared.validate_current_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="temp-broadcast2",
+                guild_id=7,
+                declaration_id=revision.declaration_id,
+                expected_revision_id=revision.revision_id,
+                expected_source_fingerprint=revision.source_fingerprint,
+                now="2026-08-01T06:00:00+00:00",
+            )
+        preview = declared.preview_historical_broadcast_memory(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="temp-broadcast3",
+            guild_id=7,
+            now="2026-08-01T06:00:00+00:00",
+        )
+        self.assertEqual(preview.items[0].source_fingerprint_state, "stale_or_unversioned")
 
     def test_no_projection_or_derived_classification_api_exists(self):
         signature = inspect.signature(declared.classify_broadcast_memory)

--- a/tests/test_declared_canon_bot_controls.py
+++ b/tests/test_declared_canon_bot_controls.py
@@ -16,7 +16,7 @@ import bnl_declared_canon as declared
 class _Author:
     def __init__(self, user_id=61):
         self.id = user_id
-        self.display_name = "Owner" if user_id == 61 else "Other"
+        self.display_name = "6 Bit" if user_id == 61 else "Test Member"
 
 
 class _Guild:
@@ -57,6 +57,9 @@ class DeclaredCanonBotControlTests(unittest.TestCase):
             {
                 "BNL_OWNER_USER_ID": "61",
                 "BNL_PRIMARY_GUILD_ID": "7",
+                "BNL_DECLARED_CANON_AUTHORITY_SECRET": (
+                    "declared-canon-test-signing-secret-0001"
+                ),
                 "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "1",
             },
             clear=False,
@@ -336,7 +339,7 @@ class DeclaredCanonBotControlTests(unittest.TestCase):
         )
 
     def test_on_message_preserves_raw_control_before_any_conversational_sink(self):
-        raw_declaration = "Owner keeps <@123>  and  exact spacing."
+        raw_declaration = "6 Bit keeps <@123>  and  exact spacing."
         payload = self.add_payload()
         payload["raw_declaration"] = raw_declaration
         command = "!bnl canon add " + json.dumps(payload)

--- a/tests/test_declared_canon_lifecycle.py
+++ b/tests/test_declared_canon_lifecycle.py
@@ -35,6 +35,9 @@ class DeclaredCanonLifecycleTests(unittest.TestCase):
             {
                 "BNL_OWNER_USER_ID": "61",
                 "BNL_PRIMARY_GUILD_ID": "7",
+                "BNL_DECLARED_CANON_AUTHORITY_SECRET": (
+                    "declared-canon-test-signing-secret-0001"
+                ),
             },
         )
         self.env.start()
@@ -104,6 +107,95 @@ class DeclaredCanonLifecycleTests(unittest.TestCase):
         )
         self.assertEqual(stored, [(created.cleaned_summary,)])
 
+    def test_all_sqlite_replace_and_upsert_forms_are_blocked(self):
+        created = self.add("replace-matrix1").primary
+        replacement = asdict(created)
+        replacement["cleaned_summary"] = "REPLACED HISTORY"
+        columns = ",".join(declared._REVISION_COLUMNS)
+        placeholders = ",".join("?" for _ in declared._REVISION_COLUMNS)
+        values = tuple(replacement[column] for column in declared._REVISION_COLUMNS)
+        statements = (
+            ("REPLACE INTO main.declared_canon_revisions (%s) VALUES (%s)" % (
+                columns, placeholders
+            ), values, "declared_canon_append_only_conflict"),
+            ("INSERT OR REPLACE INTO main.declared_canon_revisions (%s) VALUES (%s)" % (
+                columns, placeholders
+            ), values, "declared_canon_append_only_conflict"),
+            ("INSERT INTO main.declared_canon_revisions (%s) VALUES (%s) "
+             "ON CONFLICT(revision_id) DO UPDATE SET "
+             "cleaned_summary=excluded.cleaned_summary" % (columns, placeholders),
+             values, "declared_canon_append_only_conflict"),
+            ("INSERT INTO main.declared_canon_revisions (%s) VALUES (%s) "
+             "ON CONFLICT(guild_id,declaration_id,revision_number) DO UPDATE SET "
+             "cleaned_summary=excluded.cleaned_summary" % (columns, placeholders),
+             values, "declared_canon_append_only_conflict"),
+            ("INSERT INTO main.declared_canon_revisions (%s) VALUES (%s) "
+             "ON CONFLICT(guild_id,declaration_id,operation_id) DO UPDATE SET "
+             "cleaned_summary=excluded.cleaned_summary" % (columns, placeholders),
+             values, "declared_canon_append_only_conflict"),
+            ("UPDATE OR REPLACE main.declared_canon_revisions "
+             "SET cleaned_summary=? WHERE revision_id=?",
+             ("REPLACED HISTORY", created.revision_id),
+             "declared_canon_append_only_update"),
+        )
+        for statement, params, error in statements:
+            with self.subTest(statement=statement.split(" ", 3)[:3]):
+                with self.assertRaisesRegex(sqlite3.IntegrityError, error):
+                    self.conn.execute(statement, params)
+                self.conn.rollback()
+                stored = self.conn.execute(
+                    "SELECT cleaned_summary FROM main.declared_canon_revisions "
+                    "WHERE revision_id=?",
+                    (created.revision_id,),
+                ).fetchone()
+                self.assertEqual(stored, (created.cleaned_summary,))
+
+    def test_existing_damaged_schema_is_rejected_without_auto_healing(self):
+        trigger_name = "trg_declared_canon_revisions_no_delete"
+        self.conn.execute("DROP TRIGGER main.%s" % trigger_name)
+        self.conn.commit()
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "declared_canon_schema_integrity_invalid"
+        ):
+            declared.ensure_declared_canon_schema(self.conn)
+        self.assertIsNone(
+            self.conn.execute(
+                "SELECT 1 FROM main.sqlite_master WHERE type='trigger' AND name=?",
+                (trigger_name,),
+            ).fetchone()
+        )
+
+        self.conn.execute(
+            "CREATE TRIGGER main.%s BEFORE DELETE ON declared_canon_revisions "
+            "BEGIN SELECT 1; END" % trigger_name
+        )
+        self.conn.commit()
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "declared_canon_schema_integrity_invalid"
+        ):
+            declared.ensure_declared_canon_schema(self.conn)
+
+        malformed = sqlite3.connect(":memory:")
+        try:
+            malformed.execute(
+                "CREATE TABLE declared_canon_revisions (%s)"
+                % ",".join("%s TEXT" % column for column in declared._REVISION_COLUMNS)
+            )
+            malformed.commit()
+            with self.assertRaisesRegex(
+                declared.DeclaredCanonError,
+                "declared_canon_schema_integrity_invalid",
+            ):
+                declared.ensure_declared_canon_schema(malformed)
+            self.assertEqual(
+                malformed.execute(
+                    "SELECT COUNT(*) FROM main.sqlite_master WHERE type='trigger'"
+                ).fetchone()[0],
+                0,
+            )
+        finally:
+            malformed.close()
+
     def test_public_apis_accept_no_caller_built_owner_or_receipt(self):
         signature = inspect.signature(declared.add_declared_canon)
         self.assertNotIn("authority", signature.parameters)
@@ -150,6 +242,10 @@ class DeclaredCanonLifecycleTests(unittest.TestCase):
         finally:
             no_schema.close()
 
+        created = self.add("guild-binding01").primary
+        with mock.patch.dict(os.environ, {"BNL_PRIMARY_GUILD_ID": "8"}):
+            self.assertFalse(declared._stored_authority_valid(created))
+
     def test_add_separates_content_and_stores_bound_versioned_receipt(self):
         revision = self.add().primary
         self.assertEqual(revision.revision_number, 1)
@@ -177,9 +273,15 @@ class DeclaredCanonLifecycleTests(unittest.TestCase):
         forged["operation_id"] = "op_" + "3" * 32
         forged["authority_request_fingerprint"] = "req_" + "4" * 48
         forged["authority_verified"] = 1
+        former_unkeyed_digest = declared._digest(
+            declared.INTERNAL_AUTHORITY_RECEIPT_VERSION,
+            declared.STORED_AUTHORITY_BINDING_VERSION,
+            *(forged[column] for column in declared._REVISION_COLUMNS
+              if column not in {"revision_id", "authority_receipt"}),
+        )
         forged["authority_receipt"] = (
             "owner_command:declared_canon_lifecycle_v1:"
-            "declared_canon_internal_receipt_v1:add:" + "5" * 64
+            "declared_canon_internal_receipt_v1:add:" + former_unkeyed_digest
         )
         forged["revision_id"] = "drev_" + declared._digest(
             *(forged[column] for column in declared._REVISION_COLUMNS
@@ -201,6 +303,46 @@ class DeclaredCanonLifecycleTests(unittest.TestCase):
                 self.conn,
                 actor_user_id=61,
                 authority_nonce="forge-validate1",
+                guild_id=7,
+                declaration_id=forged["declaration_id"],
+                expected_revision_id=forged["revision_id"],
+                expected_source_fingerprint=forged["source_fingerprint"],
+                now="2026-08-01T12:00:00+00:00",
+            )
+            declared.preview_declared_canon(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="transaction-prev1",
+                guild_id=7,
+            )
+
+    def test_copied_valid_receipt_cannot_authorize_changed_stored_fields(self):
+        created = self.add("copy-receipt01").primary
+        forged = asdict(created)
+        forged["declaration_id"] = "dcl_" + "9" * 32
+        forged["source_row_id"] = forged["declaration_id"]
+        forged["operation_id"] = "op_" + "a" * 32
+        forged["authority_request_fingerprint"] = "req_" + "b" * 48
+        forged["revision_id"] = "drev_" + declared._digest(
+            *(forged[column] for column in declared._REVISION_COLUMNS
+              if column != "revision_id")
+        )[:40]
+        self.conn.execute(
+            "INSERT INTO main.declared_canon_revisions (%s) VALUES (%s)"
+            % (
+                ",".join(declared._REVISION_COLUMNS),
+                ",".join("?" for _ in declared._REVISION_COLUMNS),
+            ),
+            tuple(forged[column] for column in declared._REVISION_COLUMNS),
+        )
+        self.conn.commit()
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "stored_authority_invalid"
+        ):
+            declared.validate_current_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="copy-validate1",
                 guild_id=7,
                 declaration_id=forged["declaration_id"],
                 expected_revision_id=forged["revision_id"],
@@ -259,20 +401,55 @@ class DeclaredCanonLifecycleTests(unittest.TestCase):
             2,
         )
 
-    def test_receipts_require_no_secret_configuration(self):
-        created = self.add("no-secret-source1").primary
-        changed = declared.change_declared_canon_status(
-            self.conn,
-            actor_user_id=61,
-            authority_nonce="no-secret-status1",
-            guild_id=7,
-            declaration_id=created.declaration_id,
-            expected_revision_id=created.revision_id,
-            lifecycle_status="contested",
-        ).primary
-        self.assertEqual(changed.lifecycle_status, "contested")
+    def test_secret_configuration_and_rotation_fail_closed(self):
+        created = self.add("secret-source01").primary
         self.assertTrue(declared._stored_authority_valid(created))
-        self.assertTrue(declared._stored_authority_valid(changed))
+
+        before = self.conn.total_changes
+        with mock.patch.dict(
+            os.environ, {"BNL_DECLARED_CANON_AUTHORITY_SECRET": ""}
+        ):
+            with self.assertRaisesRegex(
+                declared.DeclaredCanonError,
+                "declared_canon_authority_secret_not_configured",
+            ):
+                self.add("missing-secret1")
+            self.assertFalse(declared._stored_authority_valid(created))
+        self.assertEqual(self.conn.total_changes, before)
+
+        with mock.patch.dict(
+            os.environ, {"BNL_DECLARED_CANON_AUTHORITY_SECRET": "too-short"}
+        ):
+            with self.assertRaisesRegex(
+                declared.DeclaredCanonError,
+                "declared_canon_authority_secret_invalid",
+            ):
+                self.add("short-secret01")
+            self.assertFalse(declared._stored_authority_valid(created))
+        self.assertEqual(self.conn.total_changes, before)
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "BNL_DECLARED_CANON_AUTHORITY_SECRET": (
+                    "rotated-declared-canon-test-secret-0002"
+                )
+            },
+        ):
+            self.assertFalse(declared._stored_authority_valid(created))
+            with self.assertRaisesRegex(
+                declared.DeclaredCanonError, "stored_authority_invalid"
+            ):
+                declared.change_declared_canon_status(
+                    self.conn,
+                    actor_user_id=61,
+                    authority_nonce="rotated-status1",
+                    guild_id=7,
+                    declaration_id=created.declaration_id,
+                    expected_revision_id=created.revision_id,
+                    lifecycle_status="contested",
+                )
+        self.assertEqual(self.conn.total_changes, before)
 
     def test_exact_retry_is_zero_write_and_changed_binding_rejects(self):
         first = self.add("idempotent-0001")
@@ -517,30 +694,31 @@ class DeclaredCanonLifecycleTests(unittest.TestCase):
         replacement = self.add(
             "atomic-new-001", subject_id="atomic_new"
         ).primary
-        self.conn.execute(
-            """
-            CREATE TRIGGER fail_old_supersede
-            BEFORE INSERT ON declared_canon_revisions
-            WHEN NEW.operation='supersede' AND NEW.declaration_id='%s'
-            BEGIN
-                SELECT RAISE(ABORT, 'forced_second_insert_failure');
-            END
-            """ % old.declaration_id
-        )
-        self.conn.commit()
-        with self.assertRaisesRegex(
-            sqlite3.IntegrityError, "forced_second_insert_failure"
+        real_insert = declared._insert_revision
+        inserts = {"count": 0}
+
+        def fail_second_insert(conn, payload):
+            inserts["count"] += 1
+            real_insert(conn, payload)
+            if inserts["count"] == 2:
+                raise sqlite3.IntegrityError("forced_second_insert_failure")
+
+        with mock.patch.object(
+            declared, "_insert_revision", side_effect=fail_second_insert
         ):
-            declared.supersede_declared_canon(
-                self.conn,
-                actor_user_id=61,
-                authority_nonce="atomic-super001",
-                guild_id=7,
-                declaration_id=old.declaration_id,
-                expected_revision_id=old.revision_id,
-                replacement_declaration_id=replacement.declaration_id,
-                expected_replacement_revision_id=replacement.revision_id,
-            )
+            with self.assertRaisesRegex(
+                sqlite3.IntegrityError, "forced_second_insert_failure"
+            ):
+                declared.supersede_declared_canon(
+                    self.conn,
+                    actor_user_id=61,
+                    authority_nonce="atomic-super001",
+                    guild_id=7,
+                    declaration_id=old.declaration_id,
+                    expected_revision_id=old.revision_id,
+                    replacement_declaration_id=replacement.declaration_id,
+                    expected_replacement_revision_id=replacement.revision_id,
+                )
         rows = self.rows(
             "SELECT declaration_id,revision_number,lifecycle_status "
             "FROM declared_canon_revisions ORDER BY rowid"
@@ -863,6 +1041,134 @@ class DeclaredCanonLifecycleTests(unittest.TestCase):
                     reader.rollback()
                 reader.close()
                 writer.close()
+
+    def test_temp_table_cannot_shadow_retired_main_head(self):
+        original = self.add("temp-shadow-add1").primary
+        retired = declared.retire_declared_canon(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="temp-shadow-ret1",
+            guild_id=7,
+            declaration_id=original.declaration_id,
+            expected_revision_id=original.revision_id,
+        ).primary
+        self.conn.execute(
+            "CREATE TEMP TABLE declared_canon_revisions AS "
+            "SELECT * FROM main.declared_canon_revisions "
+            "WHERE revision_id=?",
+            (original.revision_id,),
+        )
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError, "expected_revision_mismatch"
+        ):
+            declared.validate_current_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="temp-shadow-read1",
+                guild_id=7,
+                declaration_id=original.declaration_id,
+                expected_revision_id=original.revision_id,
+                expected_source_fingerprint=original.source_fingerprint,
+            )
+        latest = declared.validate_latest_declared_canon_revision(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="temp-shadow-read2",
+            guild_id=7,
+            declaration_id=retired.declaration_id,
+            expected_revision_id=retired.revision_id,
+            expected_source_fingerprint=retired.source_fingerprint,
+            expected_lifecycle_status="retired",
+        )
+        self.assertEqual(latest.revision_id, retired.revision_id)
+
+    def test_complete_chain_validation_rejects_restored_schema_with_missing_middle(self):
+        original = self.add("chain-original1").primary
+        contested = declared.change_declared_canon_status(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="chain-status01",
+            guild_id=7,
+            declaration_id=original.declaration_id,
+            expected_revision_id=original.revision_id,
+            lifecycle_status="contested",
+        ).primary
+        resolved = declared.change_declared_canon_status(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="chain-status02",
+            guild_id=7,
+            declaration_id=original.declaration_id,
+            expected_revision_id=contested.revision_id,
+            lifecycle_status="resolved",
+        ).primary
+        trigger_name = "trg_declared_canon_revisions_no_delete"
+        self.conn.execute("DROP TRIGGER main.%s" % trigger_name)
+        self.conn.execute(
+            "DELETE FROM main.declared_canon_revisions WHERE revision_id=?",
+            (contested.revision_id,),
+        )
+        self.conn.execute(declared._DECLARED_CANON_TRIGGER_DDL[trigger_name])
+        self.conn.commit()
+        declared._require_schema(self.conn)
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError,
+            "declared_canon_revision_chain_invalid",
+        ):
+            declared.validate_latest_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="chain-validate1",
+                guild_id=7,
+                declaration_id=resolved.declaration_id,
+                expected_revision_id=resolved.revision_id,
+                expected_source_fingerprint=resolved.source_fingerprint,
+                expected_lifecycle_status="resolved",
+            )
+
+    def test_internal_read_boundary_requires_snapshot_and_validates_all_chains(self):
+        created = self.add("read-boundary1").primary
+        with self.assertRaisesRegex(
+            declared.DeclaredCanonError,
+            "declared_canon_read_snapshot_required",
+        ):
+            declared.validate_declared_canon_read_boundary(self.conn, guild_id=7)
+        before = self.conn.total_changes
+        self.conn.execute("BEGIN")
+        try:
+            latest = declared.validate_declared_canon_read_boundary(
+                self.conn, guild_id=7
+            )
+            self.assertEqual(tuple(item.revision_id for item in latest), (
+                created.revision_id,
+            ))
+            self.assertTrue(self.conn.in_transaction)
+            self.assertEqual(self.conn.total_changes, before)
+        finally:
+            self.conn.rollback()
+
+    def test_schema_checks_run_inside_owned_write_and_read_transactions(self):
+        observed: list[bool] = []
+        real_require_schema = declared._require_schema
+
+        def checked(conn):
+            observed.append(bool(conn.in_transaction))
+            return real_require_schema(conn)
+
+        with mock.patch.object(declared, "_require_schema", side_effect=checked):
+            created = self.add("transaction-check1").primary
+            declared.validate_current_declared_canon_revision(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="transaction-read1",
+                guild_id=7,
+                declaration_id=created.declaration_id,
+                expected_revision_id=created.revision_id,
+                expected_source_fingerprint=created.source_fingerprint,
+                now="2026-08-01T12:00:00+00:00",
+            )
+        self.assertTrue(observed)
+        self.assertTrue(all(observed))
 
     def test_mutation_refuses_caller_owned_transaction(self):
         self.conn.execute("BEGIN")

--- a/tests/test_declared_canon_projection.py
+++ b/tests/test_declared_canon_projection.py
@@ -35,6 +35,9 @@ class DeclaredCanonProjectionTests(unittest.TestCase):
             {
                 "BNL_OWNER_USER_ID": "61",
                 "BNL_PRIMARY_GUILD_ID": "7",
+                "BNL_DECLARED_CANON_AUTHORITY_SECRET": (
+                    "declared-projection-test-authority-secret-2026-08-01"
+                ),
             },
         )
         self.env.start()
@@ -66,6 +69,46 @@ class DeclaredCanonProjectionTests(unittest.TestCase):
             expected_lifecycle_status=revision.lifecycle_status,
             root_entry_ids=root_entry_ids,
         )
+
+    def add_projection_fixture(
+        self,
+        *,
+        declaration_id,
+        revision_id,
+        value="Stale Declared projection fixture.",
+    ):
+        result = ledger.insert_ledger_entry(
+            self.conn,
+            ledger.LedgerEntry(
+                guild_id=7,
+                source_table="declared_canon_projection",
+                source_row_id=declaration_id,
+                source_revision=revision_id,
+                source_event_key="revision:%s" % revision_id,
+                source_role="declared_canon_projection",
+                entry_type="canon_reference",
+                subject_key="project:barcode_radio",
+                predicate_key="current_role",
+                value=value,
+                source_class=ledger.SourceClass.EVIDENCE_PROJECTION,
+                route_mode="declared_canon_review",
+                channel_policy="declared_canon_review",
+                visibility=ledger.Visibility.INTERNAL,
+                confidence=ledger.Confidence.LOW,
+                public_usable=False,
+                derived=True,
+                projection=True,
+                observed_at="2026-08-01T00:00:00+00:00",
+                lifecycle_status=ledger.REVIEW_ONLY_LIFECYCLE,
+                participants=(
+                    ledger.LedgerParticipant(
+                        "project:barcode_radio", "", "subject", 0
+                    ),
+                ),
+            ),
+        )
+        self.assertEqual(result.outcome, "inserted")
+        return result
 
     @staticmethod
     def create_broadcast_table(conn):
@@ -506,6 +549,153 @@ class DeclaredCanonProjectionTests(unittest.TestCase):
         ).fetchone()[0]
         self.assertEqual(live_rows, 0)
 
+    def test_terminal_projection_retracts_all_effective_older_rows_and_retry(self):
+        original_revision = self.add_claim("projection-terminal-all-add1")
+        original_projection = self.project(
+            original_revision, "projection-terminal-all-run1"
+        )
+        duplicate_projection = self.add_projection_fixture(
+            declaration_id=original_revision.declaration_id,
+            revision_id="stale-terminal-duplicate-revision",
+        )
+        self.conn.commit()
+        retired_revision = declared.retire_declared_canon(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="projection-terminal-all-retire1",
+            guild_id=7,
+            declaration_id=original_revision.declaration_id,
+            expected_revision_id=original_revision.revision_id,
+            reason="Retire every stale Declared representation.",
+            now="2026-08-01T00:02:00+00:00",
+        ).primary
+
+        terminal_projection = self.project(
+            retired_revision, "projection-terminal-all-run2"
+        )
+
+        self.assertEqual(terminal_projection.outcome, "inserted")
+        self.assertEqual(
+            {
+                row[1]
+                for row in self.conn.execute(
+                    """
+                    SELECT lineage_type,target_entry_id
+                    FROM memory_ledger_lineage WHERE entry_id=?
+                      AND lineage_type='retracts'
+                    """,
+                    (terminal_projection.entry_id,),
+                ).fetchall()
+            },
+            {original_projection.entry_id, duplicate_projection.entry_id},
+        )
+
+        late_projection = self.add_projection_fixture(
+            declaration_id=original_revision.declaration_id,
+            revision_id="late-terminal-duplicate-revision",
+        )
+        self.conn.commit()
+        retry = self.project(
+            retired_revision, "projection-terminal-all-run3"
+        )
+
+        self.assertEqual(retry.entry_id, terminal_projection.entry_id)
+        self.assertEqual(retry.outcome, "deduplicated")
+        self.assertEqual(
+            retry.reason_code,
+            "exact_source_duplicate_lineage_reconciled",
+        )
+        self.assertEqual(
+            {
+                row[0]
+                for row in self.conn.execute(
+                    """
+                    SELECT target_entry_id FROM memory_ledger_lineage
+                    WHERE entry_id=? AND lineage_type='retracts'
+                    """,
+                    (terminal_projection.entry_id,),
+                ).fetchall()
+            },
+            {
+                original_projection.entry_id,
+                duplicate_projection.entry_id,
+                late_projection.entry_id,
+            },
+        )
+        self.assertEqual(
+            ledger._effective_declared_projection_entries(
+                self.conn,
+                guild_id=7,
+                declaration_id=original_revision.declaration_id,
+                exclude_revision_id=retired_revision.revision_id,
+            ),
+            (),
+        )
+
+    def test_terminal_projection_lineage_failure_rolls_back_entry_and_edges(self):
+        original_revision = self.add_claim("projection-rollback-add1")
+        original_projection = self.project(
+            original_revision, "projection-rollback-run1"
+        )
+        duplicate_projection = self.add_projection_fixture(
+            declaration_id=original_revision.declaration_id,
+            revision_id="rollback-duplicate-revision",
+        )
+        self.conn.commit()
+        retired_revision = declared.retire_declared_canon(
+            self.conn,
+            actor_user_id=61,
+            authority_nonce="projection-rollback-retire1",
+            guild_id=7,
+            declaration_id=original_revision.declaration_id,
+            expected_revision_id=original_revision.revision_id,
+            reason="Atomic rollback fixture.",
+            now="2026-08-01T00:02:00+00:00",
+        ).primary
+        self.conn.execute(
+            """
+            CREATE TRIGGER reject_declared_projection_retraction
+            BEFORE INSERT ON memory_ledger_lineage
+            WHEN NEW.lineage_type='retracts'
+             AND NEW.target_entry_id='%s'
+            BEGIN
+                SELECT RAISE(ABORT, 'declared retraction rejected');
+            END
+            """ % duplicate_projection.entry_id
+        )
+        self.conn.commit()
+
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError, "declared retraction rejected"
+        ):
+            self.project(retired_revision, "projection-rollback-run2")
+
+        terminal_entry_id = ledger.stable_entry_id(
+            guild_id=7,
+            source_table="declared_canon_projection",
+            source_row_id=retired_revision.declaration_id,
+            source_revision=retired_revision.revision_id,
+            entry_type="canon_reference",
+            subject_key="project:barcode_radio",
+            predicate_key="current_role",
+        )
+        self.assertIsNone(
+            self.conn.execute(
+                "SELECT 1 FROM memory_ledger_entries WHERE entry_id=?",
+                (terminal_entry_id,),
+            ).fetchone()
+        )
+        self.assertEqual(
+            set(
+                ledger._effective_declared_projection_entries(
+                    self.conn,
+                    guild_id=7,
+                    declaration_id=original_revision.declaration_id,
+                )
+            ),
+            {original_projection.entry_id, duplicate_projection.entry_id},
+        )
+
     def test_typed_subject_keys_do_not_collapse_person_and_project(self):
         person = self.add_claim(
             "projection-person1",
@@ -579,7 +769,7 @@ class DeclaredCanonProjectionTests(unittest.TestCase):
             ],
         )
 
-    def test_cross_declaration_supersession_preserves_exact_lineage(self):
+    def test_cross_declaration_supersession_invalidates_all_effective_lineage(self):
         old_revision = self.add_claim(
             "projection-old-add1",
             subject_id="old_broadcast_role",
@@ -595,6 +785,15 @@ class DeclaredCanonProjectionTests(unittest.TestCase):
             replacement_revision,
             "projection-new-run1",
         )
+        old_duplicate = self.add_projection_fixture(
+            declaration_id=old_revision.declaration_id,
+            revision_id="old-cross-duplicate-revision",
+        )
+        replacement_duplicate = self.add_projection_fixture(
+            declaration_id=replacement_revision.declaration_id,
+            revision_id="replacement-cross-duplicate-revision",
+        )
+        self.conn.commit()
 
         supersession = declared.supersede_declared_canon(
             self.conn,
@@ -646,13 +845,12 @@ class DeclaredCanonProjectionTests(unittest.TestCase):
             replacement_edges,
             {
                 ("supersedes", replacement_projection.entry_id),
+                ("supersedes", replacement_duplicate.entry_id),
                 ("supersedes", old_projection.entry_id),
+                ("supersedes", old_duplicate.entry_id),
             },
         )
-        self.assertEqual(
-            old_terminal_edges,
-            {("retracts", old_projection.entry_id)},
-        )
+        self.assertEqual(old_terminal_edges, set())
 
     def test_projection_holds_source_snapshot_until_insert(self):
         handle = tempfile.NamedTemporaryFile(delete=False)

--- a/tests/test_hybrid_canon_claim_contract.py
+++ b/tests/test_hybrid_canon_claim_contract.py
@@ -13,6 +13,25 @@ import bnl_unified_intelligence_packet as packet
 
 
 class HybridCanonClaimContractTests(unittest.TestCase):
+    def setUp(self):
+        self._authority_secret = os.environ.get(
+            declared_canon.DECLARED_CANON_AUTHORITY_SECRET_ENV
+        )
+        os.environ[
+            declared_canon.DECLARED_CANON_AUTHORITY_SECRET_ENV
+        ] = "hybrid-contract-test-authority-secret-0001"
+
+    def tearDown(self):
+        if self._authority_secret is None:
+            os.environ.pop(
+                declared_canon.DECLARED_CANON_AUTHORITY_SECRET_ENV,
+                None,
+            )
+        else:
+            os.environ[
+                declared_canon.DECLARED_CANON_AUTHORITY_SECRET_ENV
+            ] = self._authority_secret
+
     def create_pr2_broadcast_table(self, conn):
         conn.execute(
             """
@@ -75,7 +94,7 @@ class HybridCanonClaimContractTests(unittest.TestCase):
                 7,
                 "2026-08-01",
                 61,
-                "Owner Fixture",
+                "6 Bit",
                 raw,
                 cleaned,
                 entry_type,

--- a/tests/test_memory_ledger_bot_paths.py
+++ b/tests/test_memory_ledger_bot_paths.py
@@ -68,6 +68,41 @@ class MemoryLedgerBotPathTests(unittest.TestCase):
     def enable(self):
         os.environ["BNL_MEMORY_LEDGER_SHADOW_ENABLED"] = "1"
 
+    def add_declared_broadcast_projection(
+        self,
+        *,
+        memory_id,
+        root_entry_id,
+        suffix,
+    ):
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            result = ledger.insert_ledger_entry(
+                conn,
+                ledger.LedgerEntry(
+                    guild_id=1,
+                    source_table="declared_canon_projection",
+                    source_row_id="bot-declared-%s" % suffix,
+                    source_revision="bot-declared-revision-%s" % suffix,
+                    source_event_key="revision:bot-%s" % suffix,
+                    source_role="declared_canon_projection",
+                    entry_type="canon_reference",
+                    subject_key="broadcast:barcode_radio",
+                    predicate_key="broadcast_memory",
+                    value="Bot-path Declared Broadcast projection.",
+                    source_class=ledger.SourceClass.EVIDENCE_PROJECTION,
+                    visibility=ledger.Visibility.INTERNAL,
+                    confidence=ledger.Confidence.LOW,
+                    public_usable=False,
+                    derived=True,
+                    projection=True,
+                    observed_at="2026-08-01T00:00:00+00:00",
+                    lifecycle_status=ledger.REVIEW_ONLY_LIFECYCLE,
+                    lineage=(("derived_from", root_entry_id),),
+                ),
+            )
+            self.assertEqual(result.outcome, "inserted")
+            return result
+
     def test_group_model_reply_is_one_room_source_with_all_participants(self):
         self.enable()
 
@@ -1003,6 +1038,145 @@ class MemoryLedgerBotPathTests(unittest.TestCase):
                 )
             },
             primary_ids,
+        )
+
+    def test_broadcast_status_resolution_retracts_declared_projection_atomically(self):
+        self.enable()
+        memory_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW declared projection status note"),
+            {
+                "cleaned_summary": "Declared projection status fixture.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        primary_id = self.rows(
+            """
+            SELECT entry_id FROM memory_ledger_entries
+            WHERE source_table='broadcast_memory'
+              AND source_role='broadcast_memory' AND source_row_id=?
+            """,
+            (str(memory_id),),
+        )[0][0]
+        projection = self.add_declared_broadcast_projection(
+            memory_id=memory_id,
+            root_entry_id=primary_id,
+            suffix="status-success",
+        )
+
+        self.assertEqual(
+            bnl01_bot._set_broadcast_memory_status(
+                1, memory_id, "resolved", 42, "6 Bit", "terminal correction"
+            ),
+            1,
+        )
+
+        status_entry = self.rows(
+            """
+            SELECT entry_id FROM memory_ledger_entries
+            WHERE source_table='broadcast_memory'
+              AND source_role='broadcast_memory_status' AND source_row_id=?
+            """,
+            (str(memory_id),),
+        )[0][0]
+        projection_status_entry = self.rows(
+            """
+            SELECT entry_id FROM memory_ledger_entries
+            WHERE source_table='broadcast_memory'
+              AND source_role='broadcast_memory_projection_status'
+              AND source_row_id=?
+            """,
+            (str(memory_id),),
+        )[0][0]
+        self.assertEqual(
+            self.rows(
+                """
+                SELECT lineage_type,target_entry_id
+                FROM memory_ledger_lineage WHERE entry_id=?
+                """,
+                (status_entry,),
+            ),
+            [("retracts", primary_id)],
+        )
+        self.assertEqual(
+            self.rows(
+                """
+                SELECT lineage_type,target_entry_id
+                FROM memory_ledger_lineage WHERE entry_id=?
+                """,
+                (projection_status_entry,),
+            ),
+            [("retracts", projection.entry_id)],
+        )
+
+    def test_broadcast_projection_retraction_failure_rolls_back_source_status(self):
+        self.enable()
+        memory_id = bnl01_bot.add_broadcast_memory_entry(
+            1,
+            _Message("RAW declared rollback status note"),
+            {
+                "cleaned_summary": "Declared rollback status fixture.",
+                "entry_type": "notable_moment",
+                "public_safe": True,
+                "usage_scope": "ambient,direct",
+            },
+        )
+        primary_id = self.rows(
+            """
+            SELECT entry_id FROM memory_ledger_entries
+            WHERE source_table='broadcast_memory'
+              AND source_role='broadcast_memory' AND source_row_id=?
+            """,
+            (str(memory_id),),
+        )[0][0]
+        projection = self.add_declared_broadcast_projection(
+            memory_id=memory_id,
+            root_entry_id=primary_id,
+            suffix="status-rollback",
+        )
+        with sqlite3.connect(bnl01_bot.DB_FILE) as conn:
+            conn.execute(
+                """
+                CREATE TRIGGER reject_bot_projection_retraction
+                BEFORE INSERT ON memory_ledger_lineage
+                WHEN NEW.lineage_type='retracts'
+                 AND NEW.target_entry_id='%s'
+                BEGIN
+                    SELECT RAISE(ABORT, 'bot projection retraction rejected');
+                END
+                """ % projection.entry_id
+            )
+
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError, "bot projection retraction rejected"
+        ):
+            bnl01_bot._set_broadcast_memory_status(
+                1, memory_id, "resolved", 42, "6 Bit", "must roll back"
+            )
+
+        self.assertEqual(
+            self.rows(
+                "SELECT status FROM broadcast_memory WHERE id=?",
+                (memory_id,),
+            ),
+            [("active",)],
+        )
+        self.assertEqual(
+            self.rows(
+                """
+                SELECT COUNT(*) FROM memory_ledger_entries
+                WHERE source_table='broadcast_memory'
+                  AND source_row_id=?
+                  AND source_role IN (
+                    'broadcast_memory_status',
+                    'broadcast_memory_projection_status'
+                  )
+                """,
+                (str(memory_id),),
+            ),
+            [(0,)],
         )
 
     def test_broadcast_status_resolution_cannot_rewrite_superseded_source(self):

--- a/tests/test_memory_ledger_v1.py
+++ b/tests/test_memory_ledger_v1.py
@@ -23,6 +23,41 @@ class MemoryLedgerV1Tests(unittest.TestCase):
     def count_entries(self):
         return self.conn.execute("SELECT COUNT(*) FROM memory_ledger_entries").fetchone()[0]
 
+    def add_declared_projection(
+        self,
+        *,
+        declaration_id,
+        revision_id,
+        root_entry_id="",
+    ):
+        lineage = (
+            (("derived_from", root_entry_id),) if root_entry_id else ()
+        )
+        entry = ledger.LedgerEntry(
+            guild_id=1,
+            source_table="declared_canon_projection",
+            source_row_id=declaration_id,
+            source_revision=revision_id,
+            source_event_key="revision:%s" % revision_id,
+            source_role="declared_canon_projection",
+            entry_type="canon_reference",
+            subject_key="broadcast:barcode_radio",
+            predicate_key="broadcast_memory",
+            value="Declared Broadcast projection fixture.",
+            source_class=ledger.SourceClass.EVIDENCE_PROJECTION,
+            visibility=ledger.Visibility.INTERNAL,
+            confidence=ledger.Confidence.LOW,
+            public_usable=False,
+            derived=True,
+            projection=True,
+            observed_at="2026-08-01T00:00:00+00:00",
+            lifecycle_status=ledger.REVIEW_ONLY_LIFECYCLE,
+            lineage=lineage,
+        )
+        result = ledger.insert_ledger_entry(self.conn, entry)
+        self.assertEqual(result.outcome, "inserted")
+        return result
+
     def add_approved_fact(
         self,
         row_id,
@@ -358,6 +393,14 @@ class MemoryLedgerV1Tests(unittest.TestCase):
             )
         )
         self.assertEqual(len(set(roots)), 2)
+        projections = tuple(
+            self.add_declared_projection(
+                declaration_id="declared-broadcast-%s" % index,
+                revision_id="declared-revision-%s" % index,
+                root_entry_id=root_entry_id,
+            ).entry_id
+            for index, root_entry_id in enumerate(roots, start=1)
+        )
         self.conn.execute(
             """
             UPDATE broadcast_memory
@@ -389,11 +432,326 @@ class MemoryLedgerV1Tests(unittest.TestCase):
             },
             set(roots),
         )
+        projection_status = self.conn.execute(
+            """
+            SELECT entry_id FROM memory_ledger_entries
+            WHERE source_table='broadcast_memory'
+              AND source_row_id='72'
+              AND source_role='broadcast_memory_projection_status'
+            """
+        ).fetchone()[0]
         self.assertEqual(
-            ledger._effective_broadcast_primary_entries(
+            {
+                row[0]
+                for row in self.conn.execute(
+                    """
+                    SELECT target_entry_id FROM memory_ledger_lineage
+                    WHERE entry_id=? AND lineage_type='retracts'
+                    """,
+                    (projection_status,),
+                ).fetchall()
+            },
+            set(projections),
+        )
+        self.assertEqual(
+            ledger.effective_broadcast_representations(
                 self.conn, guild_id=1, source_row_id=72
-            ),
+            ).all_entry_ids,
             (),
+        )
+
+    def test_broadcast_status_event_retracts_orphan_declared_projection(self):
+        self.conn.execute(
+            """
+            CREATE TABLE broadcast_memory(
+                id INTEGER PRIMARY KEY,
+                guild_id INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                corrected_by_user_id INTEGER,
+                corrected_by_name TEXT,
+                superseded_by_id INTEGER
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE TABLE declared_canon_revisions(
+                revision_id TEXT NOT NULL,
+                declaration_id TEXT NOT NULL,
+                guild_id INTEGER NOT NULL,
+                source_system TEXT NOT NULL,
+                source_row_id TEXT NOT NULL,
+                lifecycle_status TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            INSERT INTO broadcast_memory VALUES(
+                73,1,'resolved','2026-08-01T01:00:00+00:00',
+                61,'configured_owner',NULL
+            )
+            """
+        )
+        orphan = self.add_declared_projection(
+            declaration_id="orphan-declaration",
+            revision_id="orphan-revision",
+        )
+        self.conn.execute(
+            """
+            INSERT INTO declared_canon_revisions VALUES(
+                'orphan-revision','orphan-declaration',1,
+                'broadcast_memory','73','established'
+            )
+            """
+        )
+        self.conn.commit()
+
+        status = ledger.shadow_broadcast_status_event(
+            self.conn,
+            row_id=73,
+            guild_id=1,
+            status="resolved",
+            updated_at="2026-08-01T01:00:00+00:00",
+            actor_id=61,
+            actor_name="configured_owner",
+        )
+
+        self.assertEqual(status.outcome, "inserted")
+        projection_status = self.conn.execute(
+            """
+            SELECT entry_id FROM memory_ledger_entries
+            WHERE source_table='broadcast_memory'
+              AND source_row_id='73'
+              AND source_role='broadcast_memory_projection_status'
+            """
+        ).fetchone()[0]
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT lineage_type,target_entry_id
+                FROM memory_ledger_lineage WHERE entry_id=?
+                """,
+                (projection_status,),
+            ).fetchall(),
+            [("retracts", orphan.entry_id)],
+        )
+        self.assertEqual(
+            ledger.effective_broadcast_representations(
+                self.conn, guild_id=1, source_row_id=73
+            ).all_entry_ids,
+            (),
+        )
+
+    def test_broadcast_status_retry_reconciles_late_duplicate_lineage(self):
+        self.conn.execute(
+            """
+            CREATE TABLE broadcast_memory(
+                id INTEGER PRIMARY KEY,
+                guild_id INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                corrected_by_user_id INTEGER,
+                corrected_by_name TEXT,
+                superseded_by_id INTEGER
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            INSERT INTO broadcast_memory VALUES(
+                74,1,'resolved','2026-08-01T01:00:00+00:00',
+                61,'configured_owner',NULL
+            )
+            """
+        )
+        first_root = ledger.shadow_broadcast_memory_row(
+            self.conn,
+            row_id=74,
+            guild_id=1,
+            cleaned_summary="First late-lineage fixture.",
+            entry_type="notable_moment",
+            public_safe=True,
+            status="active",
+            usage_scope="ambient,direct",
+            updated_at="2026-08-01T00:00:00+00:00",
+        )
+        first_projection = self.add_declared_projection(
+            declaration_id="retry-declaration-one",
+            revision_id="retry-revision-one",
+            root_entry_id=first_root.entry_id,
+        )
+        self.conn.commit()
+        first_status = ledger.shadow_broadcast_status_event(
+            self.conn,
+            row_id=74,
+            guild_id=1,
+            status="resolved",
+            updated_at="2026-08-01T01:00:00+00:00",
+            actor_id=61,
+            actor_name="configured_owner",
+        )
+        self.assertEqual(first_status.outcome, "inserted")
+
+        late_root = ledger.shadow_broadcast_memory_row(
+            self.conn,
+            row_id=74,
+            guild_id=1,
+            cleaned_summary="Late duplicate root fixture.",
+            entry_type="notable_moment",
+            public_safe=True,
+            status="active",
+            usage_scope="ambient,direct",
+            updated_at="2026-08-01T00:01:00+00:00",
+        )
+        late_projection = self.add_declared_projection(
+            declaration_id="retry-declaration-two",
+            revision_id="retry-revision-two",
+            root_entry_id=late_root.entry_id,
+        )
+        self.conn.commit()
+
+        retry = ledger.shadow_broadcast_status_event(
+            self.conn,
+            row_id=74,
+            guild_id=1,
+            status="resolved",
+            updated_at="2026-08-01T01:00:00+00:00",
+            actor_id=61,
+            actor_name="configured_owner",
+        )
+
+        self.assertEqual(retry.entry_id, first_status.entry_id)
+        self.assertEqual(retry.outcome, "deduplicated")
+        self.assertEqual(
+            retry.reason_code,
+            "exact_source_duplicate_lineage_reconciled",
+        )
+        self.assertEqual(
+            {
+                row[0]
+                for row in self.conn.execute(
+                    """
+                    SELECT target_entry_id FROM memory_ledger_lineage
+                    WHERE entry_id=? AND lineage_type='retracts'
+                    """,
+                    (first_status.entry_id,),
+                ).fetchall()
+            },
+            {first_root.entry_id, late_root.entry_id},
+        )
+        projection_status = self.conn.execute(
+            """
+            SELECT entry_id FROM memory_ledger_entries
+            WHERE source_table='broadcast_memory'
+              AND source_row_id='74'
+              AND source_role='broadcast_memory_projection_status'
+            """
+        ).fetchone()[0]
+        self.assertEqual(
+            {
+                row[0]
+                for row in self.conn.execute(
+                    """
+                    SELECT target_entry_id FROM memory_ledger_lineage
+                    WHERE entry_id=? AND lineage_type='retracts'
+                    """,
+                    (projection_status,),
+                ).fetchall()
+            },
+            {first_projection.entry_id, late_projection.entry_id},
+        )
+        self.assertEqual(
+            ledger.effective_broadcast_representations(
+                self.conn, guild_id=1, source_row_id=74
+            ).all_entry_ids,
+            (),
+        )
+
+    def test_broadcast_status_projection_failure_rolls_back_all_lineage(self):
+        self.conn.execute(
+            """
+            CREATE TABLE broadcast_memory(
+                id INTEGER PRIMARY KEY,
+                guild_id INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                corrected_by_user_id INTEGER,
+                corrected_by_name TEXT,
+                superseded_by_id INTEGER
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            INSERT INTO broadcast_memory VALUES(
+                75,1,'resolved','2026-08-01T01:00:00+00:00',
+                61,'configured_owner',NULL
+            )
+            """
+        )
+        root = ledger.shadow_broadcast_memory_row(
+            self.conn,
+            row_id=75,
+            guild_id=1,
+            cleaned_summary="Atomic rollback fixture.",
+            entry_type="notable_moment",
+            public_safe=True,
+            status="active",
+            usage_scope="ambient,direct",
+            updated_at="2026-08-01T00:00:00+00:00",
+        )
+        projection = self.add_declared_projection(
+            declaration_id="rollback-declaration",
+            revision_id="rollback-revision",
+            root_entry_id=root.entry_id,
+        )
+        self.conn.execute(
+            """
+            CREATE TRIGGER reject_projection_retraction
+            BEFORE INSERT ON memory_ledger_lineage
+            WHEN NEW.lineage_type='retracts'
+             AND NEW.target_entry_id='%s'
+            BEGIN
+                SELECT RAISE(ABORT, 'projection retraction rejected');
+            END
+            """ % projection.entry_id
+        )
+        self.conn.commit()
+
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError, "projection retraction rejected"
+        ):
+            ledger.shadow_broadcast_status_event(
+                self.conn,
+                row_id=75,
+                guild_id=1,
+                status="resolved",
+                updated_at="2026-08-01T01:00:00+00:00",
+                actor_id=61,
+                actor_name="configured_owner",
+            )
+
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT COUNT(*) FROM memory_ledger_entries
+                WHERE source_table='broadcast_memory'
+                  AND source_row_id='75'
+                  AND source_role IN (
+                    'broadcast_memory_status',
+                    'broadcast_memory_projection_status'
+                  )
+                """
+            ).fetchone()[0],
+            0,
+        )
+        self.assertEqual(
+            ledger.effective_broadcast_representations(
+                self.conn, guild_id=1, source_row_id=75
+            ).all_entry_ids,
+            tuple(sorted((root.entry_id, projection.entry_id))),
         )
 
     def test_broadcast_status_event_fails_closed_on_actor_or_stale_snapshot(self):

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -1617,6 +1617,9 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
             {
                 "BNL_OWNER_USER_ID": "61",
                 "BNL_PRIMARY_GUILD_ID": "1",
+                "BNL_DECLARED_CANON_AUTHORITY_SECRET": (
+                    "packet-test-declared-authority-secret-0001"
+                ),
             },
             clear=False,
         ):


### PR DESCRIPTION
## Declared Canon hardening follow-up

This mandatory follow-up closes the fail-open and invalidation gaps found after #414 merged. It keeps PR 2 non-live and does not begin PR 3.

### Security and integrity corrections
- replaces deterministic unkeyed authority receipts with HMAC-SHA256 receipts using `BNL_DECLARED_CANON_AUTHORITY_SECRET`
- fails closed when that secret is missing, short, or rotated; this PR does **not** configure or deploy the secret
- validates the exact append-only schema, triggers, indexes, immutable rows, revision IDs, and complete revision chains
- prevents a forged prior/latest row from being laundered through a new mutation
- uses coherent `main`-qualified SQLite read snapshots so WAL changes cannot splice validation reads
- fingerprints the complete Broadcast row, including future/unknown columns, so source schema drift requires review

### Broadcast and Ledger corrections
- retracts every effective Broadcast representation, including Declared projections, on terminal source transitions
- reconciles duplicate roots, terminal projections, retries, and replacement paths transactionally
- preserves the zero-Ledger path when shadowing is disabled and no prior representation exists
- keeps all Declared projections internal, derived, review-only, nonpublic, and excluded from live packets

### Review feedback
- addresses both unresolved post-merge findings on #414: complete Broadcast invalidation and BARCODE-safe owner fixture labels
- does not reply to or resolve the original review threads automatically

### Preserved boundaries
- no historical classification, backfill, or source migration
- no live packet or response authority
- no website mutation
- no deployment, VPS action, runtime flag change, or secret provisioning
- no production data write

### Verification
- exact reviewed GitHub/local tree: `dfd66a4edee77993bc0b4acdd87afe6d9a7904d8`
- focused dependency-free matrix: 151 passed
- compilation and diff validation: passed
- independent architecture, code, and security reviews: merge-ready
- full dependency-installed Python 3.9 and 3.12 CI is required before merge

This follow-up must merge before universal Open Signal admission work begins.