### PR TITLE
Repair exact-reply pronoun clarification

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -23485,8 +23485,10 @@ def _exact_reply_canon_subject_references(
     """Use one exact BNL reply as identity-only pronoun binding.
 
     Prior model prose never becomes factual evidence here.  It may identify a
-    single approved canon subject for the current deictic/pronoun reference;
-    zero or multiple matches remain unresolved.
+    single approved canon subject for the current deictic/pronoun reference.
+    When the current relationship question explicitly names an object, that
+    object cannot also satisfy its pronoun slot.  One remaining source subject
+    may provide identity-only binding; otherwise ambiguity remains closed.
     """
 
     if (
@@ -23539,9 +23541,49 @@ def _exact_reply_canon_subject_references(
             if str(alias or "").strip()
         ):
             resolved.append((identity.key, identity.name))
-    if len(resolved) == 1:
-        return tuple(resolved), "resolved"
     if resolved:
+        relation_object = re.search(
+            r"\b(?:connected|related)\s+to\b(?P<object>[^?!;\n]*)",
+            unicodedata.normalize("NFKC", str(current_text or "")).replace(
+                "’",
+                "'",
+            ),
+            re.I,
+        )
+        if relation_object is not None:
+            object_text = relation_object.group("object")
+            resolved_by_key = dict(resolved)
+            object_keys = {
+                identity.key
+                for identity in eligible
+                if identity.key in resolved_by_key
+                and any(
+                    re.search(
+                        r"(?<![a-z0-9])%s(?![a-z0-9])"
+                        % re.escape(
+                            unicodedata.normalize("NFKC", alias).replace(
+                                "’",
+                                "'",
+                            )
+                        ),
+                        object_text,
+                        re.I,
+                    )
+                    for alias in (identity.name, *identity.aliases)
+                    if str(alias or "").strip()
+                )
+            }
+            remaining = tuple(
+                identity
+                for identity in resolved
+                if identity[0] not in object_keys
+            )
+            if object_keys:
+                if len(remaining) == 1:
+                    return remaining, "resolved"
+                return (), "ambiguous"
+        if len(resolved) == 1:
+            return tuple(resolved), "resolved"
         return (), "ambiguous"
     if _EXACT_REPLY_CANON_IDENTITY_QUERY_RE.search(current_text or ""):
         return (), "unresolved"
@@ -36950,6 +36992,11 @@ async def send_planned_conversation_response(
             ordinary_chat_single_packet_execution.block_reason
         )
     )
+    single_packet_block_reason = str(
+        ordinary_chat_single_packet_execution.block_reason
+        if ordinary_chat_single_packet_execution is not None
+        else ""
+    ).lower()
     typed_single_packet_candidate = bool(
         single_packet_cutover
         and synthesis_candidate_active
@@ -37382,9 +37429,19 @@ async def send_planned_conversation_response(
             final_frame_revalidation.status,
             len(final_frame_revalidation.reason_codes),
         )
+        deterministic_frame_clarification = bool(
+            deterministic_single_packet_block
+            and final_frame_revalidation.status == "ambiguous"
+            and (
+                "frame_ambiguous" in single_packet_block_reason
+                or "deterministic_task_clarify"
+                in single_packet_block_reason
+            )
+        )
         if (
             single_packet_cutover
             and final_frame_revalidation.status != "valid"
+            and not deterministic_frame_clarification
         ):
             if synthesis_decision is not None:
                 synthesis_decision = (
@@ -37412,6 +37469,15 @@ async def send_planned_conversation_response(
                 "frame_presend_failed",
             )
             return model_decision
+        if deterministic_frame_clarification:
+            guard_diagnostics[
+                "deterministic_frame_clarification"
+            ] = True
+            logging.info(
+                "situation_frame_clarification_send_allowed "
+                "revision=%s status=ambiguous",
+                situation_frame.frame_revision,
+            )
     sent_message_ids = []
     try:
         if len(response) <= 2000:

--- a/tests/test_ordinary_chat_acceptance_contract_matrix.py
+++ b/tests/test_ordinary_chat_acceptance_contract_matrix.py
@@ -334,6 +334,86 @@ class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
         self.assertEqual(frame.tasks[0].authority_scope, "packet")
         self.assertEqual(frame.tasks[0].subject_indexes, (0, 1))
 
+    def test_exact_bnl_reply_excludes_explicit_relationship_object(self):
+        reply_text = (
+            "Cache Back is a founding BARCODE member and BARCODE Archive "
+            "specialist. They emerged when a laptop cache containing "
+            "Call'em Bini's music and project files was cleared, though "
+            "the two remain distinct entities."
+        )
+        context = bnl01_bot.ConversationContextResult(
+            rendered_context=(
+                "BNL-01 (exact Discord reply source): " + reply_text
+            ),
+            selected_row_ids=(77,),
+            same_room_paired_turn_count=0,
+            unpaired_row_count=1,
+            cross_channel_paired_turn_count=0,
+            current_message_duplicates_removed=0,
+            visibility_policy_exclusions=0,
+            selection_reasons=("discord_reply_source",),
+            final_char_count=len(reply_text),
+            referent_status="resolved",
+            referent_candidate_count=1,
+            referent_selected_row_ids=(77,),
+            referent_reason="discord_reply_source",
+        )
+        question = "How is he connected to Call'em Bini?"
+
+        identity_subjects, identity_status = (
+            bnl01_bot._exact_reply_canon_subject_references(
+                context,
+                question,
+            )
+        )
+
+        self.assertEqual(identity_status, "resolved")
+        self.assertEqual(
+            identity_subjects,
+            (("cache_back", "Cache Back"),),
+        )
+
+        addressing = bnl01_bot.DiscordTurnAddressing(
+            speaker="Test Member",
+            explicit_tag_recipients=("@BNL-01",),
+            reply_target="BNL-01",
+            explicitly_mentions_bnl=False,
+            reply_targets_bnl=True,
+            directly_targets_bnl=True,
+            targets_other_human=False,
+            plain_text_names_bnl=False,
+            speaker_user_id=101,
+            source_message_id=302,
+            reply_message_id=701,
+            reply_conversation_row_id=77,
+        )
+        decision = bnl01_bot.build_live_conversation_orchestration_decision(
+            engagement_decision="answer",
+            engagement_reason="direct_request",
+            channel_policy="sealed_test",
+            addressings=(addressing,),
+            context_result=context,
+            moment_situation=None,
+            guild_id=1,
+            channel_id=10,
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            current_text=question,
+            current_speaker_user_ids=(101,),
+            current_speaker_labels=("Test Member",),
+            influence_mode="live",
+            packet_revision="turn_exact_reply_relation_object",
+        )
+
+        frame = decision.situation_frame
+        self.assertEqual(frame.status, "resolved")
+        self.assertEqual(
+            tuple(subject.entity_ref for subject in frame.subjects),
+            ("call_em_bini", "cache_back"),
+        )
+        self.assertEqual(frame.tasks[0].authority_scope, "packet")
+        self.assertEqual(frame.tasks[0].subject_indexes, (0, 1))
+
     def test_exact_bnl_reply_pronoun_identity_ambiguity_fails_closed(self):
         question = "How is he connected to Call'em Bini?"
         cases = (
@@ -428,6 +508,54 @@ class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
                     "mac_modem",
                     tuple(subject.entity_ref for subject in frame.subjects),
                 )
+
+    def test_exact_bnl_reply_does_not_treat_pre_copula_alias_as_subject(self):
+        cases = (
+            (
+                "According to Cache Back, the person in question is "
+                "Call'em Bini.",
+                "Who is he?",
+            ),
+            (
+                "Call'em Bini's music is the material Cache Back "
+                "emerged from.",
+                "Who is he?",
+            ),
+            (
+                "Call'em Bini is a founding BARCODE member.",
+                "How is he connected to Call'em Bini?",
+            ),
+        )
+
+        for reply_text, question in cases:
+            with self.subTest(reply_text=reply_text, question=question):
+                context = bnl01_bot.ConversationContextResult(
+                    rendered_context=(
+                        "BNL-01 (exact Discord reply source): " + reply_text
+                    ),
+                    selected_row_ids=(77,),
+                    same_room_paired_turn_count=0,
+                    unpaired_row_count=1,
+                    cross_channel_paired_turn_count=0,
+                    current_message_duplicates_removed=0,
+                    visibility_policy_exclusions=0,
+                    selection_reasons=("discord_reply_source",),
+                    final_char_count=len(reply_text),
+                    referent_status="resolved",
+                    referent_candidate_count=1,
+                    referent_selected_row_ids=(77,),
+                    referent_reason="discord_reply_source",
+                )
+
+                identity_subjects, identity_status = (
+                    bnl01_bot._exact_reply_canon_subject_references(
+                        context,
+                        question,
+                    )
+                )
+
+                self.assertEqual(identity_subjects, ())
+                self.assertEqual(identity_status, "ambiguous")
 
     def test_exact_bnl_reply_without_canon_alias_keeps_ordinary_continuity(self):
         reply_text = "I compared the two options and preferred the first."

--- a/tests/test_shared_brain_synthesis_bot_path.py
+++ b/tests/test_shared_brain_synthesis_bot_path.py
@@ -1347,8 +1347,32 @@ class SharedBrainSynthesisBotPathTests(
 
     async def test_single_packet_deterministic_clarification_bypasses_factual_guard_and_sends(self):
         message = FakeMessage()
+        message.content = "Tell me about Jordan."
+        situation_frame = bnl01_bot.build_situation_frame_v1(
+            route_allowed=True,
+            route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            conversation_surface=(
+                bnl01_bot.CONVERSATION_SURFACE_MENTION_OR_REPLY
+            ),
+            channel_policy="public_context",
+            current_text=message.content,
+            current_speaker_user_ids=(message.author.id,),
+            current_speaker_labels=(message.author.display_name,),
+            addressee_kinds=("discord_mention",),
+            explicit_mention_count=1,
+            referent_status="ambiguous",
+            response_act="clarify",
+            packet_revision="turn_ambiguous_clarification",
+        )
         reason = "candidate_prompt_frame_ambiguous"
-        run = SimpleNamespace(run_id="single-block-run")
+        run = SimpleNamespace(
+            run_id="single-block-run",
+            basis=SimpleNamespace(
+                packet=SimpleNamespace(
+                    source_snapshot_digest="source-digest"
+                )
+            ),
+        )
         decision = SimpleNamespace(
             run=run,
             candidate_selected=False,
@@ -1399,6 +1423,8 @@ class SharedBrainSynthesisBotPathTests(
                 allow_model_save=False,
                 mark_recent_direct=False,
                 ordinary_chat_single_packet_execution=execution,
+                situation_frame=situation_frame,
+                situation_frame_current_text=message.content,
             )
 
         self.assertEqual(message.replies, [execution.response])


### PR DESCRIPTION
## Summary

The second-user live acceptance run after #441 passed the shared-brain identity, entity canon, multi-entity comparison, exact human-reply memory, latest broadcast memory, Journal/Relay, queue safety-hold, and ordinary knowledge checks. One exact-reply continuation failed silently:

1. BNL-01 answered `who is Cache Back?` and mentioned both Cache Back and Call'em Bini.
2. The tester replied directly to that exact BNL answer: `How is he connected to Call'em Bini?`
3. Runtime recorded `single_packet_frame_ambiguous` and sent no response.

## Repair

- Treat an explicitly named relationship object (`connected/related to <object>`) as ineligible to satisfy the question's pronoun.
- Bind the pronoun only when exactly one approved canon identity remains in the exact BNL reply.
- Keep plural, possessive, pre-copula, and same-object cases ambiguous and fail closed.
- Permit the already-built deterministic clarification to send when final frame revalidation remains genuinely ambiguous.
- Continue suppressing stale, invalid, unrelated local-block, and provider/model candidates.

No ordinary-chat scope, privacy boundary, provider-call budget, corrective-call budget, queue gate, or other rollout gate changes are included.

## Verification

- Focused acceptance/revalidation suite: **392 passed**
- Full repository check: **2,276 passed**
- `git diff --check`: passed
- Independent repair review: passed
- Independent final integration/safety audit: passed
- Remote parent verified: `eb8e81318293b3e5f8e7700104c6828011a22166`
- Tested/remote tree verified: `8a813ae2fc2b7e1bb40f99cbe8efb3528a6987e2`

## Separate operational follow-up

The live canon proof also found two current `public_home` Cache Back → Call'em Bini `originated_from` declarations. That append-only data cleanup is intentionally outside this code PR. A read-only, fail-closed diagnostic will compare the unprinted fingerprints and lineage; only an exact duplicate produces the authenticated owner retirement command.