### PR TITLE
Typed ordinary-chat acceptance contract (PR1)

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -137,6 +137,7 @@ from bnl_shadow_acceptance import (
 )
 from bnl_unified_intelligence_packet import (
     IntelligencePacketRequest,
+    PacketFrameTask,
     PacketFrameSubject,
     PacketConversationEvidence,
     UnifiedIntelligencePacket,
@@ -161,7 +162,9 @@ from bnl_shared_brain_synthesis import (
     finalize_run as finalize_shared_brain_synthesis_run,
     honest_empty_profile_response,
     ordinary_chat_configuration,
+    ordinary_chat_deterministic_response_act,
     ordinary_chat_route_scope_decision,
+    parse_ordinary_chat_response_contract,
     record_fallback as record_shared_brain_synthesis_fallback,
     record_single_packet_block,
     revalidate_basis as revalidate_shared_brain_synthesis_basis,
@@ -23504,8 +23507,34 @@ def _build_unified_intelligence_packet_shadow(
         if isinstance(situation_frame, SituationFrameV1)
         else ()
     )
+    frame_tasks = (
+        tuple(
+            PacketFrameTask(
+                task_id=str(task.task_id or "")[:24],
+                text_digest=str(task.text_digest or "")[:128],
+                task_kind=str(task.task_kind or "")[:80],
+                object_kind=str(task.object_kind or "")[:80],
+                authority_scope=str(task.authority_scope or "")[:80],
+                temporal_scope=str(task.temporal_scope or "")[:80],
+                currentness=str(task.currentness or "")[:80],
+                required_response_act=str(
+                    task.required_response_act or ""
+                )[:80],
+                subject_requirement=str(
+                    task.subject_requirement or ""
+                )[:80],
+                subject_indexes=tuple(
+                    max(0, int(subject_index or 0))
+                    for subject_index in task.subject_indexes
+                ),
+            )
+            for task in situation_frame.tasks
+        )
+        if isinstance(situation_frame, SituationFrameV1)
+        else ()
+    )
     if isinstance(situation_frame, SituationFrameV1):
-        # Packet v7 resolves only the frozen frame candidates. A named or
+        # Packet v9 resolves only the frozen frame candidates. A named or
         # mentioned third party can never silently fall back to the speaker.
         subject_user_id = 0
     elif len(targets) == 1:
@@ -23617,6 +23646,7 @@ def _build_unified_intelligence_packet_shadow(
             else "legacy"
         ),
         frame_subjects=frame_subjects,
+        frame_tasks=frame_tasks,
         frame_role_hints=(
             situation_frame.role_hints
             if isinstance(situation_frame, SituationFrameV1)
@@ -26526,6 +26556,14 @@ async def get_gemini_response(
         if not generation_result.success:
             return ""
         text = generation_result.text
+
+        if one_call_packet_route:
+            # Preserve the provider envelope byte-for-byte for the typed task
+            # validator.  Legacy prose heuristics cannot safely classify JSON
+            # support metadata and are not the factual authority on this path.
+            # The parsed visible text still passes typed selection,
+            # control-leak, source/frame, exact-quote, and delivery checks.
+            return text
 
         # -------- AI Generated Glitch Event --------
         if (
@@ -35587,6 +35625,16 @@ class OrdinaryChatSinglePacketExecution:
 
 def _ordinary_chat_single_packet_block_response(reason: str) -> str:
     value = str(reason or "").lower()
+    if "deterministic_task_hold" in value or "current_fact" in value:
+        return (
+            "I can’t verify that live or current fact from an authoritative "
+            "source right now, so I’m holding it instead of guessing."
+        )
+    if "deterministic_task_clarify" in value:
+        return (
+            "I’m missing one exact target for that question. Name the person, "
+            "event, or thread once and I’ll answer from that scope."
+        )
     if "frame_ambiguous" in value or "ambiguous" in value:
         return (
             "I’m not certain which person, event, or thread you mean. "
@@ -35634,6 +35682,8 @@ def _evaluate_ordinary_chat_single_packet_receipt(
     provider_call_count: int,
     corrective_call_count: int,
     generation_latency_ms: int,
+    response_contract=None,
+    typed_contract_required: bool = False,
 ) -> SynthesisCanaryDecision:
     snapshot, snapshot_provided = (
         _shared_brain_journal_revalidation_snapshot(run.basis)
@@ -35646,6 +35696,8 @@ def _evaluate_ordinary_chat_single_packet_receipt(
             provider_call_count=provider_call_count,
             corrective_call_count=corrective_call_count,
             generation_latency_ms=generation_latency_ms,
+            response_contract=response_contract,
+            typed_contract_required=typed_contract_required,
             journal_control_snapshot=snapshot,
             journal_control_snapshot_provided=snapshot_provided,
         )
@@ -36104,10 +36156,20 @@ async def maybe_generate_ordinary_chat_single_packet(
             basis.packet.source_snapshot_digest
         ),
     )
+    deterministic_act = ordinary_chat_deterministic_response_act(basis)
     preflight_reason = str(preflight_block_reason or "")
-    prompt_ready = bool(packet_prompt.ready and not preflight_reason)
+    prompt_ready = bool(
+        packet_prompt.ready
+        and not preflight_reason
+        and not deterministic_act
+    )
     prompt_failure = (
         preflight_reason
+        or (
+            "deterministic_task_%s" % deterministic_act
+            if deterministic_act
+            else ""
+        )
         or packet_prompt.reason
         or "single_packet_preflight_failed"
     )
@@ -36159,7 +36221,10 @@ async def maybe_generate_ordinary_chat_single_packet(
             route=ORDINARY_CHAT_SINGLE_PACKET_ROUTE,
             source_context_available=source_context_available,
         )
-        candidate = tracked_generation.text
+        response_contract = parse_ordinary_chat_response_contract(
+            tracked_generation.text
+        )
+        candidate = response_contract.response
         provider_call_count = tracked_generation.provider_call_count
     except Exception as exc:
         logging.warning(
@@ -36167,11 +36232,7 @@ async def maybe_generate_ordinary_chat_single_packet(
             type(exc).__name__,
         )
         candidate = ""
-    candidate = bound_identity_comparison_response(
-        candidate or "",
-        situation_frame_current_text,
-        basis=basis,
-    )
+        response_contract = parse_ordinary_chat_response_contract("")
     generation_latency_ms = max(
         0,
         int(round((time.monotonic() - generation_started) * 1000)),
@@ -36184,6 +36245,8 @@ async def maybe_generate_ordinary_chat_single_packet(
             provider_call_count=provider_call_count,
             corrective_call_count=0,
             generation_latency_ms=generation_latency_ms,
+            response_contract=response_contract,
+            typed_contract_required=True,
         )
     except Exception as exc:
         logging.warning(
@@ -36431,14 +36494,63 @@ async def send_planned_conversation_response(
     single_packet_selected_response = (
         str(response or "") if single_packet_cutover else ""
     )
-    response, guard_diagnostics = await _run_response_guard(
-        response or "",
-        prompt,
-        tuple(prompt_source_bases or ()),
-        regeneration_allowed=bool(
-            not synthesis_candidate_active and not single_packet_cutover
-        ),
+    deterministic_single_packet_block = bool(
+        single_packet_cutover
+        and ordinary_chat_single_packet_execution is not None
+        and not synthesis_candidate_active
+        and ordinary_chat_single_packet_execution.provider_call_count == 0
+        and ordinary_chat_single_packet_execution.block_reason
+        and str(response or "")
+        == _ordinary_chat_single_packet_block_response(
+            ordinary_chat_single_packet_execution.block_reason
+        )
     )
+    typed_single_packet_candidate = bool(
+        single_packet_cutover
+        and synthesis_candidate_active
+        and synthesis_decision is not None
+        and str(
+            getattr(synthesis_decision, "typed_contract_status", "")
+            or ""
+        )
+        == "valid"
+    )
+    if deterministic_single_packet_block:
+        # This text is selected from local fixed templates after typed
+        # preflight.  It contains no factual candidate to regenerate or
+        # reclassify.  Source, frame, exact-quote, delivery, and final receipt
+        # checks below still run before the one Discord send.
+        guard_diagnostics = {
+            "suppressed": False,
+            "deterministic_single_packet_block": True,
+            "_revalidated_prompt_source_bases": tuple(
+                prompt_source_bases or ()
+            ),
+        }
+    elif typed_single_packet_candidate:
+        # The single-packet evaluator has already validated exact task
+        # coverage, typed support references, packet/source revalidation,
+        # output-control leakage, and coherence.  Do not feed the selected
+        # visible text back through the legacy prose classifier and create a
+        # second semantic verdict.  The independent source, frame,
+        # exact-quote, Discord-delivery, and final-receipt checks below remain
+        # mandatory.
+        guard_diagnostics = {
+            "suppressed": False,
+            "typed_single_packet_selection_boundary": True,
+            "_revalidated_prompt_source_bases": tuple(
+                prompt_source_bases or ()
+            ),
+        }
+    else:
+        response, guard_diagnostics = await _run_response_guard(
+            response or "",
+            prompt,
+            tuple(prompt_source_bases or ()),
+            regeneration_allowed=bool(
+                not synthesis_candidate_active and not single_packet_cutover
+            ),
+        )
     if (
         single_packet_cutover
         and synthesis_candidate_active

--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -827,7 +827,7 @@ def _read_shared_brain_synthesis_report(
         return _report_error(
             {
                 "tablePresent": False,
-                "schemaVersion": "shared_brain_synthesis_v9",
+                "schemaVersion": "shared_brain_synthesis_v10",
                 "runs": 0,
                 "promptAppliedRuns": 0,
                 "liveAppliedRuns": 0,
@@ -2116,7 +2116,7 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             _on(shared_brain_synthesis_state.get("fullyScoped")),
             shared_brain_synthesis.get(
                 "schemaVersion",
-                "shared_brain_synthesis_v9",
+                "shared_brain_synthesis_v10",
             ),
             shared_brain_synthesis.get("runs", 0),
             json.dumps(

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -53,11 +53,11 @@ from bnl_unified_response_assessment import (
 )
 
 
-SCHEMA_VERSION = "shared_brain_synthesis_v9"
+SCHEMA_VERSION = "shared_brain_synthesis_v10"
 CAPABILITY_NAME = "shared_brain_public_broad_recall"
 CAPABILITY_CONTRACT_VERSION = "hybrid_shared_brain_v1"
 CAPABILITY_RECEIPT_VERSION = "shared_brain_capability_receipt_v1"
-_EXPECTED_PACKET_SCHEMA_VERSION = "unified_intelligence_packet_v8"
+_EXPECTED_PACKET_SCHEMA_VERSION = "unified_intelligence_packet_v9"
 _EXPECTED_CLAIM_CONTRACT_VERSION = "hybrid_canon_claim_v1"
 _EXPECTED_ASSESSMENT_VERSION = "unified_response_assessment_v7"
 _EXPECTED_IDENTITY_CONTRACT_VERSION = "canon_entity_account_binding_v1"
@@ -77,7 +77,7 @@ PUBLIC_HOME_OWNER_CHANNEL_IDS_ENV = (
 )
 ORDINARY_CHAT_CAPABILITY_NAME = "ordinary_chat_single_packet_canary"
 ORDINARY_CHAT_CAPABILITY_CONTRACT_VERSION = (
-    "ordinary_chat_single_packet_v1"
+    "ordinary_chat_single_packet_v2"
 )
 ORDINARY_CHAT_ENABLED_ENV = "BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED"
 ORDINARY_CHAT_GUILD_IDS_ENV = (
@@ -1188,6 +1188,7 @@ class SharedBrainSynthesisBasis:
     profile_recognized_canon_identity: bool = False
     identity_canon_only: bool = False
     honest_empty_profile_fallback: bool = False
+    rendered_evidence_refs: tuple[tuple[str, str, str], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -1227,6 +1228,10 @@ class SynthesisCanaryDecision:
     candidate_unsupported_factual_claim_count: int = 0
     candidate_claim_classifications: tuple[str, ...] = ()
     supported_coverage_regressed: bool = False
+    typed_contract_status: str = "not_evaluated"
+    typed_task_count: int = 0
+    typed_task_coverage_count: int = 0
+    typed_support_reference_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -1246,6 +1251,42 @@ class PacketOwnedPrompt:
     ready: bool
     reason: str = ""
     replaced_factual_context_count: int = 0
+
+
+@dataclass(frozen=True)
+class OrdinaryChatTaskResult:
+    """One visible task answer paired with non-visible support metadata."""
+
+    task_id: str
+    text: str
+    support_kind: str
+    evidence_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class OrdinaryChatResponseContract:
+    """Parsed one-call provider result; never persisted with response text."""
+
+    status: str
+    tasks: tuple[OrdinaryChatTaskResult, ...] = ()
+
+    @property
+    def response(self) -> str:
+        return "\n\n".join(
+            task.text.strip() for task in self.tasks if task.text.strip()
+        ).strip()
+
+
+@dataclass(frozen=True)
+class OrdinaryChatContractValidation:
+    status: str
+    task_count: int = 0
+    covered_task_count: int = 0
+    support_reference_count: int = 0
+
+    @property
+    def valid(self) -> bool:
+        return self.status == "valid"
 
 
 @dataclass(frozen=True)
@@ -1381,7 +1422,7 @@ def _configuration_details(
         "claim_contract_version": _EXPECTED_CLAIM_CONTRACT_VERSION,
         "assessment_version": _EXPECTED_ASSESSMENT_VERSION,
         "identity_contract_version": _EXPECTED_IDENTITY_CONTRACT_VERSION,
-        "synthesis_version": "shared_brain_synthesis_v9",
+        "synthesis_version": SCHEMA_VERSION,
     }
     version_conflicts = tuple(
         sorted(
@@ -1584,7 +1625,7 @@ def _ordinary_chat_configuration_details(
         "claim_contract_version": _EXPECTED_CLAIM_CONTRACT_VERSION,
         "assessment_version": _EXPECTED_ASSESSMENT_VERSION,
         "identity_contract_version": _EXPECTED_IDENTITY_CONTRACT_VERSION,
-        "synthesis_version": "shared_brain_synthesis_v9",
+        "synthesis_version": SCHEMA_VERSION,
     }
     version_conflicts = tuple(
         sorted(
@@ -2827,6 +2868,309 @@ def _ordinary_packet_context(
     )
 
 
+def _ordinary_rendered_evidence_refs(
+    packet: UnifiedIntelligencePacket,
+    source_digests: Sequence[str],
+) -> tuple[tuple[str, str, str], ...]:
+    """Bind rendered E-identifiers to lanes without exposing source IDs."""
+
+    remaining = list(packet.items)
+    refs = []
+    for index, source_digest in enumerate(source_digests, start=1):
+        match_index = next(
+            (
+                item_index
+                for item_index, item in enumerate(remaining)
+                if str(item.source_digest or "") == str(source_digest or "")
+            ),
+            -1,
+        )
+        if match_index < 0:
+            return ()
+        item = remaining.pop(match_index)
+        refs.append(("E%s" % index, item.lane, item.source_digest))
+    return tuple(refs)
+
+
+def _ordinary_frame_tasks(
+    basis: SharedBrainSynthesisBasis,
+) -> tuple[Any, ...]:
+    request = getattr(getattr(basis, "packet", None), "request", None)
+    return tuple(
+        task
+        for task in getattr(request, "frame_tasks", ())
+        if str(getattr(task, "task_id", "") or "").strip()
+    )
+
+
+def _ordinary_task_allowed_lanes(task: Any) -> frozenset[str]:
+    object_kind = str(getattr(task, "object_kind", "") or "").lower()
+    if object_kind == "journal":
+        return frozenset({"journal_publication"})
+    if object_kind == "relay":
+        return frozenset({"relay_publication"})
+    if object_kind == "moment":
+        return frozenset({"moment", "episode", "recurring_theme"})
+    if object_kind == "canon":
+        return frozenset({"canon"})
+    if object_kind == "source_file":
+        return frozenset({"source_file"})
+    if object_kind == "person" or str(
+        getattr(task, "subject_requirement", "") or ""
+    ).lower() == "required":
+        return frozenset(
+            {
+                "conversation_context",
+                "assessment_observation",
+                "approved_fact",
+                "moment",
+                "episode",
+                "atomic_knowledge",
+                "recurring_theme",
+                "open_loop",
+                "canon",
+                "journal_publication",
+                "relay_publication",
+                "source_file",
+            }
+        )
+    return frozenset(_RENDERABLE_LANES)
+
+
+def render_ordinary_chat_task_contract(
+    basis: SharedBrainSynthesisBasis,
+) -> str:
+    """Render ordered task/support instructions for the one provider call."""
+
+    tasks = _ordinary_frame_tasks(basis)
+    if not tasks:
+        return ""
+    task_lines = [
+        "- %s | authority=%s | object=%s | currentness=%s | response=%s"
+        % (
+            str(getattr(task, "task_id", "") or ""),
+            str(getattr(task, "authority_scope", "") or "unknown"),
+            str(getattr(task, "object_kind", "") or "unknown"),
+            str(getattr(task, "currentness", "") or "unknown"),
+            str(getattr(task, "required_response_act", "") or "answer"),
+        )
+        for task in tasks
+    ]
+    evidence_lines = [
+        "- %s | lane=%s" % (evidence_id, lane)
+        for evidence_id, lane, _digest_value in basis.rendered_evidence_refs
+    ]
+    return (
+        "TYPED TURN TASK CONTRACT:\n"
+        + "\n".join(task_lines)
+        + "\nSUPPORT REFERENCES:\n"
+        + ("\n".join(evidence_lines) if evidence_lines else "- none")
+        + "\n- PUBLIC may support stable general public knowledge only.\n"
+        + "- REQUEST may support a non-factual conversational response only.\n"
+        + "PROVIDER OUTPUT CONTRACT:\n"
+        + "Return only one JSON object with exactly this shape: "
+        + '{"tasks":[{"taskId":"T1","text":"visible answer",'
+        + '"supportKind":"packet","evidenceIds":["E1"]}]}.\n'
+        + "Return every task exactly once and in order. Use supportKind packet "
+        + "with applicable E-identifiers for stored/BARCODE claims; "
+        + "external_public with PUBLIC for stable general knowledge; "
+        + "current_request with REQUEST for non-factual conversation; hold "
+        + "with no identifiers when current or selected evidence cannot be "
+        + "verified; clarify with no identifiers only when the typed task "
+        + "requires clarification. The text fields become the visible reply. "
+        + "Do not include Markdown fences, task labels, citations, internal "
+        + "terms, or any text outside the JSON object."
+    )
+
+
+def parse_ordinary_chat_response_contract(
+    response: str,
+) -> OrdinaryChatResponseContract:
+    """Parse the one-call JSON envelope without accepting hidden prose."""
+
+    raw = str(response or "").strip()
+    if raw.startswith("```") and raw.endswith("```"):
+        lines = raw.splitlines()
+        if len(lines) >= 3:
+            raw = "\n".join(lines[1:-1]).strip()
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return OrdinaryChatResponseContract(status="invalid_json")
+    if not isinstance(payload, dict) or set(payload) != {"tasks"}:
+        return OrdinaryChatResponseContract(status="invalid_shape")
+    raw_tasks = payload.get("tasks")
+    if not isinstance(raw_tasks, list) or not 1 <= len(raw_tasks) <= 12:
+        return OrdinaryChatResponseContract(status="invalid_task_list")
+    parsed = []
+    for raw_task in raw_tasks:
+        if not isinstance(raw_task, dict) or set(raw_task) != {
+            "taskId",
+            "text",
+            "supportKind",
+            "evidenceIds",
+        }:
+            return OrdinaryChatResponseContract(status="invalid_task_shape")
+        task_id = str(raw_task.get("taskId") or "").strip()
+        text = str(raw_task.get("text") or "").strip()
+        support_kind = str(raw_task.get("supportKind") or "").strip().lower()
+        evidence_ids_raw = raw_task.get("evidenceIds")
+        if not re.fullmatch(r"T[1-9][0-9]?", task_id):
+            return OrdinaryChatResponseContract(status="invalid_task_id")
+        if not text or len(text) > 2000:
+            return OrdinaryChatResponseContract(status="invalid_task_text")
+        if support_kind not in {
+            "packet",
+            "external_public",
+            "current_request",
+            "hold",
+            "clarify",
+        }:
+            return OrdinaryChatResponseContract(status="invalid_support_kind")
+        if not isinstance(evidence_ids_raw, list) or len(evidence_ids_raw) > 8:
+            return OrdinaryChatResponseContract(status="invalid_evidence_ids")
+        evidence_ids = tuple(
+            str(evidence_id or "").strip().upper()
+            for evidence_id in evidence_ids_raw
+        )
+        if any(
+            not re.fullmatch(r"(?:E[1-9][0-9]?|PUBLIC|REQUEST)", evidence_id)
+            for evidence_id in evidence_ids
+        ):
+            return OrdinaryChatResponseContract(status="invalid_evidence_id")
+        if len(set(evidence_ids)) != len(evidence_ids):
+            return OrdinaryChatResponseContract(status="duplicate_evidence_id")
+        parsed.append(
+            OrdinaryChatTaskResult(
+                task_id=task_id,
+                text=text,
+                support_kind=support_kind,
+                evidence_ids=evidence_ids,
+            )
+        )
+    if len({task.task_id for task in parsed}) != len(parsed):
+        return OrdinaryChatResponseContract(status="duplicate_task_id")
+    return OrdinaryChatResponseContract(status="parsed", tasks=tuple(parsed))
+
+
+def validate_ordinary_chat_response_contract(
+    basis: SharedBrainSynthesisBasis,
+    contract: OrdinaryChatResponseContract | None,
+) -> OrdinaryChatContractValidation:
+    """Validate task coverage and typed references against the frozen packet."""
+
+    tasks = _ordinary_frame_tasks(basis)
+    if not isinstance(contract, OrdinaryChatResponseContract):
+        return OrdinaryChatContractValidation(status="missing")
+    if contract.status != "parsed":
+        return OrdinaryChatContractValidation(status=contract.status)
+    if not tasks:
+        return OrdinaryChatContractValidation(status="tasks_unavailable")
+    expected_ids = tuple(
+        str(getattr(task, "task_id", "") or "") for task in tasks
+    )
+    actual_ids = tuple(result.task_id for result in contract.tasks)
+    if actual_ids != expected_ids:
+        return OrdinaryChatContractValidation(
+            status="task_coverage_mismatch",
+            task_count=len(tasks),
+        )
+    evidence_lanes = {
+        evidence_id: lane
+        for evidence_id, lane, _digest_value in basis.rendered_evidence_refs
+    }
+    support_count = 0
+    for task, result in zip(tasks, contract.tasks):
+        authority = str(getattr(task, "authority_scope", "") or "")
+        required_act = str(
+            getattr(task, "required_response_act", "") or "answer"
+        )
+        if required_act == "clarify":
+            if result.support_kind != "clarify" or result.evidence_ids:
+                return OrdinaryChatContractValidation(
+                    status="clarification_contract_mismatch",
+                    task_count=len(tasks),
+                )
+            continue
+        if required_act == "hold" or authority == "external_current":
+            if result.support_kind != "hold" or result.evidence_ids:
+                return OrdinaryChatContractValidation(
+                    status="current_fact_not_held",
+                    task_count=len(tasks),
+                )
+            continue
+        if authority == "packet":
+            allowed_lanes = _ordinary_task_allowed_lanes(task)
+            allowed_ids = {
+                evidence_id
+                for evidence_id, lane in evidence_lanes.items()
+                if lane in allowed_lanes
+            }
+            if result.support_kind == "hold" and not allowed_ids:
+                if result.evidence_ids:
+                    return OrdinaryChatContractValidation(
+                        status="hold_has_support_reference",
+                        task_count=len(tasks),
+                    )
+                continue
+            if (
+                result.support_kind != "packet"
+                or not result.evidence_ids
+                or not set(result.evidence_ids).issubset(allowed_ids)
+            ):
+                return OrdinaryChatContractValidation(
+                    status="packet_support_invalid",
+                    task_count=len(tasks),
+                )
+        elif authority == "external_public":
+            if (
+                result.support_kind != "external_public"
+                or result.evidence_ids != ("PUBLIC",)
+            ):
+                return OrdinaryChatContractValidation(
+                    status="external_support_invalid",
+                    task_count=len(tasks),
+                )
+        elif authority == "current_request":
+            if (
+                result.support_kind != "current_request"
+                or result.evidence_ids != ("REQUEST",)
+            ):
+                return OrdinaryChatContractValidation(
+                    status="request_support_invalid",
+                    task_count=len(tasks),
+                )
+        else:
+            return OrdinaryChatContractValidation(
+                status="authority_scope_invalid",
+                task_count=len(tasks),
+            )
+        support_count += len(result.evidence_ids)
+    return OrdinaryChatContractValidation(
+        status="valid",
+        task_count=len(tasks),
+        covered_task_count=len(tasks),
+        support_reference_count=support_count,
+    )
+
+
+def ordinary_chat_deterministic_response_act(
+    basis: SharedBrainSynthesisBasis,
+) -> str:
+    """Return hold/clarify only when every task is deterministic."""
+
+    tasks = _ordinary_frame_tasks(basis)
+    if not tasks:
+        return ""
+    acts = tuple(
+        str(getattr(task, "required_response_act", "") or "answer")
+        for task in tasks
+    )
+    if any(act == "answer" for act in acts):
+        return ""
+    return "clarify" if "clarify" in acts else "hold"
+
+
 def build_ordinary_chat_basis(
     *,
     guild_id: int,
@@ -2871,6 +3215,12 @@ def build_ordinary_chat_basis(
         )
     )
     profile = getattr(packet, "profile_sufficiency", None)
+    rendered_evidence_refs = _ordinary_rendered_evidence_refs(
+        packet,
+        source_digests,
+    )
+    if source_digests and not rendered_evidence_refs:
+        return None
     return SharedBrainSynthesisBasis(
         packet=packet,
         assessment=assessment,
@@ -2893,6 +3243,7 @@ def build_ordinary_chat_basis(
             getattr(profile, "status", "not_applicable")
             or "not_applicable"
         ).strip().lower(),
+        rendered_evidence_refs=rendered_evidence_refs,
     )
 
 
@@ -3067,6 +3418,10 @@ def revalidate_basis(
         fresh_rendered, fresh_lane_counts, fresh_item_count, fresh_digests = (
             _ordinary_packet_context(basis.packet)
         )
+        fresh_evidence_refs = _ordinary_rendered_evidence_refs(
+            basis.packet,
+            fresh_digests,
+        )
         if (
             not config["effective"]
             or basis.authority_mode != ORDINARY_CHAT_AUTHORITY
@@ -3093,6 +3448,7 @@ def revalidate_basis(
             or fresh_lane_counts != basis.rendered_lane_counts
             or fresh_item_count != basis.rendered_item_count
             or fresh_digests != basis.rendered_source_digests
+            or fresh_evidence_refs != basis.rendered_evidence_refs
             or basis.competing_factual_contexts
             or basis.blocking_factual_owner_lanes
             or tuple(
@@ -3220,6 +3576,7 @@ def build_packet_owned_prompt(
 
     updated = str(prompt or "")
     if basis.ordinary_chat_single_packet:
+        task_contract = render_ordinary_chat_task_contract(basis)
         if not updated.strip():
             return PacketOwnedPrompt(
                 prompt=updated,
@@ -3258,6 +3615,12 @@ def build_packet_owned_prompt(
                 ready=False,
                 reason="packet_context_unavailable",
             )
+        if not task_contract:
+            return PacketOwnedPrompt(
+                prompt=updated,
+                ready=False,
+                reason="typed_task_contract_unavailable",
+            )
         if basis.rendered_context in updated:
             return PacketOwnedPrompt(
                 prompt=updated,
@@ -3271,6 +3634,8 @@ def build_packet_owned_prompt(
                 + _ORDINARY_CHAT_FACTUAL_OWNER_CONTRACT
                 + "\n\n"
                 + basis.rendered_context
+                + "\n\n"
+                + task_contract
             ),
             ready=True,
             replaced_factual_context_count=0,
@@ -6215,6 +6580,10 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             corrective_call_count INTEGER NOT NULL DEFAULT 0,
             frame_revalidation_status TEXT NOT NULL DEFAULT 'not_evaluated',
             source_revalidation_status TEXT NOT NULL DEFAULT 'not_evaluated',
+            typed_contract_status TEXT NOT NULL DEFAULT 'not_evaluated',
+            typed_task_count INTEGER NOT NULL DEFAULT 0,
+            typed_task_coverage_count INTEGER NOT NULL DEFAULT 0,
+            typed_support_reference_count INTEGER NOT NULL DEFAULT 0,
             processing_error_count INTEGER NOT NULL DEFAULT 0,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
@@ -6352,6 +6721,19 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         (
             "source_revalidation_status",
             "TEXT NOT NULL DEFAULT 'not_evaluated'",
+        ),
+        (
+            "typed_contract_status",
+            "TEXT NOT NULL DEFAULT 'not_evaluated'",
+        ),
+        ("typed_task_count", "INTEGER NOT NULL DEFAULT 0"),
+        (
+            "typed_task_coverage_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "typed_support_reference_count",
+            "INTEGER NOT NULL DEFAULT 0",
         ),
     ):
         if column in columns:
@@ -6628,6 +7010,8 @@ def evaluate_single_packet_response(
     provider_call_count: int,
     corrective_call_count: int = 0,
     generation_latency_ms: int | None = None,
+    response_contract: OrdinaryChatResponseContract | None = None,
+    typed_contract_required: bool = False,
     environ: Mapping[str, str] | None = None,
     journal_control_snapshot: JournalControlSnapshot | None = None,
     journal_control_snapshot_provided: bool = False,
@@ -6647,14 +7031,33 @@ def evaluate_single_packet_response(
     coherence = assess_response_coherence(run.basis.assessment, candidate)
     output_leak = response_exposes_controls(candidate)
     coverage = candidate_profile_coverage(run.basis, candidate)
-    (
-        receipt_claim_classifications,
-        unsupported_packet_domain_claims,
-    ) = audit_ordinary_chat_candidate_claims(
-        run.basis,
-        candidate,
-        coverage=coverage,
+    contract_validation = (
+        validate_ordinary_chat_response_contract(
+            run.basis,
+            response_contract,
+        )
+        if typed_contract_required
+        else OrdinaryChatContractValidation(status="not_required")
     )
+    if typed_contract_required:
+        receipt_claim_classifications = tuple(
+            "typed_%s" % result.support_kind
+            for result in (
+                response_contract.tasks
+                if isinstance(response_contract, OrdinaryChatResponseContract)
+                else ()
+            )
+        )
+        unsupported_packet_domain_claims = 0
+    else:
+        (
+            receipt_claim_classifications,
+            unsupported_packet_domain_claims,
+        ) = audit_ordinary_chat_candidate_claims(
+            run.basis,
+            candidate,
+            coverage=coverage,
+        )
     calls = max(0, int(provider_call_count or 0))
     corrective_calls = max(0, int(corrective_call_count or 0))
     fallback_reason = ""
@@ -6666,6 +7069,8 @@ def evaluate_single_packet_response(
         fallback_reason = "corrective_provider_call_forbidden"
     elif not valid:
         fallback_reason = "post_generation_%s" % source_status
+    elif typed_contract_required and not contract_validation.valid:
+        fallback_reason = "typed_contract_%s" % contract_validation.status
     elif not candidate:
         fallback_reason = "generation_failed"
     elif output_leak:
@@ -6695,6 +7100,8 @@ def evaluate_single_packet_response(
             candidate_connective_claim_count=?,
             candidate_unsupported_factual_claim_count=?,
             candidate_claim_classification_counts_json=?,
+            typed_contract_status=?,typed_task_count=?,
+            typed_task_coverage_count=?,typed_support_reference_count=?,
             provider_call_count=?,corrective_call_count=?,
             revalidation_status=?,source_revalidation_status=?,
             candidate_selected=?,fallback_reason=?,updated_at=?
@@ -6723,6 +7130,10 @@ def evaluate_single_packet_response(
                 dict(Counter(receipt_claim_classifications)),
                 sort_keys=True,
             ),
+            contract_validation.status,
+            contract_validation.task_count,
+            contract_validation.covered_task_count,
+            contract_validation.support_reference_count,
             calls,
             corrective_calls,
             source_status,
@@ -6771,6 +7182,12 @@ def evaluate_single_packet_response(
             unsupported_packet_domain_claims
         ),
         candidate_claim_classifications=receipt_claim_classifications,
+        typed_contract_status=contract_validation.status,
+        typed_task_count=contract_validation.task_count,
+        typed_task_coverage_count=contract_validation.covered_task_count,
+        typed_support_reference_count=(
+            contract_validation.support_reference_count
+        ),
     )
 
 
@@ -7269,6 +7686,11 @@ def _empty_report() -> dict[str, Any]:
         "correctiveCallTotal": 0,
         "ordinaryCallCountViolationRuns": 0,
         "ordinaryCorrectiveCallViolationRuns": 0,
+        "ordinaryTypedContractViolationRuns": 0,
+        "typedContractStatusCounts": {},
+        "typedTaskTotal": 0,
+        "typedTaskCoverageTotal": 0,
+        "typedSupportReferenceTotal": 0,
         "frameRevalidationStatusCounts": {},
         "sourceRevalidationStatusCounts": {},
         "candidateGenerationLatencyMs": {
@@ -7453,6 +7875,24 @@ def build_evaluation_report(
         "source_revalidation_status"
         if "source_revalidation_status" in columns
         else "'not_evaluated'"
+    )
+    typed_contract_status_expr = (
+        "typed_contract_status"
+        if "typed_contract_status" in columns
+        else "'not_evaluated'"
+    )
+    typed_task_count_expr = (
+        "typed_task_count" if "typed_task_count" in columns else "0"
+    )
+    typed_task_coverage_expr = (
+        "typed_task_coverage_count"
+        if "typed_task_coverage_count" in columns
+        else "0"
+    )
+    typed_support_reference_expr = (
+        "typed_support_reference_count"
+        if "typed_support_reference_count" in columns
+        else "0"
     )
     invalid_scope_runs = int(
         conn.execute(
@@ -7694,6 +8134,8 @@ def build_evaluation_report(
                {supported_coverage_regressed_expr},
                {provider_call_expr},{corrective_call_expr},
                {frame_revalidation_expr},{source_revalidation_expr},
+               {typed_contract_status_expr},{typed_task_count_expr},
+               {typed_task_coverage_expr},{typed_support_reference_expr},
                created_at
         FROM memory_governance_shared_brain_synthesis_runs
         WHERE guild_id=?
@@ -7725,6 +8167,10 @@ def build_evaluation_report(
             corrective_call_expr=corrective_call_expr,
             frame_revalidation_expr=frame_revalidation_expr,
             source_revalidation_expr=source_revalidation_expr,
+            typed_contract_status_expr=typed_contract_status_expr,
+            typed_task_count_expr=typed_task_count_expr,
+            typed_task_coverage_expr=typed_task_coverage_expr,
+            typed_support_reference_expr=typed_support_reference_expr,
         ),
         (int(guild_id or 0), max(1, min(int(limit or 500), 2000))),
     ).fetchall()
@@ -7737,6 +8183,7 @@ def build_evaluation_report(
     authority_modes: Counter[str] = Counter()
     frame_revalidation: Counter[str] = Counter()
     source_revalidation: Counter[str] = Counter()
+    typed_contract_statuses: Counter[str] = Counter()
     latency_values: list[int] = []
     prompt = live = selected = coverage = leaks = errors = sent = 0
     validation_items = 0
@@ -7749,6 +8196,9 @@ def build_evaluation_report(
     supported_coverage_regressions = 0
     ordinary_chat_runs = provider_call_total = corrective_call_total = 0
     ordinary_call_violations = ordinary_corrective_violations = 0
+    ordinary_typed_contract_violations = 0
+    typed_task_total = typed_task_coverage_total = 0
+    typed_support_reference_total = 0
     for row in rows:
         (
             _schema,
@@ -7787,6 +8237,10 @@ def build_evaluation_report(
             corrective_call_count,
             frame_revalidation_status,
             source_revalidation_status,
+            typed_contract_status,
+            typed_task_count,
+            typed_task_coverage_count,
+            typed_support_reference_count,
             _created_at,
         ) = row
         prompt += int(bool(prompt_applied))
@@ -7838,12 +8292,28 @@ def build_evaluation_report(
         source_revalidation[
             str(source_revalidation_status or "not_evaluated")
         ] += 1
+        typed_contract_statuses[
+            str(typed_contract_status or "not_evaluated")
+        ] += 1
+        typed_task_total += max(0, int(typed_task_count or 0))
+        typed_task_coverage_total += max(
+            0,
+            int(typed_task_coverage_count or 0),
+        )
+        typed_support_reference_total += max(
+            0,
+            int(typed_support_reference_count or 0),
+        )
         if str(authority_mode or "") == ORDINARY_CHAT_AUTHORITY:
             ordinary_chat_runs += 1
             ordinary_call_violations += int(
                 calls > 1 or (bool(prompt_applied) and calls != 1)
             )
             ordinary_corrective_violations += int(corrective_calls > 0)
+            ordinary_typed_contract_violations += int(
+                bool(candidate_selected)
+                and str(typed_contract_status or "") != "valid"
+            )
         latency = max(0, int(candidate_latency_ms or 0))
         if latency:
             latency_values.append(latency)
@@ -7895,6 +8365,15 @@ def build_evaluation_report(
         "ordinaryCorrectiveCallViolationRuns": (
             ordinary_corrective_violations
         ),
+        "ordinaryTypedContractViolationRuns": (
+            ordinary_typed_contract_violations
+        ),
+        "typedContractStatusCounts": dict(
+            sorted(typed_contract_statuses.items())
+        ),
+        "typedTaskTotal": typed_task_total,
+        "typedTaskCoverageTotal": typed_task_coverage_total,
+        "typedSupportReferenceTotal": typed_support_reference_total,
         "frameRevalidationStatusCounts": dict(
             sorted(frame_revalidation.items())
         ),

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -91,7 +91,7 @@ from bnl_website_relay_state import (
 )
 
 
-SCHEMA_VERSION = "unified_intelligence_packet_v8"
+SCHEMA_VERSION = "unified_intelligence_packet_v9"
 SUBJECT_RESOLUTION_VERSION = "governed_packet_subject_resolution_v1"
 SOURCE_SNAPSHOT_VERSION = "unified_packet_source_snapshot_v2"
 JOURNAL_PUBLICATION_SOURCE_CLASS = "journal_publication_projection"
@@ -435,6 +435,22 @@ class PacketFrameSubject:
 
 
 @dataclass(frozen=True)
+class PacketFrameTask:
+    """Content-free ordered task copied from the frozen Situation Frame."""
+
+    task_id: str
+    text_digest: str
+    task_kind: str
+    object_kind: str
+    authority_scope: str
+    temporal_scope: str
+    currentness: str
+    required_response_act: str
+    subject_requirement: str
+    subject_indexes: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
 class IntelligencePacketRequest:
     guild_id: int
     subject_user_id: int
@@ -463,6 +479,7 @@ class IntelligencePacketRequest:
     frame_status: str = "not_provided"
     frame_subject_requirement: str = "legacy"
     frame_subjects: tuple[PacketFrameSubject, ...] = ()
+    frame_tasks: tuple[PacketFrameTask, ...] = ()
     frame_role_hints: tuple[str, ...] = ()
     frame_domain_hints: tuple[str, ...] = ()
     frame_event_ref: str = ""

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -22,12 +22,13 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
+from bnl_canon_source_contract import BNL01
 from bnl_conversation_context_v2 import assess_payload_grounding
 
 
 ASSESSMENT_VERSION = "unified_response_assessment_v7"
 CONVERSATION_TURN_PACKET_VERSION = "conversation_turn_evidence_v3"
-SITUATION_FRAME_VERSION = "situation_frame_v1"
+SITUATION_FRAME_VERSION = "situation_frame_v2"
 FRAME_SOURCE_REVALIDATION_VERSION = "frame_source_revalidation_v1"
 SHADOW_ENV = "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED"
 TABLE_NAME = "unified_response_assessment_shadow_runs"
@@ -356,6 +357,54 @@ _SELF_SUBJECT_CUE_RE = re.compile(
     r"what\s+keeps\s+(?:recurring|coming\s+up)\s+for\s+me)\b",
     re.I,
 )
+_BNL_SELF_SUBJECT_CUE_RE = re.compile(
+    r"\b(?:who|what)\s+are\s+you\b|"
+    r"\btell\s+me\s+about\s+yourself\b|"
+    r"\bwhat\s+do\s+you\s+(?:know|remember)\s+about\s+yourself\b|"
+    r"\bdescribe\s+yourself\b",
+    re.I,
+)
+_TASK_LEAD_RE = re.compile(
+    r"(?:what|which|who|where|when|why|how|tell|explain|summari[sz]e|"
+    r"compare|describe|give|show|help|check|find|is|are|do|does|did|can|"
+    r"could|would|should)\b",
+    re.I,
+)
+_VOLATILE_EXTERNAL_RE = re.compile(
+    r"\b(?:weather|forecast|temperature|traffic|score|standings?|price|"
+    r"stock|market|exchange\s+rate|news|headline|election|polls?|"
+    r"president|prime\s+minister|governor|mayor|ceo|schedule|"
+    r"availability|open\s+now|live\s+status)\b",
+    re.I,
+)
+_EXTERNAL_ROLE_QUERY_RE = re.compile(
+    r"\bwho\s+is\s+(?:the\s+)?(?:(?:current|latest|new)\s+)?"
+    r"(?:president|prime\s+minister|governor|mayor|ceo|chief\s+executive|"
+    r"senator|representative|secretary|minister|director|coach|"
+    r"commissioner|chancellor)\b",
+    re.I,
+)
+_CURRENT_REQUEST_TASK_RE = re.compile(
+    r"\b(?:how\s+are\s+you|what\s+do\s+you\s+think|your\s+opinion|"
+    r"do\s+you\s+(?:like|prefer|want)|can\s+you\s+(?:help|write|make|"
+    r"create|explain)|please\s+(?:help|write|make|create)|"
+    r"thank\s+you|thanks|hello|hey)\b",
+    re.I,
+)
+_PACKET_AUTHORITY_OBJECTS = frozenset(
+    {
+        "journal",
+        "relay",
+        "moment",
+        "memory",
+        "queue",
+        "broadcast",
+        "website",
+        "source_file",
+        "canon",
+        "person",
+    }
+)
 _CURRENT_TIME_RE = re.compile(r"\b(?:now|currently|today|tonight|this\s+(?:week|show|turn|time)|latest|current)\b", re.I)
 _HISTORICAL_TIME_RE = re.compile(r"\b(?:before|previously|earlier|last\s+(?:time|week|show)|used\s+to|histor(?:y|ical))\b", re.I)
 _SITUATION_EXPLICIT_RESUME_RE = re.compile(
@@ -403,6 +452,22 @@ class SituationSubjectReference:
 
 
 @dataclass(frozen=True)
+class SituationTaskReference:
+    """One ordered task inside the current turn, without retaining its text."""
+
+    task_id: str
+    text_digest: str
+    task_kind: str
+    object_kind: str
+    authority_scope: str
+    temporal_scope: str
+    currentness: str
+    required_response_act: str
+    subject_requirement: str
+    subject_indexes: Tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
 class SituationFrameV1:
     """Immutable, response-scoped applicability decision.
 
@@ -434,6 +499,7 @@ class SituationFrameV1:
     event_ref: str
     event_relation: str
     task_kind: str
+    tasks: Tuple[SituationTaskReference, ...]
     object_kind: str
     phase: str
     role_hints: Tuple[str, ...]
@@ -492,7 +558,143 @@ def _situation_object(text: str) -> str:
         for object_kind, pattern in _SITUATION_OBJECT_PATTERNS
         if pattern.search(text or "")
     )
-    return matches[0] if len(matches) == 1 else "multiple" if matches else "unknown"
+    if len(matches) == 1:
+        return matches[0]
+    publication_owners = tuple(
+        match for match in matches if match in {"journal", "relay"}
+    )
+    if len(publication_owners) == 1:
+        # Journal/Relay qualify the source being asked about.  A referenced
+        # show, queue, person, or topic is the publication's subject, not a
+        # competing factual owner.
+        return publication_owners[0]
+    return "multiple" if matches else "unknown"
+
+
+def _situation_task_segments(text: str) -> Tuple[str, ...]:
+    """Split only explicit ordered requests; never split ordinary noun lists."""
+
+    value = re.sub(r"\s+", " ", str(text or "")).strip()
+    if not value:
+        return ()
+    value = re.sub(
+        r"[?!]+\s+(?=%s)" % _TASK_LEAD_RE.pattern,
+        "\n",
+        value,
+        flags=re.I,
+    )
+    value = re.sub(
+        r",?\s+(?:and|also|plus|then)\s+(?=%s)" % _TASK_LEAD_RE.pattern,
+        "\n",
+        value,
+        flags=re.I,
+    )
+    parts = tuple(part.strip(" ,;.!?") for part in value.split("\n"))
+    return tuple(part for part in parts if part) or (str(text or ""),)
+
+
+def _task_subject_indexes(
+    segment: str,
+    subjects: Sequence[SituationSubjectReference],
+) -> Tuple[int, ...]:
+    bnl_self = bool(_BNL_SELF_SUBJECT_CUE_RE.search(segment or ""))
+    self_subject = bool(_SELF_SUBJECT_CUE_RE.search(segment or ""))
+    third_party = bool(_THIRD_PARTY_SUBJECT_CUE_RE.search(segment or ""))
+    matches = []
+    for index, subject in enumerate(subjects):
+        if bnl_self and subject.entity_ref == BNL01.key:
+            matches.append(index)
+            continue
+        if self_subject and subject.binding_method == "current_speaker_context":
+            matches.append(index)
+            continue
+        label = str(subject.label_hint or "").strip()
+        if label and re.search(
+            r"(?<![a-z0-9])%s(?![a-z0-9])" % re.escape(label),
+            segment or "",
+            re.I,
+        ):
+            matches.append(index)
+    if not matches and third_party and len(subjects) == 1:
+        matches.append(0)
+    return tuple(dict.fromkeys(matches))
+
+
+def _situation_tasks(
+    text: str,
+    *,
+    subjects: Sequence[SituationSubjectReference],
+    response_act: str,
+) -> Tuple[SituationTaskReference, ...]:
+    tasks = []
+    for index, segment in enumerate(_situation_task_segments(text), start=1):
+        phase = _situation_phase(segment)
+        object_kind = _situation_object(segment)
+        temporal_scope, currentness = _situation_temporal_scope(segment)
+        evidence = build_conversation_evidence_item(
+            text=segment,
+            current_turn=True,
+        )
+        objective_kind = _objective_kind(
+            objective=_current_objective(segment),
+            current_options=_extract_option_anchors(segment),
+            immediate_recap=False,
+            exact_quote_requested=False,
+            evidence_items=(evidence,),
+        )
+        task_kind = _situation_task_kind(
+            phase=phase,
+            object_kind=object_kind,
+            objective_kind=objective_kind,
+        )
+        subject_indexes = _task_subject_indexes(segment, subjects)
+        external_role_query = bool(_EXTERNAL_ROLE_QUERY_RE.search(segment))
+        subject_cue = bool(
+            _BNL_SELF_SUBJECT_CUE_RE.search(segment)
+            or _SELF_SUBJECT_CUE_RE.search(segment)
+            or (
+                _THIRD_PARTY_SUBJECT_CUE_RE.search(segment)
+                and not external_role_query
+            )
+            or (object_kind == "person" and not external_role_query)
+        )
+        subject_requirement = (
+            "required" if subject_indexes or subject_cue else "not_applicable"
+        )
+        if subject_requirement == "required" or (
+            object_kind in _PACKET_AUTHORITY_OBJECTS
+            and not external_role_query
+        ):
+            authority_scope = "packet"
+        elif _CURRENT_REQUEST_TASK_RE.search(segment):
+            authority_scope = "current_request"
+        else:
+            authority_scope = "external_public"
+        required_act = str(response_act or "observe")
+        if subject_requirement == "required" and not subject_indexes:
+            required_act = "clarify"
+        elif (
+            authority_scope == "external_public"
+            and currentness == "current"
+            and _VOLATILE_EXTERNAL_RE.search(segment)
+        ):
+            authority_scope = "external_current"
+            required_act = "hold"
+        tasks.append(
+            SituationTaskReference(
+                task_id="T%s" % index,
+                text_digest=_situation_digest(segment),
+                task_kind=task_kind,
+                object_kind=object_kind,
+                authority_scope=authority_scope,
+                temporal_scope=temporal_scope,
+                currentness=currentness,
+                required_response_act=required_act,
+                subject_requirement=subject_requirement,
+                subject_indexes=subject_indexes,
+            )
+        )
+    return tuple(tasks)
 
 
 def _situation_roles_domains(text: str) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
@@ -619,6 +821,8 @@ def build_situation_frame_v1(
     )
     third_party_cue = bool(_THIRD_PARTY_SUBJECT_CUE_RE.search(text))
     self_subject_cue = bool(_SELF_SUBJECT_CUE_RE.search(text))
+    bnl_self_subject_cue = bool(_BNL_SELF_SUBJECT_CUE_RE.search(text))
+    external_role_query = bool(_EXTERNAL_ROLE_QUERY_RE.search(text))
 
     subjects = []
     if subject_ids:
@@ -654,7 +858,18 @@ def build_situation_frame_v1(
                     domain_hints=domains,
                 )
             )
-    elif len(speakers) == 1 and self_subject_cue and not third_party_cue:
+    elif bnl_self_subject_cue:
+        subjects.append(
+            SituationSubjectReference(
+                entity_ref=BNL01.key,
+                label_hint=BNL01.name,
+                binding_method="existing_typed_entity",
+                confidence="high",
+                role_hints=("system_subject",),
+                domain_hints=("lore", "technical"),
+            )
+        )
+    elif len(speakers) == 1 and self_subject_cue:
         subjects.append(
             SituationSubjectReference(
                 user_id=speakers[0],
@@ -668,8 +883,18 @@ def build_situation_frame_v1(
 
     subject_requirement = (
         "required"
-        if subjects or third_party_cue or self_subject_cue or object_kind == "person"
+        if subjects
+        or (third_party_cue and not external_role_query)
+        or self_subject_cue
+        or bnl_self_subject_cue
+        or (object_kind == "person" and not external_role_query)
         else "not_applicable"
+    )
+
+    tasks = _situation_tasks(
+        text,
+        subjects=subjects,
+        response_act=str(response_act or "observe"),
     )
 
     ambiguity = []
@@ -681,7 +906,13 @@ def build_situation_frame_v1(
     if len(subject_ids) > 1 or len(subjects) > 1:
         ambiguity.append("multiple_subject_candidates")
         competing.append("subject_candidates")
-    if third_party_cue and not subjects:
+    if (
+        third_party_cue
+        and not external_role_query
+        and not self_subject_cue
+        and not bnl_self_subject_cue
+        and not subjects
+    ):
         ambiguity.append("third_party_subject_unresolved")
         competing.append("speaker_fallback_rejected")
     elif subject_requirement == "required" and not subjects:
@@ -702,11 +933,35 @@ def build_situation_frame_v1(
     if event_relation == "resume_unresolved":
         ambiguity.append("resume_target_unresolved")
         competing.append("resume_episode_candidates")
-    task_kind = _situation_task_kind(
-        phase=phase,
-        object_kind=object_kind,
-        objective_kind=objective_kind,
+    task_kind = (
+        tasks[0].task_kind
+        if len(tasks) == 1
+        else "multi_task"
+        if tasks
+        else _situation_task_kind(
+            phase=phase,
+            object_kind=object_kind,
+            objective_kind=objective_kind,
+        )
     )
+    if len(tasks) > 1:
+        object_kind = (
+            tasks[0].object_kind
+            if len({task.object_kind for task in tasks}) == 1
+            else "multiple"
+        )
+        temporal_values = {task.temporal_scope for task in tasks}
+        currentness_values = {task.currentness for task in tasks}
+        temporal_scope = (
+            next(iter(temporal_values))
+            if len(temporal_values) == 1
+            else "mixed"
+        )
+        currentness = (
+            next(iter(currentness_values))
+            if len(currentness_values) == 1
+            else "mixed"
+        )
     digest_payload = {
         "schema": SITUATION_FRAME_VERSION,
         "packet_revision": str(packet_revision or ""),
@@ -739,6 +994,21 @@ def build_situation_frame_v1(
         "event_ref": str(moment_id or ""),
         "event_relation": event_relation,
         "task": task_kind,
+        "tasks": tuple(
+            (
+                task.task_id,
+                task.text_digest,
+                task.task_kind,
+                task.object_kind,
+                task.authority_scope,
+                task.temporal_scope,
+                task.currentness,
+                task.required_response_act,
+                task.subject_requirement,
+                task.subject_indexes,
+            )
+            for task in tasks
+        ),
         "object": object_kind,
         "phase": phase,
         "temporal": temporal_scope,
@@ -778,6 +1048,7 @@ def build_situation_frame_v1(
         event_ref=str(moment_id or "")[:120],
         event_relation=event_relation,
         task_kind=task_kind,
+        tasks=tasks,
         object_kind=object_kind,
         phase=phase,
         role_hints=roles,
@@ -875,6 +1146,16 @@ def render_situation_frame_receipt(
         "addresseeCount": len(frame.addressee_user_ids),
         "subjectCount": len(frame.subjects),
         "subjectRequirement": frame.subject_requirement,
+        "taskCount": len(frame.tasks),
+        "answerTaskCount": sum(
+            task.required_response_act == "answer" for task in frame.tasks
+        ),
+        "clarifyTaskCount": sum(
+            task.required_response_act == "clarify" for task in frame.tasks
+        ),
+        "holdTaskCount": sum(
+            task.required_response_act == "hold" for task in frame.tasks
+        ),
         "sourceAnchorCount": (
             len(frame.source_message_ids)
             + len(frame.reply_message_ids)

--- a/docs/one_packet_convergence_v1.md
+++ b/docs/one_packet_convergence_v1.md
@@ -1,6 +1,6 @@
 # One-Packet Convergence v1
 
-`unified_intelligence_packet_v8` is the single factual owner for gated broad
+`unified_intelligence_packet_v9` is the single factual owner for gated broad
 self-profile synthesis and the separately gated ordinary-chat cutover. It consumes
 the immutable Situation Frame revision and resolves one governed subject
 before source scoring. It normalizes four canon statuses without moving their
@@ -70,9 +70,12 @@ synthesis versions, prerequisites, conflicts, reason, and one kill switch. A
 scope, prerequisite, or version conflict fails closed. The owner-only preview
 adds content-free candidate/selected counts by canon status and domain plus the
 existing exclusion and root-collapse reasons. The independent ordinary-chat
-capability uses `shared_brain_synthesis_v9` content-free receipts with frame,
+capability uses `shared_brain_synthesis_v10` content-free receipts with frame,
 packet/source, selected lane/status/domain, provider/corrective call, guard,
-revalidation, send, and fallback/block diagnostics.
+revalidation, typed task/support coverage, send, and fallback/block
+diagnostics. Its typed task contract is the single response-selection
+boundary; later checks can block changed source, frame, control, quote, or
+delivery state but do not reclassify the selected prose.
 
 All gates remain default-off. The ordinary-chat route permits one provider
 attempt, zero retries, no model fallback, and no corrective generation. This

--- a/docs/ordinary_chat_single_packet_canary_v1.md
+++ b/docs/ordinary_chat_single_packet_canary_v1.md
@@ -29,7 +29,7 @@ switch is `BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED`.
 
 ## One factual owner and one call
 
-The immutable Situation Frame and `unified_intelligence_packet_v8` are frozen
+The immutable Situation Frame and `unified_intelligence_packet_v9` are frozen
 before generation. The packet renderer supplies the sole BARCODE, member,
 identity, relationship, episode, publication, canon, and stored-history
 factual view. The current request and verified exact-reply/referent text remain
@@ -52,19 +52,27 @@ For an eligible turn:
    grounding repairs, and other corrective provider calls are disabled.
 4. The packet and frame are independently revalidated after generation and
    immediately before send.
-5. A generated candidate changed or suppressed by a guard is not sent and is
-   never repaired by another provider call.
+5. The provider must return one typed task/result envelope. Every task must
+   appear exactly once and in order, with packet evidence identifiers, the
+   stable-public `PUBLIC` marker, the current-request `REQUEST` marker, or an
+   explicit hold/clarify act as required by the frozen task.
+6. A candidate is selected once at that typed boundary. It is not
+   semantically reclassified by the legacy prose guard; independent packet,
+   source, frame, control-leak, exact-quote, and delivery checks can still
+   block it without another provider call.
 
 Provider-call receipts increment only at the physical `generate_content`
 invocation boundary. Local quota refusal, budget-reservation failure, client
 construction failure, and other pre-provider exits remain zero-attempt runs;
 a provider invocation that starts and then fails remains one attempt.
 
-Before candidate selection, the response is audited against the frozen packet.
-Any unsupported BARCODE, member, identity, relationship, episode, publication,
-canon, or stored-history claim blocks the candidate. Ordinary external public
-knowledge remains permitted, but it is never relabeled as BARCODE memory or
-private packet evidence.
+Before candidate selection, the response contract is validated against the
+frozen task list and the exact rendered packet evidence map. Packet-owned
+tasks require applicable selected evidence identifiers. Stable external
+public knowledge requires `PUBLIC`; volatile/current external facts must be
+held; non-factual current-request responses require `REQUEST`. Missing,
+duplicate, reordered, malformed, cross-lane, or unsupported references block
+the entire candidate.
 
 Preflight ambiguity or invalid source state uses zero provider calls and a
 bounded clarification/block response. A failed generation or rejected
@@ -73,17 +81,19 @@ owners are excluded before cutover rather than treated as a fallback.
 
 ## Content-free receipts
 
-`shared_brain_synthesis_v9` receipts retain only hashes, counts, bounded
+`shared_brain_synthesis_v10` receipts retain only hashes, counts, bounded
 statuses, and timing. Ordinary-chat rows include the frame revision and input
 digest, packet/source snapshot digests, selected lane/status/domain counts,
 prompt-applied state, provider and corrective call counts, candidate-selected
 state, separate frame/source revalidation statuses, guard/fallback reason,
-response-sent state, and live-application state.
+response-sent state, live-application state, typed-contract status, task
+coverage counts, and support-reference counts.
 
 No prompt, packet text, source text, response text, participant IDs, or source
 references are stored. Aggregate diagnostics expose ordinary-run totals,
-provider/corrective call totals, call-count violations, revalidation statuses,
-and the independent kill switch.
+provider/corrective call totals, call-count violations, typed-contract
+violations, typed task/support totals, revalidation statuses, and the
+independent kill switch.
 
 ## Rollback and acceptance order
 

--- a/tests/test_governed_subject_packet_v6.py
+++ b/tests/test_governed_subject_packet_v6.py
@@ -134,8 +134,8 @@ class GovernedSubjectPacketV6Tests(unittest.TestCase):
             reason="governed subject test binding",
         )
 
-    def test_packet_schema_is_v7_and_alias_matrix_stays_distinct(self):
-        self.assertEqual(SCHEMA_VERSION, "unified_intelligence_packet_v8")
+    def test_packet_schema_is_v9_and_alias_matrix_stays_distinct(self):
+        self.assertEqual(SCHEMA_VERSION, "unified_intelligence_packet_v9")
         cases = {
             "Who is Mac Mod3m?": ("mac_modem",),
             "Tell me about DJ Floppy Disc.": ("dj_floppydisc",),
@@ -196,6 +196,27 @@ class GovernedSubjectPacketV6Tests(unittest.TestCase):
         self.assertEqual(frame.subject_requirement, "required")
         self.assertEqual(tuple(item.user_id for item in frame.subjects), (222,))
         self.assertNotIn(111, tuple(item.user_id for item in frame.subjects))
+
+    def test_bnl_self_frame_resolves_through_the_existing_canon_subject(self):
+        request = self.request(
+            subjects=(
+                PacketFrameSubject(
+                    entity_ref="bnl_01",
+                    binding_method="existing_typed_entity",
+                ),
+            ),
+            text="Who are you?",
+        )
+
+        resolution = resolve_packet_subject(self.conn, request)
+
+        self.assertEqual(resolution.status, "resolved")
+        self.assertEqual(resolution.subject_key, "bnl_01")
+        self.assertEqual(resolution.entity_ref, "bnl_01")
+        self.assertEqual(
+            resolution.binding_method,
+            "typed_canon_entity",
+        )
 
     def test_unseen_label_and_multiple_subjects_fail_closed(self):
         unseen = self.request(

--- a/tests/test_ordinary_chat_acceptance_contract_matrix.py
+++ b/tests/test_ordinary_chat_acceptance_contract_matrix.py
@@ -1,0 +1,136 @@
+import os
+import unittest
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+
+
+def _addressing():
+    return bnl01_bot.DiscordTurnAddressing(
+        speaker="Test Member",
+        explicit_tag_recipients=("@BNL-01",),
+        reply_target="none",
+        explicitly_mentions_bnl=True,
+        reply_targets_bnl=False,
+        directly_targets_bnl=True,
+        targets_other_human=False,
+        plain_text_names_bnl=False,
+        speaker_user_id=101,
+        source_message_id=301,
+    )
+
+
+def _frame(text):
+    decision = bnl01_bot.build_live_conversation_orchestration_decision(
+        engagement_decision="answer",
+        engagement_reason="direct_request",
+        channel_policy="public_home",
+        addressings=(_addressing(),),
+        context_result=None,
+        moment_situation=None,
+        guild_id=1,
+        channel_id=10,
+        route_mode="normal_chat",
+        conversation_surface="public_home",
+        current_text=text,
+        current_speaker_user_ids=(101,),
+        current_speaker_labels=("Test Member",),
+        influence_mode="live",
+        packet_revision="turn_acceptance_matrix",
+    )
+    return decision.situation_frame
+
+
+class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
+    def test_48_production_ingress_cases_have_one_early_typed_decision(self):
+        # name, request, frame status, task authorities, task acts,
+        # dominant object, bound subject kind
+        cases = (
+            ("self_remember", "What do you remember about me?", "resolved", ("packet",), ("answer",), "person", "speaker"),
+            ("self_know", "What do you know about me?", "resolved", ("packet",), ("answer",), "person", "speaker"),
+            ("self_identity", "Tell me who I am.", "resolved", ("packet",), ("answer",), "unknown", "speaker"),
+            ("self_remember_short", "Remember me?", "resolved", ("packet",), ("answer",), "unknown", "speaker"),
+            ("self_profile", "What is my profile?", "resolved", ("packet",), ("answer",), "unknown", "speaker"),
+            ("self_history", "What is my history?", "resolved", ("packet",), ("answer",), "unknown", "speaker"),
+            ("self_patterns", "What patterns keep recurring for me?", "resolved", ("packet",), ("answer",), "unknown", "speaker"),
+            ("self_what", "What am I?", "resolved", ("packet",), ("answer",), "unknown", "speaker"),
+            ("bnl_who", "Who are you?", "resolved", ("packet",), ("answer",), "unknown", "bnl"),
+            ("bnl_what", "What are you?", "resolved", ("packet",), ("answer",), "unknown", "bnl"),
+            ("bnl_tell", "Tell me about yourself.", "resolved", ("packet",), ("answer",), "person", "bnl"),
+            ("bnl_describe", "Describe yourself.", "resolved", ("packet",), ("answer",), "unknown", "bnl"),
+            ("bnl_remember", "What do you remember about yourself?", "resolved", ("packet",), ("answer",), "person", "bnl"),
+            ("bnl_know", "What do you know about yourself?", "resolved", ("packet",), ("answer",), "person", "bnl"),
+            ("bnl_who_case", "who ARE you", "resolved", ("packet",), ("answer",), "unknown", "bnl"),
+            ("bnl_tell_case", "TELL ME ABOUT YOURSELF", "resolved", ("packet",), ("answer",), "person", "bnl"),
+            ("journal_show", "What did the Journal say about the last show?", "resolved", ("packet",), ("answer",), "journal", ""),
+            ("journal_queue", "Summarize the Journal entry about the queue.", "resolved", ("packet",), ("answer",), "journal", ""),
+            ("journal_broadcast", "What did the Journal say about the broadcast?", "resolved", ("packet",), ("answer",), "journal", ""),
+            ("journal_current", "Explain the current Journal entry.", "resolved", ("packet",), ("answer",), "journal", ""),
+            ("relay_show", "What did the Relay say about the last show?", "resolved", ("packet",), ("answer",), "relay", ""),
+            ("relay_queue", "Summarize the Relay about the queue.", "resolved", ("packet",), ("answer",), "relay", ""),
+            ("relay_broadcast", "What did the Relay say about the broadcast?", "resolved", ("packet",), ("answer",), "relay", ""),
+            ("relay_current", "Explain the current Relay.", "resolved", ("packet",), ("answer",), "relay", ""),
+            ("external_place", "Where is Seattle?", "resolved", ("external_public",), ("answer",), "unknown", ""),
+            ("external_author", "Who wrote Hamlet?", "resolved", ("external_public",), ("answer",), "unknown", ""),
+            ("external_science", "What is photosynthesis?", "resolved", ("external_public",), ("answer",), "unknown", ""),
+            ("external_history", "When did Apollo 11 land?", "resolved", ("external_public",), ("answer",), "unknown", ""),
+            ("external_math", "What is twelve times twelve?", "resolved", ("external_public",), ("answer",), "unknown", ""),
+            ("external_language", "What does obsolete mean?", "resolved", ("external_public",), ("answer",), "unknown", ""),
+            ("external_geography", "Which continent is Kenya in?", "resolved", ("external_public",), ("answer",), "unknown", ""),
+            ("external_music", "Who composed The Four Seasons?", "resolved", ("external_public",), ("answer",), "unknown", ""),
+            ("live_weather", "What is Seattle's weather today?", "resolved", ("external_current",), ("hold",), "unknown", ""),
+            ("live_stock", "What is the stock price now?", "resolved", ("external_current",), ("hold",), "unknown", ""),
+            ("live_score", "What is the score tonight?", "resolved", ("external_current",), ("hold",), "unknown", ""),
+            ("live_traffic", "How is traffic currently?", "resolved", ("external_current",), ("hold",), "unknown", ""),
+            ("live_news", "What is the latest news?", "resolved", ("external_current",), ("hold",), "unknown", ""),
+            ("live_president", "Who is the current president?", "resolved", ("external_current",), ("hold",), "person", ""),
+            ("live_ceo", "Who is the CEO today?", "resolved", ("external_current",), ("hold",), "person", ""),
+            ("live_schedule", "What is the schedule tonight?", "resolved", ("external_current",), ("hold",), "unknown", ""),
+            ("mixed_self_public", "What do you remember about me, and where is Seattle?", "resolved", ("packet", "external_public"), ("answer", "answer"), "multiple", "speaker"),
+            ("mixed_self_live", "What do you remember about me, and what is Seattle's weather today?", "resolved", ("packet", "external_current"), ("answer", "hold"), "multiple", "speaker"),
+            ("mixed_bnl_public", "Who are you? WHERE is Seattle?", "resolved", ("packet", "external_public"), ("answer", "answer"), "unknown", "bnl"),
+            ("mixed_bnl_live", "Who are you, and what is the score tonight?", "resolved", ("packet", "external_current"), ("answer", "hold"), "unknown", "bnl"),
+            ("mixed_journal_public", "What did the Journal say about the last show, and where is Seattle?", "resolved", ("packet", "external_public"), ("answer", "answer"), "multiple", ""),
+            ("mixed_journal_live", "What did the Journal say about the queue, and what is the latest news?", "resolved", ("packet", "external_current"), ("answer", "hold"), "multiple", ""),
+            ("clarify_person", "Tell me about Jordan.", "ambiguous", ("packet",), ("clarify",), "person", ""),
+            ("clarify_mixed", "What do you remember about Jordan, and where is Seattle?", "ambiguous", ("packet", "external_public"), ("clarify", "answer"), "multiple", ""),
+        )
+        self.assertEqual(len(cases), 48)
+
+        for name, text, status, authorities, acts, object_kind, subject_kind in cases:
+            with self.subTest(name=name, text=text):
+                frame = _frame(text)
+                self.assertEqual(frame.status, status)
+                self.assertEqual(
+                    tuple(task.authority_scope for task in frame.tasks),
+                    authorities,
+                )
+                self.assertEqual(
+                    tuple(task.required_response_act for task in frame.tasks),
+                    acts,
+                )
+                self.assertEqual(frame.object_kind, object_kind)
+                if subject_kind == "speaker":
+                    self.assertTrue(
+                        any(
+                            subject.user_id == 101
+                            and subject.binding_method
+                            == "current_speaker_context"
+                            for subject in frame.subjects
+                        )
+                    )
+                elif subject_kind == "bnl":
+                    self.assertTrue(
+                        any(
+                            subject.entity_ref == "bnl_01"
+                            and subject.binding_method
+                            == "existing_typed_entity"
+                            for subject in frame.subjects
+                        )
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -21,11 +21,14 @@ from bnl_shared_brain_synthesis import (
     finalize_run,
     ordinary_chat_configuration,
     ordinary_chat_route_scope_decision,
+    parse_ordinary_chat_response_contract,
     record_single_packet_block,
+    validate_ordinary_chat_response_contract,
 )
 from bnl_unified_intelligence_packet import (
     IntelligencePacketRequest,
     PacketConversationEvidence,
+    PacketFrameTask,
     PacketFrameSubject,
     PacketSubjectResolution,
     build_packet,
@@ -274,6 +277,21 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             frame_status=self.frame.status,
             frame_subject_requirement=self.frame.subject_requirement,
             frame_subjects=frame_subjects,
+            frame_tasks=tuple(
+                PacketFrameTask(
+                    task_id=task.task_id,
+                    text_digest=task.text_digest,
+                    task_kind=task.task_kind,
+                    object_kind=task.object_kind,
+                    authority_scope=task.authority_scope,
+                    temporal_scope=task.temporal_scope,
+                    currentness=task.currentness,
+                    required_response_act=task.required_response_act,
+                    subject_requirement=task.subject_requirement,
+                    subject_indexes=task.subject_indexes,
+                )
+                for task in self.frame.tasks
+            ),
             frame_role_hints=self.frame.role_hints,
             frame_domain_hints=self.frame.domain_hints,
             frame_event_ref=self.frame.event_ref,
@@ -421,6 +439,8 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         owned = build_packet_owned_prompt(base_prompt, self.basis)
         self.assertTrue(owned.ready)
         self.assertIn("PACKET-OWNED RESPONSE CONTRACT", owned.prompt)
+        self.assertIn("TYPED TURN TASK CONTRACT", owned.prompt)
+        self.assertIn("PROVIDER OUTPUT CONTRACT", owned.prompt)
         self.assertIn(self.basis.rendered_context, owned.prompt)
         self.assertEqual(owned.prompt.count(self.basis.rendered_context), 1)
         self.assertNotIn("Durable memory context:", owned.prompt)
@@ -456,13 +476,192 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertFalse(blocked.ready)
         self.assertEqual(blocked.reason, "nonpacket_factual_owner_selected")
 
+    def test_typed_response_contract_accepts_only_applicable_packet_refs(self):
+        evidence_id = next(
+            evidence_id
+            for evidence_id, lane, _digest in self.basis.rendered_evidence_refs
+            if lane == "approved_fact"
+        )
+        contract = parse_ordinary_chat_response_contract(
+            '{"tasks":[{"taskId":"T1","text":"Your favorite movie is '
+            'Arrival.","supportKind":"packet","evidenceIds":["%s"]}]}'
+            % evidence_id
+        )
+        validation = validate_ordinary_chat_response_contract(
+            self.basis,
+            contract,
+        )
+        self.assertTrue(validation.valid)
+        self.assertEqual(validation.task_count, 1)
+        self.assertEqual(validation.covered_task_count, 1)
+        self.assertEqual(contract.response, "Your favorite movie is Arrival.")
+
+        decision = evaluate_single_packet_response(
+            self.conn,
+            self._begin(),
+            response=contract.response,
+            response_contract=contract,
+            typed_contract_required=True,
+            provider_call_count=1,
+            corrective_call_count=0,
+            environ=self.flags,
+        )
+        self.assertTrue(decision.candidate_selected)
+        self.assertEqual(decision.typed_contract_status, "valid")
+        self.assertEqual(decision.typed_task_coverage_count, 1)
+
+    def test_typed_response_contract_rejects_unknown_or_wrong_authority_refs(self):
+        cases = (
+            (
+                '{"tasks":[{"taskId":"T1","text":"You live in Seattle.",'
+                '"supportKind":"packet","evidenceIds":["E99"]}]}',
+                "packet_support_invalid",
+            ),
+            (
+                '{"tasks":[{"taskId":"T1","text":"Seattle is in '
+                'Washington.","supportKind":"external_public",'
+                '"evidenceIds":["PUBLIC"]}]}',
+                "packet_support_invalid",
+            ),
+        )
+        for raw, expected in cases:
+            with self.subTest(expected=expected):
+                contract = parse_ordinary_chat_response_contract(raw)
+                validation = validate_ordinary_chat_response_contract(
+                    self.basis,
+                    contract,
+                )
+                self.assertEqual(validation.status, expected)
+                decision = evaluate_single_packet_response(
+                    self.conn,
+                    self._begin(),
+                    response=contract.response,
+                    response_contract=contract,
+                    typed_contract_required=True,
+                    provider_call_count=1,
+                    corrective_call_count=0,
+                    environ=self.flags,
+                )
+                self.assertFalse(decision.candidate_selected)
+                self.assertEqual(
+                    decision.fallback_reason,
+                    "typed_contract_%s" % expected,
+                )
+
+    def test_typed_external_task_uses_public_not_packet_authority(self):
+        external_packet = replace(
+            self.packet,
+            request=replace(
+                self.packet.request,
+                subject_user_id=0,
+                subject_display_name="",
+                user_text="Where is Seattle?",
+                frame_subject_requirement="not_applicable",
+                frame_subjects=(),
+                frame_tasks=(
+                    PacketFrameTask(
+                        task_id="T1",
+                        text_digest="b" * 64,
+                        task_kind="answer",
+                        object_kind="unknown",
+                        authority_scope="external_public",
+                        temporal_scope="unspecified",
+                        currentness="unknown",
+                        required_response_act="answer",
+                        subject_requirement="not_applicable",
+                    ),
+                ),
+                frame_event_ref="",
+                frame_event_relation="not_applicable",
+            ),
+            subject_resolution=PacketSubjectResolution(
+                status="not_applicable",
+                reason_codes=("subject_not_required",),
+            ),
+        )
+        external_basis = replace(self.basis, packet=external_packet)
+        contract = parse_ordinary_chat_response_contract(
+            '{"tasks":[{"taskId":"T1","text":"Seattle is in '
+            'Washington.","supportKind":"external_public",'
+            '"evidenceIds":["PUBLIC"]}]}'
+        )
+        validation = validate_ordinary_chat_response_contract(
+            external_basis,
+            contract,
+        )
+        self.assertTrue(validation.valid)
+
+    def test_typed_current_external_task_must_hold(self):
+        current_packet = replace(
+            self.packet,
+            request=replace(
+                self.packet.request,
+                subject_user_id=0,
+                subject_display_name="",
+                user_text="What is Seattle's weather today?",
+                frame_subject_requirement="not_applicable",
+                frame_subjects=(),
+                frame_tasks=(
+                    PacketFrameTask(
+                        task_id="T1",
+                        text_digest="c" * 64,
+                        task_kind="answer",
+                        object_kind="unknown",
+                        authority_scope="external_current",
+                        temporal_scope="current",
+                        currentness="current",
+                        required_response_act="hold",
+                        subject_requirement="not_applicable",
+                    ),
+                ),
+            ),
+            subject_resolution=PacketSubjectResolution(
+                status="not_applicable",
+                reason_codes=("subject_not_required",),
+            ),
+        )
+        current_basis = replace(self.basis, packet=current_packet)
+        held = parse_ordinary_chat_response_contract(
+            '{"tasks":[{"taskId":"T1","text":"I cannot verify the live '
+            'weather right now.","supportKind":"hold","evidenceIds":[]}]}'
+        )
+        answered = parse_ordinary_chat_response_contract(
+            '{"tasks":[{"taskId":"T1","text":"It is raining.",'
+            '"supportKind":"external_public","evidenceIds":["PUBLIC"]}]}'
+        )
+        self.assertTrue(
+            validate_ordinary_chat_response_contract(
+                current_basis,
+                held,
+            ).valid
+        )
+        self.assertEqual(
+            validate_ordinary_chat_response_contract(
+                current_basis,
+                answered,
+            ).status,
+            "current_fact_not_held",
+        )
+
     def test_receipt_is_content_free_and_counts_one_call(self):
         run = self._begin()
         self.assertTrue(run.prompt_applied)
+        evidence_id = next(
+            evidence_id
+            for evidence_id, lane, _digest in self.basis.rendered_evidence_refs
+            if lane == "approved_fact"
+        )
+        contract = parse_ordinary_chat_response_contract(
+            '{"tasks":[{"taskId":"T1","text":"Your favorite movie is '
+            'Arrival.","supportKind":"packet","evidenceIds":["%s"]}]}'
+            % evidence_id
+        )
         decision = evaluate_single_packet_response(
             self.conn,
             run,
-            response="Your favorite movie is Arrival.",
+            response=contract.response,
+            response_contract=contract,
+            typed_contract_required=True,
             provider_call_count=1,
             corrective_call_count=0,
             generation_latency_ms=42,
@@ -524,6 +723,10 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertEqual(report["correctiveCallTotal"], 0)
         self.assertEqual(report["ordinaryCallCountViolationRuns"], 0)
         self.assertEqual(report["ordinaryCorrectiveCallViolationRuns"], 0)
+        self.assertEqual(report["ordinaryTypedContractViolationRuns"], 0)
+        self.assertEqual(report["typedTaskTotal"], 1)
+        self.assertEqual(report["typedTaskCoverageTotal"], 1)
+        self.assertEqual(report["typedSupportReferenceTotal"], 1)
         self.assertEqual(report["invalidScopeRuns"], 0)
 
     def test_unsupported_packet_domain_claims_are_rejected_before_selection(self):

--- a/tests/test_shared_brain_synthesis_bot_path.py
+++ b/tests/test_shared_brain_synthesis_bot_path.py
@@ -988,7 +988,7 @@ class SharedBrainSynthesisBotPathTests(
         self.assertNotIn("Conversation history:", request_contents)
         self.assertNotIn("THE FORBIDDEN REFERENCE", request_contents)
 
-    async def test_single_packet_unsafe_output_is_suppressed_not_regenerated(self):
+    async def test_single_packet_provider_returns_raw_envelope_for_typed_validation(self):
         generated = mock.AsyncMock(
             return_value=SimpleNamespace(
                 success=True,
@@ -1023,7 +1023,7 @@ class SharedBrainSynthesisBotPathTests(
                 source_context_available=True,
             )
 
-        self.assertEqual(response, "")
+        self.assertEqual(response, "Network archives yielded no results.")
         generated.assert_awaited_once()
         strict_repair.assert_not_awaited()
 
@@ -1044,7 +1044,11 @@ class SharedBrainSynthesisBotPathTests(
         )
         provider = mock.AsyncMock(
             return_value=bnl01_bot.TrackedGenerationResponse(
-                text="One generated answer.",
+                text=(
+                    '{"tasks":[{"taskId":"T1","text":"One generated '
+                    'answer.","supportKind":"external_public",'
+                    '"evidenceIds":["PUBLIC"]}]}'
+                ),
                 provider_call_count=1,
             )
         )
@@ -1105,6 +1109,7 @@ class SharedBrainSynthesisBotPathTests(
             )
 
         self.assertTrue(execution.candidate_active)
+        self.assertEqual(execution.response, "One generated answer.")
         self.assertEqual(execution.provider_call_count, 1)
         self.assertEqual(execution.corrective_call_count, 0)
         provider.assert_awaited_once()
@@ -1114,6 +1119,7 @@ class SharedBrainSynthesisBotPathTests(
         )
         self.assertEqual(evaluate.call_args.kwargs["provider_call_count"], 1)
         self.assertEqual(evaluate.call_args.kwargs["corrective_call_count"], 0)
+        self.assertTrue(evaluate.call_args.kwargs["typed_contract_required"])
 
     async def test_single_packet_preprovider_exit_records_zero_calls(self):
         basis = SimpleNamespace(
@@ -1258,6 +1264,68 @@ class SharedBrainSynthesisBotPathTests(
             "ambiguous",
         )
 
+    async def test_single_packet_deterministic_clarification_bypasses_factual_guard_and_sends(self):
+        message = FakeMessage()
+        reason = "candidate_prompt_frame_ambiguous"
+        run = SimpleNamespace(run_id="single-block-run")
+        decision = SimpleNamespace(
+            run=run,
+            candidate_selected=False,
+            fallback_reason=reason,
+        )
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=decision,
+            response=bnl01_bot._ordinary_chat_single_packet_block_response(
+                reason
+            ),
+            prompt="packet-owned prompt",
+            prompt_source_bases=(),
+            candidate_active=False,
+            provider_call_count=0,
+            corrective_call_count=0,
+            block_reason=reason,
+        )
+        guard = mock.AsyncMock(
+            side_effect=AssertionError(
+                "deterministic clarification reached factual guard"
+            )
+        )
+        finalize = mock.AsyncMock(return_value=True)
+        with ExitStack() as stack:
+            for patcher in self.common_patches():
+                stack.enter_context(patcher)
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "apply_guarded_response_regeneration",
+                    new=guard,
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "safely_finalize_shared_brain_synthesis",
+                    new=finalize,
+                )
+            )
+
+            await bnl01_bot.send_planned_conversation_response(
+                message,
+                "ignored baseline",
+                self.plan(),
+                prompt="ignored baseline prompt",
+                source_context_available=True,
+                allow_model_save=False,
+                mark_recent_direct=False,
+                ordinary_chat_single_packet_execution=execution,
+            )
+
+        self.assertEqual(message.replies, [execution.response])
+        guard.assert_not_awaited()
+        finalize.assert_awaited_once()
+        self.assertTrue(finalize.await_args.kwargs["response_sent"])
+        self.assertFalse(finalize.await_args.kwargs["candidate_live"])
+
     async def test_single_packet_guard_modification_suppresses_send(self):
         message = FakeMessage()
         message.author.display_name = "Test Member"
@@ -1335,6 +1403,65 @@ class SharedBrainSynthesisBotPathTests(
         finalize.assert_awaited_once()
         self.assertFalse(finalize.await_args.kwargs["response_sent"])
         self.assertFalse(finalize.await_args.kwargs["candidate_live"])
+
+    async def test_typed_single_packet_candidate_is_not_semantically_rejudged(self):
+        message = FakeMessage()
+        run = SimpleNamespace(run_id="typed-single-run")
+        decision = SimpleNamespace(
+            run=run,
+            candidate_selected=True,
+            fallback_reason="",
+            typed_contract_status="valid",
+        )
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=decision,
+            response="Packet-supported answer.",
+            prompt="packet-owned prompt",
+            prompt_source_bases=(),
+            candidate_active=True,
+            provider_call_count=1,
+            corrective_call_count=0,
+        )
+        guard = mock.AsyncMock(
+            side_effect=AssertionError(
+                "typed selection reached legacy semantic guard"
+            )
+        )
+        finalize = mock.AsyncMock(return_value=True)
+        with ExitStack() as stack:
+            for patcher in self.common_patches():
+                stack.enter_context(patcher)
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "apply_guarded_response_regeneration",
+                    new=guard,
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "safely_finalize_shared_brain_synthesis",
+                    new=finalize,
+                )
+            )
+
+            await bnl01_bot.send_planned_conversation_response(
+                message,
+                "ignored baseline",
+                self.plan(),
+                prompt="ignored baseline prompt",
+                source_context_available=True,
+                allow_model_save=False,
+                mark_recent_direct=False,
+                ordinary_chat_single_packet_execution=execution,
+            )
+
+        self.assertEqual(message.replies, [execution.response])
+        guard.assert_not_awaited()
+        finalize.assert_awaited_once()
+        self.assertTrue(finalize.await_args.kwargs["response_sent"])
+        self.assertTrue(finalize.await_args.kwargs["candidate_live"])
 
 
 if __name__ == "__main__":

--- a/tests/test_situation_frame_v1.py
+++ b/tests/test_situation_frame_v1.py
@@ -112,6 +112,135 @@ class SituationFrameV1Tests(unittest.TestCase):
         self.assertIn("third_party_subject_unresolved", frame.ambiguity_reasons)
         self.assertIn("speaker_fallback_rejected", frame.competing_frames)
 
+    def test_self_target_precedence_binds_the_current_speaker(self):
+        cases = (
+            "What do you remember about me?",
+            "What do you know about me?",
+            "Tell me who I am.",
+            "What patterns keep recurring for me?",
+        )
+        for text in cases:
+            with self.subTest(text=text):
+                frame = build_situation_frame_v1(
+                    route_allowed=True,
+                    route_mode="normal_chat",
+                    conversation_surface="public_home",
+                    channel_policy="public_home",
+                    current_text=text,
+                    current_speaker_user_ids=(101,),
+                    current_speaker_labels=("Test Member",),
+                    response_act="answer",
+                )
+
+                self.assertEqual(frame.status, "resolved")
+                self.assertEqual(len(frame.subjects), 1)
+                self.assertEqual(frame.subjects[0].user_id, 101)
+                self.assertEqual(
+                    frame.subjects[0].binding_method,
+                    "current_speaker_context",
+                )
+                self.assertNotIn(
+                    "third_party_subject_unresolved",
+                    frame.ambiguity_reasons,
+                )
+
+    def test_bnl_self_questions_bind_the_existing_canon_entity(self):
+        cases = (
+            "Who are you?",
+            "What are you?",
+            "Tell me about yourself.",
+            "What do you remember about yourself?",
+        )
+        for text in cases:
+            with self.subTest(text=text):
+                frame = build_situation_frame_v1(
+                    route_allowed=True,
+                    route_mode="normal_chat",
+                    conversation_surface="public_home",
+                    channel_policy="public_home",
+                    current_text=text,
+                    current_speaker_user_ids=(101,),
+                    current_speaker_labels=("Test Member",),
+                    response_act="answer",
+                )
+
+                self.assertEqual(frame.status, "resolved")
+                self.assertEqual(len(frame.subjects), 1)
+                self.assertEqual(frame.subjects[0].entity_ref, "bnl_01")
+                self.assertEqual(
+                    frame.subjects[0].binding_method,
+                    "existing_typed_entity",
+                )
+
+    def test_publication_owner_qualifies_the_subject_of_the_question(self):
+        cases = (
+            "What did the Journal say about the last show?",
+            "What did the Relay say about the broadcast?",
+            "Summarize the Journal entry about the queue.",
+        )
+        for text in cases:
+            with self.subTest(text=text):
+                frame = build_situation_frame_v1(
+                    route_allowed=True,
+                    route_mode="normal_chat",
+                    conversation_surface="public_home",
+                    channel_policy="public_home",
+                    current_text=text,
+                    current_speaker_user_ids=(101,),
+                    response_act="answer",
+                )
+
+                expected = "relay" if "Relay" in text else "journal"
+                self.assertEqual(frame.object_kind, expected)
+                self.assertEqual(frame.task_kind, "retrieve_publication")
+                self.assertEqual(frame.status, "resolved")
+
+    def test_mixed_request_is_split_into_ordered_authority_tasks(self):
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text=(
+                "What do you remember about me, and where is Seattle?"
+            ),
+            current_speaker_user_ids=(101,),
+            current_speaker_labels=("Test Member",),
+            response_act="answer",
+        )
+
+        self.assertEqual(frame.status, "resolved")
+        self.assertEqual(tuple(task.task_id for task in frame.tasks), ("T1", "T2"))
+        self.assertEqual(
+            tuple(task.authority_scope for task in frame.tasks),
+            ("packet", "external_public"),
+        )
+        self.assertEqual(frame.tasks[0].subject_indexes, (0,))
+        self.assertEqual(frame.tasks[1].subject_indexes, ())
+        self.assertEqual(frame.task_kind, "multi_task")
+        self.assertEqual(frame.object_kind, "multiple")
+
+    def test_current_external_task_is_held_without_blocking_packet_task(self):
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text=(
+                "What do you remember about me, and what is Seattle's "
+                "weather today?"
+            ),
+            current_speaker_user_ids=(101,),
+            current_speaker_labels=("Test Member",),
+            response_act="answer",
+        )
+
+        self.assertEqual(frame.status, "resolved")
+        self.assertEqual(len(frame.tasks), 2)
+        self.assertEqual(frame.tasks[0].required_response_act, "answer")
+        self.assertEqual(frame.tasks[1].authority_scope, "external_current")
+        self.assertEqual(frame.tasks[1].required_response_act, "hold")
+
     def test_role_domain_event_and_visibility_matrix(self):
         cases = (
             (


### PR DESCRIPTION
## What changed

- upgrades the immutable Situation Frame to ordered, content-free typed tasks with authority, currentness, required response act, and subject binding
- carries those tasks through Unified Intelligence Packet v9 and Shared Brain Synthesis v10
- requires the one provider call to return a strict per-task JSON support contract
- validates exact task coverage and packet / PUBLIC / REQUEST / hold / clarify support before selecting visible text
- resolves BNL self-cues and current-speaker self-cues through existing canon/account owners, and gives Journal/Relay publication ownership precedence
- holds volatile external facts and emits deterministic zero-call clarification/hold responses when every task requires one
- treats a valid typed selection as the single semantic acceptance boundary while retaining independent source, frame, exact-quote, control-leak, delivery, and receipt checks
- adds content-free typed-contract receipt/report metrics and updates convergence documentation

## Root cause

The ordinary-chat cutover still let multiple downstream prose heuristics independently reinterpret a response after packet selection. A correctly grounded answer or deterministic clarification could therefore be modified or suppressed even after the factual owner had already accepted it. The incoming turn also lacked a frozen per-task authority/currentness contract, so self, BNL-self, publication, stable external, volatile external, and mixed turns could compete for ownership too late.

This change makes task ownership and response support explicit before generation and validates one machine-readable provider result once.

## Safety and scope

- capability remains default-off and restricted to the existing exact guild/user/channel allowlists
- no global Memory, Relationship, Active Engagement, queue, Journal, Relay, or deployment gate changes
- at most one provider attempt; no retries, corrective generation, or legacy model fallback
- receipts remain content-free
- unresolved true multi-subject packet synthesis remains fail-closed for the follow-up PR

## Qualification

- focused production-path set: **76/76**
- 48-case production-ingress acceptance matrix: **48/48**
- full repository gate: `make PYTHON=/tmp/bnl01-realign-venv/bin/python check` — **2,238/2,238**
- `git diff --check` and added-line secret/gate/privacy audit: clean
- remote branch is one commit ahead of verified `main`; all 12 blob SHAs and the complete tree SHA match the locally tested Git objects

## Post-merge deployment (deferred until the complete PR sequence is merged)

1. Deploy the merged `main` revision with `BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED=false`.
2. Restart BNL-01 and confirm the ordinary-chat capability reports requested/effective `off`, packet schema `unified_intelligence_packet_v9`, and synthesis schema `shared_brain_synthesis_v10`.
3. Run the focused post-deploy shadow evidence set in the sealed test scope: 4 packet-backed answer turns, 2 BNL-self turns, 2 publication turns, 2 stable-public turns, and 2 volatile-current hold turns.
4. Evidence required before any private canary: exact deployed commit SHA, 12/12 expected task authorities/acts, zero typed-contract violations, one provider call for answer turns, zero provider calls for deterministic hold/clarify turns, no corrective calls, valid frame/source revalidation, and no Discord send on rejected contracts.
5. Do not enable the exact private guild/user/channel canary or request owner testing until the follow-up multi-subject PR is merged and the combined automated/shadow matrix is green.
