### PR TITLE
Keep ordinary packets on generic identity queries

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -18018,6 +18018,51 @@ def _is_broadcast_memory_relevant(text: str) -> bool:
         "maintenance", "running joke", "status", "happening"
     ))
 
+
+def _broadcast_memory_requires_specialized_owner(text: str) -> bool:
+    """Keep explicit broadcast requests on the specialized owner.
+
+    Generic questions about a BARCODE person can still produce an entity match
+    in broadcast memory.  That match is supporting evidence, not user intent to
+    leave the ordinary-chat packet route.  Only language that actually asks
+    about the show, an episode, a broadcast, or its queue claims the specialized
+    broadcast owner.
+    """
+
+    normalized = re.sub(r"\s+", " ", str(text or "")).strip().lower()
+    if not normalized:
+        return False
+    if any(
+        phrase in normalized
+        for phrase in (
+            "barcode radio",
+            "broadcast memory",
+            "running joke",
+            "show status",
+            "show schedule",
+            "queue status",
+            "queue open",
+            "queue closed",
+            "submissions open",
+            "submissions closed",
+        )
+    ):
+        return True
+    if re.search(r"\b(?:broadcast|episode)\b", normalized):
+        return True
+    if re.search(r"\bshow\b", normalized) and not re.search(
+        r"\bshow\s+me\b",
+        normalized,
+    ):
+        return True
+    return bool(
+        re.search(r"\bqueue\b", normalized)
+        and re.search(
+            r"\b(?:radio|track|song|submission|open|closed|status)\b",
+            normalized,
+        )
+    )
+
 def _is_show_state_status_query(text: str) -> bool:
     t = (text or "").lower().strip()
     if not t:
@@ -32522,12 +32567,27 @@ def build_user_aware_prompt(
             "or claim exact wording. A Moment gist, memory tier, relationship note, "
             "summary, or prior BNL reply is never quote authority.\n"
         )
