### PR TITLE
Converge situation-aware episodes and recurring themes

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -23117,7 +23117,12 @@ def build_live_conversation_orchestration_decision(
         else ()
     )
     moment_state = (
-        "recent_%s" % moment_situation.lifecycle_status
+        (
+            str(getattr(moment_situation, "selection_reason", "") or "")
+            if str(getattr(moment_situation, "selection_reason", "") or "")
+            not in {"", "recent_match"}
+            else "recent_%s" % moment_situation.lifecycle_status
+        )
         if moment_situation is not None
         else "none"
     )
@@ -23413,7 +23418,7 @@ def _build_unified_intelligence_packet_shadow(
         else ()
     )
     if isinstance(situation_frame, SituationFrameV1):
-        # Packet v6 resolves only the frozen frame candidates. A named or
+        # Packet v7 resolves only the frozen frame candidates. A named or
         # mentioned third party can never silently fall back to the speaker.
         subject_user_id = 0
     elif len(targets) == 1:

--- a/bnl_moment_engine.py
+++ b/bnl_moment_engine.py
@@ -42,6 +42,7 @@ EPISODE_INACTIVITY_SECONDS = 24 * 60 * 60
 EPISODE_REOPEN_SECONDS = 30 * 24 * 60 * 60
 TURN_SITUATION_RECENCY_SECONDS = 45 * 60
 CONTRIBUTION_GIST_VERSION = "moment_contribution_gist_v1"
