### PR TITLE
Add shadow Situation Frame v1

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -174,8 +174,11 @@ from bnl_unified_response_assessment import (
     ConversationOrchestrationDecision,
     ConversationOrchestrationInput,
     ConversationEvidenceItem,
+    FrameSourceRevalidationResult,
+    SituationFrameV1,
     UnifiedResponseAssessment,
     assess_response_coherence,
+    build_situation_frame_v1,
     build_conversation_evidence_item,
     build_unified_response_assessment,
     coordinate_conversation_turn,
@@ -183,6 +186,8 @@ from bnl_unified_response_assessment import (
     persist_shadow_run as persist_unified_response_assessment_shadow_run,
     render_sealed_canary_brief,
     response_exposes_canary_control_markers,
+    revalidate_situation_frame,
+    render_situation_frame_receipt,
     render_conversation_orchestration_prompt,
     shadow_enabled as unified_response_assessment_shadow_enabled,
     with_prompt_lane_presence,
@@ -22984,6 +22989,15 @@ def build_live_conversation_orchestration_decision(
     moment_situation: MomentSituationReference | None,
     guild_id: int = 0,
     channel_id: int = 0,
+    route_mode: str = ROUTE_MODE_NORMAL_CHAT,
+    conversation_surface: str = "unknown",
+    current_text: str = "",
+    current_speaker_user_ids: tuple[int, ...] = (),
+    current_speaker_labels: tuple[str, ...] = (),
+    addressee_user_ids: tuple[int, ...] = (),
+    subject_user_ids: tuple[int, ...] = (),
+    subject_label_hints: tuple[str, ...] = (),
+    subject_entity_refs: tuple[str, ...] = (),
     influence_mode: str | None = None,
     packet_revision: str = "",
     governed_memory_state: str = "",
@@ -23030,11 +23044,10 @@ def build_live_conversation_orchestration_decision(
             channel_policy=channel_policy,
         )
     )
+    route_allowed = str(channel_policy or "unknown") in CONVERSATIONAL_POLICIES
     decision = coordinate_conversation_turn(
         ConversationOrchestrationInput(
-            route_allowed=(
-                str(channel_policy or "unknown") in CONVERSATIONAL_POLICIES
-            ),
+            route_allowed=route_allowed,
             engagement_decision=engagement_decision,
             engagement_reason=engagement_reason,
             response_obligation=response_obligation,
@@ -23091,6 +23104,80 @@ def build_live_conversation_orchestration_decision(
             ),
         )
     )
+    frame_subject_labels = tuple(
+        dict.fromkeys(
+            str(label or "").lstrip("@").strip()[:72]
+            for label in (
+                *subject_label_hints,
+                *(
+                    context_result.referent_candidate_labels
+                    if context_result is not None
+                    else ()
+                ),
+                *(
+                    recipient
+                    for meta in addressings
+                    for recipient in meta.explicit_tag_recipients
+                    if str(recipient or "").strip().casefold()
+                    not in {"@bnl-01", "bnl-01"}
+                ),
+            )
+            if str(label or "").strip()
+        )
+    )
+    situation_frame = build_situation_frame_v1(
+        route_allowed=route_allowed,
+        route_mode=str(route_mode or ROUTE_MODE_NORMAL_CHAT),
+        conversation_surface=str(conversation_surface or "unknown"),
+        channel_policy=str(channel_policy or "unknown"),
+        current_text=str(current_text or ""),
+        current_speaker_user_ids=current_speaker_user_ids,
+        current_speaker_labels=(
+            current_speaker_labels
+            or tuple(meta.speaker for meta in addressings if meta.speaker)
+        ),
+        addressee_kinds=tuple(
+            meta.address_kind for meta in addressed if meta.address_kind
+        ),
+        addressee_user_ids=addressee_user_ids,
+        source_message_ids=tuple(
+            meta.source_message_id
+            for meta in addressings
+            if int(meta.source_message_id or 0) > 0
+        ),
+        reply_message_ids=tuple(
+            meta.reply_message_id
+            for meta in addressings
+            if int(meta.reply_message_id or 0) > 0
+        ),
+        exact_source_row_ids=tuple(
+            meta.reply_conversation_row_id
+            for meta in addressings
+            if int(meta.reply_conversation_row_id or 0) > 0
+        ),
+        explicit_mention_count=sum(
+            len(meta.explicit_tag_recipients) for meta in addressings
+        ),
+        subject_user_ids=subject_user_ids,
+        subject_label_hints=frame_subject_labels,
+        subject_entity_refs=subject_entity_refs,
+        moment_id=(
+            moment_situation.moment_id
+            if moment_situation is not None
+            else ""
+        ),
+        moment_situation_state=moment_state,
+        moment_topic_coherent=bool(
+            moment_situation and moment_situation.topic_coherent
+        ),
+        moment_participant_overlap=bool(
+            moment_situation and moment_situation.participant_overlap
+        ),
+        referent_status=referent_status,
+        response_act=decision.response_act,
+        packet_revision=str(packet_revision or decision.packet_revision),
+    )
+    decision = replace(decision, situation_frame=situation_frame)
     logging.info(
         "conversation_orchestration_decision act=%s reason=%s "
         "response_required=%s address_kind=%s referent_status=%s "
@@ -23116,6 +23203,20 @@ def build_live_conversation_orchestration_decision(
         decision.packet_version,
         decision.packet_revision,
     )
+    logging.info(
+        "situation_frame_shadow version=%s revision=%s digest=%s "
+        "status=%s subject_count=%s ambiguity_count=%s event_relation=%s "
+        "phase=%s object_kind=%s behavior_changed=0 authority_applied=0",
+        situation_frame.schema_version,
+        situation_frame.frame_revision,
+        situation_frame.input_evidence_digest,
+        situation_frame.status,
+        len(situation_frame.subjects),
+        len(situation_frame.ambiguity_reasons),
+        situation_frame.event_relation,
+        situation_frame.phase,
+        situation_frame.object_kind,
+    )
     return decision
 
 
@@ -23135,6 +23236,7 @@ def _build_unified_intelligence_packet_shadow(
     source_context_snapshot: str,
     source_context_authorized: bool,
     current_direct: bool,
+    situation_frame: SituationFrameV1 | None = None,
 ) -> UnifiedIntelligencePacket | None:
     """Build and persist one packet receipt without exposing it to the prompt."""
 
@@ -23273,6 +23375,7 @@ def build_unified_response_assessment_shadow(
     current_direct: bool = True,
     broadcast_memory_present: bool = False,
     intelligence_packet_out: dict | None = None,
+    situation_frame: SituationFrameV1 | None = None,
 ) -> UnifiedResponseAssessment | None:
     """Build a shadow view from evidence already selected by existing owners."""
     if not unified_response_assessment_shadow_enabled():
@@ -23411,6 +23514,7 @@ def build_unified_response_assessment_shadow(
         source_context_snapshot=source_context_snapshot,
         source_context_authorized=bool(source_context_present),
         current_direct=current_direct,
+        situation_frame=situation_frame,
     )
     packet_usable = bool(
         intelligence_packet is not None
@@ -23423,6 +23527,26 @@ def build_unified_response_assessment_shadow(
     if intelligence_packet_out is not None:
         intelligence_packet_out["packet"] = intelligence_packet
         intelligence_packet_out["usable"] = packet_usable
+        intelligence_packet_out["situation_frame"] = situation_frame
+    frame_revalidation = (
+        revalidate_situation_frame(
+            situation_frame,
+            current_text=current_text,
+            route_mode=route_mode,
+            conversation_surface=conversation_surface,
+            channel_policy=channel_policy,
+            packet_source_snapshot_digest=str(
+                getattr(
+                    intelligence_packet,
+                    "source_snapshot_digest",
+                    "",
+                )
+                or ""
+            ),
+        )
+        if isinstance(situation_frame, SituationFrameV1)
+        else None
+    )
     canon_relevant = _canon_relevant_to_response(current_text)
     if intelligence_packet is None:
         assessment_moment_refs = (
@@ -23623,6 +23747,8 @@ def build_unified_response_assessment_shadow(
             if packet_profile is not None
             else ()
         ),
+        situation_frame=situation_frame,
+        frame_revalidation=frame_revalidation,
     )
 
 
@@ -23643,6 +23769,21 @@ def record_unified_response_assessment_shadow(
         if isinstance(basis, UnifiedMomentCanaryPromptSourceBasis):
             assessment = basis.assessment
             break
+    frame_revalidation = (guard_diagnostics or {}).get(
+        "_situation_frame_revalidation"
+    )
+    if (
+        assessment is not None
+        and isinstance(assessment.situation_frame, SituationFrameV1)
+        and isinstance(
+            frame_revalidation,
+            FrameSourceRevalidationResult,
+        )
+    ):
+        assessment = replace(
+            assessment,
+            frame_revalidation=frame_revalidation,
+        )
     if assessment is None:
         return ""
     try:
@@ -29558,6 +29699,18 @@ async def build_active_batch_orchestration(
         moment_situation=moment_situation,
         guild_id=guild_id,
         channel_id=channel_id,
+        route_mode=route_mode,
+        conversation_surface=conversation_surface_for_channel_policy(
+            channel_policy,
+            is_active_channel,
+        ),
+        current_text=combined_text,
+        current_speaker_user_ids=tuple(unique_user_ids),
+        current_speaker_labels=tuple(
+            _safe_prompt_display_label(name, "")
+            for name, _content, _uid in collapsed_items
+            if _safe_prompt_display_label(name, "")
+        ),
         packet_revision=conversation_turn_packet_revision(
             guild_id=guild_id,
             channel_id=channel_id,
@@ -30300,6 +30453,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     intelligence_packet_out=(
                         batch_intelligence_packet_out
                     ),
+                    situation_frame=(
+                        orchestration_state["decision"].situation_frame
+                    ),
                 )
             )
             batch_unified_moment_canary_basis = (
@@ -30883,6 +31039,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             ),
             prompt_source_bases=tuple(batch_prompt_source_bases),
             regeneration_allowed=not batch_synthesis_candidate_active,
+            situation_frame=(
+                orchestration_state["decision"].situation_frame
+            ),
         )
         if (
             batch_synthesis_candidate_active
@@ -30962,6 +31121,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                             batch_prompt_source_bases
                         ),
                         regeneration_allowed=True,
+                        situation_frame=(
+                            orchestration_state["decision"].situation_frame
+                        ),
                     )
                 )
         guard_triggered = bool(
@@ -31143,6 +31305,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                         batch_prompt_source_bases
                     ),
                     regeneration_allowed=True,
+                    situation_frame=(
+                        orchestration_state["decision"].situation_frame
+                    ),
                 )
             )
             if guard_diagnostics.get("suppressed"):
@@ -31224,6 +31389,42 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 guard_status="batch_prompt_source_presend_failed",
             )
             return
