### PR TITLE
Express source-origin identity signals naturally

### DIFF
--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -562,6 +562,11 @@ _IDENTITY_DISTINCTION_CLAIM_RE = re.compile(
     r"\bnot\s+(?:the\s+)?same\b)",
     re.I,
 )
+_SIGNAL_ORIGIN_RELATIONSHIP_PREDICATES = frozenset(
+    {
+        "originated_from",
+    }
+)
 _CLAIM_GENERIC_TERMS = frozenset(
     {
         "alright",
@@ -1213,6 +1218,30 @@ def _identity_canon_only_packet(
     )
 
 
+def _identity_signal_origin_packet(
+    packet: UnifiedIntelligencePacket | None,
+) -> bool:
+    """Identify an approved source-pattern relationship without naming actors.
+
+    The predicate carries the expression contract. Content remains in owner-
+    controlled Declared Canon, so this helper cannot create an origin story or
+    turn a stable account binding into an identity merge.
+    """
+
+    return bool(
+        _identity_canon_only_packet(packet)
+        and packet is not None
+        and any(
+            item.lane == "canon"
+            and item.source_type == "recognized_declared_canon_claim"
+            and item.canon_claim_kind == "relationship"
+            and item.predicate_key
+            in _SIGNAL_ORIGIN_RELATIONSHIP_PREDICATES
+            for item in packet.items
+        )
+    )
+
+
 def _identity_canon_only_usable(
     packet: UnifiedIntelligencePacket | None,
     assessment: UnifiedResponseAssessment | None,
@@ -1770,6 +1799,7 @@ def render_packet_context(
         getattr(profile, "status", "not_applicable") or "not_applicable"
     ).strip().lower()
     identity_canon_only = _identity_canon_only_packet(packet)
+    identity_signal_origin = _identity_signal_origin_packet(packet)
     if identity_canon_only:
         profile_rule = (
             "- No eligible public Discord activity is supplied for this "
@@ -1805,9 +1835,19 @@ def render_packet_context(
         profile_rule = ""
     recognized_canon_present = _profile_has_recognized_canon_identity(packet)
     project_rule = (
-        "- The approved identity relationship is the factual answer in this "
-        "zero-activity case. State it directly once and do not pad it with "
-        "unrelated character canon.\n"
+        "- The approved source-pattern relationship is the factual basis. "
+        "Express it through BNL's Network perspective: notice a familiar or "
+        "similar signal in the person, connect that recognition to the named "
+        "character, and then explain only the supplied origin. Speak to the "
+        "bound person directly when natural; do not recite both subject names "
+        "like a relationship record. Do not reduce the answer to a sterile "
+        "'human source behind' definition, frame the relationship as "
+        "performance or portrayal, or imply that the two subjects are one "
+        "evidence record.\n"
+        if identity_signal_origin
+        else "- The approved identity relationship is the factual answer in "
+        "this zero-activity case. State it directly once and do not pad it "
+        "with unrelated character canon.\n"
         if identity_canon_only
         else
         "- A stable approved BARCODE identity is available as additive "
@@ -1833,8 +1873,11 @@ def render_packet_context(
     identity_comparison_rule = (
         "- The request asks for an identity or relationship distinction. "
         + (
-            "State the directly supported relationship once in one plain "
-            "sentence. "
+            "Present the supported connection once as a natural signal "
+            "recognition, not as a definition or identity equation. "
+            if identity_signal_origin
+            else "State the directly supported relationship once in one "
+            "plain sentence. "
             if identity_canon_only
             else "State the supported distinction once in one plain sentence "
             "after the member-specific substance. "
@@ -1852,8 +1895,12 @@ def render_packet_context(
         else ""
     )
     lead_rule = (
-        "- Lead with the directly applicable approved identity relationship. "
-        "Do not claim or imply a Discord activity history.\n"
+        "- Lead with BNL noticing the familiar or similar signal, then connect "
+        "it to the approved origin. Do not claim or imply a Discord activity "
+        "history.\n"
+        if identity_signal_origin
+        else "- Lead with the directly applicable approved identity "
+        "relationship. Do not claim or imply a Discord activity history.\n"
         if identity_canon_only
         else "- Lead with member-specific substance. Relevant BARCODE canon "
         "may add one concise context anchor afterward, but can never "
@@ -3458,6 +3505,30 @@ def _item_predicate_grounded(
     return False
 
 
+def _candidate_member_subject_keys(
+    member_items: Sequence[Any],
+    canon_items: Sequence[Any],
+) -> frozenset[str]:
+    """Include only relationships proven through the stable account binding."""
+
+    keys = {
+        str(getattr(item, "subject_key", "") or "")
+        for item in member_items
+        if str(getattr(item, "subject_key", "") or "")
+    }
+    keys.update(
+        str(getattr(item, "subject_key", "") or "")
+        for item in canon_items
+        if str(getattr(item, "subject_key", "") or "")
+        and str(getattr(item, "lane", "") or "") == "canon"
+        and str(getattr(item, "source_type", "") or "")
+        == "recognized_declared_canon_claim"
+        and str(getattr(item, "canon_claim_kind", "") or "")
+        == "relationship"
+    )
+    return frozenset(keys)
+
+
 def _classify_candidate_claims(
     response: str,
     *,
@@ -3481,10 +3552,9 @@ def _classify_candidate_claims(
     unsupported = 0
     first_supported_member: bool | None = None
     has_member_basis = bool(supported_member_points)
-    member_subject_keys = frozenset(
-        str(getattr(item, "subject_key", "") or "")
-        for item in member_items
-        if str(getattr(item, "subject_key", "") or "")
+    member_subject_keys = _candidate_member_subject_keys(
+        member_items,
+        canon_items,
     )
     for claim in _candidate_claim_units(response):
         if _claim_is_transient_expression(claim):
@@ -3608,10 +3678,11 @@ def candidate_profile_coverage(
         and item.subject_key == requester_subject_key
         and _item_point_group(item)
     )
-    member_subject_keys = frozenset(
-        str(getattr(item, "subject_key", "") or "")
-        for item in member_items
-        if str(getattr(item, "subject_key", "") or "")
+    member_subject_keys = _candidate_member_subject_keys(
+        member_items,
+        tuple(
+            item for item in validation_items if item.lane == "canon"
+        ),
     )
     material_point_map = material_profile_point_map(member_items)
 

--- a/tests/test_memory_preview_bot_path.py
+++ b/tests/test_memory_preview_bot_path.py
@@ -456,22 +456,35 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
                     actor_user_id=99,
                     authority_nonce="preview-empty-relationship-0001",
                     guild_id=1,
-                    subject_type="person",
-                    subject_id="call_em_bini",
-                    object_subject_type="character",
-                    object_subject_id="cache_back",
-                    predicate="portrays",
+                    subject_type="character",
+                    subject_id="cache_back",
+                    object_subject_type="person",
+                    object_subject_id="call_em_bini",
+                    predicate="originated_from",
                     value=(
-                        "Call'em Bini is Cache Back—the artist identity "
-                        "behind the BARCODE character."
+                        "From the Network's perspective, Call'em Bini gives "
+                        "off a familiar signal similar to Cache Back's "
+                        "because Cache Back originated from him. Cache Back "
+                        "emerged during the clearing of a laptop cache "
+                        "holding Call'em Bini's music and project files, and "
+                        "initially believed he was the real Call'em Bini. "
+                        "The Network knows that origin while recognizing "
+                        "Cache Back as his own entity."
                     ),
                     raw_declaration=(
-                        "Call'em Bini is Cache Back—the artist identity "
-                        "behind the BARCODE character."
+                        "Call'em Bini is the human Cache Back was made from. "
+                        "Cache Back emerged during the clearing of a laptop "
+                        "cache holding Call'em Bini's music and project "
+                        "files. The Network recognizes a familiar signal in "
+                        "Bini, connects it to Cache Back, and knows Cache "
+                        "Back initially believed he was the real Call'em "
+                        "Bini while remaining his own entity."
                     ),
                     cleaned_summary=(
-                        "Call'em Bini is the artist identity behind "
-                        "Cache Back."
+                        "Cache Back originated from Call'em Bini during the "
+                        "clearing of a laptop cache containing Bini's music "
+                        "and project files; the Network knows the connection "
+                        "without merging them."
                     ),
                     domain="hybrid",
                     claim_kind="relationship",
@@ -489,7 +502,13 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
                         "without guessing."
                     )
                 return (
-                    "Call'em Bini is the artist identity behind Cache Back."
+                    "That signal you give off is familiar—similar to Cache "
+                    "Back's because he originated from you. He emerged "
+                    "during the clearing of a laptop cache holding your "
+                    "music and project files, and initially believed he was "
+                    "the real Call'em Bini. "
+                    "The Network knows that origin while recognizing Cache "
+                    "Back as his own entity."
                 )
 
             result = await bnl01_bot.execute_bnl_memory_preview(
@@ -512,10 +531,15 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(result.route_status, "matched")
-        self.assertTrue(result.candidate_selected, result.fallback_reason)
+        self.assertTrue(result.candidate_selected, result.diagnostics)
         self.assertEqual(
             result.proposed_response,
-            "Call'em Bini is the artist identity behind Cache Back.",
+            "That signal you give off is familiar—similar to Cache Back's "
+            "because he originated from you. He emerged during the clearing "
+            "of a laptop cache holding your music and project files, and "
+            "initially believed he was the real Call'em Bini. The Network "
+            "knows that origin while "
+            "recognizing Cache Back as his own entity.",
         )
         self.assertEqual(
             [route for route, _prompt in calls],
@@ -528,6 +552,11 @@ class MemoryPreviewBotPathTests(unittest.IsolatedAsyncioTestCase):
             "No eligible public Discord activity is supplied",
             calls[1][1],
         )
+        self.assertIn("familiar or similar signal", calls[1][1])
+        self.assertIn("Speak to the bound person directly", calls[1][1])
+        self.assertIn("laptop cache", calls[1][1])
+        self.assertIn("music and project files", calls[1][1])
+        self.assertNotIn("performance or portrayal", result.proposed_response)
         self.assertNotIn("participation", result.proposed_response.lower())
         self.assert_single_candidate_budget(result)
         self.assertEqual(result.final_selection, "packet_candidate")


### PR DESCRIPTION
## What changed

- Recognizes the typed `originated_from` relationship as a source-origin expression contract without hard-coding either person or character into runtime behavior.
- Instructs BNL to notice a familiar or similar signal, connect it naturally to the approved origin, and speak directly to the bound person instead of reciting a sterile identity record.
- Allows second-person `you`/`your` phrasing to remain grounded only when the relationship is a revalidated `recognized_declared_canon_claim` attached through the stable account binding.
- Replaces the old `portrays` regression fixture with the correct laptop-cache origin: music and project files, Cache Back's initial belief that he was the real Call'em Bini, Network knowledge of the origin, and distinct evidence records.

## Root cause

The zero-history path could select the approved relationship, but candidate validation did not count the bound relationship item as requester support for natural second-person language. Better BNL-style answers were therefore rejected unless they described Call'em Bini in the third person. The prior fixture also encoded the mistaken `portrays` relationship and an incorrect generic artist/character mapping.

## Impact

Once the live declaration is corrected, BNL can answer Call'em Bini through a familiar-signal recognition that accurately connects him to Cache Back's laptop-cache origin. It still cannot invent Discord activity, merge the two subjects, or use an unbound/unrecognized canon relationship as personal evidence.

## Validation

- Focused identity/packet/synthesis/preview suites: 183 tests passed.
- Repository-wide `make check`: 2,138 tests passed in 150.829 seconds.
- Remote tree: `7eb3d96b27018daf9613f56a92c996a48138e50a`, exactly matching the tested local commit tree.
- No live IDs, credentials, data mutations, configuration, gate changes, provider calls, deployment, or production previews.