### PR TITLE
Add bounded ordinary-chat scope expansion

### DIFF
--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -78,9 +78,12 @@ PUBLIC_HOME_OWNER_CHANNEL_IDS_ENV = (
 )
 ORDINARY_CHAT_CAPABILITY_NAME = "ordinary_chat_single_packet_canary"
 ORDINARY_CHAT_CAPABILITY_CONTRACT_VERSION = (
-    "ordinary_chat_single_packet_v3"
+    "ordinary_chat_single_packet_v4"
 )
 ORDINARY_CHAT_ENABLED_ENV = "BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED"
+ORDINARY_CHAT_SCOPED_EXPANSION_ENABLED_ENV = (
+    "BNL_ORDINARY_CHAT_SINGLE_PACKET_SCOPED_EXPANSION_ENABLED"
+)
 ORDINARY_CHAT_GUILD_IDS_ENV = (
     "BNL_ORDINARY_CHAT_SINGLE_PACKET_GUILD_IDS"
 )
@@ -104,8 +107,10 @@ _MAX_SCOPED_USERS = 8
 _MAX_SCOPED_CHANNELS = 4
 _MAX_PUBLIC_HOME_OWNER_CHANNELS = 1
 _MAX_ORDINARY_CHAT_GUILDS = 1
-_MAX_ORDINARY_CHAT_USERS = 1
-_MAX_ORDINARY_CHAT_CHANNELS = 1
+_PRIVATE_ORDINARY_CHAT_USERS = 1
+_PRIVATE_ORDINARY_CHAT_CHANNELS = 1
+_MAX_ORDINARY_CHAT_SCOPED_USERS = 8
+_MAX_ORDINARY_CHAT_SCOPED_CHANNELS = 4
 _LIVE_GATES = (
     "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED",
     "BNL_RELATIONSHIP_V2_LIVE_ENABLED",
@@ -1594,9 +1599,12 @@ def configuration(
 def _ordinary_chat_configuration_details(
     environ: Mapping[str, str],
 ) -> dict[str, Any]:
-    """Resolve the exact one-guild/user/channel ordinary-chat authority."""
+    """Resolve private or explicitly expanded ordinary-chat authority."""
 
     requested = _flag(environ.get(ORDINARY_CHAT_ENABLED_ENV, ""))
+    scoped_expansion_requested = _flag(
+        environ.get(ORDINARY_CHAT_SCOPED_EXPANSION_ENABLED_ENV, "")
+    )
     guilds = _positive_ids(environ.get(ORDINARY_CHAT_GUILD_IDS_ENV, ""))
     users = _positive_ids(environ.get(ORDINARY_CHAT_USER_IDS_ENV, ""))
     channels = _positive_ids(
@@ -1607,10 +1615,22 @@ def _ordinary_chat_configuration_details(
         or _flag(environ.get(PUBLIC_HOME_OWNER_ENABLED_ENV, ""))
     )
     scope_present = bool(guilds and users and channels)
+    expanded_scope_present = bool(
+        len(users) > _PRIVATE_ORDINARY_CHAT_USERS
+        or len(channels) > _PRIVATE_ORDINARY_CHAT_CHANNELS
+    )
     scope_within_limits = bool(
         len(guilds) == _MAX_ORDINARY_CHAT_GUILDS
-        and len(users) == _MAX_ORDINARY_CHAT_USERS
-        and len(channels) == _MAX_ORDINARY_CHAT_CHANNELS
+        and 1 <= len(users) <= _MAX_ORDINARY_CHAT_SCOPED_USERS
+        and 1 <= len(channels) <= _MAX_ORDINARY_CHAT_SCOPED_CHANNELS
+    )
+    expansion_authorized = bool(
+        not expanded_scope_present or scoped_expansion_requested
+    )
+    scope_mode = (
+        "bounded_expansion"
+        if expanded_scope_present
+        else "private_acceptance"
     )
     packet_ready = packet_shadow_enabled(environ)
     assessment_ready = assessment_shadow_enabled(environ)
@@ -1643,7 +1663,12 @@ def _ordinary_chat_configuration_details(
     prerequisites_ready = bool(
         packet_ready and assessment_ready and not version_conflicts
     )
-    fully_scoped = bool(requested and scope_present and scope_within_limits)
+    fully_scoped = bool(
+        requested
+        and scope_present
+        and scope_within_limits
+        and expansion_authorized
+    )
     effective = bool(
         fully_scoped
         and prerequisites_ready
@@ -1654,6 +1679,12 @@ def _ordinary_chat_configuration_details(
         reason = "disabled"
     elif scope_present and not scope_within_limits:
         reason = "scope_limit_exceeded"
+    elif (
+        scope_present
+        and expanded_scope_present
+        and not scoped_expansion_requested
+    ):
+        reason = "scoped_expansion_not_enabled"
     elif not fully_scoped:
         reason = "scope_incomplete"
     elif comparison_authority_requested:
@@ -1668,6 +1699,14 @@ def _ordinary_chat_configuration_details(
         reason = ORDINARY_CHAT_AUTHORITY
     return {
         "requested": requested,
+        "scoped_expansion_requested": scoped_expansion_requested,
+        "scoped_expansion_effective": bool(
+            effective
+            and expanded_scope_present
+            and scoped_expansion_requested
+        ),
+        "expanded_scope_present": expanded_scope_present,
+        "scope_mode": scope_mode,
         "effective": effective,
         "reason": reason,
         "authority_mode": ORDINARY_CHAT_AUTHORITY,
@@ -1676,6 +1715,7 @@ def _ordinary_chat_configuration_details(
         "channels": channels,
         "channel_policies": _ORDINARY_CHAT_CHANNEL_POLICIES,
         "scope_present": scope_present,
+        "scope_within_limits": scope_within_limits,
         "fully_scoped": fully_scoped,
         "packet_ready": packet_ready,
         "assessment_ready": assessment_ready,
@@ -1686,7 +1726,9 @@ def _ordinary_chat_configuration_details(
         "comparison_authority_requested": comparison_authority_requested,
         "scope_digest": (
             _digest(
-                "ordinary_chat_single_packet_scope_v1",
+                "ordinary_chat_single_packet_scope_v2",
+                scope_mode,
+                scoped_expansion_requested,
                 tuple(sorted(guilds)),
                 tuple(sorted(users)),
                 tuple(sorted(channels)),
@@ -1723,6 +1765,14 @@ def ordinary_chat_configuration(
         "capability": ORDINARY_CHAT_CAPABILITY_NAME,
         "contract_version": ORDINARY_CHAT_CAPABILITY_CONTRACT_VERSION,
         "configured_enabled": details["requested"],
+        "scoped_expansion_configured_enabled": details[
+            "scoped_expansion_requested"
+        ],
+        "scoped_expansion_effective": details[
+            "scoped_expansion_effective"
+        ],
+        "expanded_scope_present": details["expanded_scope_present"],
+        "scope_mode": details["scope_mode"],
         "effective": details["effective"],
         "reason": details["reason"],
         "authority_mode": ORDINARY_CHAT_AUTHORITY,
@@ -1739,6 +1789,14 @@ def ordinary_chat_configuration(
         "conflicts": conflicts,
         "scope_digest": details["scope_digest"],
         "kill_switch_env": ORDINARY_CHAT_ENABLED_ENV,
+        "expansion_gate_env": (
+            ORDINARY_CHAT_SCOPED_EXPANSION_ENABLED_ENV
+        ),
+        "max_scoped_guilds": _MAX_ORDINARY_CHAT_GUILDS,
+        "private_user_count": _PRIVATE_ORDINARY_CHAT_USERS,
+        "private_channel_count": _PRIVATE_ORDINARY_CHAT_CHANNELS,
+        "max_scoped_users": _MAX_ORDINARY_CHAT_SCOPED_USERS,
+        "max_scoped_channels": _MAX_ORDINARY_CHAT_SCOPED_CHANNELS,
         "provider_call_limit": 1,
         "corrective_call_limit": 0,
     }

--- a/docs/one_packet_convergence_v1.md
+++ b/docs/one_packet_convergence_v1.md
@@ -80,6 +80,14 @@ diagnostics. Its typed task contract is the single response-selection
 boundary; later checks can block changed source, frame, control, quote, or
 delivery state but do not reclassify the selected prose.
 
+The ordinary-chat contract defaults to the accepted one-guild, one-user,
+one-channel private scope. Multi-user or multi-channel rollout requires the
+independent scoped-expansion gate and remains capped at one guild, eight
+explicit users, and four explicit channels. Additional IDs without that gate,
+missing allowlists, or any over-limit scope fail closed before prompt
+construction. The scope digest binds both the authorization mode and exact
+allowlists without exposing their IDs.
+
 All gates remain default-off. The ordinary-chat route permits one provider
 attempt, zero retries, no model fallback, and no corrective generation. This
 version performs no deployment, historical

--- a/docs/ordinary_chat_single_packet_canary_v1.md
+++ b/docs/ordinary_chat_single_packet_canary_v1.md
@@ -1,11 +1,13 @@
-# Ordinary-Chat Single-Packet Canary v1
+# Ordinary-Chat Single-Packet Canary and Scoped Expansion
 
-This capability cuts one exact ordinary-chat scope over to a single factual
-prompt owner and a single provider attempt. It is disabled by default and is
-separate from the broad-profile comparison canary and public-home recall
-owner.
+This capability cuts an explicitly bounded ordinary-chat scope over to a
+single factual prompt owner and a single provider attempt. It is disabled by
+default and is separate from the broad-profile comparison canary and
+public-home recall owner. The default remains the original private acceptance
+scope; contract v4 adds a second gate for controlled multi-user or
+multi-channel expansion.
 
-## Exact default-off scope
+## Default-off private acceptance scope
 
 All four values are required:
 
@@ -14,18 +16,47 @@ All four values are required:
 - `BNL_ORDINARY_CHAT_SINGLE_PACKET_USER_IDS=<one user id>`
 - `BNL_ORDINARY_CHAT_SINGLE_PACKET_CHANNEL_IDS=<one channel id>`
 
-The three allowlists must each contain exactly one positive ID. The route is
-limited to direct, text-only `normal_chat` turns in `sealed_test`,
-`public_home`, or `public_context`. Direct-payload tasks, simple greetings,
-show/status answers, media turns, commands, Journal/Relay controls, website
-read-model answers, Broadcast-memory answers, and community-visual owners
-stay on their established routes.
+Without the scoped-expansion gate, the three allowlists must each contain
+exactly one positive ID. Additional user or channel IDs fail closed with
+`scoped_expansion_not_enabled`; deploying contract v4 without changing the
+environment therefore preserves the accepted private routing and prompt-owner
+behavior.
+
+The route is limited to direct, text-only `normal_chat` turns in
+`sealed_test`, `public_home`, or `public_context`. Direct-payload tasks, simple
+greetings, show/status answers, media turns, commands, Journal/Relay controls,
+website read-model answers, Broadcast-memory answers, and community-visual
+owners stay on their established routes.
 
 The capability fails closed when packet or response-assessment shadows are
 unavailable, a prerequisite schema version differs, a global Memory
 Governance/Relationship/Active Engagement live gate is active, or either
 older shared-brain synthesis authority is requested. Its independent rollback
 switch is `BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED`.
+
+## Separately gated bounded expansion
+
+Expanding beyond the private acceptance scope additionally requires:
+
+- `BNL_ORDINARY_CHAT_SINGLE_PACKET_SCOPED_EXPANSION_ENABLED=true`
+
+The expanded contract remains limited to:
+
+- exactly one guild;
+- one to eight explicitly allowlisted users; and
+- one to four explicitly allowlisted channels.
+
+The expansion gate never supplies or infers IDs. An empty allowlist remains
+incomplete, more than one guild or an over-limit user/channel list fails with
+`scope_limit_exceeded`, and a non-allowlisted request still fails before prompt
+construction or provider use. The primary ordinary-chat kill switch, global
+live-gate conflicts, specialized-owner exclusions, one-provider-call limit,
+and zero-corrective-call limit are unchanged.
+
+Content-free configuration diagnostics expose the private or
+`bounded_expansion` scope mode, allowlist counts, hard caps, expansion-gate
+state, expansion-effective state, and a scope digest that changes when either
+the allowlists or expansion authorization changes. IDs are not exposed.
 
 ## One factual owner and one call
 
@@ -106,14 +137,32 @@ independent kill switch.
 
 ## Rollback and acceptance order
 
-Rollback requires no database deletion:
+Full rollback requires no database deletion:
 
 1. Set `BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED=false` or remove it.
 2. Restart the bot.
 3. Confirm the ordinary-chat capability is requested/effective `off`.
+
+Expansion-only rollback keeps the accepted private canary available:
+
+1. Restore exactly one approved user and one approved channel in the
+   allowlists.
+2. Set
+   `BNL_ORDINARY_CHAT_SINGLE_PACKET_SCOPED_EXPANSION_ENABLED=false` or remove
+   it in the same environment edit.
+3. Restart the bot and confirm `scope_mode=private_acceptance`,
+   `scoped_expansion_effective=false`, and ordinary-chat effective `on`.
 
 With the switch off, ordinary-chat prompt bytes and established generation
 behavior remain unchanged. Deployment and private live acceptance are separate
 operations: merge the complete PR sequence first, run the combined automated
 suite and 60-case acceptance matrix, then enable only the exact private scope
 for the approved provider-shadow and owner acceptance runs.
+
+After private acceptance passes, deploy contract v4 with the expansion gate
+absent or false and confirm the existing private scope remains effective. Then
+enable expansion for one additional approved user in the already accepted
+channel. Validate one ordinary multi-subject turn and one explicit specialized
+Broadcast-memory turn before adding another user or any channel. Expand one
+dimension at a time; do not enable the global Memory Governance, Relationship,
+or Active Engagement live gates during this rollout.

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -11,6 +11,7 @@ import bnl_relationship_engine as relationships
 from bnl_shared_brain_synthesis import (
     ORDINARY_CHAT_AUTHORITY,
     ORDINARY_CHAT_ROUTE_FAMILY,
+    ORDINARY_CHAT_SCOPED_EXPANSION_ENABLED_ENV,
     audit_ordinary_chat_candidate_claims,
     begin_single_packet_run,
     build_evaluation_report,
@@ -496,7 +497,7 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         )
         return replace(self.basis, packet=packet)
 
-    def test_configuration_is_default_off_exact_scope_and_conflict_closed(self):
+    def test_configuration_is_default_off_private_scope_and_conflict_closed(self):
         disabled = ordinary_chat_configuration(
             {
                 **self.flags,
@@ -508,6 +509,21 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
 
         configured = ordinary_chat_configuration(self.flags)
         self.assertTrue(configured["effective"])
+        self.assertEqual(
+            configured["contract_version"],
+            "ordinary_chat_single_packet_v4",
+        )
+        self.assertEqual(configured["scope_mode"], "private_acceptance")
+        self.assertFalse(
+            configured["scoped_expansion_configured_enabled"]
+        )
+        self.assertFalse(configured["scoped_expansion_effective"])
+        self.assertFalse(configured["expanded_scope_present"])
+        self.assertEqual(configured["max_scoped_guilds"], 1)
+        self.assertEqual(configured["private_user_count"], 1)
+        self.assertEqual(configured["private_channel_count"], 1)
+        self.assertEqual(configured["max_scoped_users"], 8)
+        self.assertEqual(configured["max_scoped_channels"], 4)
         self.assertEqual(configured["provider_call_limit"], 1)
         self.assertEqual(configured["corrective_call_limit"], 0)
         self.assertEqual(
@@ -515,14 +531,36 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             "BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED",
         )
 
-        expanded = ordinary_chat_configuration(
+        expanded_without_gate = ordinary_chat_configuration(
             {
                 **self.flags,
                 "BNL_ORDINARY_CHAT_SINGLE_PACKET_USER_IDS": "7,8",
             }
         )
-        self.assertFalse(expanded["effective"])
-        self.assertEqual(expanded["reason"], "scope_limit_exceeded")
+        self.assertFalse(expanded_without_gate["effective"])
+        self.assertTrue(expanded_without_gate["expanded_scope_present"])
+        self.assertEqual(
+            expanded_without_gate["reason"],
+            "scoped_expansion_not_enabled",
+        )
+        blocked_expansion = ordinary_chat_route_scope_decision(
+            guild_id=1,
+            user_id=8,
+            channel_id=10,
+            route_mode="normal_chat",
+            channel_policy="public_context",
+            current_direct=True,
+            user_text=self.text,
+            environ={
+                **self.flags,
+                "BNL_ORDINARY_CHAT_SINGLE_PACKET_USER_IDS": "7,8",
+            },
+        )
+        self.assertFalse(blocked_expansion.eligible)
+        self.assertEqual(
+            blocked_expansion.reason,
+            "configuration_scoped_expansion_not_enabled",
+        )
 
         conflicting = ordinary_chat_configuration(
             {
@@ -534,6 +572,158 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertEqual(
             conflicting["reason"],
             "comparison_authority_conflict",
+        )
+
+    def test_bounded_expansion_requires_its_gate_and_stays_capped(self):
+        expanded_flags = {
+            **self.flags,
+            ORDINARY_CHAT_SCOPED_EXPANSION_ENABLED_ENV: "true",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_USER_IDS": "7,8",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_CHANNEL_IDS": "10,11",
+        }
+        expanded = ordinary_chat_configuration(expanded_flags)
+
+        self.assertTrue(expanded["effective"])
+        self.assertEqual(expanded["reason"], ORDINARY_CHAT_AUTHORITY)
+        self.assertEqual(expanded["scope_mode"], "bounded_expansion")
+        self.assertTrue(expanded["scoped_expansion_configured_enabled"])
+        self.assertTrue(expanded["scoped_expansion_effective"])
+        self.assertTrue(expanded["expanded_scope_present"])
+        self.assertEqual(expanded["guild_allowlist_count"], 1)
+        self.assertEqual(expanded["user_allowlist_count"], 2)
+        self.assertEqual(expanded["channel_allowlist_count"], 2)
+        self.assertEqual(
+            expanded["expansion_gate_env"],
+            ORDINARY_CHAT_SCOPED_EXPANSION_ENABLED_ENV,
+        )
+        reordered = ordinary_chat_configuration(
+            {
+                **expanded_flags,
+                "BNL_ORDINARY_CHAT_SINGLE_PACKET_USER_IDS": "8,7",
+                "BNL_ORDINARY_CHAT_SINGLE_PACKET_CHANNEL_IDS": "11,10",
+            }
+        )
+        self.assertEqual(reordered["scope_digest"], expanded["scope_digest"])
+
+        for user_id in (7, 8):
+            for channel_id in (10, 11):
+                with self.subTest(
+                    user_id=user_id,
+                    channel_id=channel_id,
+                ):
+                    decision = ordinary_chat_route_scope_decision(
+                        guild_id=1,
+                        user_id=user_id,
+                        channel_id=channel_id,
+                        route_mode="normal_chat",
+                        channel_policy="public_context",
+                        current_direct=True,
+                        user_text=self.text,
+                        environ=expanded_flags,
+                    )
+                    self.assertTrue(decision.eligible)
+
+        for override, reason in (
+            ({"user_id": 9}, "user_not_allowlisted"),
+            ({"channel_id": 12}, "channel_not_allowlisted"),
+            ({"guild_id": 2}, "guild_not_allowlisted"),
+        ):
+            with self.subTest(reason=reason):
+                common = {
+                    "guild_id": 1,
+                    "user_id": 7,
+                    "channel_id": 10,
+                    "route_mode": "normal_chat",
+                    "channel_policy": "public_context",
+                    "current_direct": True,
+                    "user_text": self.text,
+                    "environ": expanded_flags,
+                }
+                decision = ordinary_chat_route_scope_decision(
+                    **{**common, **override}
+                )
+                self.assertFalse(decision.eligible)
+                self.assertEqual(decision.reason, reason)
+
+        oversized_users = ordinary_chat_configuration(
+            {
+                **expanded_flags,
+                "BNL_ORDINARY_CHAT_SINGLE_PACKET_USER_IDS": ",".join(
+                    str(value) for value in range(1, 10)
+                ),
+            }
+        )
+        self.assertFalse(oversized_users["effective"])
+        self.assertEqual(
+            oversized_users["reason"],
+            "scope_limit_exceeded",
+        )
+
+        oversized_channels = ordinary_chat_configuration(
+            {
+                **expanded_flags,
+                "BNL_ORDINARY_CHAT_SINGLE_PACKET_CHANNEL_IDS": (
+                    "10,11,12,13,14"
+                ),
+            }
+        )
+        self.assertFalse(oversized_channels["effective"])
+        self.assertEqual(
+            oversized_channels["reason"],
+            "scope_limit_exceeded",
+        )
+
+        oversized_guilds = ordinary_chat_configuration(
+            {
+                **expanded_flags,
+                "BNL_ORDINARY_CHAT_SINGLE_PACKET_GUILD_IDS": "1,2",
+            }
+        )
+        self.assertFalse(oversized_guilds["effective"])
+        self.assertEqual(
+            oversized_guilds["reason"],
+            "scope_limit_exceeded",
+        )
+
+        maximum_scope = ordinary_chat_configuration(
+            {
+                **expanded_flags,
+                "BNL_ORDINARY_CHAT_SINGLE_PACKET_USER_IDS": ",".join(
+                    str(value) for value in range(1, 9)
+                ),
+                "BNL_ORDINARY_CHAT_SINGLE_PACKET_CHANNEL_IDS": (
+                    "10,11,12,13"
+                ),
+            }
+        )
+        self.assertTrue(maximum_scope["effective"])
+        self.assertEqual(maximum_scope["user_allowlist_count"], 8)
+        self.assertEqual(maximum_scope["channel_allowlist_count"], 4)
+
+    def test_expansion_gate_alone_does_not_expand_private_scope(self):
+        expanded_gate_only = ordinary_chat_configuration(
+            {
+                **self.flags,
+                ORDINARY_CHAT_SCOPED_EXPANSION_ENABLED_ENV: "true",
+            }
+        )
+        private = ordinary_chat_configuration(self.flags)
+
+        self.assertTrue(expanded_gate_only["effective"])
+        self.assertEqual(
+            expanded_gate_only["scope_mode"],
+            "private_acceptance",
+        )
+        self.assertTrue(
+            expanded_gate_only["scoped_expansion_configured_enabled"]
+        )
+        self.assertFalse(
+            expanded_gate_only["scoped_expansion_effective"]
+        )
+        self.assertFalse(expanded_gate_only["expanded_scope_present"])
+        self.assertNotEqual(
+            expanded_gate_only["scope_digest"],
+            private["scope_digest"],
         )
 
     def test_scope_excludes_wrong_identity_media_and_specialized_routes(self):

--- a/tests/test_unified_response_assessment_bot_paths.py
+++ b/tests/test_unified_response_assessment_bot_paths.py
@@ -269,7 +269,7 @@ class UnifiedResponseAssessmentBotPathTests(unittest.TestCase):
             assessment.excluded_lanes,
         )
 
-    def test_incidental_broadcast_entity_match_keeps_ordinary_packet_owner(self):
+    def test_expanded_second_user_keeps_ordinary_packet_owner(self):
         text = (
             "What do you know about Mac Modem, and what do you know "
             "about DJ Floppy Disc?"
@@ -284,8 +284,12 @@ class UnifiedResponseAssessmentBotPathTests(unittest.TestCase):
             "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_ENABLED": "false",
             "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_ENABLED": "false",
             "BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED": "true",
+            (
+                "BNL_ORDINARY_CHAT_SINGLE_PACKET_"
+                "SCOPED_EXPANSION_ENABLED"
+            ): "true",
             "BNL_ORDINARY_CHAT_SINGLE_PACKET_GUILD_IDS": "1",
-            "BNL_ORDINARY_CHAT_SINGLE_PACKET_USER_IDS": "101",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_USER_IDS": "101,202",
             "BNL_ORDINARY_CHAT_SINGLE_PACKET_CHANNEL_IDS": "303",
             "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
             "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
@@ -358,9 +362,9 @@ class UnifiedResponseAssessmentBotPathTests(unittest.TestCase):
         ):
             metadata = {}
             prompt, *_ = bnl01_bot.build_user_aware_prompt(
-                101,
+                202,
                 1,
-                "Member 1",
+                "Member 2",
                 text,
                 channel_name="bnl-testing",
                 channel_id=303,


### PR DESCRIPTION
## Summary

- preserve the accepted one-guild / one-user / one-channel private ordinary-chat canary as the default
- add a separate default-off scoped-expansion gate for one guild, up to eight explicit users, and up to four explicit channels
- fail closed when extra IDs are configured without the expansion gate, when a scope is incomplete, or when a hard cap is exceeded
- expose only counts, caps, scope mode, gate state, and an authorization-bound scope digest in diagnostics
- keep specialized-owner exclusions, one provider call, zero corrective calls, and all global live-gate conflicts unchanged
- cover the exact Mac Modem / DJ Floppy Disc regression for a second allowlisted user

## Validation

- focused ordinary-chat and owner-routing tests: 212 passed
- post-adjustment focused tests: 51 passed
- full suite: 2,253 passed
- `git diff --check`: clean
- remote tree `c1a6e44126a904231162ac7b0a05ebe1c25b3591` exactly matches the locally tested tree

## Rollout

Deploy the code with `BNL_ORDINARY_CHAT_SINGLE_PACKET_SCOPED_EXPANSION_ENABLED` absent or false and the existing private allowlists unchanged. After inert deployment evidence passes, add exactly one approved second user in the existing channel and enable the expansion gate atomically. Validate one ordinary multi-subject prompt and one explicit Broadcast-memory prompt before any further expansion.