### PR TITLE
Add family-neutral Living Canon recurrence

### DIFF
--- a/bnl_canon_source_contract.py
+++ b/bnl_canon_source_contract.py
@@ -22,6 +22,12 @@ LIVING_CANON_ADAPTER_VERSION = "living_canon_adapter_v1"
 OPEN_SIGNAL_ADAPTER_VERSION = "open_signal_adapter_v3"
 WEBSITE_LORE_ADAPTER_VERSION = "website_lore_review_adapter_v1"
 LIVING_CANON_RECURRENCE_VERSION = "living_canon_recurrence_v1"
+LIVING_CANON_GROUPING_SIGNATURE_VERSION = (
+    "living_canon_exact_root_grouping_v1"
+)
+ATOMIC_KNOWLEDGE_LIFECYCLE_SCHEMA_VERSION = (
+    "memory_ledger_atomic_knowledge_lifecycle_v1"
+)
 PUBLIC_ASSESSMENT_EVIDENCE_VERSION = "public_assessment_evidence_v3"
 ENTITY_ACCOUNT_BINDING_CONTRACT_VERSION = "canon_entity_account_binding_v1"
 
@@ -200,6 +206,8 @@ class CanonClaim:
     supersedes: tuple[str, ...] = ()
     correction_of: tuple[str, ...] = ()
     recurrence_contract_version: str = ""
+    grouping_signature_version: str = ""
+    grouping_identity: str = ""
     projection_state: str = "shadow"
     projection_version: str = HYBRID_CANON_CLAIM_CONTRACT_VERSION
     subject_type: str = ""
@@ -405,6 +413,14 @@ def _claim_revision_payload(
         claim.projection_state,
         claim.projection_version,
     )
