### PR TITLE
Task-scoped multi-subject packets (PR2)

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -24068,6 +24068,7 @@ def build_unified_response_assessment_shadow(
                     )
                     not in {
                         "resolved",
+                        "multi_resolved",
                         "not_applicable",
                         "legacy",
                     }

--- a/bnl_shadow_acceptance.py
+++ b/bnl_shadow_acceptance.py
@@ -827,7 +827,7 @@ def _read_shared_brain_synthesis_report(
         return _report_error(
             {
                 "tablePresent": False,
-                "schemaVersion": "shared_brain_synthesis_v10",
+                "schemaVersion": "shared_brain_synthesis_v11",
                 "runs": 0,
                 "promptAppliedRuns": 0,
                 "liveAppliedRuns": 0,
@@ -2116,7 +2116,7 @@ def render_v2_shadow_acceptance_lines(snapshot: Mapping[str, Any]) -> List[str]:
             _on(shared_brain_synthesis_state.get("fullyScoped")),
             shared_brain_synthesis.get(
                 "schemaVersion",
-                "shared_brain_synthesis_v10",
+                "shared_brain_synthesis_v11",
             ),
             shared_brain_synthesis.get("runs", 0),
             json.dumps(

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -42,6 +42,7 @@ from bnl_unified_intelligence_packet import (
     SCHEMA_VERSION as PACKET_SCHEMA_VERSION,
     UnifiedIntelligencePacket,
     mark_packet_application,
+    packet_subject_resolutions,
     revalidate_packet,
     shadow_enabled as packet_shadow_enabled,
 )
@@ -53,11 +54,11 @@ from bnl_unified_response_assessment import (
 )
 
 
-SCHEMA_VERSION = "shared_brain_synthesis_v10"
+SCHEMA_VERSION = "shared_brain_synthesis_v11"
 CAPABILITY_NAME = "shared_brain_public_broad_recall"
 CAPABILITY_CONTRACT_VERSION = "hybrid_shared_brain_v1"
 CAPABILITY_RECEIPT_VERSION = "shared_brain_capability_receipt_v1"
-_EXPECTED_PACKET_SCHEMA_VERSION = "unified_intelligence_packet_v9"
+_EXPECTED_PACKET_SCHEMA_VERSION = "unified_intelligence_packet_v10"
 _EXPECTED_CLAIM_CONTRACT_VERSION = "hybrid_canon_claim_v1"
 _EXPECTED_ASSESSMENT_VERSION = "unified_response_assessment_v7"
 _EXPECTED_IDENTITY_CONTRACT_VERSION = "canon_entity_account_binding_v1"
@@ -77,7 +78,7 @@ PUBLIC_HOME_OWNER_CHANNEL_IDS_ENV = (
 )
 ORDINARY_CHAT_CAPABILITY_NAME = "ordinary_chat_single_packet_canary"
 ORDINARY_CHAT_CAPABILITY_CONTRACT_VERSION = (
-    "ordinary_chat_single_packet_v2"
+    "ordinary_chat_single_packet_v3"
 )
 ORDINARY_CHAT_ENABLED_ENV = "BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED"
 ORDINARY_CHAT_GUILD_IDS_ENV = (
@@ -1188,7 +1189,9 @@ class SharedBrainSynthesisBasis:
     profile_recognized_canon_identity: bool = False
     identity_canon_only: bool = False
     honest_empty_profile_fallback: bool = False
-    rendered_evidence_refs: tuple[tuple[str, str, str], ...] = ()
+    rendered_evidence_refs: tuple[
+        tuple[str, str, str, tuple[int, ...]], ...
+    ] = ()
 
 
 @dataclass(frozen=True)
@@ -2537,6 +2540,27 @@ def render_packet_context(
             ),
         )
     )
+    resolutions = packet_subject_resolutions(packet)
+    if len(resolutions) > 1:
+        first_by_subject = []
+        for resolution in resolutions:
+            accepted_keys = {
+                str(resolution.subject_key or ""),
+                str(resolution.entity_ref or ""),
+            } - {""}
+            first_item = next(
+                (
+                    item
+                    for item in ordered_items
+                    if str(item.subject_key or "") in accepted_keys
+                ),
+                None,
+            )
+            if first_item is not None and first_item not in first_by_subject:
+                first_by_subject.append(first_item)
+        ordered_items = tuple(first_by_subject) + tuple(
+            item for item in ordered_items if item not in first_by_subject
+        )
     adaptive_support = _adaptive_supporting_observation_map(
         packet,
         ordered_items,
@@ -2871,7 +2895,7 @@ def _ordinary_packet_context(
 def _ordinary_rendered_evidence_refs(
     packet: UnifiedIntelligencePacket,
     source_digests: Sequence[str],
-) -> tuple[tuple[str, str, str], ...]:
+) -> tuple[tuple[str, str, str, tuple[int, ...]], ...]:
     """Bind rendered E-identifiers to lanes without exposing source IDs."""
 
     remaining = list(packet.items)
@@ -2888,7 +2912,25 @@ def _ordinary_rendered_evidence_refs(
         if match_index < 0:
             return ()
         item = remaining.pop(match_index)
-        refs.append(("E%s" % index, item.lane, item.source_digest))
+        subject_indexes = tuple(
+            subject_index
+            for subject_index, resolution in enumerate(
+                packet_subject_resolutions(packet)
+            )
+            if item.subject_key
+            in {
+                str(resolution.subject_key or ""),
+                str(resolution.entity_ref or ""),
+            }
+        )
+        refs.append(
+            (
+                "E%s" % index,
+                item.lane,
+                item.source_digest,
+                subject_indexes,
+            )
+        )
     return tuple(refs)
 
 
@@ -2946,19 +2988,39 @@ def render_ordinary_chat_task_contract(
     if not tasks:
         return ""
     task_lines = [
-        "- %s | authority=%s | object=%s | currentness=%s | response=%s"
+        "- %s | authority=%s | object=%s | currentness=%s | response=%s "
+        "| subjects=%s"
         % (
             str(getattr(task, "task_id", "") or ""),
             str(getattr(task, "authority_scope", "") or "unknown"),
             str(getattr(task, "object_kind", "") or "unknown"),
             str(getattr(task, "currentness", "") or "unknown"),
             str(getattr(task, "required_response_act", "") or "answer"),
+            ",".join(
+                "S%s" % (int(subject_index) + 1)
+                for subject_index in getattr(task, "subject_indexes", ())
+            )
+            or "none",
         )
         for task in tasks
     ]
     evidence_lines = [
-        "- %s | lane=%s" % (evidence_id, lane)
-        for evidence_id, lane, _digest_value in basis.rendered_evidence_refs
+        "- %s | lane=%s | subjects=%s"
+        % (
+            evidence_id,
+            lane,
+            ",".join(
+                "S%s" % (int(subject_index) + 1)
+                for subject_index in subject_indexes
+            )
+            or "none",
+        )
+        for (
+            evidence_id,
+            lane,
+            _digest_value,
+            subject_indexes,
+        ) in basis.rendered_evidence_refs
     ]
     return (
         "TYPED TURN TASK CONTRACT:\n"
@@ -3075,9 +3137,14 @@ def validate_ordinary_chat_response_contract(
             status="task_coverage_mismatch",
             task_count=len(tasks),
         )
-    evidence_lanes = {
-        evidence_id: lane
-        for evidence_id, lane, _digest_value in basis.rendered_evidence_refs
+    evidence_scope = {
+        evidence_id: (lane, tuple(subject_indexes))
+        for (
+            evidence_id,
+            lane,
+            _digest_value,
+            subject_indexes,
+        ) in basis.rendered_evidence_refs
     }
     support_count = 0
     for task, result in zip(tasks, contract.tasks):
@@ -3101,12 +3168,34 @@ def validate_ordinary_chat_response_contract(
             continue
         if authority == "packet":
             allowed_lanes = _ordinary_task_allowed_lanes(task)
+            required_subject_indexes = set(
+                int(subject_index)
+                for subject_index in getattr(task, "subject_indexes", ())
+            )
             allowed_ids = {
                 evidence_id
-                for evidence_id, lane in evidence_lanes.items()
+                for evidence_id, (
+                    lane,
+                    subject_indexes,
+                ) in evidence_scope.items()
                 if lane in allowed_lanes
+                and (
+                    not required_subject_indexes
+                    or required_subject_indexes.intersection(subject_indexes)
+                )
             }
-            if result.support_kind == "hold" and not allowed_ids:
+            covered_subject_indexes = {
+                subject_index
+                for evidence_id in allowed_ids
+                for subject_index in evidence_scope[evidence_id][1]
+                if subject_index in required_subject_indexes
+            }
+            missing_subject_evidence = bool(
+                required_subject_indexes - covered_subject_indexes
+            )
+            if result.support_kind == "hold" and (
+                not allowed_ids or missing_subject_evidence
+            ):
                 if result.evidence_ids:
                     return OrdinaryChatContractValidation(
                         status="hold_has_support_reference",
@@ -3117,6 +3206,14 @@ def validate_ordinary_chat_response_contract(
                 result.support_kind != "packet"
                 or not result.evidence_ids
                 or not set(result.evidence_ids).issubset(allowed_ids)
+                or missing_subject_evidence
+                or required_subject_indexes
+                - {
+                    subject_index
+                    for evidence_id in result.evidence_ids
+                    for subject_index in evidence_scope[evidence_id][1]
+                    if subject_index in required_subject_indexes
+                }
             ):
                 return OrdinaryChatContractValidation(
                     status="packet_support_invalid",

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -91,7 +91,7 @@ from bnl_website_relay_state import (
 )
 
 
-SCHEMA_VERSION = "unified_intelligence_packet_v9"
+SCHEMA_VERSION = "unified_intelligence_packet_v10"
 SUBJECT_RESOLUTION_VERSION = "governed_packet_subject_resolution_v1"
 SOURCE_SNAPSHOT_VERSION = "unified_packet_source_snapshot_v2"
 JOURNAL_PUBLICATION_SOURCE_CLASS = "journal_publication_projection"
@@ -510,7 +510,12 @@ class PacketSubjectResolution:
 
     @property
     def applicable(self) -> bool:
-        return self.status in {"resolved", "not_applicable", "legacy"}
+        return self.status in {
+            "resolved",
+            "multi_resolved",
+            "not_applicable",
+            "legacy",
+        }
 
 
 @dataclass(frozen=True)
@@ -655,6 +660,8 @@ class UnifiedIntelligencePacket:
     source_snapshot_digest: str = ""
     profile_sufficiency: ProfileSufficiency = ProfileSufficiency()
     validation_items: tuple[IntelligencePacketItem, ...] = ()
+    subject_resolutions: tuple[PacketSubjectResolution, ...] = ()
+    component_packets: tuple["UnifiedIntelligencePacket", ...] = ()
 
     @property
     def detailed_lanes(self) -> tuple[str, ...]:
@@ -741,6 +748,31 @@ class UnifiedIntelligencePacket:
                 for lane in self.diagnostics.missing_lanes
             )
         )
+
+
+def packet_subject_resolutions(
+    packet: UnifiedIntelligencePacket,
+) -> tuple[PacketSubjectResolution, ...]:
+    """Return every independently governed packet subject in frame order."""
+
+    if packet.subject_resolutions:
+        return packet.subject_resolutions
+    if packet.subject_resolution.status in {"resolved", "legacy"}:
+        return (packet.subject_resolution,)
+    return ()
+
+
+def packet_subject_keys(
+    packet: UnifiedIntelligencePacket,
+) -> tuple[str, ...]:
+    return tuple(
+        dict.fromkeys(
+            value
+            for resolution in packet_subject_resolutions(packet)
+            for value in (resolution.subject_key, resolution.entity_ref)
+            if str(value or "").strip()
+        )
+    )
 
 
 def _flag(value: Any) -> bool:
@@ -5785,6 +5817,83 @@ def _publication_revalidation_payload(item: IntelligencePacketItem) -> dict[str,
     return dict(value) if isinstance(value, dict) else {}
 
 
+def _merge_packet_items(
+    packets: Sequence[UnifiedIntelligencePacket],
+    *,
+    validation: bool = False,
+) -> tuple[IntelligencePacketItem, ...]:
+    merged = []
+    seen = set()
+    for packet in packets:
+        source = packet.validation_items if validation else packet.items
+        for item in source:
+            key = (
+                item.lane,
+                item.source_ref,
+                item.source_digest,
+                item.subject_key,
+                item.predicate_key,
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(item)
+    return tuple(merged)
+
+
+def _revalidate_multi_packet_in_snapshot(
+    conn: sqlite3.Connection,
+    packet: UnifiedIntelligencePacket,
+    *,
+    environ: Mapping[str, str] | None = None,
+    journal_control_snapshot: JournalControlSnapshot | None = None,
+    journal_control_snapshot_provided: bool = False,
+) -> PacketRevalidationResult:
+    components = tuple(packet.component_packets)
+    changed = 0
+    errors = 0
+    statuses = []
+    if (
+        packet.subject_resolution.status != "multi_resolved"
+        or packet.subject_resolutions
+        != tuple(component.subject_resolution for component in components)
+        or packet.items != _merge_packet_items(components)
+        or packet.validation_items
+        != _merge_packet_items(components, validation=True)
+    ):
+        changed += 1
+    for component in components:
+        result = _revalidate_packet_in_snapshot(
+            conn,
+            component,
+            environ=environ,
+            journal_control_snapshot=journal_control_snapshot,
+            journal_control_snapshot_provided=(
+                journal_control_snapshot_provided
+            ),
+        )
+        changed += int(result.changed_source_count or 0)
+        errors += int(result.processing_error_count or 0)
+        statuses.append(result.status)
+    if errors:
+        status = "processing_error"
+    elif "subject_binding_changed" in statuses:
+        status = "subject_binding_changed"
+    elif changed:
+        status = "source_changed"
+    elif "passed_with_provider_snapshot" in statuses:
+        status = "passed_with_provider_snapshot"
+    else:
+        status = "passed"
+    return PacketRevalidationResult(
+        valid=not errors and not changed,
+        status=status,
+        changed_source_count=changed,
+        processing_error_count=errors,
+        subject_resolution_status="multi_resolved",
+    )
+
+
 def _revalidate_packet_in_snapshot(
     conn: sqlite3.Connection,
     packet: UnifiedIntelligencePacket,
@@ -5794,6 +5903,16 @@ def _revalidate_packet_in_snapshot(
     journal_control_snapshot_provided: bool = False,
 ) -> PacketRevalidationResult:
     """Re-read every durable source without applying packet content live."""
+    if packet.component_packets:
+        return _revalidate_multi_packet_in_snapshot(
+            conn,
+            packet,
+            environ=environ,
+            journal_control_snapshot=journal_control_snapshot,
+            journal_control_snapshot_provided=(
+                journal_control_snapshot_provided
+            ),
+        )
     changed = 0
     errors = 0
     current_subject_resolution = resolve_packet_subject(
@@ -6023,15 +6142,44 @@ def _packet_invariants(
     packet: UnifiedIntelligencePacket,
 ) -> tuple[str, ...]:
     invalid = []
-    subject = _request_subject_key(packet.request)
     accepted_subject_keys = {
-        value
-        for value in (
-            packet.subject_resolution.subject_key,
-            packet.subject_resolution.entity_ref,
-        )
-        if value
+        value for value in packet_subject_keys(packet) if value
     }
+    if packet.component_packets:
+        if packet.subject_resolution.status != "multi_resolved":
+            invalid.append("multi_subject_summary_status_invalid")
+        if packet.subject_resolutions != tuple(
+            component.subject_resolution
+            for component in packet.component_packets
+        ):
+            invalid.append("multi_subject_resolution_mismatch")
+        if any(
+            resolution.status != "resolved"
+            for resolution in packet.subject_resolutions
+        ):
+            invalid.append("multi_subject_component_unresolved")
+        if packet.items != _merge_packet_items(packet.component_packets):
+            invalid.append("multi_subject_item_merge_mismatch")
+        if packet.validation_items != _merge_packet_items(
+            packet.component_packets,
+            validation=True,
+        ):
+            invalid.append("multi_subject_validation_merge_mismatch")
+        referenced_indexes = {
+            subject_index
+            for task in packet.request.frame_tasks
+            for subject_index in task.subject_indexes
+        }
+        if (
+            referenced_indexes != set(range(len(packet.subject_resolutions)))
+            or any(
+                subject_index < 0
+                or subject_index >= len(packet.subject_resolutions)
+                for task in packet.request.frame_tasks
+                for subject_index in task.subject_indexes
+            )
+        ):
+            invalid.append("multi_subject_task_scope_invalid")
     governed_subject_required = bool(
         str(packet.request.frame_subject_requirement or "").strip().lower()
         == "required"
@@ -6130,7 +6278,7 @@ def _packet_invariants(
         if item.revalidation_kind == "recognized_canon" and not (
             item.lane == "canon"
             and item.source_type == "recognized_canon_fact"
-            and item.subject_key == subject
+            and item.subject_key in accepted_subject_keys
             and item.source_class == SourceClass.APPROVED_CANON.value
         ):
             invalid.append("recognized_canon_scope_violation")
@@ -6165,7 +6313,7 @@ def _packet_invariants(
         if item.supporting_observations and not (
             item.lane in {"atomic_knowledge", "recurring_theme"}
             and item.source_type == "topic_or_motif"
-            and item.subject_key == subject
+            and item.subject_key in accepted_subject_keys
         ):
             invalid.append("supporting_observation_scope_violation")
         if item.canon_status == CanonStatus.LIVING.value and not (
@@ -6183,7 +6331,7 @@ def _packet_invariants(
         if item.lane == "recurring_theme" and not (
             item.source_type == "topic_or_motif"
             and item.revalidation_kind == "recurring_theme"
-            and item.subject_key == subject
+            and item.subject_key in accepted_subject_keys
             and bool(item.root_identities)
             and bool(item.occurrence_identities)
             and (
@@ -6239,13 +6387,13 @@ def _packet_invariants(
             and bool(item.occurrence_identities)
             and (
                 item.lane != "approved_fact"
-                or item.subject_key == subject
+                or item.subject_key in accepted_subject_keys
             )
             and (
                 item.source_type != "recognized_declared_canon_claim"
                 or (
                     item.lane == "canon"
-                    and item.subject_key == subject
+                    and item.subject_key in accepted_subject_keys
                 )
             )
         ):
@@ -6285,7 +6433,7 @@ def _packet_invariants(
         if item.revalidation_kind == "recognized_canon" and not (
             item.lane == "canon"
             and item.source_type == "recognized_canon_fact"
-            and item.subject_key == subject
+            and item.subject_key in accepted_subject_keys
             and item.source_class == SourceClass.APPROVED_CANON.value
         ):
             invalid.append("validation_support_canon_scope_violation")
@@ -6300,17 +6448,434 @@ def _packet_invariants(
     return tuple(dict.fromkeys(invalid))
 
 
+def _task_scoped_multi_subject_requested(
+    request: IntelligencePacketRequest,
+) -> bool:
+    subjects = tuple(request.frame_subjects)
+    tasks = tuple(request.frame_tasks)
+    if (
+        str(request.frame_status or "").lower() != "resolved"
+        or len(subjects) < 2
+        or not tasks
+    ):
+        return False
+    referenced = {
+        subject_index
+        for task in tasks
+        for subject_index in task.subject_indexes
+    }
+    return bool(
+        referenced == set(range(len(subjects)))
+        and all(
+            0 <= subject_index < len(subjects)
+            for task in tasks
+            for subject_index in task.subject_indexes
+        )
+        and all(
+            task.subject_requirement != "required"
+            or bool(task.subject_indexes)
+            for task in tasks
+        )
+    )
+
+
+def _sum_component_counter(
+    components: Sequence[UnifiedIntelligencePacket],
+    attribute: str,
+) -> dict[str, int]:
+    result: Counter[str] = Counter()
+    for component in components:
+        result.update(
+            {
+                str(key): int(value or 0)
+                for key, value in dict(
+                    getattr(component.diagnostics, attribute, {}) or {}
+                ).items()
+            }
+        )
+    return dict(sorted(result.items()))
+
+
+def _component_query_status(
+    components: Sequence[UnifiedIntelligencePacket],
+    attribute: str,
+) -> str:
+    statuses = tuple(
+        str(getattr(component.diagnostics, attribute, "not_requested") or "")
+        for component in components
+    )
+    active = tuple(status for status in statuses if status != "not_requested")
+    if not active:
+        return "not_requested"
+    return active[0] if len(set(active)) == 1 else "component_conflict"
+
+
+def _build_task_scoped_multi_subject_packet(
+    conn: sqlite3.Connection,
+    request: IntelligencePacketRequest,
+    *,
+    persist: bool,
+    environ: Mapping[str, str] | None,
+) -> UnifiedIntelligencePacket | None:
+    subjects = tuple(request.frame_subjects)
+    component_budget = max(
+        400,
+        min(max(int(request.budget_chars or 2400), 400), 6000)
+        // len(subjects),
+    )
+    components = []
+    for subject_index, subject in enumerate(subjects):
+        component_tasks = tuple(
+            replace(task, subject_indexes=(0,))
+            for task in request.frame_tasks
+            if subject_index in task.subject_indexes
+        )
+        component_request = replace(
+            request,
+            subject_user_id=0,
+            subject_entity_ref="",
+            budget_chars=component_budget,
+            frame_status="resolved",
+            frame_subject_requirement="required",
+            frame_subjects=(subject,),
+            frame_tasks=component_tasks,
+        )
+        component = build_packet(
+            conn,
+            component_request,
+            persist=False,
+            environ=environ,
+            _component_build=True,
+        )
+        if (
+            component is None
+            or component.subject_resolution.status != "resolved"
+            or component.diagnostics.processing_errors
+            or component.diagnostics.invalid_invariants
+            or not component.diagnostics.revalidation_status.startswith(
+                "passed"
+            )
+        ):
+            return build_packet(
+                conn,
+                request,
+                persist=persist,
+                environ=environ,
+                _component_build=True,
+            )
+        components.append(component)
+    components_tuple = tuple(components)
+    resolutions = tuple(
+        component.subject_resolution for component in components_tuple
+    )
+    resolution_identities = tuple(
+        str(resolution.entity_ref or resolution.subject_key or "")
+        for resolution in resolutions
+    )
+    if (
+        any(not identity for identity in resolution_identities)
+        or len(set(resolution_identities)) != len(resolution_identities)
+    ):
+        return build_packet(
+            conn,
+            request,
+            persist=persist,
+            environ=environ,
+            _component_build=True,
+        )
+    summary_resolution = PacketSubjectResolution(
+        status="multi_resolved",
+        binding_method="task_scoped_components",
+        confidence="authoritative",
+        candidate_count=len(resolutions),
+        binding_digest=_digest(
+            SUBJECT_RESOLUTION_VERSION,
+            "task_scoped_components",
+            tuple(
+                (
+                    resolution.subject_user_id,
+                    resolution.subject_key,
+                    resolution.entity_ref,
+                    resolution.binding_method,
+                    resolution.binding_digest,
+                )
+                for resolution in resolutions
+            ),
+        ),
+        reason_codes=("task_scoped_subjects_resolved",),
+    )
+    items = _merge_packet_items(components_tuple)
+    validation_items = _merge_packet_items(
+        components_tuple,
+        validation=True,
+    )
+    exclusions = tuple(
+        exclusion
+        for component in components_tuple
+        for exclusion in component.exclusions
+    )
+    diagnostics = IntelligencePacketDiagnostics(
+        candidates_by_lane=_sum_component_counter(
+            components_tuple,
+            "candidates_by_lane",
+        ),
+        selected_by_lane=dict(
+            sorted(Counter(item.lane for item in items).items())
+        ),
+        selected_by_source_class=dict(
+            sorted(Counter(item.source_class for item in items).items())
+        ),
+        candidates_by_canon_status=_sum_component_counter(
+            components_tuple,
+            "candidates_by_canon_status",
+        ),
+        selected_by_canon_status=dict(
+            sorted(
+                Counter(
+                    item.canon_status for item in items if item.canon_status
+                ).items()
+            )
+        ),
+        candidates_by_canon_domain=_sum_component_counter(
+            components_tuple,
+            "candidates_by_canon_domain",
+        ),
+        selected_by_canon_domain=dict(
+            sorted(
+                Counter(
+                    item.canon_domain for item in items if item.canon_domain
+                ).items()
+            )
+        ),
+        selected_atomic_states=_sum_component_counter(
+            components_tuple,
+            "selected_atomic_states",
+        ),
+        validation_support_by_lane=dict(
+            sorted(Counter(item.lane for item in validation_items).items())
+        ),
+        excluded_by_reason=_sum_component_counter(
+            components_tuple,
+            "excluded_by_reason",
+        ),
+        missing_lanes=list(
+            dict.fromkeys(
+                lane
+                for component in components_tuple
+                for lane in component.diagnostics.missing_lanes
+            )
+        ),
+        conflict_reasons=list(
+            dict.fromkeys(
+                reason
+                for component in components_tuple
+                for reason in component.diagnostics.conflict_reasons
+            )
+        ),
+        visibility_exclusions=sum(
+            component.diagnostics.visibility_exclusions
+            for component in components_tuple
+        ),
+        budget_exclusions=sum(
+            component.diagnostics.budget_exclusions
+            for component in components_tuple
+        ),
+        duplicate_suppression=sum(
+            component.diagnostics.duplicate_suppression
+            for component in components_tuple
+        ),
+        root_collapse_suppression=sum(
+            component.diagnostics.root_collapse_suppression
+            for component in components_tuple
+        ),
+        shared_root_projection_count=sum(
+            component.diagnostics.shared_root_projection_count
+            for component in components_tuple
+        ),
+        canon_identity_status="task_scoped_multi",
+        canon_identity_stable_row_count=sum(
+            component.diagnostics.canon_identity_stable_row_count
+            for component in components_tuple
+        ),
+        subject_resolution_status="multi_resolved",
+        subject_resolution_method="task_scoped_components",
+        subject_resolution_candidate_count=len(resolutions),
+        frame_applicability_exclusion_count=sum(
+            component.diagnostics.frame_applicability_exclusion_count
+            for component in components_tuple
+        ),
+        episode_query_status=_component_query_status(
+            components_tuple,
+            "episode_query_status",
+        ),
+        episode_candidate_count=sum(
+            component.diagnostics.episode_candidate_count
+            for component in components_tuple
+        ),
+        theme_query_status=_component_query_status(
+            components_tuple,
+            "theme_query_status",
+        ),
+        theme_independent_root_count=sum(
+            component.diagnostics.theme_independent_root_count
+            for component in components_tuple
+        ),
+        theme_independent_occurrence_count=sum(
+            component.diagnostics.theme_independent_occurrence_count
+            for component in components_tuple
+        ),
+        journal_query_status=_component_query_status(
+            components_tuple,
+            "journal_query_status",
+        ),
+        journal_control_status=_component_query_status(
+            components_tuple,
+            "journal_control_status",
+        ),
+        journal_candidate_count=sum(
+            component.diagnostics.journal_candidate_count
+            for component in components_tuple
+        ),
+        relay_query_status=_component_query_status(
+            components_tuple,
+            "relay_query_status",
+        ),
+        relay_candidate_count=sum(
+            component.diagnostics.relay_candidate_count
+            for component in components_tuple
+        ),
+        publication_projection_count=sum(
+            item.lane in {"journal_publication", "relay_publication"}
+            for item in items
+        ),
+    )
+    prompt_digest_payload = tuple(
+        (
+            item.lane,
+            item.source_class,
+            item.source_ref,
+            item.source_digest,
+            item.lifecycle,
+            item.usage,
+            item.root_identities,
+            item.occurrence_identities,
+            item.point_identity,
+            item.canon_status,
+            item.canon_domain,
+            item.canon_claim_kind,
+        )
+        for item in items
+    )
+    validation_digest_payload = tuple(
+        (
+            item.lane,
+            item.source_class,
+            item.source_ref,
+            item.source_digest,
+            item.lifecycle,
+            item.usage,
+            item.root_identities,
+            item.occurrence_identities,
+            item.point_identity,
+            item.canon_status,
+            item.canon_domain,
+            item.canon_claim_kind,
+        )
+        for item in validation_items
+    )
+    diagnostics.packet_digest = _digest(
+        SCHEMA_VERSION,
+        request.frame_revision,
+        request.frame_input_evidence_digest,
+        summary_resolution,
+        resolutions,
+        prompt_digest_payload,
+        validation_digest_payload,
+    )
+    source_snapshot_digest = _digest(
+        SOURCE_SNAPSHOT_VERSION,
+        request.frame_revision,
+        request.frame_input_evidence_digest,
+        summary_resolution.binding_digest,
+        tuple(
+            component.source_snapshot_digest
+            for component in components_tuple
+        ),
+        prompt_digest_payload,
+        validation_digest_payload,
+    )
+    packet = UnifiedIntelligencePacket(
+        schema_version=SCHEMA_VERSION,
+        packet_id="uip_"
+        + _digest(
+            SCHEMA_VERSION,
+            request.guild_id,
+            tuple(resolution.subject_key for resolution in resolutions),
+            request.route_mode,
+            request.channel_policy,
+            request.frame_revision,
+            diagnostics.packet_digest,
+        )[:40],
+        request=request,
+        items=items,
+        exclusions=exclusions,
+        diagnostics=diagnostics,
+        subject_resolution=summary_resolution,
+        subject_resolutions=resolutions,
+        component_packets=components_tuple,
+        source_snapshot_digest=source_snapshot_digest,
+        profile_sufficiency=ProfileSufficiency(),
+        validation_items=validation_items,
+    )
+    diagnostics.invalid_invariants.extend(_packet_invariants(packet))
+    revalidation = revalidate_packet(conn, packet, environ=environ)
+    diagnostics.revalidation_status = revalidation.status
+    diagnostics.revalidation_changed_count = (
+        revalidation.changed_source_count
+    )
+    if revalidation.processing_error_count:
+        diagnostics.processing_errors.extend(
+            "revalidation_error"
+            for _ in range(revalidation.processing_error_count)
+        )
+    if not revalidation.valid:
+        diagnostics.invalid_invariants.append(
+            "packet_source_revalidation_failed"
+        )
+    diagnostics.invalid_invariants = list(
+        dict.fromkeys(diagnostics.invalid_invariants)
+    )
+    if persist:
+        diagnostics.receipt_run_id = persist_packet_run(
+            conn,
+            packet,
+            created_at=request.now or "",
+        )
+    return packet
+
+
 def build_packet(
     conn: sqlite3.Connection,
     request: IntelligencePacketRequest,
     *,
     persist: bool = True,
     environ: Mapping[str, str] | None = None,
+    _component_build: bool = False,
 ) -> UnifiedIntelligencePacket | None:
     """Build one deterministic shadow packet from existing source owners."""
     if not shadow_enabled(environ):
         return None
     ensure_schema(conn)
+    if (
+        not _component_build
+        and _task_scoped_multi_subject_requested(request)
+    ):
+        return _build_task_scoped_multi_subject_packet(
+            conn,
+            request,
+            persist=persist,
+            environ=environ,
+        )
     diagnostics = IntelligencePacketDiagnostics()
     exclusions: list[IntelligencePacketExclusion] = []
     subject_resolution = resolve_packet_subject(
@@ -6607,7 +7172,7 @@ def persist_packet_run(
             packet.packet_id,
             packet.schema_version,
             int(packet.request.guild_id or 0),
-            _digest(_request_subject_key(packet.request))[:16],
+            _digest(packet_subject_keys(packet))[:16],
             str(packet.request.route_mode or "unknown")[:80],
             str(packet.request.channel_policy or "unknown")[:80],
             str(packet.request.visibility_allowance or "unknown")[:80],

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -22,13 +22,13 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
-from bnl_canon_source_contract import BNL01
+from bnl_canon_source_contract import BNL01, CANON_ENTITY_IDENTITIES
 from bnl_conversation_context_v2 import assess_payload_grounding
 
 
 ASSESSMENT_VERSION = "unified_response_assessment_v7"
 CONVERSATION_TURN_PACKET_VERSION = "conversation_turn_evidence_v3"
-SITUATION_FRAME_VERSION = "situation_frame_v2"
+SITUATION_FRAME_VERSION = "situation_frame_v3"
 FRAME_SOURCE_REVALIDATION_VERSION = "frame_source_revalidation_v1"
 SHADOW_ENV = "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED"
 TABLE_NAME = "unified_response_assessment_shadow_runs"
@@ -602,17 +602,48 @@ def _task_subject_indexes(
     third_party = bool(_THIRD_PARTY_SUBJECT_CUE_RE.search(segment or ""))
     matches = []
     for index, subject in enumerate(subjects):
+        if int(subject.user_id or 0) > 0 and re.search(
+            r"<@!?%s>" % int(subject.user_id),
+            segment or "",
+        ):
+            matches.append(index)
+            continue
         if bnl_self and subject.entity_ref == BNL01.key:
             matches.append(index)
             continue
         if self_subject and subject.binding_method == "current_speaker_context":
             matches.append(index)
             continue
-        label = str(subject.label_hint or "").strip()
-        if label and re.search(
-            r"(?<![a-z0-9])%s(?![a-z0-9])" % re.escape(label),
-            segment or "",
-            re.I,
+        canon_subject = next(
+            (
+                candidate
+                for candidate in CANON_ENTITY_IDENTITIES
+                if candidate.key == subject.entity_ref
+            ),
+            None,
+        )
+        labels = tuple(
+            dict.fromkeys(
+                str(label or "").strip()
+                for label in (
+                    subject.label_hint,
+                    canon_subject.name if canon_subject is not None else "",
+                    *(
+                        canon_subject.aliases
+                        if canon_subject is not None
+                        else ()
+                    ),
+                )
+                if str(label or "").strip()
+            )
+        )
+        if any(
+            re.search(
+                r"(?<![a-z0-9])%s(?![a-z0-9])" % re.escape(label),
+                segment or "",
+                re.I,
+            )
+            for label in labels
         ):
             matches.append(index)
     if not matches and third_party and len(subjects) == 1:
@@ -830,35 +861,53 @@ def build_situation_frame_v1(
             subjects.append(
                 SituationSubjectReference(
                     user_id=user_id,
-                    entity_ref=(entity_refs[index] if index < len(entity_refs) else ""),
+                    entity_ref="",
                     label_hint=(label_hints[index] if index < len(label_hints) else ""),
                     binding_method="existing_typed_target",
-                    confidence="high" if len(subject_ids) == 1 else "ambiguous",
+                    confidence="high",
                     role_hints=roles,
                     domain_hints=domains,
                 )
             )
-    elif label_hints or entity_refs:
-        count = max(len(label_hints), len(entity_refs))
-        for index in range(count):
-            entity_ref = (
-                entity_refs[index] if index < len(entity_refs) else ""
+    if entity_refs:
+        for entity_ref in entity_refs:
+            canon_subject = next(
+                (
+                    candidate
+                    for candidate in CANON_ENTITY_IDENTITIES
+                    if candidate.key == entity_ref
+                ),
+                None,
             )
             subjects.append(
                 SituationSubjectReference(
                     entity_ref=entity_ref,
-                    label_hint=(label_hints[index] if index < len(label_hints) else ""),
-                    binding_method=(
-                        "existing_typed_entity"
-                        if entity_ref
-                        else "reversible_label_hint"
+                    label_hint=(
+                        canon_subject.name
+                        if canon_subject is not None
+                        else entity_ref
                     ),
-                    confidence="high" if entity_ref else "low",
+                    binding_method="existing_typed_entity",
+                    confidence="high",
                     role_hints=roles,
                     domain_hints=domains,
                 )
             )
-    elif bnl_self_subject_cue:
+    elif not subject_ids and label_hints:
+        for label_hint in label_hints:
+            subjects.append(
+                SituationSubjectReference(
+                    label_hint=label_hint,
+                    binding_method="reversible_label_hint",
+                    confidence="low",
+                    role_hints=roles,
+                    domain_hints=domains,
+                )
+            )
+    if (
+        bnl_self_subject_cue
+        and not any(subject.entity_ref == BNL01.key for subject in subjects)
+    ):
         subjects.append(
             SituationSubjectReference(
                 entity_ref=BNL01.key,
@@ -869,7 +918,11 @@ def build_situation_frame_v1(
                 domain_hints=("lore", "technical"),
             )
         )
-    elif len(speakers) == 1 and self_subject_cue:
+    if (
+        len(speakers) == 1
+        and self_subject_cue
+        and not any(subject.user_id == speakers[0] for subject in subjects)
+    ):
         subjects.append(
             SituationSubjectReference(
                 user_id=speakers[0],
@@ -903,7 +956,26 @@ def build_situation_frame_v1(
     if normalized_referent in {"ambiguous", "unresolved"}:
         ambiguity.append("referent_%s" % normalized_referent)
         competing.append("nearby_referent_candidates")
-    if len(subject_ids) > 1 or len(subjects) > 1:
+    referenced_subject_indexes = {
+        subject_index
+        for task in tasks
+        for subject_index in task.subject_indexes
+    }
+    incomplete_task_subject_scope = any(
+        task.subject_requirement == "required"
+        and not task.subject_indexes
+        for task in tasks
+    )
+    unscoped_subject_candidates = bool(
+        subjects
+        and set(range(len(subjects))) - referenced_subject_indexes
+    )
+    if len(subjects) > 8:
+        ambiguity.append("subject_candidate_limit_exceeded")
+        competing.append("subject_candidates")
+    if len(subjects) > 1 and (
+        incomplete_task_subject_scope or unscoped_subject_candidates
+    ):
         ambiguity.append("multiple_subject_candidates")
         competing.append("subject_candidates")
     if (

--- a/docs/one_packet_convergence_v1.md
+++ b/docs/one_packet_convergence_v1.md
@@ -1,10 +1,12 @@
 # One-Packet Convergence v1
 
-`unified_intelligence_packet_v9` is the single factual owner for gated broad
-self-profile synthesis and the separately gated ordinary-chat cutover. It consumes
-the immutable Situation Frame revision and resolves one governed subject
-before source scoring. It normalizes four canon statuses without moving their
-source authority:
+`unified_intelligence_packet_v10` is the single factual owner for gated broad
+self-profile synthesis and the separately gated ordinary-chat cutover. It
+consumes the immutable Situation Frame revision and resolves each governed
+task subject before source scoring. A true multi-subject ordinary request runs
+the existing single-subject path once per scoped subject and freezes those
+components into one composite packet. It normalizes four canon statuses
+without moving their source authority:
 
 - Legacy facts use the static canon adapter.
 - Declared claims require the effective broad-recall capability and a current
@@ -57,12 +59,13 @@ Specialized operational routes stay outside this cutover.
 
 For frame-backed turns, a stable Discord account binding outranks typed canon
 aliases; exact approved aliases may identify canon-only subjects but display
-labels remain reversible hints and never merge accounts. Multiple candidates,
-unseen label-only subjects, retired bindings, binding collisions, and changed
-bindings fail closed. Role, domain, event, task, phase, and currentness filters
-run before scoring. Relationship remains private tone-only context, and Source
-File snapshots remain internal unless their existing route contract authorizes
-them.
+labels remain reversible hints and never merge accounts. Multiple explicit
+subjects are accepted only when every candidate is bound to a frozen task;
+unscoped candidates, unseen label-only subjects, retired bindings, binding
+collisions, and changed bindings fail closed. Role, domain, event, task, phase,
+and currentness filters run before scoring. Relationship remains private
+tone-only context, and Source File snapshots remain internal unless their
+existing route contract authorizes them.
 
 `shared_brain_capability_receipt_v1` binds the broad-recall requested/effective state to the
 exact hashed scope, authority mode, packet, claim, assessment, identity, and
@@ -70,7 +73,7 @@ synthesis versions, prerequisites, conflicts, reason, and one kill switch. A
 scope, prerequisite, or version conflict fails closed. The owner-only preview
 adds content-free candidate/selected counts by canon status and domain plus the
 existing exclusion and root-collapse reasons. The independent ordinary-chat
-capability uses `shared_brain_synthesis_v10` content-free receipts with frame,
+capability uses `shared_brain_synthesis_v11` content-free receipts with frame,
 packet/source, selected lane/status/domain, provider/corrective call, guard,
 revalidation, typed task/support coverage, send, and fallback/block
 diagnostics. Its typed task contract is the single response-selection

--- a/docs/ordinary_chat_single_packet_canary_v1.md
+++ b/docs/ordinary_chat_single_packet_canary_v1.md
@@ -29,12 +29,19 @@ switch is `BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED`.
 
 ## One factual owner and one call
 
-The immutable Situation Frame and `unified_intelligence_packet_v9` are frozen
-before generation. The packet renderer supplies the sole BARCODE, member,
-identity, relationship, episode, publication, canon, and stored-history
-factual view. The current request and verified exact-reply/referent text remain
-task evidence. Persona, style, route behavior, and safety remain expression
-owners but cannot create facts.
+The immutable Situation Frame v3 and `unified_intelligence_packet_v10` are
+frozen before generation. The packet renderer supplies the sole BARCODE,
+member, identity, relationship, episode, publication, canon, and
+stored-history factual view. The current request and verified exact-reply or
+referent text remain task evidence. Persona, style, route behavior, and safety
+remain expression owners but cannot create facts.
+
+A true multi-subject request is still one governed packet and one provider
+attempt. Each frozen task names its required subject indexes. The packet runs
+the existing single-subject resolution and selection path once per referenced
+subject, then merges those immutable component packets into a task-scoped
+composite. An extra unscoped candidate, unresolved component, changed binding,
+or incomplete task-to-subject map fails closed before generation.
 
 The cutover prompt omits legacy conversation history, durable memory tiers,
 Relationship facts/counters, duplicate Broadcast/show/site/source blocks,
@@ -55,7 +62,9 @@ For an eligible turn:
 5. The provider must return one typed task/result envelope. Every task must
    appear exactly once and in order, with packet evidence identifiers, the
    stable-public `PUBLIC` marker, the current-request `REQUEST` marker, or an
-   explicit hold/clarify act as required by the frozen task.
+   explicit hold/clarify act as required by the frozen task. Packet answers
+   must cover every subject required by that task and cannot borrow another
+   task's subject evidence.
 6. A candidate is selected once at that typed boundary. It is not
    semantically reclassified by the legacy prose guard; independent packet,
    source, frame, control-leak, exact-quote, and delivery checks can still
@@ -81,7 +90,7 @@ owners are excluded before cutover rather than treated as a fallback.
 
 ## Content-free receipts
 
-`shared_brain_synthesis_v10` receipts retain only hashes, counts, bounded
+`shared_brain_synthesis_v11` receipts retain only hashes, counts, bounded
 statuses, and timing. Ordinary-chat rows include the frame revision and input
 digest, packet/source snapshot digests, selected lane/status/domain counts,
 prompt-applied state, provider and corrective call counts, candidate-selected
@@ -106,5 +115,5 @@ Rollback requires no database deletion:
 With the switch off, ordinary-chat prompt bytes and established generation
 behavior remain unchanged. Deployment and private live acceptance are separate
 operations: merge the complete PR sequence first, run the combined automated
-suite, then enable only the exact private scope for the approved acceptance
-matrix.
+suite and 60-case acceptance matrix, then enable only the exact private scope
+for the approved provider-shadow and owner acceptance runs.

--- a/tests/test_governed_subject_packet_v6.py
+++ b/tests/test_governed_subject_packet_v6.py
@@ -19,6 +19,7 @@ from bnl_unified_intelligence_packet import (
     IntelligencePacketItem,
     IntelligencePacketRequest,
     PacketConversationEvidence,
+    PacketFrameTask,
     PacketFrameSubject,
     PacketSubjectResolution,
     SCHEMA_VERSION,
@@ -91,6 +92,7 @@ class GovernedSubjectPacketV6Tests(unittest.TestCase):
         object_kind="person",
         phase="request",
         evidence=(),
+        tasks=(),
         budget_chars=2400,
     ):
         return IntelligencePacketRequest(
@@ -106,12 +108,13 @@ class GovernedSubjectPacketV6Tests(unittest.TestCase):
             direct_state="direct",
             budget_chars=budget_chars,
             conversation_evidence=tuple(evidence),
-            frame_schema_version="situation_frame_v1",
+            frame_schema_version="situation_frame_v3",
             frame_revision="sf_test_subject_01",
             frame_input_evidence_digest="a" * 64,
             frame_status=frame_status,
             frame_subject_requirement=requirement,
             frame_subjects=tuple(subjects),
+            frame_tasks=tuple(tasks),
             frame_role_hints=tuple(role_hints),
             frame_domain_hints=tuple(domain_hints),
             frame_event_relation="uncertain",
@@ -134,8 +137,8 @@ class GovernedSubjectPacketV6Tests(unittest.TestCase):
             reason="governed subject test binding",
         )
 
-    def test_packet_schema_is_v9_and_alias_matrix_stays_distinct(self):
-        self.assertEqual(SCHEMA_VERSION, "unified_intelligence_packet_v9")
+    def test_packet_schema_is_v10_and_alias_matrix_stays_distinct(self):
+        self.assertEqual(SCHEMA_VERSION, "unified_intelligence_packet_v10")
         cases = {
             "Who is Mac Mod3m?": ("mac_modem",),
             "Tell me about DJ Floppy Disc.": ("dj_floppydisc",),
@@ -217,6 +220,111 @@ class GovernedSubjectPacketV6Tests(unittest.TestCase):
             resolution.binding_method,
             "typed_canon_entity",
         )
+
+    def test_task_scoped_multi_subject_packet_resolves_each_subject_once(self):
+        request = self.request(
+            subjects=(
+                PacketFrameSubject(
+                    entity_ref="cache_back",
+                    label_hint="Cache Back",
+                    binding_method="existing_typed_entity",
+                ),
+                PacketFrameSubject(
+                    entity_ref="mac_modem",
+                    label_hint="Mac Modem",
+                    binding_method="existing_typed_entity",
+                ),
+            ),
+            tasks=(
+                PacketFrameTask(
+                    task_id="T1",
+                    text_digest="1" * 64,
+                    task_kind="answer",
+                    object_kind="person",
+                    authority_scope="packet",
+                    temporal_scope="unspecified",
+                    currentness="unknown",
+                    required_response_act="answer",
+                    subject_requirement="required",
+                    subject_indexes=(0, 1),
+                ),
+            ),
+            text="Compare Cache Back and Mac Modem.",
+            object_kind="person",
+        )
+
+        packet = build_packet(self.conn, request, environ=self.flags)
+
+        self.assertIsNotNone(packet)
+        self.assertEqual(packet.subject_resolution.status, "multi_resolved")
+        self.assertEqual(
+            tuple(
+                resolution.entity_ref
+                for resolution in packet.subject_resolutions
+            ),
+            ("cache_back", "mac_modem"),
+        )
+        self.assertEqual(len(packet.component_packets), 2)
+        selected_subjects = {
+            item.subject_key for item in packet.items if item.lane == "canon"
+        }
+        self.assertTrue({"cache_back", "mac_modem"}.issubset(selected_subjects))
+        self.assertEqual(packet.diagnostics.invalid_invariants, [])
+        self.assertTrue(
+            packet.diagnostics.revalidation_status.startswith("passed")
+        )
+
+        revalidation = revalidate_packet(
+            self.conn,
+            packet,
+            environ=self.flags,
+        )
+        self.assertTrue(revalidation.valid)
+        self.assertEqual(
+            revalidation.subject_resolution_status,
+            "multi_resolved",
+        )
+
+    def test_multi_subject_packet_rejects_duplicate_resolved_identity(self):
+        self.bind(222, "mac_modem", "subject-bind-nonce-multi-0001")
+        self.bind(223, "mac_modem", "subject-bind-nonce-multi-0002")
+        request = self.request(
+            subjects=(
+                PacketFrameSubject(
+                    user_id=222,
+                    binding_method="existing_typed_target",
+                ),
+                PacketFrameSubject(
+                    user_id=223,
+                    binding_method="existing_typed_target",
+                ),
+            ),
+            tasks=(
+                PacketFrameTask(
+                    task_id="T1",
+                    text_digest="2" * 64,
+                    task_kind="compare",
+                    object_kind="person",
+                    authority_scope="packet",
+                    temporal_scope="unspecified",
+                    currentness="unknown",
+                    required_response_act="answer",
+                    subject_requirement="required",
+                    subject_indexes=(0, 1),
+                ),
+            ),
+            text="Compare <@222> and <@223>.",
+        )
+
+        packet = build_packet(self.conn, request, environ=self.flags)
+
+        self.assertIsNotNone(packet)
+        self.assertNotEqual(
+            packet.subject_resolution.status,
+            "multi_resolved",
+        )
+        self.assertFalse(packet.component_packets)
+        self.assertFalse(packet.diagnostics.revalidation_status.startswith("passed"))
 
     def test_unseen_label_and_multiple_subjects_fail_closed(self):
         unseen = self.request(

--- a/tests/test_ordinary_chat_acceptance_contract_matrix.py
+++ b/tests/test_ordinary_chat_acceptance_contract_matrix.py
@@ -131,6 +131,100 @@ class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
                         )
                     )
 
+    def test_12_true_multi_subject_cases_bind_each_task_scope(self):
+        # name, request, ordered task subject entity keys
+        cases = (
+            (
+                "compare_cache_mac",
+                "Compare Cache Back and Mac Modem.",
+                (("cache_back", "mac_modem"),),
+            ),
+            (
+                "compare_dj_mac",
+                "Compare DJ Floppy Disc and Mac Mod3m.",
+                (("dj_floppydisc", "mac_modem"),),
+            ),
+            (
+                "cache_then_mac",
+                "Tell me about Cache Back, and tell me about Mac Modem.",
+                (("cache_back",), ("mac_modem",)),
+            ),
+            (
+                "cache_role_mac_role",
+                "What is Cache Back's role, and what is Mac Modem's role?",
+                (("cache_back",), ("mac_modem",)),
+            ),
+            (
+                "cache_who_mac_who",
+                "Who is Cache Back? Who is Mac Modem?",
+                (("cache_back",), ("mac_modem",)),
+            ),
+            (
+                "mac_then_dj",
+                "What do you know about Mac Modem, and what do you know "
+                "about DJ Floppy Disc?",
+                (("mac_modem",), ("dj_floppydisc",)),
+            ),
+            (
+                "six_bit_mac",
+                "Compare 6 Bit and Mac Modem.",
+                (("6_bit", "mac_modem"),),
+            ),
+            (
+                "bnl_six_bit",
+                "Compare BNL-01 and 6 Bit.",
+                (("6_bit", "bnl_01"),),
+            ),
+            (
+                "sheila_cliff",
+                "What is the difference between Sheila and Cliff?",
+                (("sheila", "cliff"),),
+            ),
+            (
+                "cache_six_bit",
+                "What is the relationship between Cache Back and 6 Bit?",
+                (("6_bit", "cache_back"),),
+            ),
+            (
+                "three_way",
+                "Compare Cache Back, Call'em Bini, and Mac Modem.",
+                (("cache_back", "mac_modem", "call_em_bini"),),
+            ),
+            (
+                "one_then_pair",
+                "Who is Cache Back? Compare Call'em Bini and Mac Modem.",
+                (("cache_back",), ("mac_modem", "call_em_bini")),
+            ),
+        )
+        self.assertEqual(len(cases), 12)
+
+        for name, text, expected_task_subjects in cases:
+            with self.subTest(name=name, text=text):
+                frame = _frame(text)
+                subject_keys = tuple(
+                    subject.entity_ref for subject in frame.subjects
+                )
+                actual_task_subjects = tuple(
+                    tuple(
+                        subject_keys[index]
+                        for index in task.subject_indexes
+                    )
+                    for task in frame.tasks
+                )
+
+                self.assertEqual(frame.status, "resolved")
+                self.assertEqual(
+                    actual_task_subjects,
+                    expected_task_subjects,
+                )
+                self.assertTrue(
+                    all(
+                        task.subject_requirement == "required"
+                        and task.required_response_act == "answer"
+                        for task in frame.tasks
+                    )
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -23,6 +23,7 @@ from bnl_shared_brain_synthesis import (
     ordinary_chat_route_scope_decision,
     parse_ordinary_chat_response_contract,
     record_single_packet_block,
+    render_packet_context,
     validate_ordinary_chat_response_contract,
 )
 from bnl_unified_intelligence_packet import (
@@ -319,6 +320,152 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             environ=self.flags,
         )
 
+    def _multi_subject_basis(self, text, subjects):
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            channel_policy="public_context",
+            current_text=text,
+            current_speaker_user_ids=(7,),
+            current_speaker_labels=("Test Member",),
+            addressee_kinds=("discord_mention",),
+            source_message_ids=(401,),
+            explicit_mention_count=1,
+            subject_label_hints=tuple(label for _key, label in subjects),
+            subject_entity_refs=tuple(key for key, _label in subjects),
+            referent_status="resolved",
+            response_act="answer",
+            packet_revision="turn_multi_subject_01",
+        )
+        self.assertEqual(frame.status, "resolved")
+        request = IntelligencePacketRequest(
+            guild_id=1,
+            subject_user_id=0,
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            channel_id=10,
+            channel_name="bnl-testing",
+            channel_policy="public_context",
+            visibility_allowance="public_safe",
+            user_text=text,
+            participant_user_ids=(7,),
+            direct_state="direct",
+            budget_chars=5000,
+            conversation_evidence=(
+                PacketConversationEvidence(
+                    text=text,
+                    speaker_user_id=7,
+                    speaker_label="Test Member",
+                    current_turn=True,
+                ),
+            ),
+            declared_canon_authorized=True,
+            frame_schema_version=frame.schema_version,
+            frame_revision=frame.frame_revision,
+            frame_input_evidence_digest=frame.input_evidence_digest,
+            frame_status=frame.status,
+            frame_subject_requirement=frame.subject_requirement,
+            frame_subjects=tuple(
+                PacketFrameSubject(
+                    user_id=subject.user_id,
+                    entity_ref=subject.entity_ref,
+                    label_hint=subject.label_hint,
+                    binding_method=subject.binding_method,
+                    confidence=subject.confidence,
+                    role_hints=subject.role_hints,
+                    domain_hints=subject.domain_hints,
+                )
+                for subject in frame.subjects
+            ),
+            frame_tasks=tuple(
+                PacketFrameTask(
+                    task_id=task.task_id,
+                    text_digest=task.text_digest,
+                    task_kind=task.task_kind,
+                    object_kind=task.object_kind,
+                    authority_scope=task.authority_scope,
+                    temporal_scope=task.temporal_scope,
+                    currentness=task.currentness,
+                    required_response_act=task.required_response_act,
+                    subject_requirement=task.subject_requirement,
+                    subject_indexes=task.subject_indexes,
+                )
+                for task in frame.tasks
+            ),
+            frame_role_hints=frame.role_hints,
+            frame_domain_hints=frame.domain_hints,
+            frame_event_ref=frame.event_ref,
+            frame_event_relation=frame.event_relation,
+            frame_task_kind=frame.task_kind,
+            frame_object_kind=frame.object_kind,
+            frame_phase=frame.phase,
+            frame_temporal_scope=frame.temporal_scope,
+            frame_currentness=frame.currentness,
+            now="2026-08-10T12:02:00+00:00",
+        )
+        packet = build_packet(
+            self.conn,
+            request,
+            persist=True,
+            environ=self.flags,
+        )
+        self.assertIsNotNone(packet)
+        self.assertEqual(packet.subject_resolution.status, "multi_resolved")
+        frame_revalidation = revalidate_situation_frame(
+            frame,
+            current_text=text,
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            channel_policy="public_context",
+            packet_source_snapshot_digest=packet.source_snapshot_digest,
+        )
+        profile = packet.profile_sufficiency
+        assessment = build_unified_response_assessment(
+            guild_id=1,
+            route_mode="normal_chat",
+            channel_policy="public_context",
+            conversation_surface="mention_or_reply",
+            current_speaker_user_ids=(7,),
+            participant_user_ids=(7,),
+            speaker_labels=("Test Member",),
+            current_exchange_source_ids=(),
+            governed_entry_ids=packet.governed_refs,
+            canon_refs=packet.canon_refs,
+            prompt_lanes=("current_exchange",),
+            current_text=text,
+            packet_selected_lanes=packet.assessment_lanes,
+            packet_excluded_lanes=packet.assessment_exclusions,
+            packet_conflict_reasons=packet.diagnostics.conflict_reasons,
+            packet_missing_lanes=packet.assessment_missing_lanes,
+            packet_revalidation_status=packet.diagnostics.revalidation_status,
+            profile_sufficiency_status=profile.status,
+            profile_sufficiency_met=profile.satisfied,
+            profile_required_point_count=profile.required_point_count,
+            profile_selected_point_count=profile.selected_point_count,
+            profile_independent_root_count=profile.independent_root_count,
+            profile_independent_occurrence_count=(
+                profile.independent_occurrence_count
+            ),
+            profile_sufficiency_reasons=profile.reason_codes,
+            situation_frame=frame,
+            frame_revalidation=frame_revalidation,
+        )
+        basis = build_ordinary_chat_basis(
+            guild_id=1,
+            user_id=7,
+            channel_id=10,
+            route_mode="normal_chat",
+            channel_policy="public_context",
+            current_direct=True,
+            user_text=text,
+            packet=packet,
+            assessment=assessment,
+            environ=self.flags,
+        )
+        self.assertIsNotNone(basis)
+        return basis
+
     def _basis_for_canon_entity(self, entity_key, label):
         entity_ref = "canon:%s" % entity_key
         packet = replace(
@@ -479,7 +626,12 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
     def test_typed_response_contract_accepts_only_applicable_packet_refs(self):
         evidence_id = next(
             evidence_id
-            for evidence_id, lane, _digest in self.basis.rendered_evidence_refs
+            for (
+                evidence_id,
+                lane,
+                _digest,
+                _subject_indexes,
+            ) in self.basis.rendered_evidence_refs
             if lane == "approved_fact"
         )
         contract = parse_ordinary_chat_response_contract(
@@ -547,6 +699,156 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                     decision.fallback_reason,
                     "typed_contract_%s" % expected,
                 )
+
+    def test_multi_subject_comparison_requires_support_for_every_subject(self):
+        basis = self._multi_subject_basis(
+            "Compare Cache Back and Mac Modem.",
+            (("cache_back", "Cache Back"), ("mac_modem", "Mac Modem")),
+        )
+        evidence_by_subject = {
+            subject_indexes: evidence_id
+            for (
+                evidence_id,
+                lane,
+                _digest,
+                subject_indexes,
+            ) in basis.rendered_evidence_refs
+            if lane == "canon" and len(subject_indexes) == 1
+        }
+        cache_evidence = evidence_by_subject[(0,)]
+        mac_evidence = evidence_by_subject[(1,)]
+        valid = parse_ordinary_chat_response_contract(
+            '{"tasks":[{"taskId":"T1","text":"Cache Back protects '
+            'archive continuity, while Mac Modem introduces unstable '
+            'distortions.","supportKind":"packet","evidenceIds":["%s",'
+            '"%s"]}]}' % (cache_evidence, mac_evidence)
+        )
+        incomplete = parse_ordinary_chat_response_contract(
+            '{"tasks":[{"taskId":"T1","text":"They differ.",'
+            '"supportKind":"packet","evidenceIds":["%s"]}]}'
+            % cache_evidence
+        )
+
+        self.assertTrue(
+            validate_ordinary_chat_response_contract(basis, valid).valid
+        )
+        self.assertEqual(
+            validate_ordinary_chat_response_contract(
+                basis,
+                incomplete,
+            ).status,
+            "packet_support_invalid",
+        )
+        prompt = build_packet_owned_prompt("Current request.", basis)
+        self.assertTrue(prompt.ready)
+        self.assertIn("subjects=S1,S2", prompt.prompt)
+
+    def test_multi_subject_render_reserves_evidence_for_each_subject(self):
+        basis = self._multi_subject_basis(
+            "Compare Cache Back and Mac Modem.",
+            (("cache_back", "Cache Back"), ("mac_modem", "Mac Modem")),
+        )
+        cache_item = next(
+            item
+            for item in basis.packet.items
+            if item.lane == "canon" and item.subject_key == "cache_back"
+        )
+        mac_item = next(
+            item
+            for item in basis.packet.items
+            if item.lane == "canon" and item.subject_key == "mac_modem"
+        )
+        dense_cache = tuple(
+            replace(
+                cache_item,
+                source_ref="dense-cache-%s" % index,
+                source_digest="%064x" % (index + 1),
+            )
+            for index in range(8)
+        )
+        dense_packet = replace(
+            basis.packet,
+            items=(*dense_cache, mac_item),
+        )
+
+        _rendered, _lanes, _count, source_digests = render_packet_context(
+            dense_packet,
+            max_items=4,
+        )
+
+        self.assertIn(mac_item.source_digest, source_digests)
+
+    def test_separate_subject_tasks_reject_cross_task_evidence(self):
+        basis = self._multi_subject_basis(
+            "Who is Cache Back? Who is Mac Modem?",
+            (("cache_back", "Cache Back"), ("mac_modem", "Mac Modem")),
+        )
+        evidence_by_subject = {
+            subject_indexes: evidence_id
+            for (
+                evidence_id,
+                lane,
+                _digest,
+                subject_indexes,
+            ) in basis.rendered_evidence_refs
+            if lane == "canon" and len(subject_indexes) == 1
+        }
+        crossed = parse_ordinary_chat_response_contract(
+            '{"tasks":['
+            '{"taskId":"T1","text":"Cache answer.","supportKind":'
+            '"packet","evidenceIds":["%s"]},'
+            '{"taskId":"T2","text":"Mac answer.","supportKind":'
+            '"packet","evidenceIds":["%s"]}'
+            ']}' % (evidence_by_subject[(1,)], evidence_by_subject[(0,)])
+        )
+
+        self.assertEqual(
+            validate_ordinary_chat_response_contract(
+                basis,
+                crossed,
+            ).status,
+            "packet_support_invalid",
+        )
+
+    def test_missing_one_comparison_subject_requires_a_hold(self):
+        basis = self._multi_subject_basis(
+            "Compare Cache Back and Call'em Bini.",
+            (
+                ("cache_back", "Cache Back"),
+                ("call_em_bini", "Call'em Bini"),
+            ),
+        )
+        cache_evidence = next(
+            evidence_id
+            for (
+                evidence_id,
+                lane,
+                _digest,
+                subject_indexes,
+            ) in basis.rendered_evidence_refs
+            if lane == "canon" and subject_indexes == (0,)
+        )
+        held = parse_ordinary_chat_response_contract(
+            '{"tasks":[{"taskId":"T1","text":"I do not have enough '
+            'selected evidence for both sides of that comparison.",'
+            '"supportKind":"hold","evidenceIds":[]}]}'
+        )
+        partial = parse_ordinary_chat_response_contract(
+            '{"tasks":[{"taskId":"T1","text":"They differ.",'
+            '"supportKind":"packet","evidenceIds":["%s"]}]}'
+            % cache_evidence
+        )
+
+        self.assertTrue(
+            validate_ordinary_chat_response_contract(basis, held).valid
+        )
+        self.assertEqual(
+            validate_ordinary_chat_response_contract(
+                basis,
+                partial,
+            ).status,
+            "packet_support_invalid",
+        )
 
     def test_typed_external_task_uses_public_not_packet_authority(self):
         external_packet = replace(
@@ -648,7 +950,12 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertTrue(run.prompt_applied)
         evidence_id = next(
             evidence_id
-            for evidence_id, lane, _digest in self.basis.rendered_evidence_refs
+            for (
+                evidence_id,
+                lane,
+                _digest,
+                _subject_indexes,
+            ) in self.basis.rendered_evidence_refs
             if lane == "approved_fact"
         )
         contract = parse_ordinary_chat_response_contract(

--- a/tests/test_situation_frame_v1.py
+++ b/tests/test_situation_frame_v1.py
@@ -172,6 +172,89 @@ class SituationFrameV1Tests(unittest.TestCase):
                     "existing_typed_entity",
                 )
 
+    def test_multiple_explicit_mentions_bind_to_one_task_without_ambiguity(self):
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text="Compare <@202> and <@303>.",
+            current_speaker_user_ids=(101,),
+            current_speaker_labels=("Test Member",),
+            subject_user_ids=(202, 303),
+            subject_label_hints=("First Member", "Second Member"),
+            response_act="answer",
+        )
+
+        self.assertEqual(frame.status, "resolved")
+        self.assertEqual(
+            tuple(subject.user_id for subject in frame.subjects),
+            (202, 303),
+        )
+        self.assertEqual(frame.tasks[0].subject_indexes, (0, 1))
+
+    def test_unscoped_second_candidate_still_fails_closed(self):
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text="Tell me about <@202>.",
+            current_speaker_user_ids=(101,),
+            subject_user_ids=(202, 303),
+            subject_label_hints=("First Member", "Second Member"),
+            response_act="answer",
+        )
+
+        self.assertEqual(frame.status, "ambiguous")
+        self.assertIn("multiple_subject_candidates", frame.ambiguity_reasons)
+
+    def test_more_than_eight_scoped_subjects_fails_closed(self):
+        subject_ids = tuple(range(201, 210))
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text="Compare %s."
+            % " and ".join("<@%s>" % user_id for user_id in subject_ids),
+            current_speaker_user_ids=(101,),
+            subject_user_ids=subject_ids,
+            response_act="answer",
+        )
+
+        self.assertEqual(frame.status, "ambiguous")
+        self.assertIn(
+            "subject_candidate_limit_exceeded",
+            frame.ambiguity_reasons,
+        )
+
+    def test_self_and_explicit_subjects_are_scoped_to_separate_tasks(self):
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text=(
+                "What do you remember about me, and who is <@202>?"
+            ),
+            current_speaker_user_ids=(101,),
+            current_speaker_labels=("Test Member",),
+            subject_user_ids=(202,),
+            subject_label_hints=("Other Member",),
+            response_act="answer",
+        )
+
+        self.assertEqual(frame.status, "resolved")
+        self.assertEqual(
+            tuple(subject.user_id for subject in frame.subjects),
+            (202, 101),
+        )
+        self.assertEqual(
+            tuple(task.subject_indexes for task in frame.tasks),
+            ((1,), (0,)),
+        )
+
     def test_publication_owner_qualifies_the_subject_of_the_question(self):
         cases = (
             "What did the Journal say about the last show?",


### PR DESCRIPTION
## What changed

- upgrades the immutable Situation Frame to v3 so true multi-subject requests are accepted only when every explicit subject is bound to an ordered task
- caps one turn at eight governed subjects; unscoped extras still fail closed before generation
- upgrades the Unified Intelligence Packet to v10 and resolves each task subject through the existing single-subject owner, then freezes those independently revalidated components into one composite packet
- rejects unresolved components and duplicate logical identities instead of comparing the same governed identity twice
- upgrades Shared Brain Synthesis to v11, labels rendered evidence with subject indexes, and requires every packet-backed task to cite applicable evidence for every subject in that task
- rejects cross-task subject citations and permits a no-reference hold only when one or more required subjects lack selected applicable evidence
- reserves rendered evidence for each resolved subject so a dense first profile cannot crowd later subjects out
- updates content-free receipts/report fallbacks and operator/convergence documentation

## Root cause

The prior contract correctly froze ordered tasks but intentionally treated every request with more than one governed subject as globally ambiguous. The packet also had one subject-resolution slot, and rendered evidence was lane-scoped rather than task-and-subject-scoped. Comparisons and separate questions about multiple known subjects therefore could not proceed without either guessing a global subject or weakening evidence ownership.

This change keeps the existing single-subject resolver and source adapters as the authority. It composes their frozen results per task and validates subject coverage at the one typed response-selection boundary.

## Safety and scope

- stacked on PR #437; merge PR #437 first
- ordinary-chat canary, packet shadow, and response-assessment shadow remain default-off
- no global Memory, Relationship, Active Engagement, queue, Journal, Relay, or deployment gate changes
- at most one provider attempt; no retry, corrective generation, or legacy model fallback
- unresolved, changed, over-limit, unscoped, or duplicate-identity subjects fail closed
- component and composite source snapshots are revalidated before selection and send
- receipts remain content-free; no prompt, evidence text, response text, participant ID, or source reference is persisted

## Qualification

- committed-tree repository gate: **2,249/2,249**
- focused frame/packet/synthesis/bot/shadow set: **216/216**
- combined acceptance matrix: **60/60** (48 PR1 authority/currentness cases + 12 true multi-subject cases)
- explicit duplicate-identity, over-eight-subject, missing-subject-evidence, cross-task-citation, and dense-first-subject regressions: green
- schema-staleness scan, compile gate, `git diff --check`, secret/privacy scan, and empty-environment gate audit: clean
- all **11** changed blob SHAs and complete tree `99a2ef22c128d7836e536ef12ad81992169212c7` match the locally tested commit
- remote branch is exactly one commit ahead and zero behind PR1, with exact file/stat parity

## Post-merge deployment and evidence (deferred)

1. Merge PR #437, then merge this PR. Deploy only the resulting `main` commit with `BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED=false`.
2. Capture the deployed commit SHA, restart BNL-01, and confirm ordinary chat reports requested/effective `off`, packet schema `unified_intelligence_packet_v10`, Situation Frame `situation_frame_v3`, and synthesis schema `shared_brain_synthesis_v11`.
3. In the sealed test scope only, run the 12-case multi-subject provider-shadow set: two direct comparisons, four separate-subject questions, the 6 Bit/Mac comparison, BNL-01/6 Bit comparison, Sheila/Cliff comparison, Cache Back/6 Bit relationship, the three-subject comparison, and the one-task-plus-pair case represented in the acceptance matrix.
4. Required evidence before owner testing: **12/12** resolved frames with exact task subject indexes; one distinct resolved component per subject; composite status `multi_resolved`; valid component and composite source revalidation; every answered task cites rendered evidence covering every required subject; zero cross-task citations; zero typed-contract violations; exactly one provider call for answer turns; zero retries/corrective calls/model fallback; and no Discord send for rejected contracts.
5. Confirm content-free receipts only, then disable the canary and restart. If any condition fails, keep it disabled and retain the failing content-free run IDs/statuses for diagnosis.
6. Only after that evidence is green, enable the exact approved private guild/user/channel scope for the owner acceptance prompts. Roll back immediately by setting `BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED=false` and restarting.