+SITUATION_EPISODE_READ_VERSION = "situation_episode_read_v1"
 EPISODE_EVENT_TYPES = (
     "action",
     "reaction",
@@ -49,6 +50,8 @@ EPISODE_EVENT_TYPES = (
     "assignment",
     "outcome",
     "open_loop",
+    "correction",
+    "retest",
 )
 
 STOP = set("a an and are as at be but by for from how i in is it me my of on or our that the this to was we what when where who why with you your did do does about into can could would should just yep yes no ok okay hey hi hello thanks thank lol lmao got noted also ask asked".split())
@@ -122,6 +125,50 @@ _EPISODE_OPEN_LOOP_RE = re.compile(
     r"pending|waiting\s+on)\b",
     re.I,
 )
+_EPISODE_CORRECTION_RE = re.compile(
+    r"\b(?:correction|correct(?:ed|ion)?|actually|i\s+meant|"
+    r"not\s+that|that(?:'|’)s\s+wrong|instead|replace(?:d|ment)?)\b",
+    re.I,
+)
+_EPISODE_RETEST_RE = re.compile(
+    r"\b(?:retest|test\s+again|test\b.{0,80}\bagain|try\s+again|"
+    r"retry|rerun|re-run|"
+    r"second\s+pass|verify\s+again)\b",
+    re.I,
+)
+_DELAYED_CONTINUATION_RE = re.compile(
+    r"\b(?:late|delayed)\s+(?:reply|response)|"
+    r"\b(?:replying|responding|coming)\s+(?:back\s+)?(?:late|later)|"
+    r"\bcoming\s+back\s+to\s+this\b",
+    re.I,
+)
+_EXPLICIT_CROSS_CHANNEL_CONTINUATION_RE = re.compile(
+    r"\b(?:resume|continue|return(?:ing)?\s+to|back\s+to|"
+    r"pick\s+(?:this|that|it)\s+back\s+up|"
+    r"pick\s+up\s+where\s+we\s+left\s+off)\b"
+    r".{0,96}<#([1-9]\d*)>|"
+    r"<#([1-9]\d*)>.{0,96}"
+    r"\b(?:resume|continue|return(?:ing)?\s+to|back\s+to|"
+    r"pick\s+(?:this|that|it)\s+back\s+up|"
+    r"pick\s+up\s+where\s+we\s+left\s+off)\b",
+    re.I,
+)
+_EPISODE_NEXT_QUERY_RE = re.compile(
+    r"\b(?:what\s+happened\s+next|what\s+came\s+next|"
+    r"next\s+(?:step|phase|part)|after\s+that)\b",
+    re.I,
+)
+_EPISODE_OPEN_QUERY_RE = re.compile(
+    r"\b(?:what\s+(?:is|was|remains?)\s+(?:still\s+)?open|"
+    r"what\s+remains|unresolved|open\s+(?:question|loop)s?|"
+    r"still\s+(?:pending|needed?))\b",
+    re.I,
+)
+_EPISODE_CHANGE_QUERY_RE = re.compile(
+    r"\b(?:what\s+changed|what\s+was\s+corrected|"
+    r"what\s+did\s+we\s+correct|correction|revised?|amended?)\b",
+    re.I,
+)
 VIS_RANK = {"public": 0, "public_safe": 0, "reference_canon": 0, "internal": 2, "private": 3, "mod": 3, "sealed_test": 4, "protected": 4, "ai_image_tool": 4, "unknown": 5}
 PUBLIC_CROSS_CHANNEL_POLICIES = frozenset({"public_home", "public_context"})
 SOURCE_LIFECYCLES_USABLE_FOR_MOMENTS = frozenset({"active", "review_only"})
@@ -150,6 +197,41 @@ class PublicParticipantMomentGist:
     salience: float
     visibility: str
     canonical_ledger_entry_id: str
+
+
+@dataclass(frozen=True)
+class PublicSituationMomentGist:
+    """One source-revalidated public Moment projection for an event query."""
+
+    moment_id: str
+    summary: str
+    last_activity_at: str
+    salience: float
+    visibility: str
+    canonical_ledger_entry_id: str
+
+
+@dataclass(frozen=True)
+class SituationAwareEpisodeGist:
+    """Read-only episode projection selected against one Situation Frame."""
+
+    schema_version: str
+    moment_id: str
+    episode_id: str
+    gist: str
+    frame_type: str
+    link_role: str
+    episode_lifecycle: str
+    sequence_index: int
+    moment_count: int
+    open_loop_count: int
+    semantic_types: tuple[str, ...]
+    last_activity_at: str
+    visibility: str
+    canonical_ledger_entry_id: str
+    subject_key: str
+    event_relation: str
+    uncertainty_status: str
 
 
 @dataclass(frozen=True)
@@ -186,6 +268,9 @@ class MomentSituationReference:
     participant_overlap: bool
     topic_coherent: bool
     last_activity_at: str
+    source_channel_id: int = 0
+    cross_channel_continuation: bool = False
+    selection_reason: str = "recent_match"
 
 
 @dataclass(frozen=True)
@@ -2856,6 +2941,13 @@ def _episode_event_types(source: SourceEntry) -> tuple[str, ...]:
         observed.add("outcome")
     if frame_type == "question" or _EPISODE_OPEN_LOOP_RE.search(value):
         observed.add("open_loop")
+    if (
+        frame_type in {"correction", "correction_replacement", "replacement"}
+        or _EPISODE_CORRECTION_RE.search(value)
+    ):
+        observed.add("correction")
+    if _EPISODE_RETEST_RE.search(value):
+        observed.add("retest")
     return tuple(
         event_type
         for event_type in EPISODE_EVENT_TYPES
@@ -4225,6 +4317,40 @@ def recent_moment_situation_for_assessment(
         or int(channel_id or 0) <= 0
     ):
         return None
+    continuation_match = _EXPLICIT_CROSS_CHANNEL_CONTINUATION_RE.search(
+        str(topic_text or "")
+    )
+    cross_channel_id = 0
+    if continuation_match:
+        cross_channel_id = int(
+            next(
+                (
+                    group
+                    for group in continuation_match.groups()
+                    if str(group or "").isdigit()
+                ),
+                0,
+            )
+            or 0
+        )
+    cross_channel = bool(
+        cross_channel_id > 0 and cross_channel_id != int(channel_id or 0)
+    )
+    delayed_continuation = bool(
+        _DELAYED_CONTINUATION_RE.search(str(topic_text or ""))
+    )
+    resume_requested = bool(
+        _EPISODE_RESUME_RE.search(str(topic_text or ""))
+        or delayed_continuation
+    )
+    source_channel_id = (
+        cross_channel_id if cross_channel else int(channel_id or 0)
+    )
+    effective_recency_seconds = (
+        max(int(recency_seconds or 0), EPISODE_REOPEN_SECONDS)
+        if resume_requested
+        else max(1, int(recency_seconds or 1))
+    )
     base = _parse_ts(now or _now())
     rows = conn.execute(
         """
@@ -4235,11 +4361,11 @@ def recent_moment_situation_for_assessment(
         WHERE guild_id=? AND channel_id=? AND channel_policy=? AND route_mode=?
           AND lifecycle_status IN ('open','finalized','rejected','needs_review')
         ORDER BY last_activity_at DESC,moment_id DESC
-        LIMIT 8
+        LIMIT 32
         """,
         (
             int(guild_id),
-            int(channel_id),
+            source_channel_id,
             str(channel_policy or "unknown"),
             str(route_mode or "unknown"),
         ),
@@ -4273,7 +4399,7 @@ def recent_moment_situation_for_assessment(
         except (TypeError, ValueError):
             continue
         age_seconds = (base - parsed_activity).total_seconds()
-        if age_seconds < 0 or age_seconds > max(1, int(recency_seconds or 1)):
+        if age_seconds < 0 or age_seconds > effective_recency_seconds:
             continue
         moment_id = str(row[0] or "")
         participant_overlap = False
@@ -4311,6 +4437,17 @@ def recent_moment_situation_for_assessment(
             participant_overlap=participant_overlap,
             topic_coherent=topic_coherent,
             last_activity_at=last_activity,
+            source_channel_id=source_channel_id,
+            cross_channel_continuation=cross_channel,
+            selection_reason=(
+                "explicit_cross_channel_resume"
+                if cross_channel
+                else "explicit_delayed_resume"
+                if delayed_continuation
+                else "explicit_resume"
+                if resume_requested
+                else "recent_match"
+            ),
         )
         candidates.append(
             (
@@ -4325,6 +4462,41 @@ def recent_moment_situation_for_assessment(
     if not candidates:
         return None
     candidates.sort(key=lambda item: item[0], reverse=True)
+    if resume_requested:
+        eligible = [
+            item
+            for item in candidates
+            if item[1].topic_coherent
+            and (
+                not scoped_participants
+                or item[1].participant_overlap
+            )
+        ]
+        episode_groups: dict[str, list[tuple[Any, MomentSituationReference]]] = {}
+        for item in eligible:
+            moment_id = item[1].moment_id
+            linked = conn.execute(
+                """
+                SELECT DISTINCT episode_id
+                FROM memory_moment_episode_moments
+                WHERE moment_id=?
+                ORDER BY episode_id
+                """,
+                (moment_id,),
+            ).fetchall()
+            if len(linked) > 1:
+                return None
+            occurrence_key = (
+                "episode:%s" % str(linked[0][0])
+                if linked
+                else "moment:%s" % moment_id
+            )
+            episode_groups.setdefault(occurrence_key, []).append(item)
+        if len(episode_groups) != 1:
+            return None
+        only_group = next(iter(episode_groups.values()))
+        only_group.sort(key=lambda item: item[0], reverse=True)
+        return only_group[0][1]
     return candidates[0][1]
 
 
@@ -5110,6 +5282,363 @@ def select_public_participant_moment_gists(
         if len(selected) >= max(1, int(max_results or 0)):
             break
     return tuple(selected)
+
+
+def select_public_situation_moment_gists(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    topic_text: str = "",
+    broad_recall: bool = False,
+    token_budget: int = 180,
+    freshness_days: int = 3650,
+    allowed_channel_policies: tuple[str, ...] = (),
+    max_results: int = 6,
+) -> tuple[PublicSituationMomentGist, ...]:
+    """Return bounded source-revalidated Moment summaries for event queries."""
+
+    ensure_moment_schema(conn)
+    policies = tuple(
+        sorted(
+            {
+                _canon(policy)
+                for policy in (allowed_channel_policies or ())
+                if _canon(policy) in PUBLIC_CROSS_CHANNEL_POLICIES
+            }
+        )
+    )
+    if not policies:
+        return ()
+    relevance_text = _recall_topic_focus(topic_text)
+    family = _topic_family(relevance_text, "conversation")
+    signature = _topic_signature(relevance_text, "conversation")
+    if not broad_recall and not signature:
+        return ()
+    cutoff = (
+        datetime.now(timezone.utc) - timedelta(days=max(1, freshness_days))
+    ).isoformat()
+    placeholders = ",".join("?" for _ in policies)
+    rows = conn.execute(
+        f"""
+        SELECT moment_id,summary,topic_family,topic_signature,visibility,
+               last_activity_at,salience,channel_id,channel_policy,route_mode,
+               canonical_ledger_entry_id
+        FROM memory_moment_windows
+        WHERE guild_id=? AND channel_policy IN ({placeholders})
+          AND route_mode IN (
+              'normal_chat','direct_payload','direct_payload_task'
+          )
+          AND lifecycle_status='finalized' AND public_usable=1
+          AND last_activity_at>=?
+        ORDER BY salience DESC,last_activity_at DESC,moment_id
+        LIMIT 100
+        """,
+        (int(guild_id or 0), *policies, cutoff),
+    ).fetchall()
+    selected: list[PublicSituationMomentGist] = []
+    seen: set[str] = set()
+    used_words = 0
+    for row in rows:
+        moment_id = str(row[0] or "")
+        summary = re.sub(r"\s+", " ", str(row[1] or "")).strip()
+        visibility = str(row[4] or "unknown")
+        if (
+            not summary
+            or summary.casefold() in seen
+            or visibility not in {"public", "public_safe"}
+        ):
+            continue
+        if not broad_recall and not _coherent(
+            family,
+            signature,
+            str(row[2] or ""),
+            _load_sig(str(row[3] or "[]")),
+        ):
+            continue
+        if not _moment_is_renderable(
+            conn,
+            moment_id=moment_id,
+            summary=summary,
+            guild_id=int(guild_id or 0),
+            channel_id=int(row[7] or 0),
+            channel_policy=str(row[8] or ""),
+            route_mode=str(row[9] or "unknown"),
+            visibility=visibility,
+            canonical_ledger_entry_id=str(row[10] or ""),
+        ):
+            continue
+        words = summary.split()
+        if (
+            used_words + len(words) > max(1, int(token_budget or 0))
+            or len(selected) >= max(1, int(max_results or 0))
+        ):
+            continue
+        selected.append(
+            PublicSituationMomentGist(
+                moment_id=moment_id,
+                summary=summary,
+                last_activity_at=str(row[5] or ""),
+                salience=float(row[6] or 0),
+                visibility=visibility,
+                canonical_ledger_entry_id=str(row[10] or ""),
+            )
+        )
+        seen.add(summary.casefold())
+        used_words += len(words)
+    return tuple(selected)
+
+
+def _episode_projection_for_moment(
+    conn: sqlite3.Connection,
+    moment_id: str,
+) -> dict[str, Any] | None:
+    rows = conn.execute(
+        """
+        SELECT link.episode_id,link.link_role,episode.lifecycle_status,
+               episode.open_loop_count,episode.semantic_types_json,
+               episode.moment_count
+        FROM memory_moment_episode_moments link
+        JOIN memory_moment_episodes episode
+          ON episode.episode_id=link.episode_id
+        WHERE link.moment_id=?
+          AND episode.lifecycle_status IN ('active','finalized')
+        ORDER BY link.episode_id
+        """,
+        (str(moment_id or ""),),
+    ).fetchall()
+    if len(rows) != 1:
+        return None
+    row = rows[0]
+    ordered_moments = tuple(
+        str(item[0])
+        for item in conn.execute(
+            """
+            SELECT link.moment_id
+            FROM memory_moment_episode_moments link
+            JOIN memory_moment_windows window
+              ON window.moment_id=link.moment_id
+            WHERE link.episode_id=? AND window.lifecycle_status='finalized'
+            ORDER BY window.window_started_at,window.last_activity_at,
+                     link.moment_id
+            """,
+            (str(row[0] or ""),),
+        ).fetchall()
+    )
+    if (
+        not ordered_moments
+        or str(moment_id or "") not in ordered_moments
+        or len(ordered_moments) != int(row[5] or 0)
+    ):
+        return None
+    try:
+        semantic_types = tuple(
+            event_type
+            for event_type in json.loads(str(row[4] or "[]"))
+            if event_type in EPISODE_EVENT_TYPES
+        )
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    return {
+        "episode_id": str(row[0] or ""),
+        "link_role": str(row[1] or ""),
+        "lifecycle": str(row[2] or ""),
+        "open_loop_count": max(0, int(row[3] or 0)),
+        "semantic_types": semantic_types,
+        "moment_count": len(ordered_moments),
+        "sequence_index": ordered_moments.index(str(moment_id or "")),
+    }
+
+
+def select_situation_aware_episode_gists(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    participant_key: str = "",
+    topic_text: str = "",
+    frame_event_ref: str = "",
+    frame_event_relation: str = "uncertain",
+    frame_phase: str = "",
+    broad_recall: bool = False,
+    allowed_channel_policies: tuple[str, ...] = (),
+    max_results: int = 4,
+) -> tuple[SituationAwareEpisodeGist, ...]:
+    """Apply one frame to existing Moment/episode projections, read-only."""
+
+    typed_participant = (
+        str(participant_key or "")
+        if re.fullmatch(
+            r"discord_user:[1-9]\d*",
+            str(participant_key or ""),
+        )
+        else ""
+    )
+    source_rows: list[dict[str, Any]] = []
+    if typed_participant:
+        for gist in select_public_participant_moment_gists(
+            conn,
+            guild_id=int(guild_id or 0),
+            participant_key=typed_participant,
+            topic_text=topic_text,
+            broad_recall=broad_recall or bool(frame_event_ref),
+            token_budget=240,
+            freshness_days=3650,
+            allowed_channel_policies=allowed_channel_policies,
+            max_results=12,
+        ):
+            source_rows.append(
+                {
+                    "moment_id": gist.moment_id,
+                    "gist": gist.contribution_gist,
+                    "frame_type": gist.frame_type,
+                    "last_activity_at": gist.last_activity_at,
+                    "visibility": gist.visibility,
+                    "canonical_ledger_entry_id": (
+                        gist.canonical_ledger_entry_id
+                    ),
+                    "subject_key": typed_participant,
+                }
+            )
+    else:
+        for gist in select_public_situation_moment_gists(
+            conn,
+            guild_id=int(guild_id or 0),
+            topic_text=topic_text,
+            broad_recall=broad_recall or bool(frame_event_ref),
+            token_budget=240,
+            freshness_days=3650,
+            allowed_channel_policies=allowed_channel_policies,
+            max_results=12,
+        ):
+            source_rows.append(
+                {
+                    "moment_id": gist.moment_id,
+                    "gist": gist.summary,
+                    "frame_type": "shared_event_summary",
+                    "last_activity_at": gist.last_activity_at,
+                    "visibility": gist.visibility,
+                    "canonical_ledger_entry_id": (
+                        gist.canonical_ledger_entry_id
+                    ),
+                    "subject_key": "",
+                }
+            )
+    if not source_rows:
+        return ()
+
+    relation = str(frame_event_relation or "uncertain").strip().lower()
+    if relation in {"new_event_same_participant", "new_event_or_uncertain"}:
+        return ()
+    anchor = (
+        _episode_projection_for_moment(conn, str(frame_event_ref or ""))
+        if str(frame_event_ref or "")
+        else None
+    )
+    selected: list[SituationAwareEpisodeGist] = []
+    for source in source_rows:
+        moment_id = str(source["moment_id"])
+        episode = _episode_projection_for_moment(conn, moment_id)
+        if str(frame_event_ref or "") and anchor is None:
+            if moment_id != str(frame_event_ref):
+                continue
+        elif anchor is not None and relation in {
+            "same_event",
+            "same_event_new_phase",
+            "resume",
+        } and (
+            episode is None
+            or episode["episode_id"] != anchor["episode_id"]
+        ):
+            continue
+        if (
+            _EPISODE_NEXT_QUERY_RE.search(str(topic_text or ""))
+            and anchor is not None
+            and (
+                episode is None
+                or episode["episode_id"] != anchor["episode_id"]
+                or episode["sequence_index"] <= anchor["sequence_index"]
+            )
+        ):
+            continue
+        if (
+            _EPISODE_OPEN_QUERY_RE.search(str(topic_text or ""))
+            and (episode is None or episode["open_loop_count"] <= 0)
+        ):
+            continue
+        semantic_types = (
+            tuple(episode["semantic_types"]) if episode is not None else ()
+        )
+        frame_type = str(source["frame_type"] or "")
+        phase = str(frame_phase or "").strip().lower()
+        if (
+            (_EPISODE_CHANGE_QUERY_RE.search(str(topic_text or "")) or phase == "correction")
+            and "correction" not in semantic_types
+            and frame_type
+            not in {"correction", "correction_replacement", "replacement"}
+        ):
+            continue
+        if phase == "retest" and "retest" not in semantic_types:
+            continue
+        if phase == "completion" and "outcome" not in semantic_types:
+            continue
+        link_role = str(episode["link_role"] if episode else "standalone")
+        derived_relation = {
+            "opened": "new_event",
+            "extended": "same_event_new_phase",
+            "reopened": "resume",
+        }.get(link_role, relation)
+        selected.append(
+            SituationAwareEpisodeGist(
+                schema_version=SITUATION_EPISODE_READ_VERSION,
+                moment_id=moment_id,
+                episode_id=str(episode["episode_id"] if episode else ""),
+                gist=str(source["gist"] or ""),
+                frame_type=frame_type,
+                link_role=link_role,
+                episode_lifecycle=str(
+                    episode["lifecycle"] if episode else "finalized_moment"
+                ),
+                sequence_index=int(
+                    episode["sequence_index"] if episode else 0
+                ),
+                moment_count=int(episode["moment_count"] if episode else 1),
+                open_loop_count=int(
+                    episode["open_loop_count"] if episode else 0
+                ),
+                semantic_types=semantic_types,
+                last_activity_at=str(source["last_activity_at"] or ""),
+                visibility=str(source["visibility"] or "unknown"),
+                canonical_ledger_entry_id=str(
+                    source["canonical_ledger_entry_id"] or ""
+                ),
+                subject_key=str(source["subject_key"] or ""),
+                event_relation=derived_relation,
+                uncertainty_status=(
+                    "source_backed_episode"
+                    if episode is not None
+                    else "standalone_moment_only"
+                ),
+            )
+        )
+    if relation == "resume" and not anchor:
+        episode_ids = {
+            item.episode_id
+            for item in selected
+            if item.episode_id
+        }
+        if len(episode_ids) != 1:
+            return ()
+        selected = [
+            item for item in selected if item.episode_id in episode_ids
+        ]
+    selected.sort(
+        key=lambda item: (
+            item.last_activity_at,
+            item.sequence_index,
+            item.moment_id,
+        ),
+        reverse=not bool(_EPISODE_NEXT_QUERY_RE.search(str(topic_text or ""))),
+    )
+    return tuple(selected[: max(1, min(int(max_results or 1), 8))])
 
 
 def render_shadow_moment_context(

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -55,7 +55,7 @@ SCHEMA_VERSION = "shared_brain_synthesis_v7"
 CAPABILITY_NAME = "shared_brain_public_broad_recall"
 CAPABILITY_CONTRACT_VERSION = "hybrid_shared_brain_v1"
 CAPABILITY_RECEIPT_VERSION = "shared_brain_capability_receipt_v1"
-_EXPECTED_PACKET_SCHEMA_VERSION = "unified_intelligence_packet_v6"
+_EXPECTED_PACKET_SCHEMA_VERSION = "unified_intelligence_packet_v7"
 _EXPECTED_CLAIM_CONTRACT_VERSION = "hybrid_canon_claim_v1"
 _EXPECTED_ASSESSMENT_VERSION = "unified_response_assessment_v7"
 _EXPECTED_IDENTITY_CONTRACT_VERSION = "canon_entity_account_binding_v1"
@@ -91,7 +91,9 @@ _RENDERABLE_LANES = {
     "assessment_observation",
     "approved_fact",
     "moment",
+    "episode",
     "atomic_knowledge",
+    "recurring_theme",
     "open_loop",
     "canon",
     "source_file",
@@ -102,7 +104,9 @@ _PROFILE_MEMBER_LANES = frozenset(
         "assessment_observation",
         "conversation_context",
         "moment",
+        "episode",
         "atomic_knowledge",
+        "recurring_theme",
     }
 )
 _CLAIM_MEMBER_LANES = frozenset(
@@ -111,7 +115,9 @@ _CLAIM_MEMBER_LANES = frozenset(
         "assessment_observation",
         "approved_fact",
         "moment",
+        "episode",
         "atomic_knowledge",
+        "recurring_theme",
         "open_loop",
     }
 )
@@ -128,7 +134,9 @@ _LANE_LABELS = {
     "assessment_observation": "question-scoped public observation",
     "approved_fact": "approved direct fact",
     "moment": "episode gist",
+    "episode": "frame-bound episode",
     "atomic_knowledge": "durable observation",
+    "recurring_theme": "recurring-theme evidence",
     "open_loop": "unresolved thread",
     "canon": "approved canon",
     "source_file": "authorized source context",
@@ -182,12 +190,14 @@ _EVIDENCE_STOPWORDS = {
 _LANE_RENDER_PRIORITY = {
     "approved_fact": 0,
     "atomic_knowledge": 1,
-    "moment": 2,
-    "assessment_observation": 3,
-    "open_loop": 4,
-    "conversation_context": 5,
-    "canon": 6,
-    "source_file": 7,
+    "recurring_theme": 1,
+    "episode": 2,
+    "moment": 3,
+    "assessment_observation": 4,
+    "open_loop": 5,
+    "conversation_context": 6,
+    "canon": 7,
+    "source_file": 8,
 }
 _PROFILE_GENERIC_TERMS = frozenset(
     {
@@ -1766,6 +1776,8 @@ def render_packet_context(
         qualifier = ""
         if item.lane == "moment":
             qualifier = "; paraphrase only"
+        elif item.lane == "episode":
+            qualifier = "; frame-bound; paraphrase only"
         elif item.lane == "assessment_observation":
             qualifier = (
                 "; one public historical example; assessment only, "
@@ -1776,6 +1788,14 @@ def render_packet_context(
                 "; established"
                 if item.lifecycle == "established"
                 else "; tentative observation"
+            )
+        elif item.lane == "recurring_theme":
+            qualifier = (
+                "; two or more independent roots and occurrences; "
+                "revisable pattern"
+                if item.uncertainty_status
+                == "independent_recurrence_established"
+                else "; one occurrence only; not established recurrence"
             )
         elif item.lane == "open_loop":
             qualifier = "; unresolved, not settled fact"
@@ -3631,7 +3651,8 @@ def _item_predicate_grounded(
         return False
 
     if (
-        str(getattr(item, "lane", "") or "") == "atomic_knowledge"
+        str(getattr(item, "lane", "") or "")
+        in {"atomic_knowledge", "recurring_theme"}
         and str(getattr(item, "source_type", "") or "")
         == "topic_or_motif"
         and tuple(getattr(item, "supporting_observations", ()) or ())

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -26,6 +26,8 @@ from bnl_canon_source_contract import (
     CANON_FACTS,
     CANON_MEMBER_IDENTITIES,
     CANON_SOURCE_CONTRACT_VERSION,
+    LIVING_CANON_GROUPING_SIGNATURE_VERSION,
+    LIVING_CANON_RECURRENCE_VERSION,
     SIX_BIT,
     CanonStatus,
     Confidence,
@@ -68,12 +70,16 @@ from bnl_memory_ledger import (
     select_public_conversation_assessment_evidence,
     subject_key_for_user,
 )
-from bnl_moment_engine import select_public_participant_moment_gists
+from bnl_moment_engine import (
+    SITUATION_EPISODE_READ_VERSION,
+    select_public_participant_moment_gists,
+    select_situation_aware_episode_gists,
+)
 from bnl_profile_points import material_profile_point_map
 from bnl_relationship_engine import shadow_packet_posture
 
 
-SCHEMA_VERSION = "unified_intelligence_packet_v6"
+SCHEMA_VERSION = "unified_intelligence_packet_v7"
 SUBJECT_RESOLUTION_VERSION = "governed_packet_subject_resolution_v1"
 SOURCE_SNAPSHOT_VERSION = "unified_packet_source_snapshot_v1"
 TABLE_NAME = "memory_governance_intelligence_packet_runs"
@@ -138,7 +144,9 @@ _LANE_CAPS = {
     "assessment_observation": 4,
     "approved_fact": 4,
     "moment": 3,
+    "episode": 4,
     "atomic_knowledge": 6,
+    "recurring_theme": 3,
     "open_loop": 3,
     "canon": 4,
     "source_file": 2,
@@ -150,6 +158,8 @@ _BROAD_PROFILE_LANE_CAPS = {
     "assessment_observation": 4,
     "atomic_knowledge": 6,
     "moment": 2,
+    "episode": 2,
+    "recurring_theme": 2,
     "open_loop": 1,
     "canon": 1,
     "source_file": 1,
@@ -161,7 +171,9 @@ _VALIDATION_SUPPORT_LANES = frozenset(
         "assessment_observation",
         "approved_fact",
         "moment",
+        "episode",
         "atomic_knowledge",
+        "recurring_theme",
         "open_loop",
         "canon",
         "source_file",
@@ -172,7 +184,9 @@ _CLAIM_SUBJECT_SCOPED_LANES = frozenset(
         "assessment_observation",
         "approved_fact",
         "moment",
+        "episode",
         "atomic_knowledge",
+        "recurring_theme",
         "open_loop",
     }
 )
@@ -219,6 +233,8 @@ _ASSESSMENT_LANE_MAP = {
     "atomic_knowledge": "governed_memory",
     "open_loop": "governed_memory",
     "moment": "prior_moment",
+    "episode": "prior_moment",
+    "recurring_theme": "governed_memory",
     "canon": "canon",
     "source_file": "source_context",
     "relationship_posture": "relationship",
@@ -232,6 +248,24 @@ _ADDITIVE_PREDICATES = {
     "topic_or_motif",
 }
 _LIVING_CANON_NEUTRAL_PREDICATE_PREFIX = "conversation_motif_neutral_"
+_RECURRING_THEME_QUERY_RE = re.compile(
+    r"\b(?:recurring\s+(?:theme|pattern|topic|motif)s?|"
+    r"what\s+keeps\s+(?:recurring|coming\s+up|happening)|"
+    r"what\s+(?:themes?|patterns?)\s+(?:keep\s+)?"
+    r"(?:recurring|coming\s+up)|again\s+and\s+again|"
+    r"common\s+(?:theme|pattern)s?)\b",
+    re.I,
+)
+_EPISODE_QUERY_RE = re.compile(
+    r"\b(?:what\s+happened(?:\s+next)?|what\s+came\s+next|"
+    r"what\s+(?:is|was|remains?)\s+(?:still\s+)?open|"
+    r"what\s+remains|what\s+changed|what\s+was\s+corrected|"
+    r"what\s+was\s+(?:retested|tested\s+again|completed|resolved)|"
+    r"(?:correction|retest|retry|completion)\s+(?:history|result|status)|"
+    r"(?:resume|continue|reopen|return\s+to)\s+(?:that|this|the)|"
+    r"(?:moment|episode|open\s+loop|unresolved\s+thread)s?)\b",
+    re.I,
+)
 _TERM_RE = re.compile(r"[a-z0-9][a-z0-9'’-]*", re.I)
 _TERM_STOPWORDS = {
     "a",
@@ -475,6 +509,11 @@ class IntelligencePacketItem:
     canon_status: str = ""
     canon_domain: str = ""
     canon_claim_kind: str = ""
+    event_ref: str = ""
+    episode_ref: str = ""
+    event_relation: str = ""
+    phase: str = ""
+    uncertainty_status: str = ""
 
 
 @dataclass(frozen=True)
@@ -509,6 +548,11 @@ class IntelligencePacketDiagnostics:
     subject_resolution_method: str = "none"
     subject_resolution_candidate_count: int = 0
     frame_applicability_exclusion_count: int = 0
+    episode_query_status: str = "not_requested"
+    episode_candidate_count: int = 0
+    theme_query_status: str = "not_requested"
+    theme_independent_root_count: int = 0
+    theme_independent_occurrence_count: int = 0
     processing_errors: list[str] = field(default_factory=list)
     invalid_invariants: list[str] = field(default_factory=list)
     revalidation_status: str = "not_evaluated"
@@ -594,13 +638,21 @@ class UnifiedIntelligencePacket:
         return tuple(
             item.source_ref
             for item in self.items
-            if item.lane in {"approved_fact", "atomic_knowledge", "open_loop"}
+            if item.lane
+            in {
+                "approved_fact",
+                "atomic_knowledge",
+                "recurring_theme",
+                "open_loop",
+            }
         )
 
     @property
     def moment_refs(self) -> tuple[str, ...]:
         return tuple(
-            item.source_ref for item in self.items if item.lane == "moment"
+            item.source_ref
+            for item in self.items
+            if item.lane in {"moment", "episode"}
         )
 
     @property
@@ -1615,6 +1667,43 @@ def _moment_root_metadata(
     )
 
 
+def _moment_all_root_metadata(
+    conn: sqlite3.Connection,
+    *,
+    moment_id: str,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return independent human lineage for a subject-neutral event gist."""
+
+    try:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT member.ledger_entry_id
+            FROM memory_moment_members member
+            JOIN main.memory_ledger_entries entry
+              ON entry.entry_id=member.ledger_entry_id
+            WHERE member.moment_id=?
+              AND member.membership_role='human_author'
+              AND entry.source_role='user'
+              AND entry.lifecycle_status='active'
+              AND entry.derived=0 AND entry.projection=0
+            ORDER BY member.ledger_entry_id
+            """,
+            (str(moment_id or ""),),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        rows = ()
+    roots: list[str] = []
+    occurrences: list[str] = []
+    for (entry_id,) in rows:
+        root = knowledge_root_identity(conn, str(entry_id or ""))
+        occurrence = knowledge_occurrence_identity(conn, str(entry_id or ""))
+        if root:
+            roots.append(root)
+        if occurrence:
+            occurrences.append(occurrence)
+    return tuple(dict.fromkeys(roots)), tuple(dict.fromkeys(occurrences))
+
+
 def _profile_member_item(
     request: IntelligencePacketRequest,
     item: IntelligencePacketItem,
@@ -1803,7 +1892,9 @@ def _relevant(
     if broad and lane in {
         "approved_fact",
         "moment",
+        "episode",
         "atomic_knowledge",
+        "recurring_theme",
         "open_loop",
     }:
         return True
@@ -1912,6 +2003,20 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             "INTEGER NOT NULL DEFAULT 0",
         ),
         ("source_snapshot_digest", "TEXT NOT NULL DEFAULT ''"),
+        (
+            "episode_query_status",
+            "TEXT NOT NULL DEFAULT 'not_requested'",
+        ),
+        ("episode_candidate_count", "INTEGER NOT NULL DEFAULT 0"),
+        (
+            "theme_query_status",
+            "TEXT NOT NULL DEFAULT 'not_requested'",
+        ),
+        ("theme_independent_root_count", "INTEGER NOT NULL DEFAULT 0"),
+        (
+            "theme_independent_occurrence_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
     ):
         try:
             conn.execute(
@@ -2629,6 +2734,152 @@ def _governed_items(
     return items
 
 
+def _episode_projection_digest(
+    item: Any,
+    roots: tuple[str, ...],
+    occurrences: tuple[str, ...],
+) -> str:
+    return _digest(
+        SITUATION_EPISODE_READ_VERSION,
+        item,
+        roots,
+        occurrences,
+    )
+
+
+def _episode_items(
+    conn: sqlite3.Connection,
+    request: IntelligencePacketRequest,
+    subject_resolution: PacketSubjectResolution,
+    diagnostics: IntelligencePacketDiagnostics,
+    exclusions: list[IntelligencePacketExclusion],
+) -> list[IntelligencePacketItem]:
+    """Read one frame-bound Moment/episode lane without owning lifecycle."""
+
+    if not _EPISODE_QUERY_RE.search(str(request.user_text or "")):
+        return []
+    diagnostics.episode_query_status = "requested"
+    subject_required = (
+        str(request.frame_subject_requirement or "").strip().lower()
+        == "required"
+    )
+    subject_key = str(subject_resolution.subject_key or "")
+    if subject_required and not re.fullmatch(
+        r"discord_user:[1-9]\d*",
+        subject_key,
+    ):
+        diagnostics.episode_query_status = "subject_has_no_discord_activity"
+        return []
+    participant_key = subject_key if subject_required else ""
+    rows = select_situation_aware_episode_gists(
+        conn,
+        guild_id=int(request.guild_id or 0),
+        participant_key=participant_key,
+        topic_text=str(request.user_text or "")[:8000],
+        frame_event_ref=str(request.frame_event_ref or ""),
+        frame_event_relation=str(request.frame_event_relation or "uncertain"),
+        frame_phase=str(request.frame_phase or ""),
+        broad_recall=bool(request.frame_event_ref),
+        allowed_channel_policies=("public_home", "public_context"),
+        max_results=4,
+    )
+    diagnostics.episode_candidate_count = len(rows)
+    diagnostics.episode_query_status = "selected" if rows else (
+        "ambiguous_or_unavailable"
+        if str(request.frame_event_relation or "")
+        in {"resume", "resume_unresolved", "concurrent_activity"}
+        else "no_applicable_episode"
+    )
+    items: list[IntelligencePacketItem] = []
+    for row in rows:
+        roots, occurrences = (
+            _moment_root_metadata(
+                conn,
+                moment_id=row.moment_id,
+                subject_key=participant_key,
+            )
+            if participant_key
+            else _moment_all_root_metadata(
+                conn,
+                moment_id=row.moment_id,
+            )
+        )
+        if not roots or not occurrences:
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane="episode",
+                reason="episode_root_lineage_missing",
+                source_class="moment_gist",
+            )
+            continue
+        source_digest = _episode_projection_digest(row, roots, occurrences)
+        source_ref = "episode:%s:moment:%s" % (
+            row.episode_id or "standalone",
+            row.moment_id,
+        )
+        item = IntelligencePacketItem(
+            lane="episode",
+            source_class="moment_gist",
+            source_type=(
+                "participant_episode_gist"
+                if participant_key
+                else "situation_episode_summary"
+            ),
+            source_ref=source_ref,
+            source_digest=source_digest,
+            subject_key=(
+                participant_key
+                or "event:%s" % (row.episode_id or row.moment_id)
+            ),
+            predicate_key="episode_%s" % (
+                str(request.frame_task_kind or request.frame_phase or "event")
+            ),
+            text=str(row.gist or "")[:1200],
+            visibility=row.visibility,
+            confidence="high",
+            lifecycle=row.episode_lifecycle,
+            authority=_AUTHORITY_RANK["moment_gist"],
+            lineage=roots,
+            observed_at=row.last_activity_at,
+            usage="episode_paraphrase",
+            score=88.0 + min(4, row.sequence_index),
+            revalidation_kind="episode",
+            revalidation_key=row.moment_id,
+            root_identities=roots,
+            occurrence_identities=occurrences,
+            point_identity=(
+                _point_identity(
+                    subject_key=participant_key,
+                    predicate_key="episode",
+                    text=row.gist,
+                )
+                if participant_key
+                else ""
+            ),
+            event_ref=row.moment_id,
+            episode_ref=row.episode_id,
+            event_relation=row.event_relation,
+            phase=str(request.frame_phase or ""),
+            uncertainty_status=row.uncertainty_status,
+        )
+        if not _route_allows_item(request, item):
+            diagnostics.visibility_exclusions += 1
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane="episode",
+                reason="episode_visibility",
+                source_class=item.source_class,
+            )
+            continue
+        diagnostics.candidates_by_lane["episode"] = (
+            diagnostics.candidates_by_lane.get("episode", 0) + 1
+        )
+        items.append(item)
+    return items
+
+
 def _declared_items(
     conn: sqlite3.Connection,
     request: IntelligencePacketRequest,
@@ -3215,6 +3466,118 @@ def _living_claim_for_candidate(
     return claim, ""
 
 
+def _provisional_theme_candidate_valid(
+    conn: sqlite3.Connection,
+    request: IntelligencePacketRequest,
+    candidate: Mapping[str, Any],
+    roots: Sequence[Mapping[str, Any]],
+) -> bool:
+    """Validate a single-occurrence theme for sealed uncertainty preview."""
+
+    if str(request.channel_policy or "").strip().lower() != "sealed_test":
+        return False
+    try:
+        proof = json.loads(str(candidate.get("recurrence_proof_json") or "{}"))
+        stored_occurrences = json.loads(
+            str(candidate.get("occurrence_ids_json") or "[]")
+        )
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return False
+    if not isinstance(proof, dict) or not isinstance(stored_occurrences, list):
+        return False
+    root_entry_ids = tuple(
+        sorted(
+            str(root.get("root_entry_id") or "")
+            for root in roots
+            if str(root.get("root_entry_id") or "")
+        )
+    )
+    authoritative_occurrences = tuple(
+        sorted(
+            {
+                identity
+                for identity in (
+                    knowledge_occurrence_identity(conn, entry_id)
+                    for entry_id in root_entry_ids
+                )
+                if identity
+            }
+        )
+    )
+    normalized_stored = tuple(
+        sorted(
+            str(identity or "").strip()
+            for identity in stored_occurrences
+            if str(identity or "").strip()
+        )
+    )
+    if (
+        str(candidate.get("candidate_type") or "") != "topic_or_motif"
+        or str(candidate.get("candidate_state") or "") != "provisional"
+        or str(candidate.get("lifecycle_reason") or "")
+        != "single_occurrence_provisional"
+        or str(candidate.get("recurrence_contract_version") or "")
+        != LIVING_CANON_RECURRENCE_VERSION
+        or str(candidate.get("grouping_signature_version") or "")
+        != LIVING_CANON_GROUPING_SIGNATURE_VERSION
+        or not re.fullmatch(
+            r"[0-9a-f]{64}",
+            str(candidate.get("grouping_identity") or ""),
+        )
+        or str(candidate.get("canon_domain") or "")
+        not in {"real_community", "lore", "hybrid"}
+        or str(candidate.get("canon_claim_kind") or "")
+        != "behavior_pattern"
+        or not bool(candidate.get("candidate_eligible"))
+        or bool(candidate.get("public_usable"))
+        or bool(candidate.get("live_eligible"))
+        or str(candidate.get("invalidated_reason") or "")
+        or str(candidate.get("lifecycle_schema_version") or "")
+        != ATOMIC_KNOWLEDGE_LIFECYCLE_SCHEMA_VERSION
+        or int(candidate.get("conflict_value_count") or 0) != 1
+        or int(candidate.get("reinforcement_count") or 0) != 1
+        or int(candidate.get("independent_occurrence_count") or 0) != 1
+        or int(candidate.get("eligible_independent_root_count") or 0)
+        != len(root_entry_ids)
+        or len(authoritative_occurrences) != 1
+        or normalized_stored != authoritative_occurrences
+        or proof.get("candidate_state") != "provisional"
+        or proof.get("candidate_eligible") is not True
+        or proof.get("source_eligible") is not True
+        or proof.get("roots_valid") is not True
+        or proof.get("occurrence_bounded") is not True
+        or proof.get("correction_fence_clear") is not True
+        or proof.get("contradiction_clear") is not True
+        or int(proof.get("independent_root_count") or 0)
+        != len(root_entry_ids)
+        or int(proof.get("independent_occurrence_count") or 0) != 1
+        or str(proof.get("root_digest") or "")
+        != str(candidate.get("root_digest") or "")
+        or str(proof.get("occurrence_digest") or "")
+        != str(candidate.get("occurrence_digest") or "")
+        or not roots
+        or not all(
+            _atomic_root_valid(request, candidate, root) for root in roots
+        )
+    ):
+        return False
+    return not any(
+        conn.execute(
+            """
+            SELECT 1 FROM main.memory_ledger_lineage
+            WHERE guild_id=? AND target_entry_id=?
+              AND lineage_type IN ('correction_of','supersedes','retracts')
+            LIMIT 1
+            """,
+            (
+                int(request.guild_id or 0),
+                str(root.get("root_entry_id") or ""),
+            ),
+        ).fetchone()
+        for root in roots
+    )
+
+
 def _atomic_member_fact_authorized(
     candidate: Mapping[str, Any],
     authority_class: str,
@@ -3252,6 +3615,11 @@ def _atomic_items(
 ) -> list[IntelligencePacketItem]:
     if int(request.subject_user_id or 0) <= 0:
         return []
+    theme_query = bool(
+        _RECURRING_THEME_QUERY_RE.search(str(request.user_text or ""))
+    )
+    if theme_query:
+        diagnostics.theme_query_status = "requested"
     subject = _request_subject_key(request)
     candidate_ids = tuple(
         str(row[0])
@@ -3282,6 +3650,7 @@ def _atomic_items(
         roots = _atomic_root_snapshot(conn, candidate_id)
         living_marked = _living_candidate_marked(candidate)
         living_claim = None
+        provisional_theme = False
         candidate_type = str(candidate.get("candidate_type") or "")
         authority_class = str(
             candidate.get("consolidated_authority_class")
@@ -3292,9 +3661,6 @@ def _atomic_items(
             "open_loop"
             if candidate_type == "open_loop_or_question"
             else "atomic_knowledge"
-        )
-        diagnostics.candidates_by_lane[lane] = (
-            diagnostics.candidates_by_lane.get(lane, 0) + 1
         )
         review_status = str(candidate.get("review_status") or "")
         review_due = _parse_time(candidate.get("review_due_at"))
@@ -3308,6 +3674,18 @@ def _atomic_items(
                 candidate,
                 roots,
             )
+            if (
+                reason
+                and theme_query
+                and _provisional_theme_candidate_valid(
+                    conn,
+                    request,
+                    candidate,
+                    roots,
+                )
+            ):
+                provisional_theme = True
+                reason = ""
             if reason:
                 diagnostics.candidates_by_canon_status[
                     CanonStatus.LIVING.value
@@ -3326,7 +3704,14 @@ def _atomic_items(
                         0,
                     ) + 1
             else:
-                authority_class = living_claim.source_class.value
+                lane = "recurring_theme" if theme_query else lane
+                if living_claim is not None:
+                    authority_class = living_claim.source_class.value
+                elif provisional_theme:
+                    authority_class = SourceClass.EVIDENCE_PROJECTION.value
+        diagnostics.candidates_by_lane[lane] = (
+            diagnostics.candidates_by_lane.get(lane, 0) + 1
+        )
         if not reason and candidate.get("lifecycle_schema_version") != (
             ATOMIC_KNOWLEDGE_LIFECYCLE_SCHEMA_VERSION
         ):
@@ -3370,6 +3755,8 @@ def _atomic_items(
         visibility = (
             living_claim.visibility.value
             if living_claim is not None
+            else "sealed_test"
+            if provisional_theme
             else str(candidate.get("visibility") or "unknown")
         )
         if not reason and _public_route(request) and visibility not in _PUBLIC_VISIBILITIES:
@@ -3434,7 +3821,7 @@ def _atomic_items(
         text = str(candidate.get("normalized_value") or "").strip()
         if not reason and not _relevant(
             request_terms=request_terms,
-            broad=broad,
+            broad=broad or (theme_query and lane == "recurring_theme"),
             lane=lane,
             text=text,
             predicate_key=str(candidate.get("predicate_key") or ""),
@@ -3444,7 +3831,7 @@ def _atomic_items(
         source_digest = (
             (
                 _living_atomic_candidate_digest(conn, candidate_id)
-                if living_claim is not None
+                if living_claim is not None or provisional_theme
                 else _atomic_candidate_digest(conn, candidate_id)
             )
             if not reason
@@ -3469,6 +3856,8 @@ def _atomic_items(
         confidence = (
             living_claim.confidence.value
             if living_claim is not None
+            else Confidence.LOW.value
+            if provisional_theme
             else str(
                 candidate.get("consolidated_confidence_class")
                 or candidate.get("confidence_class")
@@ -3535,6 +3924,21 @@ def _atomic_items(
                 source_class=authority_class,
             )
             continue
+        if lane == "recurring_theme":
+            diagnostics.theme_independent_root_count = max(
+                diagnostics.theme_independent_root_count,
+                len(root_identities),
+            )
+            diagnostics.theme_independent_occurrence_count = max(
+                diagnostics.theme_independent_occurrence_count,
+                len(occurrence_identities),
+            )
+            if not provisional_theme:
+                diagnostics.theme_query_status = "established"
+            elif diagnostics.theme_query_status != "established":
+                diagnostics.theme_query_status = (
+                    "provisional_single_occurrence"
+                )
         items.append(
             IntelligencePacketItem(
                 lane=lane,
@@ -3552,7 +3956,15 @@ def _atomic_items(
                 participants=participants,
                 lineage=root_entry_ids,
                 observed_at=str(candidate.get("last_seen_at") or ""),
-                usage="tentative" if state == "provisional" else "content",
+                usage=(
+                    "provisional_single_occurrence"
+                    if provisional_theme
+                    else "established_recurrence"
+                    if lane == "recurring_theme"
+                    else "tentative"
+                    if state == "provisional"
+                    else "content"
+                ),
                 score=base_score
                 + 0.4
                 * len(
@@ -3563,7 +3975,11 @@ def _atomic_items(
                         | set(tags)
                     )
                 ),
-                revalidation_kind="atomic",
+                revalidation_kind=(
+                    "recurring_theme"
+                    if lane == "recurring_theme"
+                    else "atomic"
+                ),
                 revalidation_key=candidate_id,
                 root_identities=root_identities,
                 occurrence_identities=occurrence_identities,
@@ -3590,8 +4006,17 @@ def _atomic_items(
                     if living_claim is not None
                     else ""
                 ),
+                uncertainty_status=(
+                    "single_occurrence_not_recurrence"
+                    if provisional_theme
+                    else "independent_recurrence_established"
+                    if lane == "recurring_theme"
+                    else ""
+                ),
             )
         )
+    if theme_query and diagnostics.theme_query_status == "requested":
+        diagnostics.theme_query_status = "no_authoritative_theme"
     return items
 
 
@@ -4020,9 +4445,23 @@ def _apply_current_turn_precedence(
                 source_class=item.source_class,
             )
             continue
+        if item.lane == "recurring_theme" and item.subject_key == subject:
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane=item.lane,
+                reason="current_turn_correction_precedence",
+                source_class=item.source_class,
+            )
+            continue
         if (
             item.lane
-            in {"approved_fact", "atomic_knowledge", "open_loop"}
+            in {
+                "approved_fact",
+                "atomic_knowledge",
+                "recurring_theme",
+                "open_loop",
+            }
             and item.subject_key == subject
             and predicate_terms
             and current_terms & predicate_terms
@@ -4126,7 +4565,9 @@ def _filter_frame_applicable_candidates(
         "assessment_observation",
         "approved_fact",
         "moment",
+        "episode",
         "atomic_knowledge",
+        "recurring_theme",
         "open_loop",
         "canon",
         "relationship_posture",
@@ -4163,10 +4604,20 @@ def _filter_frame_applicable_candidates(
         ):
             exclude(item, "current_operational_source_precedence")
             continue
-        if item.lane == "moment" and frame_event_ref:
-            item_event_ref = str(item.revalidation_key or "").strip()
+        if item.lane in {"moment", "episode"} and frame_event_ref:
+            item_event_ref = str(
+                item.event_ref or item.revalidation_key or ""
+            ).strip()
             if event_relation in {"same_event", "same_event_new_phase", "resume"}:
-                if item_event_ref != frame_event_ref:
+                if (
+                    item_event_ref != frame_event_ref
+                    and not (
+                        item.lane == "episode"
+                        and item.episode_ref
+                        and item.event_relation
+                        in {"same_event", "same_event_new_phase", "resume"}
+                    )
+                ):
                     exclude(item, "frame_event_mismatch")
                     continue
             elif event_relation in {
@@ -4272,11 +4723,13 @@ def _select_items(
     broad_lane_priority = {
         "current_intent": 0,
         "approved_fact": 1,
-        "atomic_knowledge": 2,
+        "recurring_theme": 2,
+        "atomic_knowledge": 3,
         "conversation_context": 3,
         "assessment_observation": 4,
-        "moment": 5,
-        "open_loop": 6,
+        "episode": 5,
+        "moment": 6,
+        "open_loop": 7,
         "canon": 8,
         "source_file": 9,
         "relationship_posture": 10,
@@ -4288,19 +4741,23 @@ def _select_items(
                 "conversation_context": 1,
                 "assessment_observation": 2,
                 "approved_fact": 3,
-                "atomic_knowledge": 4,
-                "moment": 5,
-                "open_loop": 6,
+                "recurring_theme": 4,
+                "atomic_knowledge": 5,
+                "episode": 6,
+                "moment": 7,
+                "open_loop": 8,
             }
         )
     governed_subject_priority = {
         "current_intent": 0,
         "approved_fact": 1,
         "atomic_knowledge": 1,
+        "recurring_theme": 1,
         "conversation_context": 1,
         "assessment_observation": 1,
         "open_loop": 1,
-        "moment": 2,
+        "episode": 2,
+        "moment": 3,
         "canon": 3,
         "relationship_posture": 4,
         "source_file": 5,
@@ -4765,6 +5222,60 @@ def _moment_version(
     return ""
 
 
+def _episode_version(
+    conn: sqlite3.Connection,
+    packet: UnifiedIntelligencePacket,
+    item: IntelligencePacketItem,
+) -> str:
+    participant_key = (
+        item.subject_key
+        if item.source_type == "participant_episode_gist"
+        else ""
+    )
+    rows = select_situation_aware_episode_gists(
+        conn,
+        guild_id=int(packet.request.guild_id or 0),
+        participant_key=participant_key,
+        topic_text=str(packet.request.user_text or "")[:8000],
+        frame_event_ref=str(packet.request.frame_event_ref or ""),
+        frame_event_relation=str(
+            packet.request.frame_event_relation or "uncertain"
+        ),
+        frame_phase=str(packet.request.frame_phase or ""),
+        broad_recall=bool(packet.request.frame_event_ref),
+        allowed_channel_policies=("public_home", "public_context"),
+        max_results=4,
+    )
+    for row in rows:
+        source_ref = "episode:%s:moment:%s" % (
+            row.episode_id or "standalone",
+            row.moment_id,
+        )
+        if source_ref != item.source_ref:
+            continue
+        roots, occurrences = (
+            _moment_root_metadata(
+                conn,
+                moment_id=row.moment_id,
+                subject_key=participant_key,
+            )
+            if participant_key
+            else _moment_all_root_metadata(
+                conn,
+                moment_id=row.moment_id,
+            )
+        )
+        if (
+            roots != item.root_identities
+            or occurrences != item.occurrence_identities
+            or row.event_relation != item.event_relation
+            or row.uncertainty_status != item.uncertainty_status
+        ):
+            return ""
+        return _episode_projection_digest(row, roots, occurrences)
+    return ""
+
+
 def _canon_version(item: IntelligencePacketItem) -> str:
     for fact in CANON_FACTS:
         if _canon_digest(fact) == item.revalidation_key:
@@ -4854,6 +5365,61 @@ def _living_atomic_version(
         and item.canon_claim_kind == claim.claim_kind.value
         and item.root_identities == root_identities
         and item.occurrence_identities == occurrence_identities
+    ):
+        return ""
+    return _living_atomic_candidate_digest(conn, candidate_id)
+
+
+def _recurring_theme_version(
+    conn: sqlite3.Connection,
+    packet: UnifiedIntelligencePacket,
+    item: IntelligencePacketItem,
+) -> str:
+    candidate_id = str(item.revalidation_key or "")
+    candidate = _atomic_candidate_row(conn, candidate_id)
+    roots = _atomic_root_snapshot(conn, candidate_id)
+    if item.canon_status == CanonStatus.LIVING.value:
+        return _living_atomic_version(conn, item)
+    if not (
+        item.usage == "provisional_single_occurrence"
+        and item.uncertainty_status == "single_occurrence_not_recurrence"
+        and _provisional_theme_candidate_valid(
+            conn,
+            packet.request,
+            candidate,
+            roots,
+        )
+    ):
+        return ""
+    root_entry_ids = tuple(
+        str(root.get("root_entry_id") or "")
+        for root in roots
+        if str(root.get("root_entry_id") or "")
+    )
+    root_identities = tuple(
+        dict.fromkeys(
+            identity
+            for identity in (
+                knowledge_root_identity(conn, entry_id)
+                for entry_id in root_entry_ids
+            )
+            if identity
+        )
+    )
+    occurrence_identities = tuple(
+        dict.fromkeys(
+            identity
+            for identity in (
+                knowledge_occurrence_identity(conn, entry_id)
+                for entry_id in root_entry_ids
+            )
+            if identity
+        )
+    )
+    if (
+        item.root_identities != root_identities
+        or item.occurrence_identities != occurrence_identities
+        or len(occurrence_identities) != 1
     ):
         return ""
     return _living_atomic_candidate_digest(conn, candidate_id)
@@ -5042,6 +5608,8 @@ def _revalidate_packet_in_snapshot(
                 current = _ledger_entry_digest(conn, item.revalidation_key)
             elif item.revalidation_kind == "moment":
                 current = _moment_version(conn, packet, item)
+            elif item.revalidation_kind == "episode":
+                current = _episode_version(conn, packet, item)
             elif item.revalidation_kind == "atomic":
                 current = (
                     _living_atomic_version(conn, item)
@@ -5050,6 +5618,12 @@ def _revalidate_packet_in_snapshot(
                         conn,
                         item.revalidation_key,
                     )
+                )
+            elif item.revalidation_kind == "recurring_theme":
+                current = _recurring_theme_version(
+                    conn,
+                    packet,
+                    item,
                 )
             elif item.revalidation_kind == "canon":
                 current = _canon_version(item)
@@ -5181,8 +5755,10 @@ def _packet_invariants(
                 "approved_fact",
                 "assessment_observation",
                 "atomic_knowledge",
+                "recurring_theme",
                 "open_loop",
                 "moment",
+                "episode",
                 "relationship_posture",
             }
             and subject_scope_enforced
@@ -5191,7 +5767,7 @@ def _packet_invariants(
             invalid.append("selected_subject_violation")
         if item.lane == "relationship_posture" and item.usage != "tone_only":
             invalid.append("relationship_fact_authority_violation")
-        if item.revalidation_kind == "atomic" and item.lifecycle not in {
+        if item.revalidation_kind in {"atomic", "recurring_theme"} and item.lifecycle not in {
             "established",
             "provisional",
         }:
@@ -5232,23 +5808,62 @@ def _packet_invariants(
         ):
             invalid.append("profile_item_root_lineage_violation")
         if item.supporting_observations and not (
-            item.lane == "atomic_knowledge"
+            item.lane in {"atomic_knowledge", "recurring_theme"}
             and item.source_type == "topic_or_motif"
             and item.subject_key == subject
         ):
             invalid.append("supporting_observation_scope_violation")
         if item.canon_status == CanonStatus.LIVING.value and not (
-            item.lane == "atomic_knowledge"
+            item.lane in {"atomic_knowledge", "recurring_theme"}
             and item.source_type == "topic_or_motif"
             and item.lifecycle == "established"
             and item.source_class == SourceClass.EVIDENCE_PROJECTION.value
-            and item.revalidation_kind == "atomic"
+            and item.revalidation_kind in {"atomic", "recurring_theme"}
             and item.canon_domain in {"real_community", "lore", "hybrid"}
             and item.canon_claim_kind == "behavior_pattern"
             and len(item.root_identities) >= 2
             and len(item.occurrence_identities) >= 2
         ):
             invalid.append("living_canon_contract_violation")
+        if item.lane == "recurring_theme" and not (
+            item.source_type == "topic_or_motif"
+            and item.revalidation_kind == "recurring_theme"
+            and item.subject_key == subject
+            and bool(item.root_identities)
+            and bool(item.occurrence_identities)
+            and (
+                (
+                    item.canon_status == CanonStatus.LIVING.value
+                    and item.usage == "established_recurrence"
+                    and item.uncertainty_status
+                    == "independent_recurrence_established"
+                    and len(item.root_identities) >= 2
+                    and len(item.occurrence_identities) >= 2
+                )
+                or (
+                    not item.canon_status
+                    and item.lifecycle == "provisional"
+                    and item.usage == "provisional_single_occurrence"
+                    and item.uncertainty_status
+                    == "single_occurrence_not_recurrence"
+                    and len(item.occurrence_identities) == 1
+                    and packet.request.channel_policy == "sealed_test"
+                )
+            )
+        ):
+            invalid.append("recurring_theme_contract_violation")
+        if item.lane == "episode" and not (
+            item.revalidation_kind == "episode"
+            and item.source_class == "moment_gist"
+            and item.source_type
+            in {"participant_episode_gist", "situation_episode_summary"}
+            and item.event_ref
+            and item.uncertainty_status
+            in {"source_backed_episode", "standalone_moment_only"}
+            and item.root_identities
+            and item.occurrence_identities
+        ):
+            invalid.append("episode_lane_contract_violation")
         if item.canon_status == CanonStatus.OPEN_SIGNAL.value and not (
             item.lane == "assessment_observation"
             and item.revalidation_kind == "public_assessment"
@@ -5383,6 +5998,15 @@ def build_packet(
                 diagnostics,
                 exclusions,
                 broad=broad,
+            )
+        )
+        candidates.extend(
+            _episode_items(
+                conn,
+                request,
+                subject_resolution,
+                diagnostics,
+                exclusions,
             )
         )
         candidates.extend(
@@ -5673,7 +6297,10 @@ def persist_packet_run(
             frame_revision=?,frame_input_digest=?,
             subject_resolution_status=?,subject_resolution_method=?,
             subject_resolution_candidate_count=?,
-            frame_applicability_exclusion_count=?,source_snapshot_digest=?
+            frame_applicability_exclusion_count=?,source_snapshot_digest=?,
+            episode_query_status=?,episode_candidate_count=?,
+            theme_query_status=?,theme_independent_root_count=?,
+            theme_independent_occurrence_count=?
         WHERE run_id=?
         """,
         (
@@ -5693,6 +6320,13 @@ def persist_packet_run(
                 packet.diagnostics.frame_applicability_exclusion_count or 0
             ),
             packet.source_snapshot_digest,
+            packet.diagnostics.episode_query_status,
+            int(packet.diagnostics.episode_candidate_count or 0),
+            packet.diagnostics.theme_query_status,
+            int(packet.diagnostics.theme_independent_root_count or 0),
+            int(
+                packet.diagnostics.theme_independent_occurrence_count or 0
+            ),
             run_id,
         ),
     )
@@ -5791,6 +6425,11 @@ def _empty_report() -> dict[str, Any]:
         "subjectResolutionStatusCounts": {},
         "subjectResolutionMethodCounts": {},
         "frameApplicabilityExclusions": 0,
+        "episodeQueryStatusCounts": {},
+        "episodeCandidateTotal": 0,
+        "themeQueryStatusCounts": {},
+        "themeIndependentRootTotal": 0,
+        "themeIndependentOccurrenceTotal": 0,
         "promptAppliedRuns": 0,
         "liveAppliedRuns": 0,
         "contentFieldsPresent": [],
@@ -5842,7 +6481,7 @@ def build_evaluation_report(
                processing_error_count,
                invalid_invariant_count,revalidation_status,
                revalidation_changed_count,prompt_applied,live_applied,
-               %s,%s,%s,
+               %s,%s,%s,%s,%s,%s,%s,%s,
                created_at
         FROM memory_governance_intelligence_packet_runs
         WHERE guild_id=?
@@ -5867,6 +6506,11 @@ def build_evaluation_report(
             column("subject_resolution_status", "'not_evaluated'"),
             column("subject_resolution_method", "'none'"),
             column("frame_applicability_exclusion_count", "0"),
+            column("episode_query_status", "'not_requested'"),
+            column("episode_candidate_count", "0"),
+            column("theme_query_status", "'not_requested'"),
+            column("theme_independent_root_count", "0"),
+            column("theme_independent_occurrence_count", "0"),
         ),
         (int(guild_id or 0), max(1, min(int(limit or 1000), 5000))),
     ).fetchall()
@@ -5881,11 +6525,14 @@ def build_evaluation_report(
     profile_reasons: Counter[str] = Counter()
     subject_statuses: Counter[str] = Counter()
     subject_methods: Counter[str] = Counter()
+    episode_statuses: Counter[str] = Counter()
+    theme_statuses: Counter[str] = Counter()
     item_total = validation_item_total = 0
     conflicts = visibility = budget = duplicates = 0
     root_collapses = shared_roots = profile_met = 0
     profile_points = profile_roots = profile_occurrences = 0
     errors = invalid = changed = prompt = live = frame_exclusions = 0
+    episode_candidates = theme_roots = theme_occurrences = 0
     for row in rows:
         (
             _schema,
@@ -5919,6 +6566,11 @@ def build_evaluation_report(
             subject_resolution_status,
             subject_resolution_method,
             frame_exclusion_count,
+            episode_query_status,
+            episode_candidate_count,
+            theme_query_status,
+            theme_root_count,
+            theme_occurrence_count,
             _created_at,
         ) = row
         item_total += int(item_count or 0)
@@ -5974,6 +6626,11 @@ def build_evaluation_report(
         ] += 1
         subject_methods[str(subject_resolution_method or "none")] += 1
         frame_exclusions += int(frame_exclusion_count or 0)
+        episode_statuses[str(episode_query_status or "not_requested")] += 1
+        episode_candidates += int(episode_candidate_count or 0)
+        theme_statuses[str(theme_query_status or "not_requested")] += 1
+        theme_roots += int(theme_root_count or 0)
+        theme_occurrences += int(theme_occurrence_count or 0)
     return {
         "tablePresent": True,
         "schemaVersion": str(rows[0][0]) if rows else SCHEMA_VERSION,
@@ -6011,6 +6668,11 @@ def build_evaluation_report(
             sorted(subject_methods.items())
         ),
         "frameApplicabilityExclusions": frame_exclusions,
+        "episodeQueryStatusCounts": dict(sorted(episode_statuses.items())),
+        "episodeCandidateTotal": episode_candidates,
+        "themeQueryStatusCounts": dict(sorted(theme_statuses.items())),
+        "themeIndependentRootTotal": theme_roots,
+        "themeIndependentOccurrenceTotal": theme_occurrences,
         "promptAppliedRuns": prompt,
         "liveAppliedRuns": live,
         "contentFieldsPresent": disallowed,

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -265,13 +265,62 @@ _TERM_FAMILIES = {
 }
 
 _SITUATION_PHASE_PATTERNS = (
-    ("correction", re.compile(r"\b(?:correction|i\s+meant|not\s+that|that(?:'|’)s\s+wrong|instead)\b", re.I)),
-    ("retest", re.compile(r"\b(?:retest|test\s+again|try\s+again|retry|rerun|re-run|second\s+pass)\b", re.I)),
-    ("failure", re.compile(r"\b(?:failed?|failure|broken|crash(?:ed)?|error|didn(?:'|’)t\s+work|not\s+working)\b", re.I)),
-    ("diagnosis", re.compile(r"\b(?:diagnos(?:e|is)|root\s+cause|why\s+did|what\s+happened|figure\s+out|investigate)\b", re.I)),
-    ("completion", re.compile(r"\b(?:complete|completed|finished|done|resolved|fixed|merged|landed)\b", re.I)),
-    ("execution", re.compile(r"\b(?:implement|build|fix|change|update|create|proceed|continue|start|run|deploy)\b", re.I)),
-    ("planning", re.compile(r"\b(?:plan|roadmap|propose|design|scope|next\s+steps?|how\s+should)\b", re.I)),
+    (
+        "correction",
+        re.compile(
+            r"\b(?:correction|i\s+meant|not\s+that|"
+            r"that(?:'|’)s\s+wrong|instead)\b",
+            re.I,
+        ),
+    ),
+    (
+        "retest",
+        re.compile(
+            r"\b(?:retest|test\s+again|test\b.{0,80}\bagain|"
+            r"try\s+again|retry|rerun|re-run|second\s+pass)\b",
+            re.I,
+        ),
+    ),
+    (
+        "failure",
+        re.compile(
+            r"\b(?:failed?|failure|broken|crash(?:ed)?|error|"
+            r"didn(?:'|’)t\s+work|not\s+working)\b",
+            re.I,
+        ),
+    ),
+    (
+        "diagnosis",
+        re.compile(
+            r"\b(?:diagnos(?:e|is)|root\s+cause|why\s+did|"
+            r"what\s+happened|figure\s+out|investigate)\b",
+            re.I,
+        ),
+    ),
+    (
+        "completion",
+        re.compile(
+            r"\b(?:complete|completed|finished|done|resolved|fixed|"
+            r"merged|landed)\b",
+            re.I,
+        ),
+    ),
+    (
+        "execution",
+        re.compile(
+            r"\b(?:implement|build|fix|change|update|create|proceed|"
+            r"continue|start|run|deploy)\b",
+            re.I,
+        ),
+    ),
+    (
+        "planning",
+        re.compile(
+            r"\b(?:plan|roadmap|propose|design|scope|next\s+steps?|"
+            r"how\s+should)\b",
+            re.I,
+        ),
+    ),
 )
 _SITUATION_OBJECT_PATTERNS = (
     ("journal", re.compile(r"\bjournal(?:s|\s+entry|\s+entries)?\b", re.I)),
@@ -302,11 +351,37 @@ _SELF_SUBJECT_CUE_RE = re.compile(
     r"\b(?:what\s+(?:am\s+i|do\s+you\s+(?:know|remember)\s+about\s+me)|"
     r"tell\s+me\s+(?:what|who)\s+i\s+am|about\s+me|my\s+(?:profile|"
     r"history|role|work|music|preferences?|goals?|memory|story)|"
-    r"remember\s+me)\b",
+    r"remember\s+me|what\s+(?:patterns?|themes?)\s+(?:keep\s+)?"
+    r"(?:recurring|coming\s+up)\s+for\s+me|"
+    r"what\s+keeps\s+(?:recurring|coming\s+up)\s+for\s+me)\b",
     re.I,
 )
 _CURRENT_TIME_RE = re.compile(r"\b(?:now|currently|today|tonight|this\s+(?:week|show|turn|time)|latest|current)\b", re.I)
 _HISTORICAL_TIME_RE = re.compile(r"\b(?:before|previously|earlier|last\s+(?:time|week|show)|used\s+to|histor(?:y|ical))\b", re.I)
+_SITUATION_EXPLICIT_RESUME_RE = re.compile(
+    r"\b(?:resume|continue|pick\s+(?:it|this|that)\s+back\s+up|"
+    r"pick\s+up\s+where\s+we\s+left\s+off|back\s+to|"
+    r"return(?:ing)?\s+to|get\s+back\s+to|reopen|"
+    r"late\s+(?:reply|response)|coming\s+back\s+to\s+this)\b",
+    re.I,
+)
+_SITUATION_EXPLICIT_NEW_EVENT_RE = re.compile(
+    r"\b(?:new|different|separate|another)\s+"
+    r"(?:event|incident|failure|attempt|run|task|discussion|thread|case)\b|"
+    r"\bnot\s+(?:the\s+)?same\s+(?:event|incident|thread|case)\b",
+    re.I,
+)
+_SITUATION_CONCURRENT_RE = re.compile(
+    r"\b(?:meanwhile|at\s+the\s+same\s+time|in\s+parallel|"
+    r"concurrent(?:ly)?|separate\s+track|alongside)\b",
+    re.I,
+)
+_SITUATION_PARTICIPANT_CHANGE_RE = re.compile(
+    r"\b(?:different|new|another)\s+"
+    r"(?:person|people|participant|team|group)s?\b|"
+    r"\b(?:someone|somebody)\s+else\b",
+    re.I,
+)
 
 
 @dataclass(frozen=True)
@@ -446,12 +521,30 @@ def _situation_temporal_scope(text: str) -> Tuple[str, str]:
 
 def _situation_event_relation(
     *,
+    current_text: str,
     moment_situation_state: str,
     moment_topic_coherent: bool,
     moment_participant_overlap: bool,
     phase: str,
 ) -> str:
     state = str(moment_situation_state or "none").strip().lower()
+    text = str(current_text or "")
+    if _SITUATION_EXPLICIT_NEW_EVENT_RE.search(text):
+        return (
+            "new_event_same_participant"
+            if moment_participant_overlap
+            else "new_event_or_uncertain"
+        )
+    if _SITUATION_CONCURRENT_RE.search(text):
+        return "concurrent_activity"
+    if _SITUATION_PARTICIPANT_CHANGE_RE.search(text):
+        return "comparison_or_participant_change"
+    if _SITUATION_EXPLICIT_RESUME_RE.search(text):
+        return (
+            "resume"
+            if state not in {"", "none"} and moment_topic_coherent
+            else "resume_unresolved"
+        )
     if state in {"", "none"}:
         return "uncertain"
     if "reopen" in state or "resume" in state:
@@ -600,11 +693,15 @@ def build_situation_frame_v1(
         competing.append("route_policy_block")
 
     event_relation = _situation_event_relation(
+        current_text=text,
         moment_situation_state=moment_situation_state,
         moment_topic_coherent=bool(moment_topic_coherent),
         moment_participant_overlap=bool(moment_participant_overlap),
         phase=phase,
     )
+    if event_relation == "resume_unresolved":
+        ambiguity.append("resume_target_unresolved")
+        competing.append("resume_episode_candidates")
     task_kind = _situation_task_kind(
         phase=phase,
         object_kind=object_kind,

--- a/docs/one_packet_convergence_v1.md
+++ b/docs/one_packet_convergence_v1.md
@@ -1,6 +1,6 @@
 # One-Packet Convergence v1
 
-`unified_intelligence_packet_v6` is the single factual owner for gated broad
+`unified_intelligence_packet_v7` is the single factual owner for gated broad
 self-profile synthesis and shadow/private ordinary-turn preview. It consumes
 the immutable Situation Frame revision and resolves one governed subject
 before source scoring. It normalizes four canon statuses without moving their
@@ -12,6 +12,26 @@ source authority:
 - Living claims require the complete recurrence, grouping, root, occurrence,
   lifecycle, visibility, and route contract.
 - Open Signal remains question-scoped and source-bound.
+
+Situation-aware event questions use a bounded `episode` lane over the current
+Moment window/episode owner. The adapter applies the immutable frame's event,
+task, phase, participant, correction, and currentness decision before scoring.
+It supports source-backed next/open/change/correction/retest/completion reads,
+unique delayed or explicit public-channel continuation, and concurrent or
+participant-change scenes. A new-event frame cannot leak the older episode;
+an unresolved or multiply matching resume fails closed. Episode text is a
+paraphrase projection, retains original human root/occurrence lineage, and is
+revalidated against the exact Moment, episode link, visibility, lifecycle,
+and source state before use.
+
+Explicit recurring-theme questions use a bounded `recurring_theme` lane over
+the existing Living recurrence proof. An established theme requires at least
+two independent eligible human roots across two independent occurrences;
+overlapping exchange/Moment representations count once, and a correction
+requires fresh recurrence. One occurrence may appear only in sealed preview,
+with an explicit `single_occurrence_not_recurrence` qualifier, and is never
+public or canon. Journal, Relay, Ambient, dossier, site, derived summary, and
+prior BNL prose remain projections and contribute zero independent recurrence.
 
 Member-specific `approved_fact`, Living, conversation, and Open evidence is
 ranked before additive project canon. Render-equivalent projections collapse
@@ -39,4 +59,5 @@ existing exclusion and root-collapse reasons.
 
 All gates remain default-off. This version performs no deployment, historical
 promotion, live activation, member-facing correction inference, or knowledge
-edit/delete function.
+edit/delete function. It does not change Journal or Relay generation,
+publication, scheduling, or lifecycle behavior.

--- a/tests/test_governed_subject_packet_v6.py
+++ b/tests/test_governed_subject_packet_v6.py
@@ -134,8 +134,8 @@ class GovernedSubjectPacketV6Tests(unittest.TestCase):
             reason="governed subject test binding",
         )
 
-    def test_packet_schema_is_v6_and_alias_matrix_stays_distinct(self):
-        self.assertEqual(SCHEMA_VERSION, "unified_intelligence_packet_v6")
+    def test_packet_schema_is_v7_and_alias_matrix_stays_distinct(self):
+        self.assertEqual(SCHEMA_VERSION, "unified_intelligence_packet_v7")
         cases = {
             "Who is Mac Mod3m?": ("mac_modem",),
             "Tell me about DJ Floppy Disc.": ("dj_floppydisc",),

--- a/tests/test_moment_episode_lifecycle_v2.py
+++ b/tests/test_moment_episode_lifecycle_v2.py
@@ -245,6 +245,124 @@ class MomentEpisodeLifecycleV2Tests(unittest.TestCase):
             1,
         )
 
+    def test_situation_reader_selects_next_phase_and_closed_open_loop(self):
+        first_moment, _ = self.finalize_shared_moment(
+            120,
+            (
+                "Let's build the synth routing and test the chorus",
+                "The synth drum patch can answer the bass",
+                "Which synth layer remains open?",
+            ),
+            users=(1, 2, 3),
+        )
+        second_moment, _ = self.finalize_shared_moment(
+            130,
+            (
+                "The synth bass routing now uses the warmer patch",
+                "Let's test the synth chorus routing again",
+                "The synth routing test passed and this is complete",
+            ),
+            minutes=10,
+            users=(1, 2, 3),
+        )
+
+        rows = moments.select_situation_aware_episode_gists(
+            self.conn,
+            guild_id=1,
+            topic_text="What happened next with the synth chorus?",
+            frame_event_ref=first_moment,
+            frame_event_relation="same_event_new_phase",
+            frame_phase="diagnosis",
+            broad_recall=True,
+            allowed_channel_policies=("public_home",),
+            max_results=4,
+        )
+        self.assertEqual(tuple(row.moment_id for row in rows), (second_moment,))
+        self.assertEqual(rows[0].sequence_index, 1)
+        self.assertIn("retest", rows[0].semantic_types)
+        self.assertIn("outcome", rows[0].semantic_types)
+        self.assertEqual(rows[0].episode_lifecycle, "finalized")
+        self.assertEqual(rows[0].event_relation, "same_event_new_phase")
+
+        open_rows = moments.select_situation_aware_episode_gists(
+            self.conn,
+            guild_id=1,
+            topic_text="What remains open with the synth chorus?",
+            frame_event_ref=second_moment,
+            frame_event_relation="same_event",
+            frame_phase="diagnosis",
+            broad_recall=True,
+            allowed_channel_policies=("public_home",),
+            max_results=4,
+        )
+        self.assertEqual(open_rows, ())
+        new_event_rows = moments.select_situation_aware_episode_gists(
+            self.conn,
+            guild_id=1,
+            topic_text="This is a different synth failure.",
+            frame_event_ref=second_moment,
+            frame_event_relation="new_event_same_participant",
+            frame_phase="failure",
+            broad_recall=True,
+            allowed_channel_policies=("public_home",),
+            max_results=4,
+        )
+        self.assertEqual(new_event_rows, ())
+
+    def test_correction_retest_reader_uses_only_fresh_episode(self):
+        first_moment, _ = self.finalize_shared_moment(
+            140,
+            (
+                "Let's build the synth routing and test the chorus",
+                "The synth drum patch can answer the bass",
+                "Which synth layer remains open?",
+            ),
+            users=(1, 2, 3),
+        )
+        corrected_moment, _ = self.finalize_shared_moment(
+            150,
+            (
+                "Actually the synth bass routing uses the warmer patch",
+                "Let's test the synth chorus routing again",
+                "The synth routing test passed and this is done",
+            ),
+            minutes=10,
+            users=(1, 2, 3),
+        )
+        self.assertEqual(
+            self.conn.execute(
+                """
+                SELECT lifecycle_status FROM memory_moment_windows
+                WHERE moment_id=?
+                """,
+                (first_moment,),
+            ).fetchone()[0],
+            "needs_review",
+        )
+
+        for query, phase, semantic_type in (
+            ("What changed with the synth routing?", "correction", "correction"),
+            ("What was retested with the synth routing?", "retest", "retest"),
+            ("What was completed with the synth routing?", "completion", "outcome"),
+        ):
+            with self.subTest(query=query):
+                rows = moments.select_situation_aware_episode_gists(
+                    self.conn,
+                    guild_id=1,
+                    topic_text=query,
+                    frame_event_ref=corrected_moment,
+                    frame_event_relation="same_event_new_phase",
+                    frame_phase=phase,
+                    broad_recall=True,
+                    allowed_channel_policies=("public_home",),
+                    max_results=4,
+                )
+                self.assertEqual(
+                    tuple(row.moment_id for row in rows),
+                    (corrected_moment,),
+                )
+                self.assertIn(semantic_type, rows[0].semantic_types)
+
     def test_topic_change_splits_and_preserves_interruption_lineage(self):
         self.finalize_shared_moment(
             200,
@@ -424,6 +542,91 @@ class MomentEpisodeLifecycleV2Tests(unittest.TestCase):
                 """
             ).fetchone()[0],
             1,
+        )
+
+    def test_delayed_and_explicit_cross_channel_resume_are_source_bounded(self):
+        moment_id, _ = self.finalize_shared_moment(
+            430,
+            (
+                "The synth routing should keep the chorus wide",
+                "The synth drum patch can answer the bass",
+                "Which synth layer should we revisit?",
+            ),
+        )
+        before = self.conn.total_changes
+        delayed = moments.recent_moment_situation_for_assessment(
+            self.conn,
+            guild_id=1,
+            channel_id=10,
+            channel_policy="public_home",
+            route_mode="normal_chat",
+            topic_text="Delayed reply: let's continue the synth routing.",
+            participant_keys=("discord_user:1",),
+            now=self.timestamp(hours=48),
+        )
+        self.assertIsNotNone(delayed)
+        self.assertEqual(delayed.moment_id, moment_id)
+        self.assertEqual(delayed.selection_reason, "explicit_delayed_resume")
+        self.assertFalse(delayed.cross_channel_continuation)
+
+        cross_channel = moments.recent_moment_situation_for_assessment(
+            self.conn,
+            guild_id=1,
+            channel_id=99,
+            channel_policy="public_home",
+            route_mode="normal_chat",
+            topic_text="Let's continue the synth routing from <#10>.",
+            participant_keys=("discord_user:1",),
+            now=self.timestamp(hours=48),
+        )
+        self.assertIsNotNone(cross_channel)
+        self.assertEqual(cross_channel.moment_id, moment_id)
+        self.assertEqual(cross_channel.source_channel_id, 10)
+        self.assertTrue(cross_channel.cross_channel_continuation)
+        self.assertEqual(
+            cross_channel.selection_reason,
+            "explicit_cross_channel_resume",
+        )
+        self.assertEqual(self.conn.total_changes, before)
+
+    def test_situation_reader_rejects_ambiguous_delayed_resume(self):
+        self.finalize_shared_moment(
+            470,
+            (
+                "The synth routing should keep the chorus wide",
+                "The synth drum patch can answer the bass",
+                "Which synth layer should we revisit?",
+            ),
+        )
+        moments.sweep_expired_episodes(
+            self.conn,
+            now=self.timestamp(hours=25),
+        )
+        self.finalize_shared_moment(
+            480,
+            (
+                "The synth routing has a warmer chorus shape",
+                "The synth drum patch follows the bass",
+                "The synth layer needs another test",
+            ),
+            hours=48,
+        )
+        moments.sweep_expired_episodes(
+            self.conn,
+            now=self.timestamp(hours=73),
+        )
+
+        self.assertIsNone(
+            moments.recent_moment_situation_for_assessment(
+                self.conn,
+                guild_id=1,
+                channel_id=10,
+                channel_policy="public_home",
+                route_mode="normal_chat",
+                topic_text="Coming back to this: continue the synth routing.",
+                participant_keys=("discord_user:1",),
+                now=self.timestamp(hours=96),
+            )
         )
 
     def test_explicit_unique_related_source_links_distinct_episodes(self):

--- a/tests/test_situation_frame_v1.py
+++ b/tests/test_situation_frame_v1.py
@@ -169,6 +169,64 @@ class SituationFrameV1Tests(unittest.TestCase):
         self.assertEqual(blocked.status, "blocked")
         self.assertEqual(blocked.visibility_allowance, "blocked")
 
+    def test_scene_transition_language_is_typed_without_guessing(self):
+        base = {
+            "route_allowed": True,
+            "route_mode": "normal_chat",
+            "conversation_surface": "public_home",
+            "channel_policy": "public_home",
+            "current_speaker_user_ids": (101,),
+            "subject_user_ids": (101,),
+            "moment_id": "moment_test_01",
+            "moment_situation_state": "recent_active",
+            "moment_topic_coherent": True,
+            "moment_participant_overlap": True,
+            "response_act": "answer",
+        }
+        cases = (
+            (
+                "This is another failure, not the same incident.",
+                "new_event_same_participant",
+            ),
+            (
+                "Meanwhile, keep the synth retest running in parallel.",
+                "concurrent_activity",
+            ),
+            (
+                "A different participant is handling the synth retest.",
+                "comparison_or_participant_change",
+            ),
+            (
+                "Correction: use the warmer synth patch instead.",
+                "same_event_new_phase",
+            ),
+        )
+        for text, expected in cases:
+            with self.subTest(text=text):
+                frame = build_situation_frame_v1(
+                    current_text=text,
+                    **base,
+                )
+                self.assertEqual(frame.event_relation, expected)
+
+        unresolved = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text="Coming back to this: continue the synth retest.",
+            current_speaker_user_ids=(101,),
+            subject_user_ids=(101,),
+            moment_situation_state="none",
+            moment_topic_coherent=False,
+            moment_participant_overlap=False,
+            response_act="answer",
+        )
+        self.assertEqual(unresolved.event_relation, "resume_unresolved")
+        self.assertEqual(unresolved.status, "ambiguous")
+        self.assertIn("resume_target_unresolved", unresolved.ambiguity_reasons)
+        self.assertIn("resume_episode_candidates", unresolved.competing_frames)
+
     def test_revalidation_is_separate_and_fails_closed_by_state(self):
         frame = build_situation_frame_v1(
             route_allowed=True,

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -20,6 +20,7 @@ from bnl_shared_brain_synthesis import render_packet_context
 from bnl_unified_intelligence_packet import (
     IntelligencePacketRequest,
     PacketConversationEvidence,
+    PacketFrameSubject,
     _safe_atomic_supporting_observation,
     build_evaluation_report,
     build_packet,
@@ -249,6 +250,57 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
         self.assertIsNotNone(row)
         return str(row[0]), living_flags
 
+    def add_provisional_living(self, *, row_id=1101):
+        living_flags = dict(self.flags)
+        living_flags[ledger.LIVING_CANON_V1_FORMATION_ENV] = "true"
+        text = (
+            "I tune ceramic antennas with copper meshes during "
+            "field experiments."
+        )
+        observed_at = "2026-07-20T10:00:00+00:00"
+        self.conn.execute(
+            """
+            INSERT INTO conversations(
+                id,guild_id,user_id,user_name,role,content,channel_id,
+                channel_policy,route_mode,timestamp
+            ) VALUES(?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                row_id,
+                1,
+                7,
+                "Test Member",
+                "user",
+                text,
+                10,
+                "public_home",
+                "normal_chat",
+                observed_at,
+            ),
+        )
+        root = ledger.shadow_conversation_row(
+            self.conn,
+            row_id=row_id,
+            user_id=7,
+            user_name="Test Member",
+            guild_id=1,
+            role="user",
+            content=text,
+            channel_name="barcode-bot",
+            channel_policy="public_home",
+            channel_id=10,
+            route_mode="normal_chat",
+            observed_at=observed_at,
+            environ=living_flags,
+        ).entry_id
+        formed = ledger.form_atomic_candidates_from_recurring_conversation(
+            self.conn,
+            trigger_entry_id=root,
+            environ=living_flags,
+        )
+        self.assertEqual(len(formed), 1)
+        return formed[0].candidate_id, living_flags
+
     def add_public_moment(self):
         base = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
         messages = (
@@ -289,6 +341,58 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
         ).fetchone()
         self.assertIsNotNone(row)
         return row[0]
+
+    def add_followup_public_moment(self):
+        base = datetime(2026, 7, 25, 12, 4, tzinfo=timezone.utc)
+        messages = (
+            (
+                210,
+                8,
+                "Test Member Two",
+                "The synth chorus now uses the warmer bass patch.",
+            ),
+            (
+                211,
+                9,
+                "Test Member Three",
+                "We decided the drum response should stay narrow.",
+            ),
+            (
+                212,
+                8,
+                "Test Member Two",
+                "The final synth balance still needs a retest.",
+            ),
+        )
+        for offset, (row_id, user_id, name, text) in enumerate(messages):
+            result = ledger.shadow_conversation_row(
+                self.conn,
+                row_id=row_id,
+                user_id=user_id,
+                user_name=name,
+                guild_id=1,
+                role="user",
+                content=text,
+                channel_policy="public_home",
+                channel_id=10,
+                channel_name="barcode-bot",
+                route_mode="normal_chat",
+                observed_at=(base + timedelta(seconds=offset)).isoformat(),
+            )
+            moments.observe_ledger_entry(self.conn, result.entry_id)
+        moments.sweep_expired_windows(
+            self.conn,
+            now=(base + timedelta(minutes=3)).isoformat(),
+        )
+        row = self.conn.execute(
+            """
+            SELECT moment_id FROM memory_moment_windows
+            WHERE lifecycle_status='finalized'
+            ORDER BY last_activity_at DESC,moment_id LIMIT 1
+            """
+        ).fetchone()
+        self.assertIsNotNone(row)
+        return str(row[0])
 
     def add_relationship_state(self):
         event_id = relationships.observe_message(
@@ -1441,6 +1545,212 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
         )
         self.assertEqual(packet.diagnostics.revalidation_status, "passed")
         self.assertFalse(packet.diagnostics.invalid_invariants)
+
+    def test_recurring_theme_lane_requires_independent_living_recurrence(self):
+        candidate_id, living_flags = self.add_established_living()
+        request = replace(
+            self.public_request(
+                text="BNL, what recurring themes keep coming up for me?"
+            ),
+            frame_schema_version="situation_frame_v1",
+            frame_revision="sf_theme_established",
+            frame_input_evidence_digest="a" * 64,
+            frame_status="resolved",
+            frame_subject_requirement="required",
+            frame_subjects=(
+                PacketFrameSubject(
+                    user_id=7,
+                    binding_method="existing_typed_target",
+                    confidence="high",
+                ),
+            ),
+        )
+
+        packet = build_packet(
+            self.conn,
+            request,
+            persist=True,
+            environ=living_flags,
+        )
+
+        item = next(
+            item
+            for item in packet.items
+            if item.source_ref == f"atomic:{candidate_id}"
+        )
+        self.assertEqual(item.lane, "recurring_theme")
+        self.assertEqual(item.usage, "established_recurrence")
+        self.assertEqual(
+            item.uncertainty_status,
+            "independent_recurrence_established",
+        )
+        self.assertGreaterEqual(len(item.root_identities), 2)
+        self.assertGreaterEqual(len(item.occurrence_identities), 2)
+        self.assertEqual(packet.diagnostics.theme_query_status, "established")
+        report = build_evaluation_report(self.conn, guild_id=1)
+        self.assertEqual(report["themeQueryStatusCounts"], {"established": 1})
+        self.assertGreaterEqual(report["themeIndependentRootTotal"], 2)
+        self.assertGreaterEqual(report["themeIndependentOccurrenceTotal"], 2)
+        self.assertEqual(report["contentFieldsPresent"], [])
+        rendered, _counts, _used, _digests = render_packet_context(packet)
+        self.assertIn(
+            "two or more independent roots and occurrences; "
+            "revisable pattern",
+            rendered,
+        )
+        self.assertEqual(
+            revalidate_packet(
+                self.conn,
+                packet,
+                environ=living_flags,
+            ).status,
+            "passed",
+        )
+
+        corrected = build_packet(
+            self.conn,
+            replace(
+                request,
+                user_text=(
+                    "Correction: ceramic antennas are not a recurring theme "
+                    "for me. What keeps recurring?"
+                ),
+            ),
+            persist=False,
+            environ=living_flags,
+        )
+        self.assertFalse(
+            any(item.lane == "recurring_theme" for item in corrected.items)
+        )
+        self.assertGreaterEqual(
+            corrected.diagnostics.excluded_by_reason.get(
+                "current_turn_correction_precedence",
+                0,
+            ),
+            1,
+        )
+
+    def test_single_occurrence_theme_is_uncertain_and_sealed_only(self):
+        candidate_id, living_flags = self.add_provisional_living()
+        frame = {
+            "frame_schema_version": "situation_frame_v1",
+            "frame_revision": "sf_theme_provisional",
+            "frame_input_evidence_digest": "b" * 64,
+            "frame_status": "resolved",
+            "frame_subject_requirement": "required",
+            "frame_subjects": (
+                PacketFrameSubject(
+                    user_id=7,
+                    binding_method="existing_typed_target",
+                    confidence="high",
+                ),
+            ),
+        }
+        sealed_request = replace(
+            self.public_request(
+                text="BNL, what recurring themes keep coming up for me?"
+            ),
+            channel_policy="sealed_test",
+            visibility_allowance="sealed_test",
+            **frame,
+        )
+        packet = build_packet(
+            self.conn,
+            sealed_request,
+            persist=False,
+            environ=living_flags,
+        )
+
+        item = next(
+            item
+            for item in packet.items
+            if item.source_ref == f"atomic:{candidate_id}"
+        )
+        self.assertEqual(item.lane, "recurring_theme")
+        self.assertEqual(item.usage, "provisional_single_occurrence")
+        self.assertEqual(item.uncertainty_status, "single_occurrence_not_recurrence")
+        self.assertEqual(len(item.occurrence_identities), 1)
+        self.assertFalse(item.canon_status)
+        rendered, _counts, _used, _digests = render_packet_context(packet)
+        self.assertIn(
+            "one occurrence only; not established recurrence",
+            rendered,
+        )
+
+        public_packet = build_packet(
+            self.conn,
+            replace(
+                sealed_request,
+                channel_policy="public_home",
+                visibility_allowance="public_safe",
+            ),
+            persist=False,
+            environ=living_flags,
+        )
+        self.assertFalse(
+            any(item.lane == "recurring_theme" for item in public_packet.items)
+        )
+        self.assertEqual(
+            public_packet.diagnostics.theme_query_status,
+            "no_authoritative_theme",
+        )
+
+    def test_frame_bound_episode_lane_selects_next_and_revalidates_sources(self):
+        first_moment = self.add_public_moment()
+        second_moment = self.add_followup_public_moment()
+        request = replace(
+            self.public_request(
+                text="BNL, what happened next with the synth chorus?"
+            ),
+            frame_schema_version="situation_frame_v1",
+            frame_revision="sf_episode_next",
+            frame_input_evidence_digest="c" * 64,
+            frame_status="resolved",
+            frame_subject_requirement="not_applicable",
+            frame_event_ref=first_moment,
+            frame_event_relation="same_event",
+            frame_task_kind="diagnosis",
+            frame_object_kind="moment",
+            frame_phase="diagnosis",
+        )
+        packet = build_packet(self.conn, request, environ=self.flags)
+
+        episodes = tuple(
+            item for item in packet.items if item.lane == "episode"
+        )
+        self.assertEqual(len(episodes), 1)
+        item = episodes[0]
+        self.assertEqual(item.event_ref, second_moment)
+        self.assertEqual(item.event_relation, "same_event_new_phase")
+        self.assertEqual(item.uncertainty_status, "source_backed_episode")
+        self.assertTrue(item.root_identities)
+        self.assertTrue(item.occurrence_identities)
+        self.assertEqual(packet.diagnostics.episode_query_status, "selected")
+        rendered, _counts, _used, _digests = render_packet_context(packet)
+        self.assertIn("frame-bound; paraphrase only", rendered)
+        report = build_evaluation_report(self.conn, guild_id=1)
+        self.assertEqual(report["episodeQueryStatusCounts"], {"selected": 1})
+        self.assertEqual(report["episodeCandidateTotal"], 1)
+        self.assertEqual(report["contentFieldsPresent"], [])
+
+        root = self.conn.execute(
+            """
+            SELECT ledger_entry_id FROM memory_moment_members
+            WHERE moment_id=? ORDER BY source_sequence LIMIT 1
+            """,
+            (second_moment,),
+        ).fetchone()[0]
+        self.conn.execute(
+            """
+            UPDATE memory_ledger_entries SET lifecycle_status='retracted'
+            WHERE entry_id=?
+            """,
+            (root,),
+        )
+        result = revalidate_packet(self.conn, packet, environ=self.flags)
+        self.assertFalse(result.valid)
+        self.assertEqual(result.status, "source_changed")
+        self.assertGreaterEqual(result.changed_source_count, 1)
 
     def test_authorized_declared_member_claim_converges_as_subject_fact(self):
         self.add_conversation_context_row()


### PR DESCRIPTION
## Summary

- add a Situation Frame-bound episode lane for what happened, resumed, changed, completed, or remains open
- add a bounded recurring-theme lane backed by the existing Living recurrence proof, with single-occurrence output restricted to sealed tests
- fail closed on ambiguous resume targets, source/lifecycle mutation, correction without fresh recurrence, and derived projection roots
- extend packet diagnostics, content-free receipts, synthesis qualifiers, and the convergence contract without changing Journal or Relay publication behavior

## Verification

- `PYTHONPATH=/tmp/bnl-python-deps-20260809 make check PYTHON=python`
- 2,173 tests passed
- `git diff --check`
- privacy scan contains only neutral Test Member fixtures
- memory, Relationship, Active Engagement, and publication/live gates remain off

All runtime influence remains behind the existing shadow/sealed configuration.