+    grouping_identity = (
+        str(claim.grouping_signature_version or ""),
+        str(claim.grouping_identity or ""),
+    )
+    # Preserve existing revision IDs for non-Living adapters.  A recurrence-
+    # verified Living claim opts into the grouping extension explicitly.
+    if any(grouping_identity):
+        payload += ("living_grouping_contract_v1", *grouping_identity)
     typed_identity = (
         str(claim.subject_type or ""),
         str(claim.object_subject_type or ""),
@@ -934,17 +950,19 @@ def adapt_declared_canon_revision(
 
 
 def _normalized_identity_tuple(value: Any) -> tuple[str, ...]:
-    if isinstance(value, str):
-        values: Iterable[Any] = (value,)
-    elif isinstance(value, Iterable):
-        values = value
-    else:
-        values = ()
-    return tuple(
-        dict.fromkeys(
-            str(item).strip() for item in values if str(item).strip()
-        )
-    )
+    """Return only a native, unique, sorted sequence of opaque identities."""
+
+    if not isinstance(value, (list, tuple)):
+        return ()
+    if not value or any(not isinstance(item, str) for item in value):
+        return ()
+    identities = tuple(str(item).strip() for item in value)
+    if (
+        any(not identity for identity in identities)
+        or len(identities) != len(set(identities))
+    ):
+        return ()
+    return tuple(sorted(identities))
 
 
 def _strict_nonnegative_int(value: Any) -> int:
@@ -955,6 +973,108 @@ def _strict_nonnegative_int(value: Any) -> int:
     except (TypeError, ValueError):
         return 0
     return max(0, parsed)
+
+
+_LIVING_CANON_PROOF_BOOL_KEYS = (
+    "candidate_eligible",
+    "source_eligible",
+    "roots_valid",
+    "occurrence_bounded",
+    "correction_fence_clear",
+    "contradiction_clear",
+)
+_LIVING_CANON_PROOF_BOUNDS = {
+    "eligible_ledger_scan_max": 1200,
+    "motif_candidates_max": 6,
+    "retained_roots_max": 12,
+    "occurrence_lookback_max": 64,
+    "idle_boundary_seconds": 30 * 60,
+}
+
+
+def _strict_json_mapping(value: Any) -> dict[str, Any] | None:
+    if type(value) is dict:
+        return dict(value)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    return dict(parsed) if isinstance(parsed, Mapping) else None
+
+
+def _strict_json_identity_tuple(value: Any) -> tuple[str, ...]:
+    parsed = value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return ()
+    if not isinstance(parsed, list):
+        return ()
+    return _normalized_identity_tuple(parsed)
+
+
+def _living_recurrence_proof(
+    row: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Return explicit proof only; lifecycle state never synthesizes proof."""
+
+    if "recurrence_proof_json" in row:
+        return _strict_json_mapping(row.get("recurrence_proof_json"))
+    if "recurrence_proof" in row:
+        return _strict_json_mapping(row.get("recurrence_proof"))
+    return None
+
+
+def _strict_native_nonnegative_int(value: Any) -> int | None:
+    if type(value) is not int or value < 0:
+        return None
+    return value
+
+
+def _strict_living_storage_bool(value: Any) -> bool:
+    return value is True or (type(value) is int and value == 1)
+
+
+def _strict_living_storage_false(value: Any) -> bool:
+    return value is False or (type(value) is int and value == 0)
+
+
+def _living_proof_bounds_valid(proof: Mapping[str, Any]) -> bool:
+    bounds = proof.get("bounds")
+    if (
+        type(bounds) is not dict
+        or set(bounds) != set(_LIVING_CANON_PROOF_BOUNDS)
+    ):
+        return False
+    for key, maximum in _LIVING_CANON_PROOF_BOUNDS.items():
+        value = _strict_native_nonnegative_int(bounds.get(key))
+        if value != maximum:
+            return False
+    return True
+
+
+def _living_digest_value(value: Any) -> str:
+    normalized = str(value or "").strip()
+    if not re.fullmatch(r"[0-9a-f]{64}", normalized):
+        return ""
+    return normalized
+
+
+def _living_knowledge_digest(*parts: Any) -> str:
+    """Mirror the Ledger producer's content-free identity digest exactly."""
+
+    return hashlib.sha256(
+        "\x1f".join(str(part or "") for part in parts).encode("utf-8")
+    ).hexdigest()
+
+
+def _living_canonical_value(value: Any) -> str:
+    """Mirror the Ledger producer's value normalization exactly."""
+
+    return re.sub(r"\s+", " ", str(value or "").strip().lower())
 
 
 def _review_only_source_claim(
@@ -1024,11 +1144,15 @@ def _adapt_living_pattern_claim(
         _mapping_text(row, "updated_at", "last_seen_at") or source_identity
     )
     try:
-        review_domain_hint = CanonDomain(_mapping_text(row, "domain"))
+        review_domain_hint = CanonDomain(
+            _mapping_text(row, "domain", "canon_domain")
+        )
     except ValueError:
         review_domain_hint = CanonDomain.REAL_COMMUNITY
     try:
-        review_kind_hint = ClaimKind(_mapping_text(row, "claim_kind"))
+        review_kind_hint = ClaimKind(
+            _mapping_text(row, "claim_kind", "canon_claim_kind")
+        )
     except ValueError:
         review_kind_hint = (
             ClaimKind.BEHAVIOR_PATTERN
@@ -1065,54 +1189,160 @@ def _adapt_living_pattern_claim(
         )
     if not root_ids:
         return review("living_source_lineage_missing")
+    recurrence_version = _mapping_text(
+        row,
+        "recurrence_contract_version",
+    )
+    proof = _living_recurrence_proof(row)
     if (
-        _mapping_text(row, "recurrence_contract_version")
-        != LIVING_CANON_RECURRENCE_VERSION
+        recurrence_version != LIVING_CANON_RECURRENCE_VERSION
+        or proof is None
+        or _mapping_text(proof, "recurrence_contract_version")
+        != recurrence_version
     ):
         return review("living_recurrence_unverified")
+    grouping_version = _mapping_text(row, "grouping_signature_version")
+    grouping_identity = _living_digest_value(row.get("grouping_identity"))
     try:
-        domain = CanonDomain(_mapping_text(row, "domain"))
-        claim_kind = ClaimKind(_mapping_text(row, "claim_kind"))
+        domain = CanonDomain(_mapping_text(row, "domain", "canon_domain"))
+        claim_kind = ClaimKind(
+            _mapping_text(row, "claim_kind", "canon_claim_kind")
+        )
     except ValueError:
         return review("living_domain_unverified")
     if domain not in {
         CanonDomain.REAL_COMMUNITY,
         CanonDomain.LORE,
         CanonDomain.HYBRID,
-    } or claim_kind not in {
-        ClaimKind.BEHAVIOR_PATTERN,
-        ClaimKind.TRADITION_OR_JOKE,
-    }:
+    } or claim_kind != ClaimKind.BEHAVIOR_PATTERN:
         return review(
             "living_domain_ineligible",
             review_domain=domain,
             review_kind=claim_kind,
         )
-    required_proofs = (
-        "candidate_eligible",
-        "source_eligible",
-        "roots_valid",
-        "occurrence_bounded",
-        "correction_fence_clear",
-        "contradiction_clear",
+    expected_grouping_identity = _living_knowledge_digest(
+        LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+        subject_id,
+        predicate,
+        domain.value,
     )
-    if not all(strict_contract_bool(row.get(key)) for key in required_proofs):
+    if (
+        grouping_version != LIVING_CANON_GROUPING_SIGNATURE_VERSION
+        or not grouping_identity
+        or grouping_identity != expected_grouping_identity
+        or proof.get("grouping_signature_version") != grouping_version
+        or _living_digest_value(proof.get("grouping_identity"))
+        != grouping_identity
+    ):
+        return review(
+            "living_grouping_unverified",
+            review_domain=domain,
+            review_kind=claim_kind,
+        )
+    if (
+        proof.get("candidate_state") != candidate_state
+        or not _strict_living_storage_bool(row.get("candidate_eligible"))
+        or not all(
+            proof.get(key) is True
+            for key in _LIVING_CANON_PROOF_BOOL_KEYS
+        )
+        or not _living_proof_bounds_valid(proof)
+    ):
         return review(
             "living_recurrence_unverified",
             review_domain=domain,
             review_kind=claim_kind,
         )
-    independent_roots = _strict_nonnegative_int(
+    conflict_value_count = _strict_native_nonnegative_int(
+        row.get("conflict_value_count")
+    )
+    if (
+        _mapping_text(row, "lifecycle_schema_version")
+        != ATOMIC_KNOWLEDGE_LIFECYCLE_SCHEMA_VERSION
+        or conflict_value_count is None
+        or conflict_value_count != 1
+        or _mapping_text(row, "review_status") != "not_required"
+        or "review_due_at" not in row
+        or _mapping_text(row, "review_due_at")
+        or not {"invalidated_reason", "invalidated_at"}.issubset(row)
+        or _mapping_text(row, "invalidated_reason", "invalidated_at")
+        or not _strict_living_storage_false(row.get("live_eligible"))
+    ):
+        return review(
+            "living_lifecycle_unverified",
+            review_domain=domain,
+            review_kind=claim_kind,
+        )
+    independent_roots = _strict_native_nonnegative_int(
         row.get("independent_root_count")
     )
-    independent_occurrences = _strict_nonnegative_int(
+    independent_occurrences = _strict_native_nonnegative_int(
         row.get("independent_occurrence_count")
     )
+    proof_roots = _strict_native_nonnegative_int(
+        proof.get("independent_root_count")
+    )
+    proof_occurrences = _strict_native_nonnegative_int(
+        proof.get("independent_occurrence_count")
+    )
+    eligible_independent_roots = _strict_native_nonnegative_int(
+        row.get("eligible_independent_root_count")
+    )
+    reinforcement_count = _strict_native_nonnegative_int(
+        row.get("reinforcement_count")
+    )
+    root_digest = _living_digest_value(row.get("root_digest"))
+    occurrence_digest = _living_digest_value(
+        row.get("occurrence_digest")
+    )
+    expected_root_digest = _living_knowledge_digest(*root_ids)
+    expected_occurrence_digest = _living_knowledge_digest(*occurrence_ids)
+    value_digest = _living_digest_value(row.get("value_digest"))
+    expected_value_digest = _living_knowledge_digest(
+        _living_canonical_value(value)
+    )
+    if (
+        independent_roots is None
+        or independent_occurrences is None
+        or proof_roots is None
+        or proof_occurrences is None
+        or independent_roots != proof_roots
+        or independent_occurrences != proof_occurrences
+        or independent_roots != len(root_ids)
+        or independent_occurrences != len(occurrence_ids)
+        or independent_roots > _LIVING_CANON_PROOF_BOUNDS["retained_roots_max"]
+        or independent_occurrences
+        > _LIVING_CANON_PROOF_BOUNDS["retained_roots_max"]
+        or not root_digest
+        or not occurrence_digest
+        or not value_digest
+        or value_digest != expected_value_digest
+        or root_digest != expected_root_digest
+        or occurrence_digest != expected_occurrence_digest
+        or _living_digest_value(proof.get("root_digest")) != root_digest
+        or _living_digest_value(proof.get("occurrence_digest"))
+        != occurrence_digest
+    ):
+        return review(
+            "living_recurrence_proof_mismatch",
+            review_domain=domain,
+            review_kind=claim_kind,
+        )
+    if (
+        eligible_independent_roots != independent_roots
+        or reinforcement_count != independent_occurrences
+        or _mapping_text(row, "lifecycle_reason")
+        != "independent_recurrence_established"
+        or _parse_contract_time(row.get("lifecycle_evaluated_at")) is None
+    ):
+        return review(
+            "living_lifecycle_unverified",
+            review_domain=domain,
+            review_kind=claim_kind,
+        )
     if (
         independent_roots < 2
         or independent_occurrences < 2
-        or len(root_ids) < 2
-        or len(occurrence_ids) < 2
     ):
         return review(
             "living_recurrence_insufficient",
@@ -1124,12 +1354,16 @@ def _adapt_living_pattern_claim(
         source_system,
         source_identity,
     )
-    visibility = (
-        Visibility.PUBLIC_SAFE
-        if _mapping_text(row, "visibility") in {"public", "public_safe"}
-        and strict_contract_bool(row.get("public_usable"))
-        else Visibility.INTERNAL
-    )
+    if (
+        _mapping_text(row, "visibility") not in {"public", "public_safe"}
+        or not _strict_living_storage_bool(row.get("public_usable"))
+    ):
+        return review(
+            "living_visibility_ineligible",
+            review_domain=domain,
+            review_kind=claim_kind,
+        )
+    visibility = Visibility.PUBLIC_SAFE
     claim = CanonClaim(
         claim_id=claim_id,
         revision_id="",
@@ -1154,6 +1388,8 @@ def _adapt_living_pattern_claim(
             else ()
         ),
         recurrence_contract_version=LIVING_CANON_RECURRENCE_VERSION,
+        grouping_signature_version=grouping_version,
+        grouping_identity=grouping_identity,
         projection_state="shadow",
         projection_version=LIVING_CANON_ADAPTER_VERSION,
     )
@@ -1744,6 +1980,21 @@ def canon_claim_inventory_diagnostics(
             if binding.authority_actor
             and not _opaque_actor_valid(binding.authority_actor)
         ),
+        "livingRecurrenceVerifiedCount": sum(
+            1
+            for claim in normalized_claims
+            if claim.canon_status == CanonStatus.LIVING
+            and claim.recurrence_contract_version
+            == LIVING_CANON_RECURRENCE_VERSION
+        ),
+        "livingGroupingVerifiedCount": sum(
+            1
+            for claim in normalized_claims
+            if claim.canon_status == CanonStatus.LIVING
+            and claim.grouping_signature_version
+            == LIVING_CANON_GROUPING_SIGNATURE_VERSION
+            and bool(claim.grouping_identity)
+        ),
         "sourceSystems": tuple(
             sorted({claim.source_system for claim in normalized_claims})
         ),
@@ -1854,6 +2105,10 @@ def _inventory_scoped_lineage_map(
     normalized_table = str(table_name or "").strip()
     columns = _sqlite_table_columns(conn, normalized_table)
     required = {owner_column, root_column}
+    if guild_id is not None:
+        required.add("guild_id")
+    if independent_only:
+        required.add("is_independent")
     normalized_ids = tuple(
         dict.fromkeys(str(value or "").strip() for value in owner_ids)
     )
@@ -1867,10 +2122,10 @@ def _inventory_scoped_lineage_map(
             "%s IN (%s)" % (owner_column, ",".join("?" for _ in chunk))
         ]
         params: list[Any] = list(chunk)
-        if guild_id is not None and "guild_id" in columns:
+        if guild_id is not None:
             where.append("guild_id=?")
             params.append(int(guild_id or 0))
-        if independent_only and "is_independent" in columns:
+        if independent_only:
             where.append("is_independent=1")
         query = (
             "SELECT %s,%s FROM %s WHERE %s ORDER BY %s,%s"
@@ -2314,10 +2569,32 @@ def _build_claim_contract_inventory_in_snapshot(
             "subject_key",
             "predicate_key",
             "normalized_value",
+            "value_digest",
             "visibility",
             "public_usable",
             "candidate_eligible",
+            "live_eligible",
+            "invalidated_reason",
+            "invalidated_at",
+            "lifecycle_schema_version",
+            "conflict_value_count",
+            "review_status",
+            "review_due_at",
+            "eligible_independent_root_count",
+            "reinforcement_count",
+            "lifecycle_reason",
+            "lifecycle_evaluated_at",
             "independent_root_count",
+            "recurrence_contract_version",
+            "grouping_signature_version",
+            "grouping_identity",
+            "canon_domain",
+            "canon_claim_kind",
+            "independent_occurrence_count",
+            "occurrence_ids_json",
+            "recurrence_proof_json",
+            "root_digest",
+            "occurrence_digest",
             "updated_at",
             "last_seen_at",
         ),
@@ -2345,6 +2622,11 @@ def _build_claim_contract_inventory_in_snapshot(
         normalized["root_ids"] = tuple(
             root_map.get(str(normalized.get("candidate_id") or ""), ())
         )
+        normalized["occurrence_ids"] = _strict_json_identity_tuple(
+            normalized.get("occurrence_ids_json")
+        )
+        normalized["domain"] = normalized.get("canon_domain")
+        normalized["claim_kind"] = normalized.get("canon_claim_kind")
         result = adapt_living_atomic_claim(normalized)
         reason_counts[result.reason] += 1
         if result.claim is not None:

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -16,9 +16,11 @@ import os
 import re
 import sqlite3
 from typing import Any, Iterable, Mapping
+import unicodedata
 
 from bnl_canon_source_contract import (
     Confidence,
+    LIVING_CANON_RECURRENCE_VERSION,
     PUBLIC_ASSESSMENT_EVIDENCE_VERSION,
     SourceClass,
     SourceClaim,
@@ -47,6 +49,28 @@ ATOMIC_KNOWLEDGE_LIFECYCLE_SWEEP = "atomic_knowledge_lifecycle_sweep_v1"
 MEMORY_LEDGER_SHADOW_ENV = "BNL_MEMORY_LEDGER_SHADOW_ENABLED"
 CONVERSATION_MOTIF_FORMATION_ENV = (
     "BNL_CONVERSATION_MOTIF_FORMATION_SHADOW_ENABLED"
+)
+LIVING_CANON_V1_FORMATION_ENV = (
+    "BNL_LIVING_CANON_V1_FORMATION_SHADOW_ENABLED"
+)
+LIVING_CANON_GROUPING_SIGNATURE_VERSION = (
+    "living_canon_exact_root_grouping_v1"
+)
+_LIVING_CANON_AUTHORITY_TABLES = frozenset(
+    {
+        "conversations",
+        "bnl_journal_source_events",
+        "memory_ledger_entries",
+        "memory_ledger_lineage",
+        "memory_ledger_participants",
+        "memory_ledger_knowledge_candidates",
+        "memory_ledger_knowledge_roots",
+        "memory_ledger_knowledge_participants",
+        "memory_ledger_conversation_motif_fences",
+        "memory_moment_windows",
+        "memory_moment_members",
+        "memory_moment_participants",
+    }
 )
 BNL_SUBJECT_KEY = "bnl_01"
 BNL_SELF_NAME_PREDICATE_PREFIX = "bnl_self_name:"
@@ -545,6 +569,10 @@ _CONVERSATION_CORRECTION_MAX_SCAN = 40
 _CONVERSATION_MOTIF_MAX_SCAN = 1200
 _CONVERSATION_MOTIF_MAX_CANDIDATES = 6
 _CONVERSATION_MOTIF_MAX_ROOTS = 12
+_CONVERSATION_MOTIF_NEUTRAL_PREFIX = "conversation_motif_neutral_"
+_CONVERSATION_MOTIF_NEUTRAL_FENCE_WILDCARD = (
+    "conversation_motif_neutral_*"
+)
 _CONVERSATION_MOTIF_PUBLIC_POLICIES = frozenset(
     {"public_home", "public_context", "public_selective"}
 )
@@ -1004,6 +1032,28 @@ class AtomicKnowledgeProposal:
     currentness: str = "current"
     contradiction_key: str = ""
     retrieval_tags: tuple[str, ...] = field(default_factory=tuple)
+    recurrence_contract_version: str = ""
+    grouping_signature_version: str = ""
+    grouping_identity: str = ""
+    canon_domain: str = ""
+    canon_claim_kind: str = ""
+    occurrence_ids: tuple[str, ...] = field(default_factory=tuple)
+
+
+_LIVING_CANON_FORMATION_AUTHORITY = object()
+
+
+@dataclass(frozen=True)
+class _LivingCanonFormationReceipt:
+    """Unforgeable process-local authority minted by the formation owner."""
+
+    authority: object
+
+
+def _living_canon_formation_receipt() -> _LivingCanonFormationReceipt:
+    return _LivingCanonFormationReceipt(
+        authority=_LIVING_CANON_FORMATION_AUTHORITY,
+    )
 
 
 @dataclass(frozen=True)
@@ -1018,6 +1068,32 @@ class AtomicKnowledgeResult:
         return self.outcome in {"created", "matched_existing"} and bool(
             self.candidate_id
         )
+
+
+@dataclass(frozen=True)
+class LivingCanonDryRunReport:
+    """Content-free result from the read-only PR4 recurrence analyzer."""
+
+    recurrence_contract_version: str = LIVING_CANON_RECURRENCE_VERSION
+    grouping_signature_version: str = LIVING_CANON_GROUPING_SIGNATURE_VERSION
+    proposed_count: int = 0
+    skipped_count: int = 0
+    ambiguous_count: int = 0
+    rejected_count: int = 0
+    candidate_state_counts: tuple[tuple[str, int], ...] = ()
+    reason_counts: tuple[tuple[str, int], ...] = ()
+    independent_root_count: int = 0
+    independent_occurrence_count: int = 0
+    collapsed_root_count: int = 0
+    bounds: tuple[tuple[str, int], ...] = (
+        ("eligible_ledger_scan_max", _CONVERSATION_MOTIF_MAX_SCAN),
+        ("motif_candidates_max", _CONVERSATION_MOTIF_MAX_CANDIDATES),
+        ("retained_roots_max", _CONVERSATION_MOTIF_MAX_ROOTS),
+        ("occurrence_lookback_max", _CONVERSATION_OCCURRENCE_MAX_SCAN),
+        ("idle_boundary_seconds", _CONVERSATION_MOTIF_WINDOW_SECONDS),
+    )
+    source_write_count: int = 0
+    write_occurred: bool = False
 
 
 @dataclass(frozen=True)
@@ -1135,6 +1211,38 @@ def conversation_motif_formation_enabled(
     }
 
 
+def living_canon_v1_formation_enabled(
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """Require an explicit shadow gate for the PR4 recurrence contract."""
+
+    env = os.environ if environ is None else environ
+    if not shadow_enabled(dict(env)):
+        return False
+    return str(env.get(LIVING_CANON_V1_FORMATION_ENV, "")).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+        "enabled",
+    }
+
+
+def _living_canon_main_authority_unshadowed(
+    conn: sqlite3.Connection,
+) -> bool:
+    """Reject PR4 evaluation when TEMP can shadow an authority table."""
+
+    placeholders = ",".join("?" for _name in _LIVING_CANON_AUTHORITY_TABLES)
+    return not bool(
+        conn.execute(
+            "SELECT 1 FROM temp.sqlite_master WHERE type='table' "
+            "AND name IN (%s) LIMIT 1" % placeholders,
+            tuple(sorted(_LIVING_CANON_AUTHORITY_TABLES)),
+        ).fetchone()
+    )
+
+
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -1219,7 +1327,7 @@ def current_bnl_self_name_records(
     table_names = {
         str(row[0] or "")
         for row in conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table'"
+            "SELECT name FROM main.sqlite_master WHERE type='table'"
         ).fetchall()
     }
     conversation_columns = (
@@ -1416,7 +1524,7 @@ def record_bnl_self_name_decision(
     source_entry_row = conn.execute(
         """
         SELECT entry_id
-        FROM memory_ledger_entries
+        FROM main.memory_ledger_entries
         WHERE guild_id=? AND source_table='conversations'
           AND source_row_id=? AND source_role='user'
         ORDER BY created_at,entry_id
@@ -1724,6 +1832,16 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
             review_status TEXT NOT NULL DEFAULT 'not_evaluated',
             review_due_at TEXT DEFAULT '',
             lifecycle_evaluated_at TEXT DEFAULT '',
+            recurrence_contract_version TEXT DEFAULT '',
+            grouping_signature_version TEXT DEFAULT '',
+            grouping_identity TEXT DEFAULT '',
+            canon_domain TEXT DEFAULT '',
+            canon_claim_kind TEXT DEFAULT '',
+            independent_occurrence_count INTEGER NOT NULL DEFAULT 0,
+            occurrence_ids_json TEXT NOT NULL DEFAULT '[]',
+            occurrence_digest TEXT DEFAULT '',
+            recurrence_proof_json TEXT NOT NULL DEFAULT '{}',
+            public_usable INTEGER NOT NULL DEFAULT 0,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             UNIQUE(
@@ -1863,6 +1981,16 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
         "ALTER TABLE memory_ledger_knowledge_candidates ADD COLUMN review_status TEXT NOT NULL DEFAULT 'not_evaluated'",
         "ALTER TABLE memory_ledger_knowledge_candidates ADD COLUMN review_due_at TEXT DEFAULT ''",
         "ALTER TABLE memory_ledger_knowledge_candidates ADD COLUMN lifecycle_evaluated_at TEXT DEFAULT ''",
+        "ALTER TABLE memory_ledger_knowledge_candidates ADD COLUMN recurrence_contract_version TEXT DEFAULT ''",
+        "ALTER TABLE memory_ledger_knowledge_candidates ADD COLUMN grouping_signature_version TEXT DEFAULT ''",
+        "ALTER TABLE memory_ledger_knowledge_candidates ADD COLUMN grouping_identity TEXT DEFAULT ''",
+        "ALTER TABLE memory_ledger_knowledge_candidates ADD COLUMN canon_domain TEXT DEFAULT ''",
+        "ALTER TABLE memory_ledger_knowledge_candidates ADD COLUMN canon_claim_kind TEXT DEFAULT ''",
+        "ALTER TABLE memory_ledger_knowledge_candidates ADD COLUMN independent_occurrence_count INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE memory_ledger_knowledge_candidates ADD COLUMN occurrence_ids_json TEXT NOT NULL DEFAULT '[]'",
+        "ALTER TABLE memory_ledger_knowledge_candidates ADD COLUMN occurrence_digest TEXT DEFAULT ''",
+        "ALTER TABLE memory_ledger_knowledge_candidates ADD COLUMN recurrence_proof_json TEXT NOT NULL DEFAULT '{}'",
+        "ALTER TABLE memory_ledger_knowledge_candidates ADD COLUMN public_usable INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE memory_ledger_conversation_motif_fences ADD COLUMN fence_state TEXT NOT NULL DEFAULT 'active'",
         "ALTER TABLE memory_ledger_conversation_motif_fences ADD COLUMN satisfied_at TEXT DEFAULT ''",
     ):
@@ -1903,11 +2031,16 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
         "trg_atomic_knowledge_root_change",
         "trg_atomic_knowledge_participant_delete",
         "trg_atomic_knowledge_lineage_change",
+        "trg_atomic_knowledge_root_delete_v2",
+        "trg_atomic_knowledge_root_change_v2",
+        "trg_atomic_knowledge_participant_delete_v2",
+        "trg_atomic_knowledge_lineage_change_v2",
+        "trg_conversation_motif_fence_source_delete_v1",
     ):
         cur.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
     cur.execute(
         """
-        CREATE TRIGGER IF NOT EXISTS trg_atomic_knowledge_root_delete_v2
+        CREATE TRIGGER IF NOT EXISTS trg_atomic_knowledge_root_delete_v3
         AFTER DELETE ON memory_ledger_entries
         BEGIN
           INSERT OR IGNORE INTO memory_ledger_knowledge_receipts(
@@ -1927,6 +2060,13 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
           UPDATE memory_ledger_knowledge_candidates
           SET normalized_value='',candidate_state='invalidated',
               candidate_eligible=0,live_eligible=0,
+              public_usable=CASE
+                WHEN COALESCE(recurrence_contract_version,'')='living_canon_recurrence_v1'
+                  THEN 0 ELSE public_usable END,
+              recurrence_proof_json=CASE
+                WHEN COALESCE(recurrence_contract_version,'')='living_canon_recurrence_v1'
+                  THEN '{"candidate_eligible":false,"source_eligible":false,"roots_valid":false,"invalidated":true}'
+                ELSE recurrence_proof_json END,
               invalidated_reason='root_deleted',
               invalidated_at=CURRENT_TIMESTAMP,
               lifecycle_reason='root_deleted',review_status='dirty',
@@ -1945,7 +2085,7 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
     )
     cur.execute(
         """
-        CREATE TRIGGER IF NOT EXISTS trg_atomic_knowledge_root_change_v2
+        CREATE TRIGGER IF NOT EXISTS trg_atomic_knowledge_root_change_v3
         AFTER UPDATE OF lifecycle_status,normalized_value,public_usable,
           visibility,source_class,confidence,subject_key,channel_policy,
           route_mode
@@ -2025,6 +2165,13 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
               ELSE 'invalidated'
             END,
             candidate_eligible=0,live_eligible=0,
+            public_usable=CASE
+              WHEN COALESCE(recurrence_contract_version,'')='living_canon_recurrence_v1'
+                THEN 0 ELSE public_usable END,
+            recurrence_proof_json=CASE
+              WHEN COALESCE(recurrence_contract_version,'')='living_canon_recurrence_v1'
+                THEN '{"candidate_eligible":false,"source_eligible":false,"roots_valid":false,"invalidated":true}'
+              ELSE recurrence_proof_json END,
             invalidated_reason=CASE
               WHEN NEW.lifecycle_status IN ('corrected','superseded')
                 THEN 'root_superseded'
@@ -2090,7 +2237,7 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
     )
     cur.execute(
         """
-        CREATE TRIGGER IF NOT EXISTS trg_atomic_knowledge_participant_delete_v2
+        CREATE TRIGGER IF NOT EXISTS trg_atomic_knowledge_participant_delete_v3
         AFTER DELETE ON memory_ledger_participants
         BEGIN
           INSERT OR IGNORE INTO memory_ledger_knowledge_receipts(
@@ -2111,6 +2258,13 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
           UPDATE memory_ledger_knowledge_candidates
           SET normalized_value='',candidate_state='invalidated',
               candidate_eligible=0,live_eligible=0,
+              public_usable=CASE
+                WHEN COALESCE(recurrence_contract_version,'')='living_canon_recurrence_v1'
+                  THEN 0 ELSE public_usable END,
+              recurrence_proof_json=CASE
+                WHEN COALESCE(recurrence_contract_version,'')='living_canon_recurrence_v1'
+                  THEN '{"candidate_eligible":false,"source_eligible":false,"roots_valid":false,"invalidated":true}'
+                ELSE recurrence_proof_json END,
               invalidated_reason='participant_deleted',
               invalidated_at=CURRENT_TIMESTAMP,
               lifecycle_reason='participant_deleted',review_status='dirty',
@@ -2124,7 +2278,7 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
     )
     cur.execute(
         """
-        CREATE TRIGGER IF NOT EXISTS trg_atomic_knowledge_lineage_change_v2
+        CREATE TRIGGER IF NOT EXISTS trg_atomic_knowledge_lineage_change_v3
         AFTER INSERT ON memory_ledger_lineage
         WHEN NEW.lineage_type IN ('correction_of','supersedes','retracts')
         BEGIN
@@ -2161,6 +2315,13 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
               ELSE 'invalidated'
             END,
             candidate_eligible=0,live_eligible=0,
+            public_usable=CASE
+              WHEN COALESCE(recurrence_contract_version,'')='living_canon_recurrence_v1'
+                THEN 0 ELSE public_usable END,
+            recurrence_proof_json=CASE
+              WHEN COALESCE(recurrence_contract_version,'')='living_canon_recurrence_v1'
+                THEN '{"candidate_eligible":false,"source_eligible":false,"roots_valid":false,"invalidated":true}'
+              ELSE recurrence_proof_json END,
             invalidated_reason='root_' || NEW.lineage_type,
             invalidated_at=CURRENT_TIMESTAMP,
             lifecycle_reason='root_' || NEW.lineage_type,
@@ -2175,12 +2336,19 @@ def ensure_memory_ledger_schema(conn: sqlite3.Connection) -> None:
     )
     cur.execute(
         """
-        CREATE TRIGGER IF NOT EXISTS trg_conversation_motif_fence_source_delete_v1
+        CREATE TRIGGER IF NOT EXISTS trg_conversation_motif_fence_source_delete_v2
         AFTER DELETE ON memory_ledger_entries
         BEGIN
           UPDATE memory_ledger_knowledge_candidates
           SET normalized_value='',candidate_state='invalidated',
               candidate_eligible=0,live_eligible=0,
+              public_usable=CASE
+                WHEN COALESCE(recurrence_contract_version,'')='living_canon_recurrence_v1'
+                  THEN 0 ELSE public_usable END,
+              recurrence_proof_json=CASE
+                WHEN COALESCE(recurrence_contract_version,'')='living_canon_recurrence_v1'
+                  THEN '{"candidate_eligible":false,"source_eligible":false,"roots_valid":false,"invalidated":true}'
+                ELSE recurrence_proof_json END,
               invalidated_reason='correction_fence_source_deleted',
               invalidated_at=CURRENT_TIMESTAMP,
               lifecycle_reason='correction_fence_source_deleted',
@@ -2955,10 +3123,16 @@ def _knowledge_candidate_roots(
     conn: sqlite3.Connection,
     candidate: dict[str, Any],
 ) -> tuple[list[dict[str, Any]], int]:
+    living_v1 = bool(
+        str(candidate.get("recurrence_contract_version") or "")
+        == LIVING_CANON_RECURRENCE_VERSION
+    )
+    if living_v1 and not _living_canon_main_authority_unshadowed(conn):
+        return [], 0
     rows = conn.execute(
         """
         SELECT root_entry_id,is_independent,root_status
-        FROM memory_ledger_knowledge_roots
+        FROM main.memory_ledger_knowledge_roots
         WHERE candidate_id=?
         ORDER BY root_entry_id
         """,
@@ -2966,6 +3140,36 @@ def _knowledge_candidate_roots(
     ).fetchall()
     entry_ids = tuple(str(row[0] or "") for row in rows if str(row[0] or ""))
     entries = _knowledge_entry_rows(conn, entry_ids)
+    living_states: dict[str, PublicAssessmentRootState] = {}
+    living_occurrences: dict[str, str] = {}
+    candidate_tags = set(_knowledge_retrieval_tags(candidate))
+    motif_fence = (
+        _conversation_motif_fence_row(
+            conn,
+            guild_id=int(candidate.get("guild_id") or 0),
+            subject_key=str(candidate.get("subject_key") or ""),
+            predicate_key=str(candidate.get("predicate_key") or ""),
+        )
+        if "recurring_public_conversation" in candidate_tags
+        else {}
+    )
+    motif_cutoff = _parse_knowledge_time(
+        motif_fence.get("correction_observed_at")
+    )
+    if living_v1:
+        independent_entry_ids = tuple(
+            str(row[0] or "")
+            for row in rows
+            if bool(row[1]) and str(row[0] or "")
+        )
+        living_states, living_occurrences, _living_reasons = (
+            _living_canon_root_states_and_occurrences(
+                conn,
+                guild_id=int(candidate.get("guild_id") or 0),
+                subject_key=str(candidate.get("subject_key") or ""),
+                entry_ids=independent_entry_ids,
+            )
+        )
     roots: list[dict[str, Any]] = []
     derivative_count = 0
     for entry_id, is_independent, root_status in rows:
@@ -2982,15 +3186,31 @@ def _knowledge_candidate_roots(
             candidate=candidate,
             root=root,
         ):
-            root["evidence_identity"] = _knowledge_evidence_identity(
-                conn,
-                root["entry"],
+            root_observed = _parse_knowledge_time(
+                root["entry"].get("observed_at")
             )
-            root["occurrence_identity"] = _knowledge_occurrence_identity(
-                conn,
-                root["entry"],
-            )
-            candidate_tags = set(_knowledge_retrieval_tags(candidate))
+            if motif_fence and (
+                motif_cutoff is None
+                or root_observed is None
+                or root_observed <= motif_cutoff
+            ):
+                continue
+            if living_v1:
+                state = living_states.get(str(entry_id or ""))
+                occurrence = living_occurrences.get(str(entry_id or ""), "")
+                if state is None or not occurrence:
+                    continue
+                root["evidence_identity"] = state.root_identity
+                root["occurrence_identity"] = occurrence
+            else:
+                root["evidence_identity"] = _knowledge_evidence_identity(
+                    conn,
+                    root["entry"],
+                )
+                root["occurrence_identity"] = _knowledge_occurrence_identity(
+                    conn,
+                    root["entry"],
+                )
             root["reinforcement_identity"] = (
                 root["occurrence_identity"]
                 if "recurring_public_conversation" in candidate_tags
@@ -3161,8 +3381,12 @@ def _knowledge_scope_rows(
           conflict_value_count,consolidated_authority_class,
           consolidated_confidence_class,lifecycle_support_digest,
           lifecycle_reason,review_status,review_due_at,
-          lifecycle_evaluated_at
-        FROM memory_ledger_knowledge_candidates
+          lifecycle_evaluated_at,recurrence_contract_version,
+          grouping_signature_version,grouping_identity,canon_domain,
+          canon_claim_kind,independent_occurrence_count,
+          occurrence_ids_json,occurrence_digest,recurrence_proof_json,
+          public_usable
+        FROM main.memory_ledger_knowledge_candidates
         WHERE guild_id=? AND candidate_type=? AND subject_key=?
           AND predicate_key=? AND contradiction_key=? AND visibility=?
           AND participant_scope_digest=?
@@ -3208,6 +3432,16 @@ def _knowledge_scope_rows(
         "review_status",
         "review_due_at",
         "lifecycle_evaluated_at",
+        "recurrence_contract_version",
+        "grouping_signature_version",
+        "grouping_identity",
+        "canon_domain",
+        "canon_claim_kind",
+        "independent_occurrence_count",
+        "occurrence_ids_json",
+        "occurrence_digest",
+        "recurrence_proof_json",
+        "public_usable",
     )
     return [dict(zip(keys, row)) for row in rows]
 
@@ -3259,6 +3493,13 @@ def _reconcile_atomic_knowledge_scope(
                 candidate.get("participant_scope_digest") or ""
             ),
         )
+        if str(candidate.get("recurrence_contract_version") or ""):
+            consolidation_id = _knowledge_digest(
+                consolidation_id,
+                str(candidate.get("recurrence_contract_version") or ""),
+                str(candidate.get("grouping_signature_version") or ""),
+                str(candidate.get("grouping_identity") or ""),
+            )
         group = groups.setdefault(
             consolidation_id,
             {
@@ -3288,6 +3529,11 @@ def _reconcile_atomic_knowledge_scope(
         group["recurring_public_conversation"] = any(
             "recurring_public_conversation"
             in set(_knowledge_retrieval_tags(candidate))
+            for candidate in group["candidates"]
+        )
+        group["living_canon_v1"] = any(
+            str(candidate.get("recurrence_contract_version") or "")
+            == LIVING_CANON_RECURRENCE_VERSION
             for candidate in group["candidates"]
         )
         motif_fence = (
@@ -3430,13 +3676,20 @@ def _reconcile_atomic_knowledge_scope(
         for consolidation_id, group in groups.items()
         if group["roots"] and not group["stale_retired"]
     }
-    conflict_value_count = len(active_group_ids)
+    for consolidation_id, group in groups.items():
+        group["conflict_value_count"] = sum(
+            1
+            for other_id in active_group_ids
+            if bool(groups[other_id].get("living_canon_v1"))
+            == bool(group.get("living_canon_v1"))
+        )
     changes = 0
     evaluated_at = _knowledge_time(now)
     for consolidation_id, group in groups.items():
         roots = list(group["roots"].values())
         root_count = len(group["roots"])
         reinforcement_count = len(group["evidence"])
+        conflict_value_count = int(group.get("conflict_value_count") or 0)
         duplicate_support_count = max(0, root_count - reinforcement_count)
         supporting_candidate_count = sum(
             1
@@ -3504,8 +3757,12 @@ def _reconcile_atomic_knowledge_scope(
                 bool(group["recurring_public_conversation"])
                 and reinforcement_count < 2
             ):
-                next_state = "invalidated"
-                reason = "recurring_conversation_reinforcement_lost"
+                if bool(group.get("living_canon_v1")) and reinforcement_count == 1:
+                    next_state = "provisional"
+                    reason = "single_occurrence_provisional"
+                else:
+                    next_state = "invalidated"
+                    reason = "recurring_conversation_reinforcement_lost"
             elif conflict_value_count > 1:
                 next_state = "contested"
                 reason = "unresolved_contradiction"
@@ -3537,6 +3794,8 @@ def _reconcile_atomic_knowledge_scope(
                     if bool(group["explicit_correction_source"])
                     else "authoritative_source_established"
                     if bool(group["authoritative_single_source"])
+                    else "independent_recurrence_established"
+                    if bool(group.get("living_canon_v1"))
                     else "independent_reinforcement_established"
                 )
             elif str(candidate.get("epistemic_status") or "") == "inference":
@@ -3667,6 +3926,52 @@ def _reconcile_atomic_knowledge_scope(
                       )
                     """,
                     (evaluated_at, candidate_id),
+                )
+            if str(candidate.get("recurrence_contract_version") or "") == (
+                LIVING_CANON_RECURRENCE_VERSION
+            ):
+                current_occurrence_ids = tuple(
+                    sorted(
+                        {
+                            str(
+                                root.get("reinforcement_identity")
+                                or root.get("occurrence_identity")
+                                or ""
+                            )
+                            for root in roots
+                            if str(
+                                root.get("reinforcement_identity")
+                                or root.get("occurrence_identity")
+                                or ""
+                            )
+                        }
+                    )
+                )
+                current_occurrence_digest = (
+                    _knowledge_digest(*current_occurrence_ids)
+                    if current_occurrence_ids
+                    else ""
+                )
+                conn.execute(
+                    """
+                    UPDATE memory_ledger_knowledge_candidates
+                    SET independent_occurrence_count=?,occurrence_ids_json=?,
+                        occurrence_digest=?
+                    WHERE candidate_id=?
+                    """,
+                    (
+                        len(current_occurrence_ids),
+                        json.dumps(
+                            current_occurrence_ids,
+                            separators=(",", ":"),
+                        ),
+                        current_occurrence_digest,
+                        candidate_id,
+                    ),
+                )
+                _refresh_living_canon_recurrence_proof(
+                    conn,
+                    candidate_id=candidate_id,
                 )
     return {
         "scopes": 1,
@@ -3910,6 +4215,7 @@ def _recurring_motif_candidate_id(
     participant_scope_digest: str,
     root_digest: str,
     fallback_candidate_id: str,
+    recurrence_contract_version: str = "",
 ) -> str:
     """Reuse one nonterminal recurring-motif identity across root refreshes."""
     rows = conn.execute(
@@ -3920,6 +4226,7 @@ def _recurring_motif_candidate_id(
         WHERE guild_id=? AND candidate_type='topic_or_motif'
           AND subject_key=? AND predicate_key=? AND contradiction_key=?
           AND visibility=? AND participant_scope_digest=?
+          AND COALESCE(recurrence_contract_version,'')=?
           AND retrieval_tags_json LIKE '%recurring_public_conversation%'
         ORDER BY created_at,candidate_id
         """,
@@ -3930,6 +4237,7 @@ def _recurring_motif_candidate_id(
             str(contradiction_key or ""),
             str(visibility or ""),
             str(participant_scope_digest or ""),
+            str(recurrence_contract_version or ""),
         ),
     ).fetchall()
     # An exact legacy row must win even if terminal; otherwise the candidate
@@ -3961,6 +4269,22 @@ def _recurring_motif_candidate_id(
         )
     ]
     if not refreshable:
+        if rows and str(recurrence_contract_version or ""):
+            terminal_fingerprint = _knowledge_digest(
+                "living_canon_terminal_generations_v1",
+                str(fallback_candidate_id or ""),
+                *tuple(
+                    "%s:%s:%s:%s"
+                    % (
+                        str(row[0] or ""),
+                        str(row[1] or ""),
+                        str(row[2] or ""),
+                        str(row[3] or ""),
+                    )
+                    for row in rows
+                ),
+            )
+            return "mlkc_" + terminal_fingerprint[:40]
         return fallback_candidate_id
     refreshable.sort(
         key=lambda row: (
@@ -3972,16 +4296,153 @@ def _recurring_motif_candidate_id(
     return str(refreshable[0][0] or fallback_candidate_id)
 
 
+def _store_living_canon_contract(
+    conn: sqlite3.Connection,
+    *,
+    candidate_id: str,
+    recurrence_contract_version: str,
+    grouping_signature_version: str,
+    grouping_identity: str,
+    canon_domain: str,
+    canon_claim_kind: str,
+    occurrence_ids: tuple[str, ...],
+    occurrence_digest: str,
+) -> None:
+    """Store only formation-owner-minted recurrence metadata."""
+
+    conn.execute(
+        """
+        UPDATE main.memory_ledger_knowledge_candidates
+        SET recurrence_contract_version=?,grouping_signature_version=?,
+            grouping_identity=?,canon_domain=?,canon_claim_kind=?,
+            independent_occurrence_count=?,occurrence_ids_json=?,
+            occurrence_digest=?,recurrence_proof_json='{}',public_usable=0,
+            updated_at=?
+        WHERE candidate_id=?
+        """,
+        (
+            recurrence_contract_version,
+            grouping_signature_version,
+            grouping_identity,
+            canon_domain,
+            canon_claim_kind,
+            len(occurrence_ids),
+            json.dumps(occurrence_ids, separators=(",", ":")),
+            occurrence_digest,
+            _now(),
+            str(candidate_id or ""),
+        ),
+    )
+
+
+def _refresh_living_canon_recurrence_proof(
+    conn: sqlite3.Connection,
+    *,
+    candidate_id: str,
+) -> None:
+    """Mirror current lifecycle state into a strict content-free proof."""
+
+    row = conn.execute(
+        """
+        SELECT candidate_state,candidate_eligible,invalidated_reason,
+               eligible_independent_root_count,conflict_value_count,root_digest,
+               recurrence_contract_version,grouping_signature_version,
+               grouping_identity,canon_domain,canon_claim_kind,
+               independent_occurrence_count,occurrence_ids_json,
+               occurrence_digest
+        FROM main.memory_ledger_knowledge_candidates WHERE candidate_id=?
+        """,
+        (str(candidate_id or ""),),
+    ).fetchone()
+    if not row:
+        return
+    (
+        candidate_state,
+        candidate_eligible,
+        invalidated_reason,
+        independent_root_count,
+        conflict_value_count,
+        root_digest,
+        recurrence_contract_version,
+        grouping_signature_version,
+        grouping_identity,
+        _canon_domain,
+        _canon_claim_kind,
+        independent_occurrence_count,
+        occurrence_ids_json,
+        occurrence_digest,
+    ) = row
+    if str(recurrence_contract_version or "") != LIVING_CANON_RECURRENCE_VERSION:
+        return
+    correction_fence_clear = not str(invalidated_reason or "").startswith(
+        "conversation_motif_correction"
+    )
+    contradiction_clear = bool(
+        int(conflict_value_count or 0) <= 1
+        and str(candidate_state or "") != "contested"
+    )
+    proof = {
+        "recurrence_contract_version": str(recurrence_contract_version or ""),
+        "grouping_signature_version": str(grouping_signature_version or ""),
+        "grouping_identity": str(grouping_identity or ""),
+        "candidate_state": str(candidate_state or ""),
+        "candidate_eligible": bool(candidate_eligible),
+        "source_eligible": True,
+        "roots_valid": bool(int(independent_root_count or 0) > 0),
+        "occurrence_bounded": bool(int(independent_occurrence_count or 0) > 0),
+        "correction_fence_clear": correction_fence_clear,
+        "contradiction_clear": contradiction_clear,
+        "independent_root_count": int(independent_root_count or 0),
+        "independent_occurrence_count": int(independent_occurrence_count or 0),
+        "root_digest": str(root_digest or ""),
+        "occurrence_digest": str(occurrence_digest or ""),
+        "bounds": {
+            "eligible_ledger_scan_max": _CONVERSATION_MOTIF_MAX_SCAN,
+            "motif_candidates_max": _CONVERSATION_MOTIF_MAX_CANDIDATES,
+            "retained_roots_max": _CONVERSATION_MOTIF_MAX_ROOTS,
+            "occurrence_lookback_max": _CONVERSATION_OCCURRENCE_MAX_SCAN,
+            "idle_boundary_seconds": _CONVERSATION_MOTIF_WINDOW_SECONDS,
+        },
+    }
+    established_public = bool(
+        str(candidate_state or "") == "established"
+        and bool(candidate_eligible)
+        and int(independent_root_count or 0) >= 2
+        and int(independent_occurrence_count or 0) >= 2
+        and correction_fence_clear
+        and contradiction_clear
+    )
+    conn.execute(
+        """
+        UPDATE main.memory_ledger_knowledge_candidates
+        SET recurrence_proof_json=?,public_usable=?,updated_at=?
+        WHERE candidate_id=?
+        """,
+        (
+            json.dumps(proof, sort_keys=True, separators=(",", ":")),
+            int(established_public),
+            _now(),
+            str(candidate_id or ""),
+        ),
+    )
+
+
 def form_atomic_knowledge_candidate(
     conn: sqlite3.Connection,
     proposal: AtomicKnowledgeProposal,
+    *,
+    _living_formation_receipt: _LivingCanonFormationReceipt | None = None,
 ) -> AtomicKnowledgeResult:
     """Atomically form one candidate without owning the caller transaction."""
     ensure_memory_ledger_schema(conn)
     savepoint = f"atomic_knowledge_{id(proposal):x}"
     conn.execute(f"SAVEPOINT {savepoint}")
     try:
-        result = _form_atomic_knowledge_candidate_impl(conn, proposal)
+        result = _form_atomic_knowledge_candidate_impl(
+            conn,
+            proposal,
+            _living_formation_receipt=_living_formation_receipt,
+        )
     except Exception:
         conn.execute(f"ROLLBACK TO {savepoint}")
         conn.execute(f"RELEASE {savepoint}")
@@ -3993,6 +4454,8 @@ def form_atomic_knowledge_candidate(
 def _form_atomic_knowledge_candidate_impl(
     conn: sqlite3.Connection,
     proposal: AtomicKnowledgeProposal,
+    *,
+    _living_formation_receipt: _LivingCanonFormationReceipt | None = None,
 ) -> AtomicKnowledgeResult:
     """Create one unpromoted candidate from exact revalidated Ledger roots."""
     candidate_type = _canon(proposal.candidate_type)
@@ -4019,6 +4482,78 @@ def _form_atomic_knowledge_candidate_impl(
     )
     all_ids = tuple(sorted(set(independent_ids + derivative_ids)))
     guild_hint = 0
+    recurrence_contract_version = str(
+        proposal.recurrence_contract_version or ""
+    ).strip()
+    grouping_signature_version = str(
+        proposal.grouping_signature_version or ""
+    ).strip()
+    grouping_identity = str(proposal.grouping_identity or "").strip()
+    canon_domain = _knowledge_tag(proposal.canon_domain)
+    canon_claim_kind = _knowledge_tag(proposal.canon_claim_kind)
+    occurrence_ids = tuple(
+        sorted(
+            {
+                str(identity or "").strip()
+                for identity in proposal.occurrence_ids
+                if str(identity or "").strip()
+            }
+        )
+    )
+    living_contract_requested = any(
+        (
+            recurrence_contract_version,
+            grouping_signature_version,
+            grouping_identity,
+            canon_domain,
+            canon_claim_kind,
+            occurrence_ids,
+        )
+    )
+    living_authorized = bool(
+        _living_formation_receipt is not None
+        and _living_formation_receipt.authority
+        is _LIVING_CANON_FORMATION_AUTHORITY
+    )
+    if living_contract_requested and not living_authorized:
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_hint,
+            reason_code="living_canon_formation_authority_missing",
+            root_entry_ids=all_ids,
+        )
+    if living_authorized and not _living_canon_main_authority_unshadowed(conn):
+        return AtomicKnowledgeResult(
+            outcome="rejected",
+            reason_code="living_canon_authority_shadowed",
+            candidate_type=str(proposal.candidate_type or ""),
+            root_count=len(all_ids),
+        )
+    if living_authorized and (
+        recurrence_contract_version != LIVING_CANON_RECURRENCE_VERSION
+        or grouping_signature_version
+        != LIVING_CANON_GROUPING_SIGNATURE_VERSION
+        or not re.fullmatch(r"[0-9a-f]{64}", grouping_identity)
+        or grouping_identity
+        != _knowledge_digest(
+            LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+            subject_key,
+            predicate_key,
+            canon_domain,
+        )
+        or canon_domain not in {"real_community", "lore", "hybrid"}
+        or canon_claim_kind not in {"behavior_pattern", "tradition_or_joke"}
+        or not occurrence_ids
+        or len(occurrence_ids) > _CONVERSATION_MOTIF_MAX_ROOTS
+    ):
+        return _reject_atomic_knowledge(
+            conn,
+            proposal,
+            guild_id=guild_hint,
+            reason_code="living_canon_contract_invalid",
+            root_entry_ids=all_ids,
+        )
     if candidate_type not in KNOWLEDGE_CANDIDATE_TYPES:
         return _reject_atomic_knowledge(
             conn,
@@ -4125,6 +4660,62 @@ def _form_atomic_knowledge_candidate_impl(
     guild_hint = guild_id
     independent_entries = [entries[entry_id] for entry_id in independent_ids]
     derivative_entries = [entries[entry_id] for entry_id in derivative_ids]
+
+    living_root_states: dict[str, PublicAssessmentRootState] = {}
+    living_occurrences: dict[str, str] = {}
+    if living_authorized:
+        if (
+            candidate_type != "topic_or_motif"
+            or proposal.epistemic_status != "observed"
+            or derivative_ids
+            or not subject_key.startswith("discord_user:")
+        ):
+            return _reject_atomic_knowledge(
+                conn,
+                proposal,
+                guild_id=guild_id,
+                reason_code="living_canon_claim_kind_ineligible",
+                root_entry_ids=all_ids,
+            )
+        (
+            living_root_states,
+            living_occurrences,
+            living_reasons,
+        ) = _living_canon_root_states_and_occurrences(
+            conn,
+            guild_id=guild_id,
+            subject_key=subject_key,
+            entry_ids=independent_ids,
+        )
+        if any(entry_id not in living_root_states for entry_id in independent_ids):
+            return _reject_atomic_knowledge(
+                conn,
+                proposal,
+                guild_id=guild_id,
+                reason_code=(
+                    living_reasons[0]
+                    if living_reasons
+                    else "source_ineligible"
+                ),
+                root_entry_ids=all_ids,
+            )
+        recomputed_occurrences = tuple(
+            sorted(
+                {
+                    str(living_occurrences.get(entry_id) or "")
+                    for entry_id in independent_ids
+                    if str(living_occurrences.get(entry_id) or "")
+                }
+            )
+        )
+        if not recomputed_occurrences or recomputed_occurrences != occurrence_ids:
+            return _reject_atomic_knowledge(
+                conn,
+                proposal,
+                guild_id=guild_id,
+                reason_code="living_canon_occurrence_proof_mismatch",
+                root_entry_ids=all_ids,
+            )
 
     if any(
         entry.get("source_class") == SourceClass.LEGACY_SOURCE_BLIND.value
@@ -4401,14 +4992,33 @@ def _form_atomic_knowledge_candidate_impl(
         separators=(",", ":"),
     )
     root_digest = _knowledge_digest(*independent_ids)
+    occurrence_digest = (
+        _knowledge_digest(*occurrence_ids) if living_authorized else ""
+    )
     participant_scope_digest = _knowledge_digest(*participants)
-    candidate_id = _stable_knowledge_candidate_id(
-        guild_id=guild_id,
-        candidate_type=candidate_type,
-        subject_key=subject_key,
-        predicate_key=predicate_key,
-        contradiction_key=contradiction_key,
-        root_entry_ids=independent_ids,
+    candidate_id = (
+        "mlkc_"
+        + _knowledge_digest(
+            ATOMIC_KNOWLEDGE_SCHEMA_VERSION,
+            LIVING_CANON_RECURRENCE_VERSION,
+            grouping_identity,
+            int(guild_id or 0),
+            candidate_type,
+            subject_key,
+            predicate_key,
+            contradiction_key,
+            visibility,
+            participant_scope_digest,
+        )[:40]
+        if living_authorized
+        else _stable_knowledge_candidate_id(
+            guild_id=guild_id,
+            candidate_type=candidate_type,
+            subject_key=subject_key,
+            predicate_key=predicate_key,
+            contradiction_key=contradiction_key,
+            root_entry_ids=independent_ids,
+        )
     )
     recurring_public_conversation = bool(
         candidate_type == "topic_or_motif"
@@ -4425,6 +5035,7 @@ def _form_atomic_knowledge_candidate_impl(
             participant_scope_digest=participant_scope_digest,
             root_digest=root_digest,
             fallback_candidate_id=candidate_id,
+            recurrence_contract_version=recurrence_contract_version,
         )
     value_digest = _knowledge_digest(_canon(meaning))
     first_seen = min(
@@ -4581,10 +5192,27 @@ def _form_atomic_knowledge_candidate_impl(
             root_entry_ids=all_ids,
             proposal_digest=value_digest,
         )
+        if living_authorized:
+            _store_living_canon_contract(
+                conn,
+                candidate_id=candidate_id,
+                recurrence_contract_version=recurrence_contract_version,
+                grouping_signature_version=grouping_signature_version,
+                grouping_identity=grouping_identity,
+                canon_domain=canon_domain,
+                canon_claim_kind=canon_claim_kind,
+                occurrence_ids=occurrence_ids,
+                occurrence_digest=occurrence_digest,
+            )
         reconcile_atomic_knowledge_lifecycle(
             conn,
             candidate_ids=(candidate_id,),
         )
+        if living_authorized:
+            _refresh_living_canon_recurrence_proof(
+                conn,
+                candidate_id=candidate_id,
+            )
         return AtomicKnowledgeResult(
             candidate_id,
             "matched_existing",
@@ -4728,6 +5356,18 @@ def _form_atomic_knowledge_candidate_impl(
         derivation_paths=derivation_paths,
         now=now,
     )
+    if living_authorized:
+        _store_living_canon_contract(
+            conn,
+            candidate_id=candidate_id,
+            recurrence_contract_version=recurrence_contract_version,
+            grouping_signature_version=grouping_signature_version,
+            grouping_identity=grouping_identity,
+            canon_domain=canon_domain,
+            canon_claim_kind=canon_claim_kind,
+            occurrence_ids=occurrence_ids,
+            occurrence_digest=occurrence_digest,
+        )
 
     for superseded_id in explicitly_superseded:
         conn.execute(
@@ -4791,6 +5431,11 @@ def _form_atomic_knowledge_candidate_impl(
         conn,
         candidate_ids=(candidate_id,),
     )
+    if living_authorized:
+        _refresh_living_canon_recurrence_proof(
+            conn,
+            candidate_id=candidate_id,
+        )
     return AtomicKnowledgeResult(
         candidate_id,
         event_type,
@@ -4979,6 +5624,165 @@ def _conversation_motif_family_matches(
     )
 
 
+_CONVERSATION_MOTIF_EXACT_TOKEN_RE = re.compile(
+    r"[a-z0-9]+(?:['’][a-z0-9]+)?",
+    re.I,
+)
+_CONVERSATION_MOTIF_EXACT_REFERENCE_RE = re.compile(
+    r"\b(?:this|that|these|those|same|above|earlier|previous|latter)\b",
+    re.I,
+)
+_CONVERSATION_MOTIF_EXACT_DROP = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "am",
+        "are",
+        "be",
+        "been",
+        "being",
+        "is",
+        "was",
+        "were",
+        "really",
+        "just",
+    }
+)
+
+
+def _conversation_motif_exact_inflection(value: str) -> str:
+    token = str(value or "")
+    if len(token) > 5 and token.endswith("ies"):
+        return token[:-3] + "y"
+    if len(token) > 5 and token.endswith(("ches", "shes", "sses", "xes", "zes")):
+        return token[:-2]
+    if len(token) > 5 and token.endswith("ing"):
+        base = token[:-3]
+        if len(base) >= 3 and base[-1:] == base[-2:-1] and base[-1] != "s":
+            base = base[:-1]
+        return base
+    if len(token) > 4 and token.endswith("ed"):
+        return token[:-2]
+    if (
+        len(token) > 3
+        and token.endswith("s")
+        and not token.endswith(("is", "ous", "ss", "us"))
+    ):
+        return token[:-1]
+    return token
+
+
+def _conversation_motif_exact_signature(value: str) -> tuple[str, ...]:
+    """Return one conservative ordered signature for an authoritative root."""
+
+    source_text = re.sub(r"\s+", " ", str(value or "")).strip()
+    if (
+        not _conversation_motif_terms(source_text)
+        or _CONVERSATION_MOTIF_EXACT_REFERENCE_RE.search(source_text)
+    ):
+        return ()
+    normalized = unicodedata.normalize("NFKC", source_text).casefold()
+    normalized = normalized.replace("’", "'")
+    tokens = list(_CONVERSATION_MOTIF_EXACT_TOKEN_RE.findall(normalized))
+    signature: list[str] = []
+    leading_actor = True
+    for token in tokens:
+        if token in _CONVERSATION_MOTIF_EXACT_DROP:
+            continue
+        if leading_actor and token in {"i", "we"}:
+            continue
+        leading_actor = False
+        signature.append(_conversation_motif_exact_inflection(token))
+    if not 3 <= len(signature) <= 32:
+        return ()
+    return tuple(signature)
+
+
+def _conversation_motif_neutral_predicate(
+    signature: tuple[str, ...],
+    *,
+    subject_key: str,
+) -> str:
+    if not signature or not str(subject_key or ""):
+        return ""
+    return "%s%s" % (
+        _CONVERSATION_MOTIF_NEUTRAL_PREFIX,
+        _knowledge_digest(
+            LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+            str(subject_key or ""),
+            "real_community",
+            *signature,
+        )[:20],
+    )
+
+
+def _conversation_motif_neutral_groups(
+    entries: list[dict[str, Any]],
+    *,
+    subject_key: str,
+    diagnostics: dict[str, int] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Group only identical ordered signatures; ambiguous bags fail closed."""
+
+    grouped: dict[tuple[str, ...], list[dict[str, Any]]] = {}
+    for entry in entries:
+        signature = _conversation_motif_exact_signature(
+            str(entry.get("validated_text") or entry.get("normalized_value") or "")
+        )
+        if not signature:
+            if diagnostics is not None:
+                diagnostics["meaning_ambiguous_review_only"] = int(
+                    diagnostics.get("meaning_ambiguous_review_only", 0) or 0
+                ) + 1
+            continue
+        grouped.setdefault(signature, []).append(entry)
+    bag_orders: dict[tuple[str, ...], set[tuple[str, ...]]] = {}
+    for signature in grouped:
+        bag_orders.setdefault(tuple(sorted(signature)), set()).add(signature)
+    ambiguous = {
+        signature
+        for signatures in bag_orders.values()
+        if len(signatures) > 1
+        for signature in signatures
+    }
+    if ambiguous and diagnostics is not None:
+        diagnostics["meaning_ambiguous_review_only"] = int(
+            diagnostics.get("meaning_ambiguous_review_only", 0) or 0
+        ) + len(ambiguous)
+    result: dict[str, dict[str, Any]] = {}
+    for signature, signature_entries in sorted(
+        grouped.items(),
+        key=lambda item: (
+            -len({str(row.get("occurrence_identity") or "") for row in item[1]}),
+            item[0],
+        ),
+    ):
+        if signature in ambiguous:
+            continue
+        predicate = _conversation_motif_neutral_predicate(
+            signature,
+            subject_key=str(subject_key or ""),
+        )
+        if not predicate:
+            continue
+        result["neutral:%s" % predicate] = {
+            "predicate": predicate,
+            "label": " ".join(signature),
+            "entries": list(signature_entries),
+            "tags": (
+                "family_neutral",
+                "recurring_public_conversation",
+                LIVING_CANON_RECURRENCE_VERSION,
+                LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+            ),
+            "neutral": True,
+            "living_v1": True,
+            "signature": signature,
+        }
+    return result
+
+
 def _conversation_motif_predicates_for_values(
     values: Iterable[str],
 ) -> tuple[str, ...]:
@@ -5019,29 +5823,104 @@ def _conversation_motif_fence_row(
     guild_id: int,
     subject_key: str,
     predicate_key: str,
+    fence_overrides: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> dict[str, str]:
-    row = conn.execute(
+    requested_predicate = str(predicate_key or "")
+    include_neutral_wildcard = bool(
+        requested_predicate.startswith(_CONVERSATION_MOTIF_NEUTRAL_PREFIX)
+        and requested_predicate != _CONVERSATION_MOTIF_NEUTRAL_FENCE_WILDCARD
+    )
+    rows = conn.execute(
         """
         SELECT correction_entry_id,correction_observed_at,reason_code,
-               fence_state,satisfied_at
-        FROM memory_ledger_conversation_motif_fences
-        WHERE guild_id=? AND subject_key=? AND predicate_key=?
+               fence_state,satisfied_at,predicate_key
+        FROM main.memory_ledger_conversation_motif_fences
+        WHERE guild_id=? AND subject_key=?
+          AND (
+            predicate_key=?
+            OR (?=1 AND predicate_key='conversation_motif_neutral_*')
+          )
+        ORDER BY predicate_key
         """,
         (
             int(guild_id or 0),
             str(subject_key or ""),
-            str(predicate_key or ""),
+            requested_predicate,
+            int(include_neutral_wildcard),
         ),
-    ).fetchone()
-    if not row:
-        return {}
-    return {
-        "correction_entry_id": str(row[0] or ""),
-        "correction_observed_at": str(row[1] or ""),
-        "reason_code": str(row[2] or ""),
-        "fence_state": str(row[3] or "active"),
-        "satisfied_at": str(row[4] or ""),
+    ).fetchall()
+    by_predicate = {
+        str(row[5] or ""): {
+            "correction_entry_id": str(row[0] or ""),
+            "correction_observed_at": str(row[1] or ""),
+            "reason_code": str(row[2] or ""),
+            "fence_state": str(row[3] or "active"),
+            "satisfied_at": str(row[4] or ""),
+            "predicate_key": str(row[5] or ""),
+        }
+        for row in rows
+        if str(row[5] or "")
     }
+    allowed_override_predicates = {requested_predicate}
+    if include_neutral_wildcard:
+        allowed_override_predicates.add(
+            _CONVERSATION_MOTIF_NEUTRAL_FENCE_WILDCARD
+        )
+    for override_predicate, override in (fence_overrides or {}).items():
+        normalized_predicate = str(override_predicate or "")
+        if normalized_predicate in allowed_override_predicates and override:
+            by_predicate[normalized_predicate] = {
+                "correction_entry_id": str(
+                    override.get("correction_entry_id") or ""
+                ),
+                "correction_observed_at": str(
+                    override.get("correction_observed_at") or ""
+                ),
+                "reason_code": str(override.get("reason_code") or ""),
+                "fence_state": str(
+                    override.get("fence_state") or "active"
+                ),
+                "satisfied_at": str(override.get("satisfied_at") or ""),
+                "predicate_key": normalized_predicate,
+            }
+    exact = by_predicate.get(requested_predicate)
+    wildcard = by_predicate.get(_CONVERSATION_MOTIF_NEUTRAL_FENCE_WILDCARD)
+    row = exact or wildcard
+    if wildcard and str(wildcard.get("fence_state") or "active") == "active":
+        exact_satisfies_wildcard = bool(
+            exact
+            and str(exact.get("fence_state") or "") == "satisfied"
+            and str(exact.get("correction_entry_id") or "")
+            == str(wildcard.get("correction_entry_id") or "")
+            and _parse_knowledge_time(exact.get("satisfied_at")) is not None
+            and _parse_knowledge_time(
+                wildcard.get("correction_observed_at")
+            )
+            is not None
+            and _parse_knowledge_time(exact.get("satisfied_at"))
+            > _parse_knowledge_time(wildcard.get("correction_observed_at"))
+        )
+        if not exact_satisfies_wildcard:
+            if (
+                exact
+                and str(exact.get("fence_state") or "active") == "active"
+                and _parse_knowledge_time(
+                    exact.get("correction_observed_at")
+                )
+                is not None
+                and _parse_knowledge_time(
+                    wildcard.get("correction_observed_at")
+                )
+                is not None
+                and _parse_knowledge_time(exact.get("correction_observed_at"))
+                > _parse_knowledge_time(wildcard.get("correction_observed_at"))
+            ):
+                row = exact
+            else:
+                row = wildcard
+    if row is None:
+        return {}
+    return dict(row)
 
 
 def _conversation_motif_entries_after_fence(
@@ -5051,12 +5930,14 @@ def _conversation_motif_entries_after_fence(
     subject_key: str,
     predicate_key: str,
     entries: list[dict[str, Any]],
+    fence_overrides: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, str]]:
     fence = _conversation_motif_fence_row(
         conn,
         guild_id=guild_id,
         subject_key=subject_key,
         predicate_key=predicate_key,
+        fence_overrides=fence_overrides,
     )
     if not fence:
         return entries, {}
@@ -5082,23 +5963,42 @@ def _withhold_conversation_motif_candidates(
 ) -> None:
     if not predicate_keys:
         return
-    placeholders = ",".join("?" for _predicate in predicate_keys)
+    wildcard_neutral = _CONVERSATION_MOTIF_NEUTRAL_FENCE_WILDCARD in set(
+        predicate_keys
+    )
+    exact_predicates = tuple(
+        predicate
+        for predicate in predicate_keys
+        if predicate != _CONVERSATION_MOTIF_NEUTRAL_FENCE_WILDCARD
+    )
+    predicate_clauses: list[str] = []
+    predicate_params: list[str] = []
+    if exact_predicates:
+        predicate_clauses.append(
+            "predicate_key IN (%s)"
+            % ",".join("?" for _predicate in exact_predicates)
+        )
+        predicate_params.extend(exact_predicates)
+    if wildcard_neutral:
+        predicate_clauses.append("predicate_key LIKE 'conversation_motif_neutral_%'")
+    if not predicate_clauses:
+        return
     candidate_ids = tuple(
         str(row[0] or "")
         for row in conn.execute(
             f"""
             SELECT candidate_id
-            FROM memory_ledger_knowledge_candidates
+            FROM main.memory_ledger_knowledge_candidates
             WHERE guild_id=? AND subject_key=?
               AND candidate_type='topic_or_motif'
-              AND predicate_key IN ({placeholders})
+              AND ({' OR '.join(predicate_clauses)})
               AND retrieval_tags_json LIKE '%recurring_public_conversation%'
             ORDER BY candidate_id
             """,
             (
                 int(guild_id or 0),
                 str(subject_key or ""),
-                *predicate_keys,
+                *predicate_params,
             ),
         ).fetchall()
         if str(row[0] or "")
@@ -5111,13 +6011,23 @@ def _withhold_conversation_motif_candidates(
     )
     conn.execute(
         f"""
-        UPDATE memory_ledger_knowledge_candidates
+        UPDATE main.memory_ledger_knowledge_candidates
         SET candidate_state=CASE
               WHEN candidate_state IN ('superseded','retired','invalidated')
                 THEN candidate_state
               ELSE 'contested'
             END,
             candidate_eligible=0,live_eligible=0,
+            public_usable=CASE
+              WHEN COALESCE(recurrence_contract_version,'')=?
+                THEN 0
+              ELSE public_usable
+            END,
+            recurrence_proof_json=CASE
+              WHEN COALESCE(recurrence_contract_version,'')=?
+                THEN '{{"candidate_eligible":false,"source_eligible":false,"roots_valid":false,"correction_fence_clear":false,"invalidated":true}}'
+              ELSE recurrence_proof_json
+            END,
             invalidated_reason=CASE
               WHEN candidate_state IN ('superseded','retired','invalidated')
                 THEN invalidated_reason
@@ -5138,6 +6048,8 @@ def _withhold_conversation_motif_candidates(
         WHERE candidate_id IN ({candidate_placeholders})
         """,
         (
+            LIVING_CANON_RECURRENCE_VERSION,
+            LIVING_CANON_RECURRENCE_VERSION,
             reason_code,
             now,
             reason_code,
@@ -5161,13 +6073,16 @@ def _withhold_conversation_motif_candidates(
         )
 
 
-def _upsert_conversation_motif_correction_fences(
+def _conversation_motif_correction_predicates(
     conn: sqlite3.Connection,
     *,
-    correction_entry: dict[str, Any],
+    correction_entry: Mapping[str, Any],
     related_entry_ids: tuple[str, ...],
     reason_code: str,
+    include_neutral: bool = False,
 ) -> tuple[str, ...]:
+    """Return the deterministic finite predicates affected by a correction."""
+
     related = _knowledge_entry_rows(
         conn,
         tuple(
@@ -5187,7 +6102,48 @@ def _upsert_conversation_motif_correction_fences(
             for entry in related.values()
         ),
     ]
-    predicate_keys = _conversation_motif_predicates_for_values(values)
+    predicate_keys = set(_conversation_motif_predicates_for_values(values))
+    if include_neutral:
+        neutral_predicates = {
+            predicate
+            for entry in related.values()
+            for signature in (
+                _conversation_motif_exact_signature(
+                    str(entry.get("normalized_value") or "")
+                ),
+            )
+            for predicate in (
+                _conversation_motif_neutral_predicate(
+                    signature,
+                    subject_key=str(correction_entry.get("subject_key") or ""),
+                ),
+            )
+            if signature and predicate
+        }
+        predicate_keys.update(neutral_predicates)
+        if not neutral_predicates and reason_code in {
+            "conversation_motif_correction_ambiguous",
+            "conversation_motif_correction_unresolved",
+        }:
+            predicate_keys.add(_CONVERSATION_MOTIF_NEUTRAL_FENCE_WILDCARD)
+    return tuple(sorted(predicate_keys))
+
+
+def _upsert_conversation_motif_correction_fences(
+    conn: sqlite3.Connection,
+    *,
+    correction_entry: dict[str, Any],
+    related_entry_ids: tuple[str, ...],
+    reason_code: str,
+    include_neutral: bool = False,
+) -> tuple[str, ...]:
+    predicate_keys = _conversation_motif_correction_predicates(
+        conn,
+        correction_entry=correction_entry,
+        related_entry_ids=related_entry_ids,
+        reason_code=reason_code,
+        include_neutral=include_neutral,
+    )
     observed = _parse_knowledge_time(correction_entry.get("observed_at"))
     observed_at = _knowledge_time(observed) if observed is not None else ""
     guild_id = int(correction_entry.get("guild_id") or 0)
@@ -5278,7 +6234,8 @@ def _finalize_conversation_motif_refresh(
         return False
     state = conn.execute(
         """
-        SELECT candidate_state,invalidated_reason
+        SELECT candidate_state,invalidated_reason,
+               recurrence_contract_version,independent_occurrence_count
         FROM memory_ledger_knowledge_candidates
         WHERE candidate_id=?
         """,
@@ -5290,6 +6247,9 @@ def _finalize_conversation_motif_refresh(
         correction_fence
         and str(correction_fence.get("fence_state") or "active")
         == "active"
+    )
+    living_v1 = bool(
+        str(state[2] or "") == LIVING_CANON_RECURRENCE_VERSION
     )
     refreshable = str(state[0] or "") in {
         "candidate",
@@ -5314,6 +6274,7 @@ def _finalize_conversation_motif_refresh(
             WHERE guild_id=? AND subject_key=?
               AND candidate_type='topic_or_motif'
               AND predicate_key=? AND candidate_id<>?
+              AND COALESCE(recurrence_contract_version,'')=?
               AND retrieval_tags_json LIKE '%recurring_public_conversation%'
             ORDER BY candidate_id
             """,
@@ -5322,6 +6283,7 @@ def _finalize_conversation_motif_refresh(
                 str(subject_key or ""),
                 str(predicate_key or ""),
                 candidate_id,
+                str(state[2] or ""),
             ),
         ).fetchall()
         if str(row[0] or "")
@@ -5359,31 +6321,64 @@ def _finalize_conversation_motif_refresh(
                 candidate_type="topic_or_motif",
                 root_entry_ids=root_entry_ids,
             )
-    if active_correction_fence:
+    correction_recurrence_satisfied = bool(
+        active_correction_fence
+        and (not living_v1 or int(state[3] or 0) >= 2)
+    )
+    if correction_recurrence_satisfied:
         satisfied_at = _now()
-        conn.execute(
-            """
-            UPDATE memory_ledger_conversation_motif_fences
-            SET fence_state='satisfied',satisfied_at=?,updated_at=?
-            WHERE guild_id=? AND subject_key=? AND predicate_key=?
-              AND correction_entry_id=?
-            """,
-            (
-                satisfied_at,
-                satisfied_at,
-                int(guild_id or 0),
-                str(subject_key or ""),
-                str(predicate_key or ""),
-                str(correction_fence.get("correction_entry_id") or ""),
-            ),
-        )
+        fence_predicate = str(correction_fence.get("predicate_key") or "")
+        if fence_predicate == _CONVERSATION_MOTIF_NEUTRAL_FENCE_WILDCARD:
+            conn.execute(
+                """
+                INSERT INTO memory_ledger_conversation_motif_fences(
+                  guild_id,subject_key,predicate_key,correction_entry_id,
+                  correction_observed_at,reason_code,fence_state,satisfied_at,
+                  created_at,updated_at
+                ) VALUES(?,?,?,?,?,?,?,?,?,?)
+                ON CONFLICT(guild_id,subject_key,predicate_key) DO UPDATE SET
+                  correction_entry_id=excluded.correction_entry_id,
+                  correction_observed_at=excluded.correction_observed_at,
+                  reason_code=excluded.reason_code,fence_state='satisfied',
+                  satisfied_at=excluded.satisfied_at,updated_at=excluded.updated_at
+                """,
+                (
+                    int(guild_id or 0),
+                    str(subject_key or ""),
+                    str(predicate_key or ""),
+                    str(correction_fence.get("correction_entry_id") or ""),
+                    str(correction_fence.get("correction_observed_at") or ""),
+                    str(correction_fence.get("reason_code") or ""),
+                    "satisfied",
+                    satisfied_at,
+                    satisfied_at,
+                    satisfied_at,
+                ),
+            )
+        else:
+            conn.execute(
+                """
+                UPDATE memory_ledger_conversation_motif_fences
+                SET fence_state='satisfied',satisfied_at=?,updated_at=?
+                WHERE guild_id=? AND subject_key=? AND predicate_key=?
+                  AND correction_entry_id=?
+                """,
+                (
+                    satisfied_at,
+                    satisfied_at,
+                    int(guild_id or 0),
+                    str(subject_key or ""),
+                    str(predicate_key or ""),
+                    str(correction_fence.get("correction_entry_id") or ""),
+                ),
+            )
     reconcile_atomic_knowledge_lifecycle(
         conn,
         candidate_ids=(candidate_id,),
     )
     if (
         superseded_sibling_ids
-        or active_correction_fence
+        or correction_recurrence_satisfied
         or result.reason_code == "conversation_motif_roots_refreshed"
     ):
         _record_knowledge_receipt(
@@ -5392,7 +6387,7 @@ def _finalize_conversation_motif_refresh(
             event_type="refreshed",
             reason_code=(
                 "conversation_motif_post_correction_reestablished"
-                if active_correction_fence
+                if correction_recurrence_satisfied
                 else "conversation_motif_bounded_refresh"
             ),
             candidate_id=candidate_id,
@@ -5467,18 +6462,20 @@ def _conversation_motif_roots_by_occurrence(
     return tuple(sorted(selected)), tuple(sorted(selected_occurrences))
 
 
-def _sync_bounded_conversation_motif_corrections(
+def _bounded_conversation_motif_corrections(
     conn: sqlite3.Connection,
     *,
     guild_id: int,
     subject_key: str,
     max_scan: int,
-) -> None:
-    """Discover recent raw corrections missed while formation was disabled."""
+    include_neutral: bool = False,
+) -> tuple[tuple[dict[str, Any], tuple[str, ...], str], ...]:
+    """Resolve a bounded correction set without mutating lifecycle state."""
+
     rows = conn.execute(
         """
         SELECT entry_id,normalized_value
-        FROM memory_ledger_entries
+        FROM main.memory_ledger_entries
         WHERE guild_id=? AND subject_key=?
           AND entry_type='observation' AND predicate_key='conversation'
           AND source_table='conversations' AND source_role='user'
@@ -5513,6 +6510,7 @@ def _sync_bounded_conversation_motif_corrections(
     # Apply oldest first so a newer correction deterministically owns a
     # family fence.  The total work remains bounded by the scans above and in
     # the conservative raw resolver.
+    resolved: list[tuple[dict[str, Any], tuple[str, ...], str]] = []
     for correction_entry_id, correction_value in reversed(corrections):
         correction_entry = _knowledge_entry_rows(
             conn,
@@ -5527,7 +6525,7 @@ def _sync_bounded_conversation_motif_corrections(
                     for row in conn.execute(
                         """
                         SELECT target_entry_id
-                        FROM memory_ledger_lineage
+                        FROM main.memory_ledger_lineage
                         WHERE entry_id=?
                           AND lineage_type IN ('correction_of','supersedes')
                         ORDER BY target_entry_id
@@ -5564,22 +6562,110 @@ def _sync_bounded_conversation_motif_corrections(
             if ambiguous_targets
             else "conversation_motif_correction_unresolved"
         )
+        related_entry_ids = tuple(
+            sorted(
+                {
+                    str(entry_id or "")
+                    for entry_id in (
+                        correction_target,
+                        *ambiguous_targets,
+                    )
+                    if str(entry_id or "")
+                }
+            )
+        )
+        resolved.append((correction_entry, related_entry_ids, reason_code))
+    return tuple(resolved)
+
+
+def _preview_conversation_motif_correction_fences(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    subject_key: str,
+    max_scan: int,
+    include_neutral: bool = False,
+) -> dict[str, dict[str, str]]:
+    """Compute the fences formation would sync, without writing any table."""
+
+    planned: dict[str, dict[str, str]] = {}
+    for correction_entry, related_entry_ids, reason_code in (
+        _bounded_conversation_motif_corrections(
+            conn,
+            guild_id=int(guild_id or 0),
+            subject_key=str(subject_key or ""),
+            max_scan=max_scan,
+            include_neutral=include_neutral,
+        )
+    ):
+        observed = _parse_knowledge_time(correction_entry.get("observed_at"))
+        if observed is None:
+            continue
+        observed_at = _knowledge_time(observed)
+        correction_entry_id = str(correction_entry.get("entry_id") or "")
+        for predicate_key in _conversation_motif_correction_predicates(
+            conn,
+            correction_entry=correction_entry,
+            related_entry_ids=related_entry_ids,
+            reason_code=reason_code,
+            include_neutral=include_neutral,
+        ):
+            existing = _conversation_motif_fence_row(
+                conn,
+                guild_id=int(guild_id or 0),
+                subject_key=str(subject_key or ""),
+                predicate_key=predicate_key,
+                fence_overrides=planned,
+            )
+            existing_time = _parse_knowledge_time(
+                existing.get("correction_observed_at")
+            )
+            if existing and existing_time is not None and existing_time > observed:
+                continue
+            if (
+                existing
+                and str(existing.get("correction_entry_id") or "")
+                == correction_entry_id
+                and str(existing.get("fence_state") or "active")
+                == "satisfied"
+            ):
+                continue
+            planned[predicate_key] = {
+                "correction_entry_id": correction_entry_id,
+                "correction_observed_at": observed_at,
+                "reason_code": reason_code,
+                "fence_state": "active",
+                "satisfied_at": "",
+                "predicate_key": predicate_key,
+            }
+    return planned
+
+
+def _sync_bounded_conversation_motif_corrections(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    subject_key: str,
+    max_scan: int,
+    include_neutral: bool = False,
+) -> None:
+    """Discover recent raw corrections missed while formation was disabled."""
+
+    for correction_entry, related_entry_ids, reason_code in (
+        _bounded_conversation_motif_corrections(
+            conn,
+            guild_id=int(guild_id or 0),
+            subject_key=str(subject_key or ""),
+            max_scan=max_scan,
+            include_neutral=include_neutral,
+        )
+    ):
         _upsert_conversation_motif_correction_fences(
             conn,
             correction_entry=correction_entry,
-            related_entry_ids=tuple(
-                sorted(
-                    {
-                        str(entry_id or "")
-                        for entry_id in (
-                            correction_target,
-                            *ambiguous_targets,
-                        )
-                        if str(entry_id or "")
-                    }
-                )
-            ),
+            related_entry_ids=related_entry_ids,
             reason_code=reason_code,
+            include_neutral=include_neutral,
         )
 
 
@@ -6636,6 +7722,12 @@ def _main_public_assessment_route_authority(
     resolved = raw_route or receipt_route
     if not resolved:
         return None
+    # Conversation-continuity is a historical/backfill route.  A mutable raw
+    # label is never sufficient authority for that route; require the exact
+    # immutable Journal receipt.  Native normal_chat capture remains bound by
+    # its raw route column as before.
+    if resolved == "conversation_continuity" and receipt_route != resolved:
+        return None
     return resolved, receipt_snapshot
 
 
@@ -7132,6 +8224,8 @@ def _main_public_assessment_occurrence_candidates(
 def _main_public_assessment_occurrence_identity(
     conn: sqlite3.Connection,
     entry: Mapping[str, Any],
+    *,
+    raw_exchange_only: bool = False,
 ) -> str:
     """Recompute the bounded exchange identity from the current main state."""
 
@@ -7143,9 +8237,10 @@ def _main_public_assessment_occurrence_identity(
         or str(entry.get("source_role") or "").lower() != "user"
     ):
         return root_identity
-    moment_occurrence = _main_public_assessment_moment_occurrence(conn, entry)
-    if moment_occurrence is not None:
-        return moment_occurrence
+    if not raw_exchange_only:
+        moment_occurrence = _main_public_assessment_moment_occurrence(conn, entry)
+        if moment_occurrence is not None:
+            return moment_occurrence
     observed = _parse_knowledge_time(entry.get("observed_at"))
     current_sequence = _public_assessment_int(entry.get("source_sequence"))
     if observed is None or current_sequence is None or current_sequence <= 0:
@@ -7758,6 +8853,7 @@ def read_public_assessment_root_state(
     entry_id: str,
     guild_id: int,
     subject_key: str,
+    _living_formation_receipt: _LivingCanonFormationReceipt | None = None,
 ) -> PublicAssessmentRootState | None:
     """Return one content-bound Open Signal root or fail closed.
 
@@ -7768,6 +8864,11 @@ def read_public_assessment_root_state(
     state and digest.
     """
 
+    living_validation = bool(
+        _living_formation_receipt is not None
+        and _living_formation_receipt.authority
+        is _LIVING_CANON_FORMATION_AUTHORITY
+    )
     required_ledger_tables = (
         "memory_ledger_entries",
         "memory_ledger_lineage",
@@ -8036,7 +9137,11 @@ def read_public_assessment_root_state(
         str(entry.get("normalized_value") or "")
     )
     root_identity = _main_public_assessment_root_identity(conn, entry)
-    occurrence_identity = _main_public_assessment_occurrence_identity(conn, entry)
+    occurrence_identity = _main_public_assessment_occurrence_identity(
+        conn,
+        entry,
+        raw_exchange_only=living_validation,
+    )
     if (
         not safe_text
         or semantics.attribution_mode
@@ -8048,25 +9153,32 @@ def read_public_assessment_root_state(
     ):
         return None
 
-    fences = _main_public_assessment_fences(
-        conn,
-        guild_id=int(guild_id or 0),
-        subject_key=expected_subject,
-    )
-    if fences is None:
-        return None
-    later_guard_state = _main_public_assessment_later_guard_state(
-        conn,
-        entry=entry,
-        semantics=semantics,
-    )
-    if later_guard_state is None:
-        return None
-    later_guards, unresolved_later_correction, polarity_conflict = (
-        later_guard_state
-    )
-    if unresolved_later_correction or polarity_conflict:
-        return None
+    if living_validation:
+        # Living formation applies correction fences only after the meaning
+        # predicate has been determined.  Global subject fences here would
+        # incorrectly erase unrelated topics.
+        fences: tuple[tuple[str, ...], ...] = ()
+        later_guards: tuple[Any, ...] = ()
+    else:
+        fences = _main_public_assessment_fences(
+            conn,
+            guild_id=int(guild_id or 0),
+            subject_key=expected_subject,
+        )
+        if fences is None:
+            return None
+        later_guard_state = _main_public_assessment_later_guard_state(
+            conn,
+            entry=entry,
+            semantics=semantics,
+        )
+        if later_guard_state is None:
+            return None
+        later_guards, unresolved_later_correction, polarity_conflict = (
+            later_guard_state
+        )
+        if unresolved_later_correction or polarity_conflict:
+            return None
     observed = _parse_knowledge_time(entry.get("observed_at"))
     if observed is None:
         return None
@@ -8113,6 +9225,467 @@ def read_public_assessment_root_state(
         derived=False,
         projection=False,
     )
+
+
+def _living_canon_raw_exchange_component(
+    conn: sqlite3.Connection,
+    entry: Mapping[str, Any],
+) -> tuple[str, tuple[str, ...], tuple[str, int, str]]:
+    """Return a bounded exchange keyed by its earliest raw-authoritative root."""
+
+    current_id = str(entry.get("entry_id") or "")
+    observed_at = str(entry.get("observed_at") or "")
+    observed = _parse_knowledge_time(observed_at)
+    scope = (
+        int(entry.get("guild_id") or 0),
+        int(entry.get("channel_id") or 0),
+        str(entry.get("channel_policy") or ""),
+        str(entry.get("subject_key") or ""),
+    )
+    if not current_id or observed is None or not all((scope[0], scope[1], scope[2], scope[3])):
+        return "", (), ("", 0, "")
+    params = (
+        scope[0],
+        scope[3],
+        scope[1],
+        scope[2],
+        observed_at,
+        _CONVERSATION_OCCURRENCE_MAX_SCAN + 1,
+    )
+    before = conn.execute(
+        """
+        SELECT entry_id,observed_at,source_sequence
+        FROM main.memory_ledger_entries
+        WHERE guild_id=? AND subject_key=? AND source_table='conversations'
+          AND source_role='user' AND channel_id=? AND channel_policy=?
+          AND observed_at<=?
+        ORDER BY observed_at DESC,source_sequence DESC,entry_id DESC LIMIT ?
+        """,
+        params,
+    ).fetchall()
+    after = conn.execute(
+        """
+        SELECT entry_id,observed_at,source_sequence
+        FROM main.memory_ledger_entries
+        WHERE guild_id=? AND subject_key=? AND source_table='conversations'
+          AND source_role='user' AND channel_id=? AND channel_policy=?
+          AND observed_at>=?
+        ORDER BY observed_at,source_sequence,entry_id LIMIT ?
+        """,
+        params,
+    ).fetchall()
+    row_map = {
+        str(row[0] or ""): (
+            str(row[0] or ""),
+            str(row[1] or ""),
+            int(row[2] or 0),
+        )
+        for row in (*before, *after)
+        if str(row[0] or "")
+    }
+    ordered = sorted(
+        row_map.values(),
+        key=lambda row: (
+            _parse_knowledge_time(row[1])
+            or datetime.min.replace(tzinfo=timezone.utc),
+            row[2],
+            row[0],
+        ),
+    )
+    current_index = next(
+        (index for index, row in enumerate(ordered) if row[0] == current_id),
+        -1,
+    )
+    if current_index < 0:
+        return "", (), ("", 0, "")
+    left = current_index
+    while left > 0:
+        newer = _parse_knowledge_time(ordered[left][1])
+        older = _parse_knowledge_time(ordered[left - 1][1])
+        if newer is None or older is None or newer < older:
+            return "", (), ("", 0, "")
+        if (newer - older).total_seconds() > _CONVERSATION_MOTIF_WINDOW_SECONDS:
+            break
+        left -= 1
+    right = current_index
+    while right + 1 < len(ordered):
+        older = _parse_knowledge_time(ordered[right][1])
+        newer = _parse_knowledge_time(ordered[right + 1][1])
+        if newer is None or older is None or newer < older:
+            return "", (), ("", 0, "")
+        if (newer - older).total_seconds() > _CONVERSATION_MOTIF_WINDOW_SECONDS:
+            break
+        right += 1
+    members = ordered[left : right + 1]
+    if (
+        len(members) > _CONVERSATION_OCCURRENCE_MAX_SCAN
+        or (left == 0 and len(before) > _CONVERSATION_OCCURRENCE_MAX_SCAN)
+        or (right == len(ordered) - 1 and len(after) > _CONVERSATION_OCCURRENCE_MAX_SCAN)
+    ):
+        return "", (), ("", 0, "")
+    anchor = members[0] if members else ("", "", 0)
+    if not anchor[0]:
+        return "", (), ("", 0, "")
+    identity = _knowledge_digest("conversation_occurrence", *scope, anchor[0])
+    return identity, tuple(row[0] for row in members), (
+        anchor[1],
+        anchor[2],
+        anchor[0],
+    )
+
+
+def _living_canon_validated_moment_members(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    subject_key: str,
+    target_id: str,
+) -> tuple[str, ...] | None:
+    """Validate one finalized Moment and return only this subject's roots."""
+
+    target = _main_public_assessment_entry(conn, str(target_id or ""))
+    moment_id = str(target.get("source_row_id") or "") if target else ""
+    expected_target_id = (
+        stable_entry_id(
+            guild_id=int(guild_id or 0),
+            source_table="memory_moment_windows",
+            source_row_id=moment_id,
+            source_revision="1",
+            entry_type="shared_moment",
+            subject_key="moment:%s" % moment_id,
+            predicate_key="shared_moment",
+        )
+        if moment_id
+        else ""
+    )
+    if not target or (
+        str(target_id or "") != expected_target_id
+        or int(target.get("guild_id") or 0) != int(guild_id or 0)
+        or str(target.get("source_table") or "") != "memory_moment_windows"
+        or str(target.get("source_revision") or "") != "1"
+        or str(target.get("source_role") or "") != "derived_assessment"
+        or str(target.get("entry_type") or "") != "shared_moment"
+        or str(target.get("subject_key") or "") != "moment:%s" % moment_id
+        or str(target.get("predicate_key") or "") != "shared_moment"
+        or str(target.get("source_class") or "")
+        != SourceClass.DERIVED_SUMMARY.value
+        or str(target.get("lifecycle_status") or "") != REVIEW_ONLY_LIFECYCLE
+        or str(target.get("visibility") or "")
+        not in {Visibility.PUBLIC.value, Visibility.PUBLIC_SAFE.value}
+        or _public_assessment_bool_state(target.get("public_usable")) is not True
+        or _public_assessment_bool_state(target.get("derived")) is not True
+        or _public_assessment_bool_state(target.get("projection")) is not True
+    ):
+        return None
+    required_tables = {
+        "memory_moment_windows",
+        "memory_moment_members",
+        "memory_moment_participants",
+    }
+    main_tables = {
+        str(row[0] or "")
+        for row in conn.execute(
+            "SELECT name FROM main.sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    if not required_tables.issubset(main_tables):
+        return None
+    lineage_rows = conn.execute(
+        """
+        SELECT guild_id,lineage_type,target_entry_id
+        FROM main.memory_ledger_lineage
+        WHERE entry_id=?
+        ORDER BY guild_id,lineage_type,target_entry_id
+        LIMIT ?
+        """,
+        (str(target_id or ""), _CONVERSATION_OCCURRENCE_MAX_SCAN + 1),
+    ).fetchall()
+    if (
+        not lineage_rows
+        or len(lineage_rows) > _CONVERSATION_OCCURRENCE_MAX_SCAN
+        or any(
+            int(row[0] or 0) != int(guild_id or 0)
+            or str(row[1] or "") != "derived_from"
+            or not str(row[2] or "")
+            for row in lineage_rows
+        )
+    ):
+        return None
+    derived_targets = {str(row[2] or "") for row in lineage_rows}
+    window = conn.execute(
+        """
+        SELECT guild_id,channel_id,channel_policy,route_mode,lifecycle_status,
+               visibility,public_usable,canonical_ledger_entry_id
+        FROM main.memory_moment_windows
+        WHERE moment_id=?
+        """,
+        (moment_id,),
+    ).fetchone()
+    if not window or (
+        int(window[0] or 0) != int(guild_id or 0)
+        or int(window[1] or 0) != int(target.get("channel_id") or 0)
+        or str(window[2] or "") != str(target.get("channel_policy") or "")
+        or str(window[3] or "") != str(target.get("route_mode") or "")
+        or str(window[4] or "") != "finalized"
+        or str(window[5] or "") != str(target.get("visibility") or "")
+        or _public_assessment_bool_state(window[6]) is not True
+        or str(window[7] or "") != str(target_id or "")
+    ):
+        return None
+    member_rows = conn.execute(
+        """
+        SELECT ledger_entry_id,membership_role
+        FROM main.memory_moment_members
+        WHERE moment_id=?
+        ORDER BY ledger_entry_id
+        LIMIT ?
+        """,
+        (moment_id, _CONVERSATION_OCCURRENCE_MAX_SCAN + 1),
+    ).fetchall()
+    member_ids = tuple(str(row[0] or "") for row in member_rows)
+    if (
+        not member_ids
+        or len(member_ids) > _CONVERSATION_OCCURRENCE_MAX_SCAN
+        or set(member_ids) != derived_targets
+        or any(
+            str(row[1] or "") not in {"human_author", "bnl_participant"}
+            for row in member_rows
+        )
+    ):
+        return None
+    participant_rows = conn.execute(
+        """
+        SELECT participant_key,participant_role
+        FROM main.memory_moment_participants
+        WHERE moment_id=?
+        ORDER BY participant_key,participant_role
+        LIMIT ?
+        """,
+        (moment_id, _CONVERSATION_OCCURRENCE_MAX_SCAN + 1),
+    ).fetchall()
+    if (
+        not participant_rows
+        or len(participant_rows) > _CONVERSATION_OCCURRENCE_MAX_SCAN
+        or len(participant_rows) != len(set(participant_rows))
+    ):
+        return None
+    expected_participants: set[tuple[str, str]] = set()
+    subject_member_ids: list[str] = []
+    for member_id, membership_role in member_rows:
+        member_id = str(member_id or "")
+        membership_role = str(membership_role or "")
+        member = _main_public_assessment_entry(conn, member_id)
+        source_role = str(member.get("source_role") or "") if member else ""
+        expected_role = (
+            "human_author" if source_role == "user" else "bnl_participant"
+        )
+        participant_key = (
+            str(member.get("subject_key") or "")
+            if source_role == "user" and member
+            else BNL_SUBJECT_KEY
+        )
+        if not member or (
+            int(member.get("guild_id") or 0) != int(guild_id or 0)
+            or str(member.get("source_table") or "") != "conversations"
+            or str(member.get("entry_type") or "")
+            not in {"observation", "derived_summary"}
+            or int(member.get("channel_id") or 0) != int(window[1] or 0)
+            or str(member.get("channel_policy") or "") != str(window[2] or "")
+            or str(member.get("route_mode") or "") != str(window[3] or "")
+            or str(member.get("visibility") or "") != str(window[5] or "")
+            or str(member.get("lifecycle_status") or "")
+            not in {ACTIVE_LIFECYCLE, REVIEW_ONLY_LIFECYCLE}
+            or membership_role != expected_role
+            or not participant_key
+            or (
+                source_role == "user"
+                and _public_assessment_bool_state(member.get("public_usable"))
+                is not True
+            )
+            or conn.execute(
+                """
+                SELECT 1 FROM main.memory_ledger_lineage
+                WHERE guild_id=? AND target_entry_id=?
+                  AND lineage_type IN ('correction_of','supersedes','retracts')
+                LIMIT 1
+                """,
+                (int(guild_id or 0), member_id),
+            ).fetchone()
+        ):
+            return None
+        expected_participants.add((participant_key, expected_role))
+        if (
+            expected_role == "human_author"
+            and participant_key == str(subject_key or "")
+        ):
+            subject_member_ids.append(member_id)
+        edges = conn.execute(
+            """
+            SELECT guild_id,target_entry_id
+            FROM main.memory_ledger_lineage
+            WHERE entry_id=? AND lineage_type='part_of_moment'
+            ORDER BY guild_id,target_entry_id
+            LIMIT ?
+            """,
+            (member_id, _CONVERSATION_OCCURRENCE_MAX_SCAN + 1),
+        ).fetchall()
+        if (
+            len(edges) > _CONVERSATION_OCCURRENCE_MAX_SCAN
+            or (int(guild_id or 0), str(target_id or "")) not in edges
+            or any(
+                int(edge[0] or 0) != int(guild_id or 0)
+                or not str(edge[1] or "")
+                for edge in edges
+            )
+        ):
+            return None
+    if (
+        set(
+            (str(row[0] or ""), str(row[1] or ""))
+            for row in participant_rows
+        )
+        != expected_participants
+        or (str(subject_key or ""), "human_author")
+        not in expected_participants
+        or not subject_member_ids
+    ):
+        return None
+    return tuple(sorted(subject_member_ids))
+
+
+def _living_canon_root_states_and_occurrences(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    subject_key: str,
+    entry_ids: tuple[str, ...],
+) -> tuple[
+    dict[str, PublicAssessmentRootState],
+    dict[str, str],
+    tuple[str, ...],
+]:
+    """Bind roots to raw state, then collapse validated Moment representations."""
+
+    if not _living_canon_main_authority_unshadowed(conn):
+        return {}, {}, ("living_canon_authority_shadowed",)
+    requested = tuple(sorted({str(value or "") for value in entry_ids if str(value or "")}))
+    if not requested or len(requested) > _CONVERSATION_MOTIF_MAX_ROOTS:
+        return {}, {}, ("source_ineligible",)
+    states: dict[str, PublicAssessmentRootState] = {}
+    entries: dict[str, dict[str, Any]] = {}
+    exchanges: dict[str, str] = {}
+    anchors: dict[str, tuple[str, int, str]] = {}
+
+    def load_root(entry_id: str) -> bool:
+        if entry_id in states:
+            return True
+        state = read_public_assessment_root_state(
+            conn,
+            entry_id=entry_id,
+            guild_id=int(guild_id or 0),
+            subject_key=str(subject_key or ""),
+            _living_formation_receipt=_living_canon_formation_receipt(),
+        )
+        entry = _main_public_assessment_entry(conn, entry_id)
+        if state is None or not entry:
+            return False
+        exchange, _members, anchor = _living_canon_raw_exchange_component(
+            conn,
+            entry,
+        )
+        if not exchange or not anchor[2]:
+            return False
+        states[entry_id] = state
+        entries[entry_id] = entry
+        exchanges[entry_id] = exchange
+        anchors[exchange] = min(anchors.get(exchange, anchor), anchor)
+        return True
+
+    for entry_id in requested:
+        if not load_root(entry_id):
+            return states, {}, ("source_ineligible",)
+
+    parent: dict[str, str] = {exchange: exchange for exchange in set(exchanges.values())}
+
+    def find(value: str) -> str:
+        parent.setdefault(value, value)
+        while parent[value] != value:
+            parent[value] = parent[parent[value]]
+            value = parent[value]
+        return value
+
+    def union(left: str, right: str) -> None:
+        left_root, right_root = find(left), find(right)
+        if left_root == right_root:
+            return
+        left_anchor = anchors.get(left_root, ("", 0, left_root))
+        right_anchor = anchors.get(right_root, ("", 0, right_root))
+        winner, loser = (
+            (left_root, right_root)
+            if left_anchor <= right_anchor
+            else (right_root, left_root)
+        )
+        parent[loser] = winner
+        anchors[winner] = min(left_anchor, right_anchor)
+
+    reasons: set[str] = set()
+    pending = list(requested)
+    seen_roots: set[str] = set()
+    seen_moments: set[str] = set()
+    while pending:
+        root_id = pending.pop()
+        if root_id in seen_roots:
+            continue
+        seen_roots.add(root_id)
+        if len(seen_roots) > _CONVERSATION_OCCURRENCE_MAX_SCAN:
+            return states, {}, ("unbounded_occurrence_withheld",)
+        links = conn.execute(
+            """
+            SELECT guild_id,target_entry_id
+            FROM main.memory_ledger_lineage
+            WHERE entry_id=? AND lineage_type='part_of_moment'
+            ORDER BY guild_id,target_entry_id
+            LIMIT ?
+            """,
+            (root_id, _CONVERSATION_OCCURRENCE_MAX_SCAN + 1),
+        ).fetchall()
+        if len(links) > _CONVERSATION_OCCURRENCE_MAX_SCAN:
+            return states, {}, ("unbounded_occurrence_withheld",)
+        for edge_guild, target_id in links:
+            target_id = str(target_id or "")
+            if int(edge_guild or 0) != int(guild_id or 0) or not target_id:
+                return states, {}, ("moment_lifecycle_or_membership_ineligible",)
+            if target_id in seen_moments:
+                continue
+            member_ids = _living_canon_validated_moment_members(
+                conn,
+                guild_id=int(guild_id or 0),
+                subject_key=str(subject_key or ""),
+                target_id=target_id,
+            )
+            if not member_ids or root_id not in member_ids:
+                return states, {}, ("moment_lifecycle_or_membership_ineligible",)
+            if any(not load_root(member_id) for member_id in member_ids):
+                return states, {}, ("moment_lifecycle_or_membership_ineligible",)
+            seen_moments.add(target_id)
+            first_exchange = exchanges[member_ids[0]]
+            for member_id in member_ids:
+                union(first_exchange, exchanges[member_id])
+                pending.append(member_id)
+            reasons.add("same_root_projection_collapsed")
+            if len(member_ids) > 1 or len(seen_moments) > 1:
+                reasons.add("overlapping_occurrence_representation_collapsed")
+
+    component_identity: dict[str, str] = {}
+    for exchange in tuple(parent):
+        root = find(exchange)
+        component_identity[exchange] = root
+    occurrences = {
+        entry_id: component_identity.get(exchange, exchange)
+        for entry_id, exchange in exchanges.items()
+        if entry_id in requested
+    }
+    return states, occurrences, tuple(sorted(reasons))
 
 
 def _public_assessment_scope_text(value: str) -> str:
@@ -8787,6 +10360,330 @@ def project_retained_conversations_to_ledger(
     return counts
 
 
+_LIVING_CANON_STRICT_ROOTS_PER_GROUP = 2
+
+
+def _living_canon_prevalidation_entries(
+    entries: Iterable[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Choose at most two likely-independent roots before strict validation.
+
+    Ledger timestamps can only affect bounded nomination here.  They never
+    confer eligibility; the selected roots are subsequently rebound to main
+    raw authority.  Prefer roots separated by an idle boundary, then fill.
+    """
+
+    ordered = sorted(
+        (dict(entry) for entry in entries),
+        key=lambda entry: (
+            str(entry.get("observed_at") or ""),
+            str(entry.get("entry_id") or ""),
+        ),
+        reverse=True,
+    )
+    selected: list[dict[str, Any]] = []
+    for entry in ordered:
+        observed = _parse_knowledge_time(entry.get("observed_at"))
+        scope = (
+            int(entry.get("channel_id") or 0),
+            str(entry.get("channel_policy") or ""),
+        )
+        if observed is None:
+            continue
+        if all(
+            scope
+            != (
+                int(prior.get("channel_id") or 0),
+                str(prior.get("channel_policy") or ""),
+            )
+            or abs(
+                (
+                    observed
+                    - (_parse_knowledge_time(prior.get("observed_at")) or observed)
+                ).total_seconds()
+            )
+            > _CONVERSATION_MOTIF_WINDOW_SECONDS
+            for prior in selected
+        ):
+            selected.append(entry)
+            if len(selected) >= _LIVING_CANON_STRICT_ROOTS_PER_GROUP:
+                return selected
+    selected_ids = {str(entry.get("entry_id") or "") for entry in selected}
+    for entry in ordered:
+        if str(entry.get("entry_id") or "") in selected_ids:
+            continue
+        selected.append(entry)
+        if len(selected) >= _LIVING_CANON_STRICT_ROOTS_PER_GROUP:
+            break
+    return selected
+
+
+def _living_canon_rejection_reason_counts(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    subject_key: str,
+    max_scan: int,
+) -> Counter[str]:
+    """Classify bounded rows excluded by the eligible-history SQL."""
+
+    reasons: Counter[str] = Counter()
+    rows = conn.execute(
+        """
+        SELECT visibility,public_usable,derived,projection,source_role,
+               source_class,channel_policy,lifecycle_status
+        FROM main.memory_ledger_entries
+        WHERE guild_id=? AND subject_key=? AND source_table='conversations'
+          AND entry_type='observation' AND predicate_key='conversation'
+        ORDER BY observed_at DESC,source_sequence DESC,entry_id DESC
+        LIMIT ?
+        """,
+        (
+            int(guild_id or 0),
+            str(subject_key or ""),
+            max(1, min(int(max_scan or 1), _CONVERSATION_MOTIF_MAX_SCAN)),
+        ),
+    ).fetchall()
+    for row in rows:
+        if (
+            str(row[0] or "")
+            not in {Visibility.PUBLIC.value, Visibility.PUBLIC_SAFE.value}
+            or _public_assessment_bool_state(row[1]) is not True
+            or str(row[6] or "") not in _CONVERSATION_MOTIF_PUBLIC_POLICIES
+        ):
+            reasons["visibility_ineligible"] += 1
+        if (
+            _public_assessment_bool_state(row[2]) is not False
+            or _public_assessment_bool_state(row[3]) is not False
+            or str(row[4] or "").lower() != "user"
+            or str(row[5] or "") != SourceClass.PUBLIC_OBSERVATION.value
+        ):
+            reasons["derived_source_not_independent"] += 1
+    return reasons
+
+
+def _living_canon_analyze_groups(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    subject_key: str,
+    trigger_entry_id: str = "",
+    max_scan: int = _CONVERSATION_MOTIF_MAX_SCAN,
+    diagnostics: dict[str, int] | None = None,
+    fence_overrides: Mapping[str, Mapping[str, Any]] | None = None,
+) -> tuple[list[dict[str, Any]], Counter[str], int, int]:
+    """Group cheaply, then strictly validate at most 6 x 2 roots."""
+
+    reasons = _living_canon_rejection_reason_counts(
+        conn,
+        guild_id=int(guild_id or 0),
+        subject_key=str(subject_key or ""),
+        max_scan=max_scan,
+    )
+    history = _conversation_motif_history(
+        conn,
+        guild_id=int(guild_id or 0),
+        subject_key=str(subject_key or ""),
+        max_scan=max_scan,
+        diagnostics=diagnostics,
+        require_legacy_occurrence=False,
+    )
+    grouped: dict[str, dict[str, Any]] = {}
+    unmatched: list[dict[str, Any]] = []
+    for entry in history:
+        matches = _conversation_motif_family_matches(
+            tuple(entry.get("terms") or ())
+        )
+        if not matches:
+            unmatched.append(entry)
+        for family, label in matches:
+            group = grouped.setdefault(
+                "family:%s" % family,
+                {
+                    "predicate": "conversation_motif_%s" % family,
+                    "family": family,
+                    "label": label,
+                    "entries": [],
+                    "tags": (
+                        family,
+                        "recurring_public_conversation",
+                        LIVING_CANON_RECURRENCE_VERSION,
+                        LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+                    ),
+                    "living_v1": True,
+                },
+            )
+            group["entries"].append(entry)
+    grouped.update(
+        _conversation_motif_neutral_groups(
+            unmatched,
+            subject_key=str(subject_key or ""),
+            diagnostics=diagnostics,
+        )
+    )
+    ranked: list[tuple[int, float, str, dict[str, Any]]] = []
+    for group_key, group in grouped.items():
+        nominated = _living_canon_prevalidation_entries(group["entries"])
+        last_seen = max(
+            (str(entry.get("observed_at") or "") for entry in nominated),
+            default="",
+        )
+        parsed = _parse_knowledge_time(last_seen)
+        ranked.append(
+            (-len(nominated), -(parsed.timestamp() if parsed else 0.0), group_key, group)
+        )
+
+    existing_rows = conn.execute(
+        """
+        SELECT predicate_key,candidate_state,invalidated_reason
+        FROM main.memory_ledger_knowledge_candidates
+        WHERE guild_id=? AND subject_key=? AND candidate_type='topic_or_motif'
+          AND COALESCE(recurrence_contract_version,'')=?
+        ORDER BY candidate_id
+        """,
+        (
+            int(guild_id or 0),
+            str(subject_key or ""),
+            LIVING_CANON_RECURRENCE_VERSION,
+        ),
+    ).fetchall()
+    existing_by_predicate: dict[str, list[tuple[str, str]]] = {}
+    active_provisional_count = 0
+    for predicate, state, invalidated_reason in existing_rows:
+        existing_by_predicate.setdefault(str(predicate or ""), []).append(
+            (str(state or ""), str(invalidated_reason or ""))
+        )
+        if str(state or "") == "provisional":
+            active_provisional_count += 1
+
+    accepted: list[dict[str, Any]] = []
+    rejected = 0
+    for _count, _last_seen, _group_key, group in sorted(ranked)[:
+        _CONVERSATION_MOTIF_MAX_CANDIDATES
+    ]:
+        fenced_entries, fence = _conversation_motif_entries_after_fence(
+            conn,
+            guild_id=int(guild_id or 0),
+            subject_key=str(subject_key or ""),
+            predicate_key=str(group["predicate"]),
+            entries=list(group["entries"]),
+            fence_overrides=fence_overrides,
+        )
+        active_fence = bool(
+            fence and str(fence.get("fence_state") or "active") == "active"
+        )
+        if active_fence:
+            reasons["correction_fence_active"] += 1
+        nominated = _living_canon_prevalidation_entries(fenced_entries)
+        nominated_ids = tuple(
+            str(entry.get("entry_id") or "")
+            for entry in nominated
+            if str(entry.get("entry_id") or "")
+        )
+        if not nominated_ids:
+            rejected += 1
+            if fence and str(fence.get("fence_state") or "active") == "active":
+                reasons["fresh_recurrence_required_after_correction"] += 1
+            continue
+        states, occurrence_map, root_reasons = (
+            _living_canon_root_states_and_occurrences(
+                conn,
+                guild_id=int(guild_id or 0),
+                subject_key=str(subject_key or ""),
+                entry_ids=nominated_ids,
+            )
+        )
+        reasons.update(root_reasons)
+        if (
+            any(entry_id not in states for entry_id in nominated_ids)
+            or any(entry_id not in occurrence_map for entry_id in nominated_ids)
+            or not occurrence_map
+        ):
+            rejected += 1
+            if not root_reasons:
+                reasons["source_ineligible"] += 1
+            continue
+        authoritative: list[dict[str, Any]] = []
+        expected_signature = tuple(group.get("signature") or ())
+        expected_family = str(group.get("family") or "")
+        for nominated_entry in nominated:
+            entry_id = str(nominated_entry.get("entry_id") or "")
+            state = states.get(entry_id)
+            occurrence = occurrence_map.get(entry_id, "")
+            if state is None or not occurrence:
+                continue
+            terms = _conversation_motif_terms(state.text)
+            if expected_family and expected_family not in {
+                family for family, _label in _conversation_motif_family_matches(terms)
+            }:
+                continue
+            if expected_signature and _conversation_motif_exact_signature(
+                state.text
+            ) != expected_signature:
+                reasons["meaning_ambiguous_review_only"] += 1
+                continue
+            item = dict(nominated_entry)
+            item["normalized_value"] = state.text
+            item["validated_text"] = state.text
+            item["terms"] = terms
+            item["root_identity"] = state.root_identity
+            item["occurrence_identity"] = occurrence
+            authoritative.append(item)
+        root_ids, occurrence_ids = _conversation_motif_roots_by_occurrence(
+            authoritative
+        )
+        if not root_ids or not occurrence_ids:
+            rejected += 1
+            reasons["source_ineligible"] += 1
+            continue
+        collapsed = max(0, len(root_ids) - len(occurrence_ids))
+        if collapsed:
+            reasons["same_occurrence_collapsed"] += collapsed
+        if active_fence and len(occurrence_ids) < 2:
+            reasons["fresh_recurrence_required_after_correction"] += 1
+        existing = existing_by_predicate.get(str(group["predicate"]), [])
+        if any(
+            state == "contested"
+            and invalidated_reason
+            in {"unresolved_contradiction", "explicitly_contested_evidence"}
+            for state, invalidated_reason in existing
+        ):
+            reasons["contradiction_contested"] += 1
+        if (
+            len(occurrence_ids) == 1
+            and str(trigger_entry_id or "")
+            and str(trigger_entry_id or "") not in root_ids
+        ):
+            rejected += 1
+            continue
+        if (
+            len(occurrence_ids) == 1
+            and not existing
+            and active_provisional_count >= _CONVERSATION_MOTIF_MAX_CANDIDATES
+        ):
+            rejected += 1
+            reasons["provisional_subject_bound_reached"] += 1
+            continue
+        if len(occurrence_ids) == 1 and not existing:
+            active_provisional_count += 1
+        result_group = dict(group)
+        result_group["entries"] = authoritative
+        result_group["root_ids"] = root_ids
+        result_group["occurrence_ids"] = occurrence_ids
+        result_group["correction_fence"] = fence
+        accepted.append(result_group)
+    if diagnostics is not None:
+        for reason, count in reasons.items():
+            diagnostics[reason] = int(diagnostics.get(reason, 0) or 0) + int(count)
+        diagnostics["strict_validation_group_count"] = len(
+            sorted(ranked)[:_CONVERSATION_MOTIF_MAX_CANDIDATES]
+        )
+        diagnostics["strict_validation_root_count"] = sum(
+            len(group.get("root_ids") or ()) for group in accepted
+        )
+    return accepted, reasons, rejected, len(history)
+
+
 def form_atomic_candidates_from_recurring_conversation(
     conn: sqlite3.Connection,
     *,
@@ -8803,7 +10700,11 @@ def form_atomic_candidates_from_recurring_conversation(
     lifecycle. It never turns one exchange into recurrence and never promotes
     raw text into scalar identity or role facts.
     """
-    if not conversation_motif_formation_enabled(environ):
+    legacy_formation = conversation_motif_formation_enabled(environ)
+    living_v1_formation = living_canon_v1_formation_enabled(environ)
+    if not legacy_formation and not living_v1_formation:
+        return []
+    if living_v1_formation and not _living_canon_main_authority_unshadowed(conn):
         return []
     ensure_memory_ledger_schema(conn)
     trigger_id = str(trigger_entry_id or "").strip()
@@ -8826,66 +10727,98 @@ def form_atomic_candidates_from_recurring_conversation(
     ):
         return []
 
-    project_retained_conversations_to_ledger(
-        conn,
-        guild_id=int(guild_id or 0),
-        subject_key=str(subject_key),
-        max_scan=max_scan,
-        diagnostics=diagnostics,
-        environ=environ,
-    )
+    # Preserve the legacy path exactly.  Living v1 never silently projects
+    # retained history; historical projection remains a separately gated
+    # operation.
+    if legacy_formation and not living_v1_formation:
+        project_retained_conversations_to_ledger(
+            conn,
+            guild_id=int(guild_id or 0),
+            subject_key=str(subject_key),
+            max_scan=max_scan,
+            diagnostics=diagnostics,
+            environ=environ,
+        )
     _sync_bounded_conversation_motif_corrections(
         conn,
         guild_id=int(guild_id or 0),
         subject_key=str(subject_key),
         max_scan=max_scan,
+        include_neutral=living_v1_formation,
     )
-    history = _conversation_motif_history(
-        conn,
-        guild_id=int(guild_id or 0),
-        subject_key=str(subject_key),
-        max_scan=max_scan,
-        diagnostics=diagnostics,
-    )
-    if not history:
-        _record_knowledge_receipt(
+    if living_v1_formation:
+        analyzed_groups, _analysis_reasons, _rejected, history_count = (
+            _living_canon_analyze_groups(
+                conn,
+                guild_id=int(guild_id or 0),
+                subject_key=str(subject_key),
+                trigger_entry_id=trigger_id,
+                max_scan=max_scan,
+                diagnostics=diagnostics,
+            )
+        )
+        grouped = {
+            str(group.get("predicate") or ""): group
+            for group in analyzed_groups
+        }
+        history: list[dict[str, Any]] = [
+            entry for group in analyzed_groups for entry in group["entries"]
+        ]
+        if history_count <= 0:
+            _record_knowledge_receipt(
+                conn,
+                guild_id=int(guild_id or 0),
+                event_type="formation_skipped",
+                reason_code="conversation_motif_no_eligible_history",
+                candidate_type="topic_or_motif",
+            )
+            return []
+    else:
+        history = _conversation_motif_history(
             conn,
             guild_id=int(guild_id or 0),
-            event_type="formation_skipped",
-            reason_code="conversation_motif_no_eligible_history",
-            candidate_type="topic_or_motif",
+            subject_key=str(subject_key),
+            max_scan=max_scan,
+            diagnostics=diagnostics,
         )
-        return []
-
-    grouped: dict[str, dict[str, Any]] = {}
-    for entry in history:
-        matches = _conversation_motif_family_matches(
-            tuple(entry.get("terms") or ())
-        )
-        if not matches and diagnostics is not None:
-            diagnostics["ledger_rows_family_unmatched"] = (
-                int(
-                    diagnostics.get(
-                        "ledger_rows_family_unmatched",
-                        0,
-                    )
-                    or 0
+        if not history:
+            _record_knowledge_receipt(
+                conn,
+                guild_id=int(guild_id or 0),
+                event_type="formation_skipped",
+                reason_code="conversation_motif_no_eligible_history",
+                candidate_type="topic_or_motif",
+            )
+            return []
+        grouped = {}
+        for entry in history:
+            matches = _conversation_motif_family_matches(
+                tuple(entry.get("terms") or ())
+            )
+            if not matches and diagnostics is not None:
+                diagnostics["ledger_rows_family_unmatched"] = (
+                    int(diagnostics.get("ledger_rows_family_unmatched", 0) or 0)
+                    + 1
                 )
-                + 1
-            )
-        for family, label in matches:
-            group = grouped.setdefault(
-                "family:%s" % family,
-                {
-                    "predicate": "conversation_motif_%s" % family,
-                    "label": label,
-                    "entries": [],
-                    "tags": (family, "recurring_public_conversation"),
-                },
-            )
-            group["entries"].append(entry)
+            for family, label in matches:
+                group = grouped.setdefault(
+                    "family:%s" % family,
+                    {
+                        "predicate": "conversation_motif_%s" % family,
+                        "label": label,
+                        "entries": [],
+                        "tags": (family, "recurring_public_conversation"),
+                        "living_v1": False,
+                    },
+                )
+                group["entries"].append(entry)
     if diagnostics is not None:
-        diagnostics["motif_families_matched"] = len(grouped)
+        diagnostics["motif_families_matched"] = sum(
+            1 for group in grouped.values() if not group.get("neutral")
+        )
+        diagnostics["motif_neutral_groups_proposed"] = sum(
+            1 for group in grouped.values() if group.get("neutral")
+        )
 
     results: list[AtomicKnowledgeResult] = []
     ranked_groups: list[tuple[int, float, str, dict[str, Any]]] = []
@@ -8927,7 +10860,11 @@ def form_atomic_candidates_from_recurring_conversation(
         root_ids, occurrence_ids = _conversation_motif_roots_by_occurrence(
             list(group["entries"])
         )
-        if len(occurrence_ids) < 2 or len(root_ids) < 2:
+        minimum_recurrence = 1 if group.get("living_v1") else 2
+        if (
+            len(occurrence_ids) < minimum_recurrence
+            or len(root_ids) < minimum_recurrence
+        ):
             if diagnostics is not None:
                 diagnostics["motif_families_recurrence_not_met"] = (
                     int(
@@ -8948,6 +10885,17 @@ def form_atomic_candidates_from_recurring_conversation(
             ),
             "",
         )
+        living_v1 = bool(group.get("living_v1"))
+        grouping_identity = (
+            _knowledge_digest(
+                LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+                str(subject_key),
+                str(group["predicate"]),
+                "real_community",
+            )
+            if living_v1
+            else ""
+        )
         result = form_atomic_knowledge_candidate(
             conn,
             AtomicKnowledgeProposal(
@@ -8956,14 +10904,14 @@ def form_atomic_candidates_from_recurring_conversation(
                 subject_display_name=display_name,
                 predicate_key=str(group["predicate"]),
                 meaning=(
-                    "Recurring public conversation about %s."
+                    "Possible public conversation theme about %s."
                     % str(group["label"]).strip()
                 ),
                 root_entry_ids=root_ids,
                 participant_keys=(str(subject_key),),
                 epistemic_status="observed",
                 uncertainty_note=(
-                    "Repeated public conversation observation; not a scalar "
+                    "Cautious public conversation observation; not a scalar "
                     "identity fact or exact quote."
                 ),
                 currentness="historical",
@@ -8971,6 +10919,19 @@ def form_atomic_candidates_from_recurring_conversation(
                     "%s:%s" % (str(subject_key), str(group["predicate"]))
                 ),
                 retrieval_tags=tuple(group["tags"]),
+                recurrence_contract_version=(
+                    LIVING_CANON_RECURRENCE_VERSION if living_v1 else ""
+                ),
+                grouping_signature_version=(
+                    LIVING_CANON_GROUPING_SIGNATURE_VERSION if living_v1 else ""
+                ),
+                grouping_identity=grouping_identity,
+                canon_domain="real_community" if living_v1 else "",
+                canon_claim_kind="behavior_pattern" if living_v1 else "",
+                occurrence_ids=occurrence_ids if living_v1 else (),
+            ),
+            _living_formation_receipt=(
+                _living_canon_formation_receipt() if living_v1 else None
             ),
         )
         _finalize_conversation_motif_refresh(
@@ -8983,6 +10944,15 @@ def form_atomic_candidates_from_recurring_conversation(
             correction_fence=dict(group.get("correction_fence") or {}),
         )
         results.append(result)
+        if diagnostics is not None and living_v1:
+            reason_key = (
+                "independent_recurrence_established"
+                if len(occurrence_ids) >= 2 and len(root_ids) >= 2
+                else "single_occurrence_provisional"
+            )
+            diagnostics[reason_key] = int(
+                diagnostics.get(reason_key, 0) or 0
+            ) + 1
         if len(results) >= _CONVERSATION_MOTIF_MAX_CANDIDATES:
             break
     if diagnostics is not None:
@@ -9001,6 +10971,93 @@ def form_atomic_candidates_from_recurring_conversation(
             ),
         )
     return results
+
+
+def preview_living_canon_formation(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    subject_key: str,
+    max_scan: int = _CONVERSATION_MOTIF_MAX_SCAN,
+) -> LivingCanonDryRunReport:
+    """Analyze existing source-bound Ledger roots without schema or data writes."""
+
+    before = int(conn.total_changes)
+    if (
+        int(guild_id or 0) <= 0
+        or not str(subject_key or "").startswith("discord_user:")
+        or not {
+            "memory_ledger_entries",
+            "memory_ledger_lineage",
+            "memory_ledger_participants",
+            "memory_ledger_conversation_motif_fences",
+            "conversations",
+        }.issubset(
+            {
+                str(row[0] or "")
+                for row in conn.execute(
+                    "SELECT name FROM main.sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+        )
+        or not _living_canon_main_authority_unshadowed(conn)
+    ):
+        return LivingCanonDryRunReport(
+            skipped_count=1,
+            reason_counts=(("source_ineligible", 1),),
+            source_write_count=int(conn.total_changes) - before,
+            write_occurred=int(conn.total_changes) != before,
+        )
+
+    diagnostics: dict[str, int] = {}
+    pending_fences = _preview_conversation_motif_correction_fences(
+        conn,
+        guild_id=int(guild_id or 0),
+        subject_key=str(subject_key),
+        max_scan=max_scan,
+        include_neutral=True,
+    )
+    groups, reasons, rejected, _history_count = _living_canon_analyze_groups(
+        conn,
+        guild_id=int(guild_id or 0),
+        subject_key=str(subject_key),
+        max_scan=max_scan,
+        diagnostics=diagnostics,
+        fence_overrides=pending_fences,
+    )
+    state_counts: Counter[str] = Counter()
+    root_total = occurrence_total = collapsed_total = 0
+    for group in groups:
+        roots = tuple(group.get("root_ids") or ())
+        occurrences = tuple(group.get("occurrence_ids") or ())
+        root_total += len(roots)
+        occurrence_total += len(occurrences)
+        collapsed_total += max(0, len(roots) - len(occurrences))
+        state = "established" if len(roots) >= 2 and len(occurrences) >= 2 else "provisional"
+        state_counts[state] += 1
+        reasons[
+            "independent_recurrence_established"
+            if state == "established"
+            else "single_occurrence_provisional"
+        ] += 1
+    changes = int(conn.total_changes) - before
+    return LivingCanonDryRunReport(
+        proposed_count=len(groups),
+        skipped_count=sum(
+            value
+            for key, value in reasons.items()
+            if key in {"source_ineligible", "unbounded_occurrence_withheld"}
+        ),
+        ambiguous_count=int(reasons.get("meaning_ambiguous_review_only", 0)),
+        rejected_count=int(rejected),
+        candidate_state_counts=tuple(sorted(state_counts.items())),
+        reason_counts=tuple(sorted(reasons.items())),
+        independent_root_count=root_total,
+        independent_occurrence_count=occurrence_total,
+        collapsed_root_count=collapsed_total,
+        source_write_count=changes,
+        write_occurred=bool(changes),
+    )
 
 
 def form_atomic_candidates_from_moment(
@@ -9892,7 +11949,7 @@ def _finalized_conversation_correction_resolution(
     rows = conn.execute(
         """
         SELECT DISTINCT e.entry_id,e.normalized_value
-        FROM memory_ledger_entries e
+        FROM main.memory_ledger_entries e
         JOIN memory_moment_members m
           ON m.ledger_entry_id=e.entry_id
         JOIN memory_moment_windows w
@@ -9911,7 +11968,7 @@ def _finalized_conversation_correction_resolution(
           AND w.lifecycle_status='finalized'
           AND w.public_usable=1
           AND NOT EXISTS (
-            SELECT 1 FROM memory_ledger_lineage l
+            SELECT 1 FROM main.memory_ledger_lineage l
             WHERE l.guild_id=e.guild_id
               AND l.target_entry_id=e.entry_id
               AND l.lineage_type IN (
@@ -9980,7 +12037,7 @@ def _raw_conversation_correction_resolution(
     rows = conn.execute(
         """
         SELECT e.entry_id,e.normalized_value
-        FROM memory_ledger_entries e
+        FROM main.memory_ledger_entries e
         WHERE e.guild_id=? AND e.subject_key=?
           AND e.entry_id<>?
           AND e.source_table='conversations' AND e.source_role='user'
@@ -9991,7 +12048,7 @@ def _raw_conversation_correction_resolution(
           AND e.visibility IN ('public','public_safe')
           AND e.source_sequence<?
           AND NOT EXISTS (
-            SELECT 1 FROM memory_ledger_lineage l
+            SELECT 1 FROM main.memory_ledger_lineage l
             WHERE l.guild_id=e.guild_id
               AND l.target_entry_id=e.entry_id
               AND l.lineage_type IN (

--- a/bnl_memory_preview.py
+++ b/bnl_memory_preview.py
@@ -18,6 +18,10 @@ from collections import Counter
 from typing import Any, Callable, Mapping
 from urllib.parse import quote
 
+from bnl_canon_source_contract import (
+    LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+    LIVING_CANON_RECURRENCE_VERSION,
+)
 from bnl_conversation_context_v2 import (
     ConversationContextRequest,
     assemble_conversation_context_v2,
@@ -50,6 +54,7 @@ from bnl_unified_response_assessment import (
 
 
 PREVIEW_SCHEMA_VERSION = "bnl_memory_preview_v2"
+LIVING_CANON_PREVIEW_SCHEMA_VERSION = "living_canon_preview_v1"
 SIMULATED_ROUTE_MODE = "normal_chat"
 SIMULATED_CHANNEL_POLICY = "public_home"
 SIMULATED_CHANNEL_NAME = "barcode-bot"
@@ -80,6 +85,50 @@ _PREVIEW_PROMPT_CONTROL_LABEL_RE = re.compile(
     r"broadcast memory)\b",
     re.I,
 )
+_LIVING_CANON_PREVIEW_STATES = frozenset(
+    {
+        "candidate",
+        "provisional",
+        "established",
+        "contested",
+        "superseded",
+        "retired",
+        "review_only",
+        "proposed",
+        "skipped",
+        "ambiguous",
+        "rejected",
+        "withheld",
+    }
+)
+_LIVING_CANON_PREVIEW_REASONS = frozenset(
+    {
+        "single_occurrence_provisional",
+        "independent_recurrence_established",
+        "same_occurrence_collapsed",
+        "overlapping_occurrence_representation_collapsed",
+        "same_root_projection_collapsed",
+        "unbounded_occurrence_withheld",
+        "correction_fence_active",
+        "fresh_recurrence_required_after_correction",
+        "source_ineligible",
+        "visibility_ineligible",
+        "derived_source_not_independent",
+        "meaning_ambiguous_review_only",
+        "contradiction_contested",
+        "moment_lifecycle_or_membership_ineligible",
+        "candidate_limit_reached",
+        "provisional_subject_bound_reached",
+        "no_eligible_recurrence",
+    }
+)
+_LIVING_CANON_PREVIEW_BOUND_LIMITS = {
+    "eligible_ledger_scan_max": 1200,
+    "motif_candidates_max": 6,
+    "retained_roots_max": 12,
+    "occurrence_lookback_max": 64,
+    "idle_boundary_seconds": 30 * 60,
+}
 
 
 @dataclass(frozen=True)
@@ -100,6 +149,27 @@ BaselinePromptBuilder = Callable[
     [sqlite3.Connection, MemoryPreviewRequest, Mapping[str, str]],
     tuple[str, tuple[str, ...]],
 ]
+
+
+@dataclass(frozen=True)
+class LivingCanonPreviewDiagnostics:
+    schema_version: str = LIVING_CANON_PREVIEW_SCHEMA_VERSION
+    status: str = "not_evaluated"
+    status_reason: str = ""
+    recurrence_contract_version: str = "unverified"
+    grouping_signature_version: str = "unverified"
+    proposed_count: int = 0
+    skipped_count: int = 0
+    ambiguous_count: int = 0
+    rejected_count: int = 0
+    candidate_state_counts: tuple[tuple[str, int], ...] = ()
+    reason_counts: tuple[tuple[str, int], ...] = ()
+    independent_root_count: int = 0
+    independent_occurrence_count: int = 0
+    collapsed_root_count: int = 0
+    bounds: tuple[tuple[str, int], ...] = ()
+    source_write_count: int = 0
+    source_write_occurred: bool = False
 
 
 @dataclass(frozen=True)
@@ -137,6 +207,9 @@ class MemoryPreviewDiagnostics:
     prompt_owner_reason: str = ""
     replaced_factual_context_count: int = 0
     omission_reason_codes: tuple[str, ...] = ()
+    living_canon: LivingCanonPreviewDiagnostics = field(
+        default_factory=LivingCanonPreviewDiagnostics
+    )
 
 
 @dataclass
@@ -680,6 +753,281 @@ def _request_with_conversation_context(
     )
 
 
+def _preview_report_field(report: Any, name: str, default: Any) -> Any:
+    if isinstance(report, Mapping):
+        return report.get(name, default)
+    return getattr(report, name, default)
+
+
+def _preview_nonnegative_count(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return 0
+    return max(0, min(parsed, 1_000_000_000))
+
+
+def _content_free_count_pairs(
+    value: Any,
+    *,
+    allowed: frozenset[str],
+    unknown_label: str,
+) -> tuple[tuple[str, int], ...]:
+    items = value.items() if isinstance(value, Mapping) else value
+    counter: Counter[str] = Counter()
+    try:
+        pairs = tuple(items or ())
+    except TypeError:
+        return ()
+    for item in pairs:
+        if not isinstance(item, (tuple, list)) or len(item) != 2:
+            continue
+        label = str(item[0] or "").strip().casefold()
+        count = _preview_nonnegative_count(item[1])
+        if count <= 0:
+            continue
+        counter[label if label in allowed else unknown_label] += count
+    return tuple(sorted(counter.items()))
+
+
+def _content_free_preview_bounds(value: Any) -> tuple[tuple[str, int], ...]:
+    items = value.items() if isinstance(value, Mapping) else value
+    try:
+        supplied = dict(items or ())
+    except (TypeError, ValueError):
+        return ()
+    if set(supplied) != set(_LIVING_CANON_PREVIEW_BOUND_LIMITS):
+        return ()
+    if any(
+        type(supplied.get(key)) is not int
+        or supplied[key] < 0
+        for key in _LIVING_CANON_PREVIEW_BOUND_LIMITS
+    ):
+        return ()
+    bounds = tuple(
+        (
+            key,
+            supplied[key],
+        )
+        for key in _LIVING_CANON_PREVIEW_BOUND_LIMITS
+    )
+    if any(
+        value != _LIVING_CANON_PREVIEW_BOUND_LIMITS[key]
+        for key, value in bounds
+    ):
+        return ()
+    return bounds
+
+
+def _native_preview_count(value: Any) -> bool:
+    return type(value) is int and value >= 0
+
+
+def _native_preview_count_pairs(value: Any) -> bool:
+    items = value.items() if isinstance(value, Mapping) else value
+    try:
+        pairs = tuple(items or ())
+    except TypeError:
+        return False
+    return all(
+        isinstance(item, (tuple, list))
+        and len(item) == 2
+        and isinstance(item[0], str)
+        and bool(item[0].strip())
+        and _native_preview_count(item[1])
+        for item in pairs
+    )
+
+
+def build_living_canon_preview_diagnostics(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    subject_key: str,
+    analyzer: Callable[..., Any] | None = None,
+) -> LivingCanonPreviewDiagnostics:
+    """Consume the pure recurrence analyzer without exposing its evidence."""
+
+    selected_analyzer = analyzer or getattr(
+        ledger,
+        "preview_living_canon_formation",
+        None,
+    )
+    if not callable(selected_analyzer):
+        return LivingCanonPreviewDiagnostics(
+            status="unavailable",
+            status_reason="pure_analyzer_unavailable",
+        )
+    before_changes = int(getattr(conn, "total_changes", 0) or 0)
+    try:
+        report = selected_analyzer(
+            conn,
+            guild_id=int(guild_id or 0),
+            subject_key=str(subject_key or ""),
+            max_scan=1200,
+        )
+    except Exception:
+        after_changes = int(getattr(conn, "total_changes", 0) or 0)
+        write_count = max(0, after_changes - before_changes)
+        return LivingCanonPreviewDiagnostics(
+            status="rejected",
+            status_reason="pure_analyzer_error",
+            source_write_count=write_count,
+            source_write_occurred=bool(write_count),
+        )
+    after_changes = int(getattr(conn, "total_changes", 0) or 0)
+    observed_write_count = max(0, after_changes - before_changes)
+    reported_write_count = _preview_nonnegative_count(
+        _preview_report_field(report, "source_write_count", 0)
+    )
+    reported_write_occurred = _preview_report_field(
+        report,
+        "write_occurred",
+        None,
+    )
+    source_write_count = max(observed_write_count, reported_write_count)
+    source_write_occurred = bool(
+        source_write_count or reported_write_occurred is not False
+    )
+    recurrence_version = str(
+        _preview_report_field(
+            report,
+            "recurrence_contract_version",
+            "",
+        )
+        or ""
+    ).strip()
+    grouping_version = str(
+        _preview_report_field(
+            report,
+            "grouping_signature_version",
+            "",
+        )
+        or ""
+    ).strip()
+    versions_valid = bool(
+        recurrence_version == LIVING_CANON_RECURRENCE_VERSION
+        and grouping_version == LIVING_CANON_GROUPING_SIGNATURE_VERSION
+    )
+    bounds = _content_free_preview_bounds(
+        _preview_report_field(report, "bounds", ())
+    )
+    raw_counts = {
+        name: _preview_report_field(report, name, 0)
+        for name in (
+            "proposed_count",
+            "skipped_count",
+            "ambiguous_count",
+            "rejected_count",
+            "independent_root_count",
+            "independent_occurrence_count",
+            "collapsed_root_count",
+        )
+    }
+    proposed_count = _preview_nonnegative_count(raw_counts["proposed_count"])
+    skipped_count = _preview_nonnegative_count(raw_counts["skipped_count"])
+    ambiguous_count = _preview_nonnegative_count(raw_counts["ambiguous_count"])
+    rejected_count = _preview_nonnegative_count(raw_counts["rejected_count"])
+    raw_state_counts = _preview_report_field(
+        report,
+        "candidate_state_counts",
+        (),
+    )
+    raw_reason_counts = _preview_report_field(report, "reason_counts", ())
+    candidate_state_counts = _content_free_count_pairs(
+        raw_state_counts,
+        allowed=_LIVING_CANON_PREVIEW_STATES,
+        unknown_label="unrecognized_state",
+    )
+    reason_counts = _content_free_count_pairs(
+        raw_reason_counts,
+        allowed=_LIVING_CANON_PREVIEW_REASONS,
+        unknown_label="unrecognized_reason_code",
+    )
+    independent_root_count = _preview_nonnegative_count(
+        raw_counts["independent_root_count"]
+    )
+    independent_occurrence_count = _preview_nonnegative_count(
+        raw_counts["independent_occurrence_count"]
+    )
+    collapsed_root_count = _preview_nonnegative_count(
+        raw_counts["collapsed_root_count"]
+    )
+    state_map = dict(candidate_state_counts)
+    report_valid = bool(
+        all(_native_preview_count(value) for value in raw_counts.values())
+        and _native_preview_count_pairs(raw_state_counts)
+        and _native_preview_count_pairs(raw_reason_counts)
+        and proposed_count <= _LIVING_CANON_PREVIEW_BOUND_LIMITS[
+            "motif_candidates_max"
+        ]
+        and max(
+            skipped_count,
+            ambiguous_count,
+            rejected_count,
+        )
+        <= _LIVING_CANON_PREVIEW_BOUND_LIMITS["eligible_ledger_scan_max"]
+        and set(state_map).issubset({"provisional", "established"})
+        and "unrecognized_reason_code" not in dict(reason_counts)
+        and sum(state_map.values()) == proposed_count
+        and independent_root_count
+        <= (
+            _LIVING_CANON_PREVIEW_BOUND_LIMITS["motif_candidates_max"]
+            * _LIVING_CANON_PREVIEW_BOUND_LIMITS["retained_roots_max"]
+        )
+        and independent_occurrence_count <= independent_root_count
+        and collapsed_root_count
+        == independent_root_count - independent_occurrence_count
+    )
+    status = "analyzed"
+    status_reason = "pure_analyzer_complete"
+    if source_write_occurred:
+        status = "rejected"
+        status_reason = "pure_analyzer_write_detected"
+    elif not versions_valid:
+        status = "rejected"
+        status_reason = "pure_analyzer_version_unverified"
+    elif not bounds:
+        status = "rejected"
+        status_reason = "pure_analyzer_bounds_unverified"
+    elif not report_valid:
+        status = "rejected"
+        status_reason = "pure_analyzer_report_invalid"
+    report_trusted = status == "analyzed"
+    return LivingCanonPreviewDiagnostics(
+        status=status,
+        status_reason=status_reason,
+        recurrence_contract_version=(
+            recurrence_version if versions_valid else "unverified"
+        ),
+        grouping_signature_version=(
+            grouping_version if versions_valid else "unverified"
+        ),
+        proposed_count=proposed_count if report_trusted else 0,
+        skipped_count=skipped_count if report_trusted else 0,
+        ambiguous_count=ambiguous_count if report_trusted else 0,
+        rejected_count=rejected_count if report_trusted else 0,
+        candidate_state_counts=(
+            candidate_state_counts if report_trusted else ()
+        ),
+        reason_counts=reason_counts if report_trusted else (),
+        independent_root_count=(
+            independent_root_count if report_trusted else 0
+        ),
+        independent_occurrence_count=(
+            independent_occurrence_count if report_trusted else 0
+        ),
+        collapsed_root_count=(
+            collapsed_root_count if report_trusted else 0
+        ),
+        bounds=bounds,
+        source_write_count=source_write_count,
+        source_write_occurred=source_write_occurred,
+    )
+
+
 def _formation_and_lifecycle(
     conn: sqlite3.Connection,
     request: MemoryPreviewRequest,
@@ -916,6 +1264,7 @@ def _diagnostics(
     packet: UnifiedIntelligencePacket | None = None,
     assessment: UnifiedResponseAssessment | None = None,
     packet_prompt: PacketOwnedPrompt | None = None,
+    living_canon: LivingCanonPreviewDiagnostics | None = None,
 ) -> MemoryPreviewDiagnostics:
     lifecycle = lifecycle or {}
     profile = (
@@ -1088,6 +1437,7 @@ def _diagnostics(
             else 0
         ),
         omission_reason_codes=tuple(sorted(omission_reasons)),
+        living_canon=(living_canon or LivingCanonPreviewDiagnostics()),
     )
 
 
@@ -1131,8 +1481,28 @@ def prepare_memory_preview(
         base=environ,
     )
     conn: sqlite3.Connection | None = None
+    living_canon = LivingCanonPreviewDiagnostics()
     try:
         conn = _open_read_only_memory_clone(request.source_db_path)
+        analysis_conn = sqlite3.connect(":memory:", check_same_thread=False)
+        try:
+            # Fork the already-frozen source image.  The analyzer remains
+            # disposable without taking a second source snapshot that could
+            # drift from the packet/assessment/prompt snapshot.
+            conn.backup(analysis_conn)
+            living_canon = build_living_canon_preview_diagnostics(
+                analysis_conn,
+                guild_id=request.guild_id,
+                subject_key=ledger.subject_key_for_user(
+                    request.subject_user_id
+                ),
+            )
+        finally:
+            # The analyzer always receives a disposable clone.  DDL and TEMP
+            # objects do not increment total_changes, so write diagnostics
+            # alone cannot prove that a connection is safe for downstream
+            # packet or prompt owners.
+            analysis_conn.close()
         conversation_context = _preview_conversation_context(
             conn,
             request,
@@ -1178,6 +1548,7 @@ def prepare_memory_preview(
                 formation_reason_codes=formation_reasons,
                 source_funnel_counts=source_funnel,
                 lifecycle=lifecycle,
+                living_canon=living_canon,
             )
             return PreparedMemoryPreview(
                 connection=conn,
@@ -1238,6 +1609,7 @@ def prepare_memory_preview(
             packet=packet,
             assessment=assessment,
             packet_prompt=packet_prompt,
+            living_canon=living_canon,
         )
         return PreparedMemoryPreview(
             connection=conn,
@@ -1272,6 +1644,7 @@ def prepare_memory_preview(
             diagnostics=_diagnostics(
                 route_status="processing_error",
                 route_reason=type(exc).__name__,
+                living_canon=living_canon,
             ),
         )
 
@@ -1562,6 +1935,7 @@ def render_content_free_diagnostics(
             prepared.packet_owned_prompt.reason or "not_evaluated"
         ),
     )
+    living = diag.living_canon
     return (
         "- preview_schema: `%s`" % diag.schema_version,
         "- simulated_route: `normal_chat/public_home/#barcode-bot`",
@@ -1573,6 +1947,29 @@ def render_content_free_diagnostics(
         % (list(diag.formation_reason_codes) or ["none"]),
         "- source_funnel: `%s`"
         % dict(diag.source_funnel_counts),
+        "- living_canon_dry_run: `status=%s reason=%s recurrence=%s "
+        "grouping=%s proposed=%s skipped=%s ambiguous=%s rejected=%s "
+        "roots=%s occurrences=%s collapsed_roots=%s "
+        "source_write_count=%s source_write_occurred=%s`"
+        % (
+            living.status,
+            living.status_reason or "none",
+            living.recurrence_contract_version,
+            living.grouping_signature_version,
+            living.proposed_count,
+            living.skipped_count,
+            living.ambiguous_count,
+            living.rejected_count,
+            living.independent_root_count,
+            living.independent_occurrence_count,
+            living.collapsed_root_count,
+            living.source_write_count,
+            str(living.source_write_occurred).lower(),
+        ),
+        "- living_canon_states: `%s`"
+        % dict(living.candidate_state_counts),
+        "- living_canon_reasons: `%s`" % dict(living.reason_counts),
+        "- living_canon_bounds: `%s`" % dict(living.bounds),
         "- lifecycle: `scopes=%s candidates=%s state_changes=%s`"
         % (
             diag.lifecycle_scopes,

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -207,6 +207,7 @@ _ADDITIVE_PREDICATES = {
     "shared_moment",
     "topic_or_motif",
 }
+_LIVING_CANON_NEUTRAL_PREDICATE_PREFIX = "conversation_motif_neutral_"
 _TERM_RE = re.compile(r"[a-z0-9][a-z0-9'’-]*", re.I)
 _TERM_STOPWORDS = {
     "a",
@@ -244,6 +245,53 @@ _TERM_STOPWORDS = {
     "with",
     "you",
 }
+
+
+def _living_candidate_pending_convergence(
+    candidate: Mapping[str, Any],
+) -> bool:
+    """Fail closed on any PR 4 Living marker until PR 5 owns the lane."""
+
+    predicate = str(candidate.get("predicate_key") or "").strip().casefold()
+    if predicate.startswith(_LIVING_CANON_NEUTRAL_PREDICATE_PREFIX):
+        return True
+    if any(
+        str(candidate.get(key) or "")
+        for key in (
+            "recurrence_contract_version",
+            "grouping_signature_version",
+            "grouping_identity",
+            "canon_domain",
+            "canon_claim_kind",
+            "occurrence_digest",
+        )
+    ):
+        return True
+    if candidate.get("independent_occurrence_count") not in {
+        None,
+        "",
+        0,
+        False,
+        "0",
+    }:
+        return True
+    if str(candidate.get("occurrence_ids_json") or "").strip() not in {
+        "",
+        "[]",
+    }:
+        return True
+    if str(candidate.get("recurrence_proof_json") or "").strip() not in {
+        "",
+        "{}",
+    }:
+        return True
+    return candidate.get("public_usable") not in {
+        None,
+        "",
+        0,
+        False,
+        "0",
+    }
 _CURRENT_CORRECTION_RE = re.compile(
     r"\b(?:correction|correcting|that's\s+wrong|that\s+is\s+wrong|"
     r"not\s+anymore|no[,;:]?\s+(?:my|i|we)|"
@@ -596,7 +644,7 @@ def _table_columns(
     return {
         str(row[1] or "")
         for row in conn.execute(
-            "PRAGMA table_info(%s)" % str(table_name or "")
+            "PRAGMA main.table_info(%s)" % str(table_name or "")
         ).fetchall()
         if len(row) > 1 and str(row[1] or "")
     }
@@ -769,7 +817,7 @@ def _canon_identity_signal(
     history_rows = conn.execute(
         """
         SELECT entry_id,subject_display_name
-        FROM memory_ledger_entries e
+        FROM main.memory_ledger_entries e
         WHERE guild_id=? AND subject_key=?
           AND source_table='conversations' AND source_role='user'
           AND channel_policy IN (
@@ -779,7 +827,7 @@ def _canon_identity_signal(
           AND public_usable=1 AND derived=0 AND projection=0
           AND lifecycle_status='active'
           AND NOT EXISTS (
-            SELECT 1 FROM memory_ledger_lineage l
+            SELECT 1 FROM main.memory_ledger_lineage l
             WHERE l.guild_id=e.guild_id AND l.target_entry_id=e.entry_id
               AND l.lineage_type IN (
                 'correction_of','supersedes','retracts'
@@ -877,7 +925,7 @@ def _conversation_root_metadata(
     entry_row = conn.execute(
         """
         SELECT entry_id
-        FROM memory_ledger_entries
+        FROM main.memory_ledger_entries
         WHERE guild_id=? AND subject_key=?
           AND source_table='conversations' AND source_row_id=?
           AND lifecycle_status='active'
@@ -952,7 +1000,7 @@ def _moment_root_metadata(
             """
             SELECT DISTINCT source.ledger_entry_id
             FROM memory_moment_contribution_sources source
-            JOIN memory_ledger_entries entry
+            JOIN main.memory_ledger_entries entry
               ON entry.entry_id=source.ledger_entry_id
             WHERE source.moment_id=? AND source.participant_key=?
               AND entry.subject_key=? AND entry.lifecycle_status='active'
@@ -1522,7 +1570,9 @@ def _ledger_entry_digest(
 ) -> str:
     columns = {
         str(row[1])
-        for row in conn.execute("PRAGMA table_info(memory_ledger_entries)").fetchall()
+        for row in conn.execute(
+            "PRAGMA main.table_info(memory_ledger_entries)"
+        ).fetchall()
     }
     if not columns or "entry_id" not in columns:
         return ""
@@ -1556,7 +1606,7 @@ def _ledger_entry_digest(
         if column in columns
     )
     row = conn.execute(
-        "SELECT %s FROM memory_ledger_entries WHERE entry_id=?"
+        "SELECT %s FROM main.memory_ledger_entries WHERE entry_id=?"
         % ",".join(selected_columns),
         (entry_id,),
     ).fetchone()
@@ -1566,7 +1616,7 @@ def _ledger_entry_digest(
     lineage = conn.execute(
         """
         SELECT lineage_type,target_entry_id
-        FROM memory_ledger_lineage
+        FROM main.memory_ledger_lineage
         WHERE guild_id=? AND entry_id=?
         ORDER BY lineage_type,target_entry_id
         """,
@@ -1575,7 +1625,7 @@ def _ledger_entry_digest(
     incoming = conn.execute(
         """
         SELECT entry_id,lineage_type
-        FROM memory_ledger_lineage
+        FROM main.memory_ledger_lineage
         WHERE guild_id=? AND target_entry_id=?
           AND lineage_type IN ('correction_of','supersedes','retracts')
         ORDER BY entry_id,lineage_type
@@ -1985,9 +2035,19 @@ def _atomic_candidate_row(
         "review_status",
         "review_due_at",
         "last_seen_at",
+        "recurrence_contract_version",
+        "grouping_signature_version",
+        "grouping_identity",
+        "canon_domain",
+        "canon_claim_kind",
+        "independent_occurrence_count",
+        "occurrence_ids_json",
+        "occurrence_digest",
+        "recurrence_proof_json",
+        "public_usable",
     )
     row = conn.execute(
-        "SELECT %s FROM memory_ledger_knowledge_candidates WHERE candidate_id=?"
+        "SELECT %s FROM main.memory_ledger_knowledge_candidates WHERE candidate_id=?"
         % ",".join(columns),
         (candidate_id,),
     ).fetchone()
@@ -2009,10 +2069,10 @@ def _atomic_root_snapshot(
                e.visibility,e.public_usable,e.derived,e.projection,
                e.lifecycle_status,e.updated_at,e.normalized_value,
                e.predicate_key,e.observed_at,e.source_sequence
-        FROM memory_ledger_knowledge_roots r
-        JOIN memory_ledger_knowledge_candidates c
+        FROM main.memory_ledger_knowledge_roots r
+        JOIN main.memory_ledger_knowledge_candidates c
           ON c.candidate_id=r.candidate_id
-        LEFT JOIN memory_ledger_entries e ON e.entry_id=r.root_entry_id
+        LEFT JOIN main.memory_ledger_entries e ON e.entry_id=r.root_entry_id
         WHERE r.is_independent=1 AND r.root_status='eligible'
           AND (
             (?<>'' AND c.consolidation_id=?)
@@ -2070,7 +2130,7 @@ def _atomic_candidate_digest(
             conn.execute(
                 """
                 SELECT entry_id,lineage_type
-                FROM memory_ledger_lineage
+                FROM main.memory_ledger_lineage
                 WHERE guild_id=? AND target_entry_id=?
                   AND lineage_type IN ('correction_of','supersedes','retracts')
                 ORDER BY entry_id,lineage_type
@@ -2245,7 +2305,7 @@ def _atomic_items(
         for row in conn.execute(
             """
             SELECT candidate_id
-            FROM memory_ledger_knowledge_candidates
+            FROM main.memory_ledger_knowledge_candidates
             WHERE guild_id=? AND subject_key=?
               AND (
                 COALESCE(canonical_candidate_id,'')=''
@@ -2286,7 +2346,13 @@ def _atomic_items(
             _parse_time(request.now) or datetime.now(timezone.utc)
         )
         reason = ""
-        if candidate.get("lifecycle_schema_version") != (
+        if _living_candidate_pending_convergence(candidate):
+            # PR 4 owns formation and proof only. Neither a curated-family nor
+            # family-neutral Living candidate can become response evidence
+            # until PR 5 converges every canon status under the one-packet
+            # factual owner.
+            reason = "living_canon_pending_packet_convergence"
+        elif candidate.get("lifecycle_schema_version") != (
             ATOMIC_KNOWLEDGE_LIFECYCLE_SCHEMA_VERSION
         ):
             reason = "atomic_lifecycle_not_reconciled"
@@ -2358,7 +2424,7 @@ def _atomic_items(
             for root in roots:
                 if conn.execute(
                     """
-                    SELECT 1 FROM memory_ledger_lineage
+                    SELECT 1 FROM main.memory_ledger_lineage
                     WHERE guild_id=? AND target_entry_id=?
                       AND lineage_type IN (
                         'correction_of','supersedes','retracts'
@@ -2425,7 +2491,7 @@ def _atomic_items(
             for row in conn.execute(
                 """
                 SELECT participant_key
-                FROM memory_ledger_knowledge_participants
+                FROM main.memory_ledger_knowledge_participants
                 WHERE candidate_id=?
                 ORDER BY participant_role,participant_key
                 """,

--- a/docs/BNL01_PUBLIC_HOME_BROAD_RECALL_OWNER.md
+++ b/docs/BNL01_PUBLIC_HOME_BROAD_RECALL_OWNER.md
@@ -98,6 +98,29 @@ Motif formation is explicitly disabled during this pass, so catch-up alone
 cannot create or promote durable memory. Later restarts resume an unfinished
 slice from the recorded cursor.
 
+## Living Canon recurrence v1 boundary
+
+PR 4 extends the existing Ledger/Moment/atomic owner with the versioned
+`living_canon_recurrence_v1` contract. The nine curated motif families remain
+strong labels, while an unmatched public-human meaning may be proposed under
+a deterministic family-neutral signature. One eligible occurrence remains
+provisional. Establishment requires at least two distinct immutable human
+roots across at least two canonical occurrences; message volume, roles,
+Relationship state, canon recognition, and confidence scores cannot replace
+that proof.
+
+Occurrence counting is exchange-anchored and bounded. Multiple rows in one
+continuous exchange, a finalized Moment representing that exchange, and
+overlapping Moment representations collapse to one occurrence. A correction,
+deletion, privacy change, retraction, or supersession removes the affected
+support, and post-correction establishment requires two fresh qualifying
+occurrences.
+
+This PR does not activate that formation path, run historical catch-up, or add
+Living claims to the live packet. Its historical analyzer is content-free and
+zero-write. Any bounded historical apply remains a separately approved
+operation, and packet convergence remains PR 5 work.
+
 ## Diagnostics and rollback
 
 Content-free synthesis receipts record `authority_mode` as either

--- a/docs/hybrid_canon_claim_contract_v1.md
+++ b/docs/hybrid_canon_claim_contract_v1.md
@@ -41,6 +41,33 @@ validity, lifecycle, and correction lineage. Claim IDs use the permanent
 `bnl_canon_claim_identity_v1` namespace, so a contract-version change creates a
 new revision without changing the logical claim identity.
 
+### Living Canon recurrence proof
+
+A Living claim must carry explicit stored proof for
+`living_canon_recurrence_v1`: an allowed community domain and pattern claim
+kind, a versioned deterministic grouping signature, distinct immutable human
+root identities, distinct canonical occurrence identities, and matching
+content-free proof counts. Blank, malformed, negative, count-mismatched, or
+inconsistent self-asserted fields fail closed. The database inventory also
+requires the current reconciled lifecycle state and stored lineage; the proof
+is a consistency contract, not a cryptographic attestation. Neither
+`candidate_state='established'` nor a finalized Moment is a substitute for
+this proof.
+
+Curated family labels and the family-neutral fallback use the same recurrence
+standard. One occurrence stays provisional; two qualifying roots across two
+qualifying occurrences may become establishment-eligible only after lifecycle
+and correction checks. Neutral patterns cannot create scalar identity, roles,
+relationships, milestones, operational truth, Declared Canon, or Legacy
+Canon.
+
+PR 4 keeps every recurrence-marked Living candidate, curated-family or
+family-neutral, outside the live packet until PR 5 owns convergence. Its
+historical preview runs against a disposable in-memory clone and
+returns only versions, states, bounds, aggregate reason counts, and an explicit
+zero-source-write receipt. It does not expose source text or identifiers, and
+it never performs historical promotion.
+
 Broadcast normalization uses `cleaned_summary` for any public-safe projection.
 `raw_note`, an internal usage scope, an inactive lifecycle, or an ambiguous
 boolean always fails closed to internal review metadata. Question-scoped Open

--- a/tests/test_hybrid_canon_claim_contract.py
+++ b/tests/test_hybrid_canon_claim_contract.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import os
 import sqlite3
 import tempfile
@@ -10,6 +12,93 @@ import bnl_declared_canon as declared_canon
 import bnl_memory_ledger as ledger
 import bnl_moment_engine as moments
 import bnl_unified_intelligence_packet as packet
+
+
+def _ledger_digest(*parts):
+    return hashlib.sha256(
+        "\x1f".join(str(part or "") for part in parts).encode("utf-8")
+    ).hexdigest()
+
+
+def _living_adapter_row():
+    subject_key = "discord_user:7"
+    predicate_key = "unseen_topic_pattern"
+    domain = "real_community"
+    root_ids = ("root-1", "root-2")
+    occurrence_ids = ("exchange-1", "exchange-2")
+    grouping_identity = _ledger_digest(
+        canon.LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+        subject_key,
+        predicate_key,
+        domain,
+    )
+    root_digest = _ledger_digest(*root_ids)
+    occurrence_digest = _ledger_digest(*occurrence_ids)
+    meaning = "They repeatedly compare unusual antenna materials."
+    proof = {
+        "recurrence_contract_version": canon.LIVING_CANON_RECURRENCE_VERSION,
+        "grouping_signature_version": (
+            canon.LIVING_CANON_GROUPING_SIGNATURE_VERSION
+        ),
+        "grouping_identity": grouping_identity,
+        "candidate_state": "established",
+        "candidate_eligible": True,
+        "source_eligible": True,
+        "roots_valid": True,
+        "occurrence_bounded": True,
+        "correction_fence_clear": True,
+        "contradiction_clear": True,
+        "independent_root_count": 2,
+        "independent_occurrence_count": 2,
+        "root_digest": root_digest,
+        "occurrence_digest": occurrence_digest,
+        "bounds": {
+            "eligible_ledger_scan_max": 1200,
+            "motif_candidates_max": 6,
+            "retained_roots_max": 12,
+            "occurrence_lookback_max": 64,
+            "idle_boundary_seconds": 1800,
+        },
+    }
+    return {
+        "candidate_id": "candidate-2",
+        "candidate_type": "topic_or_motif",
+        "candidate_state": "established",
+        "subject_key": subject_key,
+        "predicate_key": predicate_key,
+        "meaning": meaning,
+        "value_digest": _ledger_digest(" ".join(meaning.lower().split())),
+        "root_ids": root_ids,
+        "occurrence_ids": occurrence_ids,
+        "recurrence_contract_version": canon.LIVING_CANON_RECURRENCE_VERSION,
+        "grouping_signature_version": (
+            canon.LIVING_CANON_GROUPING_SIGNATURE_VERSION
+        ),
+        "grouping_identity": grouping_identity,
+        "domain": domain,
+        "claim_kind": "behavior_pattern",
+        "candidate_eligible": True,
+        "live_eligible": False,
+        "invalidated_reason": "",
+        "invalidated_at": "",
+        "lifecycle_schema_version": (
+            canon.ATOMIC_KNOWLEDGE_LIFECYCLE_SCHEMA_VERSION
+        ),
+        "conflict_value_count": 1,
+        "review_status": "not_required",
+        "review_due_at": "",
+        "eligible_independent_root_count": 2,
+        "reinforcement_count": 2,
+        "lifecycle_reason": "independent_recurrence_established",
+        "lifecycle_evaluated_at": "2026-08-02T00:00:00+00:00",
+        "independent_root_count": 2,
+        "independent_occurrence_count": 2,
+        "root_digest": root_digest,
+        "occurrence_digest": occurrence_digest,
+        "recurrence_proof_json": json.dumps(proof, sort_keys=True),
+        "visibility": "public_safe",
+        "public_usable": True,
+    }
 
 
 class HybridCanonClaimContractTests(unittest.TestCase):
@@ -1164,17 +1253,28 @@ class HybridCanonClaimContractTests(unittest.TestCase):
                 conn.close()
 
     def test_living_adapter_rejects_heterogeneous_or_unestablished_rows(self):
-        role = canon.adapt_living_atomic_claim(
-            {
-                "candidate_id": "role-candidate",
-                "candidate_type": "person_role_fact",
-                "candidate_state": "established",
-                "subject_key": "discord_user:7",
-                "predicate_key": "role",
-                "meaning": "A role claim.",
-                "root_ids": ("root-1", "root-2"),
-            }
-        )
+        for candidate_type in (
+            "person_role_fact",
+            "milestone",
+            "open_loop_or_question",
+            "inference_or_contested_claim",
+        ):
+            with self.subTest(candidate_type=candidate_type):
+                heterogeneous = canon.adapt_living_atomic_claim(
+                    {
+                        "candidate_id": "%s-candidate" % candidate_type,
+                        "candidate_type": candidate_type,
+                        "candidate_state": "established",
+                        "subject_key": "discord_user:7",
+                        "predicate_key": "heterogeneous",
+                        "meaning": "A non-topic claim.",
+                        "root_ids": ("root-1", "root-2"),
+                    }
+                )
+                self.assertEqual(
+                    heterogeneous.reason,
+                    "living_claim_kind_ineligible",
+                )
         provisional = canon.adapt_living_atomic_claim(
             {
                 "candidate_id": "provisional-candidate",
@@ -1186,11 +1286,22 @@ class HybridCanonClaimContractTests(unittest.TestCase):
                 "root_ids": ("root-1", "root-2"),
             }
         )
-        self.assertEqual(role.reason, "living_claim_kind_ineligible")
         self.assertEqual(
             provisional.reason,
             "living_lifecycle_ineligible",
         )
+        contested = canon.adapt_living_atomic_claim(
+            {
+                "candidate_id": "contested-candidate",
+                "candidate_type": "topic_or_motif",
+                "candidate_state": "contested",
+                "subject_key": "discord_user:7",
+                "predicate_key": "topic",
+                "meaning": "A contested motif.",
+                "root_ids": ("root-1", "root-2"),
+            }
+        )
+        self.assertEqual(contested.reason, "living_lifecycle_ineligible")
 
     def test_established_atomic_or_finalized_moment_needs_recurrence_proof(self):
         established = canon.adapt_living_atomic_claim(
@@ -1230,38 +1341,93 @@ class HybridCanonClaimContractTests(unittest.TestCase):
         self.assertEqual(moment.claim.lifecycle, canon.ClaimLifecycle.REVIEW_ONLY)
 
     def test_living_adapter_accepts_only_explicit_cross_occurrence_proof(self):
-        adapted = canon.adapt_living_atomic_claim(
-            {
-                "candidate_id": "candidate-2",
-                "candidate_type": "topic_or_motif",
-                "candidate_state": "established",
-                "subject_key": "discord_user:7",
-                "predicate_key": "unseen_topic_pattern",
-                "meaning": "They repeatedly compare unusual antenna materials.",
-                "root_ids": ("root-1", "root-2"),
-                "occurrence_ids": ("exchange-1", "exchange-2"),
-                "recurrence_contract_version": "living_canon_recurrence_v1",
-                "domain": "real_community",
-                "claim_kind": "behavior_pattern",
-                "candidate_eligible": True,
-                "source_eligible": True,
-                "roots_valid": True,
-                "occurrence_bounded": True,
-                "correction_fence_clear": True,
-                "contradiction_clear": True,
-                "independent_root_count": 2,
-                "independent_occurrence_count": 2,
-                "visibility": "public_safe",
-                "public_usable": True,
-            }
-        )
+        row = _living_adapter_row()
+        adapted = canon.adapt_living_atomic_claim(row)
         self.assertEqual(adapted.reason, "eligible_living")
         self.assertEqual(adapted.claim.canon_status, canon.CanonStatus.LIVING)
         self.assertEqual(
             adapted.claim.recurrence_contract_version,
             canon.LIVING_CANON_RECURRENCE_VERSION,
         )
+        self.assertEqual(
+            adapted.claim.grouping_signature_version,
+            canon.LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+        )
+        self.assertEqual(
+            adapted.claim.grouping_identity,
+            row["grouping_identity"],
+        )
         self.assertFalse(adapted.live_eligible)
+
+        for drift in (
+            {"invalidated_reason": "root_deleted"},
+            {"invalidated_at": "2026-08-01T00:00:00+00:00"},
+            {"conflict_value_count": 0},
+            {"conflict_value_count": 2},
+            {"conflict_value_count": "1"},
+            {"conflict_value_count": True},
+            {"lifecycle_schema_version": "bogus"},
+            {"review_status": "contested"},
+            {"review_status": "current", "review_due_at": "2099-01-01"},
+            {"review_due_at": "2020-01-01T00:00:00+00:00"},
+            {"review_due_at": "malformed"},
+            {"eligible_independent_root_count": 0},
+            {"reinforcement_count": 0},
+            {"lifecycle_reason": "unresolved_contradiction"},
+            {"lifecycle_evaluated_at": "malformed"},
+            {"live_eligible": True},
+        ):
+            hostile = canon.adapt_living_atomic_claim({**row, **drift})
+            self.assertEqual(hostile.reason, "living_lifecycle_unverified")
+            self.assertEqual(
+                hostile.claim.lifecycle,
+                canon.ClaimLifecycle.REVIEW_ONLY,
+            )
+        missing_review_due = dict(row)
+        missing_review_due.pop("review_due_at")
+        self.assertEqual(
+            canon.adapt_living_atomic_claim(missing_review_due).reason,
+            "living_lifecycle_unverified",
+        )
+        for missing_field in (
+            "eligible_independent_root_count",
+            "reinforcement_count",
+            "lifecycle_reason",
+            "lifecycle_evaluated_at",
+        ):
+            missing = dict(row)
+            missing.pop(missing_field)
+            self.assertEqual(
+                canon.adapt_living_atomic_claim(missing).reason,
+                "living_lifecycle_unverified",
+                missing_field,
+            )
+        self.assertEqual(
+            canon.adapt_living_atomic_claim(
+                {**row, "meaning": "Arbitrary replacement text."}
+            ).reason,
+            "living_recurrence_proof_mismatch",
+        )
+        self.assertEqual(
+            canon.adapt_living_atomic_claim(
+                {**row, "claim_kind": "tradition_or_joke"}
+            ).reason,
+            "living_domain_ineligible",
+        )
+
+        stored_proof = json.loads(row["recurrence_proof_json"])
+        stored_proof["independent_occurrence_count"] = 3
+        tampered = canon.adapt_living_atomic_claim(
+            {
+                **row,
+                "recurrence_proof_json": json.dumps(stored_proof),
+            }
+        )
+        self.assertEqual(tampered.reason, "living_recurrence_proof_mismatch")
+        self.assertEqual(
+            tampered.claim.lifecycle,
+            canon.ClaimLifecycle.REVIEW_ONLY,
+        )
 
         missing_identity = canon.adapt_living_atomic_claim(
             {
@@ -1290,6 +1456,381 @@ class HybridCanonClaimContractTests(unittest.TestCase):
             missing_identity.reason,
             "living_source_identity_missing",
         )
+
+    def test_living_adapter_rejects_forged_or_stale_recurrence_proof(self):
+        row = _living_adapter_row()
+        proof = json.loads(row["recurrence_proof_json"])
+
+        self_asserted = dict(row)
+        self_asserted.pop("recurrence_proof_json")
+        self_asserted.update(proof)
+
+        string_boolean_proof = dict(proof)
+        string_boolean_proof["source_eligible"] = "true"
+
+        wrong_grouping = "f" * 64
+        wrong_grouping_proof = dict(proof)
+        wrong_grouping_proof["grouping_identity"] = wrong_grouping
+
+        wrong_root_digest = "e" * 64
+        wrong_root_proof = dict(proof)
+        wrong_root_proof["root_digest"] = wrong_root_digest
+
+        cases = (
+            (
+                "missing stored proof",
+                self_asserted,
+                "living_recurrence_unverified",
+            ),
+            (
+                "string proof boolean",
+                {
+                    **row,
+                    "recurrence_proof_json": json.dumps(
+                        string_boolean_proof,
+                        sort_keys=True,
+                    ),
+                },
+                "living_recurrence_unverified",
+            ),
+            (
+                "wrong deterministic grouping",
+                {
+                    **row,
+                    "grouping_identity": wrong_grouping,
+                    "recurrence_proof_json": json.dumps(
+                        wrong_grouping_proof,
+                        sort_keys=True,
+                    ),
+                },
+                "living_grouping_unverified",
+            ),
+            (
+                "wrong deterministic root digest",
+                {
+                    **row,
+                    "root_digest": wrong_root_digest,
+                    "recurrence_proof_json": json.dumps(
+                        wrong_root_proof,
+                        sort_keys=True,
+                    ),
+                },
+                "living_recurrence_proof_mismatch",
+            ),
+            (
+                "same-count mutated roots",
+                {
+                    **row,
+                    "root_ids": ("root-3", "root-4"),
+                },
+                "living_recurrence_proof_mismatch",
+            ),
+            (
+                "same-count mutated occurrences",
+                {
+                    **row,
+                    "occurrence_ids": ("exchange-3", "exchange-4"),
+                },
+                "living_recurrence_proof_mismatch",
+            ),
+            (
+                "non-string occurrence identity",
+                {
+                    **row,
+                    "occurrence_ids": ("exchange-1", 2),
+                },
+                "living_recurrence_proof_mismatch",
+            ),
+        )
+        for label, candidate, expected_reason in cases:
+            with self.subTest(label=label):
+                result = canon.adapt_living_atomic_claim(candidate)
+                self.assertEqual(result.reason, expected_reason)
+                self.assertIsNotNone(result.claim)
+                self.assertEqual(
+                    result.claim.lifecycle,
+                    canon.ClaimLifecycle.REVIEW_ONLY,
+                )
+
+    def test_atomic_inventory_requires_stored_grouping_and_recurrence_proof(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE memory_ledger_knowledge_candidates (
+                  candidate_id TEXT PRIMARY KEY,
+                  guild_id INTEGER NOT NULL,
+                  candidate_type TEXT NOT NULL,
+                  candidate_state TEXT NOT NULL,
+                  subject_key TEXT NOT NULL,
+                  predicate_key TEXT NOT NULL,
+                  normalized_value TEXT NOT NULL,
+                  value_digest TEXT NOT NULL,
+                  visibility TEXT NOT NULL,
+                  public_usable INTEGER NOT NULL DEFAULT 0,
+                  candidate_eligible INTEGER NOT NULL DEFAULT 0,
+                  live_eligible INTEGER NOT NULL DEFAULT 0,
+                  invalidated_reason TEXT DEFAULT '',
+                  invalidated_at TEXT DEFAULT '',
+                  lifecycle_schema_version TEXT DEFAULT '',
+                  conflict_value_count INTEGER NOT NULL DEFAULT 0,
+                  review_status TEXT DEFAULT '',
+                  review_due_at TEXT DEFAULT '',
+                  eligible_independent_root_count INTEGER NOT NULL DEFAULT 0,
+                  reinforcement_count INTEGER NOT NULL DEFAULT 0,
+                  lifecycle_reason TEXT DEFAULT '',
+                  lifecycle_evaluated_at TEXT DEFAULT '',
+                  independent_root_count INTEGER NOT NULL DEFAULT 0,
+                  recurrence_contract_version TEXT DEFAULT '',
+                  grouping_signature_version TEXT DEFAULT '',
+                  grouping_identity TEXT DEFAULT '',
+                  canon_domain TEXT DEFAULT '',
+                  canon_claim_kind TEXT DEFAULT '',
+                  independent_occurrence_count INTEGER NOT NULL DEFAULT 0,
+                  occurrence_ids_json TEXT NOT NULL DEFAULT '[]',
+                  recurrence_proof_json TEXT NOT NULL DEFAULT '{}',
+                  root_digest TEXT DEFAULT '',
+                  occurrence_digest TEXT DEFAULT '',
+                  updated_at TEXT DEFAULT '',
+                  last_seen_at TEXT DEFAULT ''
+                );
+                CREATE TABLE memory_ledger_knowledge_roots (
+                  candidate_id TEXT NOT NULL,
+                  guild_id INTEGER NOT NULL,
+                  root_entry_id TEXT NOT NULL,
+                  is_independent INTEGER NOT NULL DEFAULT 0,
+                  PRIMARY KEY(candidate_id, root_entry_id)
+                );
+                """
+            )
+            bounds = {
+                "eligible_ledger_scan_max": 1200,
+                "motif_candidates_max": 6,
+                "retained_roots_max": 12,
+                "occurrence_lookback_max": 64,
+                "idle_boundary_seconds": 1800,
+            }
+            subject_key = "discord_user:7"
+            predicate_key = "conversation_pattern_unseen_topic"
+            domain = "real_community"
+            valid_roots = ("root:1", "root:2")
+            valid_occurrences = ("occurrence:1", "occurrence:2")
+            grouping_identity = _ledger_digest(
+                canon.LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+                subject_key,
+                predicate_key,
+                domain,
+            )
+            root_digest = _ledger_digest(*valid_roots)
+            occurrence_digest = _ledger_digest(*valid_occurrences)
+            proof = {
+                "recurrence_contract_version": (
+                    canon.LIVING_CANON_RECURRENCE_VERSION
+                ),
+                "grouping_signature_version": (
+                    canon.LIVING_CANON_GROUPING_SIGNATURE_VERSION
+                ),
+                "grouping_identity": grouping_identity,
+                "candidate_state": "established",
+                "candidate_eligible": True,
+                "source_eligible": True,
+                "roots_valid": True,
+                "occurrence_bounded": True,
+                "correction_fence_clear": True,
+                "contradiction_clear": True,
+                "independent_root_count": 2,
+                "independent_occurrence_count": 2,
+                "root_digest": root_digest,
+                "occurrence_digest": occurrence_digest,
+                "bounds": bounds,
+            }
+            base_values = (
+                1,
+                "topic_or_motif",
+                "established",
+                subject_key,
+                predicate_key,
+                "private-source-text-must-not-appear",
+                _ledger_digest("private-source-text-must-not-appear"),
+                "public_safe",
+                1,
+                1,
+                2,
+            )
+            conn.execute(
+                """
+                INSERT INTO memory_ledger_knowledge_candidates(
+                  candidate_id,guild_id,candidate_type,candidate_state,
+                  subject_key,predicate_key,normalized_value,value_digest,visibility,
+                  public_usable,candidate_eligible,independent_root_count,
+                  recurrence_contract_version,grouping_signature_version,
+                  grouping_identity,canon_domain,canon_claim_kind,
+                  independent_occurrence_count,occurrence_ids_json,
+                  recurrence_proof_json,root_digest,occurrence_digest,
+                  live_eligible,lifecycle_schema_version,invalidated_reason,
+                  invalidated_at,conflict_value_count,review_status,
+                  review_due_at,
+                  eligible_independent_root_count,reinforcement_count,
+                  lifecycle_reason,lifecycle_evaluated_at,
+                  updated_at,last_seen_at
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    "candidate-valid",
+                    *base_values,
+                    canon.LIVING_CANON_RECURRENCE_VERSION,
+                    canon.LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+                    grouping_identity,
+                    domain,
+                    "behavior_pattern",
+                    2,
+                    json.dumps(valid_occurrences),
+                    json.dumps(proof, sort_keys=True),
+                    root_digest,
+                    occurrence_digest,
+                    0,
+                    canon.ATOMIC_KNOWLEDGE_LIFECYCLE_SCHEMA_VERSION,
+                    "",
+                    "",
+                    1,
+                    "not_required",
+                    "",
+                    2,
+                    2,
+                    "independent_recurrence_established",
+                    "2026-08-02T00:00:00+00:00",
+                    "2026-08-02T00:00:00+00:00",
+                    "2026-08-02T00:00:00+00:00",
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO memory_ledger_knowledge_candidates(
+                  candidate_id,guild_id,candidate_type,candidate_state,
+                  subject_key,predicate_key,normalized_value,value_digest,visibility,
+                  public_usable,candidate_eligible,independent_root_count,
+                  root_digest,updated_at,last_seen_at
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    "candidate-old",
+                    *base_values,
+                    "c" * 64,
+                    "2026-08-02T00:00:00+00:00",
+                    "2026-08-02T00:00:00+00:00",
+                ),
+            )
+            for candidate_id, root_ids in (
+                ("candidate-valid", ("root:1", "root:2")),
+                ("candidate-old", ("root:3", "root:4")),
+            ):
+                conn.executemany(
+                    """
+                    INSERT INTO memory_ledger_knowledge_roots(
+                      candidate_id,guild_id,root_entry_id,is_independent
+                    ) VALUES(?,1,?,1)
+                    """,
+                    ((candidate_id, root_id) for root_id in root_ids),
+                )
+            conn.commit()
+
+            inventory = canon.build_claim_contract_inventory(conn, guild_id=1)
+
+            self.assertEqual(inventory["mutationCount"], 0)
+            self.assertEqual(inventory["sourceRows"]["atomic_knowledge"], 2)
+            self.assertEqual(inventory["statuses"]["living"], 1)
+            self.assertEqual(inventory["livingRecurrenceVerifiedCount"], 1)
+            self.assertEqual(inventory["livingGroupingVerifiedCount"], 1)
+            self.assertEqual(inventory["reasonCounts"]["eligible_living"], 1)
+            self.assertEqual(
+                inventory["reasonCounts"]["living_recurrence_unverified"],
+                1,
+            )
+            self.assertNotIn("private-source-text-must-not-appear", repr(inventory))
+            self.assertNotIn("root:1", repr(inventory))
+            self.assertNotIn("occurrence:1", repr(inventory))
+        finally:
+            conn.close()
+
+    def test_pre_pr4_atomic_schema_stays_review_only_and_zero_write(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE memory_ledger_knowledge_candidates (
+                  candidate_id TEXT PRIMARY KEY,
+                  guild_id INTEGER NOT NULL,
+                  candidate_type TEXT NOT NULL,
+                  candidate_state TEXT NOT NULL,
+                  subject_key TEXT NOT NULL,
+                  predicate_key TEXT NOT NULL,
+                  normalized_value TEXT NOT NULL,
+                  visibility TEXT NOT NULL,
+                  candidate_eligible INTEGER NOT NULL DEFAULT 0,
+                  independent_root_count INTEGER NOT NULL DEFAULT 0,
+                  root_digest TEXT NOT NULL,
+                  last_seen_at TEXT DEFAULT '',
+                  updated_at TEXT NOT NULL
+                );
+                CREATE TABLE memory_ledger_knowledge_roots (
+                  candidate_id TEXT NOT NULL,
+                  guild_id INTEGER NOT NULL,
+                  root_entry_id TEXT NOT NULL,
+                  is_independent INTEGER NOT NULL DEFAULT 0,
+                  PRIMARY KEY(candidate_id, root_entry_id)
+                );
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO memory_ledger_knowledge_candidates(
+                  candidate_id,guild_id,candidate_type,candidate_state,
+                  subject_key,predicate_key,normalized_value,visibility,
+                  candidate_eligible,independent_root_count,root_digest,
+                  last_seen_at,updated_at
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    "pre-pr4-candidate",
+                    1,
+                    "topic_or_motif",
+                    "established",
+                    "discord_user:7",
+                    "conversation_motif_old",
+                    "pre-pr4-private-text",
+                    "public_safe",
+                    1,
+                    2,
+                    _ledger_digest("pre-pr4-root-1", "pre-pr4-root-2"),
+                    "2026-08-01T00:00:00+00:00",
+                    "2026-08-01T00:00:00+00:00",
+                ),
+            )
+            conn.executemany(
+                """
+                INSERT INTO memory_ledger_knowledge_roots(
+                  candidate_id,guild_id,root_entry_id,is_independent
+                ) VALUES('pre-pr4-candidate',1,?,1)
+                """,
+                (("pre-pr4-root-1",), ("pre-pr4-root-2",)),
+            )
+            conn.commit()
+            before_changes = conn.total_changes
+
+            inventory = canon.build_claim_contract_inventory(conn, guild_id=1)
+
+            self.assertEqual(conn.total_changes, before_changes)
+            self.assertEqual(inventory["mutationCount"], 0)
+            self.assertEqual(inventory["sourceRows"]["atomic_knowledge"], 1)
+            self.assertEqual(inventory["statuses"]["living"], 0)
+            self.assertEqual(
+                inventory["reasonCounts"]["living_recurrence_unverified"],
+                1,
+            )
+            self.assertNotIn("pre-pr4-private-text", repr(inventory))
+            self.assertNotIn("pre-pr4-root-1", repr(inventory))
+        finally:
+            conn.close()
 
     def test_open_signal_is_ephemeral_and_source_linked(self):
         adapted = canon.adapt_open_signal_claim(
@@ -1807,6 +2348,76 @@ class HybridCanonClaimContractTests(unittest.TestCase):
         finally:
             conn.close()
 
+    def test_current_v1_living_candidate_normalizes_as_verified_living(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            ledger.ensure_memory_ledger_schema(conn)
+            conn.execute(
+                """
+                CREATE TABLE conversations(
+                  id INTEGER PRIMARY KEY,guild_id INTEGER,user_id INTEGER,
+                  user_name TEXT,role TEXT,content TEXT,channel_id INTEGER,
+                  channel_name TEXT,channel_policy TEXT,route_mode TEXT,
+                  timestamp TEXT
+                )
+                """
+            )
+            roots = []
+            for row_id, observed_at, text in (
+                (
+                    811,
+                    "2026-07-24T20:00:00+00:00",
+                    "I tune ceramic antennas with copper meshes during field experiments.",
+                ),
+                (
+                    812,
+                    "2026-07-25T20:00:00+00:00",
+                    "We tune the ceramic antenna with a copper mesh during the field experiment.",
+                ),
+            ):
+                conn.execute(
+                    "INSERT INTO conversations VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        row_id, 1, 7, "Test Member", "user", text, 10,
+                        "barcode-bot", "public_home", "normal_chat",
+                        observed_at,
+                    ),
+                )
+                roots.append(
+                    ledger.shadow_conversation_row(
+                        conn,
+                        row_id=row_id,
+                        user_id=7,
+                        user_name="Test Member",
+                        guild_id=1,
+                        role="user",
+                        content=text,
+                        channel_name="barcode-bot",
+                        channel_policy="public_home",
+                        channel_id=10,
+                        route_mode="normal_chat",
+                        observed_at=observed_at,
+                        source_sequence=row_id,
+                        environ={ledger.MEMORY_LEDGER_SHADOW_ENV: "true"},
+                    ).entry_id
+                )
+            formed = ledger.form_atomic_candidates_from_recurring_conversation(
+                conn,
+                trigger_entry_id=roots[-1],
+                environ={
+                    ledger.MEMORY_LEDGER_SHADOW_ENV: "true",
+                    ledger.LIVING_CANON_V1_FORMATION_ENV: "true",
+                },
+            )
+            self.assertEqual(len(formed), 1)
+            inventory = canon.build_claim_contract_inventory(conn, guild_id=1)
+            self.assertEqual(inventory["statuses"]["living"], 1)
+            self.assertEqual(inventory["reasonCounts"]["eligible_living"], 1)
+            self.assertEqual(inventory["livingRecurrenceVerifiedCount"], 1)
+            self.assertEqual(inventory["livingGroupingVerifiedCount"], 1)
+        finally:
+            conn.close()
+
     def test_current_finalized_moment_normalizes_as_review_only(self):
         conn = sqlite3.connect(":memory:")
         try:
@@ -1950,6 +2561,54 @@ class HybridCanonClaimContractTests(unittest.TestCase):
             self.assertEqual(roots, {"candidate-1": ["guild-1-root"]})
         finally:
             conn.close()
+
+    def test_inventory_lineage_lookup_requires_requested_scope_columns(self):
+        for omitted_column in ("guild_id", "is_independent"):
+            conn = sqlite3.connect(":memory:")
+            try:
+                definitions = {
+                    "candidate_id": "TEXT",
+                    "guild_id": "INTEGER",
+                    "root_entry_id": "TEXT",
+                    "is_independent": "INTEGER",
+                }
+                selected = tuple(
+                    column
+                    for column in definitions
+                    if column != omitted_column
+                )
+                conn.execute(
+                    "CREATE TABLE memory_ledger_knowledge_roots(%s)"
+                    % ",".join(
+                        "%s %s" % (column, definitions[column])
+                        for column in selected
+                    )
+                )
+                values = {
+                    "candidate_id": "candidate-1",
+                    "guild_id": 1,
+                    "root_entry_id": "root-x",
+                    "is_independent": 1,
+                }
+                conn.execute(
+                    "INSERT INTO memory_ledger_knowledge_roots VALUES(%s)"
+                    % ",".join("?" for _column in selected),
+                    tuple(values[column] for column in selected),
+                )
+
+                roots = canon._inventory_scoped_lineage_map(
+                    conn,
+                    table_name="memory_ledger_knowledge_roots",
+                    owner_column="candidate_id",
+                    root_column="root_entry_id",
+                    owner_ids=("candidate-1",),
+                    guild_id=1,
+                    independent_only=True,
+                )
+
+                self.assertEqual(roots, {}, omitted_column)
+            finally:
+                conn.close()
 
     def test_callem_bini_cannot_unlock_cache_back_in_broad_packet(self):
         conn = sqlite3.connect(":memory:")

--- a/tests/test_living_canon_recurrence_v1.py
+++ b/tests/test_living_canon_recurrence_v1.py
@@ -1,0 +1,1587 @@
+import hashlib
+import json
+import sqlite3
+import unittest
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+import bnl_memory_ledger as ledger
+import bnl_moment_engine as moments
+
+
+class LivingCanonRecurrenceV1Tests(unittest.TestCase):
+    def setUp(self):
+        self.conn = sqlite3.connect(":memory:")
+        ledger.ensure_memory_ledger_schema(self.conn)
+        moments.ensure_moment_schema(self.conn)
+        self.conn.execute(
+            """
+            CREATE TABLE conversations (
+              id INTEGER PRIMARY KEY,guild_id INTEGER,user_id INTEGER,
+              user_name TEXT,role TEXT,content TEXT,channel_id INTEGER,
+              channel_name TEXT,channel_policy TEXT,route_mode TEXT,
+              timestamp TEXT
+            )
+            """
+        )
+        self.v1_env = {
+            ledger.MEMORY_LEDGER_SHADOW_ENV: "true",
+            ledger.LIVING_CANON_V1_FORMATION_ENV: "true",
+        }
+
+    def tearDown(self):
+        self.conn.close()
+
+    def add_conversation(
+        self,
+        row_id,
+        text,
+        observed_at,
+        *,
+        route_mode="normal_chat",
+        user_id=7,
+        user_name="Test Member",
+        role="user",
+    ):
+        self.conn.execute(
+            "INSERT INTO conversations VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                row_id,
+                1,
+                user_id,
+                user_name,
+                role,
+                text,
+                10,
+                "barcode-bot",
+                "public_home",
+                route_mode,
+                observed_at,
+            ),
+        )
+        result = ledger.shadow_conversation_row(
+            self.conn,
+            row_id=row_id,
+            user_id=user_id,
+            user_name=user_name,
+            guild_id=1,
+            role=role,
+            content=text,
+            channel_name="barcode-bot",
+            channel_policy="public_home",
+            channel_id=10,
+            route_mode=route_mode,
+            observed_at=observed_at,
+            source_sequence=row_id,
+            environ={ledger.MEMORY_LEDGER_SHADOW_ENV: "true"},
+        )
+        self.assertIn(result.outcome, {"inserted", "deduplicated"})
+        return result.entry_id
+
+    def ensure_journal_receipt_schema(self):
+        self.conn.execute(
+            """
+            CREATE TABLE bnl_journal_source_events (
+              event_seq INTEGER PRIMARY KEY AUTOINCREMENT,
+              guild_id INTEGER NOT NULL,source_kind TEXT NOT NULL,
+              source_key TEXT NOT NULL,occurred_at_ms INTEGER NOT NULL,
+              ingested_at_ms INTEGER NOT NULL,channel_id INTEGER,
+              channel_policy TEXT NOT NULL,subject_ref TEXT NOT NULL,
+              private_display_name TEXT NOT NULL,raw_text TEXT NOT NULL,
+              sanitized_summary TEXT NOT NULL,content_hash TEXT NOT NULL,
+              public_usable INTEGER NOT NULL,metadata_json TEXT NOT NULL,
+              UNIQUE(guild_id,source_kind,source_key)
+            )
+            """
+        )
+        self.conn.executescript(
+            """
+            CREATE TRIGGER trg_bnl_journal_sources_no_duplicate_insert
+            BEFORE INSERT ON bnl_journal_source_events
+            WHEN EXISTS (
+              SELECT 1 FROM bnl_journal_source_events
+              WHERE event_seq=NEW.event_seq OR (
+                guild_id=NEW.guild_id AND source_kind=NEW.source_kind
+                AND source_key=NEW.source_key
+              )
+            ) BEGIN
+              SELECT RAISE(ABORT,'bnl_journal_source_events_duplicate_identity');
+            END;
+            CREATE TRIGGER trg_bnl_journal_sources_no_update
+            BEFORE UPDATE ON bnl_journal_source_events BEGIN
+              SELECT RAISE(ABORT,'bnl_journal_source_events_immutable');
+            END;
+            CREATE TRIGGER trg_bnl_journal_sources_no_delete
+            BEFORE DELETE ON bnl_journal_source_events BEGIN
+              SELECT RAISE(ABORT,'bnl_journal_source_events_immutable');
+            END;
+            """
+        )
+
+    def add_continuity_receipt(self, row_id, text, observed_at):
+        observed = datetime.fromisoformat(observed_at)
+        metadata = {
+            "conversationRowId": row_id,
+            "routeMode": "conversation_continuity",
+            "source": "discord_backfill",
+        }
+        self.conn.execute(
+            """
+            INSERT INTO bnl_journal_source_events(
+              guild_id,source_kind,source_key,occurred_at_ms,ingested_at_ms,
+              channel_id,channel_policy,subject_ref,private_display_name,
+              raw_text,sanitized_summary,content_hash,public_usable,
+              metadata_json
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                1, "discord_message", "legacy_row:%s" % row_id,
+                int(observed.timestamp() * 1000),
+                int(observed.timestamp() * 1000) + 1, 10, "public_home",
+                "discord_user:7", "Test Member", text, "inert summary",
+                hashlib.sha256(text.encode("utf-8")).hexdigest(), 1,
+                json.dumps(metadata, sort_keys=True, separators=(",", ":")),
+            ),
+        )
+
+    def add_moment(self, moment_id, roots, observed_at, *, edge_roots=None):
+        source_rows = []
+        for root in roots:
+            row = self.conn.execute(
+                """
+                SELECT entry_id,source_role,subject_key,subject_display_name,
+                       source_sequence,observed_at
+                FROM memory_ledger_entries WHERE entry_id=?
+                """,
+                (root,),
+            ).fetchone()
+            self.assertIsNotNone(row)
+            source_rows.append(row)
+        participant_records = {}
+        for row in source_rows:
+            role_name = "human_author" if row[1] == "user" else "bnl_participant"
+            participant_key = row[2] if row[1] == "user" else ledger.BNL_SUBJECT_KEY
+            participant_name = row[3] if row[1] == "user" else "BNL-01"
+            participant_records.setdefault(
+                (participant_key, role_name),
+                {
+                    "name": participant_name,
+                    "first": row[5],
+                    "last": row[5],
+                    "authored": 0,
+                    "order": len(participant_records),
+                },
+            )
+            record = participant_records[(participant_key, role_name)]
+            record["first"] = min(record["first"], row[5])
+            record["last"] = max(record["last"], row[5])
+            record["authored"] += int(row[1] == "user")
+        canonical = ledger.insert_ledger_entry(
+            self.conn,
+            ledger.LedgerEntry(
+                guild_id=1,
+                source_table="memory_moment_windows",
+                source_row_id=moment_id,
+                source_revision="1",
+                source_role="derived_assessment",
+                entry_type="shared_moment",
+                subject_key="moment:%s" % moment_id,
+                predicate_key="shared_moment",
+                value="Content-free recurrence fixture.",
+                source_class=ledger.SourceClass.DERIVED_SUMMARY,
+                route_mode="normal_chat",
+                channel_id=10,
+                channel_name="barcode-bot",
+                channel_policy="public_home",
+                visibility=ledger.Visibility.PUBLIC,
+                confidence=ledger.Confidence.LOW,
+                public_usable=True,
+                derived=True,
+                projection=True,
+                observed_at=observed_at,
+                lifecycle_status="review_only",
+                participants=tuple(
+                    ledger.LedgerParticipant(
+                        participant_key,
+                        record["name"],
+                        role_name,
+                        record["order"],
+                    )
+                    for (participant_key, role_name), record
+                    in participant_records.items()
+                ),
+                lineage=tuple(("derived_from", root) for root in roots),
+            ),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO memory_moment_windows(
+              moment_id,guild_id,channel_id,channel_name,channel_policy,
+              route_mode,topic_key,window_started_at,last_activity_at,
+              lifecycle_status,visibility,public_usable,salience,
+              human_entry_count,model_entry_count,participant_count,summary,
+              created_at,updated_at,canonical_ledger_entry_id
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                moment_id, 1, 10, "barcode-bot", "public_home", "normal_chat",
+                "topic-recurrence", observed_at, observed_at, "finalized",
+                "public", 1, 0.5,
+                sum(int(row[1] == "user") for row in source_rows),
+                sum(int(row[1] != "user") for row in source_rows),
+                len(participant_records), "", observed_at,
+                observed_at, canonical.entry_id,
+            ),
+        )
+        exact_edge_roots = set(roots if edge_roots is None else edge_roots)
+        for root, source in zip(roots, source_rows):
+            membership_role = (
+                "human_author" if source[1] == "user" else "bnl_participant"
+            )
+            self.conn.execute(
+                "INSERT INTO memory_moment_members VALUES(?,?,?,?,?,?)",
+                (
+                    moment_id,
+                    root,
+                    source[4],
+                    source[5],
+                    membership_role,
+                    observed_at,
+                ),
+            )
+            if root in exact_edge_roots:
+                self.conn.execute(
+                    "INSERT INTO memory_ledger_lineage VALUES(?,?,?,?,?)",
+                    (root, 1, "part_of_moment", canonical.entry_id, observed_at),
+                )
+        for (participant_key, role_name), record in participant_records.items():
+            self.conn.execute(
+                """
+                INSERT INTO memory_moment_participants(
+                  moment_id,participant_key,safe_display_name,participant_role,
+                  first_seen_at,last_seen_at,authored_entry_count,
+                  participation_order,created_at,updated_at
+                ) VALUES(?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    moment_id,
+                    participant_key,
+                    record["name"],
+                    role_name,
+                    record["first"],
+                    record["last"],
+                    record["authored"],
+                    record["order"],
+                    observed_at,
+                    observed_at,
+                ),
+            )
+
+    def form(self, trigger):
+        return ledger.form_atomic_candidates_from_recurring_conversation(
+            self.conn,
+            trigger_entry_id=trigger,
+            environ=self.v1_env,
+        )
+
+    def candidate(self):
+        return self.conn.execute(
+            """
+            SELECT candidate_id,candidate_state,reinforcement_count,
+                   eligible_independent_root_count,
+                   independent_occurrence_count,predicate_key,
+                   recurrence_contract_version,grouping_signature_version,
+                   public_usable,recurrence_proof_json
+            FROM memory_ledger_knowledge_candidates
+            WHERE recurrence_contract_version=?
+            ORDER BY created_at,candidate_id LIMIT 1
+            """,
+            (ledger.LIVING_CANON_RECURRENCE_VERSION,),
+        ).fetchone()
+
+    def test_v1_is_default_off_and_legacy_singleton_stays_unformed(self):
+        root = self.add_conversation(
+            1,
+            "I keep tuning ceramic antennas during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        legacy_env = {
+            ledger.MEMORY_LEDGER_SHADOW_ENV: "true",
+            ledger.CONVERSATION_MOTIF_FORMATION_ENV: "true",
+        }
+        self.assertEqual(
+            ledger.form_atomic_candidates_from_recurring_conversation(
+                self.conn,
+                trigger_entry_id=root,
+                environ=legacy_env,
+            ),
+            [],
+        )
+        self.assertEqual(self.candidate(), None)
+
+        self.conn.execute(
+            "INSERT INTO conversations VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                99, 1, 9, "Retained Member", "user",
+                "I arrange a memory palace beside the violet archive doorway.",
+                10, "barcode-bot", "public_home", "normal_chat",
+                "2026-07-21T10:00:00+00:00",
+            ),
+        )
+        both_env = {
+            ledger.MEMORY_LEDGER_SHADOW_ENV: "true",
+            ledger.CONVERSATION_MOTIF_FORMATION_ENV: "true",
+            ledger.LIVING_CANON_V1_FORMATION_ENV: "true",
+        }
+        self.assertEqual(
+            ledger.form_atomic_candidates_from_recurring_conversation(
+                self.conn,
+                guild_id=1,
+                subject_key="discord_user:9",
+                environ=both_env,
+            ),
+            [],
+        )
+        self.assertEqual(
+            self.conn.execute(
+                "SELECT COUNT(*) FROM memory_ledger_entries "
+                "WHERE subject_key='discord_user:9'"
+            ).fetchone()[0],
+            0,
+        )
+
+    def test_one_occurrence_is_provisional_and_two_establish(self):
+        first = self.add_conversation(
+            2,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        created = self.form(first)
+        self.assertEqual(len(created), 1)
+        row = self.candidate()
+        self.assertEqual(row[1:5], ("provisional", 1, 1, 1))
+        self.assertEqual(row[6], ledger.LIVING_CANON_RECURRENCE_VERSION)
+        self.assertEqual(row[7], ledger.LIVING_CANON_GROUPING_SIGNATURE_VERSION)
+        self.assertEqual(row[8], 0)
+
+        second = self.add_conversation(
+            3,
+            "We tune the ceramic antenna with a copper mesh during the field experiment.",
+            "2026-07-21T10:00:00+00:00",
+        )
+        replay = self.form(second)
+        self.assertEqual(len(replay), 1)
+        row = self.candidate()
+        self.assertEqual(row[1:5], ("established", 2, 2, 2))
+        proof = json.loads(row[9])
+        self.assertTrue(proof["candidate_eligible"])
+        self.assertEqual(self.form(second)[0].candidate_id, row[0])
+
+    def test_curated_family_and_neutral_groups_share_v1_recurrence_standard(self):
+        family_one = self.add_conversation(
+            5000,
+            "I tune the synth patch and drum mix for the radio track.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        self.form(family_one)
+        family_predicate = "conversation_motif_music_production"
+        family_row = self.conn.execute(
+            """
+            SELECT candidate_state,recurrence_contract_version,
+                   grouping_signature_version,eligible_independent_root_count,
+                   independent_occurrence_count,canon_domain,canon_claim_kind
+            FROM memory_ledger_knowledge_candidates WHERE predicate_key=?
+            """,
+            (family_predicate,),
+        ).fetchone()
+        self.assertEqual(family_row[0], "provisional")
+
+        family_two = self.add_conversation(
+            5001,
+            "The synth patch and drum mix shape the radio track.",
+            "2026-07-21T10:00:00+00:00",
+        )
+        self.form(family_two)
+        family_row = self.conn.execute(
+            """
+            SELECT candidate_state,recurrence_contract_version,
+                   grouping_signature_version,eligible_independent_root_count,
+                   independent_occurrence_count,canon_domain,canon_claim_kind
+            FROM memory_ledger_knowledge_candidates WHERE predicate_key=?
+              AND candidate_state!='superseded'
+            ORDER BY created_at DESC LIMIT 1
+            """,
+            (family_predicate,),
+        ).fetchone()
+        self.assertEqual(family_row[0], "established")
+
+        neutral_one = self.add_conversation(
+            5002,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-22T10:00:00+00:00",
+        )
+        self.form(neutral_one)
+        neutral_predicate = ledger._conversation_motif_neutral_predicate(
+            ledger._conversation_motif_exact_signature(
+                "I tune ceramic antennas with copper meshes during field experiments."
+            ),
+            subject_key="discord_user:7",
+        )
+        neutral_two = self.add_conversation(
+            5003,
+            "We tune the ceramic antenna with a copper mesh during the field experiment.",
+            "2026-07-23T10:00:00+00:00",
+        )
+        self.form(neutral_two)
+        neutral_row = self.conn.execute(
+            """
+            SELECT candidate_state,recurrence_contract_version,
+                   grouping_signature_version,eligible_independent_root_count,
+                   independent_occurrence_count,canon_domain,canon_claim_kind
+            FROM memory_ledger_knowledge_candidates WHERE predicate_key=?
+              AND candidate_state!='superseded'
+            ORDER BY created_at DESC LIMIT 1
+            """,
+            (neutral_predicate,),
+        ).fetchone()
+        self.assertEqual(neutral_row[0], "established")
+        self.assertEqual(family_row[1:], neutral_row[1:])
+        self.assertEqual(
+            family_row[1:],
+            (
+                ledger.LIVING_CANON_RECURRENCE_VERSION,
+                ledger.LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+                2,
+                2,
+                "real_community",
+                "behavior_pattern",
+            ),
+        )
+
+    def test_same_exchange_collapses_to_one_occurrence(self):
+        self.add_conversation(
+            4,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        second = self.add_conversation(
+            5,
+            "We tune the ceramic antenna with a copper mesh during the field experiment.",
+            "2026-07-20T10:05:00+00:00",
+        )
+        self.form(second)
+        row = self.candidate()
+        self.assertEqual(row[1], "provisional")
+        self.assertEqual(row[4], 1)
+
+    def test_occurrence_boundaries_cross_midnight_and_exact_thirty_minutes(self):
+        cross_midnight = (
+            self.add_conversation(
+                5100,
+                "I catalog amber turbines beside the western lighthouse.",
+                "2026-07-20T23:55:00+00:00",
+            ),
+            self.add_conversation(
+                5101,
+                "I catalog amber turbines beside the western lighthouse.",
+                "2026-07-21T00:05:00+00:00",
+            ),
+        )
+        exact_boundary = (
+            self.add_conversation(
+                5102,
+                "I align silver beacons beside the northern observatory.",
+                "2026-07-22T10:00:00+00:00",
+            ),
+            self.add_conversation(
+                5103,
+                "I align silver beacons beside the northern observatory.",
+                "2026-07-22T10:30:00+00:00",
+            ),
+        )
+        beyond_boundary = (
+            self.add_conversation(
+                5104,
+                "I chart violet gyroscopes beside the eastern archive.",
+                "2026-07-23T10:00:00+00:00",
+            ),
+            self.add_conversation(
+                5105,
+                "I chart violet gyroscopes beside the eastern archive.",
+                "2026-07-23T10:30:01+00:00",
+            ),
+        )
+        for roots, expected_count in (
+            (cross_midnight, 1),
+            (exact_boundary, 1),
+            (beyond_boundary, 2),
+        ):
+            with self.subTest(roots=roots):
+                states, occurrences, _reasons = (
+                    ledger._living_canon_root_states_and_occurrences(
+                        self.conn,
+                        guild_id=1,
+                        subject_key="discord_user:7",
+                        entry_ids=roots,
+                    )
+                )
+                self.assertEqual(set(states), set(roots))
+                self.assertEqual(len(set(occurrences.values())), expected_count)
+
+    def test_family_marker_without_full_match_uses_neutral_group(self):
+        root = self.add_conversation(
+            6,
+            "I arrange a memory palace beside the violet archive doorway.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        self.form(root)
+        self.assertTrue(self.candidate()[5].startswith("conversation_motif_neutral_"))
+
+    def test_public_proposal_cannot_forge_v1_authority(self):
+        root = self.add_conversation(
+            7,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        predicate = "conversation_motif_neutral_forged"
+        result = ledger.form_atomic_knowledge_candidate(
+            self.conn,
+            ledger.AtomicKnowledgeProposal(
+                candidate_type="topic_or_motif",
+                subject_key="discord_user:7",
+                predicate_key=predicate,
+                meaning="Forged Living pattern.",
+                root_entry_ids=(root,),
+                participant_keys=("discord_user:7",),
+                epistemic_status="observed",
+                currentness="historical",
+                recurrence_contract_version=ledger.LIVING_CANON_RECURRENCE_VERSION,
+                grouping_signature_version=ledger.LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+                grouping_identity="0" * 64,
+                canon_domain="real_community",
+                canon_claim_kind="behavior_pattern",
+                occurrence_ids=("forged",),
+            ),
+        )
+        self.assertEqual(result.reason_code, "living_canon_formation_authority_missing")
+
+    def test_preview_is_read_only_and_does_not_create_schema(self):
+        root = self.add_conversation(
+            8,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        self.assertTrue(root)
+        before = self.conn.total_changes
+        report = ledger.preview_living_canon_formation(
+            self.conn,
+            guild_id=1,
+            subject_key="discord_user:7",
+        )
+        self.assertFalse(report.write_occurred)
+        self.assertEqual(self.conn.total_changes, before)
+        self.assertEqual(dict(report.candidate_state_counts), {"provisional": 1})
+        self.assertGreaterEqual(
+            dict(report.reason_counts).get("single_occurrence_provisional", 0),
+            1,
+        )
+
+        empty = sqlite3.connect(":memory:")
+        try:
+            empty_report = ledger.preview_living_canon_formation(
+                empty,
+                guild_id=1,
+                subject_key="discord_user:7",
+            )
+            self.assertFalse(empty_report.write_occurred)
+            self.assertEqual(
+                empty.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type='table'"
+                ).fetchone()[0],
+                0,
+            )
+        finally:
+            empty.close()
+
+    def test_preview_reports_unbounded_occurrence_withheld_directly(self):
+        root = self.add_conversation(
+            5300,
+            "I catalog amber turbines beside the western lighthouse.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        for index in range(ledger._CONVERSATION_OCCURRENCE_MAX_SCAN + 1):
+            self.conn.execute(
+                "INSERT INTO memory_ledger_lineage VALUES(?,?,?,?,?)",
+                (
+                    root,
+                    1,
+                    "part_of_moment",
+                    "moment-target-%03d" % index,
+                    "2026-07-20T10:01:00+00:00",
+                ),
+            )
+        report = ledger.preview_living_canon_formation(
+            self.conn,
+            guild_id=1,
+            subject_key="discord_user:7",
+        )
+        self.assertGreaterEqual(
+            dict(report.reason_counts).get("unbounded_occurrence_withheld", 0),
+            1,
+        )
+        self.assertEqual(report.proposed_count, 0)
+
+    def test_preview_reports_meaning_ambiguous_review_only_directly(self):
+        root = self.add_conversation(
+            5400,
+            "I catalog amber turbines beside the western lighthouse.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        states, occurrences, _reasons = (
+            ledger._living_canon_root_states_and_occurrences(
+                self.conn,
+                guild_id=1,
+                subject_key="discord_user:7",
+                entry_ids=(root,),
+            )
+        )
+        rebound = replace(
+            states[root],
+            text="I align silver beacons beside the northern observatory.",
+        )
+        with mock.patch.object(
+            ledger,
+            "_living_canon_root_states_and_occurrences",
+            return_value=({root: rebound}, occurrences, ()),
+        ):
+            report = ledger.preview_living_canon_formation(
+                self.conn,
+                guild_id=1,
+                subject_key="discord_user:7",
+            )
+        self.assertGreaterEqual(
+            dict(report.reason_counts).get("meaning_ambiguous_review_only", 0),
+            1,
+        )
+        self.assertGreaterEqual(report.ambiguous_count, 1)
+        self.assertEqual(report.proposed_count, 0)
+
+    def test_raw_occurrence_and_candidate_stay_stable_after_moments(self):
+        roots = [
+            self.add_conversation(
+                20 + index,
+                "I tune ceramic antennas with copper meshes during field experiments.",
+                "2026-07-20T10:%02d:00+00:00" % (index * 5),
+            )
+            for index in range(3)
+        ]
+        states, occurrences, _ = ledger._living_canon_root_states_and_occurrences(
+            self.conn,
+            guild_id=1,
+            subject_key="discord_user:7",
+            entry_ids=tuple(roots),
+        )
+        self.assertEqual(len(states), 3)
+        raw_occurrence = occurrences[roots[0]]
+        self.assertEqual(set(occurrences.values()), {raw_occurrence})
+        candidate_id = self.form(roots[-1])[0].candidate_id
+
+        self.add_moment("moment-a", (roots[0],), "2026-07-20T10:20:00+00:00")
+        self.add_moment(
+            "moment-b", tuple(roots[1:]), "2026-07-20T10:21:00+00:00"
+        )
+        states, occurrences, _ = ledger._living_canon_root_states_and_occurrences(
+            self.conn,
+            guild_id=1,
+            subject_key="discord_user:7",
+            entry_ids=tuple(roots),
+        )
+        self.assertEqual(len(states), 3)
+        self.assertEqual(set(occurrences.values()), {raw_occurrence})
+        self.assertEqual(self.form(roots[-1])[0].candidate_id, candidate_id)
+
+        hostile_one = self.add_conversation(
+            40,
+            "I chart cobalt weather vanes beside the eastern observatory.",
+            "2026-07-22T10:00:00+00:00",
+        )
+        hostile_two = self.add_conversation(
+            41,
+            "I chart cobalt weather vanes beside the eastern observatory.",
+            "2026-07-23T10:00:00+00:00",
+        )
+        self.add_moment(
+            "forged-member",
+            (hostile_one, hostile_two),
+            "2026-07-23T10:10:00+00:00",
+            edge_roots=(hostile_one,),
+        )
+        states, occurrences, reasons = (
+            ledger._living_canon_root_states_and_occurrences(
+                self.conn,
+                guild_id=1,
+                subject_key="discord_user:7",
+                entry_ids=(hostile_one, hostile_two),
+            )
+        )
+        self.assertEqual(len(states), 2)
+        self.assertEqual(occurrences, {})
+        self.assertIn("moment_lifecycle_or_membership_ineligible", reasons)
+        hostile_report = ledger.preview_living_canon_formation(
+            self.conn, guild_id=1, subject_key="discord_user:7"
+        )
+        self.assertGreaterEqual(hostile_report.rejected_count, 1)
+        self.assertGreaterEqual(
+            dict(hostile_report.reason_counts).get(
+                "moment_lifecycle_or_membership_ineligible", 0
+            ),
+            1,
+        )
+
+    def test_neutral_correction_fence_requires_two_fresh_occurrences(self):
+        old = self.add_conversation(
+            30,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        self.form(old)
+        predicate = self.candidate()[5]
+        self.conn.execute(
+            """
+            INSERT INTO memory_ledger_conversation_motif_fences(
+              guild_id,subject_key,predicate_key,correction_entry_id,
+              correction_observed_at,reason_code,fence_state,satisfied_at,
+              created_at,updated_at
+            ) VALUES(?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                1, "discord_user:7", predicate, "correction-fixture",
+                "2026-07-21T10:00:00+00:00",
+                "conversation_motif_correction_ambiguous", "active", "",
+                "2026-07-21T10:00:00+00:00",
+                "2026-07-21T10:00:00+00:00",
+            ),
+        )
+        fresh_one = self.add_conversation(
+            31,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-22T10:00:00+00:00",
+        )
+        self.form(fresh_one)
+        self.assertNotEqual(self.candidate()[1], "established")
+        self.assertEqual(
+            self.conn.execute(
+                "SELECT fence_state FROM memory_ledger_conversation_motif_fences "
+                "WHERE guild_id=1 AND subject_key='discord_user:7' AND predicate_key=?",
+                (predicate,),
+            ).fetchone()[0],
+            "active",
+        )
+        fresh_two = self.add_conversation(
+            32,
+            "We tune the ceramic antenna with a copper mesh during the field experiment.",
+            "2026-07-23T10:00:00+00:00",
+        )
+        self.form(fresh_two)
+        self.assertEqual(self.candidate()[1], "established")
+        self.assertEqual(
+            self.conn.execute(
+                "SELECT fence_state FROM memory_ledger_conversation_motif_fences "
+                "WHERE guild_id=1 AND subject_key='discord_user:7' AND predicate_key=?",
+                (predicate,),
+            ).fetchone()[0],
+            "satisfied",
+        )
+
+    def test_overlapping_valid_moments_collapse_one_connected_component(self):
+        roots = [
+            self.add_conversation(
+                100 + index,
+                "I chart cobalt weather vanes beside the eastern observatory.",
+                "2026-07-%02dT10:00:00+00:00" % (20 + index),
+            )
+            for index in range(3)
+        ]
+        self.add_moment("overlap-a", tuple(roots[:2]), "2026-07-22T11:00:00+00:00")
+        self.add_moment("overlap-b", tuple(roots[1:]), "2026-07-22T12:00:00+00:00")
+
+        states, occurrences, reasons = (
+            ledger._living_canon_root_states_and_occurrences(
+                self.conn,
+                guild_id=1,
+                subject_key="discord_user:7",
+                entry_ids=tuple(roots),
+            )
+        )
+        self.assertEqual(len(states), 3)
+        self.assertEqual(len(set(occurrences.values())), 1)
+        self.assertIn("overlapping_occurrence_representation_collapsed", reasons)
+
+        formed = self.form(roots[-1])
+        self.assertEqual(len(formed), 1)
+        self.assertEqual(self.candidate()[1], "provisional")
+        self.assertEqual(self.candidate()[4], 1)
+        report = ledger.preview_living_canon_formation(
+            self.conn, guild_id=1, subject_key="discord_user:7"
+        )
+        report_reasons = dict(report.reason_counts)
+        self.assertGreaterEqual(
+            report_reasons.get("overlapping_occurrence_representation_collapsed", 0),
+            1,
+        )
+        self.assertGreaterEqual(report_reasons.get("same_occurrence_collapsed", 0), 1)
+
+    def test_producer_shaped_shared_moment_selects_only_resolved_human_roots(self):
+        target_one = self.add_conversation(
+            130,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        other_human = self.add_conversation(
+            131,
+            "I compare ceramic antenna meshes during the same field experiment.",
+            "2026-07-20T10:01:00+00:00",
+            user_id=8,
+            user_name="Other Member",
+        )
+        bnl_turn = self.add_conversation(
+            132,
+            "The antenna comparison can stay scoped to the public experiment.",
+            "2026-07-20T10:02:00+00:00",
+            user_id=0,
+            user_name="BNL-01",
+            role="model",
+        )
+        target_two = self.add_conversation(
+            133,
+            "We tune the ceramic antenna with a copper mesh during the field experiment.",
+            "2026-07-20T10:03:00+00:00",
+        )
+        self.add_moment(
+            "producer-shaped-shared",
+            (target_one, other_human, bnl_turn, target_two),
+            "2026-07-20T10:04:00+00:00",
+        )
+        target_id = self.conn.execute(
+            "SELECT canonical_ledger_entry_id FROM memory_moment_windows "
+            "WHERE moment_id='producer-shaped-shared'"
+        ).fetchone()[0]
+
+        self.assertEqual(
+            ledger._living_canon_validated_moment_members(
+                self.conn,
+                guild_id=1,
+                subject_key="discord_user:7",
+                target_id=target_id,
+            ),
+            tuple(sorted((target_one, target_two))),
+        )
+        self.assertEqual(
+            ledger._living_canon_validated_moment_members(
+                self.conn,
+                guild_id=1,
+                subject_key="discord_user:8",
+                target_id=target_id,
+            ),
+            (other_human,),
+        )
+        states, occurrences, reasons = (
+            ledger._living_canon_root_states_and_occurrences(
+                self.conn,
+                guild_id=1,
+                subject_key="discord_user:7",
+                entry_ids=(target_one, target_two),
+            )
+        )
+        self.assertEqual(set(states), {target_one, target_two})
+        self.assertEqual(len(set(occurrences.values())), 1)
+        self.assertIn("same_root_projection_collapsed", reasons)
+
+    def test_current_moment_producer_is_recurrence_compatible(self):
+        with mock.patch.dict(
+            moments.os.environ,
+            {
+                ledger.MEMORY_LEDGER_SHADOW_ENV: "1",
+                moments.MOMENT_ENGINE_SHADOW_ENV: "1",
+            },
+        ):
+            human_roots = (
+                self.add_conversation(
+                    5500,
+                    "The synth patch needs a warmer bass in the radio mix.",
+                    "2026-07-20T10:00:00+00:00",
+                ),
+                self.add_conversation(
+                    5502,
+                    "The synth patch should keep the bass warm in the radio mix.",
+                    "2026-07-20T10:02:00+00:00",
+                ),
+                self.add_conversation(
+                    5503,
+                    "Let us test the synth patch against the radio chorus.",
+                    "2026-07-20T10:03:00+00:00",
+                ),
+            )
+            bnl_root = self.add_conversation(
+                5501,
+                "I can compare the synth bass against the radio chorus.",
+                "2026-07-20T10:01:00+00:00",
+                user_id=0,
+                user_name="BNL-01",
+                role="model",
+            )
+            for root in (human_roots[0], bnl_root, *human_roots[1:]):
+                self.assertIn(
+                    moments.observe_ledger_entry(self.conn, root).outcome,
+                    {"observed", "deduplicated"},
+                )
+            moments.sweep_expired_windows(
+                self.conn,
+                now="2026-07-20T10:06:00+00:00",
+            )
+        target_id = self.conn.execute(
+            """
+            SELECT canonical_ledger_entry_id FROM memory_moment_windows
+            WHERE lifecycle_status='finalized'
+            ORDER BY window_started_at DESC LIMIT 1
+            """
+        ).fetchone()[0]
+        self.assertEqual(
+            ledger._living_canon_validated_moment_members(
+                self.conn,
+                guild_id=1,
+                subject_key="discord_user:7",
+                target_id=target_id,
+            ),
+            tuple(sorted(human_roots)),
+        )
+
+    def test_group_first_preview_has_bounded_select_count(self):
+        started = datetime(2023, 1, 1, tzinfo=timezone.utc)
+        for index in range(1200):
+            self.add_conversation(
+                2000 + index,
+                "I arrange archive token %04d beside the violet doorway." % index,
+                (started + timedelta(hours=index)).isoformat(),
+            )
+        statements = []
+        self.conn.set_trace_callback(
+            lambda sql: statements.append(sql)
+            if sql.lstrip().upper().startswith("SELECT")
+            else None
+        )
+        try:
+            report = ledger.preview_living_canon_formation(
+                self.conn,
+                guild_id=1,
+                subject_key="discord_user:7",
+                max_scan=1200,
+            )
+        finally:
+            self.conn.set_trace_callback(None)
+        self.assertLessEqual(report.proposed_count, 6)
+        self.assertLessEqual(len(statements), 256)
+
+    def test_continuity_requires_exact_immutable_journal_receipt(self):
+        text = "I tune ceramic antennas with copper meshes during field experiments."
+        first_time = "2026-07-20T10:00:00+00:00"
+        first = self.add_conversation(
+            4000, text, first_time, route_mode="conversation_continuity"
+        )
+        self.assertEqual(self.form(first), [])
+
+        self.ensure_journal_receipt_schema()
+        self.add_continuity_receipt(4000, text, first_time)
+        second_time = "2026-07-21T10:00:00+00:00"
+        second = self.add_conversation(
+            4001, text, second_time, route_mode="conversation_continuity"
+        )
+        self.add_continuity_receipt(4001, text, second_time)
+        formed = self.form(second)
+        self.assertEqual(len(formed), 1)
+        self.assertEqual(self.candidate()[1], "established")
+
+    def test_temp_shadow_cannot_bypass_main_correction_fence(self):
+        first = self.add_conversation(
+            4100,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        second = self.add_conversation(
+            4101,
+            "We tune the ceramic antenna with a copper mesh during the field experiment.",
+            "2026-07-21T10:00:00+00:00",
+        )
+        self.form(second)
+        predicate = self.candidate()[5]
+        self.conn.execute(
+            """
+            INSERT INTO main.memory_ledger_conversation_motif_fences
+            VALUES(?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                1, "discord_user:7", predicate, "main-correction",
+                "2026-07-22T10:00:00+00:00",
+                "conversation_motif_correction_ambiguous", "active", "",
+                "2026-07-22T10:00:00+00:00", "2026-07-22T10:00:00+00:00",
+            ),
+        )
+        ledger._withhold_conversation_motif_candidates(
+            self.conn,
+            guild_id=1,
+            subject_key="discord_user:7",
+            predicate_keys=(predicate,),
+            correction_entry_id="main-correction",
+            reason_code="conversation_motif_correction_ambiguous",
+        )
+        self.conn.execute(
+            """
+            CREATE TEMP TABLE memory_ledger_conversation_motif_fences(
+              guild_id,subject_key,predicate_key,correction_entry_id,
+              correction_observed_at,reason_code,fence_state,satisfied_at,
+              created_at,updated_at
+            )
+            """
+        )
+        self.assertEqual(self.form(second), [])
+        state = self.conn.execute(
+            """
+            SELECT candidate_state,public_usable,candidate_eligible
+            FROM main.memory_ledger_knowledge_candidates
+            WHERE predicate_key=?
+            """,
+            (predicate,),
+        ).fetchone()
+        self.assertEqual(state, ("contested", 0, 0))
+
+    def test_newer_active_wildcard_overrides_old_satisfied_exact_fence(self):
+        old = self.add_conversation(
+            4200,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        self.form(old)
+        predicate = self.candidate()[5]
+        self.conn.execute(
+            "INSERT INTO memory_ledger_conversation_motif_fences VALUES(?,?,?,?,?,?,?,?,?,?)",
+            (
+                1, "discord_user:7", predicate, "old-correction",
+                "2026-07-19T10:00:00+00:00", "conversation_motif_correction_ambiguous",
+                "satisfied", "2026-07-19T11:00:00+00:00",
+                "2026-07-19T10:00:00+00:00", "2026-07-19T11:00:00+00:00",
+            ),
+        )
+        self.conn.execute(
+            "INSERT INTO memory_ledger_conversation_motif_fences VALUES(?,?,?,?,?,?,?,?,?,?)",
+            (
+                1, "discord_user:7", ledger._CONVERSATION_MOTIF_NEUTRAL_FENCE_WILDCARD,
+                "new-wildcard", "2026-07-21T10:00:00+00:00",
+                "conversation_motif_correction_ambiguous", "active", "",
+                "2026-07-21T10:00:00+00:00", "2026-07-21T10:00:00+00:00",
+            ),
+        )
+        ledger._withhold_conversation_motif_candidates(
+            self.conn,
+            guild_id=1,
+            subject_key="discord_user:7",
+            predicate_keys=(ledger._CONVERSATION_MOTIF_NEUTRAL_FENCE_WILDCARD,),
+            correction_entry_id="new-wildcard",
+            reason_code="conversation_motif_correction_ambiguous",
+        )
+        fresh = self.add_conversation(
+            4201,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-22T10:00:00+00:00",
+        )
+        self.form(fresh)
+        self.assertNotEqual(self.candidate()[1], "established")
+        report = ledger.preview_living_canon_formation(
+            self.conn, guild_id=1, subject_key="discord_user:7"
+        )
+        self.assertGreaterEqual(
+            dict(report.reason_counts).get(
+                "fresh_recurrence_required_after_correction", 0
+            ),
+            1,
+        )
+        self.assertGreaterEqual(
+            dict(report.reason_counts).get("correction_fence_active", 0),
+            1,
+        )
+
+    def test_preview_plans_unsynchronized_correction_without_source_writes(self):
+        self.add_conversation(
+            5200,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        self.add_conversation(
+            5201,
+            "We tune the ceramic antenna with a copper mesh during the field experiment.",
+            "2026-07-21T10:00:00+00:00",
+        )
+        correction = self.add_conversation(
+            5202,
+            "Actually, that is wrong; disregard that pattern.",
+            "2026-07-22T10:00:00+00:00",
+        )
+        before_changes = self.conn.total_changes
+        before_fences = self.conn.execute(
+            "SELECT COUNT(*) FROM memory_ledger_conversation_motif_fences"
+        ).fetchone()[0]
+
+        report = ledger.preview_living_canon_formation(
+            self.conn,
+            guild_id=1,
+            subject_key="discord_user:7",
+        )
+
+        self.assertEqual(report.proposed_count, 0)
+        self.assertFalse(report.write_occurred)
+        self.assertEqual(report.source_write_count, 0)
+        self.assertEqual(self.conn.total_changes, before_changes)
+        self.assertEqual(
+            self.conn.execute(
+                "SELECT COUNT(*) FROM memory_ledger_conversation_motif_fences"
+            ).fetchone()[0],
+            before_fences,
+        )
+        reasons = dict(report.reason_counts)
+        self.assertGreaterEqual(reasons.get("correction_fence_active", 0), 1)
+        self.assertGreaterEqual(
+            reasons.get("fresh_recurrence_required_after_correction", 0),
+            1,
+        )
+        self.assertEqual(self.form(correction), [])
+        self.assertGreater(
+            self.conn.execute(
+                "SELECT COUNT(*) FROM memory_ledger_conversation_motif_fences"
+            ).fetchone()[0],
+            before_fences,
+        )
+
+    def test_predicate_correction_does_not_fence_unrelated_neutral_topic(self):
+        antenna = self.add_conversation(
+            4300,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        weather = self.add_conversation(
+            4301,
+            "I chart cobalt gyroscope bearings beside the eastern observatory.",
+            "2026-07-20T11:00:00+00:00",
+        )
+        self.form(antenna)
+        self.form(weather)
+        antenna_predicate = ledger._conversation_motif_neutral_predicate(
+            ledger._conversation_motif_exact_signature(
+                "I tune ceramic antennas with copper meshes during field experiments."
+            ),
+            subject_key="discord_user:7",
+        )
+        weather_predicate = ledger._conversation_motif_neutral_predicate(
+            ledger._conversation_motif_exact_signature(
+                "I chart cobalt gyroscope bearings beside the eastern observatory."
+            ),
+            subject_key="discord_user:7",
+        )
+        self.conn.execute(
+            "INSERT INTO memory_ledger_conversation_motif_fences VALUES(?,?,?,?,?,?,?,?,?,?)",
+            (
+                1, "discord_user:7", antenna_predicate, "antenna-correction",
+                "2026-07-21T10:00:00+00:00",
+                "conversation_motif_correction_ambiguous", "active", "",
+                "2026-07-21T10:00:00+00:00", "2026-07-21T10:00:00+00:00",
+            ),
+        )
+        weather_fresh = self.add_conversation(
+            4302,
+            "I chart cobalt gyroscope bearings beside the eastern observatory.",
+            "2026-07-22T11:00:00+00:00",
+        )
+        self.form(weather_fresh)
+        weather_row = self.conn.execute(
+            """
+            SELECT candidate_state,eligible_independent_root_count
+            FROM memory_ledger_knowledge_candidates
+            WHERE predicate_key=? AND recurrence_contract_version=?
+            ORDER BY created_at LIMIT 1
+            """,
+            (weather_predicate, ledger.LIVING_CANON_RECURRENCE_VERSION),
+        ).fetchone()
+        self.assertEqual(weather_row, ("established", 2))
+
+    def test_active_singleton_provisionals_are_bounded_across_restart(self):
+        started = datetime(2026, 7, 1, tzinfo=timezone.utc)
+        for index in range(10):
+            root = self.add_conversation(
+                4400 + index,
+                "I arrange unique archive token %02d beside violet doorway." % index,
+                (started + timedelta(hours=index)).isoformat(),
+            )
+            self.form(root)
+        self.assertLessEqual(
+            self.conn.execute(
+                """
+                SELECT COUNT(*) FROM memory_ledger_knowledge_candidates
+                WHERE recurrence_contract_version=? AND candidate_state='provisional'
+                """,
+                (ledger.LIVING_CANON_RECURRENCE_VERSION,),
+            ).fetchone()[0],
+            6,
+        )
+        self.conn.commit()
+        restarted = sqlite3.connect(":memory:")
+        self.conn.backup(restarted)
+        self.conn.close()
+        self.conn = restarted
+        for index in range(10, 20):
+            root = self.add_conversation(
+                4400 + index,
+                "I arrange unique archive token %02d beside violet doorway." % index,
+                (started + timedelta(hours=index)).isoformat(),
+            )
+            self.form(root)
+        self.assertLessEqual(
+            self.conn.execute(
+                """
+                SELECT COUNT(*) FROM memory_ledger_knowledge_candidates
+                WHERE recurrence_contract_version=? AND candidate_state='provisional'
+                """,
+                (ledger.LIVING_CANON_RECURRENCE_VERSION,),
+            ).fetchone()[0],
+            6,
+        )
+
+    def test_immediate_source_invalidation_clears_public_proof(self):
+        first = self.add_conversation(
+            4500,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        second = self.add_conversation(
+            4501,
+            "We tune the ceramic antenna with a copper mesh during the field experiment.",
+            "2026-07-21T10:00:00+00:00",
+        )
+        self.form(second)
+        self.conn.commit()
+        baseline = sqlite3.connect(":memory:")
+        self.conn.backup(baseline)
+        mutations = (
+            ("delete", lambda conn: conn.execute(
+                "DELETE FROM memory_ledger_entries WHERE entry_id=?", (first,)
+            )),
+            ("privacy", lambda conn: conn.execute(
+                "UPDATE memory_ledger_entries SET public_usable=0 WHERE entry_id=?",
+                (first,),
+            )),
+            ("correction", lambda conn: conn.execute(
+                "INSERT INTO memory_ledger_lineage VALUES(?,?,?,?,?)",
+                ("correction-fixture", 1, "correction_of", first, "now"),
+            )),
+            ("supersession", lambda conn: conn.execute(
+                "INSERT INTO memory_ledger_lineage VALUES(?,?,?,?,?)",
+                ("supersession-fixture", 1, "supersedes", first, "now"),
+            )),
+            ("retraction", lambda conn: conn.execute(
+                "INSERT INTO memory_ledger_lineage VALUES(?,?,?,?,?)",
+                ("retraction-fixture", 1, "retracts", first, "now"),
+            )),
+        )
+        for name, mutation in mutations:
+            with self.subTest(name=name):
+                clone = sqlite3.connect(":memory:")
+                baseline.backup(clone)
+                mutation(clone)
+                public_usable, proof_json = clone.execute(
+                    """
+                    SELECT public_usable,recurrence_proof_json
+                    FROM memory_ledger_knowledge_candidates
+                    WHERE recurrence_contract_version=?
+                    """,
+                    (ledger.LIVING_CANON_RECURRENCE_VERSION,),
+                ).fetchone()
+                self.assertEqual(public_usable, 0)
+                proof = json.loads(proof_json)
+                self.assertFalse(proof["candidate_eligible"])
+                self.assertFalse(proof["roots_valid"])
+                clone.close()
+        baseline.close()
+
+    def test_source_invalidation_preserves_legacy_public_and_proof_fields(self):
+        root = self.add_conversation(
+            4550,
+            "I maintain the public archive index for weekly field reports.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        result = ledger.form_atomic_knowledge_candidate(
+            self.conn,
+            ledger.AtomicKnowledgeProposal(
+                candidate_type="topic_or_motif",
+                subject_key="discord_user:7",
+                predicate_key="archive_index_role",
+                meaning="Maintains the public archive index.",
+                root_entry_ids=(root,),
+                participant_keys=("discord_user:7",),
+                epistemic_status="stated",
+                currentness="current",
+                retrieval_tags=("recurring_public_conversation",),
+            ),
+        )
+        self.assertEqual(result.outcome, "created")
+        fence_source = self.add_conversation(
+            4551,
+            "Correction source for the archive-index fixture.",
+            "2026-07-21T10:00:00+00:00",
+        )
+        self.conn.execute(
+            """
+            INSERT INTO memory_ledger_conversation_motif_fences(
+              guild_id,subject_key,predicate_key,correction_entry_id,
+              correction_observed_at,reason_code,fence_state,satisfied_at,
+              created_at,updated_at
+            ) VALUES(?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                1, "discord_user:7", "archive_index_role", fence_source,
+                "2026-07-21T10:00:00+00:00",
+                "conversation_motif_correction_ambiguous", "active", "",
+                "2026-07-21T10:00:00+00:00",
+                "2026-07-21T10:00:00+00:00",
+            ),
+        )
+        legacy_proof = '{"legacy_contract":"preserve_exactly"}'
+        self.conn.execute(
+            """
+            UPDATE memory_ledger_knowledge_candidates
+            SET public_usable=1,recurrence_proof_json=?
+            WHERE candidate_id=?
+            """,
+            (legacy_proof, result.candidate_id),
+        )
+        self.conn.commit()
+        baseline = sqlite3.connect(":memory:")
+        self.conn.backup(baseline)
+        mutations = (
+            ("root_delete", lambda conn: conn.execute(
+                "DELETE FROM memory_ledger_entries WHERE entry_id=?", (root,)
+            )),
+            ("privacy_change", lambda conn: conn.execute(
+                "UPDATE memory_ledger_entries SET public_usable=0 WHERE entry_id=?",
+                (root,),
+            )),
+            ("participant_delete", lambda conn: conn.execute(
+                "DELETE FROM memory_ledger_participants "
+                "WHERE entry_id=? AND participant_key='discord_user:7'",
+                (root,),
+            )),
+            ("lineage_change", lambda conn: conn.execute(
+                "INSERT INTO memory_ledger_lineage VALUES(?,?,?,?,?)",
+                ("legacy-correction", 1, "correction_of", root, "now"),
+            )),
+            ("fence_source_delete", lambda conn: conn.execute(
+                "DELETE FROM memory_ledger_entries WHERE entry_id=?",
+                (fence_source,),
+            )),
+            ("correction_withhold", lambda conn: (
+                ledger._withhold_conversation_motif_candidates(
+                    conn,
+                    guild_id=1,
+                    subject_key="discord_user:7",
+                    predicate_keys=("archive_index_role",),
+                    correction_entry_id=fence_source,
+                    reason_code="conversation_motif_correction_ambiguous",
+                )
+            )),
+        )
+        for name, mutation in mutations:
+            with self.subTest(name=name):
+                clone = sqlite3.connect(":memory:")
+                baseline.backup(clone)
+                mutation(clone)
+                row = clone.execute(
+                    """
+                    SELECT candidate_state,recurrence_contract_version,
+                           public_usable,recurrence_proof_json
+                    FROM memory_ledger_knowledge_candidates
+                    WHERE candidate_id=?
+                    """,
+                    (result.candidate_id,),
+                ).fetchone()
+                self.assertIn(row[0], {"invalidated", "contested"})
+                self.assertEqual(row[1], "")
+                self.assertEqual(row[2:], (1, legacy_proof))
+                clone.close()
+        baseline.close()
+
+    def test_candidate_identity_is_incremental_replay_invariant_and_regenerates(self):
+        self.conn.commit()
+        empty = sqlite3.connect(":memory:")
+        self.conn.backup(empty)
+        first = self.add_conversation(
+            4600,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        self.form(first)
+        second = self.add_conversation(
+            4601,
+            "We tune the ceramic antenna with a copper mesh during the field experiment.",
+            "2026-07-21T10:00:00+00:00",
+        )
+        self.form(second)
+        columns = (
+            "candidate_id,candidate_state,reinforcement_count,"
+            "eligible_independent_root_count,independent_occurrence_count,"
+            "predicate_key,recurrence_contract_version,"
+            "grouping_signature_version,grouping_identity,root_digest,"
+            "occurrence_digest,public_usable,recurrence_proof_json"
+        )
+        incremental = self.conn.execute(
+            "SELECT %s FROM memory_ledger_knowledge_candidates "
+            "WHERE recurrence_contract_version=?" % columns,
+            (ledger.LIVING_CANON_RECURRENCE_VERSION,),
+        ).fetchone()
+
+        incremental_conn = self.conn
+        replay = sqlite3.connect(":memory:")
+        empty.backup(replay)
+        self.conn = replay
+        replay_first = self.add_conversation(
+            4600,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        replay_second = self.add_conversation(
+            4601,
+            "We tune the ceramic antenna with a copper mesh during the field experiment.",
+            "2026-07-21T10:00:00+00:00",
+        )
+        self.form(replay_second)
+        clean_replay = replay.execute(
+            "SELECT %s FROM memory_ledger_knowledge_candidates "
+            "WHERE recurrence_contract_version=?" % columns,
+            (ledger.LIVING_CANON_RECURRENCE_VERSION,),
+        ).fetchone()
+        self.assertEqual(clean_replay, incremental)
+        replay.close()
+        empty.close()
+        self.conn = incremental_conn
+
+        self.conn.execute(
+            "DELETE FROM memory_ledger_entries WHERE entry_id=?", (first,)
+        )
+        fresh_one = self.add_conversation(
+            4602,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-22T10:00:00+00:00",
+        )
+        fresh_two = self.add_conversation(
+            4603,
+            "We tune the ceramic antenna with a copper mesh during the field experiment.",
+            "2026-07-23T10:00:00+00:00",
+        )
+        self.form(fresh_two)
+        generations = self.conn.execute(
+            """
+            SELECT candidate_id,candidate_state
+            FROM memory_ledger_knowledge_candidates
+            WHERE recurrence_contract_version=? ORDER BY created_at,candidate_id
+            """,
+            (ledger.LIVING_CANON_RECURRENCE_VERSION,),
+        ).fetchall()
+        self.assertEqual(len(generations), 2)
+        self.assertNotEqual(generations[0][0], generations[1][0])
+        self.assertEqual({row[1] for row in generations}, {"invalidated", "established"})
+
+    def test_preview_reports_content_free_rejection_and_contested_reasons(self):
+        first = self.add_conversation(
+            4700,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        second = self.add_conversation(
+            4701,
+            "We tune the ceramic antenna with a copper mesh during the field experiment.",
+            "2026-07-21T10:00:00+00:00",
+        )
+        self.form(second)
+        self.conn.execute(
+            """
+            UPDATE memory_ledger_knowledge_candidates
+            SET candidate_state='contested',candidate_eligible=0,
+                public_usable=0,invalidated_reason='unresolved_contradiction'
+            WHERE recurrence_contract_version=?
+            """,
+            (ledger.LIVING_CANON_RECURRENCE_VERSION,),
+        )
+        ledger.insert_ledger_entry(
+            self.conn,
+            ledger.LedgerEntry(
+                guild_id=1,source_table="conversations",source_row_id=4702,
+                source_revision="4702",source_role="user",entry_type="observation",
+                subject_key="discord_user:7",subject_display_name="Test Member",
+                predicate_key="conversation",value="Private excluded fixture text.",
+                source_class=ledger.SourceClass.PUBLIC_OBSERVATION,
+                route_mode="normal_chat",channel_id=10,channel_name="private",
+                channel_policy="private",visibility=ledger.Visibility.PRIVATE,
+                confidence=ledger.Confidence.MEDIUM,public_usable=False,
+                observed_at="2026-07-22T10:00:00+00:00",source_sequence=4702,
+                participants=(ledger.LedgerParticipant(
+                    "discord_user:7","Test Member","author",0
+                ),),
+            ),
+        )
+        ledger.insert_ledger_entry(
+            self.conn,
+            ledger.LedgerEntry(
+                guild_id=1,source_table="conversations",source_row_id=4703,
+                source_revision="4703",source_role="derived_assessment",
+                entry_type="observation",subject_key="discord_user:7",
+                subject_display_name="Test Member",predicate_key="conversation",
+                value="Derived excluded fixture text.",
+                source_class=ledger.SourceClass.DERIVED_SUMMARY,
+                route_mode="normal_chat",channel_id=10,channel_name="barcode-bot",
+                channel_policy="public_home",visibility=ledger.Visibility.PUBLIC,
+                confidence=ledger.Confidence.LOW,public_usable=False,
+                derived=True,projection=True,
+                observed_at="2026-07-23T10:00:00+00:00",source_sequence=4703,
+            ),
+        )
+        report = ledger.preview_living_canon_formation(
+            self.conn, guild_id=1, subject_key="discord_user:7"
+        )
+        reasons = dict(report.reason_counts)
+        self.assertGreaterEqual(reasons.get("visibility_ineligible", 0), 1)
+        self.assertGreaterEqual(reasons.get("derived_source_not_independent", 0), 1)
+        self.assertGreaterEqual(reasons.get("contradiction_contested", 0), 1)
+
+    def test_preview_and_untriggered_formation_share_group_ranking(self):
+        self.add_conversation(
+            4800,
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "2026-07-20T10:00:00+00:00",
+        )
+        self.add_conversation(
+            4801,
+            "I chart cobalt gyroscope bearings beside the eastern observatory.",
+            "2026-07-20T11:00:00+00:00",
+        )
+        preview = ledger.preview_living_canon_formation(
+            self.conn, guild_id=1, subject_key="discord_user:7"
+        )
+        formed = ledger.form_atomic_candidates_from_recurring_conversation(
+            self.conn,
+            guild_id=1,
+            subject_key="discord_user:7",
+            environ=self.v1_env,
+        )
+        self.assertEqual(len(formed), preview.proposed_count)
+        states = dict(preview.candidate_state_counts)
+        self.assertEqual(states, {"provisional": len(formed)})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_preview.py
+++ b/tests/test_memory_preview.py
@@ -3,16 +3,22 @@ from pathlib import Path
 import sqlite3
 import tempfile
 import unittest
+from unittest import mock
 
 from bnl_canon_source_contract import (
     Confidence,
+    LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+    LIVING_CANON_RECURRENCE_VERSION,
     SourceClass,
     Visibility,
 )
 import bnl_memory_ledger as ledger
 from bnl_memory_preview import (
+    MemoryPreviewDiagnostics,
     MemoryPreviewRequest,
     PREVIEW_FACTUAL_PLACEHOLDER,
+    PreparedMemoryPreview,
+    build_living_canon_preview_diagnostics,
     evaluate_memory_preview,
     finalize_memory_preview,
     prepare_memory_preview,
@@ -766,6 +772,324 @@ class MemoryPreviewTests(unittest.TestCase):
                     """
                 ).fetchone()[0],
                 0,
+            )
+
+    def test_living_canon_preview_is_pure_bounded_and_content_free(self):
+        source_hash_before = self._source_hash()
+
+        def analyzer(conn, *, guild_id, subject_key, max_scan):
+            self.assertEqual(guild_id, 1)
+            self.assertEqual(subject_key, "discord_user:7")
+            self.assertEqual(max_scan, 1200)
+            return {
+                "recurrence_contract_version": (
+                    LIVING_CANON_RECURRENCE_VERSION
+                ),
+                "grouping_signature_version": (
+                    LIVING_CANON_GROUPING_SIGNATURE_VERSION
+                ),
+                "proposed_count": 2,
+                "skipped_count": 3,
+                "ambiguous_count": 1,
+                "rejected_count": 4,
+                "candidate_state_counts": (
+                    ("established", 1),
+                    ("provisional", 1),
+                ),
+                "reason_counts": (
+                    ("same_root_projection_collapsed", 2),
+                    ("provisional_subject_bound_reached", 1),
+                    ("moment_lifecycle_or_membership_ineligible", 1),
+                ),
+                "independent_root_count": 4,
+                "independent_occurrence_count": 2,
+                "collapsed_root_count": 2,
+                "bounds": (
+                    ("eligible_ledger_scan_max", 1200),
+                    ("motif_candidates_max", 6),
+                    ("retained_roots_max", 12),
+                    ("occurrence_lookback_max", 64),
+                    ("idle_boundary_seconds", 1800),
+                ),
+                "source_write_count": 0,
+                "write_occurred": False,
+            }
+
+        with mock.patch.object(
+            ledger,
+            "preview_living_canon_formation",
+            side_effect=analyzer,
+            create=True,
+        ):
+            prepared = prepare_memory_preview(self._request())
+        try:
+            living = prepared.diagnostics.living_canon
+            self.assertEqual(living.status, "analyzed")
+            self.assertEqual(living.proposed_count, 2)
+            self.assertEqual(living.independent_root_count, 4)
+            self.assertEqual(living.independent_occurrence_count, 2)
+            self.assertEqual(
+                dict(living.candidate_state_counts),
+                {"established": 1, "provisional": 1},
+            )
+            self.assertEqual(
+                dict(living.reason_counts),
+                {
+                    "moment_lifecycle_or_membership_ineligible": 1,
+                    "provisional_subject_bound_reached": 1,
+                    "same_root_projection_collapsed": 2,
+                },
+            )
+            self.assertFalse(living.source_write_occurred)
+            rendered = "\n".join(render_content_free_diagnostics(prepared))
+            self.assertIn("living_canon_dry_run", rendered)
+            self.assertIn("source_write_occurred=false", rendered)
+            self.assertNotIn("discord_user:7", rendered)
+            self.assertNotIn("private-source-text-must-not-appear", rendered)
+        finally:
+            prepared.close()
+        self.assertEqual(source_hash_before, self._source_hash())
+
+    def test_living_canon_preview_rejects_write_or_unverified_version(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            report = {
+                "recurrence_contract_version": "private-version-marker",
+                "grouping_signature_version": "private-group-marker",
+                "proposed_count": 1,
+                "skipped_count": 0,
+                "ambiguous_count": 0,
+                "rejected_count": 0,
+                "candidate_state_counts": (),
+                "reason_counts": (),
+                "independent_root_count": 2,
+                "independent_occurrence_count": 2,
+                "collapsed_root_count": 0,
+                "bounds": tuple(
+                    (
+                        key,
+                        value,
+                    )
+                    for key, value in {
+                        "eligible_ledger_scan_max": 1200,
+                        "motif_candidates_max": 6,
+                        "retained_roots_max": 12,
+                        "occurrence_lookback_max": 64,
+                        "idle_boundary_seconds": 1800,
+                    }.items()
+                ),
+                "source_write_count": 1,
+                "write_occurred": True,
+            }
+            living = build_living_canon_preview_diagnostics(
+                conn,
+                guild_id=1,
+                subject_key="discord_user:7",
+                analyzer=lambda *_args, **_kwargs: report,
+            )
+            self.assertEqual(living.status, "rejected")
+            self.assertEqual(
+                living.status_reason,
+                "pure_analyzer_write_detected",
+            )
+            self.assertEqual(living.recurrence_contract_version, "unverified")
+            self.assertEqual(living.grouping_signature_version, "unverified")
+            self.assertTrue(living.source_write_occurred)
+            prepared = PreparedMemoryPreview(
+                connection=None,
+                request=self._request(),
+                environ={},
+                diagnostics=MemoryPreviewDiagnostics(living_canon=living),
+            )
+            rendered = "\n".join(render_content_free_diagnostics(prepared))
+            self.assertNotIn("private-version-marker", rendered)
+            self.assertNotIn("private-group-marker", rendered)
+        finally:
+            conn.close()
+
+    def test_living_canon_preview_rejects_incoherent_report(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            impossible = ledger.LivingCanonDryRunReport(
+                proposed_count=999_999_999,
+                candidate_state_counts=(("established", 999_999_999),),
+                independent_root_count=999_999_999,
+                independent_occurrence_count=999_999_999,
+                collapsed_root_count=999_999_999,
+            )
+            living = build_living_canon_preview_diagnostics(
+                conn,
+                guild_id=1,
+                subject_key="discord_user:7",
+                analyzer=lambda *_args, **_kwargs: impossible,
+            )
+            self.assertEqual(living.status, "rejected")
+            self.assertEqual(
+                living.status_reason,
+                "pure_analyzer_report_invalid",
+            )
+            self.assertEqual(living.proposed_count, 0)
+            self.assertEqual(living.candidate_state_counts, ())
+            self.assertEqual(living.independent_root_count, 0)
+        finally:
+            conn.close()
+
+    def test_living_canon_preview_rejects_malformed_counts_or_reason(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            for report in (
+                {
+                    **ledger.LivingCanonDryRunReport().__dict__,
+                    "proposed_count": -1,
+                },
+                {
+                    **ledger.LivingCanonDryRunReport().__dict__,
+                    "independent_root_count": "0",
+                },
+                {
+                    **ledger.LivingCanonDryRunReport().__dict__,
+                    "reason_counts": (("future_unversioned_reason", 1),),
+                },
+            ):
+                living = build_living_canon_preview_diagnostics(
+                    conn,
+                    guild_id=1,
+                    subject_key="discord_user:7",
+                    analyzer=lambda *_args, report=report, **_kwargs: report,
+                )
+                self.assertEqual(living.status, "rejected")
+                self.assertEqual(
+                    living.status_reason,
+                    "pure_analyzer_report_invalid",
+                )
+                self.assertEqual(living.proposed_count, 0)
+                self.assertEqual(living.reason_counts, ())
+        finally:
+            conn.close()
+
+    def test_rejected_living_analyzer_cannot_contaminate_downstream_preview(self):
+        private_marker = "FORGED_PRIVATE_PREVIEW_MARKER_9f23"
+
+        def analyzer(conn, *, guild_id, subject_key, max_scan):
+            conn.execute(
+                "CREATE TABLE analyzer_contamination(marker TEXT NOT NULL)"
+            )
+            conn.execute(
+                "INSERT INTO analyzer_contamination VALUES(?)",
+                (private_marker,),
+            )
+            return ledger.LivingCanonDryRunReport()
+
+        with mock.patch.object(
+            ledger,
+            "preview_living_canon_formation",
+            side_effect=analyzer,
+        ):
+            prepared = prepare_memory_preview(self._request())
+        try:
+            self.assertEqual(
+                prepared.diagnostics.living_canon.status,
+                "rejected",
+            )
+            self.assertEqual(
+                prepared.diagnostics.living_canon.status_reason,
+                "pure_analyzer_write_detected",
+            )
+            self.assertIsNotNone(prepared.connection)
+            self.assertEqual(
+                prepared.connection.execute(
+                    """
+                    SELECT COUNT(*) FROM sqlite_master
+                    WHERE type='table' AND name='analyzer_contamination'
+                    """
+                ).fetchone()[0],
+                0,
+            )
+            self.assertNotIn(private_marker, repr(prepared))
+        finally:
+            prepared.close()
+
+    def test_analyzed_temp_schema_cannot_contaminate_downstream_preview(self):
+        private_marker = "INJECTED_TEMP_SOURCE_CONTENT_8d41"
+
+        def analyzer(conn, *, guild_id, subject_key, max_scan):
+            conn.execute(
+                """
+                CREATE TEMP VIEW analyzer_contamination_view AS
+                SELECT '%s' AS marker
+                """ % private_marker
+            )
+            return ledger.LivingCanonDryRunReport()
+
+        with mock.patch.object(
+            ledger,
+            "preview_living_canon_formation",
+            side_effect=analyzer,
+        ):
+            prepared = prepare_memory_preview(self._request())
+        try:
+            self.assertEqual(
+                prepared.diagnostics.living_canon.status,
+                "analyzed",
+            )
+            self.assertIsNotNone(prepared.connection)
+            self.assertEqual(
+                prepared.connection.execute(
+                    """
+                    SELECT COUNT(*) FROM sqlite_temp_master
+                    WHERE name='analyzer_contamination_view'
+                    """
+                ).fetchone()[0],
+                0,
+            )
+            self.assertNotIn(private_marker, repr(prepared))
+        finally:
+            prepared.close()
+
+    def test_living_analysis_and_downstream_share_one_frozen_source_image(self):
+        source_marker = "SOURCE_ADVANCED_AFTER_SNAPSHOT_51c7"
+
+        def analyzer(conn, *, guild_id, subject_key, max_scan):
+            with sqlite3.connect(self.db_path) as source:
+                source.execute(
+                    "CREATE TABLE source_advanced_after_snapshot(marker TEXT)"
+                )
+                source.execute(
+                    "INSERT INTO source_advanced_after_snapshot VALUES(?)",
+                    (source_marker,),
+                )
+            return ledger.LivingCanonDryRunReport()
+
+        with mock.patch.object(
+            ledger,
+            "preview_living_canon_formation",
+            side_effect=analyzer,
+        ):
+            prepared = prepare_memory_preview(self._request())
+        try:
+            self.assertEqual(
+                prepared.diagnostics.living_canon.status,
+                "analyzed",
+            )
+            self.assertIsNotNone(prepared.connection)
+            self.assertEqual(
+                prepared.connection.execute(
+                    """
+                    SELECT COUNT(*) FROM sqlite_master
+                    WHERE name='source_advanced_after_snapshot'
+                    """
+                ).fetchone()[0],
+                0,
+            )
+            self.assertNotIn(source_marker, repr(prepared))
+        finally:
+            prepared.close()
+        with sqlite3.connect(self.db_path) as source:
+            self.assertEqual(
+                source.execute(
+                    "SELECT marker FROM source_advanced_after_snapshot"
+                ).fetchone()[0],
+                source_marker,
             )
 
     def test_diagnostics_are_content_free(self):

--- a/tests/test_public_assessment_root_state.py
+++ b/tests/test_public_assessment_root_state.py
@@ -782,14 +782,15 @@ class PublicAssessmentRootStateTests(unittest.TestCase):
         self.assertEqual(after.status, "source_changed")
 
     def test_only_approved_source_routes_are_admitted(self):
-        for route in ("normal_chat", "conversation_continuity"):
-            with self.subTest(route=route):
-                fixture = _RootStateFixture()
-                self.addCleanup(fixture.close)
-                root = fixture.add_observation(route_mode=route)
-                self.assertIsNotNone(fixture.state(root))
+        fixture = _RootStateFixture()
+        self.addCleanup(fixture.close)
+        root = fixture.add_observation(route_mode="normal_chat")
+        self.assertIsNotNone(fixture.state(root))
 
         for route in (
+            # Continuity/backfill requires an immutable Journal receipt; raw
+            # and Ledger route labels alone cannot manufacture that authority.
+            "conversation_continuity",
             "room",
             "approved_channel_history",
             "operator_command",

--- a/tests/test_public_assessment_selector_cost.py
+++ b/tests/test_public_assessment_selector_cost.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import sqlite3
 import unittest
 from datetime import datetime, timedelta, timezone
@@ -44,10 +46,94 @@ class PublicAssessmentSelectorCostTests(unittest.TestCase):
             )
             """
         )
+        self._journal_ready = False
         self.conn.commit()
 
     def tearDown(self):
         self.conn.close()
+
+    def _ensure_journal_receipt_schema(self):
+        if self._journal_ready:
+            return
+        self.conn.executescript(
+            """
+            CREATE TABLE bnl_journal_source_events (
+              event_seq INTEGER PRIMARY KEY AUTOINCREMENT,
+              guild_id INTEGER NOT NULL,source_kind TEXT NOT NULL,
+              source_key TEXT NOT NULL,occurred_at_ms INTEGER NOT NULL,
+              ingested_at_ms INTEGER NOT NULL,channel_id INTEGER,
+              channel_policy TEXT NOT NULL,subject_ref TEXT NOT NULL,
+              private_display_name TEXT NOT NULL,raw_text TEXT NOT NULL,
+              sanitized_summary TEXT NOT NULL,content_hash TEXT NOT NULL,
+              public_usable INTEGER NOT NULL,metadata_json TEXT NOT NULL,
+              UNIQUE(guild_id,source_kind,source_key)
+            );
+            CREATE TRIGGER trg_bnl_journal_sources_no_duplicate_insert
+            BEFORE INSERT ON bnl_journal_source_events
+            WHEN EXISTS (
+              SELECT 1 FROM bnl_journal_source_events
+              WHERE event_seq=NEW.event_seq OR (
+                guild_id=NEW.guild_id AND source_kind=NEW.source_kind
+                AND source_key=NEW.source_key
+              )
+            ) BEGIN
+              SELECT RAISE(ABORT,'bnl_journal_source_events_duplicate_identity');
+            END;
+            CREATE TRIGGER trg_bnl_journal_sources_no_update
+            BEFORE UPDATE ON bnl_journal_source_events
+            BEGIN
+              SELECT RAISE(ABORT,'bnl_journal_source_events_immutable');
+            END;
+            CREATE TRIGGER trg_bnl_journal_sources_no_delete
+            BEFORE DELETE ON bnl_journal_source_events
+            BEGIN
+              SELECT RAISE(ABORT,'bnl_journal_source_events_immutable');
+            END;
+            """
+        )
+        self._journal_ready = True
+
+    def _add_continuity_receipt(
+        self,
+        *,
+        row_id,
+        message_id,
+        source_text,
+        observed_at,
+    ):
+        self._ensure_journal_receipt_schema()
+        observed = datetime.fromisoformat(str(observed_at).replace("Z", "+00:00"))
+        metadata = {
+            "conversationRowId": int(row_id),
+            "messageId": int(message_id),
+            "source": "discord_backfill",
+        }
+        self.conn.execute(
+            """
+            INSERT INTO bnl_journal_source_events(
+              guild_id,source_kind,source_key,occurred_at_ms,ingested_at_ms,
+              channel_id,channel_policy,subject_ref,private_display_name,
+              raw_text,sanitized_summary,content_hash,public_usable,
+              metadata_json
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                self.GUILD_ID,
+                "discord_message",
+                str(message_id),
+                int(observed.timestamp() * 1000),
+                int(observed.timestamp() * 1000) + 1,
+                10,
+                "public_home",
+                self.SUBJECT_KEY,
+                self.USER_NAME,
+                source_text,
+                "inert summary",
+                hashlib.sha256(source_text.encode("utf-8")).hexdigest(),
+                1,
+                json.dumps(metadata, sort_keys=True, separators=(",", ":")),
+            ),
+        )
 
     def _add_source(
         self,
@@ -108,6 +194,13 @@ class PublicAssessmentSelectorCostTests(unittest.TestCase):
             source_sequence=source_sequence,
         )
         self.assertEqual(result.outcome, "inserted")
+        if str(route_mode) == "conversation_continuity":
+            self._add_continuity_receipt(
+                row_id=row_id,
+                message_id=message_id,
+                source_text=source_text,
+                observed_at=observed_at,
+            )
         return result.entry_id
 
     def _select(self, *, max_results=4):

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -1341,6 +1341,265 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
             1,
         )
 
+    def test_family_neutral_living_candidate_waits_for_pr5_convergence(self):
+        self.add_conversation_context_row()
+        _roots, candidate_id = self.add_established_atomic(
+            predicate_key="community_pattern",
+            value="careful antenna calibration",
+        )
+        self.conn.execute(
+            """
+            UPDATE memory_ledger_knowledge_candidates
+            SET predicate_key='conversation_motif_neutral_deadbeef'
+            WHERE candidate_id=?
+            """,
+            (candidate_id,),
+        )
+
+        packet = build_packet(
+            self.conn,
+            self.public_request(text="What am I all about?"),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertFalse(
+            any(
+                item.source_ref == f"atomic:{candidate_id}"
+                for item in packet.items
+            )
+        )
+        self.assertGreaterEqual(
+            packet.diagnostics.excluded_by_reason.get(
+                "living_canon_pending_packet_convergence",
+                0,
+            ),
+            1,
+        )
+
+    def test_family_matched_living_candidate_waits_for_pr5_convergence(self):
+        self.add_conversation_context_row()
+        _roots, candidate_id = self.add_established_atomic(
+            predicate_key="conversation_motif_architecture",
+            value="careful antenna calibration",
+        )
+        self.conn.execute(
+            """
+            UPDATE memory_ledger_knowledge_candidates
+            SET recurrence_contract_version=?
+            WHERE candidate_id=?
+            """,
+            (ledger.LIVING_CANON_RECURRENCE_VERSION, candidate_id),
+        )
+
+        packet = build_packet(
+            self.conn,
+            self.public_request(text="What am I all about?"),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertFalse(
+            any(
+                item.source_ref == f"atomic:{candidate_id}"
+                for item in packet.items
+            )
+        )
+        self.assertGreaterEqual(
+            packet.diagnostics.excluded_by_reason.get(
+                "living_canon_pending_packet_convergence",
+                0,
+            ),
+            1,
+        )
+
+    def test_living_recurrence_contract_stays_quarantined_after_type_drift(self):
+        self.add_conversation_context_row()
+        _roots, candidate_id = self.add_established_atomic(
+            predicate_key="conversation_motif_architecture",
+            value="careful antenna calibration",
+        )
+        self.conn.execute(
+            """
+            UPDATE memory_ledger_knowledge_candidates
+            SET recurrence_contract_version=?,
+                candidate_type='open_loop_or_question'
+            WHERE candidate_id=?
+            """,
+            (ledger.LIVING_CANON_RECURRENCE_VERSION, candidate_id),
+        )
+
+        packet = build_packet(
+            self.conn,
+            self.public_request(text="What am I all about?"),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertFalse(
+            any(
+                item.source_ref == f"atomic:{candidate_id}"
+                for item in packet.items
+            )
+        )
+        self.assertGreaterEqual(
+            packet.diagnostics.excluded_by_reason.get(
+                "living_canon_pending_packet_convergence",
+                0,
+            ),
+            1,
+        )
+
+    def test_malformed_living_version_stays_quarantined(self):
+        self.add_conversation_context_row()
+        _roots, candidate_id = self.add_established_atomic(
+            predicate_key="conversation_motif_architecture",
+            value="careful antenna calibration",
+        )
+        self.conn.execute(
+            """
+            UPDATE memory_ledger_knowledge_candidates
+            SET recurrence_contract_version='living_canon_recurrence_v1 '
+            WHERE candidate_id=?
+            """,
+            (candidate_id,),
+        )
+
+        packet = build_packet(
+            self.conn,
+            self.public_request(text="What am I all about?"),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertFalse(
+            any(item.source_ref == f"atomic:{candidate_id}" for item in packet.items)
+        )
+        self.assertGreaterEqual(
+            packet.diagnostics.excluded_by_reason.get(
+                "living_canon_pending_packet_convergence",
+                0,
+            ),
+            1,
+        )
+
+    def test_malformed_neutral_prefix_stays_quarantined(self):
+        self.add_conversation_context_row()
+        for predicate in (
+            "Conversation_Motif_Neutral_deadbeef",
+            " conversation_motif_neutral_deadbeef",
+        ):
+            with self.subTest(predicate=predicate):
+                _roots, candidate_id = self.add_established_atomic(
+                    first_row=(910 if predicate.startswith("C") else 920),
+                    predicate_key="community_pattern",
+                    value="careful antenna calibration",
+                )
+                self.conn.execute(
+                    """
+                    UPDATE memory_ledger_knowledge_candidates
+                    SET predicate_key=? WHERE candidate_id=?
+                    """,
+                    (predicate, candidate_id),
+                )
+                packet = build_packet(
+                    self.conn,
+                    self.public_request(text="What am I all about?"),
+                    persist=False,
+                    environ=self.flags,
+                )
+                self.assertFalse(
+                    any(
+                        item.source_ref == f"atomic:{candidate_id}"
+                        for item in packet.items
+                    )
+                )
+
+    def test_partial_living_metadata_stays_quarantined(self):
+        self.add_conversation_context_row()
+        drift_cases = (
+            ("grouping_signature_version", "living_grouping_v1"),
+            ("grouping_identity", "a" * 64),
+            ("canon_domain", "real_community"),
+            ("canon_claim_kind", "behavior_pattern"),
+            ("independent_occurrence_count", 2),
+            ("occurrence_ids_json", '["occurrence-1"]'),
+            ("occurrence_digest", "b" * 64),
+            ("recurrence_proof_json", '{"contract":"v1"}'),
+            ("public_usable", 1),
+        )
+        for index, (column, value) in enumerate(drift_cases, start=1):
+            with self.subTest(column=column):
+                _roots, candidate_id = self.add_established_atomic(
+                    first_row=900 + (index * 10),
+                    predicate_key="conversation_motif_architecture_%s" % index,
+                    value="careful antenna calibration %s" % index,
+                )
+                self.conn.execute(
+                    "UPDATE memory_ledger_knowledge_candidates SET %s=? "
+                    "WHERE candidate_id=?" % column,
+                    (value, candidate_id),
+                )
+                packet = build_packet(
+                    self.conn,
+                    self.public_request(text="What am I all about?"),
+                    persist=False,
+                    environ=self.flags,
+                )
+                self.assertFalse(
+                    any(
+                        item.source_ref == f"atomic:{candidate_id}"
+                        for item in packet.items
+                    )
+                )
+
+    def test_temp_candidate_shadow_cannot_bypass_living_quarantine(self):
+        self.add_conversation_context_row()
+        _roots, candidate_id = self.add_established_atomic(
+            predicate_key="conversation_motif_architecture",
+            value="careful antenna calibration",
+        )
+        self.conn.execute(
+            """
+            UPDATE main.memory_ledger_knowledge_candidates
+            SET recurrence_contract_version=?
+            WHERE candidate_id=?
+            """,
+            (ledger.LIVING_CANON_RECURRENCE_VERSION, candidate_id),
+        )
+        self.conn.execute(
+            """
+            CREATE TEMP TABLE memory_ledger_knowledge_candidates AS
+            SELECT * FROM main.memory_ledger_knowledge_candidates
+            """
+        )
+        self.conn.execute(
+            """
+            UPDATE temp.memory_ledger_knowledge_candidates
+            SET recurrence_contract_version=''
+            WHERE candidate_id=?
+            """,
+            (candidate_id,),
+        )
+
+        packet = build_packet(
+            self.conn,
+            self.public_request(text="What am I all about?"),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertFalse(
+            any(item.source_ref == f"atomic:{candidate_id}" for item in packet.items)
+        )
+        self.assertGreaterEqual(
+            packet.diagnostics.excluded_by_reason.get(
+                "living_canon_pending_packet_convergence",
+                0,
+            ),
+            1,
+        )
+
     def test_atomic_source_blind_root_fails_closed_if_state_is_malformed(self):
         self.add_conversation_context_row()
         roots, candidate_id = self.add_established_atomic(first_row=57)


### PR DESCRIPTION
## Summary

- add family-neutral Living Canon recurrence and evidence contracts
- expose default-off preview and unified-packet integration
- add bounded recurrence, authority, cost, and isolation regressions

## Scope boundary

- code only; no deployment, configuration, migration execution, VPS action, or live-gate change
- no seriousness classifier, correction-phrase feature, or member-facing knowledge edit/delete controls
- Living Canon remains non-live until the later convergence stage

## Verification

- remote tree `08d6dee8caf5625fa69c098009f5443da5271203` exactly matches the local committed tree
- 139/139 exact-tree PR 4 acceptance tests passed
- Python compilation and diff checks passed
- repository-wide worktree run: 2,116/2,116 passed; GitHub Python 3.9/3.12 CI is required on this exact remote head before merge