### PR TITLE
Converge shared brain under one packet

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -22580,6 +22580,9 @@ def _build_unified_intelligence_packet_shadow(
         visibility_allowance = "sealed_test"
     else:
         visibility_allowance = "internal"
+    shared_brain_configuration = (
+        shared_brain_synthesis_canary_configuration()
+    )
     request = IntelligencePacketRequest(
         guild_id=int(guild_id or 0),
         subject_user_id=int(subject_user_id or 0),
@@ -22599,6 +22602,9 @@ def _build_unified_intelligence_packet_shadow(
         source_context_snapshot=str(source_context_snapshot or "")[:12000],
         source_context_authorized=bool(source_context_authorized),
         immediate_recap=immediate_room_recap_requested(current_text),
+        declared_canon_authorized=bool(
+            shared_brain_configuration.get("effective")
+        ),
     )
     try:
         with sqlite3.connect(DB_FILE, timeout=0.25) as packet_conn:

--- a/bnl_canon_source_contract.py
+++ b/bnl_canon_source_contract.py
@@ -227,6 +227,17 @@ class CanonAdapterResult:
 
 
 @dataclass(frozen=True)
+class DeclaredCanonPacketSelection:
+    """Bounded PR 5 read result for the explicitly authorized packet owner."""
+
+    claims: tuple[CanonClaim, ...] = ()
+    reason: str = "disabled"
+    candidate_count: int = 0
+    rejected_count: int = 0
+    blocker_count: int = 0
+
+
+@dataclass(frozen=True)
 class Resolution:
     usable: bool
     claim: SourceClaim | None
@@ -2430,6 +2441,122 @@ def _inventory_declared_canon_claims(
         dict(stats),
         truncated,
     )
+
+
+def select_declared_canon_claims_for_packet(
+    conn: Any,
+    *,
+    guild_id: int,
+    route_mode: str,
+    channel_policy: str,
+    capability_authorized: bool = False,
+    limit: int = 200,
+    now: datetime | str | None = None,
+) -> DeclaredCanonPacketSelection:
+    """Return only current public Declared claims for the PR 5 packet owner.
+
+    Mutation authority remains in Declared Canon.  This read boundary is
+    unavailable unless the caller has already resolved the one broad-recall
+    capability as effective, and every stored revision is HMAC/source/schema
+    validated again inside the same read snapshot.
+    """
+
+    if not strict_contract_bool(capability_authorized):
+        return DeclaredCanonPacketSelection(reason="capability_disabled")
+    if (
+        int(guild_id or 0) <= 0
+        or str(route_mode or "") != "normal_chat"
+        or str(channel_policy or "") != "public_home"
+    ):
+        return DeclaredCanonPacketSelection(reason="route_scope_ineligible")
+    safe_limit = max(1, min(int(limit or 1), 200))
+    if isinstance(now, datetime):
+        evaluation_now = now
+        if evaluation_now.tzinfo is None:
+            evaluation_now = evaluation_now.replace(tzinfo=timezone.utc)
+        evaluation_now = evaluation_now.astimezone(timezone.utc)
+    elif now is None or not str(now or "").strip():
+        evaluation_now = datetime.now(timezone.utc)
+    else:
+        parsed_now = _parse_contract_time(now)
+        if parsed_now is None:
+            return DeclaredCanonPacketSelection(reason="time_invalid")
+        evaluation_now = parsed_now
+
+    with _read_snapshot(conn):
+        before_changes = int(getattr(conn, "total_changes", 0) or 0)
+        _broadcast_total, broadcast_rows, broadcast_truncated = (
+            _inventory_table_rows(
+                conn,
+                table_name="broadcast_memory",
+                wanted_columns=("id",),
+                guild_id=int(guild_id or 0),
+                limit=safe_limit,
+            )
+        )
+        (
+            general_claims,
+            broadcast_claims,
+            stats,
+            declared_truncated,
+        ) = _inventory_declared_canon_claims(
+            conn,
+            guild_id=int(guild_id or 0),
+            broadcast_rows=broadcast_rows,
+            limit=safe_limit,
+            now=evaluation_now,
+        )
+        blockers = int(bool(broadcast_truncated or declared_truncated))
+        blockers += int(stats.get("declaredBoundaryRejectedCount", 0) or 0)
+        blockers += int(stats.get("broadcastDuplicateAuthorityCount", 0) or 0)
+        blockers += int(stats.get("broadcastStaleSidecarCount", 0) or 0)
+        blockers += int(
+            stats.get("declaredOrphanBroadcastSourceCount", 0) or 0
+        )
+        all_claims = tuple(
+            sorted(
+                (*general_claims, *broadcast_claims.values()),
+                key=lambda claim: (claim.claim_id, claim.revision_id),
+            )
+        )
+        eligible = tuple(
+            claim
+            for claim in all_claims
+            if claim.canon_status == CanonStatus.DECLARED
+            and claim.lifecycle == ClaimLifecycle.ESTABLISHED
+            and claim.visibility
+            in {
+                Visibility.PUBLIC,
+                Visibility.PUBLIC_SAFE,
+                Visibility.REFERENCE_CANON,
+            }
+            and "public_home" in claim.eligible_routes
+        )
+        mutation_count = max(
+            0,
+            int(getattr(conn, "total_changes", 0) or 0) - before_changes,
+        )
+        if mutation_count:
+            return DeclaredCanonPacketSelection(
+                reason="read_boundary_mutated_state",
+                candidate_count=len(all_claims),
+                rejected_count=len(all_claims),
+                blocker_count=blockers + 1,
+            )
+        if blockers:
+            return DeclaredCanonPacketSelection(
+                reason="source_conflict",
+                candidate_count=len(all_claims),
+                rejected_count=len(all_claims),
+                blocker_count=blockers,
+            )
+        return DeclaredCanonPacketSelection(
+            claims=eligible,
+            reason="eligible" if eligible else "no_eligible_claims",
+            candidate_count=len(all_claims),
+            rejected_count=max(0, len(all_claims) - len(eligible)),
+            blocker_count=0,
+        )
 
 
 def _build_claim_contract_inventory_in_snapshot(

--- a/bnl_memory_preview.py
+++ b/bnl_memory_preview.py
@@ -37,6 +37,7 @@ from bnl_shared_brain_synthesis import (
     begin_run,
     build_basis,
     build_packet_owned_prompt,
+    configuration as shared_brain_configuration,
     evaluate_candidate,
     finalize_run,
     record_fallback,
@@ -53,7 +54,7 @@ from bnl_unified_response_assessment import (
 )
 
 
-PREVIEW_SCHEMA_VERSION = "bnl_memory_preview_v2"
+PREVIEW_SCHEMA_VERSION = "bnl_memory_preview_v3"
 LIVING_CANON_PREVIEW_SCHEMA_VERSION = "living_canon_preview_v1"
 SIMULATED_ROUTE_MODE = "normal_chat"
 SIMULATED_CHANNEL_POLICY = "public_home"
@@ -185,6 +186,10 @@ class MemoryPreviewDiagnostics:
     lifecycle_state_changes: int = 0
     packet_lane_counts: tuple[tuple[str, int], ...] = ()
     validation_support_lane_counts: tuple[tuple[str, int], ...] = ()
+    packet_canon_candidate_status_counts: tuple[tuple[str, int], ...] = ()
+    packet_canon_selected_status_counts: tuple[tuple[str, int], ...] = ()
+    packet_canon_candidate_domain_counts: tuple[tuple[str, int], ...] = ()
+    packet_canon_selected_domain_counts: tuple[tuple[str, int], ...] = ()
     packet_exclusion_reason_counts: tuple[tuple[str, int], ...] = ()
     packet_missing_lanes: tuple[str, ...] = ()
     packet_revalidation_status: str = "not_evaluated"
@@ -230,6 +235,7 @@ class PreparedMemoryPreview:
     )
     snapshot_digest: str = ""
     conversation_context_digest: str = ""
+    capability_receipt: dict[str, Any] = field(default_factory=dict)
 
     @property
     def ready(self) -> bool:
@@ -1098,6 +1104,7 @@ def _formation_and_lifecycle(
 def _packet_request(
     request: MemoryPreviewRequest,
     conversation_context: _PreviewConversationContext,
+    environ: Mapping[str, str],
 ) -> IntelligencePacketRequest:
     participant_ids = tuple(
         dict.fromkeys(
@@ -1134,6 +1141,9 @@ def _packet_request(
             ),
         ),
         now=_now(request.now),
+        declared_canon_authorized=bool(
+            shared_brain_configuration(environ).get("effective")
+        ),
     )
 
 
@@ -1216,6 +1226,7 @@ def _snapshot_digest(
     basis: SharedBrainSynthesisBasis | None,
     request: MemoryPreviewRequest,
     conversation_context_digest: str = "",
+    capability_receipt: Mapping[str, Any] | None = None,
 ) -> str:
     if packet is None:
         return ""
@@ -1239,6 +1250,16 @@ def _snapshot_digest(
             for context in request.competing_factual_contexts
         ),
         str(conversation_context_digest or ""),
+        _digest(
+            tuple(
+                sorted(
+                    (str(key), str(value))
+                    for key, value in dict(
+                        capability_receipt or {}
+                    ).items()
+                )
+            )
+        ),
         tuple(
             sorted(
                 (
@@ -1340,6 +1361,42 @@ def _diagnostics(
             tuple(
                 sorted(
                     packet.diagnostics.validation_support_by_lane.items()
+                )
+            )
+            if packet is not None
+            else ()
+        ),
+        packet_canon_candidate_status_counts=(
+            tuple(
+                sorted(
+                    packet.diagnostics.candidates_by_canon_status.items()
+                )
+            )
+            if packet is not None
+            else ()
+        ),
+        packet_canon_selected_status_counts=(
+            tuple(
+                sorted(
+                    packet.diagnostics.selected_by_canon_status.items()
+                )
+            )
+            if packet is not None
+            else ()
+        ),
+        packet_canon_candidate_domain_counts=(
+            tuple(
+                sorted(
+                    packet.diagnostics.candidates_by_canon_domain.items()
+                )
+            )
+            if packet is not None
+            else ()
+        ),
+        packet_canon_selected_domain_counts=(
+            tuple(
+                sorted(
+                    packet.diagnostics.selected_by_canon_domain.items()
                 )
             )
             if packet is not None
@@ -1480,6 +1537,9 @@ def prepare_memory_preview(
         channel_id=request.simulated_channel_id,
         base=environ,
     )
+    capability_receipt = dict(
+        shared_brain_configuration(env).get("capability_receipt") or {}
+    )
     conn: sqlite3.Connection | None = None
     living_canon = LivingCanonPreviewDiagnostics()
     try:
@@ -1536,7 +1596,11 @@ def prepare_memory_preview(
         ) = _formation_and_lifecycle(conn, effective_request, env)
         packet = build_packet(
             conn,
-            _packet_request(effective_request, conversation_context),
+            _packet_request(
+                effective_request,
+                conversation_context,
+                env,
+            ),
             persist=True,
             environ=env,
         )
@@ -1558,6 +1622,7 @@ def prepare_memory_preview(
                 conversation_context_digest=(
                     conversation_context.digest
                 ),
+                capability_receipt=capability_receipt,
             )
         assessment = _assessment_from_packet(
             packet,
@@ -1625,8 +1690,10 @@ def prepare_memory_preview(
                 basis,
                 effective_request,
                 conversation_context.digest,
+                capability_receipt,
             ),
             conversation_context_digest=conversation_context.digest,
+            capability_receipt=capability_receipt,
         )
     except (
         FileNotFoundError,
@@ -1646,6 +1713,7 @@ def prepare_memory_preview(
                 route_reason=type(exc).__name__,
                 living_canon=living_canon,
             ),
+            capability_receipt=capability_receipt,
         )
 
 
@@ -1936,11 +2004,38 @@ def render_content_free_diagnostics(
         ),
     )
     living = diag.living_canon
+    capability = dict(prepared.capability_receipt or {})
+    capability_versions = {
+        key: capability.get(key, "unverified")
+        for key in (
+            "packet_version",
+            "claim_contract_version",
+            "assessment_version",
+            "identity_contract_version",
+            "synthesis_version",
+        )
+    }
     return (
         "- preview_schema: `%s`" % diag.schema_version,
         "- simulated_route: `normal_chat/public_home/#barcode-bot`",
         "- route_interpretation: `%s` reason=`%s`"
         % (diag.route_status, diag.route_reason or "none"),
+        "- capability_receipt: `version=%s capability=%s contract=%s "
+        "requested=%s effective=%s prerequisites_ready=%s scope=%s "
+        "versions=%s conflicts=%s reason=%s kill_switch=%s`"
+        % (
+            capability.get("receipt_version", "unverified"),
+            capability.get("capability", "unverified"),
+            capability.get("contract_version", "unverified"),
+            str(bool(capability.get("requested"))).lower(),
+            str(bool(capability.get("effective"))).lower(),
+            str(bool(capability.get("prerequisites_ready"))).lower(),
+            capability.get("scope_digest", "none") or "none",
+            capability_versions,
+            list(capability.get("conflicts") or ()) or ["none"],
+            capability.get("reason", "unverified"),
+            capability.get("kill_switch", "none"),
+        ),
         "- formation_outcomes: `%s`"
         % dict(diag.formation_outcomes),
         "- formation_reasons: `%s`"
@@ -1979,6 +2074,16 @@ def render_content_free_diagnostics(
         "- packet_lanes: `%s`" % dict(diag.packet_lane_counts),
         "- validation_support_lanes: `%s`"
         % dict(diag.validation_support_lane_counts),
+        "- canon_status_counts: `candidates=%s selected=%s`"
+        % (
+            dict(diag.packet_canon_candidate_status_counts),
+            dict(diag.packet_canon_selected_status_counts),
+        ),
+        "- canon_domain_counts: `candidates=%s selected=%s`"
+        % (
+            dict(diag.packet_canon_candidate_domain_counts),
+            dict(diag.packet_canon_selected_domain_counts),
+        ),
         "- public_assessment_pool: `eligible=%s selected=%s`"
         % (
             diag.assessment_pool_eligible_count,

--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -759,7 +759,7 @@ def _read_intelligence_packet_report(
         return _report_error(
             {
                 "tablePresent": False,
-                "schemaVersion": "unified_intelligence_packet_v4",
+                "schemaVersion": "unified_intelligence_packet_v5",
                 "runs": 0,
                 "itemTotal": 0,
                 "validationItemTotal": 0,
@@ -800,7 +800,7 @@ def _read_shared_brain_synthesis_report(
         return _report_error(
             {
                 "tablePresent": False,
-                "schemaVersion": "shared_brain_synthesis_v6",
+                "schemaVersion": "shared_brain_synthesis_v7",
                 "runs": 0,
                 "promptAppliedRuns": 0,
                 "liveAppliedRuns": 0,
@@ -1921,7 +1921,7 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             intelligence_packet_state.get("reason", "disabled"),
             intelligence_packet.get(
                 "schemaVersion",
-                "unified_intelligence_packet_v4",
+                "unified_intelligence_packet_v5",
             ),
             intelligence_packet.get("runs", 0),
             intelligence_packet.get("itemTotal", 0),
@@ -1997,7 +1997,7 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             _on(shared_brain_synthesis_state.get("fullyScoped")),
             shared_brain_synthesis.get(
                 "schemaVersion",
-                "shared_brain_synthesis_v6",
+                "shared_brain_synthesis_v7",
             ),
             shared_brain_synthesis.get("runs", 0),
             json.dumps(

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -19,6 +19,10 @@ import sqlite3
 import uuid
 from typing import Any, Mapping, Sequence
 
+from bnl_canon_source_contract import (
+    ENTITY_ACCOUNT_BINDING_CONTRACT_VERSION,
+    HYBRID_CANON_CLAIM_CONTRACT_VERSION,
+)
 from bnl_memory_governance import (
     PERSONAL_RECALL_ROUTE_FAMILY,
     classify_personal_recall_intent,
@@ -40,13 +44,21 @@ from bnl_unified_intelligence_packet import (
     shadow_enabled as packet_shadow_enabled,
 )
 from bnl_unified_response_assessment import (
+    ASSESSMENT_VERSION,
     UnifiedResponseAssessment,
     assess_response_coherence,
     shadow_enabled as assessment_shadow_enabled,
 )
 
 
-SCHEMA_VERSION = "shared_brain_synthesis_v6"
+SCHEMA_VERSION = "shared_brain_synthesis_v7"
+CAPABILITY_NAME = "shared_brain_public_broad_recall"
+CAPABILITY_CONTRACT_VERSION = "hybrid_shared_brain_v1"
+CAPABILITY_RECEIPT_VERSION = "shared_brain_capability_receipt_v1"
+_EXPECTED_PACKET_SCHEMA_VERSION = "unified_intelligence_packet_v5"
+_EXPECTED_CLAIM_CONTRACT_VERSION = "hybrid_canon_claim_v1"
+_EXPECTED_ASSESSMENT_VERSION = "unified_response_assessment_v7"
+_EXPECTED_IDENTITY_CONTRACT_VERSION = "canon_entity_account_binding_v1"
 TABLE_NAME = "memory_governance_shared_brain_synthesis_runs"
 ENABLED_ENV = "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_ENABLED"
 GUILD_IDS_ENV = "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_GUILD_IDS"
@@ -761,13 +773,38 @@ def _configuration_details(
     )
     packet_ready = packet_shadow_enabled(environ)
     assessment_ready = assessment_shadow_enabled(environ)
+    prerequisite_versions = {
+        "packet_version": PACKET_SCHEMA_VERSION,
+        "claim_contract_version": HYBRID_CANON_CLAIM_CONTRACT_VERSION,
+        "assessment_version": ASSESSMENT_VERSION,
+        "identity_contract_version": (
+            ENTITY_ACCOUNT_BINDING_CONTRACT_VERSION
+        ),
+        "synthesis_version": SCHEMA_VERSION,
+    }
+    expected_versions = {
+        "packet_version": _EXPECTED_PACKET_SCHEMA_VERSION,
+        "claim_contract_version": _EXPECTED_CLAIM_CONTRACT_VERSION,
+        "assessment_version": _EXPECTED_ASSESSMENT_VERSION,
+        "identity_contract_version": _EXPECTED_IDENTITY_CONTRACT_VERSION,
+        "synthesis_version": "shared_brain_synthesis_v7",
+    }
+    version_conflicts = tuple(
+        sorted(
+            "version:%s" % name
+            for name, version in prerequisite_versions.items()
+            if version != expected_versions[name]
+        )
+    )
     active_live_gates = tuple(
         name for name in _LIVE_GATES if _flag(environ.get(name, ""))
     )
+    prerequisites_ready = bool(
+        packet_ready and assessment_ready and not version_conflicts
+    )
     effective = bool(
         fully_scoped
-        and packet_ready
-        and assessment_ready
+        and prerequisites_ready
         and not active_live_gates
     )
     if not requested:
@@ -780,7 +817,9 @@ def _configuration_details(
         reason = "scope_incomplete"
     elif active_live_gates:
         reason = "global_live_authority_detected"
-    elif not packet_ready or not assessment_ready:
+    elif version_conflicts:
+        reason = "prerequisite_version_conflict"
+    elif not prerequisites_ready:
         reason = "missing_shadow_prerequisites"
     else:
         reason = authority_mode
@@ -800,7 +839,63 @@ def _configuration_details(
         "reason": reason,
         "packet_ready": packet_ready,
         "assessment_ready": assessment_ready,
+        "prerequisites_ready": prerequisites_ready,
+        "prerequisite_versions": prerequisite_versions,
+        "version_conflicts": version_conflicts,
         "active_live_gates": active_live_gates,
+        "scope_digest": (
+            _digest(
+                "shared_brain_capability_scope_v1",
+                authority_mode,
+                tuple(sorted(guilds)),
+                tuple(sorted(users)),
+                tuple(sorted(channels)),
+                tuple(sorted(channel_policies)),
+            )
+            if requested
+            else ""
+        ),
+    }
+
+
+def _capability_receipt(details: Mapping[str, Any]) -> dict[str, Any]:
+    conflicts = list(details.get("version_conflicts") or ())
+    conflicts.extend(details.get("active_live_gates") or ())
+    if details.get("authority_mode") == "conflict":
+        conflicts.append("authority_mode_conflict")
+    return {
+        "receipt_version": CAPABILITY_RECEIPT_VERSION,
+        "capability": CAPABILITY_NAME,
+        "contract_version": CAPABILITY_CONTRACT_VERSION,
+        "requested": bool(details.get("requested")),
+        "effective": bool(details.get("effective")),
+        "authority_mode": str(details.get("authority_mode") or "none"),
+        "scope_digest": str(details.get("scope_digest") or ""),
+        "scope": {
+            "guild_count": len(details.get("guilds") or ()),
+            "user_count": len(details.get("users") or ()),
+            "channel_count": len(details.get("channels") or ()),
+            "channel_policies": tuple(
+                sorted(details.get("channel_policies") or ())
+            ),
+            "user_scope_required": bool(
+                details.get("user_scope_required")
+            ),
+        },
+        **dict(details.get("prerequisite_versions") or {}),
+        "prerequisites_ready": bool(
+            details.get("prerequisites_ready")
+        ),
+        "conflicts": tuple(dict.fromkeys(conflicts)),
+        "reason": str(details.get("reason") or "disabled"),
+        "kill_switch": (
+            PUBLIC_HOME_OWNER_ENABLED_ENV
+            if details.get("authority_mode")
+            == PUBLIC_HOME_OWNER_AUTHORITY
+            else ENABLED_ENV
+            if details.get("authority_mode") == SCOPED_CANARY_AUTHORITY
+            else "none"
+        ),
     }
 
 
@@ -811,6 +906,7 @@ def configuration(
 
     env = os.environ if environ is None else environ
     details = _configuration_details(env)
+    capability = _capability_receipt(details)
     return {
         "configured_enabled": details["requested"],
         "canary_requested": details["canary_requested"],
@@ -845,6 +941,8 @@ def configuration(
             _MAX_PUBLIC_HOME_OWNER_CHANNELS
         ),
         "active_live_gates": details["active_live_gates"],
+        "prerequisites_ready": details["prerequisites_ready"],
+        "capability_receipt": capability,
         "kill_switch_env": (
             PUBLIC_HOME_OWNER_ENABLED_ENV
             if details["authority_mode"] == PUBLIC_HOME_OWNER_AUTHORITY

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -1,10 +1,11 @@
-"""Shadow-only governed retrieval and unified intelligence packet assembly.
+"""Governed retrieval and unified intelligence packet assembly.
 
 This module owns no facts.  It coordinates references selected by the existing
 Conversation Context, Memory Governance, Ledger, Moment, Relationship, canon,
-and Source File owners into one bounded comparison packet.  The packet is never
-rendered into a live prompt in this stage. Prompt items remain bounded
-separately from the route-safe factual support retained for validation.
+and Source File owners into one bounded packet.  A separately gated synthesis
+owner may render the frozen packet for broad-profile recall; this module still
+owns no live gate or delivery authority. Prompt items remain bounded separately
+from the route-safe factual support retained for validation.
 """
 from __future__ import annotations
 
@@ -24,14 +25,18 @@ from bnl_canon_source_contract import (
     CANON_FACTS,
     CANON_MEMBER_IDENTITIES,
     CANON_SOURCE_CONTRACT_VERSION,
+    CanonStatus,
     Confidence,
     EntityAccountBinding,
     SourceClass,
     SubjectIdentity,
+    adapt_legacy_canon_fact,
+    adapt_living_atomic_claim,
     adapt_open_signal_claim,
     matching_canon_member_identities,
     normalize_canon_identity_label,
     resolve_entity_identity,
+    select_declared_canon_claims_for_packet,
     strict_contract_bool,
 )
 from bnl_memory_governance import (
@@ -59,7 +64,7 @@ from bnl_profile_points import material_profile_point_map
 from bnl_relationship_engine import shadow_packet_posture
 
 
-SCHEMA_VERSION = "unified_intelligence_packet_v4"
+SCHEMA_VERSION = "unified_intelligence_packet_v5"
 TABLE_NAME = "memory_governance_intelligence_packet_runs"
 SHADOW_ENV = "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED"
 _SHADOW_PREREQUISITES = (
@@ -247,10 +252,10 @@ _TERM_STOPWORDS = {
 }
 
 
-def _living_candidate_pending_convergence(
+def _living_candidate_marked(
     candidate: Mapping[str, Any],
 ) -> bool:
-    """Fail closed on any PR 4 Living marker until PR 5 owns the lane."""
+    """Identify every complete or partial Living candidate representation."""
 
     predicate = str(candidate.get("predicate_key") or "").strip().casefold()
     if predicate.startswith(_LIVING_CANON_NEUTRAL_PREDICATE_PREFIX):
@@ -365,6 +370,7 @@ class IntelligencePacketRequest:
     source_context_authorized: bool = False
     immediate_recap: bool = False
     now: str = ""
+    declared_canon_authorized: bool = False
 
 
 @dataclass(frozen=True)
@@ -397,6 +403,9 @@ class IntelligencePacketItem:
     action_identity: str = ""
     material_facets: tuple[str, ...] = ()
     supporting_observations: tuple[str, ...] = ()
+    canon_status: str = ""
+    canon_domain: str = ""
+    canon_claim_kind: str = ""
 
 
 @dataclass(frozen=True)
@@ -411,6 +420,10 @@ class IntelligencePacketDiagnostics:
     candidates_by_lane: dict[str, int] = field(default_factory=dict)
     selected_by_lane: dict[str, int] = field(default_factory=dict)
     selected_by_source_class: dict[str, int] = field(default_factory=dict)
+    candidates_by_canon_status: dict[str, int] = field(default_factory=dict)
+    selected_by_canon_status: dict[str, int] = field(default_factory=dict)
+    candidates_by_canon_domain: dict[str, int] = field(default_factory=dict)
+    selected_by_canon_domain: dict[str, int] = field(default_factory=dict)
     selected_atomic_states: dict[str, int] = field(default_factory=dict)
     validation_support_by_lane: dict[str, int] = field(default_factory=dict)
     excluded_by_reason: dict[str, int] = field(default_factory=dict)
@@ -1786,6 +1799,9 @@ def _assessment_observation_items_in_snapshot(
             polarity=state.semantics.polarity,
             action_identity=state.semantics.action_identity,
             material_facets=state.semantics.material_facets,
+            canon_status=adapted_claim.canon_status.value,
+            canon_domain=adapted_claim.domain.value,
+            canon_claim_kind=adapted_claim.claim_kind.value,
         )
         if not _route_allows_item(request, item):
             diagnostics.visibility_exclusions += 1
@@ -2001,6 +2017,131 @@ def _governed_items(
     return items
 
 
+def _declared_items(
+    conn: sqlite3.Connection,
+    request: IntelligencePacketRequest,
+    diagnostics: IntelligencePacketDiagnostics,
+    exclusions: list[IntelligencePacketExclusion],
+    *,
+    broad: bool,
+    request_terms: set[str],
+) -> list[IntelligencePacketItem]:
+    """Normalize current Declared claims only for the effective PR 5 owner."""
+
+    if not broad or not bool(request.declared_canon_authorized):
+        return []
+    selection = select_declared_canon_claims_for_packet(
+        conn,
+        guild_id=int(request.guild_id or 0),
+        route_mode=request.route_mode,
+        channel_policy=request.channel_policy,
+        capability_authorized=True,
+        limit=200,
+        now=request.now or None,
+    )
+    if selection.reason not in {"eligible", "no_eligible_claims"}:
+        count = max(1, int(selection.candidate_count or 0))
+        diagnostics.candidates_by_canon_status[CanonStatus.DECLARED.value] = (
+            diagnostics.candidates_by_canon_status.get(
+                CanonStatus.DECLARED.value,
+                0,
+            )
+            + count
+        )
+        diagnostics.excluded_by_reason[
+            "declared_%s" % selection.reason
+        ] = diagnostics.excluded_by_reason.get(
+            "declared_%s" % selection.reason,
+            0,
+        ) + count
+        return []
+
+    subject = subject_key_for_user(request.subject_user_id)
+    items: list[IntelligencePacketItem] = []
+    for claim in selection.claims:
+        member_claim = claim.subject_id == subject
+        lane = "approved_fact" if member_claim else "canon"
+        text = _canon_value(claim.value).strip()
+        diagnostics.candidates_by_lane[lane] = (
+            diagnostics.candidates_by_lane.get(lane, 0) + 1
+        )
+        if not text or not claim.root_ids or not claim.occurrence_ids:
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane=lane,
+                reason="declared_source_lineage_missing",
+                source_class=claim.source_class.value,
+            )
+            continue
+        if not member_claim and not _relevant(
+            request_terms=request_terms,
+            broad=broad,
+            lane=lane,
+            text=text,
+            predicate_key=claim.predicate,
+            tags=tuple(
+                _terms(claim.subject_id)
+                | _terms(claim.domain.value)
+            ),
+        ):
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane=lane,
+                reason="declared_topic_relevance",
+                source_class=claim.source_class.value,
+            )
+            continue
+        item = IntelligencePacketItem(
+            lane=lane,
+            source_class=claim.source_class.value,
+            source_type="declared_canon_claim",
+            source_ref=claim.source_refs[0],
+            source_digest=claim.revision_id,
+            subject_key=claim.subject_id,
+            predicate_key=claim.predicate,
+            text=text[:1000],
+            visibility=claim.visibility.value,
+            confidence=claim.confidence.value,
+            lifecycle=claim.lifecycle.value,
+            authority=_AUTHORITY_RANK.get(claim.source_class.value, 0),
+            participants=((subject,) if member_claim else ()),
+            lineage=claim.source_refs,
+            observed_at=claim.valid_from,
+            usage="content",
+            score=112.0 if member_claim else 94.0,
+            revalidation_kind="declared",
+            revalidation_key=claim.claim_id,
+            root_identities=claim.root_ids,
+            occurrence_identities=claim.occurrence_ids,
+            point_identity=(
+                _point_identity(
+                    subject_key=subject,
+                    predicate_key=claim.predicate,
+                    text=text,
+                )
+                if member_claim
+                else ""
+            ),
+            canon_status=claim.canon_status.value,
+            canon_domain=claim.domain.value,
+            canon_claim_kind=claim.claim_kind.value,
+        )
+        if not _route_allows_item(request, item):
+            diagnostics.visibility_exclusions += 1
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane=lane,
+                reason="declared_visibility",
+                source_class=item.source_class,
+            )
+            continue
+        items.append(item)
+    return items
+
+
 def _atomic_candidate_row(
     conn: sqlite3.Connection,
     candidate_id: str,
@@ -2012,6 +2153,7 @@ def _atomic_candidate_row(
         "subject_key",
         "predicate_key",
         "normalized_value",
+        "value_digest",
         "epistemic_status",
         "currentness",
         "candidate_state",
@@ -2023,17 +2165,21 @@ def _atomic_candidate_row(
         "candidate_eligible",
         "live_eligible",
         "invalidated_reason",
+        "invalidated_at",
         "lifecycle_schema_version",
         "consolidation_id",
         "canonical_candidate_id",
         "eligible_independent_root_count",
+        "independent_root_count",
         "reinforcement_count",
         "conflict_value_count",
         "consolidated_authority_class",
         "consolidated_confidence_class",
         "lifecycle_support_digest",
+        "lifecycle_reason",
         "review_status",
         "review_due_at",
+        "lifecycle_evaluated_at",
         "last_seen_at",
         "recurrence_contract_version",
         "grouping_signature_version",
@@ -2043,6 +2189,7 @@ def _atomic_candidate_row(
         "independent_occurrence_count",
         "occurrence_ids_json",
         "occurrence_digest",
+        "root_digest",
         "recurrence_proof_json",
         "public_usable",
     )
@@ -2123,6 +2270,8 @@ def _atomic_candidate_digest(
     candidate = _atomic_candidate_row(conn, candidate_id)
     if not candidate:
         return ""
+    stable_candidate = dict(candidate)
+    stable_candidate.pop("lifecycle_evaluated_at", None)
     roots = _atomic_root_snapshot(conn, candidate_id)
     incoming = []
     for root in roots:
@@ -2141,7 +2290,45 @@ def _atomic_candidate_digest(
                 ),
             ).fetchall()
         )
-    return _digest("atomic", candidate, roots, sorted(incoming))
+    return _digest("atomic", stable_candidate, roots, sorted(incoming))
+
+
+def _living_atomic_candidate_digest(
+    conn: sqlite3.Connection,
+    candidate_id: str,
+) -> str:
+    """Version Living evidence by proof and sources, not clone write time."""
+
+    candidate = _atomic_candidate_row(conn, candidate_id)
+    if not candidate:
+        return ""
+    stable_candidate = dict(candidate)
+    stable_candidate.pop("updated_at", None)
+    stable_candidate.pop("lifecycle_evaluated_at", None)
+    roots = _atomic_root_snapshot(conn, candidate_id)
+    incoming = []
+    for root in roots:
+        incoming.extend(
+            conn.execute(
+                """
+                SELECT entry_id,lineage_type
+                FROM main.memory_ledger_lineage
+                WHERE guild_id=? AND target_entry_id=?
+                  AND lineage_type IN ('correction_of','supersedes','retracts')
+                ORDER BY entry_id,lineage_type
+                """,
+                (
+                    int(root.get("guild_id") or 0),
+                    str(root.get("root_entry_id") or ""),
+                ),
+            ).fetchall()
+        )
+    return _digest(
+        "living_atomic_packet_source_v1",
+        stable_candidate,
+        roots,
+        sorted(incoming),
+    )
 
 
 def _atomic_root_valid(
@@ -2262,6 +2449,75 @@ def _atomic_supporting_observations(
     return tuple(observations)
 
 
+def _living_claim_for_candidate(
+    conn: sqlite3.Connection,
+    candidate: Mapping[str, Any],
+    roots: Sequence[Mapping[str, Any]],
+) -> tuple[Any | None, str]:
+    """Adapt one Living row and bind its proof to authoritative roots."""
+
+    root_entry_ids = tuple(
+        sorted(
+            str(root.get("root_entry_id") or "")
+            for root in roots
+            if str(root.get("root_entry_id") or "")
+        )
+    )
+    try:
+        stored_occurrences = json.loads(
+            str(candidate.get("occurrence_ids_json") or "[]")
+        )
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None, "living_occurrence_lineage_invalid"
+    if not isinstance(stored_occurrences, list) or any(
+        not isinstance(identity, str) or not identity.strip()
+        for identity in stored_occurrences
+    ):
+        return None, "living_occurrence_lineage_invalid"
+    normalized_stored_occurrences = tuple(
+        sorted(identity.strip() for identity in stored_occurrences)
+    )
+    if len(normalized_stored_occurrences) != len(
+        set(normalized_stored_occurrences)
+    ):
+        return None, "living_occurrence_lineage_invalid"
+    authoritative_occurrences = tuple(
+        sorted(
+            {
+                identity
+                for identity in (
+                    knowledge_occurrence_identity(conn, entry_id)
+                    for entry_id in root_entry_ids
+                )
+                if identity
+            }
+        )
+    )
+    if normalized_stored_occurrences != authoritative_occurrences:
+        return None, "living_occurrence_lineage_mismatch"
+    adapter_row = dict(candidate)
+    adapter_row.update(
+        {
+            "meaning": candidate.get("normalized_value"),
+            "root_ids": root_entry_ids,
+            "occurrence_ids": normalized_stored_occurrences,
+            "domain": candidate.get("canon_domain"),
+            "claim_kind": candidate.get("canon_claim_kind"),
+        }
+    )
+    adapted = adapt_living_atomic_claim(adapter_row)
+    claim = adapted.claim
+    if (
+        claim is None
+        or adapted.reason != "eligible_living"
+        or claim.canon_status != CanonStatus.LIVING
+        or claim.root_ids != root_entry_ids
+        or claim.occurrence_ids != normalized_stored_occurrences
+    ):
+        return None, str(adapted.reason or "living_contract_invalid")
+    return claim, ""
+
+
 def _atomic_member_fact_authorized(
     candidate: Mapping[str, Any],
     authority_class: str,
@@ -2326,6 +2582,9 @@ def _atomic_items(
     items: list[IntelligencePacketItem] = []
     for candidate_id in candidate_ids:
         candidate = _atomic_candidate_row(conn, candidate_id)
+        roots = _atomic_root_snapshot(conn, candidate_id)
+        living_marked = _living_candidate_marked(candidate)
+        living_claim = None
         candidate_type = str(candidate.get("candidate_type") or "")
         authority_class = str(
             candidate.get("consolidated_authority_class")
@@ -2346,59 +2605,82 @@ def _atomic_items(
             _parse_time(request.now) or datetime.now(timezone.utc)
         )
         reason = ""
-        if _living_candidate_pending_convergence(candidate):
-            # PR 4 owns formation and proof only. Neither a curated-family nor
-            # family-neutral Living candidate can become response evidence
-            # until PR 5 converges every canon status under the one-packet
-            # factual owner.
-            reason = "living_canon_pending_packet_convergence"
-        elif candidate.get("lifecycle_schema_version") != (
+        if living_marked:
+            living_claim, reason = _living_claim_for_candidate(
+                conn,
+                candidate,
+                roots,
+            )
+            if reason:
+                diagnostics.candidates_by_canon_status[
+                    CanonStatus.LIVING.value
+                ] = diagnostics.candidates_by_canon_status.get(
+                    CanonStatus.LIVING.value,
+                    0,
+                ) + 1
+                candidate_domain = str(
+                    candidate.get("canon_domain") or ""
+                ).strip()
+                if candidate_domain:
+                    diagnostics.candidates_by_canon_domain[
+                        candidate_domain
+                    ] = diagnostics.candidates_by_canon_domain.get(
+                        candidate_domain,
+                        0,
+                    ) + 1
+            else:
+                authority_class = living_claim.source_class.value
+        if not reason and candidate.get("lifecycle_schema_version") != (
             ATOMIC_KNOWLEDGE_LIFECYCLE_SCHEMA_VERSION
         ):
             reason = "atomic_lifecycle_not_reconciled"
-        elif str(candidate.get("candidate_state") or "") not in {
+        elif not reason and str(candidate.get("candidate_state") or "") not in {
             "established",
             "provisional",
         }:
             reason = "atomic_state"
-        elif not bool(candidate.get("candidate_eligible")):
+        elif not reason and not bool(candidate.get("candidate_eligible")):
             reason = "atomic_ineligible"
-        elif int(candidate.get("live_eligible") or 0):
+        elif not reason and int(candidate.get("live_eligible") or 0):
             diagnostics.invalid_invariants.append(
                 "atomic_live_eligible_selected_in_shadow"
             )
             reason = "atomic_live_eligible_invariant"
-        elif str(candidate.get("invalidated_reason") or ""):
+        elif not reason and str(candidate.get("invalidated_reason") or ""):
             reason = "atomic_invalidated"
-        elif int(candidate.get("conflict_value_count") or 0) > 1:
+        elif not reason and int(candidate.get("conflict_value_count") or 0) > 1:
             reason = "atomic_contested"
-        elif review_status in {"due", "retired_stale"} or (
-            review_due is not None and review_due <= request_now
+        elif not reason and (
+            review_status in {"due", "retired_stale"}
+            or (review_due is not None and review_due <= request_now)
         ):
             reason = "atomic_review_due"
-        elif review_status not in {
+        elif not reason and review_status not in {
             "current",
             "not_required",
         }:
             reason = "atomic_review_not_current"
-        elif str(candidate.get("epistemic_status") or "") in {
+        elif not reason and str(candidate.get("epistemic_status") or "") in {
             "inference",
             "contested",
         }:
             reason = "atomic_inference_or_contested"
-        elif not _atomic_member_fact_authorized(
+        elif not reason and not _atomic_member_fact_authorized(
             candidate,
             authority_class,
         ):
             reason = "atomic_member_fact_not_authorized"
-        visibility = str(candidate.get("visibility") or "unknown")
+        visibility = (
+            living_claim.visibility.value
+            if living_claim is not None
+            else str(candidate.get("visibility") or "unknown")
+        )
         if not reason and _public_route(request) and visibility not in _PUBLIC_VISIBILITIES:
             reason = "atomic_visibility"
             diagnostics.visibility_exclusions += 1
         elif not reason and not _public_route(request) and visibility not in _INTERNAL_VISIBILITIES:
             reason = "atomic_visibility"
             diagnostics.visibility_exclusions += 1
-        roots = _atomic_root_snapshot(conn, candidate_id)
         if not reason and (
             not roots
             or len(roots)
@@ -2463,7 +2745,13 @@ def _atomic_items(
         ):
             reason = "atomic_topic_relevance"
         source_digest = (
-            _atomic_candidate_digest(conn, candidate_id) if not reason else ""
+            (
+                _living_atomic_candidate_digest(conn, candidate_id)
+                if living_claim is not None
+                else _atomic_candidate_digest(conn, candidate_id)
+            )
+            if not reason
+            else ""
         )
         if not reason and not source_digest:
             reason = "atomic_source_unversioned"
@@ -2481,10 +2769,14 @@ def _atomic_items(
             )
             continue
         state = str(candidate.get("candidate_state") or "")
-        confidence = str(
-            candidate.get("consolidated_confidence_class")
-            or candidate.get("confidence_class")
-            or Confidence.UNKNOWN.value
+        confidence = (
+            living_claim.confidence.value
+            if living_claim is not None
+            else str(
+                candidate.get("consolidated_confidence_class")
+                or candidate.get("confidence_class")
+                or Confidence.UNKNOWN.value
+            )
         )
         participants = tuple(
             str(row[0])
@@ -2586,6 +2878,21 @@ def _atomic_items(
                     text=text,
                 ),
                 supporting_observations=supporting_observations,
+                canon_status=(
+                    living_claim.canon_status.value
+                    if living_claim is not None
+                    else ""
+                ),
+                canon_domain=(
+                    living_claim.domain.value
+                    if living_claim is not None
+                    else ""
+                ),
+                canon_claim_kind=(
+                    living_claim.claim_kind.value
+                    if living_claim is not None
+                    else ""
+                ),
             )
         )
     return items
@@ -2648,6 +2955,7 @@ def _canon_items(
         for fact in CANON_FACTS:
             if fact.subject.key != signal.subject.key:
                 continue
+            normalized_claim = adapt_legacy_canon_fact(fact)
             recognized_fact_keys.add((fact.subject.key, fact.predicate))
             value = _canon_value(fact.value)
             fact_text = "%s %s: %s" % (
@@ -2693,6 +3001,9 @@ def _canon_items(
                 ),
                 revalidation_kind="recognized_canon",
                 revalidation_key=source_digest,
+                canon_status=normalized_claim.canon_status.value,
+                canon_domain=normalized_claim.domain.value,
+                canon_claim_kind=normalized_claim.claim_kind.value,
             )
             if not _route_allows_item(request, item):
                 diagnostics.visibility_exclusions += 1
@@ -2708,6 +3019,7 @@ def _canon_items(
     for fact in CANON_FACTS:
         if (fact.subject.key, fact.predicate) in recognized_fact_keys:
             continue
+        normalized_claim = adapt_legacy_canon_fact(fact)
         value = _canon_value(fact.value)
         fact_text = "%s %s: %s" % (
             fact.subject.name,
@@ -2764,6 +3076,9 @@ def _canon_items(
             score=92.0,
             revalidation_kind="canon",
             revalidation_key=source_digest,
+            canon_status=normalized_claim.canon_status.value,
+            canon_domain=normalized_claim.domain.value,
+            canon_claim_kind=normalized_claim.claim_kind.value,
         )
         if not _route_allows_item(request, item):
             diagnostics.visibility_exclusions += 1
@@ -3256,6 +3571,22 @@ def _select_items(
         diagnostics.selected_by_source_class[item.source_class] = (
             diagnostics.selected_by_source_class.get(item.source_class, 0) + 1
         )
+        if item.canon_status:
+            diagnostics.selected_by_canon_status[item.canon_status] = (
+                diagnostics.selected_by_canon_status.get(
+                    item.canon_status,
+                    0,
+                )
+                + 1
+            )
+        if item.canon_domain:
+            diagnostics.selected_by_canon_domain[item.canon_domain] = (
+                diagnostics.selected_by_canon_domain.get(
+                    item.canon_domain,
+                    0,
+                )
+                + 1
+            )
         if item.revalidation_kind == "atomic":
             diagnostics.selected_atomic_states[item.lifecycle] = (
                 diagnostics.selected_atomic_states.get(item.lifecycle, 0) + 1
@@ -3580,6 +3911,96 @@ def _recognized_canon_version(
     )
 
 
+def _living_atomic_version(
+    conn: sqlite3.Connection,
+    item: IntelligencePacketItem,
+) -> str:
+    candidate_id = str(item.revalidation_key or "")
+    candidate = _atomic_candidate_row(conn, candidate_id)
+    roots = _atomic_root_snapshot(conn, candidate_id)
+    claim, reason = _living_claim_for_candidate(conn, candidate, roots)
+    if claim is None or reason:
+        return ""
+    root_entry_ids = tuple(
+        str(root.get("root_entry_id") or "")
+        for root in roots
+        if str(root.get("root_entry_id") or "")
+    )
+    root_identities = tuple(
+        dict.fromkeys(
+            identity
+            for identity in (
+                knowledge_root_identity(conn, entry_id)
+                for entry_id in root_entry_ids
+            )
+            if identity
+        )
+    )
+    occurrence_identities = tuple(
+        dict.fromkeys(
+            identity
+            for identity in (
+                knowledge_occurrence_identity(conn, entry_id)
+                for entry_id in root_entry_ids
+            )
+            if identity
+        )
+    )
+    if not (
+        item.canon_status == claim.canon_status.value
+        and item.canon_domain == claim.domain.value
+        and item.canon_claim_kind == claim.claim_kind.value
+        and item.root_identities == root_identities
+        and item.occurrence_identities == occurrence_identities
+    ):
+        return ""
+    return _living_atomic_candidate_digest(conn, candidate_id)
+
+
+def _declared_version(
+    conn: sqlite3.Connection,
+    packet: UnifiedIntelligencePacket,
+    item: IntelligencePacketItem,
+) -> str:
+    selection = select_declared_canon_claims_for_packet(
+        conn,
+        guild_id=int(packet.request.guild_id or 0),
+        route_mode=packet.request.route_mode,
+        channel_policy=packet.request.channel_policy,
+        capability_authorized=bool(
+            packet.request.declared_canon_authorized
+        ),
+        limit=200,
+        now=packet.request.now or None,
+    )
+    if selection.reason != "eligible":
+        return ""
+    claim = next(
+        (
+            candidate
+            for candidate in selection.claims
+            if candidate.claim_id == item.revalidation_key
+        ),
+        None,
+    )
+    if claim is None or not (
+        item.source_ref == claim.source_refs[0]
+        and item.source_digest == claim.revision_id
+        and item.subject_key == claim.subject_id
+        and item.predicate_key == claim.predicate
+        and item.text == _canon_value(claim.value).strip()[:1000]
+        and item.visibility == claim.visibility.value
+        and item.lifecycle == claim.lifecycle.value
+        and item.root_identities == claim.root_ids
+        and item.occurrence_identities == claim.occurrence_ids
+        and item.canon_status == claim.canon_status.value
+        and item.canon_domain == claim.domain.value
+        and item.canon_claim_kind == claim.claim_kind.value
+    ):
+        return ""
+    return claim.revision_id
+
+
 def _relationship_version(
     conn: sqlite3.Connection,
     packet: UnifiedIntelligencePacket,
@@ -3661,7 +4082,14 @@ def _revalidate_packet_in_snapshot(
             elif item.revalidation_kind == "moment":
                 current = _moment_version(conn, packet, item)
             elif item.revalidation_kind == "atomic":
-                current = _atomic_candidate_digest(conn, item.revalidation_key)
+                current = (
+                    _living_atomic_version(conn, item)
+                    if item.canon_status == CanonStatus.LIVING.value
+                    else _atomic_candidate_digest(
+                        conn,
+                        item.revalidation_key,
+                    )
+                )
             elif item.revalidation_kind == "canon":
                 current = _canon_version(item)
             elif item.revalidation_kind == "recognized_canon":
@@ -3670,6 +4098,8 @@ def _revalidate_packet_in_snapshot(
                     packet,
                     item,
                 )
+            elif item.revalidation_kind == "declared":
+                current = _declared_version(conn, packet, item)
             elif item.revalidation_kind == "relationship":
                 current = _relationship_version(
                     conn,
@@ -3800,6 +4230,47 @@ def _packet_invariants(
             and item.subject_key == subject
         ):
             invalid.append("supporting_observation_scope_violation")
+        if item.canon_status == CanonStatus.LIVING.value and not (
+            item.lane == "atomic_knowledge"
+            and item.source_type == "topic_or_motif"
+            and item.lifecycle == "established"
+            and item.source_class == SourceClass.EVIDENCE_PROJECTION.value
+            and item.revalidation_kind == "atomic"
+            and item.canon_domain in {"real_community", "lore", "hybrid"}
+            and item.canon_claim_kind == "behavior_pattern"
+            and len(item.root_identities) >= 2
+            and len(item.occurrence_identities) >= 2
+        ):
+            invalid.append("living_canon_contract_violation")
+        if item.canon_status == CanonStatus.OPEN_SIGNAL.value and not (
+            item.lane == "assessment_observation"
+            and item.revalidation_kind == "public_assessment"
+        ):
+            invalid.append("open_signal_contract_violation")
+        if item.canon_status == CanonStatus.LEGACY.value and not (
+            item.lane == "canon"
+            and item.revalidation_kind in {"canon", "recognized_canon"}
+        ):
+            invalid.append("legacy_canon_contract_violation")
+        if item.canon_status == CanonStatus.DECLARED.value and not (
+            item.source_type == "declared_canon_claim"
+            and item.lane in {"approved_fact", "canon"}
+            and item.lifecycle == "established"
+            and item.revalidation_kind == "declared"
+            and bool(item.root_identities)
+            and bool(item.occurrence_identities)
+            and (
+                item.lane != "approved_fact"
+                or item.subject_key == subject
+            )
+        ):
+            invalid.append("declared_canon_contract_violation")
+        if any(
+            (item.canon_status, item.canon_domain, item.canon_claim_kind)
+        ) and not all(
+            (item.canon_status, item.canon_domain, item.canon_claim_kind)
+        ):
+            invalid.append("partial_canon_metadata_violation")
     validation_keys = {
         (item.lane, item.source_ref, item.source_digest)
         for item in packet.validation_items
@@ -3883,6 +4354,16 @@ def build_packet(
             )
         )
         candidates.extend(
+            _declared_items(
+                conn,
+                request,
+                diagnostics,
+                exclusions,
+                broad=broad,
+                request_terms=request_terms,
+            )
+        )
+        candidates.extend(
             _atomic_items(
                 conn,
                 request,
@@ -3914,6 +4395,23 @@ def build_packet(
         )
     except (sqlite3.DatabaseError, TypeError, ValueError) as exc:
         diagnostics.processing_errors.append(type(exc).__name__)
+    for item in candidates:
+        if item.canon_status:
+            diagnostics.candidates_by_canon_status[item.canon_status] = (
+                diagnostics.candidates_by_canon_status.get(
+                    item.canon_status,
+                    0,
+                )
+                + 1
+            )
+        if item.canon_domain:
+            diagnostics.candidates_by_canon_domain[item.canon_domain] = (
+                diagnostics.candidates_by_canon_domain.get(
+                    item.canon_domain,
+                    0,
+                )
+                + 1
+            )
     selected, profile_candidates, validation_items = _select_items(
         request,
         candidates,
@@ -3936,6 +4434,9 @@ def build_packet(
             item.root_identities,
             item.occurrence_identities,
             item.point_identity,
+            item.canon_status,
+            item.canon_domain,
+            item.canon_claim_kind,
         )
         for item in selected
     )
@@ -3950,6 +4451,9 @@ def build_packet(
             item.root_identities,
             item.occurrence_identities,
             item.point_identity,
+            item.canon_status,
+            item.canon_domain,
+            item.canon_claim_kind,
         )
         for item in validation_items
     )

--- a/docs/hybrid_canon_claim_contract_v1.md
+++ b/docs/hybrid_canon_claim_contract_v1.md
@@ -61,9 +61,11 @@ and correction checks. Neutral patterns cannot create scalar identity, roles,
 relationships, milestones, operational truth, Declared Canon, or Legacy
 Canon.
 
-PR 4 keeps every recurrence-marked Living candidate, curated-family or
-family-neutral, outside the live packet until PR 5 owns convergence. Its
-historical preview runs against a disposable in-memory clone and
+PR 5 admits a recurrence-marked Living candidate only when the complete v1
+adapter proof matches the current authoritative Ledger roots and occurrence
+identities. Partial markers, malformed proof, source drift, or a projection
+root remain excluded. The historical preview runs against a disposable
+in-memory clone and
 returns only versions, states, bounds, aggregate reason counts, and an explicit
 zero-source-write receipt. It does not expose source text or identifiers, and
 it never performs historical promotion.
@@ -148,10 +150,18 @@ has no transaction and reuse a caller-owned transaction otherwise. This keeps
 revision selection, stored-receipt validation, and authoritative source-row
 revalidation on one database state while remaining zero-write.
 
-Claim-content use in the live packet, website projection, and delegated
-authority remain disabled. New Declared Ledger projections are internal,
-derived, nonpublic, and confined to the `declared_canon_review` lane until
-final convergence. Established and contested rows use the `review_only`
-lifecycle; resolved, retired, and superseded terminal rows retain the
-`resolved` lifecycle. The packet's binding lookup remains read-only and
-effective only for already-approved binding rows.
+PR 5 gives the explicitly effective broad-recall packet owner a zero-write
+Declared read boundary. It returns only current public claims after stored
+HMAC, schema, revision, source, visibility, validity, and route validation;
+the default-off packet cannot read their content. New Declared Ledger
+projections remain internal, derived, nonpublic, and confined to the
+`declared_canon_review` lane. Established and contested projections use the
+`review_only` lifecycle; resolved, retired, and superseded terminal rows retain
+the `resolved` lifecycle. Website projection and delegated authority remain
+disabled. The packet's binding lookup remains read-only and effective only for
+already-approved binding rows.
+
+This convergence does not add seriousness inference, a member-facing
+correction feature, or member edit/delete controls. Existing source lifecycle
+and lineage validation is consumed as stored authority; PR 5 adds no new
+natural-language correction behavior.

--- a/docs/one_packet_convergence_v1.md
+++ b/docs/one_packet_convergence_v1.md
@@ -1,0 +1,31 @@
+# One-Packet Convergence v1
+
+`unified_intelligence_packet_v5` is the single factual owner for gated broad
+self-profile synthesis. It normalizes four canon statuses without moving their
+source authority:
+
+- Legacy facts use the static canon adapter.
+- Declared claims require the effective broad-recall capability and a current
+  public HMAC/source/schema-validated revision.
+- Living claims require the complete recurrence, grouping, root, occurrence,
+  lifecycle, visibility, and route contract.
+- Open Signal remains question-scoped and source-bound.
+
+Member-specific `approved_fact`, Living, conversation, and Open evidence is
+ranked before additive project canon. Render-equivalent projections collapse
+by original human or declaration roots. Every durable selection is re-read
+before candidate use; a changed or invalid source forces the established
+response fallback. Broad-profile prompts have one factual packet owner, while
+current turn, exact reply context, persona, and bounded additive canon remain.
+Specialized operational routes stay outside this cutover.
+
+`shared_brain_capability_receipt_v1` binds the requested/effective state to the
+exact hashed scope, authority mode, packet, claim, assessment, identity, and
+synthesis versions, prerequisites, conflicts, reason, and one kill switch. A
+scope, prerequisite, or version conflict fails closed. The owner-only preview
+adds content-free candidate/selected counts by canon status and domain plus the
+existing exclusion and root-collapse reasons.
+
+All gates remain default-off. This version performs no deployment, historical
+promotion, live activation, member-facing correction inference, or knowledge
+edit/delete function.

--- a/tests/test_governed_broad_recall_route_expansion.py
+++ b/tests/test_governed_broad_recall_route_expansion.py
@@ -220,6 +220,23 @@ class GovernedBroadRecallRouteExpansionTests(unittest.TestCase):
             configured["kill_switch_env"],
             "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_ENABLED",
         )
+        receipt = configured["capability_receipt"]
+        self.assertEqual(
+            receipt["capability"],
+            "shared_brain_public_broad_recall",
+        )
+        self.assertEqual(
+            receipt["contract_version"],
+            "hybrid_shared_brain_v1",
+        )
+        self.assertTrue(receipt["requested"])
+        self.assertTrue(receipt["effective"])
+        self.assertTrue(receipt["prerequisites_ready"])
+        self.assertEqual(receipt["packet_version"], "unified_intelligence_packet_v5")
+        self.assertEqual(receipt["conflicts"], ())
+        self.assertTrue(receipt["scope_digest"])
+        self.assertEqual(receipt["scope"]["guild_count"], 1)
+        self.assertEqual(receipt["scope"]["channel_count"], 1)
 
         for user_id in (7, 99):
             with self.subTest(user_id=user_id):
@@ -284,6 +301,21 @@ class GovernedBroadRecallRouteExpansionTests(unittest.TestCase):
         )
         self.assertFalse(disabled["effective"])
         self.assertEqual(disabled["reason"], "disabled")
+
+    def test_capability_receipt_fails_closed_on_version_conflict(self):
+        with mock.patch(
+            "bnl_shared_brain_synthesis.PACKET_SCHEMA_VERSION",
+            "unified_intelligence_packet_unexpected",
+        ):
+            configured = configuration(self.flags)
+        self.assertFalse(configured["effective"])
+        self.assertEqual(
+            configured["reason"],
+            "prerequisite_version_conflict",
+        )
+        receipt = configured["capability_receipt"]
+        self.assertFalse(receipt["prerequisites_ready"])
+        self.assertIn("version:packet_version", receipt["conflicts"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hybrid_canon_claim_contract.py
+++ b/tests/test_hybrid_canon_claim_contract.py
@@ -827,6 +827,50 @@ class HybridCanonClaimContractTests(unittest.TestCase):
             finally:
                 conn.close()
 
+    def test_pr5_declared_packet_read_requires_effective_capability(self):
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_OWNER_USER_ID": "61", "BNL_PRIMARY_GUILD_ID": "7"},
+        ):
+            conn = sqlite3.connect(":memory:")
+            try:
+                self.create_pr2_broadcast_table(conn)
+                row_id = self.insert_pr2_broadcast(conn)
+                revision = self.classify_pr2_broadcast(conn, row_id)
+                disabled = canon.select_declared_canon_claims_for_packet(
+                    conn,
+                    guild_id=7,
+                    route_mode="normal_chat",
+                    channel_policy="public_home",
+                    capability_authorized=False,
+                    now="2026-08-01T02:00:00+00:00",
+                )
+                self.assertEqual(disabled.reason, "capability_disabled")
+                self.assertEqual(disabled.claims, ())
+
+                before = conn.total_changes
+                selected = canon.select_declared_canon_claims_for_packet(
+                    conn,
+                    guild_id=7,
+                    route_mode="normal_chat",
+                    channel_policy="public_home",
+                    capability_authorized=True,
+                    now="2026-08-01T02:00:00+00:00",
+                )
+                self.assertEqual(conn.total_changes, before)
+                self.assertEqual(selected.reason, "eligible")
+                self.assertEqual(len(selected.claims), 1)
+                self.assertEqual(
+                    selected.claims[0].source_revision,
+                    revision.revision_id,
+                )
+                self.assertEqual(
+                    selected.claims[0].value,
+                    "A source-owned Broadcast summary.",
+                )
+            finally:
+                conn.close()
+
     def test_declared_join_rejects_stale_source_and_duplicate_authority(self):
         with mock.patch.dict(
             os.environ,

--- a/tests/test_memory_preview.py
+++ b/tests/test_memory_preview.py
@@ -1108,6 +1108,14 @@ class MemoryPreviewTests(unittest.TestCase):
         self.assertIn("source_db_read_only=true", lines)
         self.assertIn("invocation_saved=false", lines)
         self.assertIn("response_saved=false", lines)
+        self.assertIn(
+            "capability=shared_brain_public_broad_recall",
+            lines,
+        )
+        self.assertIn("contract=hybrid_shared_brain_v1", lines)
+        self.assertIn("prerequisites_ready=true", lines)
+        self.assertIn("canon_status_counts", lines)
+        self.assertIn("canon_domain_counts", lines)
 
 
 if __name__ == "__main__":

--- a/tests/test_shared_brain_synthesis_canary.py
+++ b/tests/test_shared_brain_synthesis_canary.py
@@ -300,6 +300,18 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
         self.assertEqual(configured["guild_allowlist_count"], 1)
         self.assertEqual(configured["user_allowlist_count"], 1)
         self.assertEqual(configured["channel_allowlist_count"], 1)
+        receipt = configured["capability_receipt"]
+        self.assertEqual(
+            receipt["capability"],
+            "shared_brain_public_broad_recall",
+        )
+        self.assertEqual(
+            receipt["contract_version"],
+            "hybrid_shared_brain_v1",
+        )
+        self.assertTrue(receipt["prerequisites_ready"])
+        self.assertEqual(receipt["conflicts"], ())
+        self.assertTrue(receipt["scope_digest"])
 
         bounded_expansion = configuration(
             {
@@ -332,6 +344,21 @@ class SharedBrainSynthesisCanaryTests(unittest.TestCase):
         self.assertEqual(
             global_live["reason"],
             "global_live_authority_detected",
+        )
+
+        with mock.patch(
+            "bnl_shared_brain_synthesis.PACKET_SCHEMA_VERSION",
+            "unified_intelligence_packet_unexpected",
+        ):
+            version_conflict = configuration(self.flags)
+        self.assertFalse(version_conflict["effective"])
+        self.assertEqual(
+            version_conflict["reason"],
+            "prerequisite_version_conflict",
+        )
+        self.assertIn(
+            "version:packet_version",
+            version_conflict["capability_receipt"]["conflicts"],
         )
 
     def test_scope_excludes_wrong_route_surface_media_and_attribution(self):

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -183,6 +183,72 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
         ).fetchone()[0]
         return roots, canonical_id or result.candidate_id
 
+    def add_established_living(self, *, first_row=1001):
+        living_flags = dict(self.flags)
+        living_flags[ledger.LIVING_CANON_V1_FORMATION_ENV] = "true"
+        texts = (
+            "I tune ceramic antennas with copper meshes during field experiments.",
+            "We tune the ceramic antenna with a copper mesh during the field experiment.",
+        )
+        for offset, text in enumerate(texts):
+            row_id = first_row + offset
+            observed_at = (
+                datetime(2026, 7, 20 + offset, 10, tzinfo=timezone.utc)
+                .isoformat()
+            )
+            self.conn.execute(
+                """
+                INSERT INTO conversations(
+                    id,guild_id,user_id,user_name,role,content,channel_id,
+                    channel_policy,route_mode,timestamp
+                ) VALUES(?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    row_id,
+                    1,
+                    7,
+                    "Crow",
+                    "user",
+                    text,
+                    10,
+                    "public_home",
+                    "normal_chat",
+                    observed_at,
+                ),
+            )
+            root = ledger.shadow_conversation_row(
+                self.conn,
+                row_id=row_id,
+                user_id=7,
+                user_name="Crow",
+                guild_id=1,
+                role="user",
+                content=text,
+                channel_name="barcode-bot",
+                channel_policy="public_home",
+                channel_id=10,
+                route_mode="normal_chat",
+                observed_at=observed_at,
+                environ=living_flags,
+            ).entry_id
+            ledger.form_atomic_candidates_from_recurring_conversation(
+                self.conn,
+                trigger_entry_id=root,
+                environ=living_flags,
+            )
+        row = self.conn.execute(
+            """
+            SELECT candidate_id
+            FROM memory_ledger_knowledge_candidates
+            WHERE recurrence_contract_version=?
+              AND candidate_state='established'
+            ORDER BY candidate_id LIMIT 1
+            """,
+            (ledger.LIVING_CANON_RECURRENCE_VERSION,),
+        ).fetchone()
+        self.assertIsNotNone(row)
+        return str(row[0]), living_flags
+
     def add_public_moment(self):
         base = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
         messages = (
@@ -1341,7 +1407,115 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
             1,
         )
 
-    def test_family_neutral_living_candidate_waits_for_pr5_convergence(self):
+    def test_established_living_candidate_converges_into_frozen_packet(self):
+        self.add_conversation_context_row()
+        candidate_id, living_flags = self.add_established_living()
+
+        packet = build_packet(
+            self.conn,
+            self.public_request(text="What am I all about?"),
+            persist=False,
+            environ=living_flags,
+        )
+
+        item = next(
+            item
+            for item in packet.items
+            if item.source_ref == f"atomic:{candidate_id}"
+        )
+        self.assertEqual(item.canon_status, "living")
+        self.assertEqual(item.canon_domain, "real_community")
+        self.assertEqual(item.canon_claim_kind, "behavior_pattern")
+        self.assertEqual(item.lifecycle, "established")
+        self.assertGreaterEqual(len(item.root_identities), 2)
+        self.assertGreaterEqual(len(item.occurrence_identities), 2)
+        self.assertEqual(
+            packet.diagnostics.selected_by_canon_status.get("living"),
+            1,
+        )
+        self.assertEqual(
+            packet.diagnostics.selected_by_canon_domain.get(
+                "real_community"
+            ),
+            1,
+        )
+        self.assertEqual(packet.diagnostics.revalidation_status, "passed")
+        self.assertFalse(packet.diagnostics.invalid_invariants)
+
+    def test_authorized_declared_member_claim_converges_as_subject_fact(self):
+        self.add_conversation_context_row()
+        self.conn.commit()
+        authority = {
+            "BNL_OWNER_USER_ID": "61",
+            "BNL_PRIMARY_GUILD_ID": "1",
+            declared.DECLARED_CANON_AUTHORITY_SECRET_ENV: (
+                "pr5-declared-packet-authority-secret-0001"
+            ),
+        }
+        with mock.patch.dict(os.environ, authority, clear=False):
+            declared.ensure_declared_canon_schema(self.conn)
+            revision = declared.add_declared_canon(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="pr5-declared-packet-0001",
+                guild_id=1,
+                subject_type="person",
+                subject_id="discord_user:7",
+                predicate="community_role",
+                value={"role": "signal keeper", "current": True},
+                raw_declaration=(
+                    "6 Bit declares Test Member the signal keeper."
+                ),
+                cleaned_summary="Test Member is the signal keeper.",
+                domain="real_community",
+                claim_kind="role",
+                visibility="public_safe",
+                eligible_routes=("public_home",),
+                valid_from="2026-07-01T00:00:00+00:00",
+                now="2026-07-01T00:00:00+00:00",
+            ).primary
+            disabled_packet = build_packet(
+                self.conn,
+                self.public_request(text="What am I all about?"),
+                persist=False,
+                environ=self.flags,
+            )
+            self.assertFalse(
+                any(
+                    item.source_type == "declared_canon_claim"
+                    for item in disabled_packet.items
+                )
+            )
+            request = replace(
+                self.public_request(text="What am I all about?"),
+                declared_canon_authorized=True,
+            )
+            packet = build_packet(
+                self.conn,
+                request,
+                persist=False,
+                environ=self.flags,
+            )
+
+        item = next(
+            item
+            for item in packet.items
+            if item.source_type == "declared_canon_claim"
+        )
+        self.assertEqual(item.lane, "approved_fact")
+        self.assertEqual(item.subject_key, "discord_user:7")
+        self.assertEqual(item.canon_status, "declared")
+        self.assertEqual(item.canon_domain, "real_community")
+        self.assertEqual(item.canon_claim_kind, "role")
+        self.assertEqual(item.lifecycle, "established")
+        self.assertEqual(
+            item.root_identities,
+            (f"declared_canon:{revision.declaration_id}",),
+        )
+        self.assertEqual(packet.diagnostics.revalidation_status, "passed")
+        self.assertFalse(packet.diagnostics.invalid_invariants)
+
+    def test_partial_family_neutral_living_candidate_fails_closed(self):
         self.add_conversation_context_row()
         _roots, candidate_id = self.add_established_atomic(
             predicate_key="community_pattern",
@@ -1369,15 +1543,16 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
                 for item in packet.items
             )
         )
-        self.assertGreaterEqual(
-            packet.diagnostics.excluded_by_reason.get(
-                "living_canon_pending_packet_convergence",
-                0,
-            ),
-            1,
+        self.assertTrue(
+            any(
+                reason.startswith("living_") and count >= 1
+                for reason, count in (
+                    packet.diagnostics.excluded_by_reason.items()
+                )
+            )
         )
 
-    def test_family_matched_living_candidate_waits_for_pr5_convergence(self):
+    def test_partial_family_matched_living_candidate_fails_closed(self):
         self.add_conversation_context_row()
         _roots, candidate_id = self.add_established_atomic(
             predicate_key="conversation_motif_architecture",
@@ -1405,12 +1580,13 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
                 for item in packet.items
             )
         )
-        self.assertGreaterEqual(
-            packet.diagnostics.excluded_by_reason.get(
-                "living_canon_pending_packet_convergence",
-                0,
-            ),
-            1,
+        self.assertTrue(
+            any(
+                reason.startswith("living_") and count >= 1
+                for reason, count in (
+                    packet.diagnostics.excluded_by_reason.items()
+                )
+            )
         )
 
     def test_living_recurrence_contract_stays_quarantined_after_type_drift(self):
@@ -1442,12 +1618,13 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
                 for item in packet.items
             )
         )
-        self.assertGreaterEqual(
-            packet.diagnostics.excluded_by_reason.get(
-                "living_canon_pending_packet_convergence",
-                0,
-            ),
-            1,
+        self.assertTrue(
+            any(
+                reason.startswith("living_") and count >= 1
+                for reason, count in (
+                    packet.diagnostics.excluded_by_reason.items()
+                )
+            )
         )
 
     def test_malformed_living_version_stays_quarantined(self):
@@ -1475,12 +1652,13 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
         self.assertFalse(
             any(item.source_ref == f"atomic:{candidate_id}" for item in packet.items)
         )
-        self.assertGreaterEqual(
-            packet.diagnostics.excluded_by_reason.get(
-                "living_canon_pending_packet_convergence",
-                0,
-            ),
-            1,
+        self.assertTrue(
+            any(
+                reason.startswith("living_") and count >= 1
+                for reason, count in (
+                    packet.diagnostics.excluded_by_reason.items()
+                )
+            )
         )
 
     def test_malformed_neutral_prefix_stays_quarantined(self):
@@ -1592,12 +1770,13 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
         self.assertFalse(
             any(item.source_ref == f"atomic:{candidate_id}" for item in packet.items)
         )
-        self.assertGreaterEqual(
-            packet.diagnostics.excluded_by_reason.get(
-                "living_canon_pending_packet_convergence",
-                0,
-            ),
-            1,
+        self.assertTrue(
+            any(
+                reason.startswith("living_") and count >= 1
+                for reason, count in (
+                    packet.diagnostics.excluded_by_reason.items()
+                )
+            )
         )
 
     def test_atomic_source_blind_root_fails_closed_if_state_is_malformed(self):


### PR DESCRIPTION
## Summary

- converge Legacy, Declared, Living, and Open Signal through one frozen intelligence packet
- reserve subject-specific capacity before additive canon and collapse duplicate original roots
- bind selection and send-time revalidation to authority, lifecycle, visibility, validity, route, and versioned capability receipts
- add owner-only, nonpersistent convergence preview diagnostics
- preserve the existing response competitor/fallback and specialized operational routes

## Explicitly out of scope

- no seriousness inference
- no new correction function
- no member-facing memory edit/delete controls
- no deployment, configuration, migration, VPS, or live-gate change

## Verification

- exact local tree: `bfc0157262cfbd44cc39a3df8ed8bf341fd4ddce`
- 2,120/2,120 repository tests passed under pinned runtime dependencies
- 127/127 focused packet, canon, preview, and synthesis tests passed
- GitHub Python 3.9 and 3.12 jobs are required before merge
