### PR TITLE
Repair ordinary chat shared-brain canary

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -436,6 +436,7 @@ from bnl_website_relay_state import (
     save_pending_v2_publication as relay_save_pending_v2_publication,
     clear_pending_v2_publication as relay_clear_pending_v2_publication,
     normalize_text as relay_normalize_text,
+    relay_publication_query_mode,
     recent_history as relay_recent_history,
     reject_reason_for_candidate as relay_reject_reason_for_candidate,
     stock_directive_reason as relay_stock_directive_reason,
@@ -1958,6 +1959,8 @@ def is_bnl_read_model_relevant(text: str, channel_policy: str = "") -> bool:
     normalized = (text or "").lower()
     if not normalized.strip():
         return False
+    if _current_queue_state_query(normalized):
+        return True
 
     explicit_site_patterns = [
         r"\b(read model|website read model|public read model)\b",
@@ -2286,6 +2289,15 @@ def maybe_build_bnl_read_model_context(user_text: str, channel_policy: str) -> s
         return ""
     read_model = fetch_bnl_read_model()
     if not read_model:
+        return ""
+    if (
+        _current_queue_state_query(user_text)
+        and not queue_usability(read_model)["usable"]
+    ):
+        logging.info(
+            "bnl_read_model_context_skipped "
+            "reason=current_queue_owner_unavailable"
+        )
         return ""
     return build_bnl_read_model_context(read_model, user_text, channel_policy)
 
@@ -17849,6 +17861,89 @@ def get_latest_broadcast_episode_date(guild_id: int, public_only: bool = False, 
     return row[0] if row and row[0] else None
 
 
+def _broadcast_historical_recency_query(text: str) -> bool:
+    normalized = re.sub(r"\s+", " ", str(text or "")).strip().lower()
+    return bool(
+        re.search(
+            r"\b(?:last|latest|newest|most\s+recent)\s+"
+            r"(?:(?:barcode\s+radio|radio)\s+)?"
+            r"(?:show|episode|broadcast)\b",
+            normalized,
+        )
+    )
+
+
+def get_latest_eligible_broadcast_episode_entries(
+    guild_id: int,
+    *,
+    public_only: bool = True,
+    limit: int = 5,
+) -> list[dict]:
+    """Read eligible evidence from exactly one newest completed episode."""
+
+    today = datetime.now(PACIFIC_TZ).date().isoformat()
+    conn = sqlite3.connect(DB_FILE)
+    try:
+        newest_row = conn.execute(
+            """
+            SELECT date(episode_date)
+            FROM broadcast_memory
+            WHERE guild_id=?
+              AND TRIM(COALESCE(cleaned_summary,''))<>''
+              AND entry_type<>'show_state_override'
+              AND date(episode_date) IS NOT NULL
+              AND date(episode_date)<date(?)
+            ORDER BY date(episode_date) DESC,id DESC
+            LIMIT 1
+            """,
+            (int(guild_id or 0), today),
+        ).fetchone()
+        if not newest_row or not str(newest_row[0] or "").strip():
+            return []
+        selected_date = str(newest_row[0])
+        query = """
+            SELECT id, episode_date, cleaned_summary, entry_type,
+                   importance, public_safe, usage_scope
+            FROM broadcast_memory
+            WHERE guild_id=? AND status='active'
+              AND TRIM(COALESCE(cleaned_summary,''))<>''
+              AND entry_type<>'show_state_override'
+              AND COALESCE(superseded_by_id,0)=0
+              AND date(episode_date)=date(?)
+        """
+        params: list[Any] = [int(guild_id or 0), selected_date]
+        if public_only:
+            query += """
+              AND public_safe=1
+              AND (
+                instr(',' || ifnull(usage_scope,'') || ',', ',direct,')>0
+                OR instr(',' || ifnull(usage_scope,'') || ',', ',ambient,')>0
+              )
+            """
+        query += " ORDER BY id DESC LIMIT 100"
+        rows = conn.execute(query, tuple(params)).fetchall()
+    finally:
+        conn.close()
+    if not rows:
+        return []
+    selected = []
+    for row in rows:
+        selected.append(
+            {
+                "id": int(row[0] or 0),
+                "episode_date": selected_date,
+                "cleaned_summary": str(row[2] or ""),
+                "entry_type": str(row[3] or "notable_moment"),
+                "importance": str(row[4] or "medium"),
+                "public_safe": bool(row[5]),
+                "usage_scope": str(row[6] or ""),
+            }
+        )
+        if len(selected) >= max(1, min(int(limit or 1), 8)):
+            break
+    return selected
+
+
 BROADCAST_MEMORY_ALLOWED_TYPES = {
     "episode_arc", "notable_moment", "running_joke", "technical_issue",
     "moderation_context", "show_state_override",
@@ -18019,6 +18114,45 @@ def _is_broadcast_memory_relevant(text: str) -> bool:
     ))
 
 
+def _publication_read_owner_requested(text: str) -> bool:
+    return bool(
+        journal_publication_query_mode(text) != "not_requested"
+        or relay_publication_query_mode(text) != "not_requested"
+    )
+
+
+def _current_queue_state_query(text: str) -> bool:
+    normalized = re.sub(r"\s+", " ", str(text or "")).strip().lower()
+    if not normalized:
+        return False
+    queue_signal = bool(
+        re.search(
+            r"\b(?:(?:barcode\s+radio\s+)?queue|"
+            r"(?:track\s+)?submissions?|wheel\s+spins?)\b",
+            normalized,
+        )
+        or re.search(
+            r"\b(?:submit(?:ting)?|intake)\b.{0,40}"
+            r"\b(?:tracks?|songs?|music)\b",
+            normalized,
+        )
+        or re.search(
+            r"\b(?:tracks?|songs?|music)\b.{0,40}"
+            r"\b(?:submit(?:ting)?|intake)\b",
+            normalized,
+        )
+    )
+    current_state_signal = bool(
+        re.search(
+            r"\b(?:open|closed|status|state|current|currently|"
+            r"right\s+now|now|available|active|accepting|intake)\b",
+            normalized,
+        )
+        or re.search(r"\b(?:can|could|may)\s+i\b", normalized)
+    )
+    return queue_signal and current_state_signal
+
+
 def _broadcast_memory_requires_specialized_owner(text: str) -> bool:
     """Keep explicit broadcast requests on the specialized owner.
 
@@ -18031,6 +18165,10 @@ def _broadcast_memory_requires_specialized_owner(text: str) -> bool:
 
     normalized = re.sub(r"\s+", " ", str(text or "")).strip().lower()
     if not normalized:
+        return False
+    if _publication_read_owner_requested(normalized):
+        return False
+    if _current_queue_state_query(normalized):
         return False
     if any(
         phrase in normalized
@@ -18091,6 +18229,48 @@ def _is_show_state_status_query(text: str) -> bool:
 def build_broadcast_memory_context(guild_id: int, user_text: str, channel_policy: str, is_owner_or_mod: bool = False) -> str:
     include_internal = (channel_policy == "broadcast_memory") or bool(is_owner_or_mod)
     relevant = _is_broadcast_memory_relevant(user_text)
+    if _broadcast_historical_recency_query(user_text):
+        latest_entries = get_latest_eligible_broadcast_episode_entries(
+            guild_id,
+            public_only=not include_internal,
+            limit=5,
+        )
+        if not latest_entries:
+            logging.info(
+                "broadcast_memory_context_skipped "
+                "reason=latest_completed_episode_unavailable"
+            )
+            return ""
+        selected_date = latest_entries[0]["episode_date"]
+        lines = [
+            "- %s [%s] %s"
+            % (
+                selected_date,
+                entry["entry_type"],
+                _safe_truncate_summary(entry["cleaned_summary"], 180),
+            )
+            for entry in latest_entries
+            if entry.get("cleaned_summary")
+        ]
+        if not lines:
+            return ""
+        logging.info(
+            "broadcast_memory_context_loaded "
+            "reason=latest_completed_episode episode_date=%s count=%s",
+            selected_date,
+            len(lines),
+        )
+        return (
+            "Broadcast memory context for the newest completed episode "
+            f"({selected_date}):\n"
+            + "\n".join(lines)
+            + "\nLatest-episode rules:\n"
+            "- Every item above belongs to the one selected episode date.\n"
+            "- Treat that date as the latest completed show represented by "
+            "eligible Broadcast memory.\n"
+            "- Do not substitute an older episode, a future schedule, or a "
+            "show-state override."
+        )
     entity_terms = extract_broadcast_memory_query_terms(user_text)
     if entity_terms:
         logging.info(f"broadcast_memory_entity_terms terms={len(entity_terms)}")
@@ -23173,7 +23353,33 @@ def _typed_canon_subject_references(
 
     text = unicodedata.normalize("NFKC", str(current_text or ""))
     text = text.replace("’", "'").casefold()
-    matches: dict[str, str] = {}
+    factual_subject_cue_re = re.compile(
+        r"\b(?:tell\s+me\s+about|what\s+do\s+you\s+"
+        r"(?:know|remember)\s+about|what\s+happened\s+with|"
+        r"compare(?:s|d|ing)?|difference\s+between|"
+        r"relationship\s+between)\b",
+        re.I,
+    )
+    factual_subject_tail_spans = []
+    for cue in factual_subject_cue_re.finditer(text):
+        tail_start = cue.end()
+        tail_end = len(text)
+        for boundary in re.finditer(
+            r"[?!;\n]|\.(?=\s|$)",
+            text[tail_start:],
+        ):
+            boundary_start = tail_start + boundary.start()
+            if (
+                text[boundary_start : boundary_start + 1] == "."
+                and text[max(tail_start, boundary_start - 2) : boundary_start]
+                == "vs"
+            ):
+                continue
+            tail_end = boundary_start
+            break
+        factual_subject_tail_spans.append((tail_start, tail_end))
+
+    candidates: set[tuple[int, int, str, str]] = set()
     for subject in CANON_ENTITY_IDENTITIES:
         for raw_alias in (subject.name, *subject.aliases):
             alias = unicodedata.normalize("NFKC", str(raw_alias or ""))
@@ -23182,21 +23388,167 @@ def _typed_canon_subject_references(
                 continue
             escaped = re.escape(alias.casefold()).replace(r"\ ", r"\s+")
             subject_patterns = (
-                r"\b(?:who|what)\s+(?:is|was)\s+(?:the\s+)?%s"
+                r"\b(?:who|what)\s+(?:is|was)\s+(?:the\s+)?"
+                r"(?P<alias>%s)(?![a-z0-9])"
                 % escaped,
                 r"\b(?:tell\s+me\s+about|what\s+do\s+you\s+"
-                r"(?:know|remember)\s+about|what\s+happened\s+with)\s+%s"
+                r"(?:know|remember)\s+about|what\s+happened\s+with)\s+"
+                r"(?P<alias>%s)(?![a-z0-9])"
                 % escaped,
-                r"(?<![a-z0-9])%s(?:'s)?\s+(?:identity|role|history|"
+                r"(?<![a-z0-9])(?P<alias>%s)(?![a-z0-9])"
+                r"(?:'s)?\s+(?:identity|role|history|"
                 r"work|music|story|status|connection|relationship)\b"
                 % escaped,
-                r"\b(?:compare|difference\s+between|relationship\s+between)"
-                r".{0,80}(?<![a-z0-9])%s(?![a-z0-9])" % escaped,
+                r"(?<![a-z0-9])(?P<alias>%s)(?![a-z0-9])"
+                r"\s+(?:is\s+)?"
+                r"(?:connected|related)\s+to\b" % escaped,
+                r"\b(?:connected|related)\s+to\s+(?:the\s+)?"
+                r"(?P<alias>%s)(?![a-z0-9])" % escaped,
             )
-            if any(re.search(pattern, text, re.I) for pattern in subject_patterns):
-                matches[subject.key] = subject.name
-                break
-    return tuple(matches.items())
+            for pattern in subject_patterns:
+                for match in re.finditer(pattern, text, re.I):
+                    start, end = match.span("alias")
+                    candidates.add(
+                        (start, end, subject.key, subject.name)
+                    )
+            for tail_start, tail_end in factual_subject_tail_spans:
+                tail = text[tail_start:tail_end]
+                for match in re.finditer(
+                    r"(?:^[\s:—-]*|,\s*|\band\s+|"
+                    r"\b(?:vs\.?|versus)\s+)"
+                    r"\s*(?:the\s+)?(?P<alias>%s)(?![a-z0-9])"
+                    % escaped,
+                    tail,
+                    re.I,
+                ):
+                    start, end = match.span("alias")
+                    candidates.add(
+                        (
+                            tail_start + start,
+                            tail_start + end,
+                            subject.key,
+                            subject.name,
+                        )
+                    )
+
+    selected_spans: list[tuple[int, int]] = []
+    selected_keys = set()
+    for start, end, subject_key, _subject_name in sorted(
+        candidates,
+        key=lambda candidate: (
+            -(candidate[1] - candidate[0]),
+            candidate[0],
+            candidate[2],
+        ),
+    ):
+        if any(
+            start < selected_end and selected_start < end
+            for selected_start, selected_end in selected_spans
+        ):
+            continue
+        selected_spans.append((start, end))
+        selected_keys.add(subject_key)
+
+    return tuple(
+        (subject.key, subject.name)
+        for subject in CANON_ENTITY_IDENTITIES
+        if subject.key in selected_keys
+    )
+
+
+_EXACT_REPLY_PRONOUN_SUBJECT_RE = re.compile(
+    r"\b(?:he|him|his|she|her|hers|they|them|their|theirs|"
+    r"that\s+person|that\s+member|that\s+character|that\s+entity)\b",
+    re.I,
+)
+_EXACT_REPLY_CANON_IDENTITY_QUERY_RE = re.compile(
+    r"\b(?:"
+    r"who\s+(?:is|are)\s+(?:he|she|they|that\s+(?:person|member|"
+    r"character|entity))|"
+    r"(?:what\s+do\s+you\s+(?:know|remember)\s+about|tell\s+me\s+"
+    r"about|describe)\s+(?:him|her|them|that\s+(?:person|member|"
+    r"character|entity))|"
+    r"how\s+(?:is|are)\s+(?:he|she|they|that\s+(?:person|member|"
+    r"character|entity))\s+(?:connected|related)|"
+    r"(?:he|she|they|that\s+(?:person|member|character|entity))\s+"
+    r"(?:connected|related)\s+to|"
+    r"(?:his|her|their)\s+(?:role|history|story|identity|relationship|"
+    r"connection))\b",
+    re.I,
+)
+
+
+def _exact_reply_canon_subject_references(
+    context_result: ConversationContextResult | None,
+    current_text: str,
+) -> tuple[tuple[tuple[str, str], ...], str]:
+    """Use one exact BNL reply as identity-only pronoun binding.
+
+    Prior model prose never becomes factual evidence here.  It may identify a
+    single approved canon subject for the current deictic/pronoun reference;
+    zero or multiple matches remain unresolved.
+    """
+
+    if (
+        context_result is None
+        or str(context_result.referent_status or "").lower() != "resolved"
+        or str(context_result.referent_reason or "").lower()
+        != "discord_reply_source"
+        or not _EXACT_REPLY_PRONOUN_SUBJECT_RE.search(current_text or "")
+    ):
+        return (), "not_requested"
+    prefix = "BNL-01 (exact Discord reply source):"
+    exact_lines = tuple(
+        line.split(":", 1)[1].strip()
+        for line in str(context_result.rendered_context or "").splitlines()
+        if line.startswith(prefix) and ":" in line
+    )
+    if not exact_lines:
+        # An exact human reply is still valid conversation evidence, but its
+        # display label is not identity authority for canon pronouns.
+        return (), "not_requested"
+    if len(exact_lines) != 1:
+        return (), "ambiguous"
+    reply_text = unicodedata.normalize("NFKC", exact_lines[0]).replace(
+        "’",
+        "'",
+    )
+    eligible = tuple(
+        identity
+        for identity in CANON_ENTITY_IDENTITIES
+        if identity.key
+        not in {
+            "barcode",
+            "barcode_network",
+            "barcode_radio",
+            "bnl_01",
+        }
+    )
+    resolved = []
+    for identity in eligible:
+        if any(
+            re.search(
+                r"(?<![a-z0-9])%s(?![a-z0-9])"
+                % re.escape(
+                    unicodedata.normalize("NFKC", alias).replace("’", "'")
+                ),
+                reply_text,
+                re.I,
+            )
+            for alias in (identity.name, *identity.aliases)
+            if str(alias or "").strip()
+        ):
+            resolved.append((identity.key, identity.name))
+    if len(resolved) == 1:
+        return tuple(resolved), "resolved"
+    if resolved:
+        return (), "ambiguous"
+    if _EXACT_REPLY_CANON_IDENTITY_QUERY_RE.search(current_text or ""):
+        return (), "unresolved"
+    # A resolved Discord reply can carry ordinary conversational continuity
+    # without naming a canon identity.  Do not replace that exact referent
+    # with an identity failure merely because the current turn uses a pronoun.
+    return (), "not_requested"
 
 
 def build_live_conversation_orchestration_decision(
@@ -23304,12 +23656,30 @@ def build_live_conversation_orchestration_decision(
         )
     )
     typed_canon_subjects = _typed_canon_subject_references(current_text)
+    (
+        exact_reply_canon_subjects,
+        exact_reply_identity_status,
+    ) = _exact_reply_canon_subject_references(context_result, current_text)
+    if exact_reply_canon_subjects:
+        logging.info(
+            "exact_reply_canon_subject_bound count=%s method=identity_only",
+            len(exact_reply_canon_subjects),
+        )
+    frame_referent_status = (
+        exact_reply_identity_status
+        if exact_reply_identity_status in {"ambiguous", "unresolved"}
+        else referent_status
+    )
     resolved_subject_entity_refs = tuple(
         dict.fromkeys(
             str(entity_ref or "").strip()
             for entity_ref in (
                 *subject_entity_refs,
                 *(entity_ref for entity_ref, _label in typed_canon_subjects),
+                *(
+                    entity_ref
+                    for entity_ref, _label in exact_reply_canon_subjects
+                ),
             )
             if str(entity_ref or "").strip()
         )
@@ -23393,8 +23763,22 @@ def build_live_conversation_orchestration_decision(
                 ),
                 *(label for _entity_ref, label in typed_canon_subjects),
                 *(
+                    label
+                    for _entity_ref, label in exact_reply_canon_subjects
+                ),
+                *(
                     context_result.referent_candidate_labels
-                    if context_result is not None
+                    if (
+                        context_result is not None
+                        and not (
+                            str(context_result.referent_status or "").lower()
+                            == "resolved"
+                            and str(
+                                context_result.referent_reason or ""
+                            ).lower()
+                            == "discord_reply_source"
+                        )
+                    )
                     else ()
                 ),
             )
@@ -23449,7 +23833,7 @@ def build_live_conversation_orchestration_decision(
         moment_participant_overlap=bool(
             moment_situation and moment_situation.participant_overlap
         ),
-        referent_status=referent_status,
+        referent_status=frame_referent_status,
         response_act=decision.response_act,
         packet_revision=str(packet_revision or decision.packet_revision),
     )

--- a/bnl_canon_source_contract.py
+++ b/bnl_canon_source_contract.py
@@ -2463,10 +2463,12 @@ def select_declared_canon_claims_for_packet(
 
     if not strict_contract_bool(capability_authorized):
         return DeclaredCanonPacketSelection(reason="capability_disabled")
+    packet_channel_policy = str(channel_policy or "").strip().lower()
     if (
         int(guild_id or 0) <= 0
         or str(route_mode or "") != "normal_chat"
-        or str(channel_policy or "") != "public_home"
+        or packet_channel_policy
+        not in {"sealed_test", "public_home", "public_context"}
     ):
         return DeclaredCanonPacketSelection(reason="route_scope_ineligible")
     safe_limit = max(1, min(int(limit or 1), 200))
@@ -2530,7 +2532,7 @@ def select_declared_canon_claims_for_packet(
                 Visibility.PUBLIC_SAFE,
                 Visibility.REFERENCE_CANON,
             }
-            and "public_home" in claim.eligible_routes
+            and packet_channel_policy in claim.eligible_routes
         )
         mutation_count = max(
             0,

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -356,6 +356,10 @@ _JOURNAL_QUERY_CUE_RE = re.compile(
     r"\b(?:journal|daily\s+entry|weekly\s+entry)\b",
     re.IGNORECASE,
 )
+_JOURNAL_LATEST_RE = re.compile(
+    r"\b(?:latest|newest|most\s+recent|current)\b",
+    re.IGNORECASE,
+)
 _JOURNAL_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})\b")
 _JOURNAL_QUERY_STOPWORDS = _CONTEXT_TOPIC_STOPWORDS | {
     "article",
@@ -522,6 +526,8 @@ def journal_publication_query_mode(user_text: str) -> str:
         return "not_requested"
     if _JOURNAL_DATE_RE.search(text):
         return "date"
+    if _JOURNAL_LATEST_RE.search(text):
+        return "latest"
     return "requested"
 
 
@@ -797,11 +803,15 @@ def select_published_journal_entries_on_connection(
             limit=max(1, limit),
         )
     else:
-        title_rows = _latest_published_journal_rows(
-            conn,
-            guild_id=guild_id,
-            containing_title_in=str(user_text or ""),
-            limit=max(8, limit),
+        title_rows = (
+            []
+            if requested_mode == "latest"
+            else _latest_published_journal_rows(
+                conn,
+                guild_id=guild_id,
+                containing_title_in=str(user_text or ""),
+                limit=max(8, limit),
+            )
         )
         if title_rows:
             query_mode = "exact_title"
@@ -815,7 +825,9 @@ def select_published_journal_entries_on_connection(
                 limit=max(8, limit),
             )
         else:
-            query_mode = "topic"
+            query_mode = (
+                "latest" if requested_mode == "latest" else "topic"
+            )
             rows = _latest_published_journal_rows(
                 conn,
                 guild_id=guild_id,
@@ -844,7 +856,14 @@ def select_published_journal_entries_on_connection(
                                 row,
                             )
                         )
-                scored.sort(key=lambda item: (item[0], item[1]), reverse=True)
+                scored.sort(
+                    key=(
+                        (lambda item: (item[1], item[0]))
+                        if query_mode == "latest"
+                        else (lambda item: (item[0], item[1]))
+                    ),
+                    reverse=True,
+                )
                 rows = [row for _score, _timestamp, row in scored]
 
     candidate_count = len(rows)
@@ -858,7 +877,7 @@ def select_published_journal_entries_on_connection(
         if entry_id in public_excluded:
             hidden_count += 1
             continue
-        if query_mode == "topic" and entry_id in memory_excluded:
+        if query_mode in {"topic", "latest"} and entry_id in memory_excluded:
             memory_ineligible_count += 1
             continue
         publication = _journal_publication_from_row(
@@ -868,7 +887,11 @@ def select_published_journal_entries_on_connection(
         )
         if publication is not None:
             selected.append(publication)
-        if len(selected) >= max(1, min(int(limit or 1), 8)):
+        result_limit = 1 if query_mode == "latest" else max(
+            1,
+            min(int(limit or 1), 8),
+        )
+        if len(selected) >= result_limit:
             break
     if selected:
         status = "eligible"
@@ -898,6 +921,7 @@ def revalidate_published_journal_entry_on_connection(
     revision: int,
     query_mode: str,
     control_snapshot: JournalControlSnapshot | None,
+    user_text: str = "",
     now: Any = None,
 ) -> str:
     if (
@@ -908,10 +932,34 @@ def revalidate_published_journal_entry_on_connection(
     if entry_id in set(control_snapshot.public_excluded_entry_ids):
         return ""
     if (
-        query_mode == "topic"
+        query_mode in {"topic", "latest"}
         and entry_id in set(control_snapshot.memory_excluded_entry_ids)
     ):
         return ""
+    if query_mode == "latest":
+        if not str(user_text or "").strip():
+            return ""
+        selection = select_published_journal_entries_on_connection(
+            conn,
+            guild_id=guild_id,
+            user_text=user_text,
+            control_snapshot=control_snapshot,
+            now=now,
+            limit=1,
+        )
+        if (
+            selection.status != "eligible"
+            or selection.query_mode != "latest"
+            or len(selection.publications) != 1
+        ):
+            return ""
+        publication = selection.publications[0]
+        if (
+            publication.entry_id != entry_id
+            or publication.revision != int(revision)
+        ):
+            return ""
+        return publication.source_digest
     rows = _latest_published_journal_rows(
         conn,
         guild_id=guild_id,

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -42,6 +42,7 @@ from bnl_unified_intelligence_packet import (
     SCHEMA_VERSION as PACKET_SCHEMA_VERSION,
     UnifiedIntelligencePacket,
     mark_packet_application,
+    packet_subject_keys,
     packet_subject_resolutions,
     revalidate_packet,
     shadow_enabled as packet_shadow_enabled,
@@ -2442,12 +2443,18 @@ def _profile_has_recognized_canon_identity(
 ) -> bool:
     """Return recognition independently of sparse/rich profile status."""
 
+    if len(packet_subject_resolutions(packet)) != 1:
+        return False
+    selected_subject_keys = set(packet_subject_keys(packet))
+    if not selected_subject_keys:
+        selected_subject_keys.add(
+            subject_key_for_user(packet.request.subject_user_id)
+        )
     return any(
         item.lane == "canon"
         and item.source_type
         in {"recognized_canon_fact", "recognized_declared_canon_claim"}
-        and item.subject_key
-        == subject_key_for_user(packet.request.subject_user_id)
+        and item.subject_key in selected_subject_keys
         for item in packet.items
     )
 
@@ -2456,9 +2463,12 @@ def _canon_relevant_to_profile_request(
     packet: UnifiedIntelligencePacket,
     item: Any,
 ) -> bool:
-    if item.subject_key == subject_key_for_user(
-        packet.request.subject_user_id
-    ):
+    selected_subject_keys = set(packet_subject_keys(packet))
+    if not selected_subject_keys:
+        selected_subject_keys.add(
+            subject_key_for_user(packet.request.subject_user_id)
+        )
+    if item.subject_key in selected_subject_keys:
         return True
     query = re.sub(
         r"^\s*(?:hey\s+|yo\s+|hi\s+)?"
@@ -3005,6 +3015,11 @@ def _ordinary_frame_tasks(
 
 def _ordinary_task_allowed_lanes(task: Any) -> frozenset[str]:
     object_kind = str(getattr(task, "object_kind", "") or "").lower()
+    if object_kind == "queue":
+        # A usable native queue read model is a specialized owner and never
+        # reaches this packet-only path.  With that owner unavailable, no
+        # unrelated packet lane may be cited as current queue-state evidence.
+        return frozenset()
     if object_kind == "journal":
         return frozenset({"journal_publication"})
     if object_kind == "relay":
@@ -3317,10 +3332,53 @@ def ordinary_chat_deterministic_response_act(
     tasks = _ordinary_frame_tasks(basis)
     if not tasks:
         return ""
-    acts = tuple(
-        str(getattr(task, "required_response_act", "") or "answer")
-        for task in tasks
-    )
+    evidence_scope = {
+        evidence_id: (lane, tuple(subject_indexes))
+        for (
+            evidence_id,
+            lane,
+            _digest_value,
+            subject_indexes,
+        ) in basis.rendered_evidence_refs
+    }
+    acts = []
+    for task in tasks:
+        act = str(
+            getattr(task, "required_response_act", "") or "answer"
+        )
+        if (
+            act == "answer"
+            and str(getattr(task, "authority_scope", "") or "")
+            == "packet"
+        ):
+            allowed_lanes = _ordinary_task_allowed_lanes(task)
+            required_subject_indexes = set(
+                int(subject_index)
+                for subject_index in getattr(task, "subject_indexes", ())
+            )
+            allowed_ids = {
+                evidence_id
+                for evidence_id, (lane, subject_indexes) in (
+                    evidence_scope.items()
+                )
+                if lane in allowed_lanes
+                and (
+                    not required_subject_indexes
+                    or required_subject_indexes.intersection(subject_indexes)
+                )
+            }
+            covered_subject_indexes = {
+                subject_index
+                for evidence_id in allowed_ids
+                for subject_index in evidence_scope[evidence_id][1]
+                if subject_index in required_subject_indexes
+            }
+            if not allowed_ids or (
+                required_subject_indexes - covered_subject_indexes
+            ):
+                act = "hold"
+        acts.append(act)
+    acts = tuple(acts)
     if any(act == "answer" for act in acts):
         return ""
     return "clarify" if "clarify" in acts else "hold"

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -3054,6 +3054,9 @@ def _declared_items(
                 )
             )
         )
+        recognized_bound_entity_claim = bool(
+            bound_entity_claim and not member_claim
+        )
         lane = "approved_fact" if member_claim else "canon"
         text = _declared_claim_text(claim).strip()
         diagnostics.candidates_by_lane[lane] = (
@@ -3092,12 +3095,16 @@ def _declared_items(
             source_class=claim.source_class.value,
             source_type=(
                 "recognized_declared_canon_claim"
-                if bound_entity_claim
+                if recognized_bound_entity_claim
                 else "declared_canon_claim"
             ),
             source_ref=claim.source_refs[0],
             source_digest=claim.revision_id,
-            subject_key=(subject if bound_entity_claim else claim.subject_id),
+            subject_key=(
+                subject
+                if recognized_bound_entity_claim
+                else claim.subject_id
+            ),
             predicate_key=claim.predicate,
             text=text[:1000],
             visibility=claim.visibility.value,
@@ -4679,6 +4686,7 @@ def _journal_publication_items(
         "exact_identity": 160.0,
         "exact_title": 155.0,
         "exact_date": 150.0,
+        "latest": 145.0,
         "topic": 135.0,
     }
     for publication in selection.publications:
@@ -4757,6 +4765,7 @@ def _relay_publication_items(
     score_by_mode = {
         "exact_identity": 160.0,
         "exact_date": 150.0,
+        "latest": 145.0,
         "topic": 135.0,
     }
     for publication in selection.publications:
@@ -6065,6 +6074,7 @@ def _revalidate_packet_in_snapshot(
                     revision=int(payload.get("revision") or 0),
                     query_mode=str(payload.get("queryMode") or ""),
                     control_snapshot=current_journal_control,
+                    user_text=packet.request.user_text,
                     now=packet.request.now or None,
                 )
             elif item.revalidation_kind == "relay_publication":
@@ -6074,6 +6084,7 @@ def _revalidate_packet_in_snapshot(
                     guild_id=int(packet.request.guild_id or 0),
                     relay_id=str(payload.get("relayId") or ""),
                     query_mode=str(payload.get("queryMode") or ""),
+                    user_text=packet.request.user_text,
                 )
             elif item.revalidation_kind in {"current", "snapshot"}:
                 current = item.revalidation_key

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -91,13 +91,13 @@ _VISIBLE_CONTROL_MARKER_RE = re.compile(
 _SEMANTIC_WORD_RE = re.compile(r"[a-z0-9][a-z0-9'’-]*", re.I)
 _OBJECTIVE_RE = re.compile(
     r"\?|"
-    r"\b(?:choose|pick|select|compare|decide|explain|tell|show|give|help|"
+    r"\b(?:choose|pick|select|compare(?:s|d)?|decide|explain|tell|show|give|help|"
     r"recap|summari[sz]e|continue|resume|combine|fix|build|make|write|"
     r"what|which|why|how|where|when|who)\b",
     re.I,
 )
 _CHOICE_OBJECTIVE_RE = re.compile(
-    r"\b(?:choose|pick|select|compare|decide\s+between|which)\b"
+    r"\b(?:choose|pick|select|compare(?:s|d)?|decide\s+between|which)\b"
     r"|\b(?:better|best|fits?|works?|prefer)\b",
     re.I,
 )
@@ -328,7 +328,17 @@ _SITUATION_OBJECT_PATTERNS = (
     ("relay", re.compile(r"\brelay(?:s)?\b", re.I)),
     ("moment", re.compile(r"\bmoment(?:s)?\b|\bepisode(?:s)?\b", re.I)),
     ("memory", re.compile(r"\bmemory\b|\bshared\s+brain\b|\brecall\b", re.I)),
-    ("queue", re.compile(r"\bqueue\b|\bsubmission(?:s)?\b|\bwheel\s+spin(?:s)?\b", re.I)),
+    (
+        "queue",
+        re.compile(
+            r"\bqueue\b|\bsubmission(?:s)?\b|\bwheel\s+spin(?:s)?\b|"
+            r"\b(?:submit(?:ting)?|intake)\b.{0,40}"
+            r"\b(?:tracks?|songs?|music)\b|"
+            r"\b(?:tracks?|songs?|music)\b.{0,40}"
+            r"\b(?:submit(?:ting)?|intake)\b",
+            re.I,
+        ),
+    ),
     ("broadcast", re.compile(r"\bbarcode\s+radio\b|\bshow\b|\bbroadcast\b", re.I)),
     ("website", re.compile(r"\bwebsite\b|\bsite\b|\bterminal\b", re.I)),
     ("source_file", re.compile(r"\bsource\s+files?\b|\bdossier(?:s)?\b", re.I)),
@@ -366,7 +376,7 @@ _BNL_SELF_SUBJECT_CUE_RE = re.compile(
 )
 _TASK_LEAD_RE = re.compile(
     r"(?:what|which|who|where|when|why|how|tell|explain|summari[sz]e|"
-    r"compare|describe|give|show|help|check|find|is|are|do|does|did|can|"
+    r"compare(?:s|d)?|describe|give|show|help|check|find|is|are|do|does|did|can|"
     r"could|would|should)\b",
     re.I,
 )
@@ -375,6 +385,21 @@ _VOLATILE_EXTERNAL_RE = re.compile(
     r"stock|market|exchange\s+rate|news|headline|election|polls?|"
     r"president|prime\s+minister|governor|mayor|ceo|schedule|"
     r"availability|open\s+now|live\s+status)\b",
+    re.I,
+)
+_EXACT_REPLY_DEICTIC_SUBJECT_RE = re.compile(
+    r"\b(?:he|him|his|she|her|hers|they|them|their|theirs|"
+    r"that\s+person|that\s+member|that\s+character|that\s+entity)\b",
+    re.I,
+)
+_EXACT_REPLY_CONTINUITY_RE = re.compile(
+    r"\b(?:"
+    r"he|him|his|she|her|hers|they|them|their|theirs|"
+    r"that\s+(?:person|member|character|entity)|"
+    r"(?:what|which)(?:\s+[a-z0-9'-]+){0,4}\s+did\s+(?:i|you|we)\b|"
+    r"(?:why|how)\s+did\s+(?:i|you|we)\b|"
+    r"(?:i|you|we)\s+(?:said|told|gave|asked|meant|called|chose|"
+    r"preferred|compared)\b)",
     re.I,
 )
 _EXTERNAL_ROLE_QUERY_RE = re.compile(
@@ -560,6 +585,12 @@ def _situation_object(text: str) -> str:
     )
     if len(matches) == 1:
         return matches[0]
+    if "queue" in matches and set(matches).issubset(
+        {"queue", "broadcast", "website"}
+    ):
+        # BARCODE Radio and website language qualify the queue source.  They
+        # do not turn one current queue-state request into competing owners.
+        return "queue"
     publication_owners = tuple(
         match for match in matches if match in {"journal", "relay"}
     )
@@ -656,6 +687,7 @@ def _situation_tasks(
     *,
     subjects: Sequence[SituationSubjectReference],
     response_act: str,
+    exact_reply_resolved: bool = False,
 ) -> Tuple[SituationTaskReference, ...]:
     tasks = []
     for index, segment in enumerate(_situation_task_segments(text), start=1):
@@ -679,6 +711,21 @@ def _situation_tasks(
             objective_kind=objective_kind,
         )
         subject_indexes = _task_subject_indexes(segment, subjects)
+        if (
+            exact_reply_resolved
+            and _EXACT_REPLY_DEICTIC_SUBJECT_RE.search(segment)
+        ):
+            unmatched_subject_indexes = tuple(
+                subject_index
+                for subject_index in range(len(subjects))
+                if subject_index not in subject_indexes
+            )
+            if len(unmatched_subject_indexes) == 1:
+                subject_indexes = tuple(
+                    dict.fromkeys(
+                        (*subject_indexes, unmatched_subject_indexes[0])
+                    )
+                )
         external_role_query = bool(_EXTERNAL_ROLE_QUERY_RE.search(segment))
         subject_cue = bool(
             _BNL_SELF_SUBJECT_CUE_RE.search(segment)
@@ -699,6 +746,12 @@ def _situation_tasks(
             authority_scope = "packet"
         elif _CURRENT_REQUEST_TASK_RE.search(segment):
             authority_scope = "current_request"
+        elif (
+            exact_reply_resolved
+            and _EXACT_REPLY_CONTINUITY_RE.search(segment)
+            and not _VOLATILE_EXTERNAL_RE.search(segment)
+        ):
+            authority_scope = "packet"
         else:
             authority_scope = "external_public"
         required_act = str(response_act or "observe")
@@ -944,15 +997,25 @@ def build_situation_frame_v1(
         else "not_applicable"
     )
 
+    normalized_referent = str(
+        referent_status or "not_requested"
+    ).strip().lower()
+    exact_reply_resolved = bool(
+        normalized_referent == "resolved"
+        and (
+            _unique_positive_ints(reply_message_ids)
+            or _unique_positive_ints(exact_source_row_ids)
+        )
+    )
     tasks = _situation_tasks(
         text,
         subjects=subjects,
         response_act=str(response_act or "observe"),
+        exact_reply_resolved=exact_reply_resolved,
     )
 
     ambiguity = []
     competing = []
-    normalized_referent = str(referent_status or "not_requested").strip().lower()
     if normalized_referent in {"ambiguous", "unresolved"}:
         ambiguity.append("referent_%s" % normalized_referent)
         competing.append("nearby_referent_candidates")

--- a/bnl_website_relay_state.py
+++ b/bnl_website_relay_state.py
@@ -255,6 +255,10 @@ _RELAY_QUERY_ACTION_RE = re.compile(
     r"said|show|signal|status|what)\b",
     re.IGNORECASE,
 )
+_RELAY_LATEST_RE = re.compile(
+    r"\b(?:latest|newest|most\s+recent|current)\b",
+    re.IGNORECASE,
+)
 _RELAY_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})\b")
 _RELAY_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{2,159}$")
 _RELAY_QUERY_STOPWORDS = {
@@ -346,6 +350,8 @@ def relay_publication_query_mode(user_text: str) -> str:
         return "not_requested"
     if _RELAY_DATE_RE.search(text):
         return "date"
+    if _RELAY_LATEST_RE.search(text):
+        return "latest"
     return "requested"
 
 
@@ -597,7 +603,9 @@ def select_accepted_relay_publications_on_connection(
             limit=max(8, limit),
         )
     else:
-        query_mode = "topic"
+        query_mode = (
+            "latest" if requested_mode == "latest" else "topic"
+        )
         rows = _relay_publication_rows(
             conn,
             guild_id=guild_id,
@@ -631,7 +639,14 @@ def select_accepted_relay_publications_on_connection(
                             row,
                         )
                     )
-            scored.sort(key=lambda item: (item[0], item[1]), reverse=True)
+            scored.sort(
+                key=(
+                    (lambda item: (item[1], item[0]))
+                    if query_mode == "latest"
+                    else (lambda item: (item[0], item[1]))
+                ),
+                reverse=True,
+            )
             rows = [row for _score, _timestamp, row in scored]
     candidate_count = len(rows)
     selected: list[AcceptedRelayPublication] = []
@@ -653,7 +668,11 @@ def select_accepted_relay_publications_on_connection(
                 provenance_excluded += 1
             continue
         selected.append(publication)
-        if len(selected) >= max(1, min(int(limit or 1), 8)):
+        result_limit = 1 if query_mode == "latest" else max(
+            1,
+            min(int(limit or 1), 8),
+        )
+        if len(selected) >= result_limit:
             break
     if selected:
         status = "eligible"
@@ -681,7 +700,27 @@ def revalidate_accepted_relay_publication_on_connection(
     guild_id: int,
     relay_id: str,
     query_mode: str,
+    user_text: str = "",
 ) -> str:
+    if query_mode == "latest":
+        if not str(user_text or "").strip():
+            return ""
+        selection = select_accepted_relay_publications_on_connection(
+            conn,
+            guild_id=guild_id,
+            user_text=user_text,
+            limit=1,
+        )
+        if (
+            selection.status != "eligible"
+            or selection.query_mode != "latest"
+            or len(selection.publications) != 1
+        ):
+            return ""
+        publication = selection.publications[0]
+        if publication.relay_id != relay_id:
+            return ""
+        return publication.source_digest
     rows = _relay_publication_rows(
         conn,
         guild_id=guild_id,

--- a/tests/test_broadcast_memory_freshness.py
+++ b/tests/test_broadcast_memory_freshness.py
@@ -1,0 +1,242 @@
+from datetime import datetime, timedelta
+import os
+import sqlite3
+import tempfile
+import unittest
+from unittest import mock
+
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+
+
+GUILD_ID = 7101
+
+
+def _insert_memory(
+    database,
+    *,
+    episode_date,
+    summary,
+    entry_type="notable_moment",
+    status="active",
+    public_safe=1,
+    usage_scope="ambient,direct",
+    superseded_by_id=None,
+):
+    timestamp = f"{episode_date}T20:00:00+00:00"
+    with sqlite3.connect(database) as conn:
+        cursor = conn.execute(
+            """
+            INSERT INTO broadcast_memory (
+                guild_id, episode_date, submitted_by_user_id,
+                submitted_by_name, raw_note, cleaned_summary, entry_type,
+                importance, public_safe, affects_next_show, usage_scope,
+                target_show_date, valid_until, override_span_count,
+                needs_clarification, status, created_at, updated_at,
+                superseded_by_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                GUILD_ID,
+                episode_date,
+                61,
+                "6 Bit",
+                f"Raw source for {summary}",
+                summary,
+                entry_type,
+                "medium",
+                public_safe,
+                1 if entry_type == "show_state_override" else 0,
+                usage_scope,
+                episode_date if entry_type == "show_state_override" else None,
+                None,
+                1,
+                0,
+                status,
+                timestamp,
+                timestamp,
+                superseded_by_id,
+            ),
+        )
+        return int(cursor.lastrowid)
+
+
+class BroadcastMemoryFreshnessTests(unittest.TestCase):
+    RECENCY_QUERIES = (
+        "What happened on the last show?",
+        "What happened on the latest show?",
+        "What happened on the most recent show?",
+        "What happened on the last episode?",
+        "What happened on the latest episode?",
+        "What happened on the most recent episode?",
+        "What happened on the last broadcast?",
+        "What happened on the latest broadcast?",
+        "What happened on the most recent broadcast?",
+    )
+
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.database = os.path.join(
+            self.temporary_directory.name,
+            "broadcast-memory.sqlite3",
+        )
+        self.database_patch = mock.patch.object(
+            bnl01_bot,
+            "DB_FILE",
+            self.database,
+        )
+        self.database_patch.start()
+        bnl01_bot.init_db()
+
+    def tearDown(self):
+        self.database_patch.stop()
+        self.temporary_directory.cleanup()
+
+    def test_recency_variants_select_one_newest_past_episode_despite_id_order(
+        self,
+    ):
+        today = datetime.now(bnl01_bot.PACIFIC_TZ).date()
+        newest_date = (today - timedelta(days=2)).isoformat()
+        older_date = (today - timedelta(days=9)).isoformat()
+
+        newest_first_id = _insert_memory(
+            self.database,
+            episode_date=newest_date,
+            summary="NEWEST_EPISODE_PRIMARY",
+        )
+        _insert_memory(
+            self.database,
+            episode_date=newest_date,
+            summary="NEWEST_EPISODE_SECONDARY",
+            entry_type="technical_issue",
+        )
+        older_later_id = _insert_memory(
+            self.database,
+            episode_date=older_date,
+            summary="OLDER_HIGHER_ID_EPISODE",
+        )
+        self.assertGreater(older_later_id, newest_first_id)
+
+        selected = bnl01_bot.get_latest_eligible_broadcast_episode_entries(
+            GUILD_ID,
+            public_only=True,
+        )
+        self.assertEqual(
+            {entry["episode_date"] for entry in selected},
+            {newest_date},
+        )
+
+        for query in self.RECENCY_QUERIES:
+            with self.subTest(query=query):
+                self.assertTrue(
+                    bnl01_bot._broadcast_historical_recency_query(query)
+                )
+                context = bnl01_bot.build_broadcast_memory_context(
+                    GUILD_ID,
+                    query,
+                    "public_home",
+                )
+                self.assertIn(
+                    f"newest completed episode ({newest_date})",
+                    context,
+                )
+                self.assertIn("NEWEST_EPISODE_PRIMARY", context)
+                self.assertIn("NEWEST_EPISODE_SECONDARY", context)
+                self.assertNotIn(older_date, context)
+                self.assertNotIn("OLDER_HIGHER_ID_EPISODE", context)
+
+    def test_latest_episode_excludes_future_override_inactive_and_superseded_rows(
+        self,
+    ):
+        today = datetime.now(bnl01_bot.PACIFIC_TZ).date()
+        newest_date = (today - timedelta(days=2)).isoformat()
+        future_date = (today + timedelta(days=5)).isoformat()
+
+        _insert_memory(
+            self.database,
+            episode_date=newest_date,
+            summary="ELIGIBLE_NEWEST_EPISODE",
+        )
+        _insert_memory(
+            self.database,
+            episode_date=newest_date,
+            summary="INACTIVE_ROW_MUST_NOT_APPEAR",
+            status="inactive",
+        )
+        _insert_memory(
+            self.database,
+            episode_date=newest_date,
+            summary="SUPERSEDED_ROW_MUST_NOT_APPEAR",
+            superseded_by_id=999,
+        )
+        _insert_memory(
+            self.database,
+            episode_date=future_date,
+            summary="FUTURE_OVERRIDE_MUST_NOT_APPEAR",
+            entry_type="show_state_override",
+        )
+
+        context = bnl01_bot.build_broadcast_memory_context(
+            GUILD_ID,
+            "What was the latest Barcode Radio show?",
+            "public_home",
+        )
+
+        self.assertIn(f"newest completed episode ({newest_date})", context)
+        self.assertIn("ELIGIBLE_NEWEST_EPISODE", context)
+        self.assertNotIn("INACTIVE_ROW_MUST_NOT_APPEAR", context)
+        self.assertNotIn("SUPERSEDED_ROW_MUST_NOT_APPEAR", context)
+        self.assertNotIn("FUTURE_OVERRIDE_MUST_NOT_APPEAR", context)
+        self.assertNotIn(future_date, context)
+
+    def test_ineligible_latest_past_episode_holds_instead_of_falling_back(
+        self,
+    ):
+        today = datetime.now(bnl01_bot.PACIFIC_TZ).date()
+        latest_past_date = (today - timedelta(days=2)).isoformat()
+        older_date = (today - timedelta(days=9)).isoformat()
+        future_date = (today + timedelta(days=5)).isoformat()
+
+        _insert_memory(
+            self.database,
+            episode_date=older_date,
+            summary="OLDER_ELIGIBLE_EVIDENCE_MUST_NOT_BE_SUBSTITUTED",
+        )
+        _insert_memory(
+            self.database,
+            episode_date=latest_past_date,
+            summary="LATEST_EPISODE_INACTIVE",
+            status="inactive",
+        )
+        _insert_memory(
+            self.database,
+            episode_date=latest_past_date,
+            summary="LATEST_EPISODE_SUPERSEDED",
+            superseded_by_id=999,
+        )
+        _insert_memory(
+            self.database,
+            episode_date=future_date,
+            summary="FUTURE_SHOW_STATE_OVERRIDE",
+            entry_type="show_state_override",
+        )
+
+        selected = bnl01_bot.get_latest_eligible_broadcast_episode_entries(
+            GUILD_ID,
+            public_only=True,
+        )
+        context = bnl01_bot.build_broadcast_memory_context(
+            GUILD_ID,
+            "What happened on the most recent broadcast?",
+            "public_home",
+        )
+
+        self.assertEqual(selected, [])
+        self.assertEqual(context, "")
+        self.assertNotIn(
+            "OLDER_ELIGIBLE_EVIDENCE_MUST_NOT_BE_SUBSTITUTED",
+            context,
+        )

--- a/tests/test_exact_discord_reply_packet_regression.py
+++ b/tests/test_exact_discord_reply_packet_regression.py
@@ -1,0 +1,365 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest import mock
+
+
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
+
+import bnl01_bot
+import bnl_memory_ledger as ledger
+import bnl_moment_engine as moments
+import bnl_relationship_engine as relationships
+from bnl_shared_brain_synthesis import (
+    begin_single_packet_run,
+    build_ordinary_chat_basis,
+    evaluate_single_packet_response,
+    finalize_run,
+    parse_ordinary_chat_response_contract,
+    validate_ordinary_chat_response_contract,
+)
+
+
+class ExactDiscordReplyPacketRegressionTests(unittest.TestCase):
+    def setUp(self):
+        self.flags = {
+            "BNL_CONVERSATION_CONTEXT_V2_ENABLED": "true",
+            "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+            "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+            "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+            "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+            "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED": "true",
+            "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED": "true",
+            "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_ENABLED": "false",
+            "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_ENABLED": "false",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED": "true",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_GUILD_IDS": "1",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_USER_IDS": "7",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_CHANNEL_IDS": "10",
+            "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
+            "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
+            "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+        }
+        self.env = mock.patch.dict(os.environ, self.flags, clear=False)
+        self.env.start()
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.db_path = str(
+            Path(self.temporary_directory.name) / "exact-reply.sqlite3"
+        )
+        self.db_file = mock.patch.object(
+            bnl01_bot,
+            "DB_FILE",
+            self.db_path,
+        )
+        self.db_file.start()
+
+        self.now = datetime.now(timezone.utc)
+        with sqlite3.connect(self.db_path) as conn:
+            ledger.ensure_memory_ledger_schema(conn)
+            moments.ensure_moment_schema(conn)
+            relationships.ensure_relationship_v2_schema(conn)
+            conn.execute(
+                """
+                CREATE TABLE conversations (
+                    id INTEGER PRIMARY KEY,
+                    guild_id INTEGER NOT NULL,
+                    user_id INTEGER NOT NULL,
+                    user_name TEXT NOT NULL,
+                    role TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    channel_id INTEGER NOT NULL,
+                    channel_name TEXT NOT NULL,
+                    channel_policy TEXT NOT NULL,
+                    route_mode TEXT NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    message_id INTEGER
+                )
+                """
+            )
+            conn.executemany(
+                """
+                INSERT INTO conversations(
+                    id,guild_id,user_id,user_name,role,content,channel_id,
+                    channel_name,channel_policy,route_mode,timestamp,message_id
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    (
+                        100,
+                        1,
+                        7,
+                        "Test Member A",
+                        "user",
+                        "My test code is cobalt",
+                        10,
+                        "bnl-testing",
+                        "sealed_test",
+                        "normal_chat",
+                        (self.now - timedelta(minutes=2)).isoformat(),
+                        700,
+                    ),
+                    (
+                        101,
+                        1,
+                        8,
+                        "Test Member B",
+                        "user",
+                        "My test code is amber",
+                        10,
+                        "bnl-testing",
+                        "sealed_test",
+                        "normal_chat",
+                        (self.now - timedelta(minutes=1)).isoformat(),
+                        701,
+                    ),
+                ),
+            )
+
+    def tearDown(self):
+        self.db_file.stop()
+        self.temporary_directory.cleanup()
+        self.env.stop()
+
+    @staticmethod
+    def _addressing():
+        return bnl01_bot.DiscordTurnAddressing(
+            speaker="Test Member A",
+            explicit_tag_recipients=("@BNL-01",),
+            reply_target="Test Member A",
+            explicitly_mentions_bnl=True,
+            reply_targets_bnl=False,
+            directly_targets_bnl=True,
+            targets_other_human=False,
+            plain_text_names_bnl=False,
+            speaker_user_id=7,
+            source_message_id=702,
+            reply_message_id=700,
+            reply_conversation_row_id=100,
+        )
+
+    def test_exact_reply_cobalt_is_packet_evidence_and_amber_is_not_selected(
+        self,
+    ):
+        question = "what test code did I give you?"
+        result_out = {}
+        rendered_context = (
+            bnl01_bot.build_conversation_context_v2_for_prompt(
+                guild_id=1,
+                current_user_id=7,
+                channel_id=10,
+                channel_name="bnl-testing",
+                channel_policy="sealed_test",
+                route_mode="normal_chat",
+                conversation_surface="mention_or_reply",
+                current_texts=(question,),
+                current_participants={7},
+                is_direct_target=True,
+                referenced_message_ids={700},
+                referenced_conversation_row_ids={100},
+                now=self.now,
+                route_allowed_sources={"conversation_continuity"},
+                result_out=result_out,
+            )
+        )
+        context_result = result_out["result"]
+
+        self.assertEqual(context_result.referent_status, "resolved")
+        self.assertEqual(
+            context_result.referent_reason,
+            "discord_reply_source",
+        )
+        self.assertEqual(context_result.referent_selected_row_ids, (100,))
+        self.assertEqual(context_result.referent_competing_row_ids, (101,))
+        self.assertEqual(context_result.selected_row_ids, (100,))
+        self.assertIn("My test code is cobalt", rendered_context)
+        self.assertNotIn("My test code is amber", rendered_context)
+
+        conversation_basis = (
+            bnl01_bot.build_conversation_prompt_source_basis(
+                rendered_context,
+                guild_id=1,
+                current_user_id=7,
+                channel_id=10,
+                channel_name="bnl-testing",
+                channel_policy="sealed_test",
+                context_result=context_result,
+            )
+        )
+        self.assertIsNotNone(conversation_basis)
+        self.assertEqual(conversation_basis.source_row_ids, (100,))
+        self.assertEqual(
+            tuple(item.text for item in conversation_basis.evidence_items),
+            ("My test code is cobalt",),
+        )
+        # Amber is retained only as content-bearing revalidation competition;
+        # it is not selected prompt or packet evidence.
+        self.assertEqual(
+            tuple(
+                item.text
+                for item in (
+                    conversation_basis.referent_competing_evidence_items
+                )
+            ),
+            ("My test code is amber",),
+        )
+
+        orchestration = (
+            bnl01_bot.build_live_conversation_orchestration_decision(
+                engagement_decision="answer",
+                engagement_reason="direct_request",
+                channel_policy="sealed_test",
+                addressings=(self._addressing(),),
+                context_result=context_result,
+                moment_situation=None,
+                guild_id=1,
+                channel_id=10,
+                route_mode="normal_chat",
+                conversation_surface="mention_or_reply",
+                current_text=question,
+                current_speaker_user_ids=(7,),
+                current_speaker_labels=("Test Member A",),
+                influence_mode="live",
+                packet_revision="turn_exact_reply_cobalt",
+            )
+        )
+        frame = orchestration.situation_frame
+        self.assertEqual(frame.status, "resolved")
+        self.assertEqual(frame.exact_source_row_ids, (100,))
+        self.assertEqual(frame.tasks[0].authority_scope, "packet")
+        self.assertEqual(frame.tasks[0].required_response_act, "answer")
+
+        packet_out = {}
+        assessment = bnl01_bot.build_unified_response_assessment_shadow(
+            guild_id=1,
+            route_mode="normal_chat",
+            channel_policy="sealed_test",
+            conversation_surface="mention_or_reply",
+            current_text=question,
+            current_speaker_user_ids=(7,),
+            current_speaker_labels=("Test Member A",),
+            channel_id=10,
+            prompt_source_bases=(conversation_basis,),
+            prompt_lanes=("current_exchange", "conversation_context"),
+            continuity_required=True,
+            current_direct=True,
+            intelligence_packet_out=packet_out,
+            situation_frame=frame,
+        )
+        packet = packet_out["packet"]
+
+        self.assertIsNotNone(assessment)
+        self.assertTrue(packet_out["usable"])
+        self.assertTrue(
+            packet.diagnostics.revalidation_status.startswith("passed")
+        )
+        selected_context = tuple(
+            item.text
+            for item in packet.items
+            if item.lane == "conversation_context"
+        )
+        self.assertEqual(selected_context, ("My test code is cobalt",))
+        self.assertNotIn(
+            "My test code is amber",
+            tuple(item.text for item in packet.items),
+        )
+
+        ordinary_basis = build_ordinary_chat_basis(
+            guild_id=1,
+            user_id=7,
+            channel_id=10,
+            route_mode="normal_chat",
+            channel_policy="sealed_test",
+            current_direct=True,
+            user_text=question,
+            packet=packet,
+            assessment=assessment,
+            environ=self.flags,
+        )
+        self.assertIsNotNone(ordinary_basis)
+        cobalt_evidence_id = next(
+            evidence_id
+            for evidence_id, lane, _digest, _subjects in (
+                ordinary_basis.rendered_evidence_refs
+            )
+            if lane == "conversation_context"
+        )
+        response_contract = parse_ordinary_chat_response_contract(
+            '{"tasks":[{"taskId":"T1","text":"You gave me cobalt.",'
+            '"supportKind":"packet","evidenceIds":["%s"]}]}'
+            % cobalt_evidence_id
+        )
+        validation = validate_ordinary_chat_response_contract(
+            ordinary_basis,
+            response_contract,
+        )
+        self.assertTrue(validation.valid, validation.status)
+
+        with sqlite3.connect(self.db_path) as conn:
+            run = begin_single_packet_run(
+                conn,
+                ordinary_basis,
+                prompt_ready=True,
+                frame_revalidation_status="valid",
+                environ=self.flags,
+            )
+            decision = evaluate_single_packet_response(
+                conn,
+                run,
+                response=response_contract.response,
+                response_contract=response_contract,
+                typed_contract_required=True,
+                provider_call_count=1,
+                corrective_call_count=0,
+                environ=self.flags,
+            )
+            self.assertTrue(decision.candidate_selected)
+            self.assertTrue(
+                finalize_run(
+                    conn,
+                    decision,
+                    final_response=decision.response,
+                    response_sent=True,
+                    candidate_live=True,
+                    guard_status="single_packet_candidate_sent",
+                )
+            )
+
+            receipt_tables = (
+                "memory_governance_intelligence_packet_runs",
+                "memory_governance_shared_brain_synthesis_runs",
+            )
+            forbidden_content_columns = {
+                "request_text",
+                "packet_content",
+                "source_text",
+                "response_text",
+                "baseline_response",
+                "candidate_response",
+                "final_response",
+            }
+            for table in receipt_tables:
+                columns = tuple(
+                    str(column[1])
+                    for column in conn.execute(
+                        "PRAGMA table_info(%s)" % table
+                    )
+                )
+                self.assertFalse(
+                    set(columns) & forbidden_content_columns,
+                    table,
+                )
+                receipt_rows = conn.execute(
+                    "SELECT * FROM %s" % table
+                ).fetchall()
+                self.assertTrue(receipt_rows, table)
+                serialized_receipts = repr(receipt_rows).casefold()
+                self.assertNotIn("cobalt", serialized_receipts)
+                self.assertNotIn("amber", serialized_receipts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hybrid_canon_claim_contract.py
+++ b/tests/test_hybrid_canon_claim_contract.py
@@ -1038,7 +1038,15 @@ class HybridCanonClaimContractTests(unittest.TestCase):
             try:
                 self.create_pr2_broadcast_table(conn)
                 row_id = self.insert_pr2_broadcast(conn)
-                revision = self.classify_pr2_broadcast(conn, row_id)
+                revision = self.classify_pr2_broadcast(
+                    conn,
+                    row_id,
+                    eligible_routes=(
+                        "sealed_test",
+                        "public_home",
+                        "public_context",
+                    ),
+                )
                 disabled = canon.select_declared_canon_claims_for_packet(
                     conn,
                     guild_id=7,
@@ -1051,25 +1059,31 @@ class HybridCanonClaimContractTests(unittest.TestCase):
                 self.assertEqual(disabled.claims, ())
 
                 before = conn.total_changes
-                selected = canon.select_declared_canon_claims_for_packet(
-                    conn,
-                    guild_id=7,
-                    route_mode="normal_chat",
-                    channel_policy="public_home",
-                    capability_authorized=True,
-                    now="2026-08-01T02:00:00+00:00",
-                )
-                self.assertEqual(conn.total_changes, before)
-                self.assertEqual(selected.reason, "eligible")
-                self.assertEqual(len(selected.claims), 1)
-                self.assertEqual(
-                    selected.claims[0].source_revision,
-                    revision.revision_id,
-                )
-                self.assertEqual(
-                    selected.claims[0].value,
-                    "A source-owned Broadcast summary.",
-                )
+                for channel_policy in (
+                    "sealed_test",
+                    "public_home",
+                    "public_context",
+                ):
+                    with self.subTest(channel_policy=channel_policy):
+                        selected = canon.select_declared_canon_claims_for_packet(
+                            conn,
+                            guild_id=7,
+                            route_mode="normal_chat",
+                            channel_policy=channel_policy,
+                            capability_authorized=True,
+                            now="2026-08-01T02:00:00+00:00",
+                        )
+                        self.assertEqual(conn.total_changes, before)
+                        self.assertEqual(selected.reason, "eligible")
+                        self.assertEqual(len(selected.claims), 1)
+                        self.assertEqual(
+                            selected.claims[0].source_revision,
+                            revision.revision_id,
+                        )
+                        self.assertEqual(
+                            selected.claims[0].value,
+                            "A source-owned Broadcast summary.",
+                        )
             finally:
                 conn.close()
 

--- a/tests/test_ordinary_chat_acceptance_contract_matrix.py
+++ b/tests/test_ordinary_chat_acceptance_contract_matrix.py
@@ -131,7 +131,7 @@ class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
                         )
                     )
 
-    def test_12_true_multi_subject_cases_bind_each_task_scope(self):
+    def test_14_true_multi_subject_cases_bind_each_task_scope(self):
         # name, request, ordered task subject entity keys
         cases = (
             (
@@ -195,8 +195,18 @@ class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
                 "Who is Cache Back? Compare Call'em Bini and Mac Modem.",
                 (("cache_back",), ("mac_modem", "call_em_bini")),
             ),
+            (
+                "live_natural_mac_dj",
+                "what do you know about Mac Modem and DJ Floppydisc?",
+                (("dj_floppydisc", "mac_modem"),),
+            ),
+            (
+                "live_compares_typo",
+                "compares Cache Back, and Call'em Bini and Mac Modem",
+                (("cache_back", "mac_modem", "call_em_bini"),),
+            ),
         )
-        self.assertEqual(len(cases), 12)
+        self.assertEqual(len(cases), 14)
 
         for name, text, expected_task_subjects in cases:
             with self.subTest(name=name, text=text):
@@ -224,6 +234,290 @@ class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
                         for task in frame.tasks
                     )
                 )
+
+    def test_coordinated_subject_parser_does_not_promote_context_objects(self):
+        cases = (
+            (
+                "Who is DJ Floppydisc in BARCODE?",
+                ("dj_floppydisc",),
+            ),
+            (
+                "Tell me about Cache Back's work with BARCODE Radio.",
+                ("cache_back",),
+            ),
+            (
+                "What do you know about BARCODE Radio?",
+                ("barcode_radio",),
+            ),
+            (
+                "What do you know about BARCODE Network?",
+                ("barcode_network",),
+            ),
+            (
+                "What do you know about Mac Modem? Also, Cache Back is cool.",
+                ("mac_modem",),
+            ),
+        )
+        for text, expected in cases:
+            with self.subTest(text=text):
+                frame = _frame(text)
+                self.assertEqual(
+                    tuple(subject.entity_ref for subject in frame.subjects),
+                    expected,
+                )
+
+    def test_exact_bnl_reply_supplies_identity_only_pronoun_binding(self):
+        context = bnl01_bot.ConversationContextResult(
+            rendered_context=(
+                "BNL-01 (exact Discord reply source): Cache Back is a "
+                "founding BARCODE member."
+            ),
+            selected_row_ids=(77,),
+            same_room_paired_turn_count=0,
+            unpaired_row_count=1,
+            cross_channel_paired_turn_count=0,
+            current_message_duplicates_removed=0,
+            visibility_policy_exclusions=0,
+            selection_reasons=("discord_reply_source",),
+            final_char_count=96,
+            referent_status="resolved",
+            referent_candidate_count=1,
+            referent_selected_row_ids=(77,),
+            referent_reason="discord_reply_source",
+        )
+        identity_subjects, identity_status = (
+            bnl01_bot._exact_reply_canon_subject_references(
+                context,
+                "How is he connected to Call'em Bini?",
+            )
+        )
+        self.assertEqual(identity_status, "resolved")
+        self.assertEqual(identity_subjects, (("cache_back", "Cache Back"),))
+        addressing = bnl01_bot.DiscordTurnAddressing(
+            speaker="Test Member",
+            explicit_tag_recipients=("@BNL-01",),
+            reply_target="BNL-01",
+            explicitly_mentions_bnl=False,
+            reply_targets_bnl=True,
+            directly_targets_bnl=True,
+            targets_other_human=False,
+            plain_text_names_bnl=False,
+            speaker_user_id=101,
+            source_message_id=302,
+            reply_message_id=701,
+            reply_conversation_row_id=77,
+        )
+        decision = bnl01_bot.build_live_conversation_orchestration_decision(
+            engagement_decision="answer",
+            engagement_reason="direct_request",
+            channel_policy="sealed_test",
+            addressings=(addressing,),
+            context_result=context,
+            moment_situation=None,
+            guild_id=1,
+            channel_id=10,
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            current_text="How is he connected to Call'em Bini?",
+            current_speaker_user_ids=(101,),
+            current_speaker_labels=("Test Member",),
+            influence_mode="live",
+            packet_revision="turn_exact_reply_entity",
+        )
+
+        frame = decision.situation_frame
+        self.assertEqual(frame.status, "resolved")
+        self.assertEqual(
+            tuple(subject.entity_ref for subject in frame.subjects),
+            ("call_em_bini", "cache_back"),
+        )
+        self.assertEqual(frame.tasks[0].authority_scope, "packet")
+        self.assertEqual(frame.tasks[0].subject_indexes, (0, 1))
+
+    def test_exact_bnl_reply_pronoun_identity_ambiguity_fails_closed(self):
+        question = "How is he connected to Call'em Bini?"
+        cases = (
+            (
+                "ambiguous",
+                "Cache Back and Mac Modem are founding BARCODE members.",
+            ),
+            (
+                "unresolved",
+                "The archive record does not identify that person.",
+            ),
+        )
+        for identity_status, reply_text in cases:
+            with self.subTest(identity_status=identity_status):
+                context = bnl01_bot.ConversationContextResult(
+                    rendered_context=(
+                        "BNL-01 (exact Discord reply source): " + reply_text
+                    ),
+                    selected_row_ids=(77,),
+                    same_room_paired_turn_count=0,
+                    unpaired_row_count=1,
+                    cross_channel_paired_turn_count=0,
+                    current_message_duplicates_removed=0,
+                    visibility_policy_exclusions=0,
+                    selection_reasons=("discord_reply_source",),
+                    final_char_count=len(reply_text),
+                    referent_status="resolved",
+                    referent_candidate_count=1,
+                    referent_selected_row_ids=(77,),
+                    referent_reason="discord_reply_source",
+                )
+                identity_subjects, actual_identity_status = (
+                    bnl01_bot._exact_reply_canon_subject_references(
+                        context,
+                        question,
+                    )
+                )
+                self.assertEqual(identity_subjects, ())
+                self.assertEqual(actual_identity_status, identity_status)
+
+                addressing = bnl01_bot.DiscordTurnAddressing(
+                    speaker="Test Member",
+                    explicit_tag_recipients=("@BNL-01",),
+                    reply_target="BNL-01",
+                    explicitly_mentions_bnl=False,
+                    reply_targets_bnl=True,
+                    directly_targets_bnl=True,
+                    targets_other_human=False,
+                    plain_text_names_bnl=False,
+                    speaker_user_id=101,
+                    source_message_id=302,
+                    reply_message_id=701,
+                    reply_conversation_row_id=77,
+                )
+                decision = (
+                    bnl01_bot.build_live_conversation_orchestration_decision(
+                        engagement_decision="answer",
+                        engagement_reason="direct_request",
+                        channel_policy="sealed_test",
+                        addressings=(addressing,),
+                        context_result=context,
+                        moment_situation=None,
+                        guild_id=1,
+                        channel_id=10,
+                        route_mode="normal_chat",
+                        conversation_surface="mention_or_reply",
+                        current_text=question,
+                        current_speaker_user_ids=(101,),
+                        current_speaker_labels=("Test Member",),
+                        influence_mode="live",
+                        packet_revision=(
+                            "turn_exact_reply_entity_" + identity_status
+                        ),
+                    )
+                )
+
+                frame = decision.situation_frame
+                self.assertEqual(frame.status, "ambiguous")
+                self.assertIn(
+                    "referent_%s" % identity_status,
+                    frame.ambiguity_reasons,
+                )
+                self.assertEqual(
+                    tuple(subject.entity_ref for subject in frame.subjects),
+                    ("call_em_bini",),
+                )
+                self.assertNotIn(
+                    "cache_back",
+                    tuple(subject.entity_ref for subject in frame.subjects),
+                )
+                self.assertNotIn(
+                    "mac_modem",
+                    tuple(subject.entity_ref for subject in frame.subjects),
+                )
+
+    def test_exact_bnl_reply_without_canon_alias_keeps_ordinary_continuity(self):
+        reply_text = "I compared the two options and preferred the first."
+        question = "Why did you prefer them?"
+        context = bnl01_bot.ConversationContextResult(
+            rendered_context=(
+                "BNL-01 (exact Discord reply source): " + reply_text
+            ),
+            selected_row_ids=(77,),
+            same_room_paired_turn_count=0,
+            unpaired_row_count=1,
+            cross_channel_paired_turn_count=0,
+            current_message_duplicates_removed=0,
+            visibility_policy_exclusions=0,
+            selection_reasons=("discord_reply_source",),
+            final_char_count=len(reply_text),
+            referent_status="resolved",
+            referent_candidate_count=1,
+            referent_selected_row_ids=(77,),
+            referent_reason="discord_reply_source",
+        )
+
+        subjects, identity_status = (
+            bnl01_bot._exact_reply_canon_subject_references(
+                context,
+                question,
+            )
+        )
+        self.assertEqual(subjects, ())
+        self.assertEqual(identity_status, "not_requested")
+
+        addressing = bnl01_bot.DiscordTurnAddressing(
+            speaker="Test Member",
+            explicit_tag_recipients=("@BNL-01",),
+            reply_target="BNL-01",
+            explicitly_mentions_bnl=False,
+            reply_targets_bnl=True,
+            directly_targets_bnl=True,
+            targets_other_human=False,
+            plain_text_names_bnl=False,
+            speaker_user_id=101,
+            source_message_id=302,
+            reply_message_id=701,
+            reply_conversation_row_id=77,
+        )
+        decision = bnl01_bot.build_live_conversation_orchestration_decision(
+            engagement_decision="answer",
+            engagement_reason="direct_request",
+            channel_policy="sealed_test",
+            addressings=(addressing,),
+            context_result=context,
+            moment_situation=None,
+            guild_id=1,
+            channel_id=10,
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            current_text=question,
+            current_speaker_user_ids=(101,),
+            current_speaker_labels=("Test Member",),
+            influence_mode="live",
+            packet_revision="turn_exact_reply_ordinary_continuity",
+        )
+
+        self.assertEqual(decision.situation_frame.status, "resolved")
+        self.assertNotIn(
+            "referent_unresolved",
+            decision.situation_frame.ambiguity_reasons,
+        )
+
+        unrelated = bnl01_bot.build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            channel_policy="sealed_test",
+            current_text="By the way, who wrote Hamlet?",
+            current_speaker_user_ids=(101,),
+            reply_message_ids=(701,),
+            exact_source_row_ids=(77,),
+            referent_status="resolved",
+            response_act="answer",
+        )
+        self.assertEqual(unrelated.status, "resolved")
+        self.assertEqual(
+            tuple(task.authority_scope for task in unrelated.tasks),
+            ("external_public",),
+        )
+        self.assertEqual(
+            tuple(task.required_response_act for task in unrelated.tasks),
+            ("answer",),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 from unittest import mock
 
 from bnl_canon_source_contract import Confidence, SourceClass, Visibility
+import bnl_declared_canon as declared_canon
 import bnl_memory_ledger as ledger
 import bnl_moment_engine as moments
 import bnl_relationship_engine as relationships
@@ -21,6 +22,7 @@ from bnl_shared_brain_synthesis import (
     evaluate_single_packet_response,
     finalize_run,
     ordinary_chat_configuration,
+    ordinary_chat_deterministic_response_act,
     ordinary_chat_route_scope_decision,
     parse_ordinary_chat_response_contract,
     record_single_packet_block,
@@ -412,7 +414,13 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             environ=self.flags,
         )
         self.assertIsNotNone(packet)
-        self.assertEqual(packet.subject_resolution.status, "multi_resolved")
+        expected_resolution_status = (
+            "resolved" if len(subjects) == 1 else "multi_resolved"
+        )
+        self.assertEqual(
+            packet.subject_resolution.status,
+            expected_resolution_status,
+        )
         frame_revalidation = revalidate_situation_frame(
             frame,
             current_text=text,
@@ -813,6 +821,41 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertFalse(blocked.ready)
         self.assertEqual(blocked.reason, "nonpacket_factual_owner_selected")
 
+    def test_bnl_self_identity_prompt_keeps_subject_scoped_canon(self):
+        basis = self._multi_subject_basis(
+            "Who are you?",
+            (("bnl_01", "BNL-01"),),
+        )
+        self.assertEqual(basis.packet.subject_resolution.status, "resolved")
+
+        bnl_canon_digests = {
+            source_digest
+            for (
+                _evidence_id,
+                lane,
+                source_digest,
+                subject_indexes,
+            ) in basis.rendered_evidence_refs
+            if lane == "canon" and subject_indexes == (0,)
+        }
+        self.assertTrue(bnl_canon_digests)
+        self.assertTrue(
+            any(
+                item.lane == "canon"
+                and item.subject_key == "bnl_01"
+                and item.source_digest in bnl_canon_digests
+                for item in basis.packet.items
+            )
+        )
+
+        owned = build_packet_owned_prompt(
+            "Current user request: Who are you?",
+            basis,
+        )
+        self.assertTrue(owned.ready, owned.reason)
+        self.assertIn("BARCODE Network Liaison Entity", owned.prompt)
+        self.assertIn("one shared mind with filtered surfaces", owned.prompt)
+
     def test_typed_response_contract_accepts_only_applicable_packet_refs(self):
         evidence_id = next(
             evidence_id
@@ -1039,6 +1082,109 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             ).status,
             "packet_support_invalid",
         )
+
+    def test_owner_declared_cache_bini_relationship_supports_live_three_way_packet(self):
+        authority = {
+            "BNL_OWNER_USER_ID": "61",
+            "BNL_PRIMARY_GUILD_ID": "1",
+            declared_canon.DECLARED_CANON_AUTHORITY_SECRET_ENV: (
+                "ordinary-three-way-authority-secret-0001"
+            ),
+        }
+        with mock.patch.dict(os.environ, authority, clear=False):
+            self.conn.commit()
+            declared_canon.ensure_declared_canon_schema(self.conn)
+            revision = declared_canon.add_declared_canon(
+                self.conn,
+                actor_user_id=61,
+                authority_nonce="ordinary-three-way-relationship-0001",
+                guild_id=1,
+                subject_type="entity",
+                subject_id="cache_back",
+                object_subject_type="entity",
+                object_subject_id="call_em_bini",
+                predicate="originated_from",
+                value=(
+                    "Cache Back emerged while a laptop cache containing "
+                    "Call'em Bini's music and project files was cleared; "
+                    "they remain distinct entities."
+                ),
+                raw_declaration=(
+                    "Cache Back originated from data left by Call'em Bini "
+                    "during a laptop-cache clearing, while remaining his "
+                    "own distinct entity."
+                ),
+                cleaned_summary=(
+                    "Cache Back originated from Call'em Bini's cached "
+                    "project data; they are distinct entities."
+                ),
+                domain="hybrid",
+                claim_kind="relationship",
+                visibility="reference_canon",
+                eligible_routes=(
+                    "sealed_test",
+                    "public_home",
+                    "public_context",
+                ),
+                valid_from="2026-08-01T00:00:00+00:00",
+                now="2026-08-01T00:00:00+00:00",
+            ).primary
+            basis = self._multi_subject_basis(
+                "Compare Cache Back, Call'em Bini, and Mac Modem.",
+                (
+                    ("cache_back", "Cache Back"),
+                    ("call_em_bini", "Call'em Bini"),
+                    ("mac_modem", "Mac Modem"),
+                ),
+            )
+
+        declared_refs = {
+            subject_indexes: evidence_id
+            for (
+                evidence_id,
+                lane,
+                _source_digest,
+                subject_indexes,
+            ) in basis.rendered_evidence_refs
+            if lane in {"approved_fact", "canon"}
+            and any(
+                item.source_digest == _source_digest
+                and (
+                    "declared_canon:%s" % revision.declaration_id
+                    in item.root_identities
+                )
+                for item in basis.packet.items
+            )
+        }
+        self.assertEqual(set(declared_refs), {(0,), (1,)})
+        mac_evidence = next(
+            evidence_id
+            for (
+                evidence_id,
+                lane,
+                _source_digest,
+                subject_indexes,
+            ) in basis.rendered_evidence_refs
+            if lane == "canon" and subject_indexes == (2,)
+        )
+        contract = parse_ordinary_chat_response_contract(
+            '{"tasks":[{"taskId":"T1","text":"Cache Back has an '
+            "established canon origin connection to Call'em Bini while Mac "
+            'Modem has a different established role.","supportKind":'
+            '"packet","evidenceIds":["%s","%s","%s"]}]}'
+            % (
+                declared_refs[(0,)],
+                declared_refs[(1,)],
+                mac_evidence,
+            )
+        )
+        self.assertTrue(
+            validate_ordinary_chat_response_contract(
+                basis,
+                contract,
+            ).valid
+        )
+        self.assertEqual(ordinary_chat_deterministic_response_act(basis), "")
 
     def test_typed_external_task_uses_public_not_packet_authority(self):
         external_packet = replace(

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -244,6 +244,40 @@ class PublicationReadAdapterTests(unittest.TestCase):
         self.assertEqual("exact_date", by_date.query_mode)
         self.assertEqual(entry_id, by_date.publications[0].entry_id)
 
+    def test_explicit_latest_journal_prefers_publication_time_over_topic_density(self):
+        self.add_journal(
+            "journal_older_dense",
+            title="BARCODE Radio Broadcast Queue Audience",
+            excerpt="BARCODE Radio broadcast queue audience report.",
+            body="The broadcast queue and audience filled the report.",
+            published_at="2026-08-04T01:00:00Z",
+        )
+        self.add_journal(
+            "journal_newer_light",
+            title="New BARCODE Radio Note",
+            excerpt="A newer BARCODE Radio note was published.",
+            body="The new note reached the public Journal.",
+            published_at="2026-08-05T01:00:00Z",
+        )
+        selected = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text=(
+                "what did the latest Journal say about BARCODE Radio "
+                "broadcast queue audience?"
+            ),
+            control_snapshot=control_snapshot(),
+            now=NOW,
+        )
+
+        self.assertEqual(selected.status, "eligible")
+        self.assertEqual(selected.query_mode, "latest")
+        self.assertEqual(len(selected.publications), 1)
+        self.assertEqual(
+            selected.publications[0].entry_id,
+            "journal_newer_light",
+        )
+
     def test_journal_public_visibility_and_reuse_are_independent(self):
         entry_id = "journal_visibility_case"
         self.add_journal(entry_id, title="Public Ceramic Log")
@@ -389,6 +423,38 @@ class PublicationReadAdapterTests(unittest.TestCase):
         self.assertEqual(
             "site_manual_owner_receipt",
             approved.publications[0].provenance_kind,
+        )
+
+    def test_explicit_latest_relay_prefers_publication_time_over_topic_density(self):
+        self.add_relay(
+            "bnl-relay-older-dense",
+            message=(
+                "BARCODE Radio broadcast queue audience report covered the "
+                "broadcast queue and audience."
+            ),
+            published_at="2026-08-04T01:00:00Z",
+        )
+        self.add_relay(
+            "bnl-relay-newer-light",
+            message="A newer BARCODE Radio signal reached the Relay.",
+            published_at="2026-08-05T01:00:00Z",
+        )
+
+        selected = relay.select_accepted_relay_publications_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text=(
+                "what did the latest Relay say about BARCODE Radio "
+                "broadcast queue audience?"
+            ),
+        )
+
+        self.assertEqual("eligible", selected.status)
+        self.assertEqual("latest", selected.query_mode)
+        self.assertEqual(1, len(selected.publications))
+        self.assertEqual(
+            "bnl-relay-newer-light",
+            selected.publications[0].relay_id,
         )
 
     def test_relay_attempts_and_presence_are_not_accepted_speech(self):
@@ -573,6 +639,89 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
         )
         self.assertFalse(changed.valid)
         self.assertEqual("source_changed", changed.status)
+
+    def test_latest_journal_revalidation_rejects_newer_matching_publication(self):
+        snapshot = control_snapshot()
+        self.add_journal(
+            "journal_latest_old",
+            title="BARCODE Radio Old Signal",
+            excerpt="An older BARCODE Radio signal reached the Journal.",
+            body="The older radio signal was published first.",
+            published_at="2026-08-04T01:00:00Z",
+        )
+        packet = build_packet(
+            self.conn,
+            self.request(
+                "what did the latest Journal say about BARCODE Radio?",
+                snapshot=snapshot,
+                control_status="valid",
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        selected = next(
+            item
+            for item in packet.items
+            if item.lane == "journal_publication"
+        )
+        self.assertEqual("journal:journal_latest_old:1", selected.source_ref)
+
+        self.add_journal(
+            "journal_latest_new",
+            title="BARCODE Radio New Signal",
+            excerpt="A newer BARCODE Radio signal reached the Journal.",
+            body="The newer radio signal supersedes the latest selection.",
+            published_at="2026-08-05T01:00:00Z",
+        )
+        self.conn.commit()
+
+        changed = revalidate_packet(
+            self.conn,
+            packet,
+            environ=self.flags,
+            journal_control_snapshot=snapshot,
+            journal_control_snapshot_provided=True,
+        )
+        self.assertFalse(changed.valid)
+        self.assertEqual("source_changed", changed.status)
+        self.assertGreaterEqual(changed.changed_source_count, 1)
+
+    def test_latest_relay_revalidation_rejects_newer_matching_publication(self):
+        self.add_relay(
+            "bnl-latest-old",
+            message="An older BARCODE Radio signal reached the Relay.",
+            published_at="2026-08-04T01:00:00Z",
+        )
+        packet = build_packet(
+            self.conn,
+            self.request(
+                "what did the latest Relay say about BARCODE Radio?"
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        selected = next(
+            item
+            for item in packet.items
+            if item.lane == "relay_publication"
+        )
+        self.assertEqual("relay:bnl-latest-old", selected.source_ref)
+
+        self.add_relay(
+            "bnl-latest-new",
+            message="A newer BARCODE Radio signal reached the Relay.",
+            published_at="2026-08-05T01:00:00Z",
+        )
+        self.conn.commit()
+
+        changed = revalidate_packet(
+            self.conn,
+            packet,
+            environ=self.flags,
+        )
+        self.assertFalse(changed.valid)
+        self.assertEqual("source_changed", changed.status)
+        self.assertGreaterEqual(changed.changed_source_count, 1)
 
     def test_missing_hidden_and_unapproved_publications_fail_packet_closed(self):
         missing = build_packet(

--- a/tests/test_route_memory_governance.py
+++ b/tests/test_route_memory_governance.py
@@ -1153,11 +1153,29 @@ class MemoryInjectionGovernanceTests(unittest.TestCase):
             "What happened on the last BARCODE Radio episode?",
             "What does broadcast memory say about DJ Floppy Disc?",
             "Is the show schedule still active?",
-            "Is the track submission queue open?",
         )
         for text in explicit_broadcast_requests:
             with self.subTest(text=text):
                 self.assertTrue(
+                    bnl01_bot._broadcast_memory_requires_specialized_owner(
+                        text
+                    )
+                )
+
+        canonical_non_broadcast_owners = (
+            "Is the track submission queue open?",
+            "is the Barcode Radio queue open right now?",
+            "What's the status of the Barcode Radio queue?",
+            "What is the current state of the Barcode Radio queue?",
+            "Is Barcode Radio accepting submissions?",
+            "Can I submit a track right now?",
+            "Is the intake open for tracks?",
+            "what did the latest Journal say about Barcode Radio?",
+            "what did the latest Relay say about Barcode Radio?",
+        )
+        for text in canonical_non_broadcast_owners:
+            with self.subTest(text=text):
+                self.assertFalse(
                     bnl01_bot._broadcast_memory_requires_specialized_owner(
                         text
                     )

--- a/tests/test_shared_brain_synthesis_bot_path.py
+++ b/tests/test_shared_brain_synthesis_bot_path.py
@@ -1264,6 +1264,87 @@ class SharedBrainSynthesisBotPathTests(
             "ambiguous",
         )
 
+    async def test_unavailable_current_queue_holds_with_zero_provider_calls(self):
+        task = SimpleNamespace(
+            task_id="T1",
+            required_response_act="answer",
+            authority_scope="packet",
+            object_kind="queue",
+            subject_indexes=(),
+        )
+        basis = SimpleNamespace(
+            packet=SimpleNamespace(
+                source_snapshot_digest="source-digest",
+                request=SimpleNamespace(frame_tasks=(task,)),
+            ),
+            # Unrelated canon evidence must not support live queue state.
+            rendered_evidence_refs=(("E1", "canon", "digest", ()),),
+        )
+        run = SimpleNamespace(
+            prompt_applied=False,
+            fallback_reason="deterministic_task_hold",
+            revalidation_status="passed",
+            basis=basis,
+        )
+        provider = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "build_packet_owned_prompt",
+                return_value=SimpleNamespace(
+                    ready=True,
+                    prompt="packet-owned prompt",
+                    reason="",
+                ),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "revalidate_situation_frame",
+                return_value=SimpleNamespace(status="valid"),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "_begin_ordinary_chat_single_packet_receipt",
+                return_value=run,
+            ) as begin,
+            mock.patch.object(
+                bnl01_bot,
+                "get_tracked_gemini_response_with_optional_typing",
+                new=provider,
+            ),
+        ):
+            execution = (
+                await bnl01_bot.maybe_generate_ordinary_chat_single_packet(
+                    channel=FakeChannel(),
+                    prompt="base prompt",
+                    basis=basis,
+                    scope_applied=True,
+                    preflight_block_reason="",
+                    situation_frame=SimpleNamespace(),
+                    situation_frame_current_text=(
+                        "Can I submit a track right now?"
+                    ),
+                    route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy="public_context",
+                    conversation_surface="mention_or_reply",
+                    user_id=7,
+                    guild_id=1,
+                    user_display_name="Test Member",
+                    source_context_available=False,
+                )
+            )
+
+        self.assertFalse(execution.candidate_active)
+        self.assertEqual(execution.provider_call_count, 0)
+        self.assertEqual(execution.corrective_call_count, 0)
+        self.assertEqual(execution.block_reason, "deterministic_task_hold")
+        provider.assert_not_awaited()
+        self.assertFalse(begin.call_args.kwargs["prompt_ready"])
+        self.assertEqual(
+            begin.call_args.kwargs["prompt_failure_reason"],
+            "deterministic_task_hold",
+        )
+
     async def test_single_packet_deterministic_clarification_bypasses_factual_guard_and_sends(self):
         message = FakeMessage()
         reason = "candidate_prompt_frame_ambiguous"

--- a/tests/test_showday_queue_alignment.py
+++ b/tests/test_showday_queue_alignment.py
@@ -130,6 +130,76 @@ class ShowdayQueueAlignmentTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(context, "")
         fetch.assert_not_called()
 
+    def test_current_queue_owner_fails_closed_until_both_production_gates_are_ready(self):
+        questions = (
+            "is the Barcode Radio queue open right now?",
+            "What's the status of the Barcode Radio queue?",
+            "What is the current state of the Barcode Radio queue?",
+            "Is Barcode Radio accepting submissions?",
+            "Can I submit a track right now?",
+            "Is the intake open for tracks?",
+        )
+        for question in questions:
+            with self.subTest(question=question), mock.patch.dict(
+                os.environ,
+                {"BNL_QUEUE_PRODUCTION_ENABLED": "false"},
+                clear=False,
+            ), mock.patch.object(
+                bnl01_bot,
+                "fetch_bnl_read_model",
+                return_value=read_model(True),
+            ):
+                local_off = bnl01_bot.maybe_build_bnl_read_model_context(
+                    question,
+                    "public_home",
+                )
+            with mock.patch.dict(
+                os.environ,
+                {"BNL_QUEUE_PRODUCTION_ENABLED": "true"},
+                clear=False,
+            ), mock.patch.object(
+                bnl01_bot,
+                "fetch_bnl_read_model",
+                return_value=read_model(False),
+            ):
+                site_off = bnl01_bot.maybe_build_bnl_read_model_context(
+                    question,
+                    "public_home",
+                )
+
+            self.assertTrue(bnl01_bot._current_queue_state_query(question))
+            self.assertEqual(local_off, "")
+            self.assertEqual(site_off, "")
+            self.assertNotIn("auxchord", (local_off + site_off).lower())
+
+    def test_current_queue_owner_uses_only_gated_native_read_model_context(self):
+        questions = (
+            "is the Barcode Radio queue open right now?",
+            "What's the status of the Barcode Radio queue?",
+            "What is the current state of the Barcode Radio queue?",
+            "Is Barcode Radio accepting submissions?",
+            "Can I submit a track right now?",
+            "Is the intake open for tracks?",
+        )
+        for question in questions:
+            with self.subTest(question=question), mock.patch.dict(
+                os.environ,
+                {"BNL_QUEUE_PRODUCTION_ENABLED": "true"},
+                clear=False,
+            ), mock.patch.object(
+                bnl01_bot,
+                "fetch_bnl_read_model",
+                return_value=read_model(True),
+            ):
+                context = bnl01_bot.maybe_build_bnl_read_model_context(
+                    question,
+                    "public_home",
+                )
+
+            self.assertIn("Queue:", context)
+            self.assertIn("PRIVATE_TEST_QUEUE_TITLE", context)
+            self.assertNotIn("auxchord", context.lower())
+
     async def test_auxchord_generation_is_rejected_for_native_intake(self):
         generated = (
             "Auxchord channels are accepting submissions now.\n"

--- a/tests/test_situation_frame_v1.py
+++ b/tests/test_situation_frame_v1.py
@@ -172,6 +172,60 @@ class SituationFrameV1Tests(unittest.TestCase):
                     "existing_typed_entity",
                 )
 
+    def test_exact_discord_reply_uses_packet_authority_without_weakening_live_holds(self):
+        exact_reply = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            channel_policy="sealed_test",
+            current_text="what test code did i give you?",
+            current_speaker_user_ids=(101,),
+            reply_message_ids=(700,),
+            exact_source_row_ids=(77,),
+            referent_status="resolved",
+            response_act="answer",
+        )
+        live_weather = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            channel_policy="sealed_test",
+            current_text="what is Seattle's weather right now?",
+            current_speaker_user_ids=(101,),
+            reply_message_ids=(700,),
+            exact_source_row_ids=(77,),
+            referent_status="resolved",
+            response_act="answer",
+        )
+
+        self.assertEqual(exact_reply.tasks[0].authority_scope, "packet")
+        self.assertEqual(exact_reply.tasks[0].required_response_act, "answer")
+        self.assertEqual(live_weather.tasks[0].authority_scope, "external_current")
+        self.assertEqual(live_weather.tasks[0].required_response_act, "hold")
+
+    def test_barcode_radio_queue_is_one_packet_owned_queue_task(self):
+        questions = (
+            "is the Barcode Radio queue open right now?",
+            "Can I submit a track right now?",
+            "Is the intake open for tracks?",
+        )
+        for question in questions:
+            with self.subTest(question=question):
+                frame = build_situation_frame_v1(
+                    route_allowed=True,
+                    route_mode="normal_chat",
+                    conversation_surface="mention_or_reply",
+                    channel_policy="sealed_test",
+                    current_text=question,
+                    current_speaker_user_ids=(101,),
+                    response_act="answer",
+                )
+
+                self.assertEqual(frame.object_kind, "queue")
+                self.assertEqual(len(frame.tasks), 1)
+                self.assertEqual(frame.tasks[0].object_kind, "queue")
+                self.assertEqual(frame.tasks[0].authority_scope, "packet")
+
     def test_multiple_explicit_mentions_bind_to_one_task_without_ambiguity(self):
         frame = build_situation_frame_v1(
             route_allowed=True,


### PR DESCRIPTION
## Summary

Repairs the bounded two-user ordinary-chat canary failures observed in live Discord:

- binds complete canon subject lists for natural comparisons and preserves exact BNL reply identity only when unambiguous;
- makes exact Discord replies select only the replied-to human turn, while unrelated stable-public questions remain external-public;
- selects the newest eligible completed broadcast episode and revalidates latest Journal/Relay reads against their current source row;
- keeps current queue questions on the native queue owner and returns a deterministic zero-provider hold while production queue data is unavailable;
- admits current, owner-approved Declared Canon relationships on sealed_test/public_home/public_context without inventing a Cache Back/Call'em Bini relationship in code.

## Safety boundaries

- ordinary chat remains one provider call and zero corrective calls;
- Memory Governance, Relationship v2, Active Engagement v2, and production queue gates remain off;
- no deployment or environment mutation is included;
- ambiguous or missing canon identity still fails closed;
- public output does not expose owner/controller authority or private account identifiers.

The Cache Back/Call'em Bini relationship answer requires a current owner-approved Declared Canon relationship revision with all three eligible routes. The code intentionally does not hard-code that fact.

## Verification

- `make check PYTHON=.venv/bin/python`: **2,274 tests passed**
- focused shared-brain regression pack: **390 tests passed**
- `git diff --check`: passed
- independent entity/privacy, exact-reply, specialized-source, and final integration reviews: passed

Tested local commit: `3afa39d893518096bcbddd491fb77d0da19c178b`
Tested/published tree: `f3ba484647f8c677bd0d73e8532d204b6a8aa3ea`
Remote parent: `7cfc364f1ef32978402271391469264aedeaa872`
