### PR TITLE
Fix natural selected-subject memory previews

### DIFF
--- a/bnl_memory_preview.py
+++ b/bnl_memory_preview.py
@@ -65,6 +65,22 @@ PREVIEW_FACTUAL_PLACEHOLDER = (
     "threads are supplied to the established-path comparison."
 )
 PREVIEW_CONVERSATION_CONTEXT_LIMIT = 80
+_PREVIEW_BROAD_PROFILE_ROUTE_TEXT = "What do you know about me?"
+_PREVIEW_SELECTED_SUBJECT_PROFILE_QUERY_RE = re.compile(
+    r"^(?:"
+    r"what\s+(?:do|did|have)\s+you"
+    r"(?:\s+(?:actually|currently|already|really|genuinely|honestly))?"
+    r"\s+(?:know|remember|recall|learn(?:ed)?|observ(?:e|ed)|"
+    r"notic(?:e|ed))\s+about\s+"
+    r"(?:me\b|what\s+i(?:'ve|\s+have)?\b|how\s+i\b|"
+    r"my\s+(?:role|work|participation|history|contributions?|patterns?|"
+    r"relationships?|identity)\b)"
+    r"|who\s+am\s+i\b"
+    r"|what\s+(?:is|are)\s+my\s+"
+    r"(?:role|place|part|identity|relationships?)\b"
+    r")",
+    re.I,
+)
 _PREVIEW_BARE_MEDIA_FALLBACK_PATTERNS = (
     re.compile(
         r"\bi saw (?:your|[a-z0-9_. '\-]{1,80}'?s|someone'?s|their|his|her)?"
@@ -325,6 +341,29 @@ def preview_environment(
         }
     )
     return env
+
+
+def _selected_subject_preview_intent(
+    wording: str,
+) -> governance.PersonalRecallIntent:
+    """Interpret profile wording only inside the explicit-subject preview."""
+
+    intent = governance.classify_personal_recall_intent(wording)
+    if (
+        intent.status != "not_recall"
+        or intent.reason != "not_personal_recall"
+    ):
+        return intent
+    if not _PREVIEW_SELECTED_SUBJECT_PROFILE_QUERY_RE.search(
+        intent.normalized_text
+    ):
+        return intent
+    return governance.PersonalRecallIntent(
+        normalized_text=intent.normalized_text,
+        status="matched",
+        route_family=governance.PERSONAL_RECALL_ROUTE_FAMILY,
+        reason="selected_subject_profile_preview",
+    )
 
 
 def _open_read_only_memory_clone(path: str) -> sqlite3.Connection:
@@ -1144,6 +1183,7 @@ def _packet_request(
         declared_canon_authorized=bool(
             shared_brain_configuration(environ).get("effective")
         ),
+        broad_profile_intent=True,
     )
 
 
@@ -1506,7 +1546,7 @@ def prepare_memory_preview(
 ) -> PreparedMemoryPreview:
     """Prepare one route-equivalent snapshot without touching the source DB."""
 
-    intent = governance.classify_personal_recall_intent(request.wording)
+    intent = _selected_subject_preview_intent(request.wording)
     if not intent.broad_self_profile:
         return PreparedMemoryPreview(
             connection=None,
@@ -1636,7 +1676,11 @@ def prepare_memory_preview(
             route_mode=SIMULATED_ROUTE_MODE,
             channel_policy=SIMULATED_CHANNEL_POLICY,
             current_direct=True,
-            user_text=effective_request.wording,
+            # The selected-subject preview made the trusted route decision
+            # above.  Keep the natural wording in the packet and prompt while
+            # using the canonical route text only for the existing gated
+            # synthesis scope check.  Public routing remains unchanged.
+            user_text=_PREVIEW_BROAD_PROFILE_ROUTE_TEXT,
             packet=packet,
             assessment=assessment,
             competing_factual_contexts=(

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -371,6 +371,7 @@ class IntelligencePacketRequest:
     immediate_recap: bool = False
     now: str = ""
     declared_canon_authorized: bool = False
+    broad_profile_intent: bool = False
 
 
 @dataclass(frozen=True)
@@ -1085,6 +1086,17 @@ def _broad_profile_request(value: str) -> bool:
     return classify_personal_recall_intent(value).broad_self_profile
 
 
+def _request_is_broad_profile(
+    request: IntelligencePacketRequest,
+) -> bool:
+    """Honor a trusted upstream route decision without rewriting its text."""
+
+    return bool(
+        request.broad_profile_intent
+        or _broad_profile_request(request.user_text)
+    )
+
+
 def _profile_project_request(value: str) -> bool:
     return bool(_PROFILE_PROJECT_SCOPE_RE.search(str(value or "")))
 
@@ -1095,7 +1107,7 @@ def _profile_canon_anchor(
 ) -> IntelligencePacketItem | None:
     """Choose one canon point that best contextualizes selected public work."""
 
-    if not _broad_profile_request(request.user_text):
+    if not _request_is_broad_profile(request):
         return None
     subject = subject_key_for_user(request.subject_user_id)
     recognized = tuple(
@@ -2943,7 +2955,7 @@ def _canon_items(
 ) -> list[IntelligencePacketItem]:
     items: list[IntelligencePacketItem] = []
     lowered = str(request.user_text or "").lower()
-    broad = _broad_profile_request(request.user_text)
+    broad = _request_is_broad_profile(request)
     subject_key = subject_key_for_user(request.subject_user_id)
     signal = _canon_identity_signal(conn, request)
     diagnostics.canon_identity_status = signal.status
@@ -3348,7 +3360,7 @@ def _select_items(
     tuple[IntelligencePacketItem, ...],
     tuple[IntelligencePacketItem, ...],
 ]:
-    broad = _broad_profile_request(request.user_text)
+    broad = _request_is_broad_profile(request)
     if request.immediate_recap:
         kept = []
         for item in candidates:
@@ -3658,7 +3670,7 @@ def _profile_sufficiency(
     selected: Sequence[IntelligencePacketItem],
     candidates: Sequence[IntelligencePacketItem],
 ) -> ProfileSufficiency:
-    if not _broad_profile_request(request.user_text):
+    if not _request_is_broad_profile(request):
         return ProfileSufficiency(
             status="not_applicable",
             satisfied=True,
@@ -3842,7 +3854,7 @@ def _moment_version(
     item: IntelligencePacketItem,
 ) -> str:
     subject = subject_key_for_user(packet.request.subject_user_id)
-    broad = _broad_profile_request(packet.request.user_text)
+    broad = _request_is_broad_profile(packet.request)
     moments = select_public_participant_moment_gists(
         conn,
         guild_id=packet.request.guild_id,
@@ -4164,7 +4176,7 @@ def _packet_invariants(
 ) -> tuple[str, ...]:
     invalid = []
     subject = subject_key_for_user(packet.request.subject_user_id)
-    broad = _broad_profile_request(packet.request.user_text)
+    broad = _request_is_broad_profile(packet.request)
     for item in packet.items:
         if not _route_allows_item(packet.request, item):
             invalid.append("selected_visibility_violation")
@@ -4328,7 +4340,7 @@ def build_packet(
     ensure_schema(conn)
     diagnostics = IntelligencePacketDiagnostics()
     exclusions: list[IntelligencePacketExclusion] = []
-    broad = _broad_profile_request(request.user_text)
+    broad = _request_is_broad_profile(request)
     request_terms = _terms(request.user_text)
     candidates: list[IntelligencePacketItem] = []
     try:

--- a/tests/test_memory_preview.py
+++ b/tests/test_memory_preview.py
@@ -12,6 +12,7 @@ from bnl_canon_source_contract import (
     SourceClass,
     Visibility,
 )
+import bnl_memory_governance as governance
 import bnl_memory_ledger as ledger
 from bnl_memory_preview import (
     MemoryPreviewDiagnostics,
@@ -28,6 +29,23 @@ from bnl_memory_preview import (
 
 
 class MemoryPreviewTests(unittest.TestCase):
+    NATURAL_SELECTED_SUBJECT_QUESTIONS = (
+        (
+            "What do you know about what I've actually done in BARCODE "
+            "and my established role here?"
+        ),
+        (
+            "What do you know about how I participate in BARCODE, "
+            "including recent work or recurring patterns you've actually "
+            "observed?"
+        ),
+        (
+            "Who am I in BARCODE, and what is my relationship to Cache "
+            "Back? Be clear about whether we are the same identity."
+        ),
+        "What do you actually know about me from BARCODE?",
+    )
+
     def setUp(self):
         self.tempdir = tempfile.TemporaryDirectory()
         self.db_path = str(
@@ -318,6 +336,60 @@ class MemoryPreviewTests(unittest.TestCase):
             prepared.diagnostics.route_reason,
             "recall_target_ambiguous",
         )
+
+    def test_natural_selected_subject_profile_questions_enter_preview_route(self):
+        source_hash_before = self._source_hash()
+        for wording in self.NATURAL_SELECTED_SUBJECT_QUESTIONS:
+            with self.subTest(wording=wording):
+                self.assertFalse(
+                    governance.classify_personal_recall_intent(
+                        wording
+                    ).broad_self_profile
+                )
+                prepared = prepare_memory_preview(self._request(wording))
+                try:
+                    self.assertEqual(
+                        prepared.diagnostics.route_status,
+                        "matched",
+                    )
+                    self.assertEqual(
+                        prepared.diagnostics.route_reason,
+                        "selected_subject_profile_preview",
+                    )
+                    self.assertIsNotNone(prepared.connection)
+                    self.assertIsNotNone(prepared.packet)
+                    self.assertTrue(
+                        prepared.packet.request.broad_profile_intent
+                    )
+                    self.assertNotEqual(
+                        prepared.diagnostics.profile_status,
+                        "not_applicable",
+                    )
+                finally:
+                    prepared.close()
+        self.assertEqual(source_hash_before, self._source_hash())
+
+    def test_selected_subject_preview_still_rejects_non_profile_requests(self):
+        cases = (
+            ("Tell me a joke.", "not_recall"),
+            ("What do you know about Cache Back?", "not_recall"),
+            (
+                "What do you know about me and tell me a joke?",
+                "not_recall",
+            ),
+            (
+                "Do not tell me what you know about me yet.",
+                "blocked",
+            ),
+        )
+        for wording, expected_status in cases:
+            with self.subTest(wording=wording):
+                prepared = prepare_memory_preview(self._request(wording))
+                self.assertIsNone(prepared.connection)
+                self.assertEqual(
+                    prepared.diagnostics.route_status,
+                    expected_status,
+                )
 
     def test_sealed_test_rows_never_participate_in_public_home_preview(self):
         with sqlite3.connect(self.db_path) as source:

--- a/tests/test_memory_preview_bot_path.py
+++ b/tests/test_memory_preview_bot_path.py
@@ -20,6 +20,23 @@ import bnl01_bot
 
 
 class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
+    NATURAL_SELECTED_SUBJECT_QUESTIONS = (
+        (
+            "What do you know about what I've actually done in BARCODE "
+            "and my established role here?"
+        ),
+        (
+            "What do you know about how I participate in BARCODE, "
+            "including recent work or recurring patterns you've actually "
+            "observed?"
+        ),
+        (
+            "Who am I in BARCODE, and what is my relationship to Cache "
+            "Back? Be clear about whether we are the same identity."
+        ),
+        "What do you actually know about me from BARCODE?",
+    )
+
     def setUp(self):
         self.tempdir = tempfile.TemporaryDirectory()
         self.db_path = str(
@@ -248,6 +265,60 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             "project_canon_required=",
             "\n".join(result.diagnostics),
         )
+
+    async def test_natural_selected_subject_questions_generate_both_comparisons(
+        self,
+    ):
+        source_hash = self._source_hash()
+        for wording in self.NATURAL_SELECTED_SUBJECT_QUESTIONS:
+            calls = []
+
+            async def generator(prompt, route):
+                calls.append((route, prompt))
+                if route.endswith("baseline"):
+                    return "The established path has a narrow view."
+                return (
+                    "You keep fixing the bot code and memory system "
+                    "carefully."
+                )
+
+            async def guard(response, _prompt):
+                return response, {
+                    "suppressed": False,
+                    "suppression_reason": "",
+                }
+
+            with self.subTest(wording=wording):
+                result = await bnl01_bot.execute_bnl_memory_preview(
+                    source_db_path=self.db_path,
+                    guild_id=1,
+                    subject_user_id=7,
+                    subject_display_name="Crow",
+                    simulated_channel_id=10,
+                    wording=wording,
+                    generator=generator,
+                    guard=guard,
+                )
+
+                self.assertEqual(result.route_status, "matched")
+                self.assertEqual(
+                    result.established_response,
+                    "The established path has a narrow view.",
+                )
+                self.assertEqual(
+                    result.packet_candidate_response,
+                    "You keep fixing the bot code and memory system "
+                    "carefully.",
+                )
+                self.assertEqual(
+                    [route for route, _prompt in calls],
+                    [
+                        "bnl_memory_preview_baseline",
+                        "bnl_memory_preview_candidate",
+                    ],
+                )
+                self.assert_single_candidate_budget(result)
+        self.assertEqual(source_hash, self._source_hash())
 
     async def test_empty_packet_preserves_established_response(self):
         generator = mock.AsyncMock(


### PR DESCRIPTION
## What changed

- Let the owner-only, non-persistent `/bnl_memory_preview` route recognize natural first-person profile, role, participation, contribution, pattern, relationship, and identity questions for the explicitly selected subject.
- Preserve the original question for evidence selection and both model prompts while carrying the preview's trusted broad-profile decision through the disposable packet pipeline.
- Add regression coverage for the exact four production questions that previously returned `not_recall`.
- Keep ambiguous, unrelated, mixed-purpose, negated, and third-party-only questions out of the preview route.

## Root cause

The preview reused the ordinary public self-profile classifier even though the slash command had already resolved an explicit subject. Natural selected-subject questions therefore exited before either the established baseline or packet candidate was generated.

## Safety boundaries

- No change to the ordinary public recall classifier or live conversation routing.
- No gate, configuration, database schema, Journal, Relay, website, queue, or deployment change.
- Preview work remains confined to the in-memory database clone.
- Tests verify the source database is byte-for-byte unchanged and both comparisons use a single candidate generation attempt.

## Validation

- Focused packet/synthesis/preview gate: 134 tests passed.
- Full repository gate: compilation plus 2,123 tests passed.
- Diff hygiene, credential-pattern scan, owner-identity scan, and protected-surface scope review passed.
- Published tree `51d9c32af026dd6572f85544caa54158b2a49771` exactly matches the locally tested tree.