### PR TITLE
Repair BNL self-name and vocative classification with fail-closed grammar

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -47,6 +47,8 @@ from bnl_occasion import (
     store_prepared as store_prepared_occasion,
 )
 from bnl_memory_ledger import (
+    BNL_SELF_NAME_ROUTING_EVIDENCE_KINDS,
+    BNL_SELF_NAME_VALIDATION_VERSION,
     BnlSelfNameRecord,
     LedgerWriteResult,
     backfill_atomic_knowledge_candidates,
@@ -270,6 +272,7 @@ import calendar
 import time
 import threading
 import concurrent.futures
+import unicodedata
 
 from bnl_dossier_candidate_discovery import (
     DEFAULT_DISCOVERY_LANES,
@@ -11249,6 +11252,9 @@ class DiscordTurnAddressing:
     bnl_name_requires_decision: bool = False
     bnl_name_action: str = "none"
     bnl_name_prior_value: str = ""
+    bnl_name_classification: str = "none"
+    bnl_name_evidence_kind: str = ""
+    bnl_name_validation_version: str = BNL_SELF_NAME_VALIDATION_VERSION
     bnl_name_influence_mode: str = "off"
     source_message_id: int = 0
     reply_message_id: int = 0
@@ -11290,26 +11296,34 @@ _CANONICAL_BNL_NAME_RE = re.compile(
     r"\b(?:bnl|bnl-01|barcode bot)\b",
     re.I,
 )
+_SELF_NAME_VALUE_FRAGMENT = r"(?!_)\w[\w _.'’\-]{0,47}"
+_SELF_NAME_CAPTURE = rf"(?P<name>{_SELF_NAME_VALUE_FRAGMENT})"
 _SELF_NAME_EXPLICIT_PATTERNS = (
     re.compile(
         r"\b(?:can|could|may|should)\s+(?:i|we)\s+call\s+you\s+"
-        r"[\"“']?(?P<name>[A-Za-z0-9][A-Za-z0-9 _.'’\-]{0,47})",
+        r"[\"“']?" + _SELF_NAME_CAPTURE,
         re.I,
     ),
     re.compile(
         r"\b(?:i(?:'|’)?ll|i\s+will|we(?:'|’)?ll|we\s+will|"
         r"i\s+want\s+to|we\s+want\s+to|let\s+me)\s+call\s+you\s+"
-        r"[\"“']?(?P<name>[A-Za-z0-9][A-Za-z0-9 _.'’\-]{0,47})",
+        r"[\"“']?" + _SELF_NAME_CAPTURE,
         re.I,
     ),
     re.compile(
         r"\b(?:nickname|name)\s+you\s+"
-        r"[\"“']?(?P<name>[A-Za-z0-9][A-Za-z0-9 _.'’\-]{0,47})",
+        r"[\"“']?" + _SELF_NAME_CAPTURE,
         re.I,
     ),
     re.compile(
         r"\byour\s+(?:nickname|name)\s+(?:is|should\s+be|can\s+be)\s+"
-        r"[\"“']?(?P<name>[A-Za-z0-9][A-Za-z0-9 _.'’\-]{0,47})",
+        r"[\"“']?" + _SELF_NAME_CAPTURE,
+        re.I,
+    ),
+    re.compile(
+        r"\b(?:do\s+you\s+still\s+(?:want|like)\s+to\s+be\s+called|"
+        r"are\s+you\s+still\s+(?:okay|ok|good|fine)\s+with)\s+"
+        r"[\"“']?" + _SELF_NAME_CAPTURE,
         re.I,
     ),
 )
@@ -11317,6 +11331,7 @@ _SELF_NAME_TRAILING_CLAUSE_RE = re.compile(
     r"\b(?:from\s+now\s+on|if\s+that(?:'|’)?s\s+okay|"
     r"if\s+you(?:'|’)?re\s+okay\s+with\s+it|when|while|because|"
     r"unless|during|around|please|okay|ok|today|tomorrow|tonight|"
+    r"here|"
     r"for\s+(?:short|now|tonight|today)|"
     r"in\s+(?:here|this\s+(?:room|channel|server|chat)))\b.*$",
     re.I,
@@ -11420,6 +11435,11 @@ class BnlSelfNameRequest:
     name: str = ""
     prior_name: str = ""
     explicit: bool = False
+    classification: str = "non_address"
+    evidence_kind: str = ""
+    candidate: str = ""
+    ambiguous: bool = False
+    validation_version: str = BNL_SELF_NAME_VALIDATION_VERSION
 
 
 def _known_guild_human_names(guild) -> set[str]:
@@ -11473,12 +11493,21 @@ def _load_bnl_self_name_records(
                 guild_id=guild_id,
                 channel_policies=policy_scope,
             )
+            records = _validated_bnl_self_name_records(
+                conn,
+                guild_id=guild_id,
+                records=records,
+            )
     except (OSError, sqlite3.DatabaseError):
         records = ()
     return records
 
 
-def _clean_self_name_candidate(raw: str) -> str:
+def _clean_self_name_candidate(
+    raw: str,
+    *,
+    reject_generic: bool = True,
+) -> str:
     value = re.sub(r"\s+", " ", str(raw or "")).strip()
     value = value.rstrip(" \t\r\n,.;:!?\"'“”‘’")
     value = _SELF_NAME_TRAILING_CLAUSE_RE.sub("", value).strip()
@@ -11490,7 +11519,10 @@ def _clean_self_name_candidate(raw: str) -> str:
     first_word = normalized.split()[0] if normalized else ""
     if (
         not normalized
-        or normalized in _SELF_NAME_STOPWORDS
+        or (
+            reject_generic
+            and normalized in _SELF_NAME_STOPWORDS
+        )
         or first_word in _SELF_NAME_ACTION_COMPLEMENT_LEADS
         or _CANONICAL_BNL_NAME_RE.fullmatch(value)
     ):
@@ -11498,8 +11530,72 @@ def _clean_self_name_candidate(raw: str) -> str:
     return value
 
 
-def classify_bnl_self_name_request(text: str) -> BnlSelfNameRequest:
-    """Classify explicit lifecycle actions and conservative vocative proposals."""
+def _performed_self_name_clause(value: str) -> str:
+    """Return only a plausible speaker-performed naming clause."""
+
+    performed = str(value or "").strip()
+    performed = re.sub(
+        r"^(?:hey\s+|yo\s+|hi\s+|hello\s+)?"
+        r"(?:bnl|bnl-01|barcode bot)\s*[,!?:\-—]\s*",
+        "",
+        performed,
+        count=1,
+        flags=re.I,
+    )
+    performed = re.sub(
+        r"^(?:please|okay|ok|so)\s*[,!?:\-—]?\s+",
+        "",
+        performed,
+        count=1,
+        flags=re.I,
+    )
+    return performed.strip()
+
+
+def _self_name_match_has_safe_boundary(value: str, match) -> bool:
+    suffix = str(value or "")[int(match.end() or 0) :].lstrip()
+    return not suffix or suffix[0] in "?!.,;:\"'“”‘’"
+
+
+def _bare_vocative_body_targets_bnl(body: str, *, trailing: bool) -> bool:
+    """Require positive second-person structure beyond comma punctuation."""
+
+    value = re.sub(r"\s+", " ", str(body or "")).strip()
+    if not value:
+        return False
+    if trailing:
+        return bool(
+            re.search(
+                r"\b(?:you|your|yourself)\b",
+                value[-120:],
+                re.I,
+            )
+        )
+    return bool(
+        re.match(
+            r"(?:you\b|please\b|"
+            r"(?:can|could|would|will|do|did|are|were|have|has|"
+            r"should|may|might)\s+you\b|"
+            r"(?:what|why|how|when|where|who)\b.{0,28}\byou\b|"
+            r"(?:tell|help|show|give|explain|check|look|listen|answer|"
+            r"remember|remind)\b)",
+            value,
+            re.I,
+        )
+    )
+
+
+def _looks_like_discourse_modifier(candidate: str) -> bool:
+    normalized = normalize_bnl_self_name(candidate)
+    return bool(normalized and normalized.replace("-", "").endswith("ly"))
+
+
+def classify_bnl_self_name_request(
+    text: str,
+    *,
+    independent_bnl_target: bool = False,
+) -> BnlSelfNameRequest:
+    """Classify naming acts using positive grammar rather than punctuation."""
 
     value = re.sub(
         r"<@!?\d+>",
@@ -11508,29 +11604,39 @@ def classify_bnl_self_name_request(text: str) -> BnlSelfNameRequest:
         flags=re.I,
     ).strip()
     value = re.sub(r"\s+", " ", value)
+    performed = _performed_self_name_clause(value)
 
     correction_patterns = (
         re.compile(
             r"\b(?:instead\s+of|replace)\s+"
-            r"[\"“']?(?P<old>[A-Za-z0-9][A-Za-z0-9 _.'’\-]{0,47})"
+            rf"[\"“']?(?P<old>{_SELF_NAME_VALUE_FRAGMENT})"
             r"[\"”']?\s+(?:with|use)\s+"
-            r"[\"“']?(?P<new>[A-Za-z0-9][A-Za-z0-9 _.'’\-]{0,47})",
+            rf"[\"“']?(?P<new>{_SELF_NAME_VALUE_FRAGMENT})",
             re.I,
         ),
         re.compile(
             r"\b(?:stop|quit)\s+(?:calling|using)\s+(?:you\s+)?"
-            r"[\"“']?(?P<old>[A-Za-z0-9][A-Za-z0-9 _.'’\-]{0,47})"
+            rf"[\"“']?(?P<old>{_SELF_NAME_VALUE_FRAGMENT})"
             r"[\"”']?.{0,40}\b(?:call|use)\s+(?:you\s+)?"
-            r"[\"“']?(?P<new>[A-Za-z0-9][A-Za-z0-9 _.'’\-]{0,47})",
+            rf"[\"“']?(?P<new>{_SELF_NAME_VALUE_FRAGMENT})",
             re.I,
         ),
     )
     for pattern in correction_patterns:
-        match = pattern.search(value)
-        if not match:
+        match = pattern.match(performed)
+        if not match or not _self_name_match_has_safe_boundary(
+            performed,
+            match,
+        ):
             continue
-        prior_name = _clean_self_name_candidate(match.group("old"))
-        new_name = _clean_self_name_candidate(match.group("new"))
+        prior_name = _clean_self_name_candidate(
+            match.group("old"),
+            reject_generic=False,
+        )
+        new_name = _clean_self_name_candidate(
+            match.group("new"),
+            reject_generic=False,
+        )
         if prior_name and new_name and (
             normalize_bnl_self_name(prior_name)
             != normalize_bnl_self_name(new_name)
@@ -11540,52 +11646,64 @@ def classify_bnl_self_name_request(text: str) -> BnlSelfNameRequest:
                 name=new_name,
                 prior_name=prior_name,
                 explicit=True,
+                classification="explicit_correction",
+                evidence_kind="explicit_correction",
             )
 
     revoke_patterns = (
         re.compile(
             r"\b(?:can|could|should|would)\s+we\s+"
             r"(?:stop|quit)\s+(?:calling|using)\s+(?:you\s+)?"
-            r"[\"“']?(?P<name>[A-Za-z0-9][A-Za-z0-9 _.'’\-]{0,47})",
+            r"[\"“']?" + _SELF_NAME_CAPTURE,
             re.I,
         ),
         re.compile(
             r"\b(?:do\s+not|don(?:'|’)t|dont|never|stop|quit)\s+"
             r"(?:call|calling|use|using)\s+(?:you\s+)?"
-            r"[\"“']?(?P<name>[A-Za-z0-9][A-Za-z0-9 _.'’\-]{0,47})",
+            r"[\"“']?" + _SELF_NAME_CAPTURE,
             re.I,
         ),
         re.compile(
-            r"\b(?P<name>[A-Za-z0-9][A-Za-z0-9.'’\-]{0,31})\s+"
+            rf"\b(?P<name>{_SELF_NAME_VALUE_FRAGMENT})\s+"
             r"(?:is|feels|seems)\s+(?:retired|done|not\s+working)\b",
             re.I,
         ),
     )
     for pattern in revoke_patterns:
-        match = pattern.search(value)
-        if match:
-            candidate = _clean_self_name_candidate(match.group("name"))
+        match = pattern.match(performed)
+        if match and _self_name_match_has_safe_boundary(performed, match):
+            candidate = _clean_self_name_candidate(
+                match.group("name"),
+                reject_generic=False,
+            )
             if candidate:
                 return BnlSelfNameRequest(
                     action="revoke",
                     name=candidate,
                     explicit=True,
+                    classification="explicit_revocation",
+                    evidence_kind="explicit_revocation",
                 )
 
     for pattern in _SELF_NAME_EXPLICIT_PATTERNS:
-        match = pattern.search(value)
-        if match:
-            candidate = _clean_self_name_candidate(match.group("name"))
+        match = pattern.match(performed)
+        if match and _self_name_match_has_safe_boundary(performed, match):
+            candidate = _clean_self_name_candidate(
+                match.group("name"),
+                reject_generic=False,
+            )
             if candidate:
                 return BnlSelfNameRequest(
                     action="propose",
                     name=candidate,
                     explicit=True,
+                    classification="explicit_proposal",
+                    evidence_kind="explicit_proposal",
                 )
+
     greeting = re.match(
         r"^\s*(?:hey|yo|hi|hello|sup)\s+"
-        r"(?P<name>[A-Za-z0-9][A-Za-z0-9.'’\-]{0,31})"
-        r"(?:\s*[,!?:-]|\s+)",
+        r"(?P<name>[^,!?:;\n]{1,48})\s*[,!?:;\-—]",
         value,
         re.I,
     )
@@ -11596,34 +11714,266 @@ def classify_bnl_self_name_request(text: str) -> BnlSelfNameRequest:
                 action="propose",
                 name=candidate,
                 explicit=False,
+                classification="strong_greeting_vocative",
+                evidence_kind="strong_greeting_vocative",
             )
-    leading = re.match(
-        r"^\s*(?P<name>[A-Za-z0-9][A-Za-z0-9.'’\-]{0,31})\s*,",
-        value,
-        re.I,
-    )
-    if leading:
-        candidate = _clean_self_name_candidate(leading.group("name"))
-        if candidate:
-            return BnlSelfNameRequest(
-                action="propose",
-                name=candidate,
-                explicit=False,
-            )
+
     trailing = re.search(
-        r",\s*(?P<name>[A-Za-z0-9][A-Za-z0-9.'’\-]{0,31})\s*[?!.]*$",
+        r"(?P<body>.+?)[,，]\s*"
+        rf"(?P<name>{_SELF_NAME_VALUE_FRAGMENT})\s*[?!.…]*$",
         value,
         re.I,
     )
     if trailing:
+        raw_candidate = _clean_self_name_candidate(
+            trailing.group("name"),
+            reject_generic=False,
+        )
         candidate = _clean_self_name_candidate(trailing.group("name"))
-        if candidate:
+        trailing_targets_bnl = _bare_vocative_body_targets_bnl(
+            trailing.group("body"),
+            trailing=True,
+        )
+        if not independent_bnl_target and trailing_targets_bnl:
+            return BnlSelfNameRequest(
+                classification="discourse_or_ambiguous_non_address",
+                candidate=raw_candidate,
+                ambiguous=bool(raw_candidate),
+            )
+        if (
+            independent_bnl_target
+            and _looks_like_discourse_modifier(raw_candidate)
+        ):
+            return BnlSelfNameRequest(
+                classification="discourse_modifier",
+                candidate=raw_candidate,
+            )
+        if independent_bnl_target and candidate and trailing_targets_bnl:
             return BnlSelfNameRequest(
                 action="propose",
                 name=candidate,
                 explicit=False,
+                classification="target_supported_bare_vocative",
+                evidence_kind="target_supported_bare_vocative",
             )
+
+    leading = re.match(
+        rf"^\s*(?P<name>{_SELF_NAME_VALUE_FRAGMENT})\s*[,，]\s*"
+        r"(?P<body>.+)$",
+        value,
+        re.I,
+    )
+    if leading:
+        raw_candidate = _clean_self_name_candidate(
+            leading.group("name"),
+            reject_generic=False,
+        )
+        candidate = _clean_self_name_candidate(leading.group("name"))
+        if not independent_bnl_target:
+            return BnlSelfNameRequest(
+                classification="discourse_or_ambiguous_non_address",
+                candidate=raw_candidate,
+                ambiguous=bool(raw_candidate),
+            )
+        if _looks_like_discourse_modifier(raw_candidate):
+            return BnlSelfNameRequest(
+                classification="discourse_modifier",
+                candidate=raw_candidate,
+            )
+        if candidate and _bare_vocative_body_targets_bnl(
+            leading.group("body"),
+            trailing=False,
+        ):
+            return BnlSelfNameRequest(
+                action="propose",
+                name=candidate,
+                explicit=False,
+                classification="target_supported_bare_vocative",
+                evidence_kind="target_supported_bare_vocative",
+            )
+        return BnlSelfNameRequest(
+            classification="ambiguous_candidate",
+            candidate=raw_candidate,
+            ambiguous=bool(raw_candidate),
+        )
     return BnlSelfNameRequest()
+
+
+def _bnl_self_name_source_text(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    decision_entry_id: str,
+) -> str:
+    """Read one governed user root for validation without reporting content."""
+
+    tables = {
+        str(row[0] or "")
+        for row in conn.execute(
+            "SELECT name FROM main.sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    if not {
+        "conversations",
+        "memory_ledger_entries",
+        "memory_ledger_lineage",
+    }.issubset(tables):
+        return ""
+    columns = {
+        str(row[1] or "")
+        for row in conn.execute("PRAGMA table_info(conversations)").fetchall()
+    }
+    if not {"id", "guild_id", "content"}.issubset(columns):
+        return ""
+    row = conn.execute(
+        """
+        SELECT conversation.content
+        FROM memory_ledger_lineage AS edge
+        JOIN memory_ledger_entries AS root
+          ON root.entry_id=edge.target_entry_id
+         AND root.guild_id=edge.guild_id
+        JOIN conversations AS conversation
+          ON conversation.id=CAST(root.source_row_id AS INTEGER)
+         AND conversation.guild_id=root.guild_id
+        WHERE edge.guild_id=? AND edge.entry_id=?
+          AND edge.lineage_type='derived_from'
+          AND root.source_table='conversations'
+          AND root.source_role='user'
+        ORDER BY root.entry_id
+        LIMIT 1
+        """,
+        (int(guild_id), str(decision_entry_id or "")),
+    ).fetchone()
+    return str(row[0] or "") if row else ""
+
+
+def _historical_self_name_request_supports_record(
+    source_text: str,
+    record: BnlSelfNameRecord,
+) -> tuple[bool, str]:
+    """Revalidate only strong source grammar; never infer old target state."""
+
+    request = classify_bnl_self_name_request(source_text)
+    if request.evidence_kind not in {
+        "explicit_proposal",
+        "explicit_correction",
+        "explicit_revocation",
+    }:
+        return False, "weak_or_ambiguous_historical_grammar"
+    record_name = normalize_bnl_self_name(record.display_name)
+    supported_names = {
+        normalize_bnl_self_name(request.name),
+        normalize_bnl_self_name(request.prior_name),
+    }
+    supported_names.discard("")
+    if not record_name or record_name not in supported_names:
+        return False, "historical_candidate_mismatch"
+    return True, request.evidence_kind
+
+
+def _validated_bnl_self_name_records(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    records: tuple[BnlSelfNameRecord, ...],
+) -> tuple[BnlSelfNameRecord, ...]:
+    """Apply the current grammar fence without rewriting append-only history."""
+
+    validated = []
+    for record in records:
+        if record.routing_eligible:
+            validated.append(record)
+            continue
+        if record.validation_version == BNL_SELF_NAME_VALIDATION_VERSION:
+            continue
+        source_text = _bnl_self_name_source_text(
+            conn,
+            guild_id=guild_id,
+            decision_entry_id=record.entry_id,
+        )
+        supported, evidence_kind = (
+            _historical_self_name_request_supports_record(
+                source_text,
+                record,
+            )
+        )
+        if supported:
+            validated.append(
+                replace(
+                    record,
+                    validation_version=BNL_SELF_NAME_VALIDATION_VERSION,
+                    evidence_kind=evidence_kind,
+                    routing_eligible=True,
+                    validation_basis="historical_positive_revalidation",
+                    quarantine_reason="",
+                )
+            )
+    return tuple(validated)
+
+
+def build_bnl_self_name_validation_report(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    channel_policies: tuple[str, ...] = (),
+) -> dict:
+    """Return a content-free, read-only grammar quarantine inventory."""
+
+    records = current_bnl_self_name_records(
+        conn,
+        guild_id=int(guild_id),
+        channel_policies=channel_policies,
+    )
+    validated = _validated_bnl_self_name_records(
+        conn,
+        guild_id=int(guild_id),
+        records=records,
+    )
+    validated_by_id = {record.entry_id: record for record in validated}
+    reason_counts: Counter[str] = Counter()
+    recorded_current = 0
+    historical_revalidated = 0
+    receipt_parts = []
+    for record in records:
+        routed = validated_by_id.get(record.entry_id)
+        if routed is None:
+            source_text = _bnl_self_name_source_text(
+                conn,
+                guild_id=int(guild_id),
+                decision_entry_id=record.entry_id,
+            )
+            _supported, reason = (
+                _historical_self_name_request_supports_record(
+                    source_text,
+                    record,
+                )
+                if record.validation_version
+                != BNL_SELF_NAME_VALIDATION_VERSION
+                else (False, record.quarantine_reason)
+            )
+            reason_counts[reason or "unvalidated"] += 1
+            status = "quarantined"
+        elif routed.validation_basis == "recorded_current_grammar":
+            recorded_current += 1
+            status = "recorded_current"
+        else:
+            historical_revalidated += 1
+            status = "historical_revalidated"
+        receipt_parts.append(f"{record.entry_id}:{status}")
+    snapshot_digest = hashlib.sha256(
+        "\x1f".join(sorted(receipt_parts)).encode("utf-8")
+    ).hexdigest()[:16]
+    return {
+        "validationVersion": BNL_SELF_NAME_VALIDATION_VERSION,
+        "activeDecisionCount": len(records),
+        "routingEligibleCount": len(validated),
+        "recordedCurrentGrammarCount": recorded_current,
+        "historicalRevalidatedCount": historical_revalidated,
+        "quarantinedCount": len(records) - len(validated),
+        "quarantineReasons": dict(sorted(reason_counts.items())),
+        "snapshotDigest": snapshot_digest,
+        "mutationCount": 0,
+    }
 
 
 def _extract_self_name_address_candidate(
@@ -11636,17 +11986,63 @@ def _extract_self_name_address_candidate(
 def _self_name_used_as_vocative(text: str, name: str) -> bool:
     """Match a governed name only in ordinary address positions."""
 
-    words = tuple(re.findall(r"[a-z0-9]+", str(name or "").lower()))
-    if not words:
+    normalized = normalize_bnl_self_name(name)
+    if not normalized:
         return False
-    name_pattern = r"\s+".join(re.escape(word) for word in words)
-    value = re.sub(r"\s+", " ", str(text or "")).strip()
+    name_pattern = r"\s+".join(
+        re.escape(part) for part in normalized.split()
+    )
+    value = unicodedata.normalize("NFKC", str(text or "")).casefold()
+    value = re.sub(r"\s+", " ", value).strip()
     patterns = (
-        rf"^(?:hey|yo|hi|hello|sup)\s+{name_pattern}(?:\s*[,!?:-]|\s+)",
-        rf"^{name_pattern}\s*(?:[,!?:-]|\s+(?:what|why|how|when|where|who|can|could|would|do|did|are|is|please|tell|help)\b)",
+        rf"^(?:hey|yo|hi|hello|sup)\s+{name_pattern}(?:\s*[,!?:;—-]|\s+)",
+        rf"^{name_pattern}\s*(?:[,!?:;—-]|\s+(?:what|why|how|when|where|who|can|could|would|do|did|are|is|please|tell|help)\b)",
+        rf"[,;:]\s*{name_pattern}\s*[,!?:;—-]",
         rf",\s*{name_pattern}\s*[?!.]*$",
     )
-    return any(re.search(pattern, value, re.I) for pattern in patterns)
+    return any(re.search(pattern, value) for pattern in patterns)
+
+
+def _known_human_vocative_present(
+    text: str,
+    known_humans: set[str],
+) -> bool:
+    """Compare bounded address-position candidates with known humans."""
+
+    value = unicodedata.normalize("NFKC", str(text or ""))
+    value = re.sub(r"\s+", " ", value).strip()
+    candidates = []
+    patterns = (
+        re.compile(
+            r"^(?:hey|yo|hi|hello|sup)\s+"
+            r"(?P<name>[^,!?:;\n]{1,48})\s*[,!?:;—-]",
+            re.I,
+        ),
+        re.compile(
+            rf"^\s*(?P<name>{_SELF_NAME_VALUE_FRAGMENT})\s*[,，:]",
+            re.I,
+        ),
+        re.compile(
+            r"[,;:]\s*(?P<name>[^,!?:;\n]{1,48})\s*[,!?:;—-]",
+            re.I,
+        ),
+        re.compile(
+            rf"[,，]\s*(?P<name>{_SELF_NAME_VALUE_FRAGMENT})\s*[?!.…]*$",
+            re.I,
+        ),
+    )
+    for pattern in patterns:
+        candidates.extend(
+            match.group("name") for match in pattern.finditer(value)
+        )
+    return any(
+        normalized in known_humans
+        for normalized in (
+            normalize_bnl_self_name(candidate)
+            for candidate in candidates
+        )
+        if normalized
+    )
 
 
 def _resolve_bnl_self_name_address(
@@ -11655,6 +12051,9 @@ def _resolve_bnl_self_name_address(
     guild,
     channel_policy: str = "public_home",
     governed_state_enabled: bool = True,
+    independent_bnl_target: bool = False,
+    targets_other_human: bool = False,
+    known_humans: set[str] | None = None,
 ) -> tuple[bool, str, str, bool]:
     """Resolve canon/accepted/proposed/denied without inventing a name."""
 
@@ -11662,7 +12061,11 @@ def _resolve_bnl_self_name_address(
     canonical_match = _CANONICAL_BNL_NAME_RE.search(literal)
     if canonical_match:
         return True, "canonical", canonical_match.group(0), False
-    known_humans = _known_guild_human_names(guild)
+    known_humans = (
+        set(known_humans)
+        if known_humans is not None
+        else _known_guild_human_names(guild)
+    )
     records = {}
     if governed_state_enabled:
         records = {
@@ -11682,13 +12085,20 @@ def _resolve_bnl_self_name_address(
         if record.decision == "deferred":
             return True, "proposed", record.display_name, True
         return False, "denied", record.display_name, False
-    request = classify_bnl_self_name_request(literal)
+    request = classify_bnl_self_name_request(
+        literal,
+        independent_bnl_target=independent_bnl_target,
+    )
+    possible_candidate = request.name or request.candidate
+    possible_normalized = normalize_bnl_self_name(possible_candidate)
+    if possible_normalized and possible_normalized in known_humans:
+        return False, "other_human", possible_candidate, False
+    if request.action != "none" and targets_other_human:
+        return False, "ambiguous", "", False
     candidate = request.name
     explicit_proposal = request.explicit
     if candidate:
         normalized = normalize_bnl_self_name(candidate)
-        if normalized in known_humans:
-            return False, "other_human", candidate, False
         record = records.get(normalized)
         if request.action == "revoke":
             return True, "revocation", candidate, True
@@ -11838,6 +12248,14 @@ def persist_bnl_self_name_decision_after_send(
     ):
         return None
     request_action = str(addressing.bnl_name_action or "propose").lower()
+    if request_action not in {"propose", "revoke", "correct"}:
+        request_action = (
+            "correct"
+            if addressing.bnl_name_state == "correction"
+            else "revoke"
+            if addressing.bnl_name_state == "revocation"
+            else "propose"
+        )
     decisions: list[tuple[str, str]] = []
     if request_action == "correct":
         new_decision = infer_bnl_self_name_decision(
@@ -11879,7 +12297,7 @@ def persist_bnl_self_name_decision_after_send(
                 return None
             source_row = lookup_conn.execute(
                 """
-                SELECT id
+                SELECT id,content
                 FROM conversations
                 WHERE guild_id=? AND message_id=? AND role='user'
                 ORDER BY id DESC
@@ -11913,6 +12331,46 @@ def persist_bnl_self_name_decision_after_send(
                 name_digest,
             )
             return None
+        claimed_evidence_kind = str(
+            addressing.bnl_name_evidence_kind or ""
+        ).strip()
+        validation_request = classify_bnl_self_name_request(
+            str(source_row[1] or ""),
+            independent_bnl_target=(
+                claimed_evidence_kind == "target_supported_bare_vocative"
+            ),
+        )
+        expected_names = {
+            normalize_bnl_self_name(addressing.bnl_name_value),
+        }
+        if request_action == "correct":
+            expected_names.add(
+                normalize_bnl_self_name(
+                    addressing.bnl_name_prior_value
+                )
+            )
+        request_names = {
+            normalize_bnl_self_name(validation_request.name),
+            normalize_bnl_self_name(validation_request.prior_name),
+        }
+        expected_names.discard("")
+        request_names.discard("")
+        if (
+            validation_request.validation_version
+            != BNL_SELF_NAME_VALIDATION_VERSION
+            or validation_request.evidence_kind
+            not in BNL_SELF_NAME_ROUTING_EVIDENCE_KINDS
+            or not expected_names
+            or not expected_names.issubset(request_names)
+            or validation_request.action != request_action
+        ):
+            logging.info(
+                "bnl_self_name_decision_not_persisted "
+                "reason=source_grammar_not_authoritative name_digest=%s",
+                name_digest,
+            )
+            return None
+        validated_evidence_kind = validation_request.evidence_kind
         if not decision_row:
             logging.info(
                 "bnl_self_name_decision_not_persisted "
@@ -11950,6 +12408,8 @@ def persist_bnl_self_name_decision_after_send(
                     channel_policy=str(channel_policy or "unknown"),
                     route_mode=str(route_mode or ROUTE_MODE_NORMAL_CHAT),
                     response_digest=response_digest,
+                    validation_version=BNL_SELF_NAME_VALIDATION_VERSION,
+                    evidence_kind=validated_evidence_kind,
                 )
                 if result.outcome not in {"inserted", "deduplicated"}:
                     raise sqlite3.IntegrityError(
@@ -12190,6 +12650,20 @@ def resolve_discord_turn_addressing(
         )
     if direct_to_bnl is None:
         direct_to_bnl = bool(explicitly_mentions_bnl or reply_to_bnl)
+    independent_bnl_target = bool(
+        explicitly_mentions_bnl or reply_to_bnl
+    )
+    message_guild = getattr(message, "guild", None)
+    known_humans = _known_guild_human_names(message_guild)
+    explicit_other_human_target = bool(
+        any(not bot_id or user_id != bot_id for user_id in raw_ids)
+        or (reply_author and (not bot_id or reply_author_id != bot_id))
+        or reply_conversation_role == "user"
+        or _known_human_vocative_present(
+            getattr(message, "content", "") or "",
+            known_humans,
+        )
+    )
     channel_policy = resolve_channel_policy(
         getattr(message, "channel", None)
     )
@@ -12213,14 +12687,39 @@ def resolve_discord_turn_addressing(
         channel_policy=channel_policy,
         governed_state_enabled=bnl_name_influence_mode
         in {"live", "sealed_canary"},
+        independent_bnl_target=independent_bnl_target,
+        targets_other_human=explicit_other_human_target,
+        known_humans=known_humans,
     )
     self_name_request = classify_bnl_self_name_request(
-        getattr(message, "content", "") or ""
+        getattr(message, "content", "") or "",
+        independent_bnl_target=independent_bnl_target,
     )
+    if bnl_name_state == "canonical":
+        self_name_request = BnlSelfNameRequest(
+            classification="canonical_bnl_address",
+            candidate=bnl_name_value,
+        )
+    elif bnl_name_state == "accepted":
+        self_name_request = BnlSelfNameRequest(
+            classification="accepted_governed_vocative",
+            candidate=bnl_name_value,
+        )
+    elif bnl_name_state == "other_human":
+        self_name_request = BnlSelfNameRequest(
+            classification="another_human_address",
+            candidate=bnl_name_value,
+        )
+    elif bnl_name_state == "ambiguous":
+        self_name_request = BnlSelfNameRequest(
+            classification="mixed_human_ambiguous",
+            candidate=(
+                self_name_request.name or self_name_request.candidate
+            ),
+            ambiguous=True,
+        )
     targets_other_human = bool(
-        any(not bot_id or user_id != bot_id for user_id in raw_ids)
-        or (reply_author and (not bot_id or reply_author_id != bot_id))
-        or reply_conversation_role == "user"
+        explicit_other_human_target
         or bnl_name_state == "other_human"
     )
     return DiscordTurnAddressing(
@@ -12240,6 +12739,9 @@ def resolve_discord_turn_addressing(
         ),
         bnl_name_action=self_name_request.action,
         bnl_name_prior_value=self_name_request.prior_name,
+        bnl_name_classification=self_name_request.classification,
+        bnl_name_evidence_kind=self_name_request.evidence_kind,
+        bnl_name_validation_version=self_name_request.validation_version,
         bnl_name_influence_mode=bnl_name_influence_mode,
         source_message_id=int(getattr(message, "id", 0) or 0),
         reply_message_id=reply_message_id,
@@ -37556,9 +38058,33 @@ def _collect_bnl_memory_diagnostic_data(
         "claimContractVersion": "unavailable",
         "mutationCount": 0,
     }
+    self_name_validation = {
+        "validationVersion": BNL_SELF_NAME_VALIDATION_VERSION,
+        "activeDecisionCount": 0,
+        "routingEligibleCount": 0,
+        "recordedCurrentGrammarCount": 0,
+        "historicalRevalidatedCount": 0,
+        "quarantinedCount": 0,
+        "quarantineReasons": {},
+        "snapshotDigest": "unavailable",
+        "mutationCount": 0,
+    }
     try:
         diagnostic_conn = sqlite3.connect(DB_FILE)
         try:
+            try:
+                self_name_validation = (
+                    build_bnl_self_name_validation_report(
+                        diagnostic_conn,
+                        guild_id=guild_id,
+                        channel_policies=_bnl_self_name_policy_scope(policy),
+                    )
+                )
+            except Exception as exc:
+                logging.debug(
+                    "bnl_self_name_validation_report_failed error=%s",
+                    exc,
+                )
             try:
                 claim_contract_inventory = build_claim_contract_inventory(
                     diagnostic_conn,
@@ -37613,6 +38139,7 @@ def _collect_bnl_memory_diagnostic_data(
         shadow_acceptance,
         ledger_diag,
         claim_contract_inventory,
+        self_name_validation,
     )
 
 
@@ -38291,6 +38818,7 @@ async def bnl_memory_check(interaction: discord.Interaction):
             shadow_acceptance,
             ledger_diag,
             claim_contract_inventory,
+            self_name_validation,
         ) = await asyncio.to_thread(
             _collect_bnl_memory_diagnostic_data,
             guild_id=guild.id,
@@ -38341,6 +38869,15 @@ async def bnl_memory_check(interaction: discord.Interaction):
         f"- hybrid_claim_reconciliation_status: `{claim_contract_inventory.get('sourceReconciliationStatus')}`",
         f"- hybrid_claim_source_reconciled: `{'yes' if claim_contract_inventory.get('sourceAdaptedReconciled') else 'no'}`",
         f"- hybrid_claim_mutation_count: `{claim_contract_inventory.get('mutationCount', 0)}`",
+        f"- bnl_self_name_validation_version: `{self_name_validation.get('validationVersion')}`",
+        f"- bnl_self_name_active_decisions: `{self_name_validation.get('activeDecisionCount', 0)}`",
+        f"- bnl_self_name_routing_eligible: `{self_name_validation.get('routingEligibleCount', 0)}`",
+        f"- bnl_self_name_recorded_current_grammar: `{self_name_validation.get('recordedCurrentGrammarCount', 0)}`",
+        f"- bnl_self_name_historical_revalidated: `{self_name_validation.get('historicalRevalidatedCount', 0)}`",
+        f"- bnl_self_name_quarantined: `{self_name_validation.get('quarantinedCount', 0)}`",
+        f"- bnl_self_name_quarantine_reasons: `{self_name_validation.get('quarantineReasons') or {}}`",
+        f"- bnl_self_name_validation_snapshot: `{self_name_validation.get('snapshotDigest')}`",
+        f"- bnl_self_name_validation_mutation_count: `{self_name_validation.get('mutationCount', 0)}`",
         f"- conversation_context_contract: `{LAST_CONVERSATION_CONTEXT_V2_DIAGNOSTICS.get('contract_version')}`",
         f"- conversation_context_enabled: `{'yes' if conversation_context_v2_enabled() else 'no'}`",
         f"- conversation_context_last_route_mode: `{LAST_CONVERSATION_CONTEXT_V2_DIAGNOSTICS.get('route_mode')}`",

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -74,6 +74,16 @@ _LIVING_CANON_AUTHORITY_TABLES = frozenset(
 )
 BNL_SUBJECT_KEY = "bnl_01"
 BNL_SELF_NAME_PREDICATE_PREFIX = "bnl_self_name:"
+BNL_SELF_NAME_VALIDATION_VERSION = "bnl_self_name_grammar_v2"
+BNL_SELF_NAME_ROUTING_EVIDENCE_KINDS = frozenset(
+    {
+        "explicit_proposal",
+        "explicit_correction",
+        "explicit_revocation",
+        "strong_greeting_vocative",
+        "target_supported_bare_vocative",
+    }
+)
 BNL_SELF_NAME_PUBLIC_POLICIES = frozenset(
     {"public_home", "public_context", "public_selective"}
 )
@@ -1188,6 +1198,11 @@ class BnlSelfNameRecord:
     decision: str
     entry_id: str
     observed_at: str = ""
+    validation_version: str = ""
+    evidence_kind: str = ""
+    routing_eligible: bool = False
+    validation_basis: str = "unvalidated"
+    quarantine_reason: str = "missing_validation_version"
 
 
 def shadow_enabled(environ: dict[str, str] | None = None) -> bool:
@@ -1260,14 +1275,20 @@ def subject_key_for_user(user_id: int | str | None) -> str:
 def normalize_bnl_self_name(value: Any) -> str:
     """Return one conservative comparison key without inventing aliases."""
 
-    cleaned = re.sub(r"\s+", " ", str(value or "")).strip(" \t\r\n,.;:!?\"'“”‘’")
+    cleaned = unicodedata.normalize("NFKC", str(value or ""))
+    cleaned = re.sub(r"\s+", " ", cleaned).strip(
+        " \t\r\n,.;:!?\"'“”‘’"
+    )
     if not cleaned or len(cleaned) > 48:
         return ""
     if len(cleaned.split()) > 4:
         return ""
-    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9 _.'’\-]{0,47}", cleaned):
+    if not cleaned[0].isalnum() or any(
+        not (character.isalnum() or character in " _.'’-")
+        for character in cleaned
+    ):
         return ""
-    return _canon(cleaned)
+    return cleaned.casefold()
 
 
 def current_bnl_self_name_records(
@@ -1455,6 +1476,23 @@ def current_bnl_self_name_records(
         normalized = normalize_bnl_self_name(payload.get("normalized"))
         display = re.sub(r"\s+", " ", str(payload.get("name") or "")).strip()[:48]
         decision = str(payload.get("decision") or "").strip().lower()
+        validation_version = str(
+            payload.get("validation_version") or ""
+        ).strip()
+        evidence_kind = str(payload.get("evidence_kind") or "").strip()
+        routing_eligible = bool(
+            validation_version == BNL_SELF_NAME_VALIDATION_VERSION
+            and evidence_kind in BNL_SELF_NAME_ROUTING_EVIDENCE_KINDS
+        )
+        quarantine_reason = ""
+        if not routing_eligible:
+            quarantine_reason = (
+                "missing_validation_version"
+                if not validation_version
+                else "stale_validation_version"
+                if validation_version != BNL_SELF_NAME_VALIDATION_VERSION
+                else "unsupported_evidence_kind"
+            )
         if (
             not normalized
             or not display
@@ -1478,6 +1516,15 @@ def current_bnl_self_name_records(
             decision=decision,
             entry_id=str(entry_id or ""),
             observed_at=str(observed_at or ""),
+            validation_version=validation_version,
+            evidence_kind=evidence_kind,
+            routing_eligible=routing_eligible,
+            validation_basis=(
+                "recorded_current_grammar"
+                if routing_eligible
+                else "unvalidated"
+            ),
+            quarantine_reason=quarantine_reason,
         )
     return tuple(selected[key] for key in sorted(selected))
 
@@ -1496,6 +1543,8 @@ def record_bnl_self_name_decision(
     channel_policy: str,
     route_mode: str,
     response_digest: str,
+    validation_version: str = "",
+    evidence_kind: str = "",
     observed_at: str = "",
 ) -> LedgerWriteResult:
     """Record BNL's explicit accept/deny/defer/revoke decision with lineage."""
@@ -1504,6 +1553,8 @@ def record_bnl_self_name_decision(
     normalized = normalize_bnl_self_name(name)
     clean_display = re.sub(r"\s+", " ", str(name or "")).strip()[:48]
     resolved_decision = str(decision or "").strip().lower()
+    resolved_validation_version = str(validation_version or "").strip()
+    resolved_evidence_kind = str(evidence_kind or "").strip()
     if (
         int(guild_id or 0) <= 0
         or not normalized
@@ -1609,12 +1660,17 @@ def record_bnl_self_name_decision(
                 f"{source_row_id}\x1f{decision_row_id}"
             ).encode("utf-8")
         ).hexdigest()
-    source_revision = f"{resolved_decision}:{digest}"
+    source_revision = (
+        f"{resolved_decision}:"
+        f"{resolved_validation_version or 'legacy_unvalidated'}:{digest}"
+    )
     value = json.dumps(
         {
             "decision": resolved_decision,
+            "evidence_kind": resolved_evidence_kind,
             "name": clean_display,
             "normalized": normalized,
+            "validation_version": resolved_validation_version,
         },
         sort_keys=True,
         separators=(",", ":"),

--- a/docs/BNL01_CONVERSATION_ORCHESTRATION_CONTRACT.md
+++ b/docs/BNL01_CONVERSATION_ORCHESTRATION_CONTRACT.md
@@ -69,8 +69,18 @@ has decided the current packet.
 BNL self-names are learned decisions, not configured aliases.
 
 - A structurally valid vocative or explicit naming proposal may present a
-  candidate to BNL. Leading discourse words and generic commands are not name
-  proposals. No specific candidate is privileged in production code.
+  candidate to BNL. Punctuation alone never establishes both a candidate and
+  a BNL target. Leading/trailing discourse words, modifiers, generic commands,
+  quoted speech, code, titles, and discussion about a possible name are not
+  performed naming acts. This is a positive grammar contract, not a finite
+  discourse-word blacklist, and no specific candidate is privileged in
+  production code.
+- `Hey <candidate>, ...` is a strong greeting vocative when another-human and
+  quotation ambiguity are absent. A novel bare `<candidate>, ...` or
+  `..., <candidate>` requires independent BNL targeting from a Discord
+  mention/reply plus second-person address structure; the comma cannot create
+  that target. An already accepted governed name remains valid as a bare
+  vocative without proposing it again.
 - A known human display name remains a human target and cannot silently become
   a BNL name.
 - The typed lifecycle is propose, accept, reject, defer, correct, or revoke.
@@ -90,6 +100,15 @@ BNL self-names are learned decisions, not configured aliases.
 - Current routing state is freshly revalidated against both the member proposal
   and BNL's saved delivered response. A stale positive cache is never routing
   authority.
+- New decisions record `bnl_self_name_grammar_v2` and their positive evidence
+  kind in the existing Ledger value. Historical decisions remain append-only:
+  an owner-only, content-free read diagnostic counts current, revalidated, and
+  quarantined decisions without emitting names or message text. A historical
+  decision lacking the current validation revision may route only when its
+  original user root independently revalidates as an explicit naming act or
+  correction/revocation. Old greeting-only and weak comma-only history lacks
+  enough trusted target context, so it stays visible to the diagnostic but is
+  excluded from routing without mutation.
 - Decisions are scoped by guild and visibility. A sealed-test-only decision
   cannot become public routing state.
 - The existing member preferred-name system remains separate: it records what
@@ -155,7 +174,8 @@ Conversation Context v2 remains the only owner of raw nearby content.
   construction, regeneration, and the final pre-send check preserve the same
   typed reply source; a proven competing-source substitution fails closed.
 - A self-name decision is not persisted when generation fails, delivery fails,
-  parsing is ambiguous, or the source conversation cannot be linked.
+  parsing is ambiguous, the source grammar does not reproduce the claimed
+  positive evidence, or the source conversation cannot be linked.
 - A partial multi-chunk delivery writes no complete model conversation row and
   no false Discord reply identity.
 - Deterministic status and recall shortcuts cannot bypass a pending natural
@@ -171,7 +191,11 @@ Conversation Context v2 remains the only owner of raw nearby content.
 Regression coverage must include arbitrary self-name candidates, acceptance,
 denial, deferral, correction, revocation, restart persistence, deletion,
 forgetting, retraction, provenance loss, visibility boundaries, known-human
-collisions, direct and batched response obligations, resolved and unresolved
+collisions, punctuation-only discourse/modifier constructions, strong greeting
+vocatives, mention/reply-supported novel bare vocatives, quoted/discussed/code
+candidates, Unicode names, mixed-human ambiguity, validation-version history
+quarantine, content-free diagnostics, direct and batched response obligations,
+resolved and unresolved
 exact reply references, multiple replies, replies to BNL, partial sends,
 replies to another human while addressing BNL, competing newer same-room
 messages, explicit reply-scope expansion, cross-speaker structural references,

--- a/tests/test_conversation_orchestration.py
+++ b/tests/test_conversation_orchestration.py
@@ -226,6 +226,420 @@ class GovernedSelfNameTests(unittest.TestCase):
         self.assertEqual(temporal, (False, "none", "", False))
         self.assertEqual(discourse, (False, "none", "", False))
 
+    def test_punctuation_only_discourse_fails_closed_by_structure(self):
+        cases = (
+            "Personally, I think Friday works.",
+            "Apparently, the queue is moving.",
+            "Technically, that is correct.",
+            "Unfortunately, it failed.",
+            "Honestly, I am not sure.",
+            "Meanwhile, the room kept moving.",
+            "However, the queue kept moving.",
+            "But, I think Friday works.",
+            "Maybe, Friday still works.",
+            "In general, this seems fine.",
+            "In the room, the queue is moving.",
+            "HERE, the queue is moving.",
+            "Today, I finished the change.",
+            "I think Friday works, personally.",
+            "The queue is moving, apparently.",
+            "The queue is moving, in general.",
+            "Actually，I think Friday works.",
+        )
+        guild = SimpleNamespace(id=10, members=[])
+        with mock.patch.object(
+            bnl01_bot,
+            "_load_bnl_self_name_records",
+            return_value=(),
+        ):
+            baseline = {
+                text: bnl01_bot.classify_bnl_self_name_request(text)
+                for text in cases
+            }
+            for text, request in baseline.items():
+                with self.subTest(text=text):
+                    self.assertEqual(request.action, "none")
+                    self.assertEqual(request.evidence_kind, "")
+                    self.assertEqual(
+                        bnl01_bot._resolve_bnl_self_name_address(
+                            text,
+                            guild=guild,
+                        ),
+                        (False, "none", "", False),
+                    )
+            with mock.patch.object(
+                bnl01_bot,
+                "_SELF_NAME_STOPWORDS",
+                frozenset(),
+            ):
+                for text, original in baseline.items():
+                    with self.subTest(text=text, stopwords="removed"):
+                        changed = (
+                            bnl01_bot.classify_bnl_self_name_request(text)
+                        )
+                        self.assertEqual(changed.action, "none")
+                        self.assertEqual(
+                            changed.classification,
+                            original.classification,
+                        )
+
+        addressing = _addressing(bnl=False, state="none")
+        decision = bnl01_bot.build_live_conversation_orchestration_decision(
+            engagement_decision="observe",
+            engagement_reason="no_response_needed",
+            channel_policy="public_home",
+            addressings=(addressing,),
+            context_result=None,
+            moment_situation=None,
+            influence_mode="live",
+        )
+        self.assertFalse(decision.response_required)
+        self.assertEqual(decision.response_act, "observe")
+
+    def test_positive_vocative_grammar_requires_independent_targeting(self):
+        unsupported = bnl01_bot.classify_bnl_self_name_request(
+            "Blue, can you look at this?"
+        )
+        supported = bnl01_bot.classify_bnl_self_name_request(
+            "Blue, can you look at this?",
+            independent_bnl_target=True,
+        )
+        trailing = bnl01_bot.classify_bnl_self_name_request(
+            "What do you think, Blue?",
+            independent_bnl_target=True,
+        )
+        discourse_reply = bnl01_bot.classify_bnl_self_name_request(
+            "Personally, I think Friday works.",
+            independent_bnl_target=True,
+        )
+
+        self.assertEqual(unsupported.action, "none")
+        self.assertTrue(unsupported.ambiguous)
+        self.assertEqual(
+            (supported.action, supported.name, supported.evidence_kind),
+            ("propose", "Blue", "target_supported_bare_vocative"),
+        )
+        self.assertEqual(
+            (trailing.action, trailing.name, trailing.evidence_kind),
+            ("propose", "Blue", "target_supported_bare_vocative"),
+        )
+        self.assertEqual(discourse_reply.action, "none")
+        self.assertEqual(
+            discourse_reply.classification,
+            "discourse_modifier",
+        )
+
+        human = SimpleNamespace(
+            bot=False,
+            display_name="Chris",
+            global_name="",
+            name="chris-user",
+        )
+        with mock.patch.object(
+            bnl01_bot,
+            "_load_bnl_self_name_records",
+            return_value=(),
+        ):
+            self.assertEqual(
+                bnl01_bot._resolve_bnl_self_name_address(
+                    "What do you think, Chris?",
+                    guild=SimpleNamespace(id=10, members=[human]),
+                ),
+                (False, "other_human", "Chris", False),
+            )
+            self.assertEqual(
+                bnl01_bot._resolve_bnl_self_name_address(
+                    "Hey Blue, can you look at this?",
+                    guild=SimpleNamespace(id=10, members=[]),
+                    targets_other_human=True,
+                ),
+                (False, "ambiguous", "", False),
+            )
+            self.assertEqual(
+                bnl01_bot._resolve_bnl_self_name_address(
+                    "Blue, can you look at this?",
+                    guild=SimpleNamespace(id=10, members=[]),
+                    independent_bnl_target=True,
+                    targets_other_human=True,
+                ),
+                (False, "ambiguous", "", False),
+            )
+
+    def test_discord_reply_support_is_carried_into_typed_name_addressing(self):
+        author = SimpleNamespace(
+            id=44,
+            bot=False,
+            display_name="Member",
+            global_name="",
+            name="member",
+        )
+        guild = SimpleNamespace(id=10, members=[author])
+        channel = SimpleNamespace(id=700, name="home")
+        message = SimpleNamespace(
+            id=8001,
+            author=author,
+            guild=guild,
+            channel=channel,
+            content="Blue, can you look at this?",
+            raw_mentions=[],
+            mentions=[],
+            reference=None,
+        )
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "resolve_channel_policy",
+                return_value="public_home",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "conversation_orchestration_influence_mode",
+                return_value="live",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "_load_bnl_self_name_records",
+                return_value=(),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "_conversation_row_for_discord_message",
+                return_value=(0, "", ""),
+            ),
+        ):
+            unsupported = bnl01_bot.resolve_discord_turn_addressing(
+                message,
+                direct_to_bnl=False,
+                reply_to_bnl=False,
+            )
+            generic_direct = bnl01_bot.resolve_discord_turn_addressing(
+                message,
+                direct_to_bnl=True,
+                reply_to_bnl=False,
+            )
+            reply_supported = bnl01_bot.resolve_discord_turn_addressing(
+                message,
+                direct_to_bnl=True,
+                reply_to_bnl=True,
+            )
+
+        self.assertFalse(unsupported.plain_text_names_bnl)
+        self.assertEqual(unsupported.bnl_name_state, "none")
+        self.assertFalse(unsupported.bnl_name_requires_decision)
+        self.assertEqual(generic_direct.bnl_name_state, "none")
+        self.assertFalse(generic_direct.bnl_name_requires_decision)
+        self.assertTrue(reply_supported.plain_text_names_bnl)
+        self.assertEqual(reply_supported.bnl_name_state, "proposed")
+        self.assertTrue(reply_supported.bnl_name_requires_decision)
+        self.assertEqual(
+            reply_supported.bnl_name_evidence_kind,
+            "target_supported_bare_vocative",
+        )
+        self.assertEqual(
+            reply_supported.bnl_name_validation_version,
+            bnl01_bot.BNL_SELF_NAME_VALIDATION_VERSION,
+        )
+
+    def test_plain_text_human_vocatives_preserve_typed_ambiguity(self):
+        author = SimpleNamespace(
+            id=44,
+            bot=False,
+            display_name="Member",
+            global_name="",
+            name="member",
+        )
+        human = SimpleNamespace(
+            id=55,
+            bot=False,
+            display_name="Chris",
+            global_name="",
+            name="chris-user",
+        )
+        guild = SimpleNamespace(id=10, members=[author, human])
+        channel = SimpleNamespace(id=700, name="home")
+
+        def message(content, message_id):
+            return SimpleNamespace(
+                id=message_id,
+                author=author,
+                guild=guild,
+                channel=channel,
+                content=content,
+                raw_mentions=[],
+                mentions=[],
+                reference=None,
+            )
+
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "resolve_channel_policy",
+                return_value="public_home",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "conversation_orchestration_influence_mode",
+                return_value="live",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "_load_bnl_self_name_records",
+                return_value=(),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "_conversation_row_for_discord_message",
+                return_value=(0, "", ""),
+            ),
+        ):
+            human_only = bnl01_bot.resolve_discord_turn_addressing(
+                message("Hey Chris, what do you think?", 8003),
+                direct_to_bnl=False,
+                reply_to_bnl=False,
+            )
+            mixed = bnl01_bot.resolve_discord_turn_addressing(
+                message("Hey Blue, Chris, can you check this?", 8004),
+                direct_to_bnl=False,
+                reply_to_bnl=False,
+            )
+
+        self.assertTrue(human_only.targets_other_human)
+        self.assertEqual(human_only.bnl_name_state, "other_human")
+        self.assertEqual(
+            human_only.bnl_name_classification,
+            "another_human_address",
+        )
+        self.assertFalse(human_only.addresses_bnl)
+        self.assertTrue(mixed.targets_other_human)
+        self.assertEqual(mixed.bnl_name_state, "ambiguous")
+        self.assertEqual(
+            mixed.bnl_name_classification,
+            "mixed_human_ambiguous",
+        )
+        self.assertEqual(mixed.bnl_name_action, "none")
+        self.assertFalse(mixed.bnl_name_requires_decision)
+        self.assertFalse(mixed.addresses_bnl)
+
+    def test_accepted_unicode_multiword_name_routes_in_vocative_positions(self):
+        record = bnl01_bot.BnlSelfNameRecord(
+            normalized_name="módem azul",
+            display_name="Módem Azul",
+            decision="accepted",
+            entry_id="accepted-name-entry",
+            validation_version=(
+                bnl01_bot.BNL_SELF_NAME_VALIDATION_VERSION
+            ),
+            evidence_kind="explicit_proposal",
+            routing_eligible=True,
+            validation_basis="recorded_current_grammar",
+            quarantine_reason="",
+        )
+        guild = SimpleNamespace(id=10, members=[])
+        cases = (
+            "Hey MÓDEM AZUL—can you check this?",
+            "Módem Azul: can you check this?",
+            "Could you, Módem Azul, check this?",
+            "What do you think, Módem Azul?",
+        )
+        with mock.patch.object(
+            bnl01_bot,
+            "_load_bnl_self_name_records",
+            return_value=(record,),
+        ):
+            for text in cases:
+                with self.subTest(text=text):
+                    self.assertEqual(
+                        bnl01_bot._resolve_bnl_self_name_address(
+                            text,
+                            guild=guild,
+                        ),
+                        (True, "accepted", "Módem Azul", False),
+                    )
+
+            author = SimpleNamespace(
+                id=44,
+                bot=False,
+                display_name="Member",
+                global_name="",
+                name="member",
+            )
+            message = SimpleNamespace(
+                id=8002,
+                author=author,
+                guild=guild,
+                channel=SimpleNamespace(id=700, name="home"),
+                content="Could you, Módem Azul, check this?",
+                raw_mentions=[],
+                mentions=[],
+                reference=None,
+            )
+            with (
+                mock.patch.object(
+                    bnl01_bot,
+                    "resolve_channel_policy",
+                    return_value="public_home",
+                ),
+                mock.patch.object(
+                    bnl01_bot,
+                    "conversation_orchestration_influence_mode",
+                    return_value="live",
+                ),
+                mock.patch.object(
+                    bnl01_bot,
+                    "_conversation_row_for_discord_message",
+                    return_value=(0, "", ""),
+                ),
+            ):
+                addressing = bnl01_bot.resolve_discord_turn_addressing(
+                    message,
+                    direct_to_bnl=False,
+                    reply_to_bnl=False,
+                )
+
+        self.assertEqual(addressing.bnl_name_state, "accepted")
+        self.assertEqual(
+            addressing.bnl_name_classification,
+            "accepted_governed_vocative",
+        )
+        self.assertEqual(addressing.bnl_name_action, "none")
+        self.assertFalse(addressing.bnl_name_requires_decision)
+
+    def test_explicit_and_greeting_grammar_is_unicode_and_quote_safe(self):
+        explicit_cases = {
+            "Can I call you Actually?": "Actually",
+            "BNL, can I call you Módem Azul?": "Módem Azul",
+            "Can I call you O’Clock-7?": "O’Clock-7",
+            "Your nickname should be Test Lantern.": "Test Lantern",
+        }
+        for text, name in explicit_cases.items():
+            with self.subTest(text=text):
+                request = bnl01_bot.classify_bnl_self_name_request(text)
+                self.assertEqual(
+                    (request.action, request.name, request.evidence_kind),
+                    ("propose", name, "explicit_proposal"),
+                )
+
+        greeting = bnl01_bot.classify_bnl_self_name_request(
+            "Hey Módem Azul, can you check this? 👋"
+        )
+        self.assertEqual(
+            (greeting.action, greeting.name, greeting.evidence_kind),
+            ("propose", "Módem Azul", "strong_greeting_vocative"),
+        )
+
+        for text in (
+            'She asked, "Can I call you Blue?"',
+            '"Can I call you Blue?"',
+            "`Can I call you Blue?` is the example.",
+            "The phrase 'your name is Blue' appears in the draft.",
+            "Can I call you Blue/Red?",
+            "Can I call you " + ("A" * 60) + "?",
+        ):
+            with self.subTest(text=text):
+                request = bnl01_bot.classify_bnl_self_name_request(text)
+                self.assertEqual(request.action, "none")
+                self.assertEqual(request.evidence_kind, "")
+
     def test_response_decision_parser_is_explicit_and_fail_closed(self):
         self.assertEqual(
             bnl01_bot.infer_bnl_self_name_decision(
@@ -352,6 +766,295 @@ class GovernedSelfNameTests(unittest.TestCase):
                 )
 
             self.assertEqual(routed, (True, "accepted", "Blue", False))
+
+    def test_historical_weak_grammar_is_reported_and_quarantined_read_only(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = os.path.join(temp_dir, "bnl.sqlite")
+            with sqlite3.connect(db_path) as conn:
+                ensure_memory_ledger_schema(conn)
+                _seed_conversation_source_rows(
+                    conn,
+                    (
+                        1,
+                        77,
+                        "user",
+                        700,
+                        "public_home",
+                        "Can I call you Blue?",
+                    ),
+                    (
+                        2,
+                        77,
+                        "model",
+                        700,
+                        "public_home",
+                        "People can call me Blue.",
+                    ),
+                    (
+                        3,
+                        77,
+                        "user",
+                        700,
+                        "public_home",
+                        "Personally, I think Friday works.",
+                    ),
+                    (
+                        4,
+                        77,
+                        "model",
+                        700,
+                        "public_home",
+                        "People can call me Personally.",
+                    ),
+                )
+                rows = (
+                    (1, "user", "Can I call you Blue?", 8001),
+                    (2, "model", "People can call me Blue.", 9001),
+                    (
+                        3,
+                        "user",
+                        "Personally, I think Friday works.",
+                        8003,
+                    ),
+                    (
+                        4,
+                        "model",
+                        "People can call me Personally.",
+                        9004,
+                    ),
+                )
+                for row_id, role, content, message_id in rows:
+                    shadow_conversation_row(
+                        conn,
+                        row_id=row_id,
+                        user_id=44 if role == "user" else 0,
+                        user_name=(
+                            "member" if role == "user" else "BNL-01"
+                        ),
+                        guild_id=77,
+                        role=role,
+                        content=content,
+                        channel_name="home",
+                        channel_policy="public_home",
+                        channel_id=700,
+                        message_id=message_id,
+                        route_mode="normal_chat",
+                        observed_at=(
+                            NOW + timedelta(seconds=row_id)
+                        ).isoformat(),
+                    )
+                for (
+                    name,
+                    source_row,
+                    decision_row,
+                    source_message,
+                    digest,
+                ) in (
+                    ("Blue", 1, 2, 8001, "a" * 64),
+                    ("Personally", 3, 4, 8003, "b" * 64),
+                ):
+                    record_bnl_self_name_decision(
+                        conn,
+                        guild_id=77,
+                        name=name,
+                        decision="accepted",
+                        source_conversation_row_id=source_row,
+                        decision_conversation_row_id=decision_row,
+                        source_message_id=source_message,
+                        channel_id=700,
+                        channel_name="home",
+                        channel_policy="public_home",
+                        route_mode="normal_chat",
+                        response_digest=digest,
+                        observed_at=(
+                            NOW + timedelta(seconds=decision_row)
+                        ).isoformat(),
+                    )
+                conn.commit()
+                before_count = conn.execute(
+                    "SELECT COUNT(*) FROM memory_ledger_entries"
+                ).fetchone()[0]
+                report = bnl01_bot.build_bnl_self_name_validation_report(
+                    conn,
+                    guild_id=77,
+                    channel_policies=("public_home",),
+                )
+                after_count = conn.execute(
+                    "SELECT COUNT(*) FROM memory_ledger_entries"
+                ).fetchone()[0]
+
+            self.assertEqual(before_count, after_count)
+            self.assertEqual(report["activeDecisionCount"], 2)
+            self.assertEqual(report["routingEligibleCount"], 1)
+            self.assertEqual(report["historicalRevalidatedCount"], 1)
+            self.assertEqual(report["quarantinedCount"], 1)
+            self.assertEqual(report["mutationCount"], 0)
+            self.assertEqual(
+                report["quarantineReasons"],
+                {"weak_or_ambiguous_historical_grammar": 1},
+            )
+            rendered_report = json.dumps(report, sort_keys=True)
+            self.assertNotIn("Blue", rendered_report)
+            self.assertNotIn("Personally", rendered_report)
+
+            with (
+                mock.patch.object(bnl01_bot, "DB_FILE", db_path),
+                mock.patch.object(
+                    bnl01_bot,
+                    "memory_ledger_shadow_enabled",
+                    return_value=True,
+                ),
+            ):
+                records = bnl01_bot._load_bnl_self_name_records(
+                    77,
+                    "public_home",
+                )
+            self.assertEqual(len(records), 1)
+            self.assertEqual(records[0].normalized_name, "blue")
+            self.assertEqual(
+                records[0].validation_basis,
+                "historical_positive_revalidation",
+            )
+
+            greeting_record = bnl01_bot.BnlSelfNameRecord(
+                normalized_name="beacon",
+                display_name="Beacon",
+                decision="accepted",
+                entry_id="legacy-greeting-entry",
+            )
+            self.assertEqual(
+                bnl01_bot._historical_self_name_request_supports_record(
+                    "Hey Beacon, can you check this?",
+                    greeting_record,
+                ),
+                (False, "weak_or_ambiguous_historical_grammar"),
+            )
+
+    def test_punctuation_only_source_cannot_persist_name_authority(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = os.path.join(temp_dir, "bnl.sqlite")
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    """
+                    CREATE TABLE conversations (
+                        id INTEGER PRIMARY KEY,
+                        guild_id INTEGER,
+                        message_id INTEGER,
+                        role TEXT,
+                        channel_id INTEGER,
+                        content TEXT
+                    )
+                    """
+                )
+                conn.executemany(
+                    """
+                    INSERT INTO conversations (
+                        id,guild_id,message_id,role,channel_id,content
+                    ) VALUES (?,?,?,?,?,?)
+                    """,
+                    (
+                        (
+                            1,
+                            77,
+                            8001,
+                            "user",
+                            700,
+                            "Personally, I think Friday works.",
+                        ),
+                        (
+                            2,
+                            77,
+                            None,
+                            "model",
+                            700,
+                            "People can call me Personally.",
+                        ),
+                    ),
+                )
+                ensure_memory_ledger_schema(conn)
+                for row_id, role, content, message_id in (
+                    (
+                        1,
+                        "user",
+                        "Personally, I think Friday works.",
+                        8001,
+                    ),
+                    (
+                        2,
+                        "model",
+                        "People can call me Personally.",
+                        None,
+                    ),
+                ):
+                    shadow_conversation_row(
+                        conn,
+                        row_id=row_id,
+                        user_id=44 if role == "user" else 0,
+                        user_name=(
+                            "member" if role == "user" else "BNL-01"
+                        ),
+                        guild_id=77,
+                        role=role,
+                        content=content,
+                        channel_name="home",
+                        channel_policy="public_home",
+                        channel_id=700,
+                        message_id=message_id,
+                        route_mode="normal_chat",
+                        observed_at=NOW.isoformat(),
+                    )
+                conn.commit()
+
+            addressing = _addressing(
+                bnl=True,
+                state="proposed",
+                value="Personally",
+                requires_decision=True,
+            )
+            addressing = bnl01_bot.replace(
+                addressing,
+                source_message_id=8001,
+                bnl_name_action="propose",
+                bnl_name_classification="legacy_bare_comma",
+                bnl_name_evidence_kind="",
+            )
+            with (
+                mock.patch.object(bnl01_bot, "DB_FILE", db_path),
+                mock.patch.object(
+                    bnl01_bot,
+                    "memory_ledger_shadow_enabled",
+                    return_value=True,
+                ),
+                mock.patch.dict(
+                    os.environ,
+                    {
+                        "BNL_CONVERSATION_ORCHESTRATION_INFLUENCE_ENABLED": "1"
+                    },
+                    clear=False,
+                ),
+            ):
+                result = (
+                    bnl01_bot.persist_bnl_self_name_decision_after_send(
+                        guild_id=77,
+                        addressing=addressing,
+                        response="People can call me Personally.",
+                        channel_id=700,
+                        channel_name="home",
+                        channel_policy="public_home",
+                        route_mode="normal_chat",
+                    )
+                )
+            self.assertIsNone(result)
+            with sqlite3.connect(db_path) as conn:
+                self.assertEqual(
+                    conn.execute(
+                        """
+                        SELECT COUNT(*) FROM memory_ledger_entries
+                        WHERE source_table='bnl_self_name_decisions'
+                        """
+                    ).fetchone()[0],
+                    0,
+                )
 
     def test_correction_supersedes_acceptance_and_reconsideration_stays_possible(self):
         with sqlite3.connect(":memory:") as conn:
@@ -606,6 +1309,12 @@ class GovernedSelfNameTests(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result.outcome, "inserted")
         self.assertEqual(records[0].decision, "accepted")
+        self.assertTrue(records[0].routing_eligible)
+        self.assertEqual(
+            records[0].validation_version,
+            bnl01_bot.BNL_SELF_NAME_VALIDATION_VERSION,
+        )
+        self.assertEqual(records[0].evidence_kind, "explicit_proposal")
         self.assertEqual(participants, [("bnl_01",)])
 
     def test_sealed_only_name_decision_does_not_leak_to_public_routing(self):
@@ -1474,14 +2183,30 @@ class OrchestrationHardeningRegressionTests(unittest.TestCase):
             ) VALUES (?,?,?,?,?,?,?)
             """,
             (
-                (1, 77, 8001, "user", 700, "public_home", "proposal"),
-                (2, 77, 9001, "model", 700, "public_home", "acceptance"),
+                (
+                    1,
+                    77,
+                    8001,
+                    "user",
+                    700,
+                    "public_home",
+                    "Can I call you Blue?",
+                ),
+                (
+                    2,
+                    77,
+                    9001,
+                    "model",
+                    700,
+                    "public_home",
+                    "People can call me Blue.",
+                ),
             ),
         )
         ensure_memory_ledger_schema(conn)
         for row_id, role, content, message_id in (
-            (1, "user", "proposal", 8001),
-            (2, "model", "acceptance", 9001),
+            (1, "user", "Can I call you Blue?", 8001),
+            (2, "model", "People can call me Blue.", 9001),
         ):
             shadow_conversation_row(
                 conn,

--- a/tests/test_memory_diagnostic_command.py
+++ b/tests/test_memory_diagnostic_command.py
@@ -81,6 +81,19 @@ def diagnostic_data():
             "sourceAdaptedReconciled": True,
             "mutationCount": 0,
         },
+        {
+            "validationVersion": "bnl_self_name_grammar_v2",
+            "activeDecisionCount": 2,
+            "routingEligibleCount": 1,
+            "recordedCurrentGrammarCount": 0,
+            "historicalRevalidatedCount": 1,
+            "quarantinedCount": 1,
+            "quarantineReasons": {
+                "weak_or_ambiguous_historical_grammar": 1
+            },
+            "snapshotDigest": "fixture-digest",
+            "mutationCount": 0,
+        },
     )
 
 
@@ -140,6 +153,23 @@ class MemoryDiagnosticCommandTests(unittest.IsolatedAsyncioTestCase):
             )
             self.assertIn(
                 "- hybrid_claim_truncated_sources: `()`",
+                text,
+            )
+            self.assertIn(
+                "- bnl_self_name_validation_version: "
+                "`bnl_self_name_grammar_v2`",
+                text,
+            )
+            self.assertIn(
+                "- bnl_self_name_historical_revalidated: `1`",
+                text,
+            )
+            self.assertIn(
+                "- bnl_self_name_quarantined: `1`",
+                text,
+            )
+            self.assertIn(
+                "- bnl_self_name_validation_mutation_count: `0`",
                 text,
             )
             self.assertEqual(limit, 1700)


### PR DESCRIPTION
## Summary

Repairs BNL's governed self-name and vocative path with fail-closed positive grammar.

- Replaces comma-only name inference with typed evidence: explicit proposal/correction/revocation, strong greeting vocative, accepted governed-name vocative, and exact Discord mention/reply-supported bare vocative.
- Keeps discourse/modifier text, quotes/code, known-human addresses, mixed-human targets, and ambiguous candidates from creating BNL name authority.
- Revalidates the original user root immediately before post-send persistence.
- Records `bnl_self_name_grammar_v2` and evidence kind in the existing Ledger JSON value.
- Keeps historical rows append-only while excluding weak or context-incomplete legacy decisions from current routing.
- Adds an owner-only, content-free, read-only validation diagnostic.

## Root cause

The prior classifier allowed a leading or trailing comma token to supply both a novel candidate and its own BNL target. A finite stopword list happened to block a few words but could not prove a performed naming act, so discourse such as “Personally, …” could enter the governed self-name lifecycle.

## Scope and boundaries

Changed files:

- `bnl01_bot.py`
- `bnl_memory_ledger.py`
- `docs/BNL01_CONVERSATION_ORCHESTRATION_CONTRACT.md`
- `tests/test_conversation_orchestration.py`
- `tests/test_memory_diagnostic_command.py`

No database schema change, migration, backfill, history deletion, model/provider change, queue/payment/site change, public test, or live gate change. Existing self-name, Ledger, addressing, delivery, privacy, and diagnostic owners are extended; no second nickname or memory system is introduced.

Requested/default/effective gates are not modified by this diff. Runtime state and the content-free Gate 0 snapshot remain required before deployment or acceptance.

## Exact-tree evidence

- Remote parent commit/tree: `1a12fab17fd5ddb53db88c92b50984937515c10a` / `666d184a9c48f55323d4df4c889b91987b2f4f7f`
- GitHub head commit/tree: `98838708b89b92a9866ab6bdbf1541de2bae78c2` / `dbdfc79f33470fc6b464c322df69d6547e2e6663`
- Locally tested commit/tree: `95a3349ab779d88bac2d845b980ed2193568ca5d` / `dbdfc79f33470fc6b464c322df69d6547e2e6663`
- Remote blobs and complete tree were verified against the local Git object IDs before branch creation.

Verification on the exact head tree:

- Focused: `python -m unittest tests.test_conversation_orchestration tests.test_memory_diagnostic_command` — 73 passed.
- Full: `make check PYTHON=python` — compile clean; 2,147 passed in 171.364s.
- Static diff/privacy scan — no credential, uploaded-file ID, email, or private identity matches.
- Diagnostic sample is content-free and reports `mutationCount: 0`.
- GitHub Actions CI run `31360970220` / run #188 — Python 3.9: success; Python 3.12: success.

## Required matrix mapping

- Discourse/modifier and stopword independence: `test_punctuation_only_discourse_fails_closed_by_structure`
- Explicit naming, Unicode, quotes/code, invalid/overlong input: `test_explicit_and_greeting_grammar_is_unicode_and_quote_safe`
- Accepted multiword/Unicode vocatives and punctuation positions: `test_accepted_unicode_multiword_name_routes_in_vocative_positions`
- Exact reply support versus unsupported bare/generic-direct candidates: `test_discord_reply_support_is_carried_into_typed_name_addressing`
- Known-human and mixed-human ambiguity: `test_plain_text_human_vocatives_preserve_typed_ambiguity` plus existing human-address tests
- Lifecycle, delivery boundary, restart, privacy/deletion/provenance, and visibility: existing governed self-name/orchestration regression suite
- Historical quarantine, redaction, and read-only behavior: `test_historical_weak_grammar_is_reported_and_quarantined_read_only`
- Zero punctuation-only durable write: `test_punctuation_only_source_cannot_persist_name_authority`

## Rollback

Before deployment, rollback is simply closing/reverting this PR. After an approved deployment, redeploy the prior known-good `1a12fab17fd5ddb53db88c92b50984937515c10a` / `666d184a9c48f55323d4df4c889b91987b2f4f7f`, or revert the merge. Append-only self-name evidence is preserved; no migration reversal is needed.

## Post-merge deployment

- Expected merge commit/tree: pending merge commit / tree must preserve `dbdfc79f33470fc6b464c322df69d6547e2e6663`
- Target environment/service: owner-approved BNL production host / `bnl01` systemd service
- Deployment authority: separate owner-approved operation; this PR does not self-authorize
- Requested/effective gates: unchanged; verify with Gate 0 before deployment; no shared-brain, Relationship, or Engagement expansion
- Database/schema/backfill: none; historical validation remains read-only
- Rollback: deploy prior known-good `1a12fab17fd5ddb53db88c92b50984937515c10a` / `666d184a9c48f55323d4df4c889b91987b2f4f7f`, or revert the merge; preserve append-only decisions

After merge and separate deployment approval:

```text
cd /home/ubuntu/bnl01
git pull origin main
sudo systemctl restart bnl01
sudo systemctl status bnl01 --no-pager -l
git rev-parse HEAD
```

## Focused post-deploy evidence

1. Verify the service is active and the deployed commit/tree exactly match the merge.
2. Verify requested/effective gates and database identity/schema are unchanged except the declared scope.
3. Run synthetic/private non-persistent classifications for the discourse/modifier matrix; confirm no target, obligation, or self-name lifecycle/projection write.
4. Run approved private valid accepted-name and explicit-proposal fixtures; confirm typed route/decision behavior.
5. Simulate generation/send failure; confirm no self-name lifecycle/projection write.
6. Inspect the content-free historical diagnostic; confirm weak-parser-only decisions are fail-closed and stronger explicit decisions remain valid.
7. Verify recent errors, restarts, latency, and privacy-redacted receipts.
8. Do not run a public Discord test or change broader gates without separate owner approval.

Merge alone is not acceptance; Gate 0 and the private post-deploy evidence remain mandatory.