### PR TITLE
Restore SQLite 3.31 declared-canon compatibility

### DIFF
--- a/bnl_declared_canon.py
+++ b/bnl_declared_canon.py
@@ -685,7 +685,7 @@ def _read_snapshot(conn: sqlite3.Connection):
         # BEGIN is deferred in SQLite. This read pins the snapshot before any
         # validator query so a WAL writer cannot splice a newer revision/source
         # row into the remainder of the validation sequence.
-        conn.execute("SELECT 1 FROM main.sqlite_schema LIMIT 1").fetchone()
+        conn.execute("SELECT 1 FROM main.sqlite_master LIMIT 1").fetchone()
     try:
         yield
         if int(conn.total_changes or 0) != before:

--- a/tests/test_declared_canon_lifecycle.py
+++ b/tests/test_declared_canon_lifecycle.py
@@ -107,6 +107,45 @@ class DeclaredCanonLifecycleTests(unittest.TestCase):
         )
         self.assertEqual(stored, [(created.cleaned_summary,)])
 
+    def test_read_snapshot_uses_legacy_compatible_catalog_name(self):
+        class LegacyCatalogConnection:
+            def __init__(self, connection):
+                self.connection = connection
+                self.statements = []
+
+            @property
+            def in_transaction(self):
+                return self.connection.in_transaction
+
+            @property
+            def total_changes(self):
+                return self.connection.total_changes
+
+            def execute(self, statement, params=()):
+                self.statements.append(statement)
+                if "sqlite_schema" in statement.casefold():
+                    raise sqlite3.OperationalError(
+                        "no such table: main.sqlite_schema"
+                    )
+                return self.connection.execute(statement, params)
+
+            def commit(self):
+                return self.connection.commit()
+
+            def rollback(self):
+                return self.connection.rollback()
+
+        guarded = LegacyCatalogConnection(self.conn)
+        with declared._read_snapshot(guarded):
+            self.assertTrue(guarded.in_transaction)
+            self.assertEqual(guarded.execute("SELECT 1").fetchone(), (1,))
+
+        self.assertFalse(guarded.in_transaction)
+        self.assertEqual(
+            guarded.statements[:2],
+            ["BEGIN", "SELECT 1 FROM main.sqlite_master LIMIT 1"],
+        )
+
     def test_all_sqlite_replace_and_upsert_forms_are_blocked(self):
         created = self.add("replace-matrix1").primary
         replacement = asdict(created)


### PR DESCRIPTION
## What changed

- use SQLite's backward-compatible `main.sqlite_master` catalog name when pinning the declared-canon read snapshot
- add a regression test that simulates a runtime where `main.sqlite_schema` is unavailable and verifies the snapshot transaction still pins successfully

## Why

The merged #435 change passed its focused 79-test acceptance suite on the VPS, but the full production suite exposed 24 errors in unchanged declared-canon code:

```
sqlite3.OperationalError: no such table: main.sqlite_schema
```

The production interpreter is Python 3.9.5 with SQLite 3.31.1. That runtime supports the longstanding `sqlite_master` catalog name, while the newer `sqlite_schema` alias is unavailable there. Both names refer to the same schema catalog on newer SQLite versions, so this is a compatibility correction rather than a persistence or schema change.

## Impact

This restores declared-canon snapshot validation on the deployed SQLite generation so the full acceptance gate can be rerun before #435 is activated. It does not alter canon lifecycle semantics, transaction ownership, tables, rows, migrations, dependencies, configuration, provider calls, or feature gates.

## Validation

- targeted declared-canon suites: **68/68 passed**
- complete repository suite: **2,225/2,225 passed**
- `py_compile`: passed
- `git diff --check`: clean
- changed files: exactly 2

## Deployment guardrail

Keep this PR draft until review and CI are complete. Do not restart the VPS or activate the ordinary-chat canary from this PR alone. After merge, update the clean VPS checkout, rerun the full suite under the production Python/SQLite runtime, and restart only if all 2,225 tests pass. Existing comparison and global live gates remain off; the ordinary-chat canary remains default-off.