### PR TITLE
Add canonical Journal and accepted Relay read adapters

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -196,6 +196,7 @@ from bnl_unified_response_assessment import (
 )
 from bnl_journal import (
     JOURNAL_ROUTE,
+    JournalControlSnapshot,
     ensure_schema as ensure_journal_schema,
     approve_draft as approve_journal_draft,
     deliver_approved as deliver_approved_journal,
@@ -206,6 +207,8 @@ from bnl_journal import (
     regenerate_draft as regenerate_journal_draft,
     rehydrate_published_entries as rehydrate_published_journal_entries,
     reject_draft as reject_journal_draft,
+    journal_publication_query_mode,
+    parse_journal_control_snapshot,
 )
 from bnl_journal_source_store import (
     ensure_schema as ensure_journal_source_schema,
@@ -7449,7 +7452,12 @@ def _journal_control_url() -> str:
     return f"{base}/api/bnl/journal/control" if base else ""
 
 
-def _journal_control_request_sync(method: str, payload: dict | None = None) -> tuple[dict | None, str]:
+def _journal_control_request_sync(
+    method: str,
+    payload: dict | None = None,
+    *,
+    timeout_seconds: float = 10.0,
+) -> tuple[dict | None, str]:
     """Read or update the website control plane without making it a runtime dependency."""
     url = _journal_control_url()
     if not url or not BNL_API_KEY:
@@ -7461,7 +7469,10 @@ def _journal_control_request_sync(method: str, payload: dict | None = None) -> t
         headers["Content-Type"] = "application/json"
     request = urllib.request.Request(url, data=body, method=method.upper(), headers=headers)
     try:
-        with urllib.request.urlopen(request, timeout=10) as response:
+        with urllib.request.urlopen(
+            request,
+            timeout=max(0.25, min(float(timeout_seconds or 10.0), 10.0)),
+        ) as response:
             status = int(getattr(response, "status", None) or response.getcode())
             raw = response.read().decode("utf-8", errors="replace")
             data = json.loads(raw) if raw else {}
@@ -7472,6 +7483,27 @@ def _journal_control_request_sync(method: str, payload: dict | None = None) -> t
         return None, f"control_plane_http_{int(exc.code or 0)}"
     except Exception as exc:
         return None, f"control_plane_{type(exc).__name__.lower()}"
+
+
+def _journal_publication_control_snapshot_sync(
+    *,
+    now: str = "",
+) -> tuple[JournalControlSnapshot | None, str]:
+    """Fetch one fresh, authenticated visibility/reuse authority snapshot."""
+
+    control, reason = _journal_control_request_sync(
+        "GET",
+        timeout_seconds=1.5,
+    )
+    if control is None:
+        return None, reason or "control_snapshot_unavailable"
+    snapshot, parse_reason = parse_journal_control_snapshot(
+        control,
+        now=now or None,
+    )
+    if snapshot is None:
+        return None, parse_reason or "control_snapshot_invalid"
+    return snapshot, "valid"
 
 
 def _journal_control_flags(control: dict | None, fallback: dict) -> dict:
@@ -23467,6 +23499,13 @@ def _build_unified_intelligence_packet_shadow(
     shared_brain_configuration = (
         shared_brain_synthesis_canary_configuration()
     )
+    journal_control_snapshot: JournalControlSnapshot | None = None
+    journal_control_status = "not_requested"
+    if journal_publication_query_mode(current_text) != "not_requested":
+        (
+            journal_control_snapshot,
+            journal_control_status,
+        ) = _journal_publication_control_snapshot_sync()
     request = IntelligencePacketRequest(
         guild_id=int(guild_id or 0),
         subject_user_id=int(subject_user_id or 0),
@@ -23564,6 +23603,8 @@ def _build_unified_intelligence_packet_shadow(
             if isinstance(situation_frame, SituationFrameV1)
             else "unknown"
         ),
+        journal_control_snapshot=journal_control_snapshot,
+        journal_control_status=journal_control_status,
     )
     try:
         with sqlite3.connect(DB_FILE, timeout=0.25) as packet_conn:
@@ -24654,16 +24695,43 @@ def build_batch_moment_prompt_source_basis(
     )
 
 
+def _shared_brain_journal_revalidation_snapshot(
+    basis: SharedBrainSynthesisBasis,
+) -> tuple[JournalControlSnapshot | None, bool]:
+    requested = bool(
+        str(
+            getattr(
+                basis.packet.diagnostics,
+                "journal_query_status",
+                "not_requested",
+            )
+            or "not_requested"
+        )
+        != "not_requested"
+    )
+    if not requested:
+        return None, False
+    snapshot, _status = _journal_publication_control_snapshot_sync()
+    # A failed fetch is still an explicitly supplied revalidation result. The
+    # packet owner will reject it instead of silently reusing the old view.
+    return snapshot, True
+
+
 def refresh_prompt_source_basis(
     basis: PromptSourceBasis,
 ) -> tuple[PromptSourceBasis, bool]:
     """Synchronously rebuild one source basis after any provider await."""
     if isinstance(basis, SharedBrainSynthesisBasis):
         try:
+            snapshot, provided = (
+                _shared_brain_journal_revalidation_snapshot(basis)
+            )
             with sqlite3.connect(DB_FILE, timeout=0.25) as synthesis_conn:
                 valid, _status = revalidate_shared_brain_synthesis_basis(
                     synthesis_conn,
                     basis,
+                    journal_control_snapshot=snapshot,
+                    journal_control_snapshot_provided=provided,
                 )
             return basis, not valid
         except (OSError, sqlite3.DatabaseError, TypeError, ValueError):
@@ -35178,6 +35246,9 @@ def _begin_shared_brain_synthesis_receipt(
     candidate_prompt_failure_reason: str = "",
     replaced_factual_context_count: int = 0,
 ):
+    journal_snapshot, journal_snapshot_provided = (
+        _shared_brain_journal_revalidation_snapshot(basis)
+    )
     with sqlite3.connect(DB_FILE, timeout=0.25) as conn:
         run = begin_shared_brain_synthesis_run(
             conn,
@@ -35190,6 +35261,10 @@ def _begin_shared_brain_synthesis_receipt(
             replaced_factual_context_count=(
                 replaced_factual_context_count
             ),
+            journal_control_snapshot=journal_snapshot,
+            journal_control_snapshot_provided=(
+                journal_snapshot_provided
+            ),
         )
         conn.commit()
         return run
@@ -35201,6 +35276,9 @@ def _evaluate_shared_brain_synthesis_receipt(
     candidate_response: str,
     candidate_generation_latency_ms: int | None = None,
 ) -> SynthesisCanaryDecision:
+    journal_snapshot, journal_snapshot_provided = (
+        _shared_brain_journal_revalidation_snapshot(run.basis)
+    )
     with sqlite3.connect(DB_FILE, timeout=0.25) as conn:
         decision = evaluate_shared_brain_synthesis_candidate(
             conn,
@@ -35209,6 +35287,10 @@ def _evaluate_shared_brain_synthesis_receipt(
             candidate_response=candidate_response,
             candidate_generation_latency_ms=(
                 candidate_generation_latency_ms
+            ),
+            journal_control_snapshot=journal_snapshot,
+            journal_control_snapshot_provided=(
+                journal_snapshot_provided
             ),
         )
         conn.commit()

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -8,7 +8,7 @@ import urllib.error
 import urllib.request
 from dataclasses import asdict, dataclass, is_dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Mapping, Optional
 
 from bnl_canon_source_contract import (
     CANON_FACTS,
@@ -34,6 +34,10 @@ STATES = {
 }
 JOURNAL_ROUTE = "bnl_journal_generation"
 JOURNAL_GENERATION_ATTEMPTS = 4
+JOURNAL_CONTROL_SNAPSHOT_VERSION = 1
+JOURNAL_PUBLICATION_READ_VERSION = "canonical_journal_publication_read_v1"
+JOURNAL_PUBLICATION_TOPIC_SCAN_LIMIT = 200
+JOURNAL_PUBLICATION_RESULT_LIMIT = 4
 # Must match the website receiver's raw UTF-8 request-body limit. The complete
 # serialized envelope is measured; article text is never truncated to fit it.
 JOURNAL_SITE_REQUEST_BODY_MAX_BYTES = 24_000
@@ -240,6 +244,59 @@ class JournalResult:
     idempotent: bool = False
 
 
+@dataclass(frozen=True)
+class JournalControlSnapshot:
+    """Content-free site authority used by conversational Journal reads."""
+
+    snapshot_version: int
+    revision: str
+    digest: str
+    observed_at: str
+    fresh_until: str
+    fresh_for_seconds: int
+    public_excluded_entry_ids: tuple[str, ...] = ()
+    memory_excluded_entry_ids: tuple[str, ...] = ()
+
+    @property
+    def authority_identity(self) -> tuple[Any, ...]:
+        # Observation time moves on every authenticated GET. The control
+        # revision, digest, and exact exclusion sets identify authoritative
+        # state; freshness is checked independently at every use.
+        return (
+            self.snapshot_version,
+            self.revision,
+            self.digest,
+            self.public_excluded_entry_ids,
+            self.memory_excluded_entry_ids,
+        )
+
+
+@dataclass(frozen=True)
+class JournalPublication:
+    entry_id: str
+    revision: int
+    title: str
+    excerpt: str
+    sections_json: str
+    content_hash: str
+    published_at: str
+    created_at: str
+    source_window_start: str
+    source_window_end: str
+    query_mode: str
+    source_digest: str
+
+
+@dataclass(frozen=True)
+class JournalPublicationSelection:
+    status: str
+    query_mode: str
+    publications: tuple[JournalPublication, ...] = ()
+    candidate_count: int = 0
+    public_hidden_count: int = 0
+    memory_ineligible_count: int = 0
+
+
 def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -281,6 +338,594 @@ def ensure_schema(db_path: str) -> None:
 
 def table_exists(conn: sqlite3.Connection, name: str) -> bool:
     return bool(conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)).fetchone())
+
+
+_JOURNAL_CONTROL_ENTRY_ID_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$"
+)
+_JOURNAL_PUBLICATION_ID_RE = re.compile(
+    r"\bjournal_[A-Za-z0-9._:-]{3,159}\b",
+    re.IGNORECASE,
+)
+_JOURNAL_EXPLICIT_ENTRY_ID_RE = re.compile(
+    r"\b(?:journal\s+)?entry(?:\s+id)?\s*[:#=-]?\s*"
+    r"([A-Za-z0-9][A-Za-z0-9._:-]{2,159})\b",
+    re.IGNORECASE,
+)
+_JOURNAL_QUERY_CUE_RE = re.compile(
+    r"\b(?:journal|daily\s+entry|weekly\s+entry)\b",
+    re.IGNORECASE,
+)
+_JOURNAL_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})\b")
+_JOURNAL_QUERY_STOPWORDS = _CONTEXT_TOPIC_STOPWORDS | {
+    "article",
+    "called",
+    "dated",
+    "entry",
+    "find",
+    "history",
+    "latest",
+    "published",
+    "publishing",
+    "recent",
+    "show",
+    "title",
+    "titled",
+    "what",
+    "wrote",
+}
+
+
+def _publication_utc(value: Any) -> Optional[datetime]:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(
+            raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+        )
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _publication_now(value: Any = None) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    return _publication_utc(value) or datetime.now(timezone.utc)
+
+
+def _control_entry_ids(value: Any) -> Optional[tuple[str, ...]]:
+    if not isinstance(value, list) or len(value) > 20_000:
+        return None
+    items: list[str] = []
+    for candidate in value:
+        if not isinstance(candidate, str):
+            return None
+        entry_id = candidate.strip()
+        if not _JOURNAL_CONTROL_ENTRY_ID_RE.fullmatch(entry_id):
+            return None
+        items.append(entry_id)
+    if len(items) != len(set(items)):
+        return None
+    return tuple(sorted(items))
+
+
+def parse_journal_control_snapshot(
+    payload: Mapping[str, Any] | None,
+    *,
+    now: Any = None,
+) -> tuple[JournalControlSnapshot | None, str]:
+    """Validate the authenticated site's content-free control snapshot."""
+
+    if not isinstance(payload, Mapping):
+        return None, "control_snapshot_unavailable"
+    if payload.get("persisted") is not True:
+        return None, "control_snapshot_unpersisted"
+    if int(payload.get("contractVersion") or 0) != 1:
+        return None, "control_contract_mismatch"
+    if (
+        int(payload.get("controlSnapshotVersion") or 0)
+        != JOURNAL_CONTROL_SNAPSHOT_VERSION
+    ):
+        return None, "control_snapshot_version_mismatch"
+    revision = str(payload.get("controlRevision") or "").strip()
+    digest = str(payload.get("controlDigest") or "").strip().lower()
+    observed_at = str(payload.get("controlObservedAt") or "").strip()
+    fresh_until = str(payload.get("controlFreshUntil") or "").strip()
+    try:
+        fresh_for_seconds = int(payload.get("controlFreshForSeconds") or 0)
+    except (TypeError, ValueError):
+        return None, "control_snapshot_invalid"
+    public_excluded = _control_entry_ids(
+        payload.get("publicExcludedEntryIds")
+    )
+    memory_excluded = _control_entry_ids(
+        payload.get("memoryExcludedEntryIds")
+    )
+    revision_time = _publication_utc(revision)
+    observed_time = _publication_utc(observed_at)
+    fresh_until_time = _publication_utc(fresh_until)
+    if (
+        revision_time is None
+        or not re.fullmatch(r"[a-f0-9]{64}", digest)
+        or observed_time is None
+        or fresh_until_time is None
+        or not 1 <= fresh_for_seconds <= 300
+        or public_excluded is None
+        or memory_excluded is None
+    ):
+        return None, "control_snapshot_invalid"
+    declared_window = (fresh_until_time - observed_time).total_seconds()
+    if not 0 < declared_window <= fresh_for_seconds + 1:
+        return None, "control_snapshot_invalid_freshness"
+    current_time = _publication_now(now)
+    if observed_time > current_time + timedelta(seconds=30):
+        return None, "control_snapshot_clock_skew"
+    if current_time > fresh_until_time:
+        return None, "control_snapshot_stale"
+    return (
+        JournalControlSnapshot(
+            snapshot_version=JOURNAL_CONTROL_SNAPSHOT_VERSION,
+            revision=revision,
+            digest=digest,
+            observed_at=observed_at,
+            fresh_until=fresh_until,
+            fresh_for_seconds=fresh_for_seconds,
+            public_excluded_entry_ids=public_excluded,
+            memory_excluded_entry_ids=memory_excluded,
+        ),
+        "",
+    )
+
+
+def journal_control_snapshot_status(
+    snapshot: JournalControlSnapshot | None,
+    *,
+    now: Any = None,
+) -> str:
+    if not isinstance(snapshot, JournalControlSnapshot):
+        return "control_snapshot_unavailable"
+    observed = _publication_utc(snapshot.observed_at)
+    fresh_until = _publication_utc(snapshot.fresh_until)
+    revision = _publication_utc(snapshot.revision)
+    if (
+        snapshot.snapshot_version != JOURNAL_CONTROL_SNAPSHOT_VERSION
+        or revision is None
+        or observed is None
+        or fresh_until is None
+        or not re.fullmatch(r"[a-f0-9]{64}", snapshot.digest)
+        or not 1 <= int(snapshot.fresh_for_seconds or 0) <= 300
+    ):
+        return "control_snapshot_invalid"
+    current = _publication_now(now)
+    if observed > current + timedelta(seconds=30):
+        return "control_snapshot_clock_skew"
+    if current > fresh_until:
+        return "control_snapshot_stale"
+    return "valid"
+
+
+def journal_publication_query_mode(user_text: str) -> str:
+    text = str(user_text or "")
+    if _JOURNAL_PUBLICATION_ID_RE.search(text):
+        return "identity"
+    explicit = _JOURNAL_EXPLICIT_ENTRY_ID_RE.search(text)
+    if explicit and explicit.group(1).lower().startswith("journal_"):
+        return "identity"
+    if not _JOURNAL_QUERY_CUE_RE.search(text):
+        return "not_requested"
+    if _JOURNAL_DATE_RE.search(text):
+        return "date"
+    return "requested"
+
+
+def _journal_query_identity(user_text: str) -> str:
+    direct = _JOURNAL_PUBLICATION_ID_RE.search(str(user_text or ""))
+    if direct:
+        return direct.group(0)
+    explicit = _JOURNAL_EXPLICIT_ENTRY_ID_RE.search(str(user_text or ""))
+    if explicit and explicit.group(1).lower().startswith("journal_"):
+        return explicit.group(1)
+    return ""
+
+
+def _journal_query_terms(user_text: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[a-z0-9]+", str(user_text or "").lower())
+        if len(token) >= 4 and token not in _JOURNAL_QUERY_STOPWORDS
+    }
+
+
+_JOURNAL_PUBLICATION_COLUMNS = (
+    "entry_id",
+    "revision",
+    "title",
+    "excerpt",
+    "sections_json",
+    "public_payload_json",
+    "canonical_payload_bytes",
+    "content_hash",
+    "published_at",
+    "created_at",
+    "source_window_start",
+    "source_window_end",
+    "authored_at",
+)
+
+
+def _latest_published_journal_rows(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    entry_id: str = "",
+    publication_date: str = "",
+    containing_title_in: str = "",
+    limit: int = JOURNAL_PUBLICATION_TOPIC_SCAN_LIMIT,
+) -> list[dict[str, Any]]:
+    if not table_exists(conn, "bnl_journal_entries"):
+        return []
+    columns = _cols(conn, "bnl_journal_entries")
+    if not set(_JOURNAL_PUBLICATION_COLUMNS).issubset(columns):
+        return []
+    where = [
+        "e.guild_id=?",
+        "e.lifecycle_state='published'",
+        "NOT EXISTS ("
+        "SELECT 1 FROM bnl_journal_entries newer "
+        "WHERE newer.guild_id=e.guild_id "
+        "AND newer.entry_id=e.entry_id "
+        "AND newer.lifecycle_state='published' "
+        "AND newer.revision>e.revision)",
+    ]
+    params: list[Any] = [int(guild_id or 0)]
+    if entry_id:
+        where.append("e.entry_id=?")
+        params.append(entry_id)
+    if publication_date:
+        where.append(
+            "SUBSTR(COALESCE(e.published_at,e.created_at),1,10)=?"
+        )
+        params.append(publication_date)
+    if containing_title_in:
+        where.append(
+            "LENGTH(TRIM(e.title))>=3 "
+            "AND INSTR(LOWER(?),LOWER(TRIM(e.title)))>0"
+        )
+        params.append(containing_title_in)
+    params.append(max(1, min(int(limit or 1), 500)))
+    rows = conn.execute(
+        "SELECT "
+        + ",".join("e." + name for name in _JOURNAL_PUBLICATION_COLUMNS)
+        + " FROM bnl_journal_entries e WHERE "
+        + " AND ".join(where)
+        + " ORDER BY COALESCE(e.published_at,e.created_at) DESC,"
+        "e.entry_id ASC,e.revision DESC LIMIT ?",
+        tuple(params),
+    ).fetchall()
+    return [dict(zip(_JOURNAL_PUBLICATION_COLUMNS, row)) for row in rows]
+
+
+def _journal_publication_digest(
+    row: Mapping[str, Any],
+    snapshot: JournalControlSnapshot,
+    query_mode: str,
+) -> str:
+    payload = {
+        "version": JOURNAL_PUBLICATION_READ_VERSION,
+        "entryId": str(row.get("entry_id") or ""),
+        "revision": int(row.get("revision") or 0),
+        "title": str(row.get("title") or ""),
+        "excerpt": str(row.get("excerpt") or ""),
+        "sectionsJson": str(row.get("sections_json") or ""),
+        "canonicalPayloadHash": canonical_payload_hash(
+            bytes(row.get("canonical_payload_bytes") or b"")
+        ),
+        "contentHash": str(row.get("content_hash") or ""),
+        "publishedAt": str(row.get("published_at") or ""),
+        "createdAt": str(row.get("created_at") or ""),
+        "sourceWindowStart": str(row.get("source_window_start") or ""),
+        "sourceWindowEnd": str(row.get("source_window_end") or ""),
+        "queryMode": str(query_mode or ""),
+        "controlAuthority": snapshot.authority_identity,
+    }
+    return hashlib.sha256(_json(payload).encode("utf-8")).hexdigest()
+
+
+def _journal_publication_from_row(
+    row: Mapping[str, Any],
+    *,
+    snapshot: JournalControlSnapshot,
+    query_mode: str,
+) -> JournalPublication | None:
+    entry_id = str(row.get("entry_id") or "").strip()
+    title = str(row.get("title") or "").strip()
+    excerpt = str(row.get("excerpt") or "").strip()
+    content_hash = str(row.get("content_hash") or "").strip()
+    sections_json = str(row.get("sections_json") or "[]")
+    canonical_payload = bytes(row.get("canonical_payload_bytes") or b"")
+    public_payload_json = str(row.get("public_payload_json") or "")
+    try:
+        sections = json.loads(sections_json)
+        canonical_object = json.loads(canonical_payload.decode("utf-8"))
+        public_payload = json.loads(public_payload_json)
+        canonical_entry = (
+            canonical_object.get("entry")
+            if isinstance(canonical_object, dict)
+            else None
+        )
+        canonical_revision = int(
+            canonical_entry.get("revision") or 0
+            if isinstance(canonical_entry, dict)
+            else 0
+        )
+    except (
+        TypeError,
+        ValueError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ):
+        return None
+    expected_content_hash = _hash(title, excerpt, _json(sections))
+    if (
+        not _JOURNAL_CONTROL_ENTRY_ID_RE.fullmatch(entry_id)
+        or not title
+        or not excerpt
+        or not re.fullmatch(r"[a-fA-F0-9]{64}", content_hash)
+        or content_hash.lower() != expected_content_hash
+        or not isinstance(sections, list)
+        or not sections
+        or any(
+            not isinstance(section, dict)
+            or not str(section.get("heading") or "").strip()
+            or not str(section.get("body") or "").strip()
+            for section in sections
+        )
+        or public_payload != canonical_object
+        or canonical_payload != _json(canonical_object).encode("utf-8")
+        or not isinstance(canonical_entry, dict)
+        or canonical_object.get("contractVersion") != 1
+        or canonical_object.get("kind") != "journal_entry"
+        or str(canonical_entry.get("entryId") or "") != entry_id
+        or canonical_revision != int(row.get("revision") or 0)
+        or str(canonical_entry.get("title") or "") != title
+        or str(canonical_entry.get("excerpt") or "") != excerpt
+        or canonical_entry.get("sections") != sections
+        or str(canonical_entry.get("contentHash") or "").lower()
+        != content_hash.lower()
+        or str(canonical_entry.get("authoredAt") or "")
+        != str(row.get("authored_at") or "")
+        or str(canonical_entry.get("sourceWindowStart") or "")
+        != str(row.get("source_window_start") or "")
+        or str(canonical_entry.get("sourceWindowEnd") or "")
+        != str(row.get("source_window_end") or "")
+    ):
+        return None
+    return JournalPublication(
+        entry_id=entry_id,
+        revision=int(row.get("revision") or 0),
+        title=title,
+        excerpt=excerpt,
+        sections_json=sections_json,
+        content_hash=content_hash.lower(),
+        published_at=str(row.get("published_at") or ""),
+        created_at=str(row.get("created_at") or ""),
+        source_window_start=str(row.get("source_window_start") or ""),
+        source_window_end=str(row.get("source_window_end") or ""),
+        query_mode=query_mode,
+        source_digest=_journal_publication_digest(
+            row,
+            snapshot,
+            query_mode,
+        ),
+    )
+
+
+def render_journal_publication(
+    publication: JournalPublication,
+    *,
+    limit: int = 1400,
+) -> str:
+    try:
+        sections = json.loads(publication.sections_json)
+    except (TypeError, json.JSONDecodeError):
+        sections = []
+    section_text = " ".join(
+        "%s: %s"
+        % (
+            re.sub(r"\s+", " ", str(section.get("heading") or "")).strip(),
+            re.sub(r"\s+", " ", str(section.get("body") or "")).strip(),
+        )
+        for section in sections
+        if isinstance(section, dict)
+    )
+    published_date = (
+        publication.published_at or publication.created_at
+    )[:10]
+    text = (
+        'Published Journal "%s" (%s; entry %s; revision %s): %s %s'
+        % (
+            publication.title,
+            published_date,
+            publication.entry_id,
+            publication.revision,
+            publication.excerpt,
+            section_text,
+        )
+    )
+    return re.sub(r"\s+", " ", text).strip()[: max(200, int(limit or 0))]
+
+
+def select_published_journal_entries_on_connection(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    user_text: str,
+    control_snapshot: JournalControlSnapshot | None,
+    now: Any = None,
+    limit: int = JOURNAL_PUBLICATION_RESULT_LIMIT,
+) -> JournalPublicationSelection:
+    requested_mode = journal_publication_query_mode(user_text)
+    if requested_mode == "not_requested":
+        return JournalPublicationSelection("not_requested", "not_requested")
+    control_status = journal_control_snapshot_status(
+        control_snapshot,
+        now=now,
+    )
+    if control_status != "valid" or control_snapshot is None:
+        return JournalPublicationSelection(control_status, requested_mode)
+    if not table_exists(conn, "bnl_journal_entries"):
+        return JournalPublicationSelection("source_unavailable", requested_mode)
+
+    identity = _journal_query_identity(user_text)
+    publication_date_match = _JOURNAL_DATE_RE.search(str(user_text or ""))
+    publication_date = (
+        publication_date_match.group(1) if publication_date_match else ""
+    )
+    if identity:
+        query_mode = "exact_identity"
+        rows = _latest_published_journal_rows(
+            conn,
+            guild_id=guild_id,
+            entry_id=identity,
+            limit=max(1, limit),
+        )
+    else:
+        title_rows = _latest_published_journal_rows(
+            conn,
+            guild_id=guild_id,
+            containing_title_in=str(user_text or ""),
+            limit=max(8, limit),
+        )
+        if title_rows:
+            query_mode = "exact_title"
+            rows = title_rows
+        elif publication_date:
+            query_mode = "exact_date"
+            rows = _latest_published_journal_rows(
+                conn,
+                guild_id=guild_id,
+                publication_date=publication_date,
+                limit=max(8, limit),
+            )
+        else:
+            query_mode = "topic"
+            rows = _latest_published_journal_rows(
+                conn,
+                guild_id=guild_id,
+                limit=JOURNAL_PUBLICATION_TOPIC_SCAN_LIMIT,
+            )
+            terms = _journal_query_terms(user_text)
+            if terms:
+                scored: list[tuple[int, str, dict[str, Any]]] = []
+                for row in rows:
+                    candidate_terms = _topic_terms(
+                        " ".join(
+                            str(row.get(key) or "")
+                            for key in ("title", "excerpt", "sections_json")
+                        )
+                    )
+                    score = len(terms & candidate_terms)
+                    if score:
+                        scored.append(
+                            (
+                                score,
+                                str(
+                                    row.get("published_at")
+                                    or row.get("created_at")
+                                    or ""
+                                ),
+                                row,
+                            )
+                        )
+                scored.sort(key=lambda item: (item[0], item[1]), reverse=True)
+                rows = [row for _score, _timestamp, row in scored]
+
+    candidate_count = len(rows)
+    public_excluded = set(control_snapshot.public_excluded_entry_ids)
+    memory_excluded = set(control_snapshot.memory_excluded_entry_ids)
+    selected: list[JournalPublication] = []
+    hidden_count = 0
+    memory_ineligible_count = 0
+    for row in rows:
+        entry_id = str(row.get("entry_id") or "")
+        if entry_id in public_excluded:
+            hidden_count += 1
+            continue
+        if query_mode == "topic" and entry_id in memory_excluded:
+            memory_ineligible_count += 1
+            continue
+        publication = _journal_publication_from_row(
+            row,
+            snapshot=control_snapshot,
+            query_mode=query_mode,
+        )
+        if publication is not None:
+            selected.append(publication)
+        if len(selected) >= max(1, min(int(limit or 1), 8)):
+            break
+    if selected:
+        status = "eligible"
+    elif hidden_count:
+        status = "public_hidden"
+    elif memory_ineligible_count:
+        status = "memory_ineligible"
+    elif candidate_count:
+        status = "source_invalid"
+    else:
+        status = "not_found"
+    return JournalPublicationSelection(
+        status=status,
+        query_mode=query_mode,
+        publications=tuple(selected),
+        candidate_count=candidate_count,
+        public_hidden_count=hidden_count,
+        memory_ineligible_count=memory_ineligible_count,
+    )
+
+
+def revalidate_published_journal_entry_on_connection(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    entry_id: str,
+    revision: int,
+    query_mode: str,
+    control_snapshot: JournalControlSnapshot | None,
+    now: Any = None,
+) -> str:
+    if (
+        journal_control_snapshot_status(control_snapshot, now=now) != "valid"
+        or control_snapshot is None
+    ):
+        return ""
+    if entry_id in set(control_snapshot.public_excluded_entry_ids):
+        return ""
+    if (
+        query_mode == "topic"
+        and entry_id in set(control_snapshot.memory_excluded_entry_ids)
+    ):
+        return ""
+    rows = _latest_published_journal_rows(
+        conn,
+        guild_id=guild_id,
+        entry_id=entry_id,
+        limit=2,
+    )
+    if len(rows) != 1 or int(rows[0].get("revision") or 0) != int(revision):
+        return ""
+    publication = _journal_publication_from_row(
+        rows[0],
+        snapshot=control_snapshot,
+        query_mode=query_mode,
+    )
+    return publication.source_digest if publication is not None else ""
 
 
 def journal_topic_counts(sources: list[dict[str, Any]], limit: int = 30) -> dict[str, int]:

--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -778,6 +778,12 @@ def _read_intelligence_packet_report(
                 "invalidInvariants": 0,
                 "revalidationStatusCounts": {},
                 "revalidationChangedRuns": 0,
+                "journalQueryStatusCounts": {},
+                "journalControlStatusCounts": {},
+                "journalCandidateTotal": 0,
+                "relayQueryStatusCounts": {},
+                "relayCandidateTotal": 0,
+                "publicationProjectionTotal": 0,
                 "promptAppliedRuns": 0,
                 "liveAppliedRuns": 0,
                 "contentFieldsPresent": [],
@@ -801,7 +807,7 @@ def _read_shared_brain_synthesis_report(
         return _report_error(
             {
                 "tablePresent": False,
-                "schemaVersion": "shared_brain_synthesis_v7",
+                "schemaVersion": "shared_brain_synthesis_v8",
                 "runs": 0,
                 "promptAppliedRuns": 0,
                 "liveAppliedRuns": 0,
@@ -1912,7 +1918,7 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             ),
         ),
         "- relationship_legacy_v2_comparison: `%s`" % relationship.get("legacy_v2_comparison", "not_collected"),
-        "- unified_intelligence_packet: status=`%s` requested=`%s` effective=`%s` reason=`%s` schema=`%s` runs=`%s` items=`%s` validation_items=`%s` lanes=`%s` validation_lanes=`%s` sources=`%s` atomic_states=`%s` missing=`%s` conflicts=`%s` revalidation=`%s` source_changes=`%s` errors=`%s` invalid_invariants=`%s` prompt_applied=`%s` live_applied=`%s` content_fields=`%s` window_last=`%s`" % (
+        "- unified_intelligence_packet: status=`%s` requested=`%s` effective=`%s` reason=`%s` schema=`%s` runs=`%s` items=`%s` validation_items=`%s` lanes=`%s` validation_lanes=`%s` sources=`%s` atomic_states=`%s` missing=`%s` conflicts=`%s` journal_query=`%s` journal_control=`%s` relay_query=`%s` publication_projections=`%s` revalidation=`%s` source_changes=`%s` errors=`%s` invalid_invariants=`%s` prompt_applied=`%s` live_applied=`%s` content_fields=`%s` window_last=`%s`" % (
             intelligence_packet_state.get(
                 "status",
                 "unknown",
@@ -1948,6 +1954,19 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
                 sort_keys=True,
             ),
             intelligence_packet.get("conflictRuns", 0),
+            json.dumps(
+                intelligence_packet.get("journalQueryStatusCounts", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                intelligence_packet.get("journalControlStatusCounts", {}),
+                sort_keys=True,
+            ),
+            json.dumps(
+                intelligence_packet.get("relayQueryStatusCounts", {}),
+                sort_keys=True,
+            ),
+            intelligence_packet.get("publicationProjectionTotal", 0),
             json.dumps(
                 intelligence_packet.get(
                     "revalidationStatusCounts",
@@ -1998,7 +2017,7 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             _on(shared_brain_synthesis_state.get("fullyScoped")),
             shared_brain_synthesis.get(
                 "schemaVersion",
-                "shared_brain_synthesis_v7",
+                "shared_brain_synthesis_v8",
             ),
             shared_brain_synthesis.get("runs", 0),
             json.dumps(

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -27,6 +27,7 @@ from bnl_memory_governance import (
     PERSONAL_RECALL_ROUTE_FAMILY,
     classify_personal_recall_intent,
 )
+from bnl_journal import JournalControlSnapshot
 from bnl_memory_ledger import (
     public_assessment_candidate_core_text,
     public_assessment_claim_compatible,
@@ -51,11 +52,11 @@ from bnl_unified_response_assessment import (
 )
 
 
-SCHEMA_VERSION = "shared_brain_synthesis_v7"
+SCHEMA_VERSION = "shared_brain_synthesis_v8"
 CAPABILITY_NAME = "shared_brain_public_broad_recall"
 CAPABILITY_CONTRACT_VERSION = "hybrid_shared_brain_v1"
 CAPABILITY_RECEIPT_VERSION = "shared_brain_capability_receipt_v1"
-_EXPECTED_PACKET_SCHEMA_VERSION = "unified_intelligence_packet_v7"
+_EXPECTED_PACKET_SCHEMA_VERSION = "unified_intelligence_packet_v8"
 _EXPECTED_CLAIM_CONTRACT_VERSION = "hybrid_canon_claim_v1"
 _EXPECTED_ASSESSMENT_VERSION = "unified_response_assessment_v7"
 _EXPECTED_IDENTITY_CONTRACT_VERSION = "canon_entity_account_binding_v1"
@@ -96,6 +97,8 @@ _RENDERABLE_LANES = {
     "recurring_theme",
     "open_loop",
     "canon",
+    "journal_publication",
+    "relay_publication",
     "source_file",
 }
 _PROFILE_MEMBER_LANES = frozenset(
@@ -139,6 +142,8 @@ _LANE_LABELS = {
     "recurring_theme": "recurring-theme evidence",
     "open_loop": "unresolved thread",
     "canon": "approved canon",
+    "journal_publication": "canonical Journal publication",
+    "relay_publication": "accepted Relay publication",
     "source_file": "authorized source context",
 }
 _CONTROL_MARKERS = (
@@ -188,6 +193,8 @@ _EVIDENCE_STOPWORDS = {
     "your",
 }
 _LANE_RENDER_PRIORITY = {
+    "journal_publication": 0,
+    "relay_publication": 0,
     "approved_fact": 0,
     "atomic_knowledge": 1,
     "recurring_theme": 1,
@@ -812,7 +819,7 @@ def _configuration_details(
         "claim_contract_version": _EXPECTED_CLAIM_CONTRACT_VERSION,
         "assessment_version": _EXPECTED_ASSESSMENT_VERSION,
         "identity_contract_version": _EXPECTED_IDENTITY_CONTRACT_VERSION,
-        "synthesis_version": "shared_brain_synthesis_v7",
+        "synthesis_version": "shared_brain_synthesis_v8",
     }
     version_conflicts = tuple(
         sorted(
@@ -1799,6 +1806,11 @@ def render_packet_context(
             )
         elif item.lane == "open_loop":
             qualifier = "; unresolved, not settled fact"
+        elif item.lane in {"journal_publication", "relay_publication"}:
+            qualifier = (
+                "; exact published prose; publication continuity only; "
+                "zero independent fact or recurrence weight"
+            )
         line = "[E%s | %s%s] %s" % (
             len(lines) + 1,
             label,
@@ -2173,6 +2185,8 @@ def revalidate_basis(
     basis: SharedBrainSynthesisBasis,
     *,
     environ: Mapping[str, str] | None = None,
+    journal_control_snapshot: JournalControlSnapshot | None = None,
+    journal_control_snapshot_provided: bool = False,
 ) -> tuple[bool, str]:
     env = os.environ if environ is None else environ
     details = _configuration_details(env)
@@ -2256,7 +2270,15 @@ def revalidate_basis(
         )
     ):
         return False, "scope_or_basis_changed"
-    result = revalidate_packet(conn, basis.packet, environ=env)
+    result = revalidate_packet(
+        conn,
+        basis.packet,
+        environ=env,
+        journal_control_snapshot=journal_control_snapshot,
+        journal_control_snapshot_provided=(
+            journal_control_snapshot_provided
+        ),
+    )
     return result.valid, result.status
 
 
@@ -4333,6 +4355,8 @@ def begin_run(
     candidate_prompt_failure_reason: str = "",
     replaced_factual_context_count: int = 0,
     environ: Mapping[str, str] | None = None,
+    journal_control_snapshot: JournalControlSnapshot | None = None,
+    journal_control_snapshot_provided: bool = False,
 ) -> SynthesisCanaryRun:
     ensure_schema(conn)
     run_id = "sbsr_" + uuid.uuid4().hex
@@ -4340,6 +4364,10 @@ def begin_run(
         conn,
         basis,
         environ=environ,
+        journal_control_snapshot=journal_control_snapshot,
+        journal_control_snapshot_provided=(
+            journal_control_snapshot_provided
+        ),
     )
     prompt_applied = bool(
         valid
@@ -4469,6 +4497,8 @@ def evaluate_candidate(
     candidate_response: str,
     candidate_generation_latency_ms: int | None = None,
     environ: Mapping[str, str] | None = None,
+    journal_control_snapshot: JournalControlSnapshot | None = None,
+    journal_control_snapshot_provided: bool = False,
 ) -> SynthesisCanaryDecision:
     baseline = str(baseline_response or "").strip()
     candidate = str(candidate_response or "").strip()
@@ -4476,6 +4506,10 @@ def evaluate_candidate(
         conn,
         run.basis,
         environ=environ,
+        journal_control_snapshot=journal_control_snapshot,
+        journal_control_snapshot_provided=(
+            journal_control_snapshot_provided
+        ),
     )
     baseline_coherence = assess_response_coherence(
         run.basis.assessment,

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -70,6 +70,13 @@ from bnl_memory_ledger import (
     select_public_conversation_assessment_evidence,
     subject_key_for_user,
 )
+from bnl_journal import (
+    JournalControlSnapshot,
+    journal_control_snapshot_status,
+    render_journal_publication,
+    revalidate_published_journal_entry_on_connection,
+    select_published_journal_entries_on_connection,
+)
 from bnl_moment_engine import (
     SITUATION_EPISODE_READ_VERSION,
     select_public_participant_moment_gists,
@@ -77,11 +84,18 @@ from bnl_moment_engine import (
 )
 from bnl_profile_points import material_profile_point_map
 from bnl_relationship_engine import shadow_packet_posture
+from bnl_website_relay_state import (
+    render_accepted_relay_publication,
+    revalidate_accepted_relay_publication_on_connection,
+    select_accepted_relay_publications_on_connection,
+)
 
 
-SCHEMA_VERSION = "unified_intelligence_packet_v7"
+SCHEMA_VERSION = "unified_intelligence_packet_v8"
 SUBJECT_RESOLUTION_VERSION = "governed_packet_subject_resolution_v1"
-SOURCE_SNAPSHOT_VERSION = "unified_packet_source_snapshot_v1"
+SOURCE_SNAPSHOT_VERSION = "unified_packet_source_snapshot_v2"
+JOURNAL_PUBLICATION_SOURCE_CLASS = "journal_publication_projection"
+RELAY_PUBLICATION_SOURCE_CLASS = "relay_publication_projection"
 TABLE_NAME = "memory_governance_intelligence_packet_runs"
 SHADOW_ENV = "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED"
 _SHADOW_PREREQUISITES = (
@@ -149,6 +163,8 @@ _LANE_CAPS = {
     "recurring_theme": 3,
     "open_loop": 3,
     "canon": 4,
+    "journal_publication": 4,
+    "relay_publication": 4,
     "source_file": 2,
     "relationship_posture": 1,
 }
@@ -176,6 +192,8 @@ _VALIDATION_SUPPORT_LANES = frozenset(
         "recurring_theme",
         "open_loop",
         "canon",
+        "journal_publication",
+        "relay_publication",
         "source_file",
     }
 )
@@ -454,6 +472,8 @@ class IntelligencePacketRequest:
     frame_phase: str = ""
     frame_temporal_scope: str = "unspecified"
     frame_currentness: str = "unknown"
+    journal_control_snapshot: JournalControlSnapshot | None = None
+    journal_control_status: str = "not_requested"
 
 
 @dataclass(frozen=True)
@@ -553,6 +573,12 @@ class IntelligencePacketDiagnostics:
     theme_query_status: str = "not_requested"
     theme_independent_root_count: int = 0
     theme_independent_occurrence_count: int = 0
+    journal_query_status: str = "not_requested"
+    journal_control_status: str = "not_requested"
+    journal_candidate_count: int = 0
+    relay_query_status: str = "not_requested"
+    relay_candidate_count: int = 0
+    publication_projection_count: int = 0
     processing_errors: list[str] = field(default_factory=list)
     invalid_invariants: list[str] = field(default_factory=list)
     revalidation_status: str = "not_evaluated"
@@ -659,6 +685,14 @@ class UnifiedIntelligencePacket:
     def canon_refs(self) -> tuple[str, ...]:
         return tuple(
             item.source_ref for item in self.items if item.lane == "canon"
+        )
+
+    @property
+    def publication_refs(self) -> tuple[str, ...]:
+        return tuple(
+            item.source_ref
+            for item in self.items
+            if item.lane in {"journal_publication", "relay_publication"}
         )
 
     @property
@@ -2017,6 +2051,21 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             "theme_independent_occurrence_count",
             "INTEGER NOT NULL DEFAULT 0",
         ),
+        (
+            "journal_query_status",
+            "TEXT NOT NULL DEFAULT 'not_requested'",
+        ),
+        (
+            "journal_control_status",
+            "TEXT NOT NULL DEFAULT 'not_requested'",
+        ),
+        ("journal_candidate_count", "INTEGER NOT NULL DEFAULT 0"),
+        (
+            "relay_query_status",
+            "TEXT NOT NULL DEFAULT 'not_requested'",
+        ),
+        ("relay_candidate_count", "INTEGER NOT NULL DEFAULT 0"),
+        ("publication_projection_count", "INTEGER NOT NULL DEFAULT 0"),
     ):
         try:
             conn.execute(
@@ -4516,6 +4565,192 @@ def _frame_allowed_canon_domains(
     return allowed
 
 
+def _publication_exclusion_reason(prefix: str, status: str) -> str:
+    safe_status = re.sub(
+        r"[^a-z0-9_]+",
+        "_",
+        str(status or "unavailable").strip().lower(),
+    ).strip("_")
+    return "%s_%s" % (prefix, safe_status or "unavailable")
+
+
+def _journal_publication_items(
+    conn: sqlite3.Connection,
+    request: IntelligencePacketRequest,
+    diagnostics: IntelligencePacketDiagnostics,
+    exclusions: list[IntelligencePacketExclusion],
+) -> list[IntelligencePacketItem]:
+    selection = select_published_journal_entries_on_connection(
+        conn,
+        guild_id=int(request.guild_id or 0),
+        user_text=request.user_text,
+        control_snapshot=request.journal_control_snapshot,
+        now=request.now or None,
+    )
+    diagnostics.journal_query_status = selection.status
+    diagnostics.journal_candidate_count = int(selection.candidate_count or 0)
+    if selection.status == "not_requested":
+        diagnostics.journal_control_status = str(
+            request.journal_control_status or "not_requested"
+        )
+        return []
+    diagnostics.journal_control_status = (
+        "valid"
+        if selection.status
+        in {
+            "eligible",
+            "not_found",
+            "public_hidden",
+            "memory_ineligible",
+            "source_invalid",
+            "source_unavailable",
+        }
+        and isinstance(request.journal_control_snapshot, JournalControlSnapshot)
+        else (
+            str(request.journal_control_status)
+            if str(request.journal_control_status or "not_requested")
+            != "not_requested"
+            else selection.status
+        )
+    )
+    if not selection.publications:
+        _add_exclusion(
+            diagnostics,
+            exclusions,
+            lane="journal_publication",
+            reason=_publication_exclusion_reason(
+                "journal",
+                selection.status,
+            ),
+            source_class=JOURNAL_PUBLICATION_SOURCE_CLASS,
+        )
+        return []
+    items: list[IntelligencePacketItem] = []
+    score_by_mode = {
+        "exact_identity": 160.0,
+        "exact_title": 155.0,
+        "exact_date": 150.0,
+        "topic": 135.0,
+    }
+    for publication in selection.publications:
+        diagnostics.candidates_by_lane["journal_publication"] = (
+            diagnostics.candidates_by_lane.get("journal_publication", 0)
+            + 1
+        )
+        items.append(
+            IntelligencePacketItem(
+                lane="journal_publication",
+                source_class=JOURNAL_PUBLICATION_SOURCE_CLASS,
+                source_type="canonical_published_journal",
+                source_ref="journal:%s:%s"
+                % (publication.entry_id, publication.revision),
+                source_digest=publication.source_digest,
+                subject_key="bnl_01",
+                predicate_key="published_journal_entry",
+                text=render_journal_publication(publication),
+                visibility="public",
+                confidence=Confidence.APPROVED.value,
+                lifecycle="published",
+                authority=0,
+                observed_at=(
+                    publication.published_at or publication.created_at
+                ),
+                usage="publication_projection",
+                score=score_by_mode.get(publication.query_mode, 130.0),
+                revalidation_kind="journal_publication",
+                revalidation_key=json.dumps(
+                    {
+                        "entryId": publication.entry_id,
+                        "revision": publication.revision,
+                        "queryMode": publication.query_mode,
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+                attribution_mode="publication_only",
+                uncertainty_status=(
+                    "derived_publication_zero_fact_weight"
+                ),
+            )
+        )
+    diagnostics.publication_projection_count += len(items)
+    return items
+
+
+def _relay_publication_items(
+    conn: sqlite3.Connection,
+    request: IntelligencePacketRequest,
+    diagnostics: IntelligencePacketDiagnostics,
+    exclusions: list[IntelligencePacketExclusion],
+) -> list[IntelligencePacketItem]:
+    selection = select_accepted_relay_publications_on_connection(
+        conn,
+        guild_id=int(request.guild_id or 0),
+        user_text=request.user_text,
+    )
+    diagnostics.relay_query_status = selection.status
+    diagnostics.relay_candidate_count = int(selection.candidate_count or 0)
+    if selection.status == "not_requested":
+        return []
+    if not selection.publications:
+        _add_exclusion(
+            diagnostics,
+            exclusions,
+            lane="relay_publication",
+            reason=_publication_exclusion_reason(
+                "relay",
+                selection.status,
+            ),
+            source_class=RELAY_PUBLICATION_SOURCE_CLASS,
+        )
+        return []
+    items: list[IntelligencePacketItem] = []
+    score_by_mode = {
+        "exact_identity": 160.0,
+        "exact_date": 150.0,
+        "topic": 135.0,
+    }
+    for publication in selection.publications:
+        diagnostics.candidates_by_lane["relay_publication"] = (
+            diagnostics.candidates_by_lane.get("relay_publication", 0)
+            + 1
+        )
+        items.append(
+            IntelligencePacketItem(
+                lane="relay_publication",
+                source_class=RELAY_PUBLICATION_SOURCE_CLASS,
+                source_type="accepted_relay_publication",
+                source_ref="relay:%s" % publication.relay_id,
+                source_digest=publication.source_digest,
+                subject_key="bnl_01",
+                predicate_key="accepted_relay_publication",
+                text=render_accepted_relay_publication(publication),
+                visibility="public",
+                confidence=Confidence.APPROVED.value,
+                lifecycle="published",
+                authority=0,
+                observed_at=publication.published_timestamp,
+                usage="publication_projection",
+                score=score_by_mode.get(publication.query_mode, 130.0),
+                revalidation_kind="relay_publication",
+                revalidation_key=json.dumps(
+                    {
+                        "relayId": publication.relay_id,
+                        "queryMode": publication.query_mode,
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+                attribution_mode="publication_only",
+                uncertainty_status=(
+                    "derived_publication_zero_fact_weight"
+                ),
+            )
+        )
+    diagnostics.publication_projection_count += len(items)
+    return items
+
+
 def _filter_frame_applicable_candidates(
     request: IntelligencePacketRequest,
     subject_resolution: PacketSubjectResolution,
@@ -4722,6 +4957,8 @@ def _select_items(
     profile_candidates: list[IntelligencePacketItem] = []
     broad_lane_priority = {
         "current_intent": 0,
+        "journal_publication": 1,
+        "relay_publication": 1,
         "approved_fact": 1,
         "recurring_theme": 2,
         "atomic_knowledge": 3,
@@ -4750,6 +4987,8 @@ def _select_items(
         )
     governed_subject_priority = {
         "current_intent": 0,
+        "journal_publication": 1,
+        "relay_publication": 1,
         "approved_fact": 1,
         "atomic_knowledge": 1,
         "recurring_theme": 1,
@@ -5521,11 +5760,21 @@ def _relationship_version(
     return str(posture.get("source_digest") or "")
 
 
+def _publication_revalidation_payload(item: IntelligencePacketItem) -> dict[str, Any]:
+    try:
+        value = json.loads(str(item.revalidation_key or "{}"))
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
 def _revalidate_packet_in_snapshot(
     conn: sqlite3.Connection,
     packet: UnifiedIntelligencePacket,
     *,
     environ: Mapping[str, str] | None = None,
+    journal_control_snapshot: JournalControlSnapshot | None = None,
+    journal_control_snapshot_provided: bool = False,
 ) -> PacketRevalidationResult:
     """Re-read every durable source without applying packet content live."""
     changed = 0
@@ -5563,6 +5812,29 @@ def _revalidate_packet_in_snapshot(
             for item in (*packet.items, *packet.validation_items)
         }.values()
     )
+    current_journal_control = (
+        journal_control_snapshot
+        if journal_control_snapshot_provided
+        else packet.request.journal_control_snapshot
+    )
+    journal_query_requested = (
+        str(packet.diagnostics.journal_query_status or "not_requested")
+        != "not_requested"
+    )
+    if journal_control_snapshot_provided and journal_query_requested:
+        original_control = packet.request.journal_control_snapshot
+        if (
+            not isinstance(original_control, JournalControlSnapshot)
+            or not isinstance(current_journal_control, JournalControlSnapshot)
+            or journal_control_snapshot_status(
+                current_journal_control,
+                now=packet.request.now or None,
+            )
+            != "valid"
+            or original_control.authority_identity
+            != current_journal_control.authority_identity
+        ):
+            changed += 1
     for item in revalidation_items:
         try:
             if item.revalidation_kind == "conversation":
@@ -5648,6 +5920,25 @@ def _revalidate_packet_in_snapshot(
                     item,
                     environ=environ,
                 )
+            elif item.revalidation_kind == "journal_publication":
+                payload = _publication_revalidation_payload(item)
+                current = revalidate_published_journal_entry_on_connection(
+                    conn,
+                    guild_id=int(packet.request.guild_id or 0),
+                    entry_id=str(payload.get("entryId") or ""),
+                    revision=int(payload.get("revision") or 0),
+                    query_mode=str(payload.get("queryMode") or ""),
+                    control_snapshot=current_journal_control,
+                    now=packet.request.now or None,
+                )
+            elif item.revalidation_kind == "relay_publication":
+                payload = _publication_revalidation_payload(item)
+                current = revalidate_accepted_relay_publication_on_connection(
+                    conn,
+                    guild_id=int(packet.request.guild_id or 0),
+                    relay_id=str(payload.get("relayId") or ""),
+                    query_mode=str(payload.get("queryMode") or ""),
+                )
             elif item.revalidation_kind in {"current", "snapshot"}:
                 current = item.revalidation_key
             else:
@@ -5685,6 +5976,8 @@ def revalidate_packet(
     packet: UnifiedIntelligencePacket,
     *,
     environ: Mapping[str, str] | None = None,
+    journal_control_snapshot: JournalControlSnapshot | None = None,
+    journal_control_snapshot_provided: bool = False,
 ) -> PacketRevalidationResult:
     """Revalidate every source against one coherent database snapshot."""
 
@@ -5696,6 +5989,10 @@ def revalidate_packet(
             conn,
             packet,
             environ=environ,
+            journal_control_snapshot=journal_control_snapshot,
+            journal_control_snapshot_provided=(
+                journal_control_snapshot_provided
+            ),
         )
     finally:
         if owns_snapshot and conn.in_transaction:
@@ -5745,6 +6042,22 @@ def _packet_invariants(
         != packet.subject_resolution.status
     ):
         invalid.append("subject_resolution_receipt_mismatch")
+    for lane, status in (
+        (
+            "journal_publication",
+            packet.diagnostics.journal_query_status,
+        ),
+        (
+            "relay_publication",
+            packet.diagnostics.relay_query_status,
+        ),
+    ):
+        if status not in {"not_requested", "eligible"}:
+            invalid.append("%s_query_failed_closed" % lane)
+        elif status == "eligible" and not any(
+            item.lane == lane for item in packet.items
+        ):
+            invalid.append("%s_selection_missing" % lane)
     broad = _request_is_broad_profile(packet.request)
     for item in packet.items:
         if not _route_allows_item(packet.request, item):
@@ -5767,6 +6080,31 @@ def _packet_invariants(
             invalid.append("selected_subject_violation")
         if item.lane == "relationship_posture" and item.usage != "tone_only":
             invalid.append("relationship_fact_authority_violation")
+        if item.lane in {"journal_publication", "relay_publication"} and not (
+            item.usage == "publication_projection"
+            and item.lifecycle == "published"
+            and item.visibility in _PUBLIC_VISIBILITIES
+            and item.attribution_mode == "publication_only"
+            and item.uncertainty_status
+            == "derived_publication_zero_fact_weight"
+            and not item.root_identities
+            and not item.occurrence_identities
+            and not item.point_identity
+            and not item.canon_status
+            and not item.canon_domain
+            and not item.canon_claim_kind
+            and (
+                item.lane == "journal_publication"
+                and item.source_class == JOURNAL_PUBLICATION_SOURCE_CLASS
+                and item.source_type == "canonical_published_journal"
+                and item.revalidation_kind == "journal_publication"
+                or item.lane == "relay_publication"
+                and item.source_class == RELAY_PUBLICATION_SOURCE_CLASS
+                and item.source_type == "accepted_relay_publication"
+                and item.revalidation_kind == "relay_publication"
+            )
+        ):
+            invalid.append("publication_projection_authority_violation")
         if item.revalidation_kind in {"atomic", "recurring_theme"} and item.lifecycle not in {
             "established",
             "provisional",
@@ -5983,6 +6321,22 @@ def build_packet(
             _conversation_items(conn, request, diagnostics, exclusions)
         )
         candidates.extend(
+            _journal_publication_items(
+                conn,
+                request,
+                diagnostics,
+                exclusions,
+            )
+        )
+        candidates.extend(
+            _relay_publication_items(
+                conn,
+                request,
+                diagnostics,
+                exclusions,
+            )
+        )
+        candidates.extend(
             _assessment_observation_items(
                 conn,
                 request,
@@ -6116,6 +6470,11 @@ def build_packet(
         )
         for item in validation_items
     )
+    journal_control_identity = (
+        request.journal_control_snapshot.authority_identity
+        if isinstance(request.journal_control_snapshot, JournalControlSnapshot)
+        else (str(request.journal_control_status or "not_requested"),)
+    )
     diagnostics.packet_digest = _digest(
         SCHEMA_VERSION,
         request.frame_revision,
@@ -6123,6 +6482,7 @@ def build_packet(
         subject_resolution,
         prompt_digest_payload,
         validation_digest_payload,
+        journal_control_identity,
         profile_sufficiency,
     )
     source_snapshot_digest = _digest(
@@ -6132,6 +6492,7 @@ def build_packet(
         subject_resolution.binding_digest,
         prompt_digest_payload,
         validation_digest_payload,
+        journal_control_identity,
     )
     packet_id = "uip_" + _digest(
         SCHEMA_VERSION,
@@ -6300,7 +6661,10 @@ def persist_packet_run(
             frame_applicability_exclusion_count=?,source_snapshot_digest=?,
             episode_query_status=?,episode_candidate_count=?,
             theme_query_status=?,theme_independent_root_count=?,
-            theme_independent_occurrence_count=?
+            theme_independent_occurrence_count=?,journal_query_status=?,
+            journal_control_status=?,journal_candidate_count=?,
+            relay_query_status=?,relay_candidate_count=?,
+            publication_projection_count=?
         WHERE run_id=?
         """,
         (
@@ -6327,6 +6691,12 @@ def persist_packet_run(
             int(
                 packet.diagnostics.theme_independent_occurrence_count or 0
             ),
+            packet.diagnostics.journal_query_status,
+            packet.diagnostics.journal_control_status,
+            int(packet.diagnostics.journal_candidate_count or 0),
+            packet.diagnostics.relay_query_status,
+            int(packet.diagnostics.relay_candidate_count or 0),
+            int(packet.diagnostics.publication_projection_count or 0),
             run_id,
         ),
     )
@@ -6430,6 +6800,12 @@ def _empty_report() -> dict[str, Any]:
         "themeQueryStatusCounts": {},
         "themeIndependentRootTotal": 0,
         "themeIndependentOccurrenceTotal": 0,
+        "journalQueryStatusCounts": {},
+        "journalControlStatusCounts": {},
+        "journalCandidateTotal": 0,
+        "relayQueryStatusCounts": {},
+        "relayCandidateTotal": 0,
+        "publicationProjectionTotal": 0,
         "promptAppliedRuns": 0,
         "liveAppliedRuns": 0,
         "contentFieldsPresent": [],
@@ -6481,7 +6857,7 @@ def build_evaluation_report(
                processing_error_count,
                invalid_invariant_count,revalidation_status,
                revalidation_changed_count,prompt_applied,live_applied,
-               %s,%s,%s,%s,%s,%s,%s,%s,
+               %s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,
                created_at
         FROM memory_governance_intelligence_packet_runs
         WHERE guild_id=?
@@ -6511,6 +6887,12 @@ def build_evaluation_report(
             column("theme_query_status", "'not_requested'"),
             column("theme_independent_root_count", "0"),
             column("theme_independent_occurrence_count", "0"),
+            column("journal_query_status", "'not_requested'"),
+            column("journal_control_status", "'not_requested'"),
+            column("journal_candidate_count", "0"),
+            column("relay_query_status", "'not_requested'"),
+            column("relay_candidate_count", "0"),
+            column("publication_projection_count", "0"),
         ),
         (int(guild_id or 0), max(1, min(int(limit or 1000), 5000))),
     ).fetchall()
@@ -6527,12 +6909,16 @@ def build_evaluation_report(
     subject_methods: Counter[str] = Counter()
     episode_statuses: Counter[str] = Counter()
     theme_statuses: Counter[str] = Counter()
+    journal_statuses: Counter[str] = Counter()
+    journal_control_statuses: Counter[str] = Counter()
+    relay_statuses: Counter[str] = Counter()
     item_total = validation_item_total = 0
     conflicts = visibility = budget = duplicates = 0
     root_collapses = shared_roots = profile_met = 0
     profile_points = profile_roots = profile_occurrences = 0
     errors = invalid = changed = prompt = live = frame_exclusions = 0
     episode_candidates = theme_roots = theme_occurrences = 0
+    journal_candidates = relay_candidates = publication_projections = 0
     for row in rows:
         (
             _schema,
@@ -6571,6 +6957,12 @@ def build_evaluation_report(
             theme_query_status,
             theme_root_count,
             theme_occurrence_count,
+            journal_query_status,
+            journal_control_status,
+            journal_candidate_count,
+            relay_query_status,
+            relay_candidate_count,
+            publication_projection_count,
             _created_at,
         ) = row
         item_total += int(item_count or 0)
@@ -6631,6 +7023,14 @@ def build_evaluation_report(
         theme_statuses[str(theme_query_status or "not_requested")] += 1
         theme_roots += int(theme_root_count or 0)
         theme_occurrences += int(theme_occurrence_count or 0)
+        journal_statuses[str(journal_query_status or "not_requested")] += 1
+        journal_control_statuses[
+            str(journal_control_status or "not_requested")
+        ] += 1
+        journal_candidates += int(journal_candidate_count or 0)
+        relay_statuses[str(relay_query_status or "not_requested")] += 1
+        relay_candidates += int(relay_candidate_count or 0)
+        publication_projections += int(publication_projection_count or 0)
     return {
         "tablePresent": True,
         "schemaVersion": str(rows[0][0]) if rows else SCHEMA_VERSION,
@@ -6673,6 +7073,14 @@ def build_evaluation_report(
         "themeQueryStatusCounts": dict(sorted(theme_statuses.items())),
         "themeIndependentRootTotal": theme_roots,
         "themeIndependentOccurrenceTotal": theme_occurrences,
+        "journalQueryStatusCounts": dict(sorted(journal_statuses.items())),
+        "journalControlStatusCounts": dict(
+            sorted(journal_control_statuses.items())
+        ),
+        "journalCandidateTotal": journal_candidates,
+        "relayQueryStatusCounts": dict(sorted(relay_statuses.items())),
+        "relayCandidateTotal": relay_candidates,
+        "publicationProjectionTotal": publication_projections,
         "promptAppliedRuns": prompt,
         "liveAppliedRuns": live,
         "contentFieldsPresent": disallowed,

--- a/bnl_website_relay_state.py
+++ b/bnl_website_relay_state.py
@@ -12,6 +12,9 @@ from bnl_journal_source_store import record_source_event, timestamp_to_epoch_ms
 
 MAX_HISTORY = 25
 MAX_ATTEMPTS_PER_GUILD = 100
+RELAY_PUBLICATION_READ_VERSION = "accepted_relay_publication_read_v1"
+RELAY_PUBLICATION_TOPIC_SCAN_LIMIT = 200
+RELAY_PUBLICATION_RESULT_LIMIT = 4
 STOCK_FAMILIES = {
     "waiting_standby": (
         "waiting", "standing by", "standby", "awaiting signal", "awaiting fresh", "remains online",
@@ -55,6 +58,31 @@ class WebsiteRelayDecision:
     mode: str = "OBSERVATION"
     relayLane: str = "current_signal"
     metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AcceptedRelayPublication:
+    relay_id: str
+    public_message: str
+    public_directive: str
+    mode: str
+    relay_lane: str
+    event_type: str
+    published_timestamp: str
+    query_mode: str
+    provenance_kind: str
+    provenance_digest: str
+    source_digest: str
+
+
+@dataclass(frozen=True)
+class AcceptedRelayPublicationSelection:
+    status: str
+    query_mode: str
+    publications: tuple[AcceptedRelayPublication, ...] = ()
+    candidate_count: int = 0
+    unapproved_provenance_count: int = 0
+    presence_only_count: int = 0
 
 
 def utc_now_iso() -> str:
@@ -207,6 +235,467 @@ def recent_history(db_path: str, guild_id: int, limit: int = MAX_HISTORY) -> lis
             (guild_id, bounded_limit),
         ).fetchall()
     return [dict(r) for r in rows]
+
+
+_RELAY_PUBLICATION_ID_RE = re.compile(
+    r"\bbnl-[A-Za-z0-9][A-Za-z0-9._:-]{5,159}\b",
+    re.IGNORECASE,
+)
+_RELAY_EXPLICIT_ID_RE = re.compile(
+    r"\brelay(?:\s+(?:publication|message))?\s+id\s*"
+    r"[:#=-]?\s*([A-Za-z0-9][A-Za-z0-9._:-]{2,159})\b",
+    re.IGNORECASE,
+)
+_RELAY_QUERY_CUE_RE = re.compile(
+    r"\b(?:relay|website\s+(?:message|signal|status))\b",
+    re.IGNORECASE,
+)
+_RELAY_QUERY_ACTION_RE = re.compile(
+    r"\b(?:accepted|archive|find|history|latest|message|published|recent|"
+    r"said|show|signal|status|what)\b",
+    re.IGNORECASE,
+)
+_RELAY_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})\b")
+_RELAY_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{2,159}$")
+_RELAY_QUERY_STOPWORDS = {
+    "about",
+    "accepted",
+    "archive",
+    "barcode",
+    "current",
+    "dated",
+    "discord",
+    "find",
+    "from",
+    "history",
+    "latest",
+    "message",
+    "network",
+    "published",
+    "recent",
+    "relay",
+    "said",
+    "show",
+    "signal",
+    "status",
+    "that",
+    "what",
+    "website",
+    "with",
+}
+_PRESENCE_ONLY_LANES = {
+    "presence",
+    "presence_only",
+    "heartbeat",
+}
+_PRESENCE_ONLY_EVENT_TYPES = {
+    "presence",
+    "presence_only",
+    "heartbeat",
+    "online",
+    "offline",
+}
+_RELAY_PUBLICATION_COLUMNS = (
+    "relay_id",
+    "guild_id",
+    "public_message",
+    "public_directive",
+    "mode",
+    "relay_lane",
+    "event_type",
+    "highest_source_conversation_id",
+    "normalized_message",
+    "semantic_family",
+    "published_timestamp",
+)
+
+
+def _relay_table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return bool(
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        ).fetchone()
+    )
+
+
+def _relay_table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {
+        str(row[1])
+        for row in conn.execute("PRAGMA table_info(%s)" % table).fetchall()
+    }
+
+
+def relay_publication_query_mode(user_text: str) -> str:
+    text = str(user_text or "")
+    if _RELAY_PUBLICATION_ID_RE.search(text):
+        return "identity"
+    explicit = _RELAY_EXPLICIT_ID_RE.search(text)
+    if explicit and explicit.group(1).lower() not in {
+        "archive",
+        "history",
+        "message",
+        "signal",
+        "status",
+    }:
+        return "identity"
+    if not (
+        _RELAY_QUERY_CUE_RE.search(text)
+        and _RELAY_QUERY_ACTION_RE.search(text)
+    ):
+        return "not_requested"
+    if _RELAY_DATE_RE.search(text):
+        return "date"
+    return "requested"
+
+
+def _relay_query_identity(user_text: str) -> str:
+    direct = _RELAY_PUBLICATION_ID_RE.search(str(user_text or ""))
+    if direct:
+        return direct.group(0)
+    explicit = _RELAY_EXPLICIT_ID_RE.search(str(user_text or ""))
+    if explicit and explicit.group(1).lower() not in {
+        "archive",
+        "history",
+        "message",
+        "signal",
+        "status",
+    }:
+        return explicit.group(1)
+    return ""
+
+
+def _relay_query_terms(user_text: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[a-z0-9]+", str(user_text or "").lower())
+        if len(token) >= 4 and token not in _RELAY_QUERY_STOPWORDS
+    }
+
+
+def _relay_publication_rows(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    relay_id: str = "",
+    publication_date: str = "",
+    limit: int = RELAY_PUBLICATION_TOPIC_SCAN_LIMIT,
+) -> list[dict[str, Any]]:
+    if not _relay_table_exists(conn, "website_relay_history"):
+        return []
+    columns = _relay_table_columns(conn, "website_relay_history")
+    if not set(_RELAY_PUBLICATION_COLUMNS).issubset(columns):
+        return []
+    where = ["guild_id=?"]
+    params: list[Any] = [int(guild_id or 0)]
+    if relay_id:
+        where.append("relay_id=?")
+        params.append(relay_id)
+    if publication_date:
+        where.append("SUBSTR(published_timestamp,1,10)=?")
+        params.append(publication_date)
+    params.append(max(1, min(int(limit or 1), 500)))
+    rows = conn.execute(
+        "SELECT "
+        + ",".join(_RELAY_PUBLICATION_COLUMNS)
+        + " FROM website_relay_history WHERE "
+        + " AND ".join(where)
+        + " ORDER BY published_timestamp DESC,relay_id DESC LIMIT ?",
+        tuple(params),
+    ).fetchall()
+    return [dict(zip(_RELAY_PUBLICATION_COLUMNS, row)) for row in rows]
+
+
+def _relay_acceptance_provenance(
+    conn: sqlite3.Connection,
+    row: dict[str, Any],
+) -> tuple[str, str]:
+    relay_id = str(row.get("relay_id") or "")
+    relay_lane = str(row.get("relay_lane") or "").strip().lower()
+    event_type = str(row.get("event_type") or "").strip().lower()
+    if (
+        relay_lane in _PRESENCE_ONLY_LANES
+        or event_type in _PRESENCE_ONLY_EVENT_TYPES
+    ):
+        return "", "presence_only"
+    if relay_lane != "hydrated":
+        proof = hashlib.sha256(
+            ("bot_accepted_history|" + relay_id).encode("utf-8")
+        ).hexdigest()
+        return "bot_accepted_history", proof
+    if not _relay_table_exists(conn, "website_relay_attempts"):
+        return "", "site_manual_owner_receipt_missing"
+    columns = _relay_table_columns(conn, "website_relay_attempts")
+    required = {
+        "attempt_id",
+        "guild_id",
+        "trigger",
+        "outcome",
+        "accepted_relay_id",
+        "prepared_relay_id",
+        "website_published_at",
+        "completed_at",
+    }
+    if not required.issubset(columns):
+        return "", "site_manual_owner_receipt_missing"
+    receipts = conn.execute(
+        """
+        SELECT attempt_id,completed_at
+        FROM website_relay_attempts
+        WHERE guild_id=? AND outcome='published'
+          AND trigger IN ('owner_manual','owner_approved',
+                          'manual_owner_approval')
+          AND accepted_relay_id=? AND prepared_relay_id=?
+          AND website_published_at=?
+          AND TRIM(COALESCE(completed_at,''))<>''
+        ORDER BY attempt_id ASC
+        """,
+        (
+            int(row.get("guild_id") or 0),
+            relay_id,
+            relay_id,
+            str(row.get("published_timestamp") or ""),
+        ),
+    ).fetchall()
+    if not receipts:
+        # source_class/event_type values such as approved_canon are not an
+        # owner-approval receipt and deliberately do not affect this result.
+        return "", "site_manual_owner_receipt_missing"
+    proof = hashlib.sha256(
+        repr(tuple((str(item[0]), str(item[1])) for item in receipts)).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+    return "site_manual_owner_receipt", proof
+
+
+def _accepted_relay_source_digest(
+    row: dict[str, Any],
+    *,
+    query_mode: str,
+    provenance_kind: str,
+    provenance_digest: str,
+) -> str:
+    values = (
+        RELAY_PUBLICATION_READ_VERSION,
+        str(row.get("relay_id") or ""),
+        int(row.get("guild_id") or 0),
+        str(row.get("public_message") or ""),
+        str(row.get("public_directive") or ""),
+        str(row.get("mode") or ""),
+        str(row.get("relay_lane") or ""),
+        str(row.get("event_type") or ""),
+        int(row.get("highest_source_conversation_id") or 0),
+        str(row.get("normalized_message") or ""),
+        str(row.get("semantic_family") or ""),
+        str(row.get("published_timestamp") or ""),
+        str(query_mode or ""),
+        provenance_kind,
+        provenance_digest,
+    )
+    return hashlib.sha256(repr(values).encode("utf-8")).hexdigest()
+
+
+def _accepted_relay_from_row(
+    conn: sqlite3.Connection,
+    row: dict[str, Any],
+    *,
+    query_mode: str,
+) -> tuple[AcceptedRelayPublication | None, str]:
+    relay_id = str(row.get("relay_id") or "").strip()
+    public_message = str(row.get("public_message") or "").strip()
+    published_timestamp = str(row.get("published_timestamp") or "").strip()
+    if (
+        not _RELAY_ID_RE.fullmatch(relay_id)
+        or not public_message
+        or timestamp_to_epoch_ms(published_timestamp) is None
+    ):
+        return None, "source_invalid"
+    provenance_kind, provenance_digest = _relay_acceptance_provenance(
+        conn,
+        row,
+    )
+    if not provenance_kind:
+        return None, provenance_digest
+    return (
+        AcceptedRelayPublication(
+            relay_id=relay_id,
+            public_message=public_message,
+            public_directive=str(row.get("public_directive") or "").strip(),
+            mode=str(row.get("mode") or "OBSERVATION").strip(),
+            relay_lane=str(row.get("relay_lane") or "").strip(),
+            event_type=str(row.get("event_type") or "").strip(),
+            published_timestamp=published_timestamp,
+            query_mode=query_mode,
+            provenance_kind=provenance_kind,
+            provenance_digest=provenance_digest,
+            source_digest=_accepted_relay_source_digest(
+                row,
+                query_mode=query_mode,
+                provenance_kind=provenance_kind,
+                provenance_digest=provenance_digest,
+            ),
+        ),
+        "",
+    )
+
+
+def render_accepted_relay_publication(
+    publication: AcceptedRelayPublication,
+    *,
+    limit: int = 900,
+) -> str:
+    directive = (
+        " Directive: " + publication.public_directive
+        if publication.public_directive
+        else ""
+    )
+    text = "Accepted Relay %s (%s): %s%s" % (
+        publication.relay_id,
+        publication.published_timestamp[:10],
+        publication.public_message,
+        directive,
+    )
+    return re.sub(r"\s+", " ", text).strip()[: max(160, int(limit or 0))]
+
+
+def select_accepted_relay_publications_on_connection(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    user_text: str,
+    limit: int = RELAY_PUBLICATION_RESULT_LIMIT,
+) -> AcceptedRelayPublicationSelection:
+    requested_mode = relay_publication_query_mode(user_text)
+    if requested_mode == "not_requested":
+        return AcceptedRelayPublicationSelection(
+            "not_requested",
+            "not_requested",
+        )
+    if not _relay_table_exists(conn, "website_relay_history"):
+        return AcceptedRelayPublicationSelection(
+            "source_unavailable",
+            requested_mode,
+        )
+    identity = _relay_query_identity(user_text)
+    date_match = _RELAY_DATE_RE.search(str(user_text or ""))
+    publication_date = date_match.group(1) if date_match else ""
+    if identity:
+        query_mode = "exact_identity"
+        rows = _relay_publication_rows(
+            conn,
+            guild_id=guild_id,
+            relay_id=identity,
+            limit=max(1, limit),
+        )
+    elif publication_date:
+        query_mode = "exact_date"
+        rows = _relay_publication_rows(
+            conn,
+            guild_id=guild_id,
+            publication_date=publication_date,
+            limit=max(8, limit),
+        )
+    else:
+        query_mode = "topic"
+        rows = _relay_publication_rows(
+            conn,
+            guild_id=guild_id,
+            limit=RELAY_PUBLICATION_TOPIC_SCAN_LIMIT,
+        )
+        terms = _relay_query_terms(user_text)
+        if terms:
+            scored: list[tuple[int, str, dict[str, Any]]] = []
+            for row in rows:
+                candidate_terms = {
+                    token
+                    for token in re.findall(
+                        r"[a-z0-9]+",
+                        " ".join(
+                            str(row.get(key) or "").lower()
+                            for key in (
+                                "public_message",
+                                "public_directive",
+                                "event_type",
+                            )
+                        ),
+                    )
+                    if len(token) >= 4
+                }
+                score = len(terms & candidate_terms)
+                if score:
+                    scored.append(
+                        (
+                            score,
+                            str(row.get("published_timestamp") or ""),
+                            row,
+                        )
+                    )
+            scored.sort(key=lambda item: (item[0], item[1]), reverse=True)
+            rows = [row for _score, _timestamp, row in scored]
+    candidate_count = len(rows)
+    selected: list[AcceptedRelayPublication] = []
+    provenance_excluded = 0
+    presence_excluded = 0
+    invalid_count = 0
+    for row in rows:
+        publication, reason = _accepted_relay_from_row(
+            conn,
+            row,
+            query_mode=query_mode,
+        )
+        if publication is None:
+            if reason == "presence_only":
+                presence_excluded += 1
+            elif reason == "source_invalid":
+                invalid_count += 1
+            else:
+                provenance_excluded += 1
+            continue
+        selected.append(publication)
+        if len(selected) >= max(1, min(int(limit or 1), 8)):
+            break
+    if selected:
+        status = "eligible"
+    elif provenance_excluded:
+        status = "provenance_unapproved"
+    elif presence_excluded:
+        status = "presence_only"
+    elif invalid_count:
+        status = "source_invalid"
+    else:
+        status = "not_found"
+    return AcceptedRelayPublicationSelection(
+        status=status,
+        query_mode=query_mode,
+        publications=tuple(selected),
+        candidate_count=candidate_count,
+        unapproved_provenance_count=provenance_excluded,
+        presence_only_count=presence_excluded,
+    )
+
+
+def revalidate_accepted_relay_publication_on_connection(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    relay_id: str,
+    query_mode: str,
+) -> str:
+    rows = _relay_publication_rows(
+        conn,
+        guild_id=guild_id,
+        relay_id=relay_id,
+        limit=2,
+    )
+    if len(rows) != 1:
+        return ""
+    publication, _reason = _accepted_relay_from_row(
+        conn,
+        rows[0],
+        query_mode=query_mode,
+    )
+    return publication.source_digest if publication is not None else ""
 
 
 def accepted_publication_count(db_path: str, guild_id: int, event_types: tuple[str, ...] = ()) -> int:

--- a/docs/canonical_publication_read_adapters_v1.md
+++ b/docs/canonical_publication_read_adapters_v1.md
@@ -1,0 +1,57 @@
+# Canonical Publication Read Adapters v1
+
+This contract adds read-only ordinary-conversation adapters for canonical
+Journal publications and accepted Relay publications. It does not add a
+Journal or Relay store, change publication, or activate a response gate.
+
+## Journal authority
+
+The bot's `bnl_journal_entries` owner supplies immutable public content,
+revision, content hash, lifecycle, and publication time. The website's
+existing authenticated `GET /api/bnl/journal/control` owner supplies the
+independent visibility and reuse decision introduced by site PR #304:
+
+- `publicExcludedEntryIds` controls exact Discord retrieval;
+- `memoryExcludedEntryIds` separately controls topic/continuity reuse; and
+- control version, revision, digest, observed time, expiry, and `persisted`
+  status bind selection and pre-send revalidation.
+
+Missing, malformed, unpersisted, stale, or changed control state fails closed.
+Exact identity, exact title, and exact publication-date lookup may use a public
+entry even when reuse is disabled. Topic lookup requires both public visibility
+and memory eligibility. The latest published revision wins; a later draft does
+not replace it, while a later published revision invalidates an earlier packet.
+
+## Relay authority
+
+`website_relay_history` is the permanent accepted-publication owner. The
+recent-25 operational view and newest-20 website view are projections only;
+exact identity and date lookup can reach older accepted rows. Draft, rejected,
+failed, pending, and presence-only state is never accepted speech.
+
+A normal bot-owned history row is accepted provenance. A site-hydrated/manual
+row is excluded unless `website_relay_attempts` contains a completed
+`published` receipt with an explicit owner-approval trigger whose accepted ID,
+prepared ID, and website publication time exactly match the history row.
+`sourceClass=approved_canon`, projection presence, or public wording does not
+substitute for that receipt.
+
+## Packet and revalidation
+
+The packet lanes are `journal_publication` and `relay_publication`. Their items
+use `publication_projection`, public visibility, published lifecycle, and
+`publication_only` attribution. They intentionally carry no root identities,
+occurrence identities, profile point, canon status/domain/kind, or subject-fact
+authority. Rendering labels them as exact published prose with zero independent
+fact or recurrence weight.
+
+Every selected Journal item is re-read against the exact canonical revision and
+a newly fetched control authority identity. Every selected Relay is re-read
+against its exact durable row and acceptance provenance. Content or lifecycle,
+visibility/reuse, control revision/digest, Relay row, or receipt mutation makes
+the packet invalid. Receipts retain only aggregate status/count fields and
+digests; they do not retain publication text or entry IDs.
+
+All shared-brain and live-authority gates remain default-off. Journal/Relay
+generation, cadence, scheduling, acceptance, retries, delivery, rendering,
+backup, correction policy, and owner controls are unchanged.

--- a/docs/one_packet_convergence_v1.md
+++ b/docs/one_packet_convergence_v1.md
@@ -1,6 +1,6 @@
 # One-Packet Convergence v1
 
-`unified_intelligence_packet_v7` is the single factual owner for gated broad
+`unified_intelligence_packet_v8` is the single factual owner for gated broad
 self-profile synthesis and shadow/private ordinary-turn preview. It consumes
 the immutable Situation Frame revision and resolves one governed subject
 before source scoring. It normalizes four canon statuses without moving their
@@ -32,6 +32,18 @@ requires fresh recurrence. One occurrence may appear only in sealed preview,
 with an explicit `single_occurrence_not_recurrence` qualifier, and is never
 public or canon. Journal, Relay, Ambient, dossier, site, derived summary, and
 prior BNL prose remain projections and contribute zero independent recurrence.
+
+Explicit publication questions use bounded `journal_publication` and
+`relay_publication` lanes. Journal selection requires both the bot's latest
+canonical published revision and the website's authenticated, persisted,
+fresh visibility/reuse snapshot. Exact identity/title/date reads honor
+`publicVisible` but remain separate from topic reuse, which additionally
+requires `memoryEligible`. Relay selection reads the permanent accepted bot
+archive rather than its recent projection; unmatched site-hydrated records
+require an exact published-at acceptance receipt. A projection or
+`approved_canon` source-class label alone is insufficient. Both lanes are
+publication-only and carry no fact, canon, identity, Moment, Relationship,
+root, occurrence, or recurrence authority.
 
 Member-specific `approved_fact`, Living, conversation, and Open evidence is
 ranked before additive project canon. Render-equivalent projections collapse

--- a/tests/test_governed_subject_packet_v6.py
+++ b/tests/test_governed_subject_packet_v6.py
@@ -135,7 +135,7 @@ class GovernedSubjectPacketV6Tests(unittest.TestCase):
         )
 
     def test_packet_schema_is_v7_and_alias_matrix_stays_distinct(self):
-        self.assertEqual(SCHEMA_VERSION, "unified_intelligence_packet_v7")
+        self.assertEqual(SCHEMA_VERSION, "unified_intelligence_packet_v8")
         cases = {
             "Who is Mac Mod3m?": ("mac_modem",),
             "Tell me about DJ Floppy Disc.": ("dj_floppydisc",),

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -1,0 +1,611 @@
+import hashlib
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from unittest import mock
+
+import bnl_journal as journal
+import bnl_memory_ledger as ledger
+import bnl_moment_engine as moments
+import bnl_relationship_engine as relationships
+import bnl_website_relay_state as relay
+from bnl_shared_brain_synthesis import render_packet_context
+from bnl_unified_intelligence_packet import (
+    IntelligencePacketRequest,
+    build_evaluation_report,
+    build_packet,
+    revalidate_packet,
+)
+
+
+NOW = "2026-08-10T10:01:00Z"
+
+
+def control_snapshot(
+    *,
+    public_excluded=(),
+    memory_excluded=(),
+    digest="a" * 64,
+    observed_at="2026-08-10T10:00:00Z",
+    fresh_until="2026-08-10T10:02:00Z",
+):
+    return journal.JournalControlSnapshot(
+        snapshot_version=1,
+        revision="2026-08-10T09:59:00Z",
+        digest=digest,
+        observed_at=observed_at,
+        fresh_until=fresh_until,
+        fresh_for_seconds=120,
+        public_excluded_entry_ids=tuple(sorted(public_excluded)),
+        memory_excluded_entry_ids=tuple(sorted(memory_excluded)),
+    )
+
+
+class PublicationReadAdapterTests(unittest.TestCase):
+    def setUp(self):
+        handle = tempfile.NamedTemporaryFile(suffix=".sqlite3", delete=False)
+        self.db_path = handle.name
+        handle.close()
+        journal.ensure_schema(self.db_path)
+        relay.ensure_schema(self.db_path)
+        self.conn = sqlite3.connect(self.db_path)
+
+    def tearDown(self):
+        self.conn.close()
+        os.unlink(self.db_path)
+
+    def add_journal(
+        self,
+        entry_id,
+        *,
+        revision=1,
+        title="Copper Antennas",
+        excerpt="The room returned to ceramic receivers.",
+        body="A ceramic receiver found a clean carrier.",
+        published_at="2026-08-02T01:00:00Z",
+        lifecycle="published",
+    ):
+        section_values = [{"heading": "Carrier Notes", "body": body}]
+        sections = json.dumps(
+            section_values,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        content_hash = hashlib.sha256(
+            "|".join((title, excerpt, sections)).encode()
+        ).hexdigest()
+        authored_at = "2026-08-02T00:00:00Z"
+        source_window_start = "2026-08-01T00:00:00Z"
+        source_window_end = "2026-08-02T00:00:00Z"
+        public_payload = {
+            "contractVersion": 1,
+            "kind": "journal_entry",
+            "entry": {
+                "entryId": entry_id,
+                "revision": revision,
+                "entryKind": "daily",
+                "title": title,
+                "excerpt": excerpt,
+                "sections": section_values,
+                "authoredAt": authored_at,
+                "sourceWindowStart": source_window_start,
+                "sourceWindowEnd": source_window_end,
+                "contentHash": content_hash,
+            },
+        }
+        canonical_payload = json.dumps(
+            public_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO bnl_journal_entries(
+              entry_id,revision,guild_id,lifecycle_state,title,excerpt,
+              sections_json,public_payload_json,canonical_payload_bytes,
+              content_hash,source_window_start,source_window_end,authored_at,
+              approved_at,published_at,review_reason,delivery_status,
+              delivery_http_status,created_at,updated_at
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                entry_id,
+                revision,
+                1,
+                lifecycle,
+                title,
+                excerpt,
+                sections,
+                canonical_payload,
+                canonical_payload.encode(),
+                content_hash,
+                source_window_start,
+                source_window_end,
+                authored_at,
+                "2026-08-02T00:30:00Z",
+                published_at if lifecycle == "published" else None,
+                None,
+                "published" if lifecycle == "published" else None,
+                200 if lifecycle == "published" else 0,
+                "2026-08-02T00:00:00Z",
+                "2026-08-02T01:00:00Z",
+            ),
+        )
+        return content_hash
+
+    def add_relay(
+        self,
+        relay_id,
+        *,
+        message="A ceramic carrier cleared the public relay.",
+        directive="Tune the receiver toward the next clean signal.",
+        lane="current_signal",
+        event_type="public_discord_activity",
+        published_at="2026-08-03T01:00:00Z",
+    ):
+        self.conn.execute(
+            """
+            INSERT INTO website_relay_history(
+              relay_id,guild_id,public_message,public_directive,mode,
+              relay_lane,event_type,highest_source_conversation_id,
+              normalized_message,semantic_family,published_timestamp
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                relay_id,
+                1,
+                message,
+                directive,
+                "OBSERVATION",
+                lane,
+                event_type,
+                20,
+                relay.normalize_text(message),
+                relay.semantic_family(message),
+                published_at,
+            ),
+        )
+
+    def test_control_snapshot_requires_persisted_fresh_complete_contract(self):
+        payload = {
+            "contractVersion": 1,
+            "persisted": True,
+            "controlSnapshotVersion": 1,
+            "controlRevision": "2026-08-10T09:59:00Z",
+            "controlDigest": "b" * 64,
+            "controlObservedAt": "2026-08-10T10:00:00Z",
+            "controlFreshUntil": "2026-08-10T10:02:00Z",
+            "controlFreshForSeconds": 120,
+            "publicExcludedEntryIds": ["journal_hidden"],
+            "memoryExcludedEntryIds": ["journal_reuse_off"],
+        }
+        snapshot, reason = journal.parse_journal_control_snapshot(
+            payload,
+            now=NOW,
+        )
+        self.assertEqual("", reason)
+        self.assertEqual(("journal_hidden",), snapshot.public_excluded_entry_ids)
+        stale, reason = journal.parse_journal_control_snapshot(
+            payload,
+            now="2026-08-10T10:03:00Z",
+        )
+        self.assertIsNone(stale)
+        self.assertEqual("control_snapshot_stale", reason)
+        snapshot, reason = journal.parse_journal_control_snapshot(
+            {**payload, "persisted": False},
+            now=NOW,
+        )
+        self.assertIsNone(snapshot)
+        self.assertEqual("control_snapshot_unpersisted", reason)
+
+    def test_journal_exact_identity_title_date_and_latest_published_revision(self):
+        entry_id = "journal_revision_case"
+        self.add_journal(entry_id, revision=1, title="Original Carrier")
+        self.add_journal(
+            entry_id,
+            revision=2,
+            title="Revised Carrier",
+            published_at="2026-08-04T01:00:00Z",
+        )
+        self.add_journal(
+            entry_id,
+            revision=3,
+            title="Unpublished Rewrite",
+            lifecycle="draft",
+        )
+        snapshot = control_snapshot()
+        by_id = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text=f"show Journal entry {entry_id}",
+            control_snapshot=snapshot,
+            now=NOW,
+        )
+        self.assertEqual("eligible", by_id.status)
+        self.assertEqual(2, by_id.publications[0].revision)
+        by_title = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text='show the Journal titled "Revised Carrier"',
+            control_snapshot=snapshot,
+            now=NOW,
+        )
+        self.assertEqual("exact_title", by_title.query_mode)
+        self.assertEqual(entry_id, by_title.publications[0].entry_id)
+        by_date = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text="what did the Journal publish on 2026-08-04?",
+            control_snapshot=snapshot,
+            now=NOW,
+        )
+        self.assertEqual("exact_date", by_date.query_mode)
+        self.assertEqual(entry_id, by_date.publications[0].entry_id)
+
+    def test_journal_public_visibility_and_reuse_are_independent(self):
+        entry_id = "journal_visibility_case"
+        self.add_journal(entry_id, title="Public Ceramic Log")
+        exact_snapshot = control_snapshot(memory_excluded=(entry_id,))
+        exact = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text='show the Journal titled "Public Ceramic Log"',
+            control_snapshot=exact_snapshot,
+            now=NOW,
+        )
+        self.assertEqual("eligible", exact.status)
+        topic = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text="what has the Journal said about receivers?",
+            control_snapshot=exact_snapshot,
+            now=NOW,
+        )
+        self.assertEqual("memory_ineligible", topic.status)
+        hidden = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text=f"show Journal entry {entry_id}",
+            control_snapshot=control_snapshot(public_excluded=(entry_id,)),
+            now=NOW,
+        )
+        self.assertEqual("public_hidden", hidden.status)
+        unavailable = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text=f"show Journal entry {entry_id}",
+            control_snapshot=None,
+            now=NOW,
+        )
+        self.assertEqual("control_snapshot_unavailable", unavailable.status)
+        self.conn.execute(
+            """
+            UPDATE bnl_journal_entries
+            SET canonical_payload_bytes=?
+            WHERE entry_id=?
+            """,
+            (b"{}", entry_id),
+        )
+        contradictory = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text=f"show Journal entry {entry_id}",
+            control_snapshot=control_snapshot(),
+            now=NOW,
+        )
+        self.assertEqual("source_invalid", contradictory.status)
+
+    def test_relay_permanent_history_and_site_manual_provenance(self):
+        for index in range(30):
+            self.add_relay(
+                f"bnl-history-{index:02d}",
+                message=f"Permanent carrier record {index}.",
+                published_at=f"2026-07-{index + 1:02d}T01:00:00Z",
+            )
+        oldest = relay.select_accepted_relay_publications_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text="show relay bnl-history-00",
+        )
+        self.assertEqual("eligible", oldest.status)
+        self.assertEqual("bnl-history-00", oldest.publications[0].relay_id)
+        by_date = relay.select_accepted_relay_publications_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text="what Relay was published on 2026-07-01?",
+        )
+        self.assertEqual("exact_date", by_date.query_mode)
+        self.assertEqual("bnl-history-00", by_date.publications[0].relay_id)
+        by_topic = relay.select_accepted_relay_publications_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text="show recent Relay history about carrier records",
+        )
+        self.assertEqual("topic", by_topic.query_mode)
+        self.assertTrue(by_topic.publications)
+
+        manual_id = "bnl-manual-001"
+        self.add_relay(
+            manual_id,
+            message="Manual projection text.",
+            lane="hydrated",
+            event_type="approved_canon",
+            published_at="2026-08-06T01:00:00Z",
+        )
+        missing = relay.select_accepted_relay_publications_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text=f"show relay {manual_id}",
+        )
+        self.assertEqual("provenance_unapproved", missing.status)
+        self.conn.execute(
+            """
+            INSERT INTO website_relay_attempts(
+              attempt_id,guild_id,trigger,source_class,started_at,
+              completed_at,outcome,reason,aggregate_source_counts,cursor,
+              highest_eligible_conversation_id,accepted_relay_id,
+              prepared_relay_id,website_published_at,idempotent
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                "attempt-manual-001",
+                1,
+                "scheduled",
+                "approved_canon",
+                "2026-08-06T00:59:00Z",
+                "2026-08-06T01:00:01Z",
+                "published",
+                "",
+                "{}",
+                0,
+                0,
+                manual_id,
+                manual_id,
+                "2026-08-06T01:00:00Z",
+                0,
+            ),
+        )
+        misleading = relay.select_accepted_relay_publications_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text=f"show relay {manual_id}",
+        )
+        self.assertEqual("provenance_unapproved", misleading.status)
+        self.conn.execute(
+            """
+            UPDATE website_relay_attempts
+            SET trigger='owner_manual'
+            WHERE attempt_id='attempt-manual-001'
+            """
+        )
+        approved = relay.select_accepted_relay_publications_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text=f"show relay {manual_id}",
+        )
+        self.assertEqual("eligible", approved.status)
+        self.assertEqual(
+            "site_manual_owner_receipt",
+            approved.publications[0].provenance_kind,
+        )
+
+    def test_relay_attempts_and_presence_are_not_accepted_speech(self):
+        self.conn.execute(
+            """
+            INSERT INTO website_relay_attempts(
+              attempt_id,guild_id,trigger,source_class,started_at,
+              completed_at,outcome,reason,aggregate_source_counts,cursor,
+              highest_eligible_conversation_id,accepted_relay_id,
+              prepared_relay_id,website_published_at,idempotent
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                "attempt-failed-only",
+                1,
+                "scheduled",
+                "approved_canon",
+                "2026-08-06T00:00:00Z",
+                "2026-08-06T00:00:01Z",
+                "failed",
+                "provider_failed",
+                "{}",
+                0,
+                0,
+                "",
+                "bnl-failed-only",
+                "",
+                0,
+            ),
+        )
+        failed = relay.select_accepted_relay_publications_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text="show relay bnl-failed-only",
+        )
+        self.assertEqual("not_found", failed.status)
+        self.add_relay(
+            "bnl-presence-001",
+            message="BNL-01 is online.",
+            lane="presence",
+            event_type="online",
+        )
+        presence = relay.select_accepted_relay_publications_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text="show relay bnl-presence-001",
+        )
+        self.assertEqual("presence_only", presence.status)
+
+
+class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
+    def setUp(self):
+        super().setUp()
+        ledger.ensure_memory_ledger_schema(self.conn)
+        moments.ensure_moment_schema(self.conn)
+        relationships.ensure_relationship_v2_schema(self.conn)
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS conversations (
+              id INTEGER PRIMARY KEY,guild_id INTEGER,user_id INTEGER,
+              user_name TEXT,role TEXT,content TEXT,channel_id INTEGER,
+              channel_policy TEXT,route_mode TEXT NOT NULL,timestamp TEXT
+            )
+            """
+        )
+        self.flags = {
+            "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+            "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+            "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+            "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+            "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED": "true",
+            "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
+            "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
+            "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+        }
+        self.env = mock.patch.dict(os.environ, self.flags, clear=False)
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
+        super().tearDown()
+
+    def request(self, text, *, snapshot=None, control_status="not_requested"):
+        return IntelligencePacketRequest(
+            guild_id=1,
+            subject_user_id=7,
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            channel_id=10,
+            channel_policy="public_home",
+            visibility_allowance="public_safe",
+            user_text=text,
+            direct_state="direct",
+            now=NOW,
+            journal_control_snapshot=snapshot,
+            journal_control_status=control_status,
+        )
+
+    def test_packet_adapters_are_publication_only_and_revalidate_mutation(self):
+        journal_id = "journal_packet_001"
+        relay_id = "bnl-packet-001"
+        self.add_journal(journal_id, title="Packet Carrier")
+        self.add_relay(relay_id)
+        snapshot = control_snapshot()
+        journal_packet = build_packet(
+            self.conn,
+            self.request(
+                f"show Journal entry {journal_id}",
+                snapshot=snapshot,
+                control_status="valid",
+            ),
+            persist=True,
+            environ=self.flags,
+        )
+        self.assertIsNotNone(journal_packet)
+        item = next(
+            item
+            for item in journal_packet.items
+            if item.lane == "journal_publication"
+        )
+        self.assertEqual("publication_projection", item.usage)
+        self.assertEqual((), item.root_identities)
+        self.assertEqual((), item.occurrence_identities)
+        self.assertEqual("", item.canon_status)
+        self.assertFalse(journal_packet.diagnostics.invalid_invariants)
+        rendered, lanes, count, _digests = render_packet_context(journal_packet)
+        self.assertGreaterEqual(count, 1)
+        self.assertIn(("journal_publication", 1), lanes)
+        self.assertIn("zero independent fact or recurrence weight", rendered)
+        report = build_evaluation_report(self.conn, guild_id=1)
+        self.assertEqual({"eligible": 1}, report["journalQueryStatusCounts"])
+        self.assertEqual({"valid": 1}, report["journalControlStatusCounts"])
+        self.assertEqual(1, report["publicationProjectionTotal"])
+
+        same_authority = control_snapshot(
+            digest=snapshot.digest,
+            observed_at="2026-08-10T10:00:30Z",
+            fresh_until="2026-08-10T10:02:30Z",
+        )
+        valid = revalidate_packet(
+            self.conn,
+            journal_packet,
+            environ=self.flags,
+            journal_control_snapshot=same_authority,
+            journal_control_snapshot_provided=True,
+        )
+        self.assertTrue(valid.valid)
+        hidden = control_snapshot(
+            public_excluded=(journal_id,),
+            digest="c" * 64,
+        )
+        changed = revalidate_packet(
+            self.conn,
+            journal_packet,
+            environ=self.flags,
+            journal_control_snapshot=hidden,
+            journal_control_snapshot_provided=True,
+        )
+        self.assertFalse(changed.valid)
+        self.assertEqual("source_changed", changed.status)
+
+        relay_packet = build_packet(
+            self.conn,
+            self.request(f"show relay {relay_id}"),
+            persist=False,
+            environ=self.flags,
+        )
+        relay_item = next(
+            item
+            for item in relay_packet.items
+            if item.lane == "relay_publication"
+        )
+        self.assertEqual((), relay_item.root_identities)
+        self.conn.execute(
+            "UPDATE website_relay_history SET public_message=? WHERE relay_id=?",
+            ("Mutated after selection.", relay_id),
+        )
+        changed = revalidate_packet(
+            self.conn,
+            relay_packet,
+            environ=self.flags,
+        )
+        self.assertFalse(changed.valid)
+        self.assertEqual("source_changed", changed.status)
+
+    def test_missing_hidden_and_unapproved_publications_fail_packet_closed(self):
+        missing = build_packet(
+            self.conn,
+            self.request(
+                "show Journal entry journal_missing_001",
+                snapshot=control_snapshot(),
+                control_status="valid",
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertIn(
+            "journal_publication_query_failed_closed",
+            missing.diagnostics.invalid_invariants,
+        )
+        manual_id = "bnl-packet-manual-001"
+        self.add_relay(
+            manual_id,
+            lane="hydrated",
+            event_type="approved_canon",
+        )
+        unapproved = build_packet(
+            self.conn,
+            self.request(f"show relay {manual_id}"),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertIn(
+            "relay_publication_query_failed_closed",
+            unapproved.diagnostics.invalid_invariants,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add fail-closed canonical Journal publication reads using the authenticated site control snapshot
- add accepted Relay publication reads with explicit provenance for site-hydrated/manual rows
- carry both publication lanes through unified packet v8 and shared-brain synthesis v8 with zero independent fact, recurrence, or canon weight
- revalidate Journal control authority and Relay provenance/content before generation
- add content-free diagnostics and a focused publication adapter test matrix

## Safety
- read-only adapters; no Journal or Relay publication writes
- no schema, retention, queue, payment, or public visibility changes
- live gates remain off
- missing, stale, hidden, malformed, mutated, or unapproved sources fail closed

## Verification
- `python -m unittest tests.test_publication_read_adapters` — 12 passed
- `python -m unittest tests.test_unified_intelligence_packet` — 40 passed
- shared-brain/bot/governed-subject focused suite — 49 passed
- Relay event/backup/offload focused suite — 69 passed
- `make check PYTHON=python` — 2,185 passed
- `git diff --check` — clean