### PR TITLE
Harden ordinary-chat acceptance boundaries

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -537,6 +537,22 @@ class GenerationResult:
     model: str = ""
 
 
+@dataclass
+class ProviderAttemptCounter:
+    """Count provider invocations only after all local preflight succeeds."""
+
+    count: int = 0
+
+    def mark_started(self) -> None:
+        self.count += 1
+
+
+@dataclass(frozen=True)
+class TrackedGenerationResponse:
+    text: str
+    provider_call_count: int
+
+
 @dataclass(frozen=True)
 class TokenUsageBreakdown:
     total_tokens: int = 0
@@ -25397,21 +25413,52 @@ def _generation_config_for_model(
     return genai.types.GenerateContentConfig(**config_kwargs)
 
 
-async def _generate_gemini_content_with_fallback_async(contents: str, route: str):
+async def _generate_gemini_content_with_fallback_async(
+    contents: str,
+    route: str,
+    *,
+    attempt_counter: ProviderAttemptCounter | None = None,
+):
     started = time.monotonic()
     logging.info(f"gemini_generation_offloaded route={route}")
     try:
-        return await asyncio.to_thread(_generate_gemini_content_with_fallback, contents, route)
+        if attempt_counter is None:
+            return await asyncio.to_thread(
+                _generate_gemini_content_with_fallback,
+                contents,
+                route,
+            )
+        return await asyncio.to_thread(
+            _generate_gemini_content_with_fallback,
+            contents,
+            route,
+            attempt_counter=attempt_counter,
+        )
     finally:
         elapsed = time.monotonic() - started
         logging.info(f"gemini_generation_completed route={route} elapsed_seconds={elapsed:.3f}")
 
 
-async def _generate_gemini_content_result_async(contents: str, route: str) -> GenerationResult:
+async def _generate_gemini_content_result_async(
+    contents: str,
+    route: str,
+    *,
+    attempt_counter: ProviderAttemptCounter | None = None,
+) -> GenerationResult:
     started = time.monotonic()
     model = GEMINI_MODEL
     try:
-        response = await _generate_gemini_content_with_fallback_async(contents, route)
+        if attempt_counter is None:
+            response = await _generate_gemini_content_with_fallback_async(
+                contents,
+                route,
+            )
+        else:
+            response = await _generate_gemini_content_with_fallback_async(
+                contents,
+                route,
+                attempt_counter=attempt_counter,
+            )
         model = getattr(response, "model_name", GEMINI_MODEL)
         text, _tokens = _extract_text_and_tokens(response)
         elapsed = time.monotonic() - started
@@ -25439,6 +25486,7 @@ def _generate_model_with_retry(
     contents: str,
     route: str,
     policy,
+    attempt_counter: ProviderAttemptCounter | None = None,
 ):
     last_error = None
     for attempt_index in range(policy.provider_retries + 1):
@@ -25449,10 +25497,18 @@ def _generate_model_with_retry(
             attempt_index + 1,
         )
         try:
-            response = client.models.generate_content(
-                model=_gemini_model_resource_name(model_name),
+            generate_content = client.models.generate_content
+            model_resource = _gemini_model_resource_name(model_name)
+            generation_config = _generation_config_for_model(
+                model_name,
+                route,
+            )
+            if attempt_counter is not None:
+                attempt_counter.mark_started()
+            response = generate_content(
+                model=model_resource,
                 contents=contents,
-                config=_generation_config_for_model(model_name, route),
+                config=generation_config,
             )
             record_generation_token_usage(
                 response,
@@ -25485,11 +25541,16 @@ def _generate_model_with_retry(
     raise last_error or RuntimeError("provider_generation_failed")
 
 
-def _generate_gemini_content_with_fallback(contents: str, route: str):
+def _generate_gemini_content_with_fallback(
+    contents: str,
+    route: str,
+    *,
+    attempt_counter: ProviderAttemptCounter | None = None,
+):
     policy = policy_for_route(route)
     reservation = reserve_local_model_budget(contents, route)
-    client = get_gemini_client()
     try:
+        client = get_gemini_client()
         try:
             response = _generate_model_with_retry(
                 client,
@@ -25497,6 +25558,7 @@ def _generate_gemini_content_with_fallback(contents: str, route: str):
                 contents=contents,
                 route=route,
                 policy=policy,
+                attempt_counter=attempt_counter,
             )
             return RoutedGenerationResponse(
                 raw_response=response,
@@ -25528,6 +25590,7 @@ def _generate_gemini_content_with_fallback(contents: str, route: str):
                     contents=contents,
                     route=route,
                     policy=policy,
+                    attempt_counter=attempt_counter,
                 )
             except Exception as fallback_error:
                 logging.error(
@@ -26358,6 +26421,7 @@ async def get_gemini_response(
     route: str = "get_gemini_response",
     *,
     source_context_available: bool = False,
+    attempt_counter: ProviderAttemptCounter | None = None,
 ):
     try:
         one_call_packet_route = (
@@ -26448,7 +26512,17 @@ async def get_gemini_response(
 
         User: {prompt}
         BNL-01:"""
-        generation_result = await _generate_gemini_content_result_async(request_contents, route)
+        if attempt_counter is None:
+            generation_result = await _generate_gemini_content_result_async(
+                request_contents,
+                route,
+            )
+        else:
+            generation_result = await _generate_gemini_content_result_async(
+                request_contents,
+                route,
+                attempt_counter=attempt_counter,
+            )
         if not generation_result.success:
             return ""
         text = generation_result.text
@@ -28672,31 +28746,39 @@ async def get_gemini_response_with_optional_typing(
     route: str = "get_gemini_response",
     *,
     source_context_available: bool = False,
+    attempt_counter: ProviderAttemptCounter | None = None,
 ):
     """Run Gemini generation with an optional, cooldown-protected Discord typing indicator."""
-    if not BNL_TYPING_INDICATOR_ENABLED or channel is None:
-        if not BNL_TYPING_INDICATOR_ENABLED:
-            logging.info("typing_indicator_skipped reason=disabled")
+
+    async def generate():
+        if attempt_counter is None:
+            return await get_gemini_response(
+                prompt,
+                user_id,
+                guild_id,
+                route=route,
+                source_context_available=source_context_available,
+            )
         return await get_gemini_response(
             prompt,
             user_id,
             guild_id,
             route=route,
             source_context_available=source_context_available,
+            attempt_counter=attempt_counter,
         )
+
+    if not BNL_TYPING_INDICATOR_ENABLED or channel is None:
+        if not BNL_TYPING_INDICATOR_ENABLED:
+            logging.info("typing_indicator_skipped reason=disabled")
+        return await generate()
 
     channel_id = int(getattr(channel, "id", 0) or 0)
     now = datetime.now(timezone.utc)
     last_at = _channel_typing_indicator_last_at.get(channel_id)
     if last_at and (now - last_at).total_seconds() < BNL_TYPING_INDICATOR_COOLDOWN_SECONDS:
         logging.info(f"typing_indicator_skipped reason=cooldown channel={channel_id}")
-        return await get_gemini_response(
-            prompt,
-            user_id,
-            guild_id,
-            route=route,
-            source_context_available=source_context_available,
-        )
+        return await generate()
 
     typing_cm = None
     typing_started = False
@@ -28712,13 +28794,7 @@ async def get_gemini_response_with_optional_typing(
         logging.info(f"typing_indicator_failed reason={type(exc).__name__} channel={channel_id}")
 
     try:
-        return await get_gemini_response(
-            prompt,
-            user_id,
-            guild_id,
-            route=route,
-            source_context_available=source_context_available,
-        )
+        return await generate()
     finally:
         if typing_started and typing_cm is not None:
             try:
@@ -28727,6 +28803,35 @@ async def get_gemini_response_with_optional_typing(
                 logging.info(f"typing_indicator_failed reason=exit_http_exception status={getattr(exc, 'status', 'unknown')} channel={channel_id}")
             except Exception as exc:
                 logging.info(f"typing_indicator_failed reason=exit_{type(exc).__name__} channel={channel_id}")
+
+
+async def get_tracked_gemini_response_with_optional_typing(
+    channel,
+    prompt: str,
+    user_id: int,
+    guild_id: int,
+    route: str,
+    *,
+    source_context_available: bool = False,
+) -> TrackedGenerationResponse:
+    """Return text plus physical provider attempts for acceptance receipts."""
+
+    attempt_counter = ProviderAttemptCounter()
+    text = await get_gemini_response_with_optional_typing(
+        channel,
+        prompt,
+        user_id,
+        guild_id,
+        route=route,
+        source_context_available=source_context_available,
+        attempt_counter=attempt_counter,
+    )
+    return TrackedGenerationResponse(
+        text=str(text or ""),
+        provider_call_count=max(0, int(attempt_counter.count or 0)),
+    )
+
+
 SHOW_STATE_TOPIC_TTL_SECONDS = 300
 
 TYPING_RECENT_WINDOW_SECONDS = 5
@@ -36044,9 +36149,9 @@ async def maybe_generate_ordinary_chat_single_packet(
         )
 
     generation_started = time.monotonic()
-    provider_call_count = 1
+    provider_call_count = 0
     try:
-        candidate = await get_gemini_response_with_optional_typing(
+        tracked_generation = await get_tracked_gemini_response_with_optional_typing(
             channel,
             packet_prompt.prompt,
             user_id,
@@ -36054,6 +36159,8 @@ async def maybe_generate_ordinary_chat_single_packet(
             route=ORDINARY_CHAT_SINGLE_PACKET_ROUTE,
             source_context_available=source_context_available,
         )
+        candidate = tracked_generation.text
+        provider_call_count = tracked_generation.provider_call_count
     except Exception as exc:
         logging.warning(
             "ordinary_chat_single_packet_generation_failed error=%s",

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -476,6 +476,21 @@ _UNSUPPORTED_FRAMED_CONCRETE_RE = re.compile(
     re.I,
 )
 _INTERNAL_PROPER_NOUN_RE = re.compile(r"(?<!^)(?<![.!?]\s)\b[A-Z][\w'-]{2,}\b")
+_PACKET_DOMAIN_BRAND_RE = re.compile(
+    r"\b(?:BARCODE(?:\s+(?:Network|Radio))?|BNL(?:-?01)?)\b",
+    re.I,
+)
+_PACKET_DOMAIN_TITLED_RE = re.compile(
+    r"\b(?:Journal|Relay|Moment|Source\s+File)\b"
+)
+_PACKET_DOMAIN_CONCRETE_ASSERTION_RE = re.compile(
+    r"\b(?:am|are|is|was|were|has|have|had|began|started|ended|"
+    r"works?|prefers?|likes?|loves?|owns?|runs?|hosts?|manages?|"
+    r"leads?|founds?|founded|joins?|joined|releases?|released|"
+    r"publishes?|published|creates?|created|builds?|built|"
+    r"originates?|originated|becomes?|became)\b",
+    re.I,
+)
 _CONCRETE_RELATION_GENERIC_NAMES = frozenset(
     {"barcode", "bnl", "discord", "network", "radio"}
 )
@@ -4572,6 +4587,152 @@ def candidate_profile_coverage(
     )
 
 
+def _ordinary_chat_packet_domain_labels(
+    basis: SharedBrainSynthesisBasis,
+) -> tuple[str, ...]:
+    """Return governed subject labels, never arbitrary evidence values."""
+
+    packet = basis.packet
+    request = packet.request
+    labels = {
+        str(request.subject_display_name or "").strip(),
+        *(
+            str(subject.label_hint or "").strip()
+            for subject in tuple(request.frame_subjects or ())
+        ),
+    }
+    resolution = packet.subject_resolution
+    for reference in (
+        str(resolution.entity_ref or ""),
+        str(resolution.subject_key or ""),
+    ):
+        prefix, separator, suffix = reference.partition(":")
+        if not separator or prefix not in {"barcode", "canon", "entity"}:
+            continue
+        labels.add(re.sub(r"[_-]+", " ", suffix).strip())
+    return tuple(
+        sorted(
+            label
+            for label in labels
+            if len(label) >= 3
+            and label.casefold()
+            not in {"member", "unknown", "user"}
+        )
+    )
+
+
+def _ordinary_chat_packet_domain_context_active(
+    basis: SharedBrainSynthesisBasis,
+) -> bool:
+    """Return whether the current request depends on governed BARCODE truth."""
+
+    packet = basis.packet
+    request = packet.request
+    resolution = packet.subject_resolution
+    if resolution.status == "resolved" and bool(
+        int(resolution.subject_user_id or 0)
+        or str(resolution.subject_key or "")
+        or str(resolution.entity_ref or "")
+    ):
+        return True
+    if any(
+        bool(int(subject.user_id or 0) or str(subject.entity_ref or ""))
+        and str(subject.binding_method or "").lower()
+        not in {"", "none", "unresolved", "label_only"}
+        for subject in tuple(request.frame_subjects or ())
+    ):
+        return True
+    if str(request.frame_event_ref or "").strip():
+        return True
+    request_text = str(request.user_text or "")
+    return bool(
+        _PACKET_DOMAIN_BRAND_RE.search(request_text)
+        or _PACKET_DOMAIN_TITLED_RE.search(request_text)
+    )
+
+
+def _ordinary_chat_claim_mentions_label(
+    claim: str,
+    labels: Sequence[str],
+) -> bool:
+    normalized = re.sub(r"\s+", " ", str(claim or "")).casefold()
+    return any(
+        re.search(
+            r"(?<![\w])%s(?![\w])"
+            % re.escape(re.sub(r"\s+", " ", label).casefold()),
+            normalized,
+        )
+        for label in labels
+        if label
+    )
+
+
+def audit_ordinary_chat_candidate_claims(
+    basis: SharedBrainSynthesisBasis,
+    response: str,
+    *,
+    coverage: CandidateProfileCoverage | None = None,
+) -> tuple[tuple[str, ...], int]:
+    """Separate unsupported packet claims from allowed external knowledge.
+
+    The packet is authoritative only for BARCODE/member/publication/history
+    facts. General external knowledge is deliberately outside that authority
+    and is therefore not rejected merely because it is absent from the
+    packet. No external claim is relabeled as verified here.
+    """
+
+    profile = coverage or candidate_profile_coverage(basis, response)
+    claims = _candidate_claim_units(response)
+    classifications = tuple(profile.claim_classifications)
+    packet_context = _ordinary_chat_packet_domain_context_active(basis)
+    labels = _ordinary_chat_packet_domain_labels(basis)
+    if len(claims) != len(classifications):
+        if packet_context and claims:
+            return (("unsupported_packet_domain",) * len(claims), len(claims))
+        return (classifications, 0)
+
+    audited: list[str] = []
+    unsupported_packet_domain = 0
+    supported = {
+        "member_supported",
+        "canon_supported",
+        "member_and_canon_supported",
+    }
+    for claim, classification in zip(claims, classifications):
+        if classification in supported or classification == "transient_expression":
+            audited.append(classification)
+            continue
+        explicit_domain = bool(
+            _PACKET_DOMAIN_BRAND_RE.search(claim)
+            or _PACKET_DOMAIN_TITLED_RE.search(claim)
+            or _ordinary_chat_claim_mentions_label(claim, labels)
+        )
+        personal_fact = bool(
+            _UNSUPPORTED_SCALAR_ASSERTION_RE.search(claim)
+            or _UNSUPPORTED_FRAMED_CONCRETE_RE.search(claim)
+        )
+        concrete_assertion = bool(
+            classification == "unsupported_factual"
+            or personal_fact
+            or (
+                (packet_context or explicit_domain)
+                and _PACKET_DOMAIN_CONCRETE_ASSERTION_RE.search(claim)
+            )
+        )
+        packet_unsupported = bool(
+            concrete_assertion
+            and (packet_context or explicit_domain or personal_fact)
+        )
+        if packet_unsupported:
+            audited.append("unsupported_packet_domain")
+            unsupported_packet_domain += 1
+        elif classification == "unsupported_factual":
+            audited.append("external_public_knowledge")
+        else:
+            audited.append(classification)
+    return tuple(audited), unsupported_packet_domain
+
+
 def candidate_evidence_coverage(
     basis: SharedBrainSynthesisBasis,
     response: str,
@@ -5125,6 +5286,15 @@ def evaluate_single_packet_response(
     )
     coherence = assess_response_coherence(run.basis.assessment, candidate)
     output_leak = response_exposes_controls(candidate)
+    coverage = candidate_profile_coverage(run.basis, candidate)
+    (
+        receipt_claim_classifications,
+        unsupported_packet_domain_claims,
+    ) = audit_ordinary_chat_candidate_claims(
+        run.basis,
+        candidate,
+        coverage=coverage,
+    )
     calls = max(0, int(provider_call_count or 0))
     corrective_calls = max(0, int(corrective_call_count or 0))
     fallback_reason = ""
@@ -5140,10 +5310,11 @@ def evaluate_single_packet_response(
         fallback_reason = "generation_failed"
     elif output_leak:
         fallback_reason = "control_marker_leak"
+    elif unsupported_packet_domain_claims:
+        fallback_reason = "unsupported_packet_domain_claim"
     elif coherence.status == "failed":
         fallback_reason = "coherence_failed"
     candidate_selected = not fallback_reason
-    coverage = candidate_profile_coverage(run.basis, candidate)
     conn.execute(
         """
         UPDATE memory_governance_shared_brain_synthesis_runs
@@ -5187,9 +5358,9 @@ def evaluate_single_packet_response(
             coverage.canon_supported_claim_count,
             coverage.opinion_claim_count,
             coverage.connective_claim_count,
-            coverage.unsupported_factual_claim_count,
+            unsupported_packet_domain_claims,
             json.dumps(
-                dict(Counter(coverage.claim_classifications)),
+                dict(Counter(receipt_claim_classifications)),
                 sort_keys=True,
             ),
             calls,
@@ -5237,9 +5408,9 @@ def evaluate_single_packet_response(
         candidate_opinion_claim_count=coverage.opinion_claim_count,
         candidate_connective_claim_count=coverage.connective_claim_count,
         candidate_unsupported_factual_claim_count=(
-            coverage.unsupported_factual_claim_count
+            unsupported_packet_domain_claims
         ),
-        candidate_claim_classifications=coverage.claim_classifications,
+        candidate_claim_classifications=receipt_claim_classifications,
     )
 
 

--- a/docs/ordinary_chat_single_packet_canary_v1.md
+++ b/docs/ordinary_chat_single_packet_canary_v1.md
@@ -55,6 +55,17 @@ For an eligible turn:
 5. A generated candidate changed or suppressed by a guard is not sent and is
    never repaired by another provider call.
 
+Provider-call receipts increment only at the physical `generate_content`
+invocation boundary. Local quota refusal, budget-reservation failure, client
+construction failure, and other pre-provider exits remain zero-attempt runs;
+a provider invocation that starts and then fails remains one attempt.
+
+Before candidate selection, the response is audited against the frozen packet.
+Any unsupported BARCODE, member, identity, relationship, episode, publication,
+canon, or stored-history claim blocks the candidate. Ordinary external public
+knowledge remains permitted, but it is never relabeled as BARCODE memory or
+private packet evidence.
+
 Preflight ambiguity or invalid source state uses zero provider calls and a
 bounded clarification/block response. A failed generation or rejected
 candidate never falls back to the legacy generated response. Specialized

--- a/tests/test_async_relay_offload.py
+++ b/tests/test_async_relay_offload.py
@@ -203,6 +203,91 @@ class GeminiOffloadTests(unittest.IsolatedAsyncioTestCase):
             bnl01_bot.GENERATION_ERROR_LOCAL_MODEL_BUDGET,
         )
 
+    async def test_tracked_generation_counts_zero_when_local_quota_blocks(self):
+        with mock.patch.object(bnl01_bot, "BNL_TYPING_INDICATOR_ENABLED", False), \
+             mock.patch.object(bnl01_bot, "check_quota_availability", return_value=False), \
+             mock.patch.object(bnl01_bot, "_generate_gemini_content_with_fallback_async") as generate:
+            result = await bnl01_bot.get_tracked_gemini_response_with_optional_typing(
+                None,
+                "packet-owned prompt",
+                7,
+                1,
+                bnl01_bot.ORDINARY_CHAT_SINGLE_PACKET_ROUTE,
+                source_context_available=True,
+            )
+
+        self.assertEqual(result.text, "")
+        self.assertEqual(result.provider_call_count, 0)
+        generate.assert_not_called()
+
+    async def test_provider_counter_marks_successful_physical_invocation(self):
+        counter = bnl01_bot.ProviderAttemptCounter()
+        fake_client = SimpleNamespace(
+            models=SimpleNamespace(
+                generate_content=mock.Mock(
+                    return_value=gemini_response("single packet", 5)
+                )
+            )
+        )
+        with mock.patch.object(bnl01_bot, "gemini_client", fake_client), \
+             mock.patch.object(bnl01_bot, "reserve_local_model_budget", return_value=17), \
+             mock.patch.object(bnl01_bot, "release_local_model_budget"), \
+             mock.patch.object(bnl01_bot, "record_generation_token_usage"):
+            response = await bnl01_bot._generate_gemini_content_with_fallback_async(
+                "packet-owned prompt",
+                bnl01_bot.ORDINARY_CHAT_SINGLE_PACKET_ROUTE,
+                attempt_counter=counter,
+            )
+
+        self.assertEqual(
+            bnl01_bot._extract_text_and_tokens(response),
+            ("single packet", 5),
+        )
+        self.assertEqual(counter.count, 1)
+        fake_client.models.generate_content.assert_called_once()
+
+    async def test_provider_counter_stays_zero_when_client_setup_fails(self):
+        counter = bnl01_bot.ProviderAttemptCounter()
+        with mock.patch.object(bnl01_bot, "reserve_local_model_budget", return_value=17), \
+             mock.patch.object(
+                 bnl01_bot,
+                 "get_gemini_client",
+                 side_effect=RuntimeError("client setup failed"),
+             ), \
+             mock.patch.object(bnl01_bot, "release_local_model_budget") as release:
+            with self.assertRaisesRegex(RuntimeError, "client setup failed"):
+                await bnl01_bot._generate_gemini_content_with_fallback_async(
+                    "packet-owned prompt",
+                    bnl01_bot.ORDINARY_CHAT_SINGLE_PACKET_ROUTE,
+                    attempt_counter=counter,
+                )
+
+        self.assertEqual(counter.count, 0)
+        release.assert_called_once_with(17)
+
+    async def test_provider_counter_marks_failed_physical_invocation(self):
+        counter = bnl01_bot.ProviderAttemptCounter()
+        fake_client = SimpleNamespace(
+            models=SimpleNamespace(
+                generate_content=mock.Mock(
+                    side_effect=Exception("503 service unavailable")
+                )
+            )
+        )
+        with mock.patch.object(bnl01_bot, "gemini_client", fake_client), \
+             mock.patch.object(bnl01_bot, "reserve_local_model_budget", return_value=17), \
+             mock.patch.object(bnl01_bot, "release_local_model_budget"), \
+             mock.patch.object(bnl01_bot, "record_failed_generation_attempt"):
+            with self.assertRaisesRegex(Exception, "503"):
+                await bnl01_bot._generate_gemini_content_with_fallback_async(
+                    "packet-owned prompt",
+                    bnl01_bot.ORDINARY_CHAT_SINGLE_PACKET_ROUTE,
+                    attempt_counter=counter,
+                )
+
+        self.assertEqual(counter.count, 1)
+        fake_client.models.generate_content.assert_called_once()
+
     async def test_glitch_rewrite_uses_offloaded_generation(self):
         responses = [gemini_response("base text", 11), gemini_response("glitched text", 2)]
 

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -11,10 +11,12 @@ import bnl_relationship_engine as relationships
 from bnl_shared_brain_synthesis import (
     ORDINARY_CHAT_AUTHORITY,
     ORDINARY_CHAT_ROUTE_FAMILY,
+    audit_ordinary_chat_candidate_claims,
     begin_single_packet_run,
     build_evaluation_report,
     build_ordinary_chat_basis,
     build_packet_owned_prompt,
+    candidate_profile_coverage,
     evaluate_single_packet_response,
     finalize_run,
     ordinary_chat_configuration,
@@ -25,6 +27,7 @@ from bnl_unified_intelligence_packet import (
     IntelligencePacketRequest,
     PacketConversationEvidence,
     PacketFrameSubject,
+    PacketSubjectResolution,
     build_packet,
 )
 from bnl_unified_response_assessment import (
@@ -429,7 +432,7 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         decision = evaluate_single_packet_response(
             self.conn,
             run,
-            response="I can answer that directly from the current exchange.",
+            response="Your favorite movie is Arrival.",
             provider_call_count=1,
             corrective_call_count=0,
             generation_latency_ms=42,
@@ -492,6 +495,67 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertEqual(report["ordinaryCallCountViolationRuns"], 0)
         self.assertEqual(report["ordinaryCorrectiveCallViolationRuns"], 0)
         self.assertEqual(report["invalidScopeRuns"], 0)
+
+    def test_unsupported_packet_domain_claims_are_rejected_before_selection(self):
+        candidates = (
+            "Your favorite movie is Blade Runner.",
+            "You work as a network engineer.",
+            "He works as a network engineer.",
+            "You and Mac Modem are siblings.",
+            "BARCODE Radio started in 1999.",
+        )
+        for candidate in candidates:
+            with self.subTest(candidate=candidate):
+                decision = evaluate_single_packet_response(
+                    self.conn,
+                    self._begin(),
+                    response=candidate,
+                    provider_call_count=1,
+                    corrective_call_count=0,
+                    environ=self.flags,
+                )
+                self.assertFalse(decision.candidate_selected)
+                self.assertEqual(
+                    decision.fallback_reason,
+                    "unsupported_packet_domain_claim",
+                )
+                self.assertGreaterEqual(
+                    decision.candidate_unsupported_factual_claim_count,
+                    1,
+                )
+                self.assertIn(
+                    "unsupported_packet_domain",
+                    decision.candidate_claim_classifications,
+                )
+
+    def test_external_public_knowledge_is_not_made_packet_authority(self):
+        external_packet = replace(
+            self.packet,
+            request=replace(
+                self.packet.request,
+                subject_user_id=0,
+                subject_display_name="",
+                user_text="Where is Seattle?",
+                frame_subject_requirement="not_required",
+                frame_subjects=(),
+                frame_event_ref="",
+                frame_event_relation="not_applicable",
+            ),
+            subject_resolution=PacketSubjectResolution(
+                status="not_applicable",
+                reason_codes=("subject_not_required",),
+            ),
+        )
+        external_basis = replace(self.basis, packet=external_packet)
+        response = "Seattle is in Washington."
+        coverage = candidate_profile_coverage(external_basis, response)
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            external_basis,
+            response,
+            coverage=coverage,
+        )
+        self.assertEqual(unsupported, 0)
+        self.assertEqual(classifications, ("external_public_knowledge",))
 
     def test_invalid_call_counts_fail_closed_and_are_reported(self):
         run = self._begin()

--- a/tests/test_shared_brain_synthesis_bot_path.py
+++ b/tests/test_shared_brain_synthesis_bot_path.py
@@ -1042,7 +1042,12 @@ class SharedBrainSynthesisBotPathTests(
             fallback_reason="",
             run=run,
         )
-        provider = mock.AsyncMock(return_value="One generated answer.")
+        provider = mock.AsyncMock(
+            return_value=bnl01_bot.TrackedGenerationResponse(
+                text="One generated answer.",
+                provider_call_count=1,
+            )
+        )
         evaluate = mock.Mock(return_value=decision)
         with (
             mock.patch.object(
@@ -1066,7 +1071,7 @@ class SharedBrainSynthesisBotPathTests(
             ),
             mock.patch.object(
                 bnl01_bot,
-                "get_gemini_response_with_optional_typing",
+                "get_tracked_gemini_response_with_optional_typing",
                 new=provider,
             ),
             mock.patch.object(
@@ -1110,6 +1115,84 @@ class SharedBrainSynthesisBotPathTests(
         self.assertEqual(evaluate.call_args.kwargs["provider_call_count"], 1)
         self.assertEqual(evaluate.call_args.kwargs["corrective_call_count"], 0)
 
+    async def test_single_packet_preprovider_exit_records_zero_calls(self):
+        basis = SimpleNamespace(
+            packet=SimpleNamespace(source_snapshot_digest="source-digest")
+        )
+        run = SimpleNamespace(
+            prompt_applied=True,
+            fallback_reason="",
+            revalidation_status="passed",
+            basis=basis,
+        )
+        decision = SimpleNamespace(
+            candidate_selected=False,
+            fallback_reason="provider_call_count_invalid",
+            run=run,
+        )
+        provider = mock.AsyncMock(
+            return_value=bnl01_bot.TrackedGenerationResponse(
+                text="",
+                provider_call_count=0,
+            )
+        )
+        evaluate = mock.Mock(return_value=decision)
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "build_packet_owned_prompt",
+                return_value=SimpleNamespace(
+                    ready=True,
+                    prompt="packet-owned prompt",
+                    reason="",
+                ),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "revalidate_situation_frame",
+                return_value=SimpleNamespace(status="valid"),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "_begin_ordinary_chat_single_packet_receipt",
+                return_value=run,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "get_tracked_gemini_response_with_optional_typing",
+                new=provider,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "_evaluate_ordinary_chat_single_packet_receipt",
+                new=evaluate,
+            ),
+        ):
+            execution = (
+                await bnl01_bot.maybe_generate_ordinary_chat_single_packet(
+                    channel=FakeChannel(),
+                    prompt="base prompt",
+                    basis=basis,
+                    scope_applied=True,
+                    preflight_block_reason="",
+                    situation_frame=SimpleNamespace(),
+                    situation_frame_current_text="Answer this.",
+                    route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy="public_context",
+                    conversation_surface="mention_or_reply",
+                    user_id=7,
+                    guild_id=1,
+                    user_display_name="Test Member",
+                    source_context_available=True,
+                )
+            )
+
+        self.assertFalse(execution.candidate_active)
+        self.assertEqual(execution.provider_call_count, 0)
+        provider.assert_awaited_once()
+        self.assertEqual(evaluate.call_args.kwargs["provider_call_count"], 0)
+        self.assertEqual(evaluate.call_args.kwargs["corrective_call_count"], 0)
+
     async def test_single_packet_ambiguous_preflight_uses_zero_provider_calls(self):
         basis = SimpleNamespace(
             packet=SimpleNamespace(source_snapshot_digest="source-digest")
@@ -1143,7 +1226,7 @@ class SharedBrainSynthesisBotPathTests(
             ) as begin,
             mock.patch.object(
                 bnl01_bot,
-                "get_gemini_response_with_optional_typing",
+                "get_tracked_gemini_response_with_optional_typing",
                 new=provider,
             ),
         ):


### PR DESCRIPTION
## Summary

- reject unsupported BARCODE/member/identity/relationship/history claims before ordinary-chat candidate selection
- preserve ordinary external public knowledge without treating it as packet authority
- count provider attempts at the physical `generate_content` boundary, including failed invocations and excluding pre-provider exits
- document the receipt boundary and add regression coverage for invented facts, local refusal, setup failure, success, and provider failure

## Verification

- focused ordinary-chat/provider suites (39 passed)
- broad bot regressions (114 passed)
- `PYTHONPATH=/tmp/bnl01-test-deps-aug10:. make check` (2,205 passed)
- `git diff --check`
- added-line privacy/secret scan

Exact tested tree: `a15450467021376ffab90da8324046b5c043b348`