-    broadcast_context = build_broadcast_memory_context(
-        guild_id,
-        clean_content,
-        channel_policy,
-        is_owner_or_mod=prompt_operator_authority,
+    broadcast_specialized_owner = bool(
+        _broadcast_memory_requires_specialized_owner(clean_content)
     )
+    if ordinary_chat_single_packet and not broadcast_specialized_owner:
+        broadcast_context = ""
+        broadcast_entity_terms = extract_broadcast_memory_query_terms(
+            clean_content
+        )
+        if broadcast_entity_terms:
+            logging.info(
+                "broadcast_memory_context_skipped "
+                "reason=ordinary_chat_packet_owner terms=%s",
+                len(broadcast_entity_terms),
+            )
+    else:
+        broadcast_context = build_broadcast_memory_context(
+            guild_id,
+            clean_content,
+            channel_policy,
+            is_owner_or_mod=prompt_operator_authority,
+        )
     broadcast_prompt_block = ""
     if broadcast_context:
         broadcast_prompt_block = (
@@ -32557,7 +32617,7 @@ def build_user_aware_prompt(
     if community_visual_prompt_block:
         community_visual_prompt_block += "\n"
     specialized_owner_present = bool(
-        broadcast_context
+        (broadcast_context and broadcast_specialized_owner)
         or show_state_context
         or website_read_model_context
         or community_visual_prompt_block

--- a/tests/test_route_memory_governance.py
+++ b/tests/test_route_memory_governance.py
@@ -1131,6 +1131,38 @@ class MemoryPolicyGovernanceTests(unittest.TestCase):
 
 
 class MemoryInjectionGovernanceTests(unittest.TestCase):
+    def test_broadcast_owner_requires_explicit_broadcast_intent(self):
+        ordinary_identity_requests = (
+            (
+                "What do you know about Mac Modem, and what do you know "
+                "about DJ Floppy Disc?"
+            ),
+            "Compare 6 Bit and Mac Modem.",
+            "What is the difference between Sheila and Cliff?",
+            "Who is Cache Back? Who is Mac Modem?",
+        )
+        for text in ordinary_identity_requests:
+            with self.subTest(text=text):
+                self.assertFalse(
+                    bnl01_bot._broadcast_memory_requires_specialized_owner(
+                        text
+                    )
+                )
+
+        explicit_broadcast_requests = (
+            "What happened on the last BARCODE Radio episode?",
+            "What does broadcast memory say about DJ Floppy Disc?",
+            "Is the show schedule still active?",
+            "Is the track submission queue open?",
+        )
+        for text in explicit_broadcast_requests:
+            with self.subTest(text=text):
+                self.assertTrue(
+                    bnl01_bot._broadcast_memory_requires_specialized_owner(
+                        text
+                    )
+                )
+
     def test_simple_greeting_memory_context_is_skipped(self):
         context = bnl01_bot.build_user_memory_context(1, 1, route_mode=bnl01_bot.ROUTE_MODE_SIMPLE_GREETING, channel_policy="sealed_test")
         self.assertIn("skipped", context.lower())

--- a/tests/test_unified_response_assessment_bot_paths.py
+++ b/tests/test_unified_response_assessment_bot_paths.py
@@ -269,6 +269,129 @@ class UnifiedResponseAssessmentBotPathTests(unittest.TestCase):
             assessment.excluded_lanes,
         )
 
+    def test_incidental_broadcast_entity_match_keeps_ordinary_packet_owner(self):
+        text = (
+            "What do you know about Mac Modem, and what do you know "
+            "about DJ Floppy Disc?"
+        )
+        flags = {
+            "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+            "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+            "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+            "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+            "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED": "true",
+            "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED": "true",
+            "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_ENABLED": "false",
+            "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_ENABLED": "false",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED": "true",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_GUILD_IDS": "1",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_USER_IDS": "101",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_CHANNEL_IDS": "303",
+            "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
+            "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
+            "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+        }
+        packet = object()
+        assessment = SimpleNamespace()
+        ordinary_basis = object()
+        visual_basis = SimpleNamespace(status="not_requested")
+        assessment_calls = []
+
+        def assessment_builder(**kwargs):
+            assessment_calls.append(kwargs)
+            kwargs["intelligence_packet_out"]["packet"] = packet
+            return assessment
+
+        broadcast_builder = mock.Mock(
+            return_value=(
+                "Broadcast memory entity match:\n"
+                "- 2026-08-01 broadcast_memory_note: DJ Floppy Disc"
+            )
+        )
+        with (
+            mock.patch.dict(os.environ, flags, clear=False),
+            mock.patch.object(
+                bnl01_bot,
+                "get_user_profile",
+                return_value=("Member 1", ""),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "should_allow_greeting",
+                return_value=False,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "choose_response_style",
+                return_value=("balanced", "Respond naturally."),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_conversation_prompt_source_basis",
+                return_value=None,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_broadcast_memory_context",
+                new=broadcast_builder,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_community_visual_basis",
+                return_value=visual_basis,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "render_community_visual_basis_for_prompt",
+                return_value="",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_unified_response_assessment_shadow",
+                side_effect=assessment_builder,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_ordinary_chat_basis",
+                return_value=ordinary_basis,
+            ),
+        ):
+            metadata = {}
+            prompt, *_ = bnl01_bot.build_user_aware_prompt(
+                101,
+                1,
+                "Member 1",
+                text,
+                channel_name="bnl-testing",
+                channel_id=303,
+                channel_policy="sealed_test",
+                route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                is_direct_interaction=True,
+                prompt_metadata=metadata,
+            )
+
+        broadcast_builder.assert_not_called()
+        self.assertEqual(len(assessment_calls), 1)
+        self.assertFalse(
+            assessment_calls[0]["broadcast_memory_present"]
+        )
+        self.assertNotIn(
+            "broadcast_memory",
+            assessment_calls[0]["prompt_lanes"],
+        )
+        self.assertTrue(
+            metadata["ordinary_chat_single_packet_applied"]
+        )
+        self.assertIs(
+            metadata["ordinary_chat_single_packet_basis"],
+            ordinary_basis,
+        )
+        self.assertEqual(
+            metadata["ordinary_chat_single_packet_scope"].reason,
+            "eligible",
+        )
+        self.assertNotIn("Broadcast memory context:", prompt)
+
     def test_bot_recorder_persists_only_aggregate_receipt(self):
         with mock.patch.object(
             bnl01_bot,


### PR DESCRIPTION
## Root cause

The failed direct-reply turn was eligible for the ordinary-chat single-packet canary, but a generic BARCODE identity query also produced a broadcast-memory entity match. The prompt builder treated any broadcast context as a specialized owner, evicted the packet route, and sent the turn through the legacy Gemini path. That path then triggered cross-universe bleed correction and ended in a guarded generic non-answer, so Discord showed typing and received no response.

Observed production sequence:

- direct reply and sealed-test route accepted
- broadcast entity match loaded
- legacy `get_gemini_response`
- `cross_universe_bleed` corrective generation
- `continuation_mark_skipped reason=guard_fallback_or_generic_non_answer`
- no successful response send

## Fix

- Distinguish explicit broadcast/show/episode/queue intent from incidental entity matches.
- Keep ordinary identity/comparison questions on the ordinary packet owner.
- Preserve the specialized broadcast owner for explicit BARCODE Radio, broadcast-memory, show-state, episode, and queue requests.
- Log `broadcast_memory_context_skipped reason=ordinary_chat_packet_owner` when an incidental entity match is deliberately excluded.

## Regression coverage

The exact failed wording is covered end-to-end:

`What do you know about Mac Modem, and what do you know about DJ Floppy Disc?`

Additional coverage includes 6 Bit/Mac Modem, Sheila/Cliff, Cache Back/Mac Modem, and explicit broadcast/show/queue requests.

## Validation

- Focused and surrounding route suites: 210 tests passed.
- Full repository suite: 2,251 tests passed in 221.059s.
- `git diff --check`: clean.
- Published branch verified against the locally tested tree: exact parent, complete tree, three file blobs, and changed-file set all match.