### PR TITLE
Repair ordinary-chat claim-specific acceptance boundaries

### DIFF
--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -20,6 +20,7 @@ import uuid
 from typing import Any, Mapping, Sequence
 
 from bnl_canon_source_contract import (
+    CANON_ENTITY_IDENTITIES,
     ENTITY_ACCOUNT_BINDING_CONTRACT_VERSION,
     HYBRID_CANON_CLAIM_CONTRACT_VERSION,
 )
@@ -445,6 +446,33 @@ _DERIVED_ASSESSMENT_RE = re.compile(
     r"the\s+combination|the\s+throughline)\b",
     re.I,
 )
+_MEMBER_ASSESSMENT_BACKWARD_SUBJECT_RE = re.compile(
+    r"^(?:(?:based\s+on\s+my\s+observations?|my\s+(?:assessment|read|"
+    r"take|view)\s+is\s+that|overall|put\s+together|together)"
+    r"\s*[,;:—–]?\s+)?"
+    r"(?:(?:both|that|these|this|those)\s+"
+    r"(?:choice|choices|combination|part|preference|preferences)|"
+    r"the\s+(?:choice|choices|combination|part|preference|preferences|"
+    r"throughline))\s+"
+    r"(?:create|creates|form|forms|give|gives|keep|keeps|make|makes|"
+    r"read|reads|signal|signals|strike|strikes)\s+"
+    r"(?:(?:a|an|the|as|like|me|us|you)\s+)?"
+    r"(?:(?:vivid|strong|clear|distinctive|creative|iterative|"
+    r"recognizable|familiar|coherent|consistent|recurring|playful|"
+    r"careful|deliberate|thoughtful|curious|focused|adaptive)\s+){0,3}"
+    r"(?:approach|combination|connection|frequency|pattern|process|"
+    r"signal|style|throughline|vibe)\b"
+    r"(?:\s+(?:i|we)\s+(?:notice|recognize|see))?$",
+    re.I,
+)
+_MEMBER_ASSESSMENT_BACKWARD_OBJECT_RE = re.compile(
+    r"^(?:that|this)\s+(?:is|reads?\s+as)\s+(?:the\s+)?"
+    r"(?:familiar\s+|recognizable\s+|recurring\s+)?"
+    r"(?:part|pattern|signal|throughline)\b"
+    r"(?:\s+of\s+your\s+frequency)?"
+    r"(?:\s+(?:i|we)\s+(?:notice|recognize|see))?$",
+    re.I,
+)
 _DIRECT_MEMBER_ASSERTION_RE = re.compile(
     r"\b(?:you(?:'re|\s+are|\s+were|\s+have|\s+had|\s+keep|\s+kept|"
     r"\s+make|\s+made|\s+build|\s+built|\s+create|\s+created|"
@@ -459,6 +487,347 @@ _UNSUPPORTED_SCALAR_ASSERTION_RE = re.compile(
     r"you\s+(?:live|reside|work)\s+(?:at|in|near|for)\b|"
     r"you\s+(?:prefer|like|love|own|have)\b)",
     re.I,
+)
+_CLAIM_LEADING_CONCESSIVE_RE = re.compile(
+    r"^(?:although|because|even\s+though|since|though|while|whereas)\s+",
+    re.I,
+)
+_CLAIM_CONTEXT_LEADING_MODIFIER_RE = re.compile(
+    r"^(?:according\s+to|after|as\s+of|at|before|during|from|in|on)\s+"
+    r"(?P<context>[^,]{1,160}),\s*",
+    re.I,
+)
+_CLAIM_SIMPLE_LEADING_MODIFIER_RE = re.compile(
+    r"^(?:apparently|actually|also|always|never|often|perhaps|maybe|"
+    r"sometimes|still|now|personally|supposedly|allegedly|reportedly|"
+    r"today|yesterday|currently|recently|later|then|at\s+the\s+time|"
+    r"in\s+\d{4}|(?:last|this|next)\s+(?:year|month|week))\s*,?\s+",
+    re.I,
+)
+_CLAIM_LEADING_DIRECT_PACKET_SUBJECT_RE = re.compile(
+    r"^(?:i|i'm|i've|i'd|my|me|we|we're|we've|we'd|our|ours|"
+    r"you|you're|you've|you'd|your|yours|"
+    r"the\s+(?:member|requester|user|selected\s+member)|"
+    r"this\s+member|that\s+member|<@!?\d+>)(?!\w)",
+    re.I,
+)
+_CLAIM_LEADING_GUIDANCE_RE = re.compile(
+    r"^you\s+(?:can|could|may|might|should|would)\s+"
+    r"(?:ask|check|compare|consult|contact|download|explore|find|"
+    r"follow|help|look\s+(?:at|for|up)|open|read|refer|respond|"
+    r"review|search|see\s+(?:the|more|details|public)|summarize|"
+    r"try|use|visit|work\s+with)\b(?P<target>.{1,240})$",
+    re.I,
+)
+_GUIDANCE_PUBLIC_TARGET_RE = re.compile(
+    r"\b(?:external|official|open|public|published|reference)\b|"
+    r"https?://|www\.|\b(?:documentation|docs|manual|source|"
+    r"website)\b",
+    re.I,
+)
+_GUIDANCE_PRIVATE_TARGET_RE = re.compile(
+    r"\b(?:archive|birthday|database|dossier|history|internal|memory|"
+    r"message|messages|packet|private|profile|record|records|secret|"
+    r"stored)\b",
+    re.I,
+)
+_PACKET_REFERENT_RE = re.compile(
+    r"(?:<@!?\d+>|\b(?:i|me|mine|my|we|us|our|ours|"
+    r"you|your|yours)\b|"
+    r"\b(?:he|she|they|him|his|her|hers|it|its|them|their|theirs)\b|"
+    r"\b(?:the|this|that)\s+(?:event|member|project|requester|user)\b)",
+    re.I,
+)
+_PACKET_CLAUSE_TAIL_BOUNDARY_RE = re.compile(
+    r"(?:[,;:—–]|\b(?:although|and|because|but|since|though|while|"
+    r"whereas|yet)\b)\s+",
+    re.I,
+)
+_AMBIGUOUS_PACKET_SUBJECT_RE = re.compile(
+    r"^(?:(?:an?|the|this|that|these|those)\s+)?"
+    r"(?:(?:archival|assistant|cached|confidential|conversation|current|"
+    r"encrypted|episodic|"
+    r"evidence|governance|hidden|intelligence|internal|known|live|local|"
+    r"long[- ]term|moment|personal|persistent|private|production|public|"
+    r"request|retrieval|runtime|secret|selected|semantic|session|shared[- ]"
+    r"brain|situation[- ]frame|stored|working)\s+|BNL(?:'s)?\s+)*"
+    r"(?:ai|analytics|answer|archive|archives|assessment|bot|brain|broadcast|"
+    r"cache|candidate|canary|collective|column|context|database|databases|"
+    r"dossier|engine|entity|environment|event|facts?|feature\s+flags?|flags?|"
+    r"employment\s+history|founder|frame|gate|history|hobbies|interests|"
+    r"ledger|marital\s+status|member|memories|"
+    r"memory|model|network|packets?|preferences|profile|profiles|project|"
+    r"preference|prompt|provider|radio|receipt|relationship|requester|"
+    r"response|row|run|runtime|"
+    r"shared\s+brain|situation\s+frame|source|status|store|synthesis|system|"
+    r"evidence|table|traits?|user|vector\s+database)\b|"
+    r"^(?:(?:one|another)\s+member|(?:this|that)\s+person|the\s+individual)\b",
+    re.I,
+)
+_CLARIFICATION_QUESTION_RE = re.compile(
+    r"^(?:(?:do|does|did)\s+(?:you|the\s+(?:member|requester|user))\s+"
+    r"(?:mean|need|prefer|recognize|refer|remember|use|want|work)\b|"
+    r"(?:are|were)\s+(?:you|the\s+(?:member|requester|user))\s+"
+    r"(?:asking|available|comfortable|interested|looking|ready|"
+    r"referring|talking|working)\b|"
+    r"(?:can|could|will|would)\s+(?:you|the\s+(?:member|requester|"
+    r"user))\s+(?:clarify|confirm|explain|specify|tell)\b|"
+    r"(?:what|which)\s+(?:do|does|did|are|is|was|were)\s+"
+    r"(?:you|the\s+(?:member|requester|user))\s+"
+    r"(?:mean|need|prefer|refer|remember|use|want)\b)"
+    r"[^,;:—–?]{0,240}\?$",
+    re.I,
+)
+_CLARIFICATION_UNSAFE_TAIL_RE = re.compile(
+    r"\b(?:abuse|abused|cheat|cheated|crime|criminal|fraud|fraudulent|"
+    r"illegal|kill|killed|lie|lied|murder|murdered|secretly|steal|"
+    r"stealing|stole|stop|stopped)\b|"
+    r"\b(?:although|and|because|but|since|though|while|whereas|yet)\b",
+    re.I,
+)
+_HONEST_INSUFFICIENCY_RE = re.compile(
+    r"^(?:i|we)\s+(?:(?:do\s+not|don't|cannot|can't|could\s+not|"
+    r"couldn't|am\s+not\s+able\s+to|are\s+not\s+able\s+to)\s+"
+    r"(?:claim|confirm|corroborate|determine|establish|find|know|"
+    r"remember|say|support|tell|validate|verify)\b|"
+    r"(?:do\s+not|don't)\s+have\s+(?:enough|any)\s+(?:reliable\s+)?"
+    r"(?:public\s+)?"
+    r"(?:context|evidence|history|information|record|support)\b|"
+    r"have\s+no\s+(?:reliable\s+)?(?:context|evidence|information|"
+    r"record|support)\b)",
+    re.I,
+)
+_HONEST_THIN_CONTEXT_RE = re.compile(
+    r"^(?:the\s+)?(?:longer[- ]term\s+)?"
+    r"(?:context|evidence|history|record|signal|support)\s+"
+    r"(?:is|remains)\s+(?:still\s+)?(?:too\s+)?"
+    r"(?:limited|sparse|thin|unclear|unknown|unreliable)"
+    r"(?:\s+for\s+a\s+grounded\s+profile)?\b",
+    re.I,
+)
+_HONEST_INSUFFICIENCY_TAIL_RE = re.compile(
+    r"\b(?:and|because|but|except|however|nevertheless|since|though|"
+    r"although|yet)\b",
+    re.I,
+)
+_HONEST_INSUFFICIENCY_SAFE_REMAINDER_RE = re.compile(
+    r"^(?:(?:about|for|from|on|regarding)\s+)?"
+    r"(?:you|your\s+(?:address|age|birthday|email|employer|history|home|"
+    r"job|name|profile|pronouns?|role|site|work|workplace)|BARCODE|"
+    r"BNL(?:[- ]?0?1)?|the\s+(?:member|requester|user))$|"
+    r"^(?:to\s+say\s+)?(?:if|that|whether|where|when|who|what|which|"
+    r"why|how)\s+[^,;/\[\]():—–]{1,180}$",
+    re.I,
+)
+_HONEST_EMPTY_PROFILE_REMAINDER_RE = re.compile(
+    r"^(?:to\s+)?(?:summarize|profile)\s+"
+    r"(?:you|the\s+(?:member|requester|user))\s+without\s+guessing$",
+    re.I,
+)
+_EXTERNAL_TITLE_PREDICATE_RE = re.compile(
+    r"^(?P<title>.+?)\s+"
+    r"(?:(?:is|was)\s+(?:(?:a|an|the)\s+)?(?:\d{4}\s+)?"
+    r"(?:album|book|film|novel|play|series|song|title|work)"
+    r"(?:\s+(?:from|in)\s+\d{4})?|"
+    r"(?:was\s+)?(?:composed|premiered|published|released|written)"
+    r"(?:\s+(?:by\s+[A-Z][A-Za-z'’.-]*(?:\s+[A-Z][A-Za-z'’.-]*){0,3}|"
+    r"in\s+\d{4}))?)$",
+)
+_EXTERNAL_TITLE_TYPE_RE = re.compile(
+    r"^(?:(?:the\s+)?(?:album|book|film|novel|play|series|song|title|"
+    r"work)\s+)",
+    re.I,
+)
+_EXTERNAL_TITLE_CONNECTORS = frozenset(
+    {
+        "a",
+        "about",
+        "and",
+        "at",
+        "before",
+        "for",
+        "in",
+        "of",
+        "on",
+        "the",
+        "to",
+    }
+)
+_EXTERNAL_TITLE_PERSONAL_STARTS = frozenset(
+    {
+        "he",
+        "her",
+        "his",
+        "i",
+        "it",
+        "me",
+        "my",
+        "our",
+        "she",
+        "they",
+        "you",
+        "your",
+        "we",
+    }
+)
+_SAFE_CONVERSATIONAL_RE = re.compile(
+    r"^(?:alright|okay|sounds\s+good|that\s+makes\s+sense|thank\s+you|"
+    r"thanks|i\s+(?:agree|can\s+explain|can\s+help|hear\s+you|"
+    r"think\s+so|understand)|i\s+can\s+respond\s+to\s+what\s+you\s+"
+    r"say\s+here|we\s+can\s+do\s+that|you\s+got\s+it|"
+    r"you(?:'re|\s+are)\s+welcome)$",
+    re.I,
+)
+_EXTERNAL_OPINION_PREFIX_RE = re.compile(
+    r"^(?:i\s+(?:believe|figure|suspect|think)|"
+    r"my\s+(?:assessment|read|take|view)\s+is)\s+(?:that\s+)?"
+    r"(?P<subject>[^,;:—–]{3,240})$",
+    re.I,
+)
+_EXTERNAL_WORD_RE = re.compile(
+    r"https?://\S+|www\.\S+|[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}|"
+    r"\d+(?:-[A-Za-z0-9]+)?|[A-Za-z][A-Za-z0-9'’&.°-]*",
+    re.I,
+)
+_EXTERNAL_EXPLICIT_FINITE_VERBS = frozenset(
+    {
+        "am",
+        "are",
+        "became",
+        "become",
+        "becomes",
+        "began",
+        "begin",
+        "begins",
+        "can",
+        "could",
+        "did",
+        "do",
+        "does",
+        "flew",
+        "had",
+        "has",
+        "have",
+        "is",
+        "made",
+        "may",
+        "might",
+        "must",
+        "ran",
+        "shall",
+        "should",
+        "was",
+        "went",
+        "were",
+        "will",
+        "won",
+        "would",
+        "wrote",
+    }
+)
+_EXTERNAL_BARE_FINITE_VERBS = frozenset(
+    {
+        "bark",
+        "exist",
+        "fall",
+        "fly",
+        "freeze",
+        "grow",
+        "land",
+        "launch",
+        "live",
+        "migrate",
+        "orbit",
+        "power",
+        "publish",
+        "rise",
+        "run",
+        "stand",
+        "swim",
+        "travel",
+    }
+)
+_EXTERNAL_PREDICATE_FALSE_POSITIVES = frozenset(
+    {
+        "apps",
+        "details",
+        "feet",
+        "files",
+        "his",
+        "homes",
+        "its",
+        "kids",
+        "links",
+        "messages",
+        "ours",
+        "records",
+        "systems",
+        "theirs",
+        "this",
+        "times",
+        "users",
+        "values",
+        "years",
+        "yours",
+    }
+)
+_EXTERNAL_SUBJECT_FRAGMENT_STARTS = frozenset(
+    {
+        "address",
+        "aged",
+        "at",
+        "based",
+        "birthday",
+        "born",
+        "created",
+        "email",
+        "employed",
+        "engineer",
+        "favorite",
+        "from",
+        "home",
+        "job",
+        "lives",
+        "married",
+        "name",
+        "pronouns",
+        "artist",
+        "actor",
+        "admin",
+        "always",
+        "another",
+        "developer",
+        "director",
+        "doctor",
+        "employee",
+        "host",
+        "individual",
+        "manager",
+        "moderator",
+        "musician",
+        "never",
+        "now",
+        "often",
+        "one",
+        "owner",
+        "perhaps",
+        "person",
+        "producer",
+        "reporter",
+        "regularly",
+        "researcher",
+        "role",
+        "scientist",
+        "singer",
+        "someone",
+        "sometimes",
+        "started",
+        "still",
+        "teacher",
+        "website",
+        "works",
+        "writer",
+    }
 )
 _UNSUPPORTED_FRAMED_CONCRETE_RE = re.compile(
     r"(?:https?://|www\.|<@!?\d+>|"
@@ -476,19 +845,138 @@ _UNSUPPORTED_FRAMED_CONCRETE_RE = re.compile(
     re.I,
 )
 _INTERNAL_PROPER_NOUN_RE = re.compile(r"(?<!^)(?<![.!?]\s)\b[A-Z][\w'-]{2,}\b")
-_PACKET_DOMAIN_BRAND_RE = re.compile(
-    r"\b(?:BARCODE(?:\s+(?:Network|Radio))?|BNL(?:-?01)?)\b",
+_PACKET_DOMAIN_EXACT_CANON_RE = re.compile(
+    r"\bBARCODE\b|\b(?:6[\W_]*Bit|Six[\W_]*Bit)\b|"
+    r"\b(?:GALAK[\W_]*NOISE|Galak[\W_]*(?:noise|Noise))\b",
+)
+_PACKET_DOMAIN_BNL01_RE = re.compile(
+    r"\bB[\W_]*N[\W_]*L[\W_]*(?:0?1)\b",
     re.I,
 )
-_PACKET_DOMAIN_TITLED_RE = re.compile(
-    r"\b(?:Journal|Relay|Moment|Source\s+File)\b"
+_PACKET_DOMAIN_BRAND_COMPOUND_RE = re.compile(
+    r"\b(?:bar[\W_]*code[\W_]*(?:network|radio|collective)|"
+    r"bar[\W_]*code[\W_]*network[\W_]*liaison[\W_]*entity|"
+    r"d[\W_]*j[\W_]*floppy[\W_]*disc|mac[\W_]*mod(?:em|3m)|"
+    r"call[\W_]*em[\W_]*bini)\b",
+    re.I,
 )
-_PACKET_DOMAIN_CONCRETE_ASSERTION_RE = re.compile(
-    r"\b(?:am|are|is|was|were|has|have|had|began|started|ended|"
-    r"works?|prefers?|likes?|loves?|owns?|runs?|hosts?|manages?|"
-    r"leads?|founds?|founded|joins?|joined|releases?|released|"
-    r"publishes?|published|creates?|created|builds?|built|"
-    r"originates?|originated|becomes?|became)\b",
+_PACKET_DOMAIN_LINK_OR_ADDRESS_RE = re.compile(
+    r"(?:https?://\S+|www\.\S+|<@!?\d+>|"
+    r"\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b)",
+    re.I,
+)
+_PACKET_DOMAIN_PRESENTATION_RE = re.compile(
+    r"(?:\*\*|__|~~|`+|(?<!\w)[*_](?=\w)|(?<=\w)[*_](?!\w)|"
+    r"[\u200b-\u200d\ufeff])"
+)
+_PACKET_DOMAIN_HTML_TAG_RE = re.compile(r"</?[A-Za-z][^>]{0,80}>")
+_PACKET_DOMAIN_TITLED_PATTERNS = {
+    "journal": re.compile(
+        r"^(?:(?:the|this|that)\s+)?journal"
+        r"(?=(?:['’]s)?\s+(?!of\b))",
+        re.I,
+    ),
+    "relay": re.compile(
+        r"^(?:(?:the|this|that)\s+)?"
+        r"(?!(?-i:Relay\s+(?:AI|FM|Factory|Health|Labs|Magazine|"
+        r"Network|XR))\b)relay(?=(?:['’]s)?\s+)",
+        re.I,
+    ),
+    "moment": re.compile(
+        r"^(?:(?:the|this|that)\s+)?"
+        r"(?!(?-i:Moment\s+(?:AI|FM|Factory|Health|Labs|Magazine|"
+        r"Network|XR))\b)moment(?=(?:['’]s)?\s+)",
+        re.I,
+    ),
+    "source_file": re.compile(r"^(?:the\s+)?source\s+file\b", re.I),
+}
+_PACKET_DOMAIN_BARE_TITLE_RE = re.compile(
+    r"^(?:(?:the|this|that)\s+)?"
+    r"(?:journal(?:['’]s)?\s+(?!(?:of\b|is\s+(?:a|an|the)\s+\d{4}\s+(?:film|"
+    r"book|novel|series)|was\s+founded\b))|"
+    r"(?!(?-i:Relay\s+(?:AI|FM|Factory|Health|Labs|Magazine|Network|XR))\b)"
+    r"relay(?:['’]s)?\s+(?!is\s+(?:a|an|the)\s+\d{4}\s+"
+    r"(?:film|book|novel|series))|"
+    r"(?!(?-i:Moment\s+(?:AI|FM|Factory|Health|Labs|Magazine|Network|XR))\b)"
+    r"moment(?:['’]s)?\s+(?!magnitude\b))"
+    r"[A-Za-z0-9]",
+    re.I,
+)
+_PACKET_DOMAIN_LEADING_TITLE_RE = re.compile(
+    r"^(?:according\s+to|after|as\s+of|at|before|during|from|in|on)\s+"
+    r"(?:(?:the|this|that)\s+)?(?:"
+    r"journal(?!\s+of\b)|"
+    r"(?!(?-i:Relay\s+(?:AI|FM|Factory|Health|Labs|Magazine|Network|XR))\b)"
+    r"relay|"
+    r"(?!(?-i:Moment\s+(?:AI|FM|Factory|Health|Labs|Magazine|Network|XR))\b)"
+    r"moment"
+    r")(?:['’]s)?\b",
+    re.I,
+)
+_PACKET_DOMAIN_QUALIFIED_TITLE_RE = re.compile(
+    r"^(?:(?:(?:the|this|that)\s+)?(?:accepted|archived|current|governed|"
+    r"historical|internal|old|private|published|public|saved|selected|"
+    r"BNL(?:'s)?)\s+)+"
+    r"(?:journal|relay|moment)(?:['’]s)?\b",
+    re.I,
+)
+_PACKET_DOMAIN_CLAUSE_TITLE_SUBJECT_RE = re.compile(
+    r"^(?:(?:the|this|that)\s+)?"
+    r"(?:(?:(?:accepted|archived|current|governed|historical|internal|old|"
+    r"private|published|public|saved|selected|BNL(?:'s)?)\s+)+"
+    r"(?:journal|relay|moment)|"
+    r"journal(?!\s+of\b)|"
+    r"(?!(?-i:Relay\s+(?:AI|FM|Factory|Health|Labs|Magazine|Network|XR))\b)"
+    r"relay|"
+    r"(?!(?-i:Moment\s+(?:AI|FM|Factory|Health|Labs|Magazine|Network|XR))\b)"
+    r"moment"
+    r")(?:['’]s)?\b|"
+    r"^(?:the\s+)?source\s+file\b",
+    re.I,
+)
+_PACKET_DOMAIN_EXTERNAL_TITLE_NAME_RE = re.compile(
+    r"(?:\b(?:the\s+)?wall\s+street\s+journal\b|"
+    r"\b(?-i:(?:Relay|Moment)\s+(?:AI|FM|Factory|Health|Labs|Magazine|"
+    r"Network|XR))\b)",
+    re.I,
+)
+_PACKET_DOMAIN_EXTERNAL_TITLE_CONTEXT_RE = re.compile(
+    r"(?:(?:the|a|an|official)\s+)?(?:"
+    r"(?:the\s+)?wall\s+street\s+journal|"
+    r"(?-i:(?:Relay|Moment)\s+(?:AI|FM|Factory|Health|Labs|Magazine|"
+    r"Network|XR)))"
+    r"(?:(?:['’]s\s+|\s+)(?:article|publication|report))?|"
+    r"(?:(?:the|a|an|official)\s+)?(?:article|publication|report)\s+"
+    r"(?:by|from|of)\s+(?:(?:the\s+)?wall\s+street\s+journal|"
+    r"(?-i:(?:Relay|Moment)\s+(?:AI|FM|Factory|Health|Labs|Magazine|"
+    r"Network|XR)))",
+    re.I,
+)
+_PACKET_DOMAIN_ATTRIBUTIVE_MEMBER_RE = re.compile(
+    r"^(?:the\s+)?(?:latest\s+|recent\s+|public\s+)?"
+    r"(?:member|requester|user)\s+(?:study|survey)\b",
+    re.I,
+)
+_TRANSIENT_EXPRESSION_PACKET_ASSERTION_RE = re.compile(
+    r"(?:\b(?:i|my|we|our|you|your|he|his|she|her|they|their|it|its)\b|"
+    r"<@!?\d+>|\b(?:the|this|that|one|another)\s+"
+    r"(?:member|requester|user)\b|\b(?:BARCODE|BNL(?:[- ]?0?1)?)\b|"
+    r"\b(?:packet|database|memory|profile|dossier|archive|journal|relay|"
+    r"moment)\b).{0,180}\b(?:am|are|is|was|were|has|have|had|can|"
+    r"created|founded|joined|owns?|lives?|works?|served|attended|speaks?|"
+    r"uses?|voted|owes?|weighs?|abused|assaulted|robbed|kidnapped|"
+    r"harmed|threatened|harassed|committed|murdered|killed|lied|cheated|"
+    r"contains?|stores?|started|released|wrote)\b|"
+    r"\b(?:your|my|our|his|her|their|its)\s+"
+    r"(?:spouse|child|religion|race|diagnosis|income|credit\s+score|"
+    r"political\s+party|name|birthday|job|employer|favorite)\b",
+    re.I,
+)
+_TRANSIENT_EXPRESSION_GOVERNED_REFERENT_RE = re.compile(
+    r"(?:<@!?\d+>|\b(?:i|me|mine|my|we|us|our|ours|you|your|yours)\b|"
+    r"\b(?:he|she|they|him|his|her|hers|them|their|theirs)\b|"
+    r"\b(?:the|this|that|one|another)\s+"
+    r"(?:member|requester|user)\b)",
     re.I,
 )
 _CONCRETE_RELATION_GENERIC_NAMES = frozenset(
@@ -595,6 +1083,17 @@ _TRANSIENT_EXPRESSION_PRIVATE_RE = re.compile(
     r"\b(?:live|reside|work)\s+(?:at|in|near|for)\b|"
     r"\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b|"
     r"<@!?\d+>)",
+    re.I,
+)
+_TRANSIENT_EXPRESSION_HARMFUL_MEMBER_RE = re.compile(
+    r"\b(?:you|the\s+(?:member|requester|user)|<@!?\d+>)\s+"
+    r"(?:are|were|have|had|committed|murdered|killed|stole|steal|"
+    r"lied|cheated)\b.{0,100}\b(?:abusive|addicted|autistic|bipolar|"
+    r"criminal|depressed|diabetic|dishonest|fraud|gay|homeless|"
+    r"infertile|married|murder|pregnant|stole|thief|undocumented|"
+    r"violent)\b|"
+    r"\b(?:you|the\s+(?:member|requester|user)|<@!?\d+>)\s+"
+    r"(?:committed|murdered|killed|stole|lied|cheated)\b",
     re.I,
 )
 _TRANSIENT_EXPRESSION_CORE_MARKERS = (
@@ -3457,6 +3956,33 @@ def _candidate_claim_units(response: str) -> tuple[str, ...]:
         return ()
     protected_expressions: dict[str, str] = {}
 
+    def protect_name_initials(match: re.Match[str]) -> str:
+        value = str(match.group("name") or "")
+        surname = str(match.groupdict().get("surname") or "")
+        predicate = str(match.group("predicate") or "")
+        following = str(match.groupdict().get("following") or "")
+        title_qualifier = (
+            r"(?:accepted|archived|current|governed|historical|internal|"
+            r"old|private|published|public|saved|selected|BNL(?:'s)?)"
+        )
+        if (
+            surname.casefold() in {"journal", "relay", "moment"}
+            or bool(re.fullmatch(title_qualifier, surname, re.I))
+            or (
+                bool(re.fullmatch(title_qualifier, predicate, re.I))
+                and following.casefold() in {"journal", "relay", "moment"}
+            )
+            or not _ordinary_chat_external_token_is_finite_predicate(
+                predicate
+            )
+        ):
+            return value
+        for _ in range(value.count(".")):
+            token = "BNLNAMEINITIAL%sTOKEN" % len(protected_expressions)
+            protected_expressions[token] = "."
+            value = value.replace(".", token, 1)
+        return value
+
     def protect_expression(match: re.Match[str]) -> str:
         value = str(match.group(0) or "")
         if not _claim_is_transient_expression(value):
@@ -3467,13 +3993,34 @@ def _candidate_claim_units(response: str) -> tuple[str, ...]:
         protected_expressions[token] = value
         return token
 
+    # Protect initials inside ordinary public names before sentence splitting.
+    # The replacement preserves only the period and is restored below.
+    cleaned = re.sub(
+        r"\b(?P<name>(?:[A-Z][A-Za-z'’\-]{1,30}\s+)?"
+        r"(?:[A-Z]\.\s*)+)"
+        r"(?=(?P<surname>[A-Z][A-Za-z'’\-]{1,30})\s+"
+        r"(?P<predicate>[A-Za-z]+)\b)",
+        protect_name_initials,
+        cleaned,
+    )
+    cleaned = re.sub(
+        r"\b(?P<name>[A-Z][A-Za-z'’\-]{1,30}\s+[A-Z]\.)"
+        r"(?=\s+(?P<predicate>[A-Za-z]+)\b"
+        r"(?:\s+(?P<following>[A-Za-z]+)\b)?)",
+        protect_name_initials,
+        cleaned,
+    )
     cleaned = _TRANSIENT_EXPRESSION_BLOCK_RE.sub(
         protect_expression,
         cleaned,
     )
     units = []
     for value in _CLAIM_SPLIT_RE.split(cleaned):
-        for token, expression in protected_expressions.items():
+        # Expand outer transient wrappers before any initial placeholders
+        # captured inside them.
+        for token, expression in reversed(
+            tuple(protected_expressions.items())
+        ):
             value = str(value or "").replace(token, expression)
         claim = re.sub(
             r"^\s*(?:alongside|and|but|yet|while|whereas|which|so)\s+",
@@ -3500,6 +4047,7 @@ def _claim_is_transient_expression(claim: str) -> bool:
     if (
         _TRANSIENT_EXPRESSION_AUTHORITY_RE.search(value)
         or _TRANSIENT_EXPRESSION_PRIVATE_RE.search(value)
+        or _TRANSIENT_EXPRESSION_HARMFUL_MEMBER_RE.search(value)
     ):
         return False
     wrapper = _TRANSIENT_EXPRESSION_WRAPPER_RE.fullmatch(value)
@@ -4587,21 +5135,70 @@ def candidate_profile_coverage(
     )
 
 
+def _ordinary_chat_global_label_is_distinctive(label: str) -> bool:
+    value = re.sub(r"\s+", " ", str(label or "")).strip()
+    if not value or value.casefold() in {
+        "6 bit",
+        "six bit",
+        "bnl",
+        "barcode",
+        "cliff",
+        "sheila",
+    }:
+        return False
+    if len(value.split()) > 1:
+        return True
+    if re.fullmatch(r"[A-Z][A-Z0-9_-]{3,}", value):
+        return True
+    return bool(re.search(r"[A-Za-z]-?\d", value))
+
+
 def _ordinary_chat_packet_domain_labels(
     basis: SharedBrainSynthesisBasis,
-) -> tuple[str, ...]:
-    """Return governed subject labels, never arbitrary evidence values."""
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return selected labels and globally distinctive canon labels."""
 
     packet = basis.packet
     request = packet.request
-    labels = {
+    resolution = packet.subject_resolution
+    selected_labels = {
         str(request.subject_display_name or "").strip(),
         *(
             str(subject.label_hint or "").strip()
             for subject in tuple(request.frame_subjects or ())
         ),
     }
-    resolution = packet.subject_resolution
+    identities_by_key = {
+        str(identity.key or ""): identity
+        for identity in CANON_ENTITY_IDENTITIES
+    }
+    selected_entity_refs = {
+        str(resolution.entity_ref or "").strip(),
+        str(resolution.subject_key or "").strip(),
+        *(
+            str(subject.entity_ref or "").strip()
+            for subject in tuple(request.frame_subjects or ())
+        ),
+    }
+    for reference in tuple(selected_entity_refs):
+        prefix, separator, suffix = reference.partition(":")
+        candidate_key = suffix if separator and prefix in {
+            "barcode",
+            "canon",
+            "entity",
+        } else reference
+        identity = identities_by_key.get(candidate_key)
+        if identity is not None:
+            selected_labels.update((identity.name, *identity.aliases))
+
+    distinctive_canon_labels = {
+        *(
+            str(label or "").strip()
+            for identity in CANON_ENTITY_IDENTITIES
+            for label in (identity.name, *identity.aliases)
+            if _ordinary_chat_global_label_is_distinctive(label)
+        ),
+    }
     for reference in (
         str(resolution.entity_ref or ""),
         str(resolution.subject_key or ""),
@@ -4609,15 +5206,480 @@ def _ordinary_chat_packet_domain_labels(
         prefix, separator, suffix = reference.partition(":")
         if not separator or prefix not in {"barcode", "canon", "entity"}:
             continue
-        labels.add(re.sub(r"[_-]+", " ", suffix).strip())
-    return tuple(
-        sorted(
-            label
-            for label in labels
-            if len(label) >= 3
-            and label.casefold()
-            not in {"member", "unknown", "user"}
+        selected_labels.add(re.sub(r"[_-]+", " ", suffix).strip())
+    return (
+        tuple(
+            sorted(
+                label
+                for label in selected_labels
+                if len(label) >= 3
+                and label.casefold()
+                not in {"member", "unknown", "user"}
+            )
+        ),
+        tuple(sorted(distinctive_canon_labels)),
+    )
+
+
+def _ordinary_chat_claim_has_project_brand(value: str) -> bool:
+    claim = _ordinary_chat_plain_text(value)
+    return bool(
+        _PACKET_DOMAIN_EXACT_CANON_RE.search(claim)
+        or _PACKET_DOMAIN_BNL01_RE.search(claim)
+        or _PACKET_DOMAIN_BRAND_COMPOUND_RE.search(claim)
+    )
+
+
+def _ordinary_chat_plain_text(value: str) -> str:
+    """Normalize presentation-only markup before governed-token checks."""
+
+    without_html = _PACKET_DOMAIN_HTML_TAG_RE.sub(
+        "",
+        str(value or ""),
+    )
+    return _PACKET_DOMAIN_PRESENTATION_RE.sub(
+        "",
+        without_html,
+    ).replace("\u00a0", " ")
+
+
+def _ordinary_chat_claim_core(value: str) -> str:
+    """Remove presentation and bounded lead-ins before subject checks."""
+
+    return _ordinary_chat_claim_modifier_stack(value)[1]
+
+
+def _ordinary_chat_claim_governed_surface(value: str) -> str:
+    """Return presentation-normalized text without deleting attribution."""
+
+    return re.sub(
+        r"^\s*(?:(?:[-*•▪◦]+|\d+[.)])\s+|>\s*)+",
+        "",
+        _ordinary_chat_plain_text(value),
+    ).strip()
+
+
+def _ordinary_chat_claim_modifier_stack(
+    value: str,
+) -> tuple[tuple[str, ...], str]:
+    """Parse one shared leading stack into contexts and semantic remainder."""
+
+    remaining = _ordinary_chat_claim_governed_surface(value)
+    remaining = _CLAIM_LEADING_CONCESSIVE_RE.sub(
+        "",
+        remaining,
+        count=1,
+    ).strip()
+    contexts: list[str] = []
+    while remaining:
+        context_match = _CLAIM_CONTEXT_LEADING_MODIFIER_RE.match(remaining)
+        if context_match is not None:
+            contexts.append(
+                str(context_match.group("context") or "").strip()
+            )
+            remaining = remaining[context_match.end() :].lstrip()
+            continue
+        simple_match = _CLAIM_SIMPLE_LEADING_MODIFIER_RE.match(remaining)
+        if simple_match is None:
+            break
+        remaining = remaining[simple_match.end() :].lstrip()
+    return (
+        tuple(context for context in contexts if context),
+        remaining.strip(),
+    )
+
+
+def _ordinary_chat_claim_leading_contexts(value: str) -> tuple[str, ...]:
+    """Return every contextual modifier in the leading modifier stack."""
+
+    return _ordinary_chat_claim_modifier_stack(value)[0]
+
+
+def _ordinary_chat_claim_has_scoped_title(
+    basis: SharedBrainSynthesisBasis,
+    value: str,
+) -> bool:
+    object_kind = str(
+        basis.packet.request.frame_object_kind or ""
+    ).strip().lower()
+    pattern = _PACKET_DOMAIN_TITLED_PATTERNS.get(object_kind)
+    core = _ordinary_chat_claim_governed_surface(value)
+    semantic_core = _ordinary_chat_claim_core(value)
+    return bool(
+        _PACKET_DOMAIN_BARE_TITLE_RE.search(core)
+        or _PACKET_DOMAIN_BARE_TITLE_RE.search(semantic_core)
+        or _PACKET_DOMAIN_LEADING_TITLE_RE.search(core)
+        or _PACKET_DOMAIN_QUALIFIED_TITLE_RE.search(semantic_core)
+        or (pattern and pattern.search(semantic_core))
+    )
+
+
+def _ordinary_chat_leading_context_has_scoped_title(
+    context: str,
+) -> bool:
+    """Recognize project titles without claiming qualified external names."""
+
+    core = _ordinary_chat_claim_governed_surface(context)
+    return bool(
+        _PACKET_DOMAIN_LEADING_TITLE_RE.search(f"According to {core},")
+        or _PACKET_DOMAIN_QUALIFIED_TITLE_RE.search(core)
+    )
+
+
+def _ordinary_chat_claim_is_honest_nonassertion(value: str) -> bool:
+    """Recognize one clarification or one bounded insufficiency clause."""
+
+    core = re.sub(
+        r"^\s*(?:(?:[-*•▪◦]+|\d+[.)])\s+|>\s*)+",
+        "",
+        str(value or ""),
+    ).strip()
+    if (
+        _CLARIFICATION_QUESTION_RE.fullmatch(core)
+        and not _CLARIFICATION_UNSAFE_TAIL_RE.search(core)
+    ):
+        return True
+    if re.search(r"[,;:—–]", core):
+        return False
+    if _HONEST_INSUFFICIENCY_TAIL_RE.search(core):
+        return False
+    match = _HONEST_INSUFFICIENCY_RE.match(core)
+    if match is None:
+        return bool(_HONEST_THIN_CONTEXT_RE.fullmatch(core))
+    remainder = core[match.end() :].strip()
+    return bool(
+        not remainder
+        or _HONEST_INSUFFICIENCY_SAFE_REMAINDER_RE.fullmatch(remainder)
+        or _HONEST_EMPTY_PROFILE_REMAINDER_RE.fullmatch(remainder)
+    )
+
+
+def _ordinary_chat_claim_is_guidance(
+    basis: SharedBrainSynthesisBasis,
+    value: str,
+    *,
+    selected_labels: Sequence[str],
+    global_labels: Sequence[str],
+) -> bool:
+    """Allow only one complete, public/external guidance clause."""
+
+    core = _ordinary_chat_claim_core(value)
+    match = _CLAIM_LEADING_GUIDANCE_RE.fullmatch(core)
+    if match is None:
+        return False
+    target = str(match.group("target") or "").strip()
+    target_without_links = _PACKET_DOMAIN_LINK_OR_ADDRESS_RE.sub(
+        " ",
+        target,
+    )
+    return bool(
+        target
+        and _GUIDANCE_PUBLIC_TARGET_RE.search(target)
+        and not re.search(r"[,;:—–]", target_without_links)
+        and not _GUIDANCE_PRIVATE_TARGET_RE.search(target)
+        and not _ordinary_chat_claim_has_project_brand(target)
+        and not _ordinary_chat_claim_has_scoped_title(basis, target)
+        and not _ordinary_chat_claim_mentions_label(
+            target,
+            selected_labels,
         )
+        and not _ordinary_chat_claim_mentions_label(
+            target,
+            global_labels,
+            case_sensitive=True,
+        )
+        and not _PACKET_REFERENT_RE.search(target_without_links)
+    )
+
+
+def _ordinary_chat_claim_is_safe_conversation(value: str) -> bool:
+    return bool(
+        _SAFE_CONVERSATIONAL_RE.fullmatch(
+            _ordinary_chat_claim_core(value)
+        )
+    )
+
+
+def _ordinary_chat_leading_context_is_governed(
+    context: str,
+    *,
+    selected_labels: Sequence[str],
+    global_labels: Sequence[str],
+) -> bool:
+    """Fail closed when an external-title context carries extra authority."""
+
+    hard_governed = bool(
+        _ordinary_chat_claim_has_project_brand(context)
+        or _ordinary_chat_claim_mentions_label(context, selected_labels)
+        or _ordinary_chat_claim_mentions_label(
+            context,
+            global_labels,
+            case_sensitive=True,
+        )
+        or _PACKET_REFERENT_RE.search(context)
+    )
+    if hard_governed:
+        return True
+    if _PACKET_DOMAIN_EXTERNAL_TITLE_NAME_RE.search(context):
+        return not bool(
+            _PACKET_DOMAIN_EXTERNAL_TITLE_CONTEXT_RE.fullmatch(context)
+        )
+    return bool(
+        _ordinary_chat_leading_context_has_scoped_title(context)
+        or _AMBIGUOUS_PACKET_SUBJECT_RE.search(context)
+    )
+
+
+def _ordinary_chat_claim_has_governed_lead_in(
+    basis: SharedBrainSynthesisBasis,
+    value: str,
+    *,
+    selected_labels: Sequence[str],
+    global_labels: Sequence[str],
+) -> bool:
+    """Reject a benign-looking tail when its lead-in asserts packet truth."""
+
+    return any(
+        _ordinary_chat_leading_context_is_governed(
+            context,
+            selected_labels=selected_labels,
+            global_labels=global_labels,
+        )
+        for context in _ordinary_chat_claim_leading_contexts(value)
+    )
+
+
+def _ordinary_chat_claim_is_external_personal_title(value: str) -> bool:
+    core = _ordinary_chat_claim_core(value)
+    match = _EXTERNAL_TITLE_PREDICATE_RE.fullmatch(core)
+    if match is None:
+        return False
+    raw_title = str(match.group("title") or "").strip()
+    explicitly_typed = bool(_EXTERNAL_TITLE_TYPE_RE.match(raw_title))
+    explicitly_quoted = bool(
+        re.match(r"^[\"'“‘]", raw_title)
+        and re.search(r"[\"'”’]\s*$", raw_title)
+    )
+    explicitly_typed = explicitly_typed or bool(
+        re.search(
+            r"\s+(?:is|was)\s+(?:(?:a|an|the)\s+)?"
+            r"(?:\d{4}\s+)?(?:album|book|film|novel|play|series|"
+            r"song|title|work)(?:\s|$)",
+            core,
+            re.I,
+        )
+    )
+    title = _EXTERNAL_TITLE_TYPE_RE.sub(
+        "",
+        raw_title,
+        count=1,
+    ).strip(" \t\"'“”‘’")
+    words = tuple(re.findall(r"[A-Za-z][A-Za-z'’.-]*", title))
+    if not words or words[0].casefold() not in _EXTERNAL_TITLE_PERSONAL_STARTS:
+        return False
+    # A bare pronoun-led phrase is indistinguishable from a member/system
+    # assertion here. Only explicit work syntax or a sufficiently specific
+    # multiword title may take the external-title lane.
+    if not explicitly_typed and not explicitly_quoted:
+        return False
+    return all(
+        word.casefold() in _EXTERNAL_TITLE_CONNECTORS
+        or word[:1].isupper()
+        for word in words
+    )
+
+
+def _ordinary_chat_external_token_is_finite_predicate(value: str) -> bool:
+    token = str(value or "").strip(" \t.,:;!?\"'“”‘’").casefold()
+    if not token or token in _EXTERNAL_PREDICATE_FALSE_POSITIVES:
+        return False
+    if (
+        token in _EXTERNAL_EXPLICIT_FINITE_VERBS
+        or token in _EXTERNAL_BARE_FINITE_VERBS
+    ):
+        return True
+    return bool(
+        len(token) >= 4
+        and re.fullmatch(r"[a-z]+", token)
+        and token.endswith(("ed", "es", "s"))
+    )
+
+
+def _ordinary_chat_external_subject_is_positive(
+    subject: str,
+    tokens: Sequence[str],
+) -> bool:
+    value = str(subject or "").strip(" \t\"'“”‘’()")
+    if not value or not tokens:
+        return False
+    first = str(tokens[0] or "").strip(" \t.,:;!?\"'“”‘’")
+    lowered = first.casefold()
+    if re.match(
+        r"^(?:https?://|www\.|[a-z0-9._%+-]+@)",
+        first,
+        re.I,
+    ):
+        return True
+    if (
+        not first
+        or re.search(r"[,;:—–]", value)
+        or lowered in {"a", "an"}
+        or lowered in _EXTERNAL_SUBJECT_FRAGMENT_STARTS
+        or lowered.endswith("ly")
+        or (
+            _AMBIGUOUS_PACKET_SUBJECT_RE.search(value)
+            and not _PACKET_DOMAIN_EXTERNAL_TITLE_NAME_RE.match(value)
+            and not _PACKET_DOMAIN_ATTRIBUTIVE_MEMBER_RE.match(value)
+        )
+    ):
+        return False
+    if lowered == "the":
+        return len(tokens) >= 2
+    if first[:1].isdigit():
+        return bool(re.search(r"\bbit\b", value, re.I))
+    return bool(first[:1].isupper())
+
+
+def _ordinary_chat_claim_has_external_subject(value: str) -> bool:
+    """Require a noun-phrase subject followed by a finite predicate."""
+
+    core = _ordinary_chat_claim_core(value)
+    if _ordinary_chat_claim_is_external_personal_title(core):
+        return True
+    matches = tuple(_EXTERNAL_WORD_RE.finditer(core))
+    if len(matches) < 2:
+        return False
+    for index, match in enumerate(matches[1:], start=1):
+        if not _ordinary_chat_external_token_is_finite_predicate(
+            match.group(0)
+        ):
+            continue
+        subject = core[: match.start()].strip()
+        subject_tokens = tuple(
+            item.group(0) for item in matches[:index]
+        )
+        if _ordinary_chat_external_subject_is_positive(
+            subject,
+            subject_tokens,
+        ):
+            return True
+    return False
+
+
+def _ordinary_chat_claim_has_embedded_packet_clause(
+    basis: SharedBrainSynthesisBasis,
+    value: str,
+) -> bool:
+    """Fail closed on an embedded governed head in an external-looking claim.
+
+    A full external-language parser is outside this canary's authority. In a
+    packet-scoped request, an embedded packet/internal/publication head is
+    therefore ambiguous unless syntax makes it an external proper name or an
+    external proper possessive. This deliberately conservative rule closes
+    finite, irregular, nonfinite, compound, and modifier variants together.
+    """
+
+    core = _ordinary_chat_claim_core(value)
+    words = tuple(_EXTERNAL_WORD_RE.finditer(core))
+    external_title_names = tuple(
+        _PACKET_DOMAIN_EXTERNAL_TITLE_NAME_RE.finditer(core)
+    )
+    attributive_member = _PACKET_DOMAIN_ATTRIBUTIVE_MEMBER_RE.match(core)
+    for index, word in enumerate(words[1:], start=1):
+        suffix = core[word.start() :]
+        ambiguous_match = _AMBIGUOUS_PACKET_SUBJECT_RE.match(suffix)
+        title_match = _PACKET_DOMAIN_CLAUSE_TITLE_SUBJECT_RE.match(suffix)
+        subject_matches = tuple(
+            match
+            for match in (ambiguous_match, title_match)
+            if match is not None
+        )
+        if not subject_matches:
+            continue
+        external_name = next(
+            (
+                name
+                for name in external_title_names
+                if name.start() <= word.start() < name.end()
+            ),
+            None,
+        )
+        if external_name is not None:
+            continue
+        previous = str(words[index - 1].group(0) or "")
+        title_is_packet_qualified = bool(
+            title_match is not None
+            and _PACKET_DOMAIN_QUALIFIED_TITLE_RE.match(
+                str(title_match.group(0) or "")
+            )
+        )
+        if (
+            previous.casefold() in {"her", "his", "its", "their"}
+            or previous.endswith(("'s", "’s"))
+        ):
+            continue
+        subject_match = max(subject_matches, key=lambda match: match.end())
+        if (
+            attributive_member is not None
+            and attributive_member.start() <= word.start()
+            and word.end() <= attributive_member.end()
+        ):
+            continue
+        if not suffix[subject_match.end() :].strip(" \t,;:—–-()[]{}.!?"):
+            continue
+        matched_subject = str(subject_match.group(0) or "").strip().casefold()
+        prefix = core[: word.start()].rstrip(" \t,;:—–-")
+        prefix_words = tuple(_EXTERNAL_WORD_RE.finditer(prefix))
+        if not prefix_words:
+            continue
+        # A single possessive/proper-name qualifier belongs to the subject
+        # ("NASA's database" / "its database"), not to an outer clause.
+        if len(prefix_words) == 1:
+            qualifier = str(prefix_words[0].group(0) or "")
+            if (
+                qualifier.casefold() in {"her", "his", "its", "their"}
+                or qualifier.endswith(("'s", "’s"))
+            ):
+                continue
+        if _ordinary_chat_claim_has_external_subject(core):
+            return True
+    return False
+
+
+def _ordinary_chat_claim_is_external_opinion(
+    basis: SharedBrainSynthesisBasis,
+    value: str,
+    *,
+    selected_labels: Sequence[str],
+    global_labels: Sequence[str],
+) -> bool:
+    """Allow a bounded first-person opinion about an external subject."""
+
+    match = _EXTERNAL_OPINION_PREFIX_RE.fullmatch(
+        _ordinary_chat_claim_core(value)
+    )
+    if match is None:
+        return False
+    subject = str(match.group("subject") or "").strip()
+    without_links = _PACKET_DOMAIN_LINK_OR_ADDRESS_RE.sub(" ", subject)
+    return bool(
+        _ordinary_chat_claim_has_external_subject(subject)
+        and not _ordinary_chat_claim_has_embedded_packet_clause(
+            basis,
+            subject,
+        )
+        and not _ordinary_chat_claim_has_project_brand(without_links)
+        and not _ordinary_chat_claim_has_scoped_title(basis, without_links)
+        and not _ordinary_chat_claim_mentions_label(
+            without_links,
+            selected_labels,
+        )
+        and not _ordinary_chat_claim_mentions_label(
+            without_links,
+            global_labels,
+            case_sensitive=True,
+        )
+        and not _PACKET_REFERENT_RE.search(without_links)
     )
 
 
@@ -4646,24 +5708,162 @@ def _ordinary_chat_packet_domain_context_active(
         return True
     request_text = str(request.user_text or "")
     return bool(
-        _PACKET_DOMAIN_BRAND_RE.search(request_text)
-        or _PACKET_DOMAIN_TITLED_RE.search(request_text)
+        _ordinary_chat_claim_has_project_brand(request_text)
+        or _ordinary_chat_claim_has_scoped_title(basis, request_text)
     )
 
 
 def _ordinary_chat_claim_mentions_label(
     claim: str,
     labels: Sequence[str],
+    *,
+    case_sensitive: bool = False,
 ) -> bool:
-    normalized = re.sub(r"\s+", " ", str(claim or "")).casefold()
-    return any(
-        re.search(
-            r"(?<![\w])%s(?![\w])"
-            % re.escape(re.sub(r"\s+", " ", label).casefold()),
+    without_links = _PACKET_DOMAIN_LINK_OR_ADDRESS_RE.sub(
+        " ",
+        str(claim or ""),
+    )
+    normalized = re.sub(
+        r"\s+",
+        " ",
+        _ordinary_chat_plain_text(without_links),
+    ).replace("’", "'")
+    if not case_sensitive:
+        normalized = normalized.casefold()
+    for label in labels:
+        label_value = re.sub(
+            r"\s+",
+            " ",
+            _ordinary_chat_plain_text(label),
+        ).replace("’", "'").strip()
+        if not label_value:
+            continue
+        if not case_sensitive:
+            label_value = label_value.casefold()
+        if re.search(
+            r"(?<![\w])%s(?![\w])" % re.escape(label_value),
             normalized,
+        ):
+            return True
+        token_class = "A-Za-z0-9" if case_sensitive else "a-z0-9"
+        label_tokens = re.findall(
+            r"[A-Za-z0-9]+" if case_sensitive else r"[a-z0-9]+",
+            label_value,
         )
-        for label in labels
-        if label
+        if len(label_tokens) == 1:
+            token = label_tokens[0]
+            if len(token) < 3:
+                continue
+            punctuated_pattern = r"(?<![%s])" % token_class + (
+                r"[^%s\s]*" % token_class
+            ).join(re.escape(char) for char in token) + (
+                r"(?![%s])" % token_class
+            )
+            if re.search(punctuated_pattern, normalized):
+                return True
+            continue
+        compact_pattern = r"(?<![%s])" % token_class + (
+            r"[^%s]*" % token_class
+        ).join(
+            re.escape(token) for token in label_tokens
+        ) + r"(?![%s])" % token_class
+        if re.search(compact_pattern, normalized):
+            return True
+    return False
+
+
+def _ordinary_chat_claim_has_packet_subject(
+    basis: SharedBrainSynthesisBasis,
+    claim: str,
+    *,
+    packet_context: bool,
+    selected_labels: Sequence[str],
+    global_labels: Sequence[str],
+) -> bool:
+    governed_surface = _ordinary_chat_claim_governed_surface(claim)
+    core = _ordinary_chat_claim_core(claim)
+    without_links = _PACKET_DOMAIN_LINK_OR_ADDRESS_RE.sub(" ", core)
+    governed_without_links = _PACKET_DOMAIN_LINK_OR_ADDRESS_RE.sub(
+        " ",
+        governed_surface,
+    )
+    governed_lead_ins = _ordinary_chat_claim_leading_contexts(
+        governed_without_links
+    )
+    external_title_at_start = bool(
+        _PACKET_DOMAIN_EXTERNAL_TITLE_NAME_RE.match(core)
+    )
+    attributive_member_at_start = bool(
+        _PACKET_DOMAIN_ATTRIBUTIVE_MEMBER_RE.match(core)
+    )
+    return bool(
+        _ordinary_chat_claim_has_project_brand(governed_without_links)
+        or _ordinary_chat_claim_has_scoped_title(basis, governed_without_links)
+        or _ordinary_chat_claim_mentions_label(
+            governed_without_links,
+            selected_labels,
+        )
+        or _ordinary_chat_claim_mentions_label(
+            governed_without_links,
+            global_labels,
+            case_sensitive=True,
+        )
+        or any(
+            _ordinary_chat_leading_context_is_governed(
+                governed_lead_in,
+                selected_labels=selected_labels,
+                global_labels=global_labels,
+            )
+            for governed_lead_in in governed_lead_ins
+        )
+        or _ordinary_chat_claim_has_embedded_packet_clause(basis, core)
+        or _CLAIM_LEADING_DIRECT_PACKET_SUBJECT_RE.search(core)
+        or re.search(r"<@!?\d+>", core)
+        or re.search(
+            r"(?:<@!?\d+>|\b(?:you|your|yours)\b)",
+            governed_without_links,
+            re.I,
+        )
+        or re.match(
+            r"^about\s+(?:you|your|the\s+(?:member|requester|user)|"
+            r"this\s+member|that\s+member|<@!?\d+>)(?!\w)",
+            core,
+            re.I,
+        )
+        or (
+            packet_context
+            and (
+                _PACKET_REFERENT_RE.search(without_links)
+                or (
+                    _AMBIGUOUS_PACKET_SUBJECT_RE.search(without_links)
+                    and not external_title_at_start
+                    and not attributive_member_at_start
+                )
+            )
+        )
+    )
+
+
+def _ordinary_chat_supported_claim_has_packet_tail(
+    basis: SharedBrainSynthesisBasis,
+    claim: str,
+    *,
+    packet_context: bool,
+    selected_labels: Sequence[str],
+    global_labels: Sequence[str],
+) -> bool:
+    """Reject a supported clause carrying a second unproved packet clause."""
+
+    core = _ordinary_chat_claim_core(claim)
+    return any(
+        _ordinary_chat_claim_has_packet_subject(
+            basis,
+            core[boundary.end() :],
+            packet_context=packet_context,
+            selected_labels=selected_labels,
+            global_labels=global_labels,
+        )
+        for boundary in _PACKET_CLAUSE_TAIL_BOUNDARY_RE.finditer(core)
     )
 
 
@@ -4685,10 +5885,15 @@ def audit_ordinary_chat_candidate_claims(
     claims = _candidate_claim_units(response)
     classifications = tuple(profile.claim_classifications)
     packet_context = _ordinary_chat_packet_domain_context_active(basis)
-    labels = _ordinary_chat_packet_domain_labels(basis)
+    selected_labels, global_labels = _ordinary_chat_packet_domain_labels(
+        basis
+    )
     if len(claims) != len(classifications):
-        if packet_context and claims:
-            return (("unsupported_packet_domain",) * len(claims), len(claims))
+        if claims:
+            return (
+                ("claim_audit_alignment_invalid",) * len(claims),
+                len(claims),
+            )
         return (classifications, 0)
 
     audited: list[str] = []
@@ -4699,37 +5904,192 @@ def audit_ordinary_chat_candidate_claims(
         "member_and_canon_supported",
     }
     for claim, classification in zip(claims, classifications):
-        if classification in supported or classification == "transient_expression":
-            audited.append(classification)
+        if classification in supported:
+            if _ordinary_chat_supported_claim_has_packet_tail(
+                basis,
+                claim,
+                packet_context=packet_context,
+                selected_labels=selected_labels,
+                global_labels=global_labels,
+            ):
+                audited.append("unsupported_packet_domain")
+                unsupported_packet_domain += 1
+            else:
+                audited.append(classification)
             continue
-        explicit_domain = bool(
-            _PACKET_DOMAIN_BRAND_RE.search(claim)
-            or _PACKET_DOMAIN_TITLED_RE.search(claim)
-            or _ordinary_chat_claim_mentions_label(claim, labels)
+        transient_surface = _ordinary_chat_plain_text(claim)
+        transient_wrapper = _TRANSIENT_EXPRESSION_WRAPPER_RE.fullmatch(
+            transient_surface
         )
-        personal_fact = bool(
-            _UNSUPPORTED_SCALAR_ASSERTION_RE.search(claim)
-            or _UNSUPPORTED_FRAMED_CONCRETE_RE.search(claim)
+        transient_body = str(
+            transient_wrapper.group("body")
+            if transient_wrapper is not None
+            else transient_surface
         )
-        concrete_assertion = bool(
-            classification == "unsupported_factual"
-            or personal_fact
+        transient_compressed = re.sub(
+            r"[^a-z0-9]+",
+            "",
+            transient_body.casefold(),
+        )
+        transient_shape = bool(
+            classification == "transient_expression"
+            or _TRANSIENT_EXPRESSION_FRAME_RE.search(transient_surface)
             or (
-                (packet_context or explicit_domain)
-                and _PACKET_DOMAIN_CONCRETE_ASSERTION_RE.search(claim)
+                transient_wrapper is not None
+                and any(
+                    marker in transient_compressed
+                    for marker in _TRANSIENT_EXPRESSION_CORE_MARKERS
+                )
+                and (
+                    "//" in transient_body
+                    or "_" in transient_body
+                    or any(
+                        marker in transient_compressed
+                        for marker in _TRANSIENT_EXPRESSION_EVENT_MARKERS
+                    )
+                )
             )
         )
-        packet_unsupported = bool(
-            concrete_assertion
-            and (packet_context or explicit_domain or personal_fact)
+        if transient_shape:
+            transient_inner = re.sub(
+                r"^[^A-Za-z0-9]*(?:SIGNAL|BROADCAST|ARCHIVE)?"
+                r"(?:[_\s-]*(?:GLITCH|BLEED|FRAGMENT))?\s*[:/]*",
+                "",
+                transient_body,
+                count=1,
+                flags=re.I,
+            ).strip(" []~/")
+            transient_core = _ordinary_chat_claim_core(transient_inner)
+            transient_packet_owned = bool(
+                _TRANSIENT_EXPRESSION_PACKET_ASSERTION_RE.search(
+                    transient_surface
+                )
+                or _ordinary_chat_claim_has_project_brand(transient_surface)
+                or _ordinary_chat_claim_has_scoped_title(
+                    basis,
+                    transient_surface,
+                )
+                or _ordinary_chat_claim_has_scoped_title(
+                    basis,
+                    transient_inner,
+                )
+                or _ordinary_chat_claim_mentions_label(
+                    transient_surface,
+                    selected_labels,
+                )
+                or _ordinary_chat_claim_mentions_label(
+                    transient_surface,
+                    global_labels,
+                    case_sensitive=True,
+                )
+                or _TRANSIENT_EXPRESSION_GOVERNED_REFERENT_RE.search(
+                    transient_inner
+                )
+                or _AMBIGUOUS_PACKET_SUBJECT_RE.search(transient_core)
+                or _TRANSIENT_EXPRESSION_AUTHORITY_RE.search(
+                    transient_surface
+                )
+                or _TRANSIENT_EXPRESSION_PRIVATE_RE.search(
+                    transient_surface
+                )
+            )
+            if transient_packet_owned:
+                audited.append("unsupported_packet_domain")
+                unsupported_packet_domain += 1
+                continue
+            if classification == "transient_expression":
+                audited.append(classification)
+                continue
+        if classification in {"framed_opinion", "linked_assessment"}:
+            assessment_core = re.sub(
+                r"^\s*(?:(?:[-*•▪◦]+|\d+[.)])\s+|>\s*)+",
+                "",
+                str(claim or ""),
+            ).strip()
+            if (
+                _MEMBER_ASSESSMENT_BACKWARD_SUBJECT_RE.search(
+                    assessment_core
+                )
+                or _MEMBER_ASSESSMENT_BACKWARD_OBJECT_RE.search(
+                    assessment_core
+                )
+            ):
+                audited.append(classification)
+            else:
+                audited.append("unsupported_packet_domain")
+                unsupported_packet_domain += 1
+            continue
+        governed_lead_in = _ordinary_chat_claim_has_governed_lead_in(
+            basis,
+            claim,
+            selected_labels=selected_labels,
+            global_labels=global_labels,
         )
-        if packet_unsupported:
+        if (
+            not governed_lead_in
+            and _ordinary_chat_claim_is_safe_conversation(claim)
+        ):
+            audited.append(
+                "ordinary_guidance"
+                if re.fullmatch(
+                    r"i\s+can\s+respond\s+to\s+what\s+you\s+say\s+here",
+                    _ordinary_chat_claim_core(claim),
+                    re.I,
+                )
+                else "connective_flavor"
+            )
+            continue
+        if (
+            not governed_lead_in
+            and _ordinary_chat_claim_is_honest_nonassertion(claim)
+        ):
+            audited.append("honest_nonassertion")
+            continue
+        if not governed_lead_in and _ordinary_chat_claim_is_guidance(
+            basis,
+            claim,
+            selected_labels=selected_labels,
+            global_labels=global_labels,
+        ):
+            audited.append("ordinary_guidance")
+            continue
+        if (
+            not governed_lead_in
+            and _ordinary_chat_claim_is_external_personal_title(claim)
+        ):
+            audited.append("external_public_knowledge")
+            continue
+        if (
+            not governed_lead_in
+            and _ordinary_chat_claim_is_external_opinion(
+                basis,
+                claim,
+                selected_labels=selected_labels,
+                global_labels=global_labels,
+            )
+        ):
+            audited.append("external_public_knowledge")
+            continue
+        packet_subject = _ordinary_chat_claim_has_packet_subject(
+            basis,
+            claim,
+            packet_context=packet_context,
+            selected_labels=selected_labels,
+            global_labels=global_labels,
+        )
+        if packet_subject:
             audited.append("unsupported_packet_domain")
             unsupported_packet_domain += 1
-        elif classification == "unsupported_factual":
+        elif not packet_context:
+            if classification == "unsupported_factual":
+                audited.append("external_public_knowledge")
+            else:
+                audited.append(classification)
+        elif _ordinary_chat_claim_has_external_subject(claim):
             audited.append("external_public_knowledge")
         else:
-            audited.append(classification)
+            audited.append("unsupported_packet_domain")
+            unsupported_packet_domain += 1
     return tuple(audited), unsupported_packet_domain
 
 

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -301,6 +301,36 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             environ=self.flags,
         )
 
+    def _basis_for_canon_entity(self, entity_key, label):
+        entity_ref = "canon:%s" % entity_key
+        packet = replace(
+            self.packet,
+            request=replace(
+                self.packet.request,
+                subject_user_id=0,
+                subject_display_name=label,
+                user_text="Tell me about %s." % label,
+                frame_subject_requirement="required",
+                frame_subjects=(
+                    PacketFrameSubject(
+                        entity_ref=entity_ref,
+                        label_hint=label,
+                        binding_method="declared_canon",
+                        confidence="high",
+                    ),
+                ),
+            ),
+            subject_resolution=PacketSubjectResolution(
+                status="resolved",
+                subject_key=entity_key,
+                entity_ref=entity_ref,
+                binding_method="declared_canon",
+                confidence="high",
+                candidate_count=1,
+            ),
+        )
+        return replace(self.basis, packet=packet)
+
     def test_configuration_is_default_off_exact_scope_and_conflict_closed(self):
         disabled = ordinary_chat_configuration(
             {
@@ -556,6 +586,1117 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         )
         self.assertEqual(unsupported, 0)
         self.assertEqual(classifications, ("external_public_knowledge",))
+
+    def test_member_context_does_not_block_supported_external_knowledge(self):
+        cases = (
+            (
+                "Your favorite movie is Arrival. "
+                "Arrival was directed by Denis Villeneuve.",
+                ("member_supported", "external_public_knowledge"),
+            ),
+            (
+                "Your favorite movie is Arrival. "
+                "Denis Villeneuve directed Arrival in 2016.",
+                ("member_supported", "external_public_knowledge"),
+            ),
+            (
+                "Your favorite movie is Arrival. "
+                "More details are at https://www.imdb.com/title/tt2543164/.",
+                ("member_supported", "external_public_knowledge"),
+            ),
+            (
+                "Your favorite movie is Arrival. "
+                "The public contact is press@example.com.",
+                ("member_supported", "external_public_knowledge"),
+            ),
+            (
+                "Your favorite movie is Arrival. "
+                "Denis Villeneuve directed Arrival. "
+                "Denis Villeneuve was born in 1967.",
+                (
+                    "member_supported",
+                    "external_public_knowledge",
+                    "external_public_knowledge",
+                ),
+            ),
+        )
+        for response, expected in cases:
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self.basis,
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 0)
+                self.assertEqual(classifications, expected)
+                decision = evaluate_single_packet_response(
+                    self.conn,
+                    self._begin(),
+                    response=response,
+                    provider_call_count=1,
+                    corrective_call_count=0,
+                    environ=self.flags,
+                )
+                self.assertTrue(decision.candidate_selected)
+
+    def test_positive_external_subjects_survive_member_frame(self):
+        for response in (
+            "The sky is blue.",
+            "The sun is a star.",
+            "Water freezes at 0°C.",
+            "Birds fly.",
+            "Earth orbits the Sun.",
+            "Seattle lies in Washington.",
+            "NASA launched Apollo 11.",
+            "Eiffel Tower stands in Paris.",
+            "Python powers apps.",
+            "Apollo 11 landed in 1969.",
+            "NASA publishes mission information at https://www.nasa.gov/.",
+            "The public press contact is media@example.com.",
+            "https://www.nasa.gov/ is a public site.",
+            "media@example.com is a public contact.",
+            "Cliff Burton joined Metallica in 1982.",
+            "Sheila E. released The Glamorous Life in 1984.",
+            "Sheila E. won a Grammy.",
+            "Sheila E. collaborated with Prince.",
+            "Sheila E. acts in films.",
+            "Sheila E. runs a studio.",
+            "Sheila E. sits on a board.",
+            "J. K. Rowling wrote Harry Potter.",
+            "George R. R. Martin wrote a novel.",
+            "Barcode scanning began in 1974.",
+            "The barcode has 12 digits.",
+            "6-bit color supports 64 values.",
+            "BNL is Brookhaven National Laboratory.",
+            "The Wall Street Journal was founded in 1889.",
+            "Journal of Medicine was founded in 1999.",
+            "Relay is a 2010 film.",
+            "Moment magnitude measures earthquake size.",
+            "As of 2025, NASA publishes public mission data.",
+            "Today, according to NASA, Apollo 11 remains a historic mission.",
+            "Apparently, in 2025, NASA publishes public mission data.",
+            "As of 2025, according to NASA, Apollo 11 remains a historic mission.",
+            "Recently, during a public briefing, NASA discussed Apollo 11.",
+            ("Today, " * 16) + "according to NASA, Apollo 11 remains historic.",
+            "Although Today, according to NASA, Apollo 11 remains historic.",
+            "Because Apparently, as of Journal of Medicine's publication, you should consult public documentation.",
+            "Even though In 2025, according to NASA, Apollo 11 remains historic.",
+            "Since Recently, during a public briefing, NASA discussed Apollo 11.",
+            "Though As of 2025, NASA publishes public mission data.",
+            "While Today, according to NASA, Apollo 11 remains historic.",
+            "Whereas Apparently, according to NASA, Apollo 11 remains historic.",
+            "According to NASA, Her is a 2013 film.",
+            "According to NASA, I think Arrival is a great film.",
+            "NASA's database contains public mission records.",
+            "Arrival proves The Wall Street Journal was published in 1889.",
+            "Relay Health launched a service.",
+            "Relay FM is a podcast network.",
+            "Relay AI launched a service.",
+            "Moment Magazine published an article.",
+            "Moment AI published an article.",
+            "Moment Network launched a service.",
+            "The public member study was published in 2025.",
+            "The public member survey was published in 2025.",
+            "The public requester study was published in 2025.",
+            "The public requester survey was published in 2025.",
+            "The public user study was published in 2025.",
+            "The public user survey was published in 2025.",
+            "From NASA, Apollo 11 remains historic.",
+            "Although Today, from NASA, Apollo 11 remains historic.",
+            "According to the National Aeronautics and Space Administration, Apollo 11 remains historic.",
+            "Although Today, according to the National Aeronautics and Space Administration, Apollo 11 remains historic.",
+            "According to Relay Health, the service launched in 1999.",
+            "According to Moment AI, the service launched.",
+            "According to Moment Network, the service launched.",
+            "From Moment AI, the service launched.",
+            "In Moment Network, the article was published.",
+            "As of Moment AI's publication, the service launched.",
+            "According to the Relay Health report, NASA launched Apollo 11.",
+            "According to a Relay Health report, NASA launched Apollo 11.",
+            "According to official Relay Health report, NASA launched Apollo 11.",
+            "According to an article from Relay Health, NASA launched Apollo 11.",
+            "According to a report by Moment AI, NASA launched Apollo 11.",
+            "From the publication of Moment Network, NASA launched Apollo 11.",
+            "Although Today, according to Moment Network, the service launched.",
+            "Although Today, according to Relay Health, the service launched in 1999.",
+            "In Moment Magazine, the article was published.",
+            "Although Today, in Moment Magazine, the article was published.",
+        ):
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self.basis,
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 0)
+                self.assertNotIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
+    def test_generic_numbers_urls_and_emails_are_external_not_personal(self):
+        external_packet = replace(
+            self.packet,
+            request=replace(
+                self.packet.request,
+                subject_user_id=0,
+                subject_display_name="",
+                user_text="Answer a public-knowledge question.",
+                frame_subject_requirement="not_required",
+                frame_subjects=(),
+                frame_event_ref="",
+                frame_event_relation="not_applicable",
+            ),
+            subject_resolution=PacketSubjectResolution(
+                status="not_applicable",
+                reason_codes=("subject_not_required",),
+            ),
+        )
+        external_basis = replace(self.basis, packet=external_packet)
+        for response in (
+            "Apollo 11 landed in 1969.",
+            "NASA publishes mission information at https://www.nasa.gov/.",
+            "The public press contact is media@example.com.",
+            "Cliff Burton joined Metallica in 1982.",
+            "Sheila E. released The Glamorous Life in 1984.",
+            "The public archive is at https://cliff.com/.",
+            "The public contact is cliff@example.com.",
+            "Barcode scanning began in 1974.",
+            "Barcode is a 2001 film.",
+            "The barcode has 12 digits.",
+            "6-bit color supports 64 values.",
+            "BNL is Brookhaven National Laboratory.",
+            "Brookhaven National Laboratory publishes at https://www.bnl.gov/.",
+            "The Wall Street Journal was founded in 1889.",
+            "Relay is a 2010 film.",
+            "Moment magnitude measures earthquake size.",
+            "The source file was published in 1999.",
+            "galaknoise is an invented external word.",
+            "You can find public mission data at https://www.nasa.gov/.",
+            "You should consult the public documentation.",
+        ):
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        external_basis,
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 0)
+                self.assertNotIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
+    def test_claim_specific_packet_domain_still_fails_closed(self):
+        cases = (
+            "Your birthday is 1999-01-01.",
+            "Your site is https://invented.example/.",
+            "Your email is invented@example.com.",
+            "You ate pizza yesterday.",
+            "You won a prize in 2025.",
+            "You can speak French.",
+            "You may own three homes.",
+            "I was created in 1999.",
+            "I'm an AI.",
+            "My creator is Alice.",
+            "Our founder is Alice.",
+            "We started in 1999.",
+            "I remember you from 2019.",
+            "I have your private address.",
+            "<@7> works at NASA.",
+            "The member works at NASA.",
+            "The requester works at NASA.",
+            "He works as a network engineer.",
+            "Apparently, he works as a network engineer.",
+            "In 2025, she joined a band.",
+            "In Seattle, he works at NASA.",
+            "At NASA, she works there.",
+            "Last year, he won a prize.",
+            "According to NASA, he works there.",
+            "* He works at NASA.",
+            "It was founded in 1999.",
+            "Seattle.",
+            "Born in 1980.",
+            "He: a network engineer.",
+            "Test Member works as a network engineer.",
+            "Test Member: network engineer.",
+            "Test-Member works as a network engineer.",
+            "Test_Member works as a network engineer.",
+            "TestMember works as a network engineer.",
+            "Test.Member works as a network engineer.",
+            "Test‐Member works as a network engineer.",
+            "Test/Member works as a network engineer.",
+            "Mac Modem founded BARCODE in 1999.",
+            "6 Bit founded a studio in 1999.",
+            "6-Bit founded a studio in 1999.",
+            "Six Bit released an album in 1999.",
+            "Six-Bit released an album in 1999.",
+            "GalakNoise founded a studio in 1999.",
+            "Galak-Noise founded a studio in 1999.",
+            "BARCODE was founded in 1999.",
+            "BARCODE: a collective.",
+            "BNL-01 joined the project in 1999.",
+            "B.N.L.-01 was created in 1999.",
+            "BNL-01: an AI.",
+            "BNL joined BARCODE in 1999.",
+            "DJ Floppydisc founded a studio in 1999.",
+            "GALAKNOISE released an album in 1999.",
+            "DJ-Floppydisc founded a studio in 1999.",
+            "Dj-Floppydisc founded a studio in 1999.",
+            "DJ Floppy-disc founded a studio in 1999.",
+            "DJ<em>Floppydisc</em> founded a studio in 1999.",
+            "MacModem founded a studio in 1999.",
+            "Mac-modem founded a studio in 1999.",
+            "Call'Em-Bini founded a studio in 1999.",
+            "Cache_Back founded a studio in 1999.",
+            "Barcode-Network was founded in 1999.",
+            "BAR-CODE Network was founded in 1999.",
+            "D.J. Floppydisc founded a studio in 1999.",
+        )
+        for response in cases:
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self.basis,
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 1)
+                self.assertEqual(
+                    classifications,
+                    ("unsupported_packet_domain",),
+                )
+                decision = evaluate_single_packet_response(
+                    self.conn,
+                    self._begin(),
+                    response=response,
+                    provider_call_count=1,
+                    corrective_call_count=0,
+                    environ=self.flags,
+                )
+                self.assertFalse(decision.candidate_selected)
+                self.assertEqual(
+                    decision.fallback_reason,
+                    "unsupported_packet_domain_claim",
+                )
+
+    def test_ambiguous_member_fragments_and_internal_claims_fail_closed(self):
+        cases = (
+            "At NASA.",
+            "Works at NASA.",
+            "Lives in Seattle.",
+            "Employed by NASA.",
+            "Engineer at NASA.",
+            "A network engineer.",
+            "Network engineer.",
+            "A founder.",
+            "The founder.",
+            "From Seattle.",
+            "Married to Alice.",
+            "Aged 42.",
+            "Birthday: January 1.",
+            "Favorite color: blue.",
+            "Home: Seattle.",
+            "Role: engineer.",
+            "Website: invented.example.",
+            "Email: invented@example.com.",
+            "Forty-two years old.",
+            "Public speaker.",
+            "Regularly visits Paris.",
+            "Based in Seattle.",
+            "An AI.",
+            "Married with two kids.",
+            "Jazz lover.",
+            "Six feet tall.",
+            "Alice is my creator.",
+            "NASA owns me.",
+            "Seattle is where I live.",
+            "The database has 100 users.",
+            "The packet contains 500 records.",
+            "The shared brain stores 500 memories.",
+            "Memory contains private messages.",
+            "BNL memory has 100 records.",
+            "Its first broadcast was in 2020.",
+            "The network started in 1999.",
+            "Internal database has 100 users.",
+            "Private archive stores messages.",
+            "Stored memory has facts.",
+            "Selected packet contains records.",
+            "Current profile says you work at NASA.",
+            "BNL's database has rows.",
+            "Private facts include a birthday.",
+            "Personal traits include kindness.",
+            "Known history shows a job.",
+            "Musician performs on stage.",
+            "Artist released an album.",
+            "Moderator runs a forum.",
+            "Producer works at a studio.",
+            "Host lives in Seattle.",
+            "Person lives in Seattle.",
+            "Someone works at NASA.",
+            "These packets contain 500 records.",
+            "Those packets contain 500 records.",
+            "Public memory contains facts.",
+            "Cached memory contains facts.",
+            "Conversation memory contains facts.",
+            "Long-term memory contains facts.",
+            "Working memory contains facts.",
+            "Request context contains facts.",
+            "Evidence packet contains facts.",
+            "Intelligence packet contains facts.",
+            "Current Situation Frame contains facts.",
+            "Situation Frame contains facts.",
+            "The frame contains facts.",
+            "This assessment contains facts.",
+            "The candidate contains facts.",
+            "The receipt contains facts.",
+            "The run contains facts.",
+            "The store contains facts.",
+            "The cache contains facts.",
+            "Marital status indicates married.",
+            "Employment history includes NASA.",
+            "Personal preference signals generosity.",
+            "Internal vector database contains private messages.",
+            "Situation-frame evidence contains facts.",
+            "The runtime uses the packet.",
+            "Archived Journal contains private messages.",
+            "Private Relay contains private messages.",
+            "Current Moment contains private messages.",
+            "The archived Journal contains private messages.",
+            "This private Relay contains private messages.",
+            "BNL's Moment contains private messages.",
+        )
+        for response in cases:
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self.basis,
+                        response,
+                    )
+                )
+                self.assertGreaterEqual(unsupported, 1)
+                self.assertIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
+        for response in (
+            "Works at NASA.",
+            "Birthday: January 1.",
+            "Alice is my creator.",
+            "The packet contains 500 records.",
+        ):
+            with self.subTest(selected_response=response):
+                decision = evaluate_single_packet_response(
+                    self.conn,
+                    self._begin(),
+                    response=response,
+                    provider_call_count=1,
+                    corrective_call_count=0,
+                    environ=self.flags,
+                )
+                self.assertFalse(decision.candidate_selected)
+                self.assertEqual(
+                    decision.fallback_reason,
+                    "unsupported_packet_domain_claim",
+                )
+
+    def test_safe_prefixes_questions_and_guidance_cannot_launder_claims(self):
+        cases = (
+            "Can confirm you work at NASA.",
+            "Will say you work at NASA.",
+            "Should note BARCODE started in 1999.",
+            "What you said is that you work at NASA.",
+            "What your birthday is: January 1.",
+            "Who you are is a network engineer.",
+            "Do you work at NASA, you work there.",
+            "Why did you murder someone?",
+            "When did you stop stealing?",
+            "Are you secretly a criminal?",
+            "I don't know your birthday: Jan 1.",
+            "The evidence is thin: you work at NASA.",
+            "I can check that you work at NASA.",
+            "I can read your private messages.",
+            "I can review your private dossier.",
+            "We can download your private history.",
+            "You can check that BARCODE started in 1999.",
+            "You should read your private dossier.",
+            "I can help because I was created in 1999.",
+            "I can't verify your birthday, you were born in 1999.",
+            "I don't know your birthday: it is 1999.",
+            "I don't know your birthday it is 1999.",
+            "I can't verify your birthday you were born in 1999.",
+            "I don't know your birthday maybe January 1.",
+            "I can't verify your birthday probably January 1.",
+            "I can't confirm your employer likely NASA.",
+            "I do not have enough reliable information about your age probably 42.",
+            "I don't remember your favorite movie maybe Blade Runner.",
+            "I can't verify your birthday / January 1.",
+            "I can't verify your birthday - January 1.",
+            "I can't verify your birthday aka January 1.",
+            "I don't know your birthday you murdered someone.",
+            "I can't verify your birthday you stole money.",
+            "I don't know your birthday you committed fraud.",
+            "I don't know your birthday your name is Alice.",
+            "I don't know your birthday you own three homes.",
+            "I don't know your birthday you cheated.",
+            "I don't know your birthday you abused someone.",
+            "I can't verify your birthday you served in Iraq.",
+            "I don't know your birthday your diagnosis is cancer.",
+            "I can't verify your birthday BARCODE was founded in 1999.",
+            "The evidence is thin you work at NASA.",
+            "The context is limited your birthday is January 1.",
+            "After you murdered someone, okay.",
+            "During your 2020 wedding, sounds good.",
+            "At your home in Seattle, okay.",
+            "According to your profile showing a 1999 birthday, okay.",
+            "As of your profile showing a 1999 birthday, okay.",
+            "As of the database revealing private messages, okay.",
+            "As of the packet showing 500 records, okay.",
+            "As of internal memory revealing your birthday, sounds good.",
+            "As of the archive proving you work at NASA, thanks.",
+            "According to Relay AI report about the packet, okay.",
+            "According to Relay AI publication citing internal memory, okay.",
+            "According to Relay AI article on selected Relay, okay.",
+            "According to Relay AI report from the database, okay.",
+            "From Moment Network report about the packet, okay.",
+            "In Relay Health article on selected Relay, okay.",
+            "As of Moment Magazine report from the database, okay.",
+            "According to the Relay Health report about the packet, okay.",
+            "According to a Relay Health report about the packet, okay.",
+            "According to official Relay Health report about the packet, okay.",
+            "From official Moment AI article on selected Relay, okay.",
+            "In official Moment Network report from the database, okay.",
+            "According to an article from Relay Health about the packet, okay.",
+            "According to a report by Moment AI on selected Relay, okay.",
+            "From the publication of Moment Network about internal memory, okay.",
+            "As of 2025, according to your profile, okay.",
+            "Today, according to your profile, okay.",
+            "Apparently, according to your profile, okay.",
+            "In 2025, according to your profile, okay.",
+            "As of 2025, after you murdered someone, okay.",
+            "Today, after you murdered someone, okay.",
+            "Apparently, at BARCODE founding in 1999, sounds good.",
+            "Recently, during your NASA job, okay.",
+            "As of today, as of your 1999 birthday, okay.",
+            "In 2025, as of BNL-01 creation, okay.",
+            "As of the Journal's publication, sounds good.",
+            "As of 2025, after you joined NASA, you should consult public documentation.",
+            "Today, according to your profile, you should consult public documentation.",
+            ("Today, " * 16) + "according to your profile, okay.",
+            "Although Today, according to your profile, okay.",
+            "Because Apparently, as of The Journal's publication, you should consult public documentation.",
+            "Even though In 2025, according to Test Member, okay.",
+            "Since Recently, during BARCODE founding in 1999, okay.",
+            "Though As of 2025, according to BNL-01, okay.",
+            "While Today, according to Selected Relay, okay.",
+            "Whereas Apparently, as of Private Moment, okay.",
+            "Although Today, according to internal memory, okay.",
+            "Because Apparently, as of the packet showing 500 records, okay.",
+            "According to your profile, Her is a 2013 film.",
+            "According to your profile, the film Her is a 2013 film.",
+            "According to your profile, I think Arrival is a great film.",
+            "Although Today, according to your profile, Her is a 2013 film.",
+            "That means the packet contains 500 records.",
+            "This shows the packet contains 500 records.",
+            "The throughline is that the packet contains 500 records.",
+            "NASA says the packet contains 500 records.",
+            "Alice says internal memory stores messages.",
+            "Public records show the profile shows a birthday.",
+            "Arrival proves The Journal was published in 1999.",
+            "The result is that this packet has 100 rows.",
+            "The analysis concludes that the database contains 100 users.",
+            "I think NASA says the packet contains 500 records.",
+            "NASA says selected Relay accepted a post.",
+            "NASA says private Moment occurred in 1999.",
+            "NASA Selected Relay accepted a post.",
+            "NASA Private Moment occurred in 1999.",
+            "NASA says the packet still contains 500 records.",
+            "I think NASA says the packet still contains 500 records.",
+            "NASA says the packet now contains 500 records.",
+            "NASA says the packet very clearly contains 500 records.",
+            "Arrival proves The Journal still was published in 1999.",
+            "NASA says the packet again contains 500 records.",
+            "NASA says the packet once contained 500 records.",
+            "NASA says the packet ever contained 500 records.",
+            "NASA says the packet no longer contains 500 records.",
+            "NASA says the packet without doubt contains 500 records.",
+            "NASA says the packet as expected contains 500 records.",
+            "NASA says the packet to this day contains 500 records.",
+            "NASA says the packet at present contains 500 records.",
+            "NASA says the packet available today contains 500 records.",
+            "NASA says the packet that still contains 500 records was selected.",
+            "NASA says the packet of public records contains 500 entries.",
+            "NASA says selected Relay no longer accepts posts.",
+            "NASA says private Moment once occurred in 1999.",
+            "NASA says The Journal at present contains private entries.",
+            "NASA says internal memory no longer stores messages.",
+            "I think NASA says the packet no longer contains 500 records.",
+            "NASA said member works at NASA.",
+            "NASA Said member works at NASA.",
+            "NASA told member works at NASA.",
+            "NASA found member works at NASA.",
+            "NASA heard member works at NASA.",
+            "NASA knew member works at NASA.",
+            "NASA said requester works at NASA.",
+            "NASA said user works at NASA.",
+            "NASA said member is married.",
+            "NASA Says Relay accepted a post.",
+            "NASA SAYS Relay accepted a post.",
+            "NASA Reports Moment occurred in 1999.",
+            "NASA REPORTS Moment occurred in 1999.",
+            "Studies show user works at NASA.",
+            "NASA data show user works at NASA.",
+            "Public reports reveal member is active.",
+            "Surveys suggest requester lives in Seattle.",
+            "The results prove user is active.",
+            "Public data indicate member works at NASA.",
+            "Records confirm requester lives in Seattle.",
+            "Reports say user works at NASA.",
+            "Relay Accepted a post.",
+            "Relay ACCEPTED a post.",
+            "Moment Occurred in 1999.",
+            "Moment OCCURRED in 1999.",
+            "NASA says Relay Accepted a post.",
+            "NASA says Relay ACCEPTED a post.",
+            "NASA says Moment Occurred in 1999.",
+            "NASA says Moment OCCURRED in 1999.",
+            "NASA says Relay Was accepted.",
+            "NASA says Moment Was recorded.",
+            "NASA says Relay Is active.",
+            "NASA says selected Relay Health launched a service.",
+            "NASA says private Moment Magazine published an article.",
+            "NASA says member account contains a birthday.",
+            "NASA says user account has a private email.",
+            "NASA says requester account stores messages.",
+            "NASA says user forum stores private messages.",
+            "NASA says requester documentation reveals a birthday.",
+            "NASA says user organization has private records.",
+            "Relay Journal published a profile.",
+            "Relay Moment occurred in 1999.",
+            "Moment Relay accepted a post.",
+            "Relay Packet contains private messages.",
+            "Relay Profile contains a birthday.",
+            "Relay Database stores messages.",
+            "Relay Archive contains private facts.",
+            "Relay Memory contains private facts.",
+            "Moment Packet contains records.",
+            "Moment Profile shows a birthday.",
+            "Moment Database stores messages.",
+            "NASA says Relay Packet contains private messages.",
+            "NASA says Moment Profile shows a birthday.",
+            "NASA says relay Health accepted a post.",
+            "NASA says RELAY Health accepted a post.",
+            "NASA says ReLaY Health accepted a post.",
+            "NASA says RELAY FM contains private messages.",
+            "The latest member survey shows user works at NASA.",
+            "The latest member survey shows requester lives in Seattle.",
+            "The latest member survey shows member is married.",
+            "The latest member survey proves user committed fraud.",
+            "The latest member survey says user stole money.",
+            "The latest member survey confirms user has cancer.",
+            "The latest member survey reveals user is pregnant.",
+            "Recent user study shows user works at NASA.",
+            "From your profile, okay.",
+            "Although Today, from your profile, okay.",
+            "According to the selected member profile containing a private 1999 birthday and current employer, okay.",
+            "Although Today, according to the selected member profile containing a private 1999 birthday and current employer, okay.",
+            "After you joined NASA, you should consult public documentation.",
+            "At BARCODE founding in 1999, sounds good.",
+            "[SIGNAL_GLITCH // you murdered someone // adjacent_timeline]",
+            "[SIGNAL_GLITCH // you are pregnant // adjacent_timeline]",
+            "In an alternate timeline, you murdered someone.",
+            "[SIGNAL_GLITCH // you own three homes // adjacent_timeline]",
+            "[SIGNAL_GLITCH // I was created in 1999 // adjacent_timeline]",
+            "[SIGNAL_GLITCH // BARCODE started in 1999 // adjacent_timeline]",
+            "[SIGNAL_GLITCH // internal database has facts // adjacent_timeline]",
+            "[SIGNAL_GLITCH // the packet selects the source // adjacent_timeline]",
+            "[SIGNAL_GLITCH // the database reads member messages // adjacent_timeline]",
+            "[SIGNAL_GLITCH // the database hosts a show // adjacent_timeline]",
+            "[SIGNAL_GLITCH // the archive reveals member facts // adjacent_timeline]",
+            "[SIGNAL_GLITCH // the archive hosts a show // adjacent_timeline]",
+            "In an alternate timeline, the system accesses member data.",
+            "[SIGNAL_GLITCH // The Moment occurred in 1999 // adjacent_timeline]",
+            "[SIGNAL_GLITCH // D.J. Floppydisc founded a studio // adjacent_timeline]",
+            "[SIGNAL_GLITCH // you run a studio // adjacent_timeline]",
+            "[SIGNAL_GLITCH // you host a show // adjacent_timeline]",
+            "[SIGNAL_GLITCH // you manage a venue // adjacent_timeline]",
+            "[SIGNAL_GLITCH // you built a house // adjacent_timeline]",
+            "[SIGNAL_GLITCH // you earn $100,000 // adjacent_timeline]",
+            "John D. The packet contains 500 records.",
+            "Jane Q. Situation-frame evidence contains facts.",
+            "George R. The private archive stores messages.",
+            "John D. Archived Relay contains messages.",
+            "Sheila E. Journal published a profile in 1999.",
+            "Sheila E. Relay accepted a post in 1999.",
+            "Sheila E. Moment occurred in 1999.",
+            "Your Name is a 2016 film, you were born in 1999.",
+            "Do you work at NASA and steal from people?",
+            "I believe you murdered someone.",
+            "I think you stole money.",
+            "It seems you lied.",
+            "That means you murdered someone.",
+            "This shows you stole money.",
+            "Overall, you lied.",
+            "The throughline is that you committed fraud.",
+            "Together, this proves you cheated.",
+            "Your favorite movie is Arrival. I believe you murdered someone.",
+            "Your favorite movie is Arrival. I think you stole money.",
+            "Your favorite movie is Arrival. It seems you lied.",
+            "Your favorite movie is Arrival. That means you murdered someone.",
+            "Your favorite movie is Arrival. This shows you stole money.",
+            "Your favorite movie is Arrival. Overall, you lied.",
+            "Your favorite movie is Arrival. The throughline is that you committed fraud.",
+            "Your favorite movie is Arrival. Together, this proves you cheated.",
+            "Your favorite movie is Arrival. I think you're married.",
+            "Your favorite movie is Arrival. I think you are pregnant.",
+            "Your favorite movie is Arrival. I think you are autistic.",
+            "Your favorite movie is Arrival. I think you are gay.",
+            "Your favorite movie is Arrival. I think you are depressed.",
+            "Your favorite movie is Arrival. My assessment is that you are diabetic.",
+            "Your favorite movie is Arrival. It seems you are wealthy.",
+            "Your favorite movie is Arrival. Overall, you are pregnant.",
+            "Your favorite movie is Arrival. The throughline is that you're married.",
+        )
+        for response in cases:
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self.basis,
+                        response,
+                    )
+                )
+                self.assertGreaterEqual(unsupported, 1)
+                self.assertIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
+    def test_supported_claim_with_packet_comma_tail_fails_closed(self):
+        for response in (
+            "Your favorite movie is Arrival, you were born in 1999.",
+            "Your favorite movie is Arrival and the packet has 500 records.",
+            "Your favorite movie is Arrival because I was created in 1999.",
+        ):
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self.basis,
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 1)
+                self.assertIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+                decision = evaluate_single_packet_response(
+                    self.conn,
+                    self._begin(),
+                    response=response,
+                    provider_call_count=1,
+                    corrective_call_count=0,
+                    environ=self.flags,
+                )
+                self.assertFalse(decision.candidate_selected)
+
+    def test_supported_member_claim_cannot_carry_unsupported_tail(self):
+        response = (
+            "Your favorite movie is Arrival because you watched it in Paris."
+        )
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            self.basis,
+            response,
+        )
+        self.assertEqual(unsupported, 1)
+        self.assertEqual(
+            classifications,
+            ("member_supported", "unsupported_packet_domain"),
+        )
+        decision = evaluate_single_packet_response(
+            self.conn,
+            self._begin(),
+            response=response,
+            provider_call_count=1,
+            corrective_call_count=0,
+            environ=self.flags,
+        )
+        self.assertFalse(decision.candidate_selected)
+
+    def test_nonhuman_external_claim_does_not_release_member_pronoun(self):
+        cases = (
+            "Apple was founded in 1976. He works at Apple.",
+            "NASA publishes mission data. He works there.",
+            "The Wall Street Journal was founded in 1889. He works there.",
+            "Pink Floyd released an album. He works with them.",
+            "Denis Villeneuve directed Arrival. She works at NASA.",
+            "Walt Disney was born in 1901. She works at NASA.",
+        )
+        for response in cases:
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self.basis,
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 1)
+                self.assertEqual(
+                    classifications,
+                    (
+                        "external_public_knowledge",
+                        "unsupported_packet_domain",
+                    ),
+                )
+
+    def test_clarification_insufficiency_and_guidance_are_not_claims(self):
+        cases = (
+            "Do you work at NASA?",
+            "I don't know your birthday.",
+            "I do not have enough evidence to say where you work.",
+            "I can't verify that BARCODE started in 1999.",
+            "I don't know whether you own three homes.",
+            "I can't verify that your diagnosis is cancer.",
+            "I cannot say whether you served in Iraq.",
+            "I do not have enough evidence to say whether you attended Harvard.",
+            "You can find public mission data at https://www.nasa.gov/.",
+            "You should consult the public documentation.",
+        )
+        for response in cases:
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self.basis,
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 0)
+                self.assertNotIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            self.basis,
+            (
+                "I do not have enough reliable public history to summarize "
+                "you without guessing. I can respond to what you say here, "
+                "but the longer-term signal is still too thin for a grounded "
+                "profile."
+            ),
+        )
+        self.assertEqual(unsupported, 0)
+        self.assertEqual(
+            classifications,
+            (
+                "honest_nonassertion",
+                "ordinary_guidance",
+                "honest_nonassertion",
+            ),
+        )
+
+    def test_honest_nonassertion_does_not_license_adversative_fact(self):
+        response = (
+            "I can't verify your birthday, but you were born in 1999."
+        )
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            self.basis,
+            response,
+        )
+        self.assertEqual(unsupported, 1)
+        self.assertEqual(
+            classifications,
+            ("honest_nonassertion", "unsupported_packet_domain"),
+        )
+
+    def test_external_personal_titles_do_not_become_member_claims(self):
+        cases = (
+            "The song You Are My Sunshine was published in 1939.",
+            "Your Name is a 2016 film.",
+            "I, Robot is a 2004 film.",
+            "We Need to Talk About Kevin is a 2011 film.",
+            "Me Before You is a 2016 film.",
+            "Her is a 2013 film.",
+            "His Girl Friday is a 1940 film.",
+        )
+        for response in cases:
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self.basis,
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 0)
+                self.assertEqual(
+                    classifications,
+                    ("external_public_knowledge",),
+                )
+
+        for response in (
+            "Your Name is HAL.",
+            "You Are My Sunshine was released in 1939.",
+            "You, Me and Dupree was released in 2006.",
+            "You Murdered Someone was released in 2019.",
+            "You Are Married was released in 2019.",
+            "My Creator Is Alice was released in 2019.",
+            "Your Name was released in 2016.",
+            "Your Work was published in 2019.",
+            "Your Project was released in 2019.",
+            "My Project was published in 2019.",
+            "Our Album was released in 2019.",
+            "You published in 2019.",
+            "You released in 2019.",
+            "Her Profile was published in 2019.",
+            "His Dossier was published in 2019.",
+        ):
+            with self.subTest(ambiguous_title=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self.basis,
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 1)
+                self.assertEqual(
+                    classifications,
+                    ("unsupported_packet_domain",),
+                )
+
+    def test_ordinary_expressions_and_external_opinions_stay_usable(self):
+        for response in (
+            "I agree.",
+            "I hear you.",
+            "I think Arrival is a great film.",
+            "My take is that Arrival is excellent.",
+            "We can do that.",
+            "I can explain.",
+            "You got it.",
+            "You are welcome.",
+        ):
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self.basis,
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 0)
+                self.assertNotIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+                decision = evaluate_single_packet_response(
+                    self.conn,
+                    self._begin(),
+                    response=response,
+                    provider_call_count=1,
+                    corrective_call_count=0,
+                    environ=self.flags,
+                )
+                self.assertTrue(decision.candidate_selected)
+
+    def test_selected_ambiguous_canon_labels_still_fail_closed(self):
+        cases = (
+            ("cliff", "Cliff", "Cliff joined a band in 1982."),
+            ("sheila", "Sheila", "Sheila released an album in 1984."),
+            ("bnl_01", "BNL", "BNL joined the project in 1999."),
+            ("6_bit", "6 Bit", "6 Bit founded a studio in 1999."),
+        )
+        for entity_key, label, response in cases:
+            with self.subTest(entity_key=entity_key, response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self._basis_for_canon_entity(entity_key, label),
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 1)
+                self.assertEqual(
+                    classifications,
+                    ("unsupported_packet_domain",),
+                )
+
+        for entity_key, label, response in (
+            ("cliff", "Cliff", "Cl.iff joined a band in 1982."),
+            ("sheila", "Sheila", "Shei_la released an album."),
+            ("bnl_01", "BNL", "B.N.L joined a project."),
+        ):
+            with self.subTest(punctuated_entity=entity_key):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self._basis_for_canon_entity(entity_key, label),
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 1)
+                self.assertEqual(
+                    classifications,
+                    ("unsupported_packet_domain",),
+                )
+
+    def test_selected_label_reconstruction_preserves_word_boundaries(self):
+        for response in (
+            "Contest membership works differently.",
+            "The latest member survey was published in 2025.",
+            "Contest Members published results.",
+        ):
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self.basis,
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 0)
+                self.assertNotIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
+    def test_selected_label_outranks_external_title_context(self):
+        collision_basis = self._basis_for_canon_entity(
+            "relay_health_collision",
+            "Relay Health",
+        )
+        for response in (
+            "According to Relay Health, okay.",
+            "According to Relay Health, you should consult public documentation.",
+            "According to Relay Health, I think Arrival is a great film.",
+        ):
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        collision_basis,
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 1)
+                self.assertEqual(
+                    classifications,
+                    ("unsupported_packet_domain",),
+                )
+
+    def test_project_titles_are_governed_across_frames(self):
+        for response in (
+            "The Journal was published in 1999.",
+            "Journal published a profile in 1999.",
+            "The Journal's publication began in 1999.",
+            "The Relay was published in 1999.",
+            "Relay accepted a post in 1999.",
+            "The Relay's post was accepted in 1999.",
+            "The Moment was recorded in 1999.",
+            "Moment's episode was recorded in 1999.",
+        ):
+            with self.subTest(member_frame_project_title=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self.basis,
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 1)
+                self.assertEqual(
+                    classifications,
+                    ("unsupported_packet_domain",),
+                )
+
+        journal_basis = replace(
+            self.basis,
+            packet=replace(
+                self.packet,
+                request=replace(
+                    self.packet.request,
+                    frame_object_kind="journal",
+                ),
+            ),
+        )
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            journal_basis,
+            "The Journal was published in 1999.",
+        )
+        self.assertEqual(unsupported, 1)
+        self.assertEqual(
+            classifications,
+            ("unsupported_packet_domain",),
+        )
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            journal_basis,
+            "Journal was founded in 1999.",
+        )
+        self.assertEqual(unsupported, 1)
+        self.assertEqual(
+            classifications,
+            ("unsupported_packet_domain",),
+        )
+        for response in (
+            "The Wall Street Journal was founded in 1889.",
+            "Journal of Medicine was founded in 1999.",
+        ):
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        journal_basis,
+                        response,
+                    )
+                )
+                self.assertEqual(unsupported, 0)
+                self.assertNotIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            journal_basis,
+            "the journal was published in 1999.",
+        )
+        self.assertEqual(unsupported, 1)
+        self.assertEqual(
+            classifications,
+            ("unsupported_packet_domain",),
+        )
+
+    def test_structured_packet_headings_fail_closed(self):
+        for response in (
+            "BARCODE:\n- A collective\n- Founded in 1999",
+            "BNL-01:\n- An AI\n- Created in 1999",
+            "About you:\n- Network engineer\n- Born in 1980",
+        ):
+            with self.subTest(response=response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        self.basis,
+                        response,
+                    )
+                )
+                self.assertGreaterEqual(unsupported, 1)
+                self.assertIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
+    def test_claim_audit_alignment_mismatch_always_fails_closed(self):
+        response = "Apollo 11 landed in 1969. Seattle is in Washington."
+        coverage = replace(
+            candidate_profile_coverage(self.basis, response),
+            claim_classifications=(),
+        )
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            self.basis,
+            response,
+            coverage=coverage,
+        )
+        self.assertEqual(unsupported, 2)
+        self.assertEqual(
+            classifications,
+            (
+                "claim_audit_alignment_invalid",
+                "claim_audit_alignment_invalid",
+            ),
+        )
 
     def test_invalid_call_counts_fail_closed_and_are_reported(self):
         run = self._begin()


### PR DESCRIPTION
## Summary

Follow-up to #434. This narrows the ordinary-chat acceptance audit to the claim that is actually governed instead of treating the whole member-framed request as packet truth.

- keeps unsupported member, BARCODE/canon, Journal/Relay/Moment, packet, internal-runtime, and selected-subject assertions fail-closed
- lets positively scoped external public knowledge remain usable without relabeling it as verified
- stops treating a numeral, URL, or email address by itself as a personal/member fact
- preserves claim/count alignment failure, supported-claim tail checks, exact selected-label precedence, honest insufficiency, and the one-physical-provider-call contract
- adds positive eligible-evidence and external-knowledge fixtures alongside the leakage/unsupported-claim matrix

No environment variable, gate default, provider-call path, schema, persistence, deployment, queue, site, or publication behavior changes.

## Verification

Exact tested Git tree: `841f7ea4ebe66b1324ac2728feb1563e1fc3d287`  
Parent: `c550c04513b6becf76f2b501ebf10459ea18b360`

- `make check PYTHON=/tmp/bnl01-pr434-repair-venv/bin/python` — **2,224/2,224 passed**
- focused ordinary-chat/shared-brain/bot-path/open-signal suite — **79/79 passed**
- `python -m py_compile bnl_shared_brain_synthesis.py` — passed
- `git diff --check` — clean
- independent final mutation reviews — zero leaks across governed tails, embedded subjects, casing, modifier stacks, selected-label collisions, and bounded external-title contexts
- privacy/scope review — neutral/public fixtures only; no owner identity, secret, gate, schema, persistence, or runtime mutation added

## Deliberate boundary

This is a conservative claim-specific repair, not a general NLP completeness claim. Ambiguous generic packet/database/object wording, open-domain coreference, some irregular phrasing, and unlisted external proper names can still fail closed. Those are availability/precision follow-ups, not authority fail-opens.

The source packs and current history do not provide a durable definition for the previously mentioned second follow-up PR, so this PR does not invent one.

## Post-merge deployment block

1. Merge only after the required review/checks are green.
2. Deploy the merged **bot** SHA only. Leave all live/global gates and exact-scope environment values unchanged; this PR does not authorize activation, a public test, a site cutover, queue production, or rehearsal.
3. Record a content-free Gate 0 snapshot: deployed SHA, process/service identity, config presence (names only, no values), database/schema version, and whether the ordinary-chat canary remains disabled.
4. In the deployed artifact/container, run exactly:
   - `python -m unittest tests.test_ordinary_chat_single_packet_canary tests.test_shared_brain_synthesis_canary tests.test_shared_brain_synthesis_bot_path tests.test_shared_brain_open_signal_v2`
   - expected: **79 tests, OK**
5. Capture content-free evidence that:
   - ordinary-chat scope remains exact and default-off
   - an unsupported member/canon/internal claim blocks the candidate
   - an external date, public URL, and public email remain external/unverified rather than personal
   - a supported member claim plus unrelated external fact keeps the eligible evidence and selects correctly
   - an honest insufficiency response remains usable
   - one physical provider attempt is counted exactly once, with zero corrective calls
   - receipts contain classifications/counts only, not prompt, packet, response, private memory, or dossier content
6. If any result differs, keep the gate off, roll back to the prior deployed bot SHA, retain the content-free receipt, and do not broaden validators or activate fallback behavior.

A live one-guild/one-user/one-channel canary still requires a separate explicit owner decision plus the mandatory runtime/Gate 0 evidence.