+        batch_frame = orchestration_state["decision"].situation_frame
+        if isinstance(batch_frame, SituationFrameV1):
+            batch_frame_revalidation = revalidate_situation_frame(
+                batch_frame,
+                current_text=combined_text,
+                route_mode=ROUTE_MODE_NORMAL_CHAT,
+                conversation_surface=(
+                    conversation_surface_for_channel_policy(
+                        channel_policy,
+                        channel_id == get_guild_config(guild_id),
+                    )
+                ),
+                channel_policy=channel_policy,
+            )
+            guard_diagnostics.update(
+                {
+                    "situation_frame_present": True,
+                    "situation_frame_status": batch_frame.status,
+                    "situation_frame_revalidation_status": (
+                        batch_frame_revalidation.status
+                    ),
+                    "situation_frame_revalidation_reason_count": len(
+                        batch_frame_revalidation.reason_codes
+                    ),
+                    "_situation_frame_revalidation": (
+                        batch_frame_revalidation
+                    ),
+                }
+            )
+            logging.info(
+                "situation_frame_presend_shadow revision=%s status=%s "
+                "reason_count=%s behavior_changed=0 route=batch",
+                batch_frame.frame_revision,
+                batch_frame_revalidation.status,
+                len(batch_frame_revalidation.reason_codes),
+            )
         _log_batch_event(
             logging.INFO,
             "response_send_commit_start",
@@ -31579,6 +31780,7 @@ def build_user_aware_prompt(
     moment_attribution_target_user_id: int = 0,
     verified_exact_quote_authority: CurrentRoomQuoteAuthority | None = None,
     conversation_context_result: ConversationContextResult | None = None,
+    conversation_orchestration: ConversationOrchestrationDecision | None = None,
 ) -> tuple:
     print("BNL DEBUG: build_user_aware_prompt start")
     display_name, preferred_name = get_user_profile(user_id, guild_id)
@@ -31853,6 +32055,14 @@ def build_user_aware_prompt(
         source_context_snapshot=source_context_block,
         broadcast_memory_present=bool(broadcast_context),
         intelligence_packet_out=intelligence_packet_out,
+        situation_frame=(
+            conversation_orchestration.situation_frame
+            if isinstance(
+                conversation_orchestration,
+                ConversationOrchestrationDecision,
+            )
+            else None
+        ),
     )
     unified_moment_canary_basis = (
         build_unified_moment_canary_prompt_source_basis(
@@ -31932,6 +32142,24 @@ def build_user_aware_prompt(
         )
         prompt_metadata["source_safe_recall_synthesis"] = bool(
             source_safe_recall
+        )
+        prompt_metadata["situation_frame_shadow"] = (
+            conversation_orchestration.situation_frame
+            if isinstance(
+                conversation_orchestration,
+                ConversationOrchestrationDecision,
+            )
+            else None
+        )
+        prompt_metadata["situation_frame_receipt"] = (
+            render_situation_frame_receipt(
+                conversation_orchestration.situation_frame
+            )
+            if isinstance(
+                conversation_orchestration,
+                ConversationOrchestrationDecision,
+            )
+            else render_situation_frame_receipt(None)
         )
 
     room_prompt_block = ""
@@ -32919,6 +33147,13 @@ async def _generate_direct_payload_session(session_key, reason: str):
         moment_situation=session_moment_situation,
         guild_id=session["guild_id"],
         channel_id=session.get("channel_id", 0),
+        route_mode=ROUTE_MODE_DIRECT_PAYLOAD,
+        conversation_surface=conversation_surface_for_channel_policy(
+            session.get("channel_policy", "unknown")
+        ),
+        current_text=direct_content,
+        current_speaker_user_ids=(session["requester_user_id"],),
+        current_speaker_labels=(session["requester_display_name"],),
         packet_revision=conversation_turn_packet_revision(
             guild_id=session["guild_id"],
             channel_id=session.get("channel_id", 0),
@@ -32981,6 +33216,7 @@ async def _generate_direct_payload_session(session_key, reason: str):
         moment_attribution_target_user_id=moment_attribution_target_user_id,
         verified_exact_quote_authority=verified_exact_quote_authority,
         conversation_context_result=session_context_result_out.get("result"),
+        conversation_orchestration=session_orchestration,
     )
     source_context_available = bool(prompt_metadata.get("source_context_available"))
     prompt = _build_direct_payload_prompt(prompt, direct_payload_items, direct_content)
@@ -33064,6 +33300,9 @@ async def _generate_direct_payload_session(session_key, reason: str):
         prompt_source_bases=tuple(
             prompt_metadata.get("prompt_source_bases") or ()
         ),
+        situation_frame=session_orchestration.situation_frame,
+        situation_frame_current_text=direct_content,
+        situation_frame_route_mode=ROUTE_MODE_DIRECT_PAYLOAD,
     )
     if guard_diagnostics.get("suppressed"):
         logging.info("continuation_mark_skipped reason=guard_fallback_or_generic_non_answer route=%s channel_policy=%s", "direct_payload_session", session.get("channel_policy", "unknown"))
@@ -33126,6 +33365,40 @@ async def _generate_direct_payload_session(session_key, reason: str):
             "prompt_source_presend_failed",
         )
         return
+    session_frame = session_orchestration.situation_frame
+    if isinstance(session_frame, SituationFrameV1):
+        session_frame_revalidation = revalidate_situation_frame(
+            session_frame,
+            current_text=direct_content,
+            route_mode=ROUTE_MODE_DIRECT_PAYLOAD,
+            conversation_surface=conversation_surface_for_channel_policy(
+                session.get("channel_policy", "unknown")
+            ),
+            channel_policy=session.get("channel_policy", "unknown"),
+        )
+        guard_diagnostics.update(
+            {
+                "situation_frame_present": True,
+                "situation_frame_status": session_frame.status,
+                "situation_frame_revalidation_status": (
+                    session_frame_revalidation.status
+                ),
+                "situation_frame_revalidation_reason_count": len(
+                    session_frame_revalidation.reason_codes
+                ),
+                "_situation_frame_revalidation": (
+                    session_frame_revalidation
+                ),
+            }
+        )
+        logging.info(
+            "situation_frame_presend_shadow revision=%s status=%s "
+            "reason_count=%s behavior_changed=0 "
+            "route=direct_payload_session",
+            session_frame.frame_revision,
+            session_frame_revalidation.status,
+            len(session_frame_revalidation.reason_codes),
+        )
     sent_message_ids = []
     try:
         if len(response) <= 2000:
@@ -33439,6 +33712,9 @@ async def apply_guarded_response_regeneration(
     exact_quote_authority: CurrentRoomQuoteAuthority | None = None,
     third_party_attribution_requested: bool = False,
     prompt_source_bases: tuple[PromptSourceBasis, ...] = (),
+    situation_frame: SituationFrameV1 | None = None,
+    situation_frame_current_text: str = "",
+    situation_frame_route_mode: str = "",
 ) -> tuple[str, dict]:
     diagnostics = {
         "scripted_mode_leak_guard_triggered": False,
@@ -33485,6 +33761,10 @@ async def apply_guarded_response_regeneration(
         "source_safe_recall_synthesis_applied": False,
         "source_safe_recall_output_leak_guard_triggered": False,
         "source_safe_recall_output_leak_regenerated": False,
+        "situation_frame_present": False,
+        "situation_frame_status": "not_present",
+        "situation_frame_revalidation_status": "not_run",
+        "situation_frame_revalidation_reason_count": 0,
         "suppressed": False,
         "suppression_reason": "",
         "guard_fallback_or_generic_non_answer": False,
@@ -33499,6 +33779,36 @@ async def apply_guarded_response_regeneration(
         third_party_attribution_requested
     )
     prompt_source_bases = tuple(prompt_source_bases or ())
+    if isinstance(situation_frame, SituationFrameV1):
+        frame_revalidation = revalidate_situation_frame(
+            situation_frame,
+            current_text=(
+                situation_frame_current_text or current_user_text
+            ),
+            route_mode=(situation_frame_route_mode or route_mode),
+            channel_policy=channel_policy,
+        )
+        diagnostics.update(
+            {
+                "situation_frame_present": True,
+                "situation_frame_status": situation_frame.status,
+                "situation_frame_revalidation_status": (
+                    frame_revalidation.status
+                ),
+                "situation_frame_revalidation_reason_count": len(
+                    frame_revalidation.reason_codes
+                ),
+                "_situation_frame_revalidation": frame_revalidation,
+            }
+        )
+        logging.info(
+            "situation_frame_guard_shadow revision=%s status=%s "
+            "revalidation=%s reason_count=%s behavior_changed=0",
+            situation_frame.frame_revision,
+            situation_frame.status,
+            frame_revalidation.status,
+            len(frame_revalidation.reason_codes),
+        )
     source_safe_recall = bool(
         source_safe_recall_synthesis_enabled(
             guild_id=guild_id,
@@ -34967,6 +35277,8 @@ async def send_planned_conversation_response(
     third_party_attribution_requested: bool = False,
     prompt_source_bases: tuple[PromptSourceBasis, ...] = (),
     unified_response_assessment_shadow: UnifiedResponseAssessment | None = None,
+    situation_frame: SituationFrameV1 | None = None,
+    situation_frame_current_text: str = "",
     shared_brain_synthesis_canary_basis: (
         SharedBrainSynthesisBasis | None
     ) = None,
@@ -35102,6 +35414,8 @@ async def send_planned_conversation_response(
             ),
             prompt_source_bases=selected_bases,
             regeneration_allowed=regeneration_allowed,
+            situation_frame=situation_frame,
+            situation_frame_current_text=situation_frame_current_text,
         )
 
     archive_guard_triggered = bool(
@@ -35372,6 +35686,38 @@ async def send_planned_conversation_response(
             "prompt_source_presend_failed",
         )
         return model_decision
+    if isinstance(situation_frame, SituationFrameV1):
+        final_frame_revalidation = revalidate_situation_frame(
+            situation_frame,
+            current_text=(
+                situation_frame_current_text
+                or getattr(message, "content", "")
+            ),
+            route_mode=plan.route_mode,
+            channel_policy=plan.channel_policy,
+        )
+        guard_diagnostics.update(
+            {
+                "situation_frame_present": True,
+                "situation_frame_status": situation_frame.status,
+                "situation_frame_revalidation_status": (
+                    final_frame_revalidation.status
+                ),
+                "situation_frame_revalidation_reason_count": len(
+                    final_frame_revalidation.reason_codes
+                ),
+                "_situation_frame_revalidation": (
+                    final_frame_revalidation
+                ),
+            }
+        )
+        logging.info(
+            "situation_frame_presend_shadow revision=%s status=%s "
+            "reason_count=%s behavior_changed=0",
+            situation_frame.frame_revision,
+            final_frame_revalidation.status,
+            len(final_frame_revalidation.reason_codes),
+        )
     sent_message_ids = []
     try:
         if len(response) <= 2000:
@@ -36448,6 +36794,13 @@ async def on_message(message: discord.Message):
                     moment_situation=direct_moment_situation,
                     guild_id=message.guild.id,
                     channel_id=message.channel.id,
+                    route_mode=route_mode,
+                    conversation_surface=conversation_surface,
+                    current_text=direct_content,
+                    current_speaker_user_ids=(message.author.id,),
+                    current_speaker_labels=(
+                        message.author.display_name,
+                    ),
                     packet_revision=conversation_turn_packet_revision(
                         guild_id=message.guild.id,
                         channel_id=message.channel.id,
@@ -36515,6 +36868,7 @@ async def on_message(message: discord.Message):
                 conversation_context_result=direct_context_result_out.get(
                     "result"
                 ),
+                conversation_orchestration=direct_orchestration,
             )
             source_context_available = bool(prompt_metadata.get("source_context_available"))
             prompt = _build_direct_payload_prompt(prompt, direct_payload_items, direct_content)
@@ -36625,6 +36979,8 @@ async def on_message(message: discord.Message):
                 unified_response_assessment_shadow=prompt_metadata.get(
                     "unified_response_assessment_shadow"
                 ),
+                situation_frame=direct_orchestration.situation_frame,
+                situation_frame_current_text=direct_content,
                 shared_brain_synthesis_canary_basis=prompt_metadata.get(
                     "shared_brain_synthesis_canary_basis"
                 ),
@@ -36880,6 +37236,11 @@ async def on_message(message: discord.Message):
             moment_situation=direct_moment_situation,
             guild_id=message.guild.id,
             channel_id=message.channel.id,
+            route_mode=route_mode,
+            conversation_surface=conversation_surface,
+            current_text=direct_content,
+            current_speaker_user_ids=(message.author.id,),
+            current_speaker_labels=(message.author.display_name,),
             packet_revision=conversation_turn_packet_revision(
                 guild_id=message.guild.id,
                 channel_id=message.channel.id,
@@ -36944,6 +37305,7 @@ async def on_message(message: discord.Message):
             moment_attribution_target_user_id=moment_attribution_target_user_id,
             verified_exact_quote_authority=verified_exact_quote_authority,
             conversation_context_result=direct_context_result_out.get("result"),
+            conversation_orchestration=direct_orchestration,
         )
         source_context_available = bool(prompt_metadata.get("source_context_available"))
         prompt = _build_direct_payload_prompt(prompt, direct_payload_items, direct_content)
@@ -37067,6 +37429,8 @@ async def on_message(message: discord.Message):
             unified_response_assessment_shadow=prompt_metadata.get(
                 "unified_response_assessment_shadow"
             ),
+            situation_frame=direct_orchestration.situation_frame,
+            situation_frame_current_text=direct_content,
             shared_brain_synthesis_canary_basis=prompt_metadata.get(
                 "shared_brain_synthesis_canary_basis"
             ),
@@ -37266,6 +37630,11 @@ async def on_message(message: discord.Message):
             moment_situation=direct_moment_situation,
             guild_id=message.guild.id,
             channel_id=message.channel.id,
+            route_mode=route_mode,
+            conversation_surface=conversation_surface,
+            current_text=direct_content,
+            current_speaker_user_ids=(message.author.id,),
+            current_speaker_labels=(message.author.display_name,),
             packet_revision=conversation_turn_packet_revision(
                 guild_id=message.guild.id,
                 channel_id=message.channel.id,
@@ -37330,6 +37699,7 @@ async def on_message(message: discord.Message):
             moment_attribution_target_user_id=moment_attribution_target_user_id,
             verified_exact_quote_authority=verified_exact_quote_authority,
             conversation_context_result=direct_context_result_out.get("result"),
+            conversation_orchestration=direct_orchestration,
         )
         source_context_available = bool(prompt_metadata.get("source_context_available"))
         prompt = _build_direct_payload_prompt(prompt, direct_payload_items, direct_content)
@@ -37453,6 +37823,8 @@ async def on_message(message: discord.Message):
             unified_response_assessment_shadow=prompt_metadata.get(
                 "unified_response_assessment_shadow"
             ),
+            situation_frame=direct_orchestration.situation_frame,
+            situation_frame_current_text=direct_content,
             shared_brain_synthesis_canary_basis=prompt_metadata.get(
                 "shared_brain_synthesis_canary_basis"
             ),

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -12,6 +12,7 @@ authority.
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import re
 import sqlite3
@@ -25,7 +26,9 @@ from bnl_conversation_context_v2 import assess_payload_grounding
 
 
 ASSESSMENT_VERSION = "unified_response_assessment_v7"
-CONVERSATION_TURN_PACKET_VERSION = "conversation_turn_evidence_v2"
+CONVERSATION_TURN_PACKET_VERSION = "conversation_turn_evidence_v3"
+SITUATION_FRAME_VERSION = "situation_frame_v1"
+FRAME_SOURCE_REVALIDATION_VERSION = "frame_source_revalidation_v1"
 SHADOW_ENV = "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED"
 TABLE_NAME = "unified_response_assessment_shadow_runs"
 
@@ -261,6 +264,515 @@ _TERM_FAMILIES = {
     "serious": frozenset({"serious", "formal", "professional", "solemn"}),
 }
 
+_SITUATION_PHASE_PATTERNS = (
+    ("correction", re.compile(r"\b(?:correction|i\s+meant|not\s+that|that(?:'|’)s\s+wrong|instead)\b", re.I)),
+    ("retest", re.compile(r"\b(?:retest|test\s+again|try\s+again|retry|rerun|re-run|second\s+pass)\b", re.I)),
+    ("failure", re.compile(r"\b(?:failed?|failure|broken|crash(?:ed)?|error|didn(?:'|’)t\s+work|not\s+working)\b", re.I)),
+    ("diagnosis", re.compile(r"\b(?:diagnos(?:e|is)|root\s+cause|why\s+did|what\s+happened|figure\s+out|investigate)\b", re.I)),
+    ("completion", re.compile(r"\b(?:complete|completed|finished|done|resolved|fixed|merged|landed)\b", re.I)),
+    ("execution", re.compile(r"\b(?:implement|build|fix|change|update|create|proceed|continue|start|run|deploy)\b", re.I)),
+    ("planning", re.compile(r"\b(?:plan|roadmap|propose|design|scope|next\s+steps?|how\s+should)\b", re.I)),
+)
+_SITUATION_OBJECT_PATTERNS = (
+    ("journal", re.compile(r"\bjournal(?:s|\s+entry|\s+entries)?\b", re.I)),
+    ("relay", re.compile(r"\brelay(?:s)?\b", re.I)),
+    ("moment", re.compile(r"\bmoment(?:s)?\b|\bepisode(?:s)?\b", re.I)),
+    ("memory", re.compile(r"\bmemory\b|\bshared\s+brain\b|\brecall\b", re.I)),
+    ("queue", re.compile(r"\bqueue\b|\bsubmission(?:s)?\b|\bwheel\s+spin(?:s)?\b", re.I)),
+    ("broadcast", re.compile(r"\bbarcode\s+radio\b|\bshow\b|\bbroadcast\b", re.I)),
+    ("website", re.compile(r"\bwebsite\b|\bsite\b|\bterminal\b", re.I)),
+    ("source_file", re.compile(r"\bsource\s+files?\b|\bdossier(?:s)?\b", re.I)),
+    ("canon", re.compile(r"\bcanon\b|\blore\b|\bmytholog(?:y|ical)\b", re.I)),
+    ("person", re.compile(r"\b(?:who\s+is|tell\s+me\s+about|what\s+do\s+you\s+know\s+about|remember\s+about)\b", re.I)),
+)
+_SITUATION_ROLE_DOMAIN_PATTERNS = (
+    ("artist", "music", re.compile(r"\b(?:artist|song|track|album|release|music|producer|rapper|dj)\b", re.I)),
+    ("community_member", "real_community", re.compile(r"\b(?:community|member|discord|friend|mod(?:erator)?)\b", re.I)),
+    ("broadcast_participant", "broadcast_history", re.compile(r"\b(?:barcode\s+radio|broadcast|show|host|queue|submission)\b", re.I)),
+    ("operator", "operational", re.compile(r"\b(?:operator|admin|owner|run\s+the|manage|moderate)\b", re.I)),
+    ("in_world_entity", "lore", re.compile(r"\b(?:lore|canon|character|story|world|in-world)\b", re.I)),
+    ("system_subject", "technical", re.compile(r"\b(?:bot|code|database|api|memory|website|server|deploy|pr)\b", re.I)),
+)
+_THIRD_PARTY_SUBJECT_CUE_RE = re.compile(
+    r"\b(?:who\s+is|tell\s+me\s+about|what\s+do\s+you\s+(?:know|remember)\s+about|"
+    r"what\s+happened\s+with|ask(?:ing)?\s+about)\b",
+    re.I,
+)
+_CURRENT_TIME_RE = re.compile(r"\b(?:now|currently|today|tonight|this\s+(?:week|show|turn|time)|latest|current)\b", re.I)
+_HISTORICAL_TIME_RE = re.compile(r"\b(?:before|previously|earlier|last\s+(?:time|week|show)|used\s+to|histor(?:y|ical))\b", re.I)
+
+
+@dataclass(frozen=True)
+class SituationSubjectReference:
+    """One response-scoped subject candidate supplied by existing owners.
+
+    ``label_hint`` is reversible context, never identity authority.  Stable
+    identity/account binding is deliberately deferred to the existing canon
+    binding owner and packet adapter.
+    """
+
+    user_id: int = 0
+    entity_ref: str = ""
+    label_hint: str = ""
+    binding_method: str = "unresolved"
+    confidence: str = "unknown"
+    role_hints: Tuple[str, ...] = ()
+    domain_hints: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SituationFrameV1:
+    """Immutable, response-scoped applicability decision.
+
+    The frame contains typed references and hashes, not a second fact store.
+    It cannot grant visibility, create canon, merge identities, or select
+    factual evidence on its own.
+    """
+
+    schema_version: str
+    frame_revision: str
+    input_evidence_digest: str
+    current_text_digest: str
+    status: str
+    route_allowed: bool
+    route_mode: str
+    conversation_surface: str
+    channel_policy: str
+    visibility_allowance: str
+    current_speaker_user_ids: Tuple[int, ...]
+    current_speaker_labels: Tuple[str, ...]
+    addressee_kinds: Tuple[str, ...]
+    addressee_user_ids: Tuple[int, ...]
+    source_message_ids: Tuple[int, ...]
+    reply_message_ids: Tuple[int, ...]
+    exact_source_row_ids: Tuple[int, ...]
+    explicit_mention_count: int
+    subjects: Tuple[SituationSubjectReference, ...]
+    event_ref: str
+    event_relation: str
+    task_kind: str
+    object_kind: str
+    phase: str
+    role_hints: Tuple[str, ...]
+    domain_hints: Tuple[str, ...]
+    temporal_scope: str
+    currentness: str
+    objective_kind: str
+    required_response_act: str
+    decision_present: bool
+    correction_present: bool
+    unresolved_question_count: int
+    open_loop_present: bool
+    competing_frames: Tuple[str, ...]
+    ambiguity_reasons: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FrameSourceRevalidationResult:
+    """Separate immutable result; revalidation never mutates the frame."""
+
+    schema_version: str
+    frame_revision: str
+    frame_input_evidence_digest: str
+    packet_source_snapshot_digest: str
+    status: str
+    reason_codes: Tuple[str, ...]
+
+
+def _situation_digest(value: Any) -> str:
+    return hashlib.sha256(str(value or "").encode("utf-8")).hexdigest()
+
+
+def _situation_visibility(channel_policy: Any, route_allowed: bool) -> str:
+    if not route_allowed:
+        return "blocked"
+    policy = str(channel_policy or "unknown").strip().lower()
+    if policy in {"public_home", "public_selective", "public_conversation"}:
+        return "public_safe"
+    if policy == "sealed_test":
+        return "sealed_test"
+    if policy in {"internal_controlled", "admin_only", "private"}:
+        return "internal"
+    return "unknown"
+
+
+def _situation_phase(text: str) -> str:
+    for phase, pattern in _SITUATION_PHASE_PATTERNS:
+        if pattern.search(text or ""):
+            return phase
+    return "request" if _OBJECTIVE_RE.search(text or "") else "other"
+
+
+def _situation_object(text: str) -> str:
+    matches = tuple(
+        object_kind
+        for object_kind, pattern in _SITUATION_OBJECT_PATTERNS
+        if pattern.search(text or "")
+    )
+    return matches[0] if len(matches) == 1 else "multiple" if matches else "unknown"
+
+
+def _situation_roles_domains(text: str) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
+    matches = tuple(
+        (role, domain)
+        for role, domain, pattern in _SITUATION_ROLE_DOMAIN_PATTERNS
+        if pattern.search(text or "")
+    )
+    return (
+        tuple(dict.fromkeys(role for role, _domain in matches)),
+        tuple(dict.fromkeys(domain for _role, domain in matches)),
+    )
+
+
+def _situation_temporal_scope(text: str) -> Tuple[str, str]:
+    current = bool(_CURRENT_TIME_RE.search(text or ""))
+    historical = bool(_HISTORICAL_TIME_RE.search(text or ""))
+    if current and historical:
+        return "comparison", "mixed"
+    if current:
+        return "current", "current"
+    if historical:
+        return "historical", "historical"
+    return "unspecified", "unknown"
+
+
+def _situation_event_relation(
+    *,
+    moment_situation_state: str,
+    moment_topic_coherent: bool,
+    moment_participant_overlap: bool,
+    phase: str,
+) -> str:
+    state = str(moment_situation_state or "none").strip().lower()
+    if state in {"", "none"}:
+        return "uncertain"
+    if "reopen" in state or "resume" in state:
+        return "resume"
+    if moment_topic_coherent and moment_participant_overlap:
+        return "same_event_new_phase" if phase in {"correction", "retest", "diagnosis", "completion"} else "same_event"
+    if moment_topic_coherent:
+        return "comparison_or_participant_change"
+    if moment_participant_overlap:
+        return "new_event_same_participant"
+    return "new_event_or_uncertain"
+
+
+def _situation_task_kind(*, phase: str, object_kind: str, objective_kind: str) -> str:
+    if objective_kind == "compare_options":
+        return "compare"
+    if object_kind in {"journal", "relay"}:
+        return "retrieve_publication" if phase in {"request", "diagnosis"} else phase
+    if phase in {"planning", "execution", "failure", "diagnosis", "correction", "retest", "completion"}:
+        return phase
+    return "answer" if objective_kind != "unspecified" else "observe"
+
+
+def build_situation_frame_v1(
+    *,
+    route_allowed: bool,
+    route_mode: str,
+    conversation_surface: str,
+    channel_policy: str,
+    current_text: str,
+    current_speaker_user_ids: Sequence[int] = (),
+    current_speaker_labels: Sequence[str] = (),
+    addressee_kinds: Sequence[str] = (),
+    addressee_user_ids: Sequence[int] = (),
+    source_message_ids: Sequence[int] = (),
+    reply_message_ids: Sequence[int] = (),
+    exact_source_row_ids: Sequence[int] = (),
+    explicit_mention_count: int = 0,
+    subject_user_ids: Sequence[int] = (),
+    subject_label_hints: Sequence[str] = (),
+    subject_entity_refs: Sequence[str] = (),
+    moment_id: str = "",
+    moment_situation_state: str = "none",
+    moment_topic_coherent: bool = False,
+    moment_participant_overlap: bool = False,
+    referent_status: str = "not_requested",
+    response_act: str = "observe",
+    packet_revision: str = "",
+) -> SituationFrameV1:
+    """Build one deterministic shadow frame from existing typed owner output."""
+
+    text = str(current_text or "")[:8000]
+    speakers = _unique_positive_ints(current_speaker_user_ids)
+    speaker_labels = _unique_strings(current_speaker_labels)[:8]
+    target_ids = _unique_positive_ints(addressee_user_ids)
+    subject_ids = _unique_positive_ints(subject_user_ids)
+    label_hints = _unique_strings(subject_label_hints)[:8]
+    entity_refs = _unique_strings(subject_entity_refs)[:8]
+    roles, domains = _situation_roles_domains(text)
+    phase = _situation_phase(text)
+    object_kind = _situation_object(text)
+    temporal_scope, currentness = _situation_temporal_scope(text)
+    evidence = build_conversation_evidence_item(text=text, current_turn=True)
+    options = _extract_option_anchors(text)
+    objective = _current_objective(text)
+    objective_kind = _objective_kind(
+        objective=objective,
+        current_options=options,
+        immediate_recap=False,
+        exact_quote_requested=False,
+        evidence_items=(evidence,),
+    )
+    third_party_cue = bool(_THIRD_PARTY_SUBJECT_CUE_RE.search(text))
+
+    subjects = []
+    if subject_ids:
+        for index, user_id in enumerate(subject_ids):
+            subjects.append(
+                SituationSubjectReference(
+                    user_id=user_id,
+                    entity_ref=(entity_refs[index] if index < len(entity_refs) else ""),
+                    label_hint=(label_hints[index] if index < len(label_hints) else ""),
+                    binding_method="existing_typed_target",
+                    confidence="high" if len(subject_ids) == 1 else "ambiguous",
+                    role_hints=roles,
+                    domain_hints=domains,
+                )
+            )
+    elif label_hints or entity_refs:
+        count = max(len(label_hints), len(entity_refs))
+        for index in range(count):
+            subjects.append(
+                SituationSubjectReference(
+                    entity_ref=(entity_refs[index] if index < len(entity_refs) else ""),
+                    label_hint=(label_hints[index] if index < len(label_hints) else ""),
+                    binding_method="reversible_label_hint",
+                    confidence="low",
+                    role_hints=roles,
+                    domain_hints=domains,
+                )
+            )
+    elif len(speakers) == 1 and not third_party_cue:
+        subjects.append(
+            SituationSubjectReference(
+                user_id=speakers[0],
+                label_hint=(speaker_labels[0] if speaker_labels else ""),
+                binding_method="current_speaker_context",
+                confidence="contextual",
+                role_hints=roles,
+                domain_hints=domains,
+            )
+        )
+
+    ambiguity = []
+    competing = []
+    normalized_referent = str(referent_status or "not_requested").strip().lower()
+    if normalized_referent in {"ambiguous", "unresolved"}:
+        ambiguity.append("referent_%s" % normalized_referent)
+        competing.append("nearby_referent_candidates")
+    if len(subject_ids) > 1 or len(subjects) > 1:
+        ambiguity.append("multiple_subject_candidates")
+        competing.append("subject_candidates")
+    if third_party_cue and not subjects:
+        ambiguity.append("third_party_subject_unresolved")
+        competing.append("speaker_fallback_rejected")
+    if len(domains) > 1 and subjects:
+        competing.append("subject_role_domain_candidates")
+    if not route_allowed:
+        competing.append("route_policy_block")
+
+    event_relation = _situation_event_relation(
+        moment_situation_state=moment_situation_state,
+        moment_topic_coherent=bool(moment_topic_coherent),
+        moment_participant_overlap=bool(moment_participant_overlap),
+        phase=phase,
+    )
+    task_kind = _situation_task_kind(
+        phase=phase,
+        object_kind=object_kind,
+        objective_kind=objective_kind,
+    )
+    digest_payload = {
+        "schema": SITUATION_FRAME_VERSION,
+        "packet_revision": str(packet_revision or ""),
+        "text_digest": _situation_digest(text),
+        "route_allowed": bool(route_allowed),
+        "route_mode": str(route_mode or "unknown"),
+        "surface": str(conversation_surface or "unknown"),
+        "policy": str(channel_policy or "unknown"),
+        "speakers": speakers,
+        "speaker_labels": speaker_labels,
+        "addressee_kinds": _unique_strings(addressee_kinds),
+        "addressees": target_ids,
+        "source_messages": _unique_positive_ints(source_message_ids),
+        "reply_messages": _unique_positive_ints(reply_message_ids),
+        "source_rows": _unique_positive_ints(exact_source_row_ids),
+        "mention_count": max(0, int(explicit_mention_count or 0)),
+        "subjects": tuple(
+            (
+                subject.user_id,
+                subject.entity_ref,
+                subject.label_hint,
+                subject.binding_method,
+                subject.confidence,
+                subject.role_hints,
+                subject.domain_hints,
+            )
+            for subject in subjects
+        ),
+        "event_ref": str(moment_id or ""),
+        "event_relation": event_relation,
+        "task": task_kind,
+        "object": object_kind,
+        "phase": phase,
+        "temporal": temporal_scope,
+        "objective": objective_kind,
+        "response_act": str(response_act or "observe"),
+        "decision": "decision" in evidence.semantic_roles,
+        "correction": "correction" in evidence.semantic_roles,
+        "open_loop": "open_loop" in evidence.semantic_roles,
+        "ambiguity": tuple(ambiguity),
+        "competing": tuple(competing),
+    }
+    input_digest = _situation_digest(
+        json.dumps(digest_payload, sort_keys=True, separators=(",", ":"))
+    )
+    status = "blocked" if not route_allowed else "ambiguous" if ambiguity else "resolved"
+    return SituationFrameV1(
+        schema_version=SITUATION_FRAME_VERSION,
+        frame_revision="sf_" + input_digest[:24],
+        input_evidence_digest=input_digest,
+        current_text_digest=_situation_digest(text),
+        status=status,
+        route_allowed=bool(route_allowed),
+        route_mode=str(route_mode or "unknown")[:80],
+        conversation_surface=str(conversation_surface or "unknown")[:80],
+        channel_policy=str(channel_policy or "unknown")[:80],
+        visibility_allowance=_situation_visibility(channel_policy, bool(route_allowed)),
+        current_speaker_user_ids=speakers,
+        current_speaker_labels=speaker_labels,
+        addressee_kinds=_unique_strings(addressee_kinds)[:8],
+        addressee_user_ids=target_ids,
+        source_message_ids=_unique_positive_ints(source_message_ids),
+        reply_message_ids=_unique_positive_ints(reply_message_ids),
+        exact_source_row_ids=_unique_positive_ints(exact_source_row_ids),
+        explicit_mention_count=max(0, int(explicit_mention_count or 0)),
+        subjects=tuple(subjects),
+        event_ref=str(moment_id or "")[:120],
+        event_relation=event_relation,
+        task_kind=task_kind,
+        object_kind=object_kind,
+        phase=phase,
+        role_hints=roles,
+        domain_hints=domains,
+        temporal_scope=temporal_scope,
+        currentness=currentness,
+        objective_kind=objective_kind,
+        required_response_act=str(response_act or "observe")[:80],
+        decision_present="decision" in evidence.semantic_roles,
+        correction_present="correction" in evidence.semantic_roles,
+        unresolved_question_count=(text.count("?") if text else 0),
+        open_loop_present="open_loop" in evidence.semantic_roles,
+        competing_frames=tuple(competing),
+        ambiguity_reasons=tuple(ambiguity),
+    )
+
+
+def revalidate_situation_frame(
+    frame: SituationFrameV1 | None,
+    *,
+    current_text: str = "",
+    route_mode: str = "",
+    conversation_surface: str = "",
+    channel_policy: str = "",
+    packet_source_snapshot_digest: str = "",
+    source_status: str = "valid",
+) -> FrameSourceRevalidationResult:
+    """Check current inputs without mutating the frozen frame or packet."""
+
+    if not isinstance(frame, SituationFrameV1):
+        return FrameSourceRevalidationResult(
+            schema_version=FRAME_SOURCE_REVALIDATION_VERSION,
+            frame_revision="",
+            frame_input_evidence_digest="",
+            packet_source_snapshot_digest=str(packet_source_snapshot_digest or "")[:128],
+            status="invalid",
+            reason_codes=("frame_missing",),
+        )
+    reasons = []
+    if current_text and _situation_digest(str(current_text or "")[:8000]) != frame.current_text_digest:
+        reasons.append("current_text_changed")
+    if route_mode and str(route_mode) != frame.route_mode:
+        reasons.append("route_mode_changed")
+    if conversation_surface and str(conversation_surface) != frame.conversation_surface:
+        reasons.append("conversation_surface_changed")
+    if channel_policy and str(channel_policy) != frame.channel_policy:
+        reasons.append("channel_policy_changed")
+    normalized_source = str(source_status or "valid").strip().lower()
+    if normalized_source not in {"valid", "unchanged"}:
+        reasons.append("source_%s" % normalized_source)
+    if not frame.route_allowed:
+        status = "blocked"
+        reasons.append("route_policy_blocked")
+    elif any(reason.endswith("_changed") for reason in reasons):
+        status = "stale"
+    elif any(reason.startswith("source_") for reason in reasons):
+        status = "invalid"
+    elif frame.status == "ambiguous":
+        status = "ambiguous"
+        reasons.extend(frame.ambiguity_reasons)
+    elif frame.status == "resolved":
+        status = "valid"
+    else:
+        status = "invalid"
+        reasons.append("frame_status_invalid")
+    return FrameSourceRevalidationResult(
+        schema_version=FRAME_SOURCE_REVALIDATION_VERSION,
+        frame_revision=frame.frame_revision,
+        frame_input_evidence_digest=frame.input_evidence_digest,
+        packet_source_snapshot_digest=str(packet_source_snapshot_digest or "")[:128],
+        status=status,
+        reason_codes=_unique_strings(reasons),
+    )
+
+
+def render_situation_frame_receipt(
+    frame: SituationFrameV1 | None,
+    revalidation: FrameSourceRevalidationResult | None = None,
+) -> Dict[str, Any]:
+    """Return content-free diagnostics: no raw text, labels, or account IDs."""
+
+    if not isinstance(frame, SituationFrameV1):
+        return {
+            "schemaVersion": SITUATION_FRAME_VERSION,
+            "present": False,
+            "mutationCount": 0,
+        }
+    return {
+        "schemaVersion": frame.schema_version,
+        "present": True,
+        "frameRevision": frame.frame_revision,
+        "inputEvidenceDigest": frame.input_evidence_digest,
+        "status": frame.status,
+        "speakerCount": len(frame.current_speaker_user_ids),
+        "addresseeCount": len(frame.addressee_user_ids),
+        "subjectCount": len(frame.subjects),
+        "sourceAnchorCount": (
+            len(frame.source_message_ids)
+            + len(frame.reply_message_ids)
+            + len(frame.exact_source_row_ids)
+        ),
+        "ambiguityCount": len(frame.ambiguity_reasons),
+        "competingFrameCount": len(frame.competing_frames),
+        "phase": frame.phase,
+        "objectKind": frame.object_kind,
+        "eventRelation": frame.event_relation,
+        "revalidationStatus": (
+            revalidation.status
+            if isinstance(revalidation, FrameSourceRevalidationResult)
+            else "not_run"
+        ),
+        "revalidationReasonCount": (
+            len(revalidation.reason_codes)
+            if isinstance(revalidation, FrameSourceRevalidationResult)
+            else 0
+        ),
+        "mutationCount": 0,
+    }
+
 
 @dataclass(frozen=True)
 class ConversationTurnEvidencePacket:
@@ -327,6 +839,7 @@ class ConversationOrchestrationDecision:
     relationship_state: str
     canon_state: str
     source_control_state: str
+    situation_frame: SituationFrameV1 | None = None
 
     @property
     def should_generate(self) -> bool:
@@ -1078,6 +1591,8 @@ class UnifiedResponseAssessment:
     profile_independent_root_count: int = 0
     profile_independent_occurrence_count: int = 0
     profile_sufficiency_reasons: Tuple[str, ...] = ()
+    situation_frame: SituationFrameV1 | None = None
+    frame_revalidation: FrameSourceRevalidationResult | None = None
 
 
 def build_unified_response_assessment(
@@ -1134,6 +1649,8 @@ def build_unified_response_assessment(
     profile_independent_root_count: int = 0,
     profile_independent_occurrence_count: int = 0,
     profile_sufficiency_reasons: Sequence[str] = (),
+    situation_frame: SituationFrameV1 | None = None,
+    frame_revalidation: FrameSourceRevalidationResult | None = None,
 ) -> UnifiedResponseAssessment:
     """Assemble one deterministic assessment without rendering it live."""
 
@@ -1429,6 +1946,19 @@ def build_unified_response_assessment(
     diagnostics.append("criterion_count:%s" % len(criteria))
     diagnostics.append("option_count:%s" % len(current_options))
     diagnostics.append("prompt_comparison:%s" % comparison)
+    if isinstance(situation_frame, SituationFrameV1):
+        diagnostics.append("situation_frame:%s" % situation_frame.status)
+        if situation_frame.route_mode != str(route_mode or "unknown")[:80]:
+            diagnostics.append("situation_frame_route_mismatch")
+        if situation_frame.channel_policy != str(
+            channel_policy or "unknown"
+        )[:80]:
+            diagnostics.append("situation_frame_policy_mismatch")
+        if (
+            situation_frame.current_speaker_user_ids
+            and situation_frame.current_speaker_user_ids != current_speakers
+        ):
+            diagnostics.append("situation_frame_speaker_mismatch")
 
     return UnifiedResponseAssessment(
         schema_version=ASSESSMENT_VERSION,
@@ -1488,6 +2018,19 @@ def build_unified_response_assessment(
             normalized_profile_occurrences
         ),
         profile_sufficiency_reasons=normalized_profile_reasons,
+        situation_frame=(
+            situation_frame
+            if isinstance(situation_frame, SituationFrameV1)
+            else None
+        ),
+        frame_revalidation=(
+            frame_revalidation
+            if isinstance(
+                frame_revalidation,
+                FrameSourceRevalidationResult,
+            )
+            else None
+        ),
     )
 
 
@@ -2138,6 +2681,13 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             profile_independent_root_count INTEGER NOT NULL DEFAULT 0,
             profile_independent_occurrence_count INTEGER NOT NULL DEFAULT 0,
             profile_sufficiency_reasons_json TEXT NOT NULL DEFAULT '[]',
+            situation_frame_version TEXT NOT NULL DEFAULT '',
+            situation_frame_revision TEXT NOT NULL DEFAULT '',
+            situation_frame_input_digest TEXT NOT NULL DEFAULT '',
+            situation_frame_status TEXT NOT NULL DEFAULT 'not_present',
+            situation_frame_ambiguity_count INTEGER NOT NULL DEFAULT 0,
+            frame_revalidation_status TEXT NOT NULL DEFAULT 'not_run',
+            frame_revalidation_reason_count INTEGER NOT NULL DEFAULT 0,
             response_alignment TEXT NOT NULL,
             processing_errors_json TEXT NOT NULL DEFAULT '[]',
             behavior_changed INTEGER NOT NULL DEFAULT 0,
@@ -2261,6 +2811,28 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         (
             "profile_sufficiency_reasons_json",
             "TEXT NOT NULL DEFAULT '[]'",
+        ),
+        ("situation_frame_version", "TEXT NOT NULL DEFAULT ''"),
+        ("situation_frame_revision", "TEXT NOT NULL DEFAULT ''"),
+        (
+            "situation_frame_input_digest",
+            "TEXT NOT NULL DEFAULT ''",
+        ),
+        (
+            "situation_frame_status",
+            "TEXT NOT NULL DEFAULT 'not_present'",
+        ),
+        (
+            "situation_frame_ambiguity_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "frame_revalidation_status",
+            "TEXT NOT NULL DEFAULT 'not_run'",
+        ),
+        (
+            "frame_revalidation_reason_count",
+            "INTEGER NOT NULL DEFAULT 0",
         ),
     )
     for column_name, column_definition in additive_columns:
@@ -2500,6 +3072,13 @@ def persist_shadow_run(
         "profile_independent_root_count",
         "profile_independent_occurrence_count",
         "profile_sufficiency_reasons_json",
+        "situation_frame_version",
+        "situation_frame_revision",
+        "situation_frame_input_digest",
+        "situation_frame_status",
+        "situation_frame_ambiguity_count",
+        "frame_revalidation_status",
+        "frame_revalidation_reason_count",
         "response_alignment",
         "processing_errors_json",
         "behavior_changed",
@@ -2592,6 +3171,47 @@ def persist_shadow_run(
         assessment.profile_independent_root_count,
         assessment.profile_independent_occurrence_count,
         json.dumps(assessment.profile_sufficiency_reasons),
+        (
+            assessment.situation_frame.schema_version
+            if isinstance(assessment.situation_frame, SituationFrameV1)
+            else ""
+        ),
+        (
+            assessment.situation_frame.frame_revision
+            if isinstance(assessment.situation_frame, SituationFrameV1)
+            else ""
+        ),
+        (
+            assessment.situation_frame.input_evidence_digest
+            if isinstance(assessment.situation_frame, SituationFrameV1)
+            else ""
+        ),
+        (
+            assessment.situation_frame.status
+            if isinstance(assessment.situation_frame, SituationFrameV1)
+            else "not_present"
+        ),
+        (
+            len(assessment.situation_frame.ambiguity_reasons)
+            if isinstance(assessment.situation_frame, SituationFrameV1)
+            else 0
+        ),
+        (
+            assessment.frame_revalidation.status
+            if isinstance(
+                assessment.frame_revalidation,
+                FrameSourceRevalidationResult,
+            )
+            else "not_run"
+        ),
+        (
+            len(assessment.frame_revalidation.reason_codes)
+            if isinstance(
+                assessment.frame_revalidation,
+                FrameSourceRevalidationResult,
+            )
+            else 0
+        ),
         alignment,
         json.dumps(
             tuple(

--- a/docs/BNL01_CONVERSATION_ORCHESTRATION_CONTRACT.md
+++ b/docs/BNL01_CONVERSATION_ORCHESTRATION_CONTRACT.md
@@ -40,8 +40,8 @@ turn.
 5. Add content-free governed-memory, Relationship posture, canon-applicability,
    and source-control states. General durable content is not allowed to become
    a routing veto.
-6. Freeze one typed packet revision and coordinate exactly one response act for
-   it.
+6. Freeze one typed packet revision, coordinate exactly one response act, and
+   build one immutable Situation Frame v1 from those existing-owner results.
 7. If a new contribution interrupts the turn, discard the superseded draft,
    rebuild the entire packet, assign a new revision, and assess that revision
    once. No answer-intent latch survives the rebuild.
@@ -63,6 +63,46 @@ Relationship, Moment, canon, and other prompt lanes, and it may produce a
 post-send shadow receipt. It is not a second response-act authority and must not
 change answer, clarify, observe, or block after the conversation coordinator
 has decided the current packet.
+
+## Situation Frame v1 (shadow-only)
+
+The conversation coordinator now owns one immutable, response-scoped
+`situation_frame_v1`. It is a typed applicability decision, not a new context
+engine, memory store, retriever, identity service, or factual packet.
+
+The frame freezes:
+
+- its schema revision, input-evidence digest, and current-contribution digest;
+- current speakers, authoritative addressee kinds, Discord message/reply/source
+  anchors, and reversible subject candidates;
+- stable target references received from existing owners, while treating
+  display labels only as low-confidence hints;
+- current Moment reference and whether the scene is the same event, a new
+  phase, a resume, a comparison/participant change, a new event, or uncertain;
+- task, object, request phase, role/domain hints, temporal scope, currentness,
+  objective, and required response act;
+- decision, correction, unresolved-question, and open-loop states; and
+- route, surface, channel policy, visibility allowance, competing frames, and
+  material ambiguity.
+
+Frame construction is deterministic and makes no provider call. A question
+about another person never falls back to the current speaker merely because a
+stable subject binding is absent. Multiple people, unresolved referents,
+same-name candidates, blocked visibility, and competing event/role readings
+remain explicit rather than being guessed away.
+
+The frame is passed unchanged as shadow metadata through prompt construction,
+the existing packet/assessment path, response guards, and a separate pre-send
+`frame_source_revalidation_v1` result. Revalidation references the original
+frame and packet digests; it never mutates either object. During this stage the
+frame cannot change retrieval, prompt prose, generation, delivery, routing, or
+durable memory. It creates no authority and activates no gate.
+
+Only content-free frame receipts may persist: version/revision/digest, status,
+typed counts, phase/object/event-relation classifications, and revalidation
+status/reason counts. Raw contribution text, display labels, account IDs, and
+subject values are excluded from those receipts. Disabling or rolling back the
+shadow wiring requires no data deletion or backfill.
 
 ## Governed BNL self-names
 

--- a/tests/test_situation_frame_v1.py
+++ b/tests/test_situation_frame_v1.py
@@ -1,0 +1,359 @@
+import asyncio
+import json
+import os
+import sqlite3
+import unittest
+from dataclasses import FrozenInstanceError
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+from bnl_moment_engine import MomentSituationReference
+from bnl_unified_response_assessment import (
+    FRAME_SOURCE_REVALIDATION_VERSION,
+    SITUATION_FRAME_VERSION,
+    build_situation_frame_v1,
+    build_unified_response_assessment,
+    persist_shadow_run,
+    render_situation_frame_receipt,
+    revalidate_situation_frame,
+)
+
+
+def addressing(**overrides):
+    values = {
+        "speaker": "Test Member",
+        "explicit_tag_recipients": ("@BNL-01",),
+        "reply_target": "none",
+        "explicitly_mentions_bnl": True,
+        "reply_targets_bnl": False,
+        "directly_targets_bnl": True,
+        "targets_other_human": False,
+        "plain_text_names_bnl": False,
+        "source_message_id": 301,
+    }
+    values.update(overrides)
+    return bnl01_bot.DiscordTurnAddressing(**values)
+
+
+def moment(**overrides):
+    values = {
+        "moment_id": "moment_test_01",
+        "lifecycle_status": "active",
+        "qualification_type": "topic_activity",
+        "qualification_reason": "eligible_human_roots",
+        "human_entry_count": 3,
+        "model_entry_count": 1,
+        "participant_count": 2,
+        "participant_overlap": True,
+        "topic_coherent": True,
+        "last_activity_at": "2026-08-09T12:00:00+00:00",
+    }
+    values.update(overrides)
+    return MomentSituationReference(**values)
+
+
+class SituationFrameV1Tests(unittest.TestCase):
+    def test_frame_is_deterministic_immutable_and_complete(self):
+        kwargs = {
+            "route_allowed": True,
+            "route_mode": "normal_chat",
+            "conversation_surface": "public_home",
+            "channel_policy": "public_home",
+            "current_text": "Please diagnose the current memory failure and retest it.",
+            "current_speaker_user_ids": (101,),
+            "current_speaker_labels": ("Test Member",),
+            "addressee_kinds": ("discord_mention",),
+            "source_message_ids": (301,),
+            "reply_message_ids": (299,),
+            "exact_source_row_ids": (88,),
+            "explicit_mention_count": 1,
+            "subject_user_ids": (101,),
+            "moment_id": "moment_test_01",
+            "moment_situation_state": "recent_active",
+            "moment_topic_coherent": True,
+            "moment_participant_overlap": True,
+            "referent_status": "resolved",
+            "response_act": "answer",
+            "packet_revision": "turn_01",
+        }
+        first = build_situation_frame_v1(**kwargs)
+        second = build_situation_frame_v1(**kwargs)
+
+        self.assertEqual(first, second)
+        self.assertEqual(first.schema_version, SITUATION_FRAME_VERSION)
+        self.assertEqual(first.frame_revision, second.frame_revision)
+        self.assertEqual(first.input_evidence_digest, second.input_evidence_digest)
+        self.assertEqual(first.status, "resolved")
+        self.assertEqual(first.phase, "retest")
+        self.assertEqual(first.object_kind, "memory")
+        self.assertEqual(first.event_relation, "same_event_new_phase")
+        self.assertEqual(first.visibility_allowance, "public_safe")
+        self.assertEqual(first.required_response_act, "answer")
+        self.assertEqual(first.subjects[0].binding_method, "existing_typed_target")
+        with self.assertRaises(FrozenInstanceError):
+            first.status = "changed"
+
+    def test_third_party_cue_never_falls_back_to_current_speaker(self):
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text="What do you know about Jordan?",
+            current_speaker_user_ids=(101,),
+            current_speaker_labels=("Test Member",),
+            response_act="answer",
+        )
+
+        self.assertEqual(frame.subjects, ())
+        self.assertEqual(frame.status, "ambiguous")
+        self.assertIn("third_party_subject_unresolved", frame.ambiguity_reasons)
+        self.assertIn("speaker_fallback_rejected", frame.competing_frames)
+
+    def test_role_domain_event_and_visibility_matrix(self):
+        cases = (
+            (
+                "Tell me about Test Artist as an artist and community member.",
+                "recent_active",
+                True,
+                True,
+                "same_event",
+                {"music", "real_community"},
+            ),
+            (
+                "We are resuming the queue retest.",
+                "recent_reopened",
+                True,
+                True,
+                "resume",
+                {"broadcast_history"},
+            ),
+            (
+                "This is a different website failure.",
+                "recent_active",
+                False,
+                True,
+                "new_event_same_participant",
+                {"technical"},
+            ),
+        )
+        for text, state, coherent, overlap, relation, domains in cases:
+            with self.subTest(text=text):
+                frame = build_situation_frame_v1(
+                    route_allowed=True,
+                    route_mode="normal_chat",
+                    conversation_surface="sealed_test",
+                    channel_policy="sealed_test",
+                    current_text=text,
+                    current_speaker_user_ids=(101,),
+                    subject_label_hints=("Test Artist",),
+                    moment_id="moment_test_01",
+                    moment_situation_state=state,
+                    moment_topic_coherent=coherent,
+                    moment_participant_overlap=overlap,
+                    response_act="answer",
+                )
+                self.assertEqual(frame.event_relation, relation)
+                self.assertTrue(domains.issubset(set(frame.domain_hints)))
+                self.assertEqual(frame.visibility_allowance, "sealed_test")
+
+        blocked = build_situation_frame_v1(
+            route_allowed=False,
+            route_mode="normal_chat",
+            conversation_surface="forbidden",
+            channel_policy="forbidden",
+            current_text="Tell me about the Journal.",
+        )
+        self.assertEqual(blocked.status, "blocked")
+        self.assertEqual(blocked.visibility_allowance, "blocked")
+
+    def test_revalidation_is_separate_and_fails_closed_by_state(self):
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text="Explain the current Journal entry.",
+            current_speaker_user_ids=(101,),
+            response_act="answer",
+        )
+        valid = revalidate_situation_frame(
+            frame,
+            current_text="Explain the current Journal entry.",
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            packet_source_snapshot_digest="packet_digest_01",
+        )
+        stale = revalidate_situation_frame(
+            frame,
+            current_text="Explain a different Journal entry.",
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+        )
+        invalid = revalidate_situation_frame(
+            frame,
+            current_text="Explain the current Journal entry.",
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            source_status="deleted",
+        )
+
+        self.assertEqual(valid.schema_version, FRAME_SOURCE_REVALIDATION_VERSION)
+        self.assertEqual(valid.status, "valid")
+        self.assertEqual(stale.status, "stale")
+        self.assertIn("current_text_changed", stale.reason_codes)
+        self.assertEqual(invalid.status, "invalid")
+        self.assertIn("source_deleted", invalid.reason_codes)
+        self.assertEqual(frame.status, "resolved")
+
+    def test_content_free_receipt_has_no_text_labels_or_account_ids(self):
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text="Explain the current memory repair.",
+            current_speaker_user_ids=(424242,),
+            current_speaker_labels=("Test Member",),
+            subject_user_ids=(424242,),
+            subject_label_hints=("Test Member",),
+            response_act="answer",
+        )
+        result = revalidate_situation_frame(
+            frame,
+            current_text="Explain the current memory repair.",
+            route_mode="normal_chat",
+            channel_policy="public_home",
+        )
+        receipt = render_situation_frame_receipt(frame, result)
+        serialized = json.dumps(receipt, sort_keys=True)
+
+        self.assertNotIn("Explain the current memory repair", serialized)
+        self.assertNotIn("Test Member", serialized)
+        self.assertNotIn("424242", serialized)
+        self.assertEqual(receipt["mutationCount"], 0)
+        self.assertEqual(receipt["revalidationStatus"], "valid")
+
+    def test_live_coordinator_builds_frame_without_prompt_influence(self):
+        decision = bnl01_bot.build_live_conversation_orchestration_decision(
+            engagement_decision="answer",
+            engagement_reason="direct_request",
+            channel_policy="public_home",
+            addressings=(addressing(),),
+            context_result=None,
+            moment_situation=moment(),
+            guild_id=7,
+            channel_id=8,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            current_text="Please diagnose the memory failure.",
+            current_speaker_user_ids=(101,),
+            current_speaker_labels=("Test Member",),
+            influence_mode="live",
+            packet_revision="turn_02",
+        )
+        rendered = bnl01_bot.render_conversation_orchestration_prompt(decision)
+
+        self.assertIsNotNone(decision.situation_frame)
+        self.assertEqual(decision.situation_frame.current_speaker_user_ids, (101,))
+        self.assertNotIn("SITUATION_FRAME", rendered)
+        self.assertNotIn(decision.situation_frame.input_evidence_digest, rendered)
+
+    def test_assessment_receipt_persists_only_content_free_frame_state(self):
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text="Explain the current memory repair.",
+            current_speaker_user_ids=(424242,),
+            current_speaker_labels=("Test Member",),
+            response_act="answer",
+        )
+        revalidation = revalidate_situation_frame(
+            frame,
+            current_text="Explain the current memory repair.",
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+        )
+        assessment = build_unified_response_assessment(
+            guild_id=7,
+            route_mode="normal_chat",
+            channel_policy="public_home",
+            conversation_surface="public_home",
+            current_speaker_user_ids=(424242,),
+            current_text="Explain the current memory repair.",
+            situation_frame=frame,
+            frame_revalidation=revalidation,
+        )
+        conn = sqlite3.connect(":memory:")
+        run_id = persist_shadow_run(
+            conn,
+            assessment,
+            response="The current repair is in shadow verification.",
+        )
+        row = conn.execute(
+            "SELECT situation_frame_version,situation_frame_revision,"
+            "situation_frame_input_digest,situation_frame_status,"
+            "situation_frame_ambiguity_count,frame_revalidation_status,"
+            "frame_revalidation_reason_count "
+            "FROM unified_response_assessment_shadow_runs WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        raw_row = json.dumps(row)
+
+        self.assertEqual(row[0], SITUATION_FRAME_VERSION)
+        self.assertEqual(row[1], frame.frame_revision)
+        self.assertEqual(row[2], frame.input_evidence_digest)
+        self.assertEqual(row[3], "resolved")
+        self.assertEqual(row[5], "valid")
+        self.assertNotIn("Test Member", raw_row)
+        self.assertNotIn("424242", raw_row)
+
+    def test_guard_revalidates_in_shadow_without_changing_response(self):
+        text = "Explain the current memory repair."
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text=text,
+            current_speaker_user_ids=(101,),
+            response_act="answer",
+        )
+        response = "The memory repair is ready for the next automated check."
+        validated, diagnostics = asyncio.run(
+            bnl01_bot.apply_guarded_response_regeneration(
+                response,
+                prompt="",
+                user_id=101,
+                guild_id=7,
+                route_mode="normal_chat",
+                channel_policy="public_home",
+                current_user_text=text,
+                source_context_available=True,
+                regeneration_allowed=False,
+                situation_frame=frame,
+            )
+        )
+
+        self.assertEqual(validated, response)
+        self.assertFalse(diagnostics["suppressed"])
+        self.assertEqual(
+            diagnostics["situation_frame_revalidation_status"],
+            "valid",
+        )
+        self.assertEqual(
+            diagnostics["_situation_frame_revalidation"].frame_revision,
+            frame.frame_revision,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an immutable, response-scoped `situation_frame_v1` built from existing conversation, Discord-addressing, and Moment owner outputs
- thread the frame through prompt metadata, assessment, guards, and pre-send revalidation without changing routing, retrieval, prompt prose, generation, or delivery
- persist additive content-free shadow receipt fields and document the authority/rollback contract
- cover deterministic construction, ambiguity, third-party subject safety, event/role/domain classification, revalidation, privacy, coordinator wiring, persistence, and behavior neutrality

## Safety posture
- shadow-only; no gate or canary is enabled
- no provider call is added
- display labels remain reversible hints rather than identity authority
- third-party questions never fall back to the current speaker
- receipt rows exclude raw text, display labels, account IDs, and subject values

## Verification
- `PYTHONPATH=/tmp/bnl-python-deps-20260809 make check PYTHON=python`
- 2,155 tests passed
- `git diff --check`
- Python compile check for changed modules
- focused conversation orchestration, batching, Moment, exact-quote, assessment, and Situation Frame suites