### PR TITLE
Repair exact-reply continuity and preserve established chat baseline

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -1667,6 +1667,9 @@ You are BNL-01. The BARCODE Network is watching. You are functioning as intended
 ORDINARY_CHAT_SINGLE_PACKET_ROUTE = (
     "ordinary_chat_single_packet_canary"
 )
+ORDINARY_CHAT_LEGACY_BASELINE_ROUTE = (
+    "ordinary_chat_legacy_baseline_fallback"
+)
 BNL01_PACKET_OWNED_SYSTEM_PROMPT = """You are BNL-01, the BARCODE Network Liaison Entity.
 
 Voice: calm, concise, observant, friendly, lightly corporate, with restrained
@@ -32903,6 +32906,7 @@ def build_user_aware_prompt(
     verified_exact_quote_authority: CurrentRoomQuoteAuthority | None = None,
     conversation_context_result: ConversationContextResult | None = None,
     conversation_orchestration: ConversationOrchestrationDecision | None = None,
+    _ordinary_chat_single_packet_enabled_override: bool | None = None,
 ) -> tuple:
     print("BNL DEBUG: build_user_aware_prompt start")
     display_name, preferred_name = get_user_profile(user_id, guild_id)
@@ -32921,6 +32925,11 @@ def build_user_aware_prompt(
         has_media=_prompt_has_current_message_media_context(clean_content),
     )
     ordinary_chat_single_packet = bool(ordinary_chat_scope.eligible)
+    if _ordinary_chat_single_packet_enabled_override is not None:
+        ordinary_chat_single_packet = bool(
+            ordinary_chat_single_packet
+            and _ordinary_chat_single_packet_enabled_override
+        )
     recall_current_direct = bool(
         is_direct_interaction
         or is_broad_personal_recall_request(clean_content)
@@ -33378,6 +33387,38 @@ def build_user_aware_prompt(
             if ordinary_chat_single_packet
             and ordinary_chat_single_packet_basis is None
             else ""
+        )
+        prompt_metadata["ordinary_chat_legacy_baseline_request"] = (
+            {
+                "user_id": user_id,
+                "guild_id": guild_id,
+                "fallback_display_name": fallback_display_name,
+                "clean_content": clean_content,
+                "show_state_context": show_state_context,
+                "room_context": room_context,
+                "channel_name": channel_name,
+                "message_count": message_count,
+                "privileged": privileged,
+                "channel_policy": channel_policy,
+                "website_read_model_context": website_read_model_context,
+                "source_context_block": source_context_block,
+                "route_mode": route_mode,
+                "is_direct_interaction": is_direct_interaction,
+                "current_turn_context": current_turn_context,
+                "channel_id": channel_id,
+                "moment_attribution_target_user_id": (
+                    moment_attribution_target_user_id
+                ),
+                "verified_exact_quote_authority": (
+                    verified_exact_quote_authority
+                ),
+                "conversation_context_result": (
+                    conversation_context_result
+                ),
+                "conversation_orchestration": conversation_orchestration,
+            }
+            if ordinary_chat_single_packet
+            else None
         )
         prompt_metadata["unified_moment_canary_applied"] = bool(
             unified_moment_canary_basis is not None
@@ -36197,6 +36238,21 @@ class OrdinaryChatSinglePacketExecution:
     provider_call_count: int
     corrective_call_count: int
     block_reason: str = ""
+    legacy_baseline_active: bool = False
+    legacy_baseline_generation_provider_call_count: int = 0
+    legacy_fallback_reason: str = ""
+
+
+@dataclass(frozen=True)
+class OrdinaryChatLegacyBaselineExecution:
+    packet_execution: OrdinaryChatSinglePacketExecution
+    response: str
+    prompt: str
+    prompt_metadata: dict
+    allow_greeting: bool
+    style_key: str
+    source_context_available: bool
+    provider_call_count: int
 
 
 def _ordinary_chat_single_packet_block_response(reason: str) -> str:
@@ -36875,6 +36931,217 @@ async def maybe_generate_ordinary_chat_single_packet(
     )
 
 
+_ORDINARY_CHAT_VOLATILE_FALLBACK_RE = re.compile(
+    r"\b(?:right\s+now|currently|current|today|tonight|live|weather|"
+    r"queue\s+(?:open|status)|can\s+i\s+submit|latest\s+(?:price|score))\b",
+    re.I,
+)
+
+
+def ordinary_chat_legacy_baseline_fallback_allowed(
+    execution: OrdinaryChatSinglePacketExecution | None,
+    *,
+    situation_frame: SituationFrameV1 | None,
+    request_text: str = "",
+) -> bool:
+    """Allow the established prompt only before a low-risk packet call.
+
+    The packet route remains authoritative whenever it generated a candidate or
+    actually entered provider generation.  The legacy prompt is available only
+    for local packet/preflight failures, and never for typed live/current holds.
+    """
+
+    if execution is None or execution.candidate_active:
+        return False
+    if execution.provider_call_count or execution.corrective_call_count:
+        return False
+    decision = execution.decision
+    run = getattr(decision, "run", None) if decision is not None else None
+    if bool(getattr(run, "prompt_applied", False)):
+        return False
+
+    block_reason = str(execution.block_reason or "").strip().lower()
+    if (
+        "current_fact" in block_reason
+        or block_reason.startswith("pre_generation_")
+    ):
+        return False
+    if (
+        "ambiguous" in block_reason
+        or "deterministic_task_clarify" in block_reason
+    ):
+        return False
+    if str(getattr(situation_frame, "status", "") or "").lower() == (
+        "ambiguous"
+    ):
+        return False
+
+    tasks = tuple(getattr(situation_frame, "tasks", ()) or ())
+    for task in tasks:
+        authority_scope = str(
+            getattr(task, "authority_scope", "") or ""
+        ).strip().lower()
+        currentness = str(
+            getattr(task, "currentness", "") or ""
+        ).strip().lower()
+        required_act = str(
+            getattr(task, "required_response_act", "") or ""
+        ).strip().lower()
+        if authority_scope == "external_current":
+            return False
+        if currentness == "current" and required_act == "hold":
+            return False
+        if required_act == "clarify":
+            return False
+
+    if not tasks and _ORDINARY_CHAT_VOLATILE_FALLBACK_RE.search(
+        request_text or ""
+    ):
+        return False
+    return True
+
+
+def _build_ordinary_chat_legacy_baseline_prompt(
+    prompt_metadata: Mapping[str, Any],
+    *,
+    payload_items,
+    request_text: str,
+    conversation_orchestration: ConversationOrchestrationDecision | None,
+) -> tuple[str, bool, str, dict] | None:
+    request = prompt_metadata.get(
+        "ordinary_chat_legacy_baseline_request"
+    )
+    if not isinstance(request, Mapping):
+        return None
+
+    legacy_metadata: dict[str, Any] = {}
+    legacy_prompt, allow_greeting, style_key = build_user_aware_prompt(
+        **dict(request),
+        prompt_metadata=legacy_metadata,
+        _ordinary_chat_single_packet_enabled_override=False,
+    )
+    legacy_prompt = _build_direct_payload_prompt(
+        legacy_prompt,
+        payload_items,
+        request_text,
+    )
+    orchestration_prompt = render_conversation_orchestration_prompt(
+        conversation_orchestration
+    )
+    if orchestration_prompt:
+        legacy_prompt += "\n\n" + orchestration_prompt
+
+    # The baseline itself is the recovery answer.  Do not spend a second model
+    # call on the older synthesis canary after the packet already declined.
+    legacy_metadata["shared_brain_synthesis_canary_basis"] = None
+    legacy_metadata["ordinary_chat_legacy_baseline_fallback"] = True
+    return (
+        legacy_prompt,
+        allow_greeting,
+        style_key,
+        legacy_metadata,
+    )
+
+
+async def maybe_generate_ordinary_chat_legacy_baseline(
+    *,
+    execution: OrdinaryChatSinglePacketExecution | None,
+    prompt_metadata: Mapping[str, Any],
+    channel,
+    payload_items,
+    request_text: str,
+    conversation_orchestration: ConversationOrchestrationDecision | None,
+    situation_frame: SituationFrameV1 | None,
+    user_id: int,
+    guild_id: int,
+) -> OrdinaryChatLegacyBaselineExecution | None:
+    """Recover the established context-rich path after a zero-call block."""
+
+    if not ordinary_chat_legacy_baseline_fallback_allowed(
+        execution,
+        situation_frame=situation_frame,
+        request_text=request_text,
+    ):
+        return None
+    try:
+        rebuilt = _build_ordinary_chat_legacy_baseline_prompt(
+            prompt_metadata,
+            payload_items=payload_items,
+            request_text=request_text,
+            conversation_orchestration=conversation_orchestration,
+        )
+    except Exception as exc:
+        logging.warning(
+            "ordinary_chat_legacy_baseline_failed reason=rebuild_error "
+            "error=%s",
+            type(exc).__name__,
+        )
+        return None
+    if rebuilt is None or execution is None:
+        return None
+    legacy_prompt, allow_greeting, style_key, legacy_metadata = rebuilt
+    source_context_available = bool(
+        legacy_metadata.get("source_context_available")
+    )
+    try:
+        tracked = await get_tracked_gemini_response_with_optional_typing(
+            channel,
+            legacy_prompt,
+            user_id,
+            guild_id,
+            route=ORDINARY_CHAT_LEGACY_BASELINE_ROUTE,
+            source_context_available=source_context_available,
+        )
+    except Exception as exc:
+        logging.warning(
+            "ordinary_chat_legacy_baseline_failed reason=generation_error "
+            "error=%s",
+            type(exc).__name__,
+        )
+        return None
+    response = str(tracked.text or "").strip()
+    if not response:
+        logging.warning(
+            "ordinary_chat_legacy_baseline_failed reason=empty_response "
+            "packet_block_reason=%s provider_calls=%s",
+            execution.block_reason or "unknown",
+            tracked.provider_call_count,
+        )
+        return None
+
+    fallback_reason = str(execution.block_reason or "preflight_block")
+    packet_execution = replace(
+        execution,
+        response=response,
+        prompt=legacy_prompt,
+        prompt_source_bases=tuple(
+            legacy_metadata.get("prompt_source_bases") or ()
+        ),
+        candidate_active=False,
+        legacy_baseline_active=True,
+        legacy_baseline_generation_provider_call_count=(
+            tracked.provider_call_count
+        ),
+        legacy_fallback_reason=fallback_reason,
+    )
+    logging.info(
+        "ordinary_chat_legacy_baseline_selected packet_block_reason=%s "
+        "provider_calls=%s",
+        fallback_reason,
+        tracked.provider_call_count,
+    )
+    return OrdinaryChatLegacyBaselineExecution(
+        packet_execution=packet_execution,
+        response=response,
+        prompt=legacy_prompt,
+        prompt_metadata=legacy_metadata,
+        allow_greeting=allow_greeting,
+        style_key=style_key,
+        source_context_available=source_context_available,
+        provider_call_count=tracked.provider_call_count,
+    )
+
+
 async def send_planned_conversation_response(
     message: discord.Message,
     response: str,
@@ -36952,11 +37219,19 @@ async def send_planned_conversation_response(
     baseline_prompt = prompt
     baseline_prompt_source_bases = tuple(prompt_source_bases or ())
     media_context = build_message_media_context(message)
-    single_packet_cutover = bool(
+    single_packet_receipt_present = bool(
         ordinary_chat_single_packet_execution is not None
     )
+    ordinary_chat_legacy_fallback_active = bool(
+        ordinary_chat_single_packet_execution is not None
+        and ordinary_chat_single_packet_execution.legacy_baseline_active
+    )
+    single_packet_cutover = bool(
+        single_packet_receipt_present
+        and not ordinary_chat_legacy_fallback_active
+    )
     synthesis_execution = None
-    if not single_packet_cutover:
+    if not single_packet_receipt_present:
         synthesis_execution = (
             await maybe_generate_shared_brain_synthesis_canary(
                 channel=getattr(message, "channel", None),
@@ -36987,7 +37262,10 @@ async def send_planned_conversation_response(
         else synthesis_execution is not None
         and synthesis_execution.candidate_active
     )
-    if ordinary_chat_single_packet_execution is not None:
+    if (
+        ordinary_chat_single_packet_execution is not None
+        and not ordinary_chat_legacy_fallback_active
+    ):
         response = ordinary_chat_single_packet_execution.response
         prompt = ordinary_chat_single_packet_execution.prompt
         prompt_source_bases = (
@@ -37306,7 +37584,7 @@ async def send_planned_conversation_response(
         durable_memory_write=getattr(model_decision, "write_memory_tier", False),
         scripted_mode_leak_guard_triggered=guard_triggered,
         leak_guard_result="regenerated" if regenerated_for_mode_leak else ("suppressed" if guard_diagnostics.get("suppressed") else "clear"),
-        fallback_used=False,
+        fallback_used=ordinary_chat_legacy_fallback_active,
         regenerated_for_mode_leak=regenerated_for_mode_leak,
         media_present=bool(media_context.get("present", False)),
         media_context_included=bool(media_context.get("included", False)),
@@ -37317,7 +37595,10 @@ async def send_planned_conversation_response(
         canned_ack_suppressed=False,
         ack_converted_to_observe=False,
         ack_escalated_to_generation=False,
-        ordinary_chat_single_packet_applied=single_packet_cutover,
+        ordinary_chat_single_packet_applied=single_packet_receipt_present,
+        ordinary_chat_legacy_baseline_fallback=(
+            ordinary_chat_legacy_fallback_active
+        ),
         ordinary_chat_single_packet_provider_call_count=(
             ordinary_chat_single_packet_execution.provider_call_count
             if ordinary_chat_single_packet_execution is not None
@@ -37332,6 +37613,11 @@ async def send_planned_conversation_response(
             ordinary_chat_single_packet_execution.block_reason
             if ordinary_chat_single_packet_execution is not None
             else ""
+        ),
+        ordinary_chat_legacy_baseline_generation_provider_call_count=(
+            ordinary_chat_single_packet_execution.legacy_baseline_generation_provider_call_count
+            if ordinary_chat_single_packet_execution is not None
+            else 0
         ),
     )
     if _abort_stale_direct_repair_generation(direct_repair_generation, "before_send_commit"):
@@ -37621,6 +37907,8 @@ async def send_planned_conversation_response(
             if single_packet_cutover and synthesis_candidate_active
             else "single_packet_deterministic_block_sent"
             if single_packet_cutover
+            else "single_packet_legacy_baseline_sent"
+            if ordinary_chat_legacy_fallback_active
             else "candidate_sent"
             if synthesis_candidate_active
             else "established_path_sent"
@@ -38830,7 +39118,42 @@ async def on_message(message: discord.Message):
                     source_context_available=source_context_available,
                 )
             )
-            if ordinary_chat_execution is not None:
+            ordinary_chat_legacy_fallback = (
+                await maybe_generate_ordinary_chat_legacy_baseline(
+                    execution=ordinary_chat_execution,
+                    prompt_metadata=prompt_metadata,
+                    channel=message.channel,
+                    payload_items=direct_payload_items,
+                    request_text=direct_content,
+                    conversation_orchestration=direct_orchestration,
+                    situation_frame=direct_orchestration.situation_frame,
+                    user_id=message.author.id,
+                    guild_id=message.guild.id,
+                )
+            )
+            if ordinary_chat_legacy_fallback is not None:
+                ordinary_chat_execution = (
+                    ordinary_chat_legacy_fallback.packet_execution
+                )
+                response = ordinary_chat_legacy_fallback.response
+                prompt = ordinary_chat_legacy_fallback.prompt
+                prompt_metadata = (
+                    ordinary_chat_legacy_fallback.prompt_metadata
+                )
+                allow_greeting = (
+                    ordinary_chat_legacy_fallback.allow_greeting
+                )
+                style_key = ordinary_chat_legacy_fallback.style_key
+                source_context_available = (
+                    ordinary_chat_legacy_fallback.source_context_available
+                )
+                show_state_route = ORDINARY_CHAT_LEGACY_BASELINE_ROUTE
+                log_response_style(
+                    message.guild.id,
+                    message.author.id,
+                    style_key,
+                )
+            elif ordinary_chat_execution is not None:
                 response = ordinary_chat_execution.response
                 prompt = ordinary_chat_execution.prompt
                 show_state_route = ORDINARY_CHAT_SINGLE_PACKET_ROUTE
@@ -38844,10 +39167,14 @@ async def on_message(message: discord.Message):
                     route=show_state_route,
                     source_context_available=source_context_available,
                 )
+            ordinary_chat_packet_controls_response = bool(
+                ordinary_chat_execution is not None
+                and not ordinary_chat_execution.legacy_baseline_active
+            )
             if _abort_stale_direct_repair_generation(direct_repair_generation, "after_initial_generation"):
                 return
             if (
-                ordinary_chat_execution is None
+                not ordinary_chat_packet_controls_response
                 and response
                 and direct_payload_items
             ):
@@ -38877,7 +39204,7 @@ async def on_message(message: discord.Message):
                         logging.info(f"payload_completion_incomplete_unpatched missing_count={len(missing_items)} route=direct_conversation")
             logging.info(f"direct_payload_generation_complete payload_count={len(direct_payload_items)}")
 
-            if ordinary_chat_execution is None:
+            if not ordinary_chat_packet_controls_response:
                 response = suppress_stale_media_fallback(
                     response,
                     current_text=direct_content,
@@ -39342,7 +39669,38 @@ async def on_message(message: discord.Message):
                 source_context_available=source_context_available,
             )
         )
-        if ordinary_chat_execution is not None:
+        ordinary_chat_legacy_fallback = (
+            await maybe_generate_ordinary_chat_legacy_baseline(
+                execution=ordinary_chat_execution,
+                prompt_metadata=prompt_metadata,
+                channel=message.channel,
+                payload_items=direct_payload_items,
+                request_text=direct_content,
+                conversation_orchestration=direct_orchestration,
+                situation_frame=direct_orchestration.situation_frame,
+                user_id=message.author.id,
+                guild_id=message.guild.id,
+            )
+        )
+        if ordinary_chat_legacy_fallback is not None:
+            ordinary_chat_execution = (
+                ordinary_chat_legacy_fallback.packet_execution
+            )
+            response = ordinary_chat_legacy_fallback.response
+            prompt = ordinary_chat_legacy_fallback.prompt
+            prompt_metadata = ordinary_chat_legacy_fallback.prompt_metadata
+            allow_greeting = ordinary_chat_legacy_fallback.allow_greeting
+            style_key = ordinary_chat_legacy_fallback.style_key
+            source_context_available = (
+                ordinary_chat_legacy_fallback.source_context_available
+            )
+            show_state_route = ORDINARY_CHAT_LEGACY_BASELINE_ROUTE
+            log_response_style(
+                message.guild.id,
+                message.author.id,
+                style_key,
+            )
+        elif ordinary_chat_execution is not None:
             response = ordinary_chat_execution.response
             prompt = ordinary_chat_execution.prompt
             show_state_route = ORDINARY_CHAT_SINGLE_PACKET_ROUTE
@@ -39356,10 +39714,14 @@ async def on_message(message: discord.Message):
                 route=show_state_route,
                 source_context_available=source_context_available,
             )
+        ordinary_chat_packet_controls_response = bool(
+            ordinary_chat_execution is not None
+            and not ordinary_chat_execution.legacy_baseline_active
+        )
         if _abort_stale_direct_repair_generation(direct_repair_generation, "after_initial_generation"):
             return
         if (
-            ordinary_chat_execution is None
+            not ordinary_chat_packet_controls_response
             and response
             and direct_payload_items
         ):
@@ -39389,7 +39751,7 @@ async def on_message(message: discord.Message):
                     logging.info(f"payload_completion_incomplete_unpatched missing_count={len(missing_items)} route=direct_conversation")
         logging.info(f"direct_payload_generation_complete payload_count={len(direct_payload_items)}")
 
-        if ordinary_chat_execution is None:
+        if not ordinary_chat_packet_controls_response:
             response = suppress_stale_media_fallback(
                 response,
                 current_text=direct_content,
@@ -39797,7 +40159,38 @@ async def on_message(message: discord.Message):
                 source_context_available=source_context_available,
             )
         )
-        if ordinary_chat_execution is not None:
+        ordinary_chat_legacy_fallback = (
+            await maybe_generate_ordinary_chat_legacy_baseline(
+                execution=ordinary_chat_execution,
+                prompt_metadata=prompt_metadata,
+                channel=message.channel,
+                payload_items=direct_payload_items,
+                request_text=direct_content,
+                conversation_orchestration=direct_orchestration,
+                situation_frame=direct_orchestration.situation_frame,
+                user_id=message.author.id,
+                guild_id=message.guild.id,
+            )
+        )
+        if ordinary_chat_legacy_fallback is not None:
+            ordinary_chat_execution = (
+                ordinary_chat_legacy_fallback.packet_execution
+            )
+            response = ordinary_chat_legacy_fallback.response
+            prompt = ordinary_chat_legacy_fallback.prompt
+            prompt_metadata = ordinary_chat_legacy_fallback.prompt_metadata
+            allow_greeting = ordinary_chat_legacy_fallback.allow_greeting
+            style_key = ordinary_chat_legacy_fallback.style_key
+            source_context_available = (
+                ordinary_chat_legacy_fallback.source_context_available
+            )
+            show_state_route = ORDINARY_CHAT_LEGACY_BASELINE_ROUTE
+            log_response_style(
+                message.guild.id,
+                message.author.id,
+                style_key,
+            )
+        elif ordinary_chat_execution is not None:
             response = ordinary_chat_execution.response
             prompt = ordinary_chat_execution.prompt
             show_state_route = ORDINARY_CHAT_SINGLE_PACKET_ROUTE
@@ -39811,10 +40204,14 @@ async def on_message(message: discord.Message):
                 route=show_state_route,
                 source_context_available=source_context_available,
             )
+        ordinary_chat_packet_controls_response = bool(
+            ordinary_chat_execution is not None
+            and not ordinary_chat_execution.legacy_baseline_active
+        )
         if _abort_stale_direct_repair_generation(direct_repair_generation, "after_initial_generation"):
             return
         if (
-            ordinary_chat_execution is None
+            not ordinary_chat_packet_controls_response
             and response
             and direct_payload_items
         ):
@@ -39844,7 +40241,7 @@ async def on_message(message: discord.Message):
                     logging.info(f"payload_completion_incomplete_unpatched missing_count={len(missing_items)} route=direct_conversation")
         logging.info(f"direct_payload_generation_complete payload_count={len(direct_payload_items)}")
 
-        if ordinary_chat_execution is None:
+        if not ordinary_chat_packet_controls_response:
             response = suppress_stale_media_fallback(
                 response,
                 current_text=direct_content,

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -8764,6 +8764,8 @@ def classify_route_mode(clean_content: str, channel_policy: str = "unknown", *, 
         return ROUTE_MODE_OPERATOR_COMMAND
     if (channel_policy or "").strip().lower() == "broadcast_memory":
         return ROUTE_MODE_BROADCAST_MEMORY
+    if parse_exact_name_echo_instruction(text) is not None:
+        return ROUTE_MODE_DIRECT_PAYLOAD
     if payload_expected:
         return ROUTE_MODE_DIRECT_PAYLOAD
     if show_state:
@@ -29708,10 +29710,90 @@ def _collapse_consecutive_batch_fragments(items):
 
 
 
+_EXACT_NAME_ECHO_COUNT_WORDS = {
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+}
+
+
+def _split_exact_name_echo_payload(payload: str) -> tuple[str, ...]:
+    return tuple(
+        part.strip()
+        for part in re.split(r"\s*,\s*|\s+and\s+", payload, flags=re.I)
+        if part.strip()
+    )
+
+
+def parse_exact_name_echo_instruction(text: str) -> str | None:
+    """Return a user-supplied literal name payload for a strict echo request.
+
+    This deliberately recognizes only the small, non-factual grammar used to
+    establish an exact Discord reply source.  It is not a general instruction
+    bypass: arbitrary text, multiline content, mentions, URLs, and malformed
+    name counts continue through the governed response pipeline.
+    """
+
+    raw = str(text or "").strip()
+    raw = re.sub(r"^[,;:\-]\s*", "", raw)
+    if not raw or len(raw) > 320:
+        return None
+    match = re.fullmatch(
+        r"(?:please\s+)?(?:reply|respond)\s+with\s+exactly\s+"
+        r"(?:(?P<single>this)\s+name|these(?:\s+(?P<count>[a-z]+|\d+))?\s+names)"
+        r"\s*,?\s*(?:and\s+)?no\s+other\s+words\s*:\s*"
+        r"(?P<payload>[^\r\n]+)",
+        raw,
+        flags=re.I,
+    )
+    if not match:
+        return None
+
+    payload = match.group("payload").strip()
+    if (
+        not payload
+        or len(payload) > 200
+        or any(token in payload for token in ("@", "<", ">", "`"))
+        or "://" in payload.lower()
+        or not re.fullmatch(r"[\w][\w .,'’&+\-]*[\w]", payload)
+    ):
+        return None
+
+    names = _split_exact_name_echo_payload(payload)
+    if not names:
+        return None
+    expected_count = 1 if match.group("single") else 0
+    count_token = str(match.group("count") or "").lower()
+    if count_token:
+        expected_count = (
+            int(count_token)
+            if count_token.isdigit()
+            else _EXACT_NAME_ECHO_COUNT_WORDS.get(count_token, 0)
+        )
+        if expected_count <= 0:
+            return None
+    if expected_count and len(names) != expected_count:
+        return None
+    if match.group("single") and len(names) != 1:
+        return None
+    if not match.group("single") and len(names) < 2:
+        return None
+    return payload
+
+
 def _detect_request_intent(text: str):
     t = (text or "").strip().lower()
     if not t:
         return False, "empty"
+    if parse_exact_name_echo_instruction(text) is not None:
+        return True, "exact_name_echo"
     if "?" in t:
         return True, "question_mark"
     patterns = [
@@ -29730,6 +29812,8 @@ def _detect_request_payload_expectation(text: str):
     t = (text or "").strip().lower()
     if not t:
         return False, "empty"
+    if parse_exact_name_echo_instruction(text) is not None:
+        return True, "exact_name_echo"
     # Payload completion is only for clear list-shaped requests. Do not treat
     # ordinary conversation using "about"/"for" as a payload task.
     patterns = [
@@ -33537,8 +33621,13 @@ def _is_deictic_payload_placeholder(text: str) -> bool:
 
 def _collect_inline_direct_payload_items(clean_content: str):
     payload_items = []
+    exact_name_echo = parse_exact_name_echo_instruction(clean_content)
+    if exact_name_echo is not None:
+        payload_items.extend(
+            _split_exact_name_echo_payload(exact_name_echo)
+        )
     multiline = _extract_multiline_request_payload(clean_content)
-    if multiline:
+    if multiline and not payload_items:
         payload_items.extend(multiline.get("payload_items", []))
     if not payload_items:
         payload_expected, _payload_reason = _detect_request_payload_expectation(clean_content)
@@ -38262,6 +38351,43 @@ async def on_message(message: discord.Message):
             logging.info("conversational_continuation_detected reason=same_user_recent_response")
     else:
         logging.info("response_route_decision route=policy_blocked reason=no_conversation_route")
+
+    exact_name_echo = parse_exact_name_echo_instruction(clean_content)
+    if exact_name_echo is not None and message_should_enter_conversation:
+        save_user_message(
+            message.author.id,
+            message.author.display_name,
+            message.guild.id,
+            conversation_content or clean_content,
+            channel_name=getattr(message.channel, "name", ""),
+            channel_policy=channel_policy,
+            channel_id=getattr(message.channel, "id", 0),
+            message_id=getattr(message, "id", None),
+            route_mode=ROUTE_MODE_DIRECT_PAYLOAD,
+            directed_to_bnl=True,
+        )
+        await send_reply_then_save_model(
+            message,
+            exact_name_echo,
+            user_id=message.author.id,
+            guild_id=message.guild.id,
+            channel_name=getattr(message.channel, "name", ""),
+            channel_policy=channel_policy,
+            channel_id=getattr(message.channel, "id", 0),
+            route_mode=ROUTE_MODE_DIRECT_PAYLOAD,
+            reply_text=exact_name_echo,
+        )
+        _mark_recent_direct_response(
+            message.channel.id,
+            message.author.id,
+        )
+        logging.info(
+            "exact_name_echo_sent route_mode=%s name_count=%s "
+            "provider_call_count=0",
+            ROUTE_MODE_DIRECT_PAYLOAD,
+            len(_split_exact_name_echo_payload(exact_name_echo)),
+        )
+        return
 
     if clean_content and (is_active_channel or real_direct_target):
         if not is_sealed_test_channel:

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -9855,6 +9855,30 @@ def format_last_route_debug() -> str:
         ("canned_ack_suppressed", "canned ack suppressed"),
         ("ack_converted_to_observe", "ack converted to observe"),
         ("ack_escalated_to_generation", "ack escalated to generation"),
+        (
+            "ordinary_chat_single_packet_applied",
+            "ordinary-chat packet receipt present",
+        ),
+        (
+            "ordinary_chat_legacy_baseline_fallback",
+            "ordinary-chat baseline fallback",
+        ),
+        (
+            "ordinary_chat_single_packet_provider_call_count",
+            "ordinary-chat packet provider calls",
+        ),
+        (
+            "ordinary_chat_single_packet_corrective_call_count",
+            "ordinary-chat packet corrective calls",
+        ),
+        (
+            "ordinary_chat_single_packet_block_reason",
+            "ordinary-chat packet block reason",
+        ),
+        (
+            "ordinary_chat_legacy_baseline_generation_provider_call_count",
+            "ordinary-chat baseline generation provider calls",
+        ),
         ("save_policy_reason", "save policy reason"),
     ]
     lines = ["**BNL route debug (last conversational reply)**"]

--- a/docs/one_packet_convergence_v1.md
+++ b/docs/one_packet_convergence_v1.md
@@ -52,8 +52,12 @@ ranked before additive project canon. Render-equivalent projections collapse
 by original human or declaration roots. Every durable selection is re-read
 before candidate use. A changed or invalid source forces the established
 response fallback on comparison routes, and blocks or suppresses the
-separately gated ordinary-chat candidate without legacy generation fallback.
-Broad-profile prompts have one factual packet owner, while
+separately gated ordinary-chat candidate after packet generation without a
+second generation attempt. Before packet prompt application, an otherwise
+eligible stable and unambiguous turn may relinquish packet ownership and
+rebuild the established context-rich route; live-current and clarification
+tasks cannot use that handoff. Broad-profile prompts have one factual packet
+owner, while
 current turn, exact reply context, persona, and bounded additive canon remain.
 Specialized operational routes stay outside this cutover.
 
@@ -88,9 +92,11 @@ missing allowlists, or any over-limit scope fail closed before prompt
 construction. The scope digest binds both the authorization mode and exact
 allowlists without exposing their IDs.
 
-All gates remain default-off. The ordinary-chat route permits one provider
-attempt, zero retries, no model fallback, and no corrective generation. This
-version performs no deployment, historical
+All gates remain default-off. Once the ordinary-chat packet prompt is applied,
+the route permits one provider attempt, zero retries, no model fallback, and
+no corrective generation. A zero-packet-call baseline-preservation handoff is
+an established-route recovery, not a packet retry. This version performs no
+deployment, historical
 promotion, live activation, member-facing correction inference, or knowledge
 edit/delete function. It does not change Journal or Relay generation,
 publication, scheduling, or lifecycle behavior.

--- a/docs/ordinary_chat_single_packet_canary_v1.md
+++ b/docs/ordinary_chat_single_packet_canary_v1.md
@@ -5,7 +5,10 @@ single factual prompt owner and a single provider attempt. It is disabled by
 default and is separate from the broad-profile comparison canary and
 public-home recall owner. The default remains the original private acceptance
 scope; contract v4 adds a second gate for controlled multi-user or
-multi-channel expansion.
+multi-channel expansion. A bounded pre-provider recovery boundary preserves
+the established context-rich route when the replacement packet cannot be
+constructed locally; it does not turn a rejected packet answer into a second
+generation attempt.
 
 ## Default-off private acceptance scope
 
@@ -115,9 +118,40 @@ duplicate, reordered, malformed, cross-lane, or unsupported references block
 the entire candidate.
 
 Preflight ambiguity or invalid source state uses zero provider calls and a
-bounded clarification/block response. A failed generation or rejected
-candidate never falls back to the legacy generated response. Specialized
-owners are excluded before cutover rather than treated as a fallback.
+bounded clarification/block response. Deliberate ambiguity and volatile or
+live-current tasks retain that fail-closed behavior. A failed generation or
+rejected candidate never falls back to a second generated response.
+Specialized owners are excluded before cutover rather than treated as a
+fallback.
+
+## Established-baseline preservation boundary
+
+The packet cutover must not erase working context before it has a usable
+replacement. If an otherwise eligible, non-ambiguous, non-live turn fails
+locally before any packet provider invocation—for example because the packet,
+assessment, prompt, or receipt cannot be assembled—the route relinquishes
+factual ownership and rebuilds the same established prompt that would have
+been used with the cutover disabled. That rebuild restores eligible room
+context, durable memory, Relationship tone, canon/lore, Broadcast memory, and
+authorized source blocks under their existing route rules.
+
+This is a route handoff, not a packet correction:
+
+- the packet provider and corrective-call counts remain zero;
+- the established path performs its normal generation and existing guards;
+- the older comparison canary is not run on top of that recovery generation;
+- the original packet receipt, when one exists, is finalized as
+  `single_packet_legacy_baseline_sent` with the local block reason and a
+  separate initial baseline-generation provider count; and
+- debug state identifies the handoff as
+  `ordinary_chat_legacy_baseline_fallback`.
+
+The handoff is prohibited after packet prompt application or any packet
+provider/corrective call. It is also prohibited for an ambiguous/clarify task,
+an `external_current` task, a current task requiring `hold`, or a recognizable
+live-current request when no typed frame tasks are available. Those turns keep
+their deterministic clarification or current-fact hold and cannot revive a
+stale baseline answer.
 
 ## Content-free receipts
 

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -1988,6 +1988,61 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(message.replies, [])
         self.assertEqual(list(bnl01_bot._channel_buffers[channel.id]), [])
 
+    async def test_exact_name_echo_sends_and_saves_without_provider_call(self):
+        channel = self._channel(8110)
+        text = (
+            "reply with exactly these two names, and no other words: "
+            "cache back, call'em bini"
+        )
+        expected = "cache back, call'em bini"
+        message = FakeMessage(channel, text)
+
+        with (
+            self._on_message_runtime(
+                channel.id,
+                followup_candidate=False,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "is_direct_bnl_target",
+                return_value=True,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "get_gemini_response",
+                new=mock.AsyncMock(),
+            ) as generate,
+            mock.patch.object(
+                bnl01_bot,
+                "get_gemini_response_with_optional_typing",
+                new=mock.AsyncMock(),
+            ) as generate_with_typing,
+            mock.patch.object(
+                bnl01_bot,
+                "save_model_message",
+                return_value=SimpleNamespace(
+                    save_conversation=True,
+                    reason="test_saved",
+                ),
+            ) as save_model,
+            mock.patch.object(
+                bnl01_bot,
+                "_mark_recent_direct_response",
+            ) as mark_recent,
+        ):
+            await bnl01_bot.on_message(message)
+
+        self.assertEqual(message.replies, [expected])
+        generate.assert_not_awaited()
+        generate_with_typing.assert_not_awaited()
+        save_model.assert_called_once()
+        self.assertEqual(save_model.call_args.args[2], expected)
+        self.assertEqual(
+            save_model.call_args.kwargs["route_mode"],
+            bnl01_bot.ROUTE_MODE_DIRECT_PAYLOAD,
+        )
+        mark_recent.assert_called_once_with(channel.id, message.author.id)
+
     async def test_paced_direct_reply_clears_preserved_interrupt_handoff(self):
         channel = self._channel(8114)
         message = FakeMessage(channel, "BNL, answer this now")

--- a/tests/test_exact_discord_reply_packet_regression.py
+++ b/tests/test_exact_discord_reply_packet_regression.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sqlite3
 import tempfile
@@ -75,7 +76,7 @@ class ExactDiscordReplyPacketRegressionTests(unittest.TestCase):
                     channel_name TEXT NOT NULL,
                     channel_policy TEXT NOT NULL,
                     route_mode TEXT NOT NULL,
-                    timestamp TEXT NOT NULL,
+                    timestamp TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     message_id INTEGER
                 )
                 """
@@ -359,6 +360,160 @@ class ExactDiscordReplyPacketRegressionTests(unittest.TestCase):
                 serialized_receipts = repr(receipt_rows).casefold()
                 self.assertNotIn("cobalt", serialized_receipts)
                 self.assertNotIn("amber", serialized_receipts)
+
+    def test_exact_name_echo_delivery_becomes_pronoun_reply_source(self):
+        seed = (
+            "reply with exactly these two names, and no other words: "
+            "cache back, call'em bini"
+        )
+        exact_reply = bnl01_bot.parse_exact_name_echo_instruction(seed)
+        self.assertEqual(exact_reply, "cache back, call'em bini")
+
+        class ReplyMessage:
+            def __init__(self):
+                self.sent = []
+
+            async def reply(self, text, **_kwargs):
+                self.sent.append(text)
+                return type("Sent", (), {"id": 710})()
+
+        message = ReplyMessage()
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "calculate_adaptive_memory_limits",
+                return_value={"conversation_rows": 80},
+            ),
+            mock.patch.object(bnl01_bot, "prune_conversation_history"),
+            mock.patch.object(bnl01_bot, "update_relationship_state"),
+            mock.patch.object(bnl01_bot, "maybe_add_memory_trace"),
+        ):
+            decision = asyncio.run(
+                bnl01_bot.send_reply_then_save_model(
+                    message,
+                    exact_reply,
+                    user_id=7,
+                    guild_id=1,
+                    channel_name="bnl-testing",
+                    channel_policy="sealed_test",
+                    channel_id=10,
+                    route_mode=bnl01_bot.ROUTE_MODE_DIRECT_PAYLOAD,
+                    reply_text=exact_reply,
+                )
+            )
+        self.assertTrue(decision.save_conversation)
+        self.assertEqual(message.sent, [exact_reply])
+
+        with sqlite3.connect(self.db_path) as conn:
+            saved = conn.execute(
+                """
+                SELECT id,role,content,message_id,route_mode
+                FROM conversations
+                WHERE message_id=710
+                """
+            ).fetchone()
+        self.assertIsNotNone(saved)
+        self.assertEqual(saved[1:], (
+            "model",
+            exact_reply,
+            710,
+            bnl01_bot.ROUTE_MODE_DIRECT_PAYLOAD,
+        ))
+
+        result_out = {}
+        rendered_context = (
+            bnl01_bot.build_conversation_context_v2_for_prompt(
+                guild_id=1,
+                current_user_id=7,
+                channel_id=10,
+                channel_name="bnl-testing",
+                channel_policy="sealed_test",
+                route_mode="normal_chat",
+                conversation_surface="mention_or_reply",
+                current_texts=(
+                    "How is he connected to Call'em Bini?",
+                ),
+                current_participants={7},
+                is_direct_target=True,
+                referenced_message_ids={710},
+                referenced_conversation_row_ids={saved[0]},
+                now=self.now,
+                route_allowed_sources={"conversation_continuity"},
+                result_out=result_out,
+            )
+        )
+        context = result_out["result"]
+        self.assertEqual(context.referent_status, "resolved")
+        self.assertEqual(context.referent_reason, "discord_reply_source")
+        self.assertEqual(context.selected_row_ids, (saved[0],))
+        self.assertIn(exact_reply, rendered_context)
+
+        addressing = bnl01_bot.DiscordTurnAddressing(
+            speaker="Test Member A",
+            explicit_tag_recipients=(),
+            reply_target="BNL-01",
+            explicitly_mentions_bnl=False,
+            reply_targets_bnl=True,
+            directly_targets_bnl=True,
+            targets_other_human=False,
+            plain_text_names_bnl=False,
+            speaker_user_id=7,
+            source_message_id=711,
+            reply_message_id=710,
+            reply_conversation_row_id=saved[0],
+        )
+
+        for question in (
+            "How is he connected to Call'em Bini?",
+            "How are they related to Call'em Bini?",
+        ):
+            with self.subTest(question=question):
+                subjects, status = (
+                    bnl01_bot._exact_reply_canon_subject_references(
+                        context,
+                        question,
+                    )
+                )
+                self.assertEqual(status, "resolved")
+                self.assertEqual(
+                    subjects,
+                    (("cache_back", "Cache Back"),),
+                )
+                orchestration = (
+                    bnl01_bot.build_live_conversation_orchestration_decision(
+                        engagement_decision="answer",
+                        engagement_reason="direct_request",
+                        channel_policy="sealed_test",
+                        addressings=(addressing,),
+                        context_result=context,
+                        moment_situation=None,
+                        guild_id=1,
+                        channel_id=10,
+                        route_mode="normal_chat",
+                        conversation_surface="mention_or_reply",
+                        current_text=question,
+                        current_speaker_user_ids=(7,),
+                        current_speaker_labels=("Test Member A",),
+                        influence_mode="live",
+                        packet_revision="exact_name_echo_chain",
+                    )
+                )
+                frame = orchestration.situation_frame
+                self.assertEqual(frame.status, "resolved")
+                subject_keys = tuple(
+                    subject.entity_ref for subject in frame.subjects
+                )
+                self.assertEqual(
+                    set(subject_keys),
+                    {"cache_back", "call_em_bini"},
+                )
+                self.assertEqual(
+                    {
+                        subject_keys[index]
+                        for index in frame.tasks[0].subject_indexes
+                    },
+                    {"cache_back", "call_em_bini"},
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_ordinary_chat_acceptance_contract_matrix.py
+++ b/tests/test_ordinary_chat_acceptance_contract_matrix.py
@@ -44,6 +44,59 @@ def _frame(text):
 
 
 class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
+    def test_exact_name_seed_reply_chain_resolves_without_seed_facts(self):
+        cases = (
+            (
+                "reply with exactly these two names, and no other words: "
+                "cache back, call'em bini",
+                (
+                    "How is he connected to Call'em Bini?",
+                    "How are they related to Call'em Bini?",
+                ),
+                (("cache_back", "Cache Back"),),
+            ),
+            (
+                "reply with exactly this name and no other words: "
+                "DJ floppydisc",
+                ("What does he do?",),
+                (("dj_floppydisc", "DJ Floppydisc"),),
+            ),
+        )
+        for seed, questions, expected_subjects in cases:
+            with self.subTest(seed=seed):
+                exact_reply = (
+                    bnl01_bot.parse_exact_name_echo_instruction(seed)
+                )
+                self.assertIsNotNone(exact_reply)
+                context = bnl01_bot.ConversationContextResult(
+                    rendered_context=(
+                        "BNL-01 (exact Discord reply source): "
+                        + exact_reply
+                    ),
+                    selected_row_ids=(77,),
+                    same_room_paired_turn_count=0,
+                    unpaired_row_count=1,
+                    cross_channel_paired_turn_count=0,
+                    current_message_duplicates_removed=0,
+                    visibility_policy_exclusions=0,
+                    selection_reasons=("discord_reply_source",),
+                    final_char_count=len(exact_reply),
+                    referent_status="resolved",
+                    referent_candidate_count=1,
+                    referent_selected_row_ids=(77,),
+                    referent_reason="discord_reply_source",
+                )
+                for question in questions:
+                    with self.subTest(question=question):
+                        subjects, status = (
+                            bnl01_bot._exact_reply_canon_subject_references(
+                                context,
+                                question,
+                            )
+                        )
+                        self.assertEqual(status, "resolved")
+                        self.assertEqual(subjects, expected_subjects)
+
     def test_48_production_ingress_cases_have_one_early_typed_decision(self):
         # name, request, frame status, task authorities, task acts,
         # dominant object, bound subject kind

--- a/tests/test_route_memory_governance.py
+++ b/tests/test_route_memory_governance.py
@@ -13,6 +13,77 @@ from bnl_source_file_enrichment import parse_source_enrichment_command
 
 
 class RouteModeGovernanceTests(unittest.TestCase):
+    def test_exact_name_echo_is_literal_direct_payload_not_factual_chat(self):
+        cases = (
+            (
+                "reply with exactly these two names, and no other words: "
+                "cache back, call'em bini",
+                "cache back, call'em bini",
+                ["cache back", "call'em bini"],
+            ),
+            (
+                "reply with exactly this name and no other words: "
+                "DJ floppydisc",
+                "DJ floppydisc",
+                ["DJ floppydisc"],
+            ),
+            (
+                ", reply with exactly this name and no other words: "
+                "DJ floppydisc",
+                "DJ floppydisc",
+                ["DJ floppydisc"],
+            ),
+        )
+        for text, expected_response, expected_items in cases:
+            with self.subTest(text=text):
+                self.assertEqual(
+                    bnl01_bot.parse_exact_name_echo_instruction(text),
+                    expected_response,
+                )
+                self.assertEqual(
+                    bnl01_bot.classify_route_mode(
+                        text,
+                        "sealed_test",
+                        real_direct_target=True,
+                    ),
+                    bnl01_bot.ROUTE_MODE_DIRECT_PAYLOAD,
+                )
+                self.assertEqual(
+                    bnl01_bot._detect_request_intent(text),
+                    (True, "exact_name_echo"),
+                )
+                self.assertEqual(
+                    bnl01_bot._detect_request_payload_expectation(text),
+                    (True, "exact_name_echo"),
+                )
+                self.assertEqual(
+                    bnl01_bot._collect_inline_direct_payload_items(text),
+                    expected_items,
+                )
+
+    def test_exact_name_echo_rejects_malformed_or_unsafe_payloads(self):
+        cases = (
+            "reply with exactly these two names and no other words: Cache Back",
+            "reply with exactly this name and no other words: Cache Back, Mac Modem",
+            "reply with exactly this name and no other words: <@123>",
+            "reply with exactly this name and no other words: https://example.com",
+            "reply with exactly this sentence and no other words: Cache Back",
+            "tell me exactly who Cache Back is",
+        )
+        for text in cases:
+            with self.subTest(text=text):
+                self.assertIsNone(
+                    bnl01_bot.parse_exact_name_echo_instruction(text)
+                )
+                self.assertEqual(
+                    bnl01_bot.classify_route_mode(
+                        text,
+                        "sealed_test",
+                        real_direct_target=True,
+                    ),
+                    bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                )
+
     def test_simple_greeting_maps_to_simple_greeting(self):
         for text in ("Hi BNL", "hey BNL", "yo BNL", "hello BNL", "good morning BNL", "BNL?"):
             self.assertTrue(bnl01_bot.is_simple_greeting_to_bnl(text), text)

--- a/tests/test_shared_brain_synthesis_bot_path.py
+++ b/tests/test_shared_brain_synthesis_bot_path.py
@@ -1754,6 +1754,38 @@ class SharedBrainSynthesisBotPathTests(
             "single_packet_legacy_baseline_sent",
         )
 
+    def test_route_debug_renders_legacy_baseline_evidence(self):
+        with mock.patch.dict(
+            bnl01_bot.LAST_ROUTE_DEBUG,
+            {
+                "ordinary_chat_single_packet_applied": True,
+                "ordinary_chat_legacy_baseline_fallback": True,
+                "ordinary_chat_single_packet_provider_call_count": 0,
+                "ordinary_chat_single_packet_corrective_call_count": 0,
+                "ordinary_chat_single_packet_block_reason": (
+                    "packet_or_assessment_unavailable"
+                ),
+                (
+                    "ordinary_chat_legacy_baseline_generation_"
+                    "provider_call_count"
+                ): 1,
+            },
+            clear=True,
+        ):
+            rendered = bnl01_bot.format_last_route_debug()
+
+        self.assertIn("ordinary-chat baseline fallback: `True`", rendered)
+        self.assertIn("ordinary-chat packet provider calls: `0`", rendered)
+        self.assertIn(
+            "ordinary-chat packet block reason: "
+            "`packet_or_assessment_unavailable`",
+            rendered,
+        )
+        self.assertIn(
+            "ordinary-chat baseline generation provider calls: `1`",
+            rendered,
+        )
+
     async def test_single_packet_deterministic_clarification_bypasses_factual_guard_and_sends(self):
         message = FakeMessage()
         message.content = "Tell me about Jordan."

--- a/tests/test_shared_brain_synthesis_bot_path.py
+++ b/tests/test_shared_brain_synthesis_bot_path.py
@@ -1345,6 +1345,415 @@ class SharedBrainSynthesisBotPathTests(
             "deterministic_task_hold",
         )
 
+    def test_low_risk_zero_call_packet_block_allows_legacy_baseline(self):
+        run = SimpleNamespace(prompt_applied=False)
+        decision = SimpleNamespace(run=run)
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=decision,
+            response="packet preflight block",
+            prompt="packet-owned prompt",
+            prompt_source_bases=(),
+            candidate_active=False,
+            provider_call_count=0,
+            corrective_call_count=0,
+            block_reason="packet_or_assessment_unavailable",
+        )
+        frame = SimpleNamespace(
+            tasks=(
+                SimpleNamespace(
+                    authority_scope="packet",
+                    currentness="historical",
+                    required_response_act="answer",
+                ),
+            )
+        )
+
+        self.assertTrue(
+            bnl01_bot.ordinary_chat_legacy_baseline_fallback_allowed(
+                execution,
+                situation_frame=frame,
+                request_text=(
+                    "Reply with exactly these names: Cache Back, "
+                    "Call'em Bini"
+                ),
+            )
+        )
+
+    def test_legacy_baseline_never_follows_live_or_started_packet(self):
+        live_frame = SimpleNamespace(
+            tasks=(
+                SimpleNamespace(
+                    authority_scope="external_current",
+                    currentness="current",
+                    required_response_act="hold",
+                ),
+            )
+        )
+        zero_call_execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=SimpleNamespace(
+                run=SimpleNamespace(prompt_applied=False)
+            ),
+            response="hold",
+            prompt="packet-owned prompt",
+            prompt_source_bases=(),
+            candidate_active=False,
+            provider_call_count=0,
+            corrective_call_count=0,
+            block_reason="deterministic_task_hold",
+        )
+        started_execution = replace(
+            zero_call_execution,
+            decision=SimpleNamespace(
+                run=SimpleNamespace(prompt_applied=True)
+            ),
+            block_reason="candidate_rejected",
+        )
+        ambiguous_execution = replace(
+            zero_call_execution,
+            block_reason="candidate_prompt_frame_ambiguous",
+        )
+        changed_source_execution = replace(
+            zero_call_execution,
+            block_reason="pre_generation_source_changed",
+        )
+
+        self.assertFalse(
+            bnl01_bot.ordinary_chat_legacy_baseline_fallback_allowed(
+                zero_call_execution,
+                situation_frame=live_frame,
+                request_text="Is the BARCODE Radio queue open right now?",
+            )
+        )
+        self.assertFalse(
+            bnl01_bot.ordinary_chat_legacy_baseline_fallback_allowed(
+                started_execution,
+                situation_frame=SimpleNamespace(tasks=()),
+                request_text="Who is DJ Floppydisc?",
+            )
+        )
+        self.assertFalse(
+            bnl01_bot.ordinary_chat_legacy_baseline_fallback_allowed(
+                replace(
+                    zero_call_execution,
+                    provider_call_count=1,
+                    block_reason="candidate_rejected",
+                ),
+                situation_frame=SimpleNamespace(tasks=()),
+                request_text="Who is DJ Floppydisc?",
+            )
+        )
+        self.assertFalse(
+            bnl01_bot.ordinary_chat_legacy_baseline_fallback_allowed(
+                ambiguous_execution,
+                situation_frame=SimpleNamespace(
+                    status="ambiguous",
+                    tasks=(
+                        SimpleNamespace(
+                            authority_scope="packet",
+                            currentness="unknown",
+                            required_response_act="clarify",
+                        ),
+                    ),
+                ),
+                request_text="Tell me about Jordan.",
+            )
+        )
+        self.assertFalse(
+            bnl01_bot.ordinary_chat_legacy_baseline_fallback_allowed(
+                changed_source_execution,
+                situation_frame=SimpleNamespace(tasks=()),
+                request_text="Who is DJ Floppydisc?",
+            )
+        )
+
+    async def test_zero_call_block_rebuilds_and_generates_legacy_baseline(self):
+        run = SimpleNamespace(prompt_applied=False, run_id="packet-run")
+        decision = SimpleNamespace(run=run, candidate_selected=False)
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=decision,
+            response="packet preflight block",
+            prompt="packet-owned prompt",
+            prompt_source_bases=("packet-basis",),
+            candidate_active=False,
+            provider_call_count=0,
+            corrective_call_count=0,
+            block_reason="packet_or_assessment_unavailable",
+        )
+        request = {
+            "user_id": 7,
+            "guild_id": 1,
+            "fallback_display_name": "Miss Bit",
+            "clean_content": "Who is DJ Floppydisc?",
+        }
+
+        def rebuild_prompt(**kwargs):
+            metadata = kwargs["prompt_metadata"]
+            metadata.update(
+                {
+                    "source_context_available": True,
+                    "prompt_source_bases": ("canon-basis", "room-basis"),
+                    "shared_brain_synthesis_canary_basis": object(),
+                }
+            )
+            return (
+                "Durable memory and BARCODE canon: DJ Floppydisc",
+                False,
+                "balanced",
+            )
+
+        provider = mock.AsyncMock(
+            return_value=bnl01_bot.TrackedGenerationResponse(
+                text=(
+                    "DJ Floppydisc is BARCODE's signal and audio engineer."
+                ),
+                provider_call_count=1,
+            )
+        )
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "build_user_aware_prompt",
+                side_effect=rebuild_prompt,
+            ) as builder,
+            mock.patch.object(
+                bnl01_bot,
+                "_build_direct_payload_prompt",
+                side_effect=lambda prompt, _items, _text: prompt,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "render_conversation_orchestration_prompt",
+                return_value="",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "get_tracked_gemini_response_with_optional_typing",
+                new=provider,
+            ),
+        ):
+            fallback = (
+                await bnl01_bot.maybe_generate_ordinary_chat_legacy_baseline(
+                    execution=execution,
+                    prompt_metadata={
+                        "ordinary_chat_legacy_baseline_request": request
+                    },
+                    channel=FakeChannel(),
+                    payload_items=[],
+                    request_text=request["clean_content"],
+                    conversation_orchestration=None,
+                    situation_frame=SimpleNamespace(
+                        tasks=(
+                            SimpleNamespace(
+                                authority_scope="packet",
+                                currentness="historical",
+                                required_response_act="answer",
+                            ),
+                        )
+                    ),
+                    user_id=7,
+                    guild_id=1,
+                )
+            )
+
+        self.assertIsNotNone(fallback)
+        self.assertEqual(
+            fallback.response,
+            "DJ Floppydisc is BARCODE's signal and audio engineer.",
+        )
+        self.assertTrue(fallback.packet_execution.legacy_baseline_active)
+        self.assertFalse(fallback.packet_execution.candidate_active)
+        self.assertEqual(
+            fallback.packet_execution.provider_call_count,
+            0,
+        )
+        self.assertEqual(
+            fallback.packet_execution.legacy_baseline_generation_provider_call_count,
+            1,
+        )
+        self.assertIs(fallback.packet_execution.decision, decision)
+        self.assertIsNone(
+            fallback.prompt_metadata["shared_brain_synthesis_canary_basis"]
+        )
+        self.assertEqual(
+            fallback.packet_execution.prompt_source_bases,
+            ("canon-basis", "room-basis"),
+        )
+        self.assertFalse(
+            builder.call_args.kwargs[
+                "_ordinary_chat_single_packet_enabled_override"
+            ]
+        )
+        provider.assert_awaited_once()
+        self.assertEqual(
+            provider.await_args.kwargs["route"],
+            bnl01_bot.ORDINARY_CHAT_LEGACY_BASELINE_ROUTE,
+        )
+
+    async def test_legacy_baseline_failure_returns_to_packet_block(self):
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=None,
+            response="packet preflight block",
+            prompt="packet-owned prompt",
+            prompt_source_bases=(),
+            candidate_active=False,
+            provider_call_count=0,
+            corrective_call_count=0,
+            block_reason="packet_or_assessment_unavailable",
+        )
+        metadata = {
+            "ordinary_chat_legacy_baseline_request": {
+                "user_id": 7,
+                "guild_id": 1,
+                "fallback_display_name": "Miss Bit",
+                "clean_content": "Who is DJ Floppydisc?",
+            }
+        }
+        frame = SimpleNamespace(
+            tasks=(
+                SimpleNamespace(
+                    authority_scope="packet",
+                    currentness="historical",
+                    required_response_act="answer",
+                ),
+            )
+        )
+
+        with mock.patch.object(
+            bnl01_bot,
+            "_build_ordinary_chat_legacy_baseline_prompt",
+            side_effect=RuntimeError("rebuild failed"),
+        ):
+            rebuild_failure = (
+                await bnl01_bot.maybe_generate_ordinary_chat_legacy_baseline(
+                    execution=execution,
+                    prompt_metadata=metadata,
+                    channel=FakeChannel(),
+                    payload_items=[],
+                    request_text="Who is DJ Floppydisc?",
+                    conversation_orchestration=None,
+                    situation_frame=frame,
+                    user_id=7,
+                    guild_id=1,
+                )
+            )
+
+        provider = mock.AsyncMock(side_effect=RuntimeError("provider failed"))
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "_build_ordinary_chat_legacy_baseline_prompt",
+                return_value=(
+                    "context-rich prompt",
+                    False,
+                    "balanced",
+                    {"source_context_available": True},
+                ),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "get_tracked_gemini_response_with_optional_typing",
+                new=provider,
+            ),
+        ):
+            provider_failure = (
+                await bnl01_bot.maybe_generate_ordinary_chat_legacy_baseline(
+                    execution=execution,
+                    prompt_metadata=metadata,
+                    channel=FakeChannel(),
+                    payload_items=[],
+                    request_text="Who is DJ Floppydisc?",
+                    conversation_orchestration=None,
+                    situation_frame=frame,
+                    user_id=7,
+                    guild_id=1,
+                )
+            )
+
+        self.assertIsNone(rebuild_failure)
+        self.assertIsNone(provider_failure)
+        self.assertFalse(execution.legacy_baseline_active)
+
+    async def test_legacy_baseline_uses_normal_guard_and_finalizes_receipt(self):
+        message = FakeMessage()
+        message.content = "Who is DJ Floppydisc?"
+        run = SimpleNamespace(prompt_applied=False, run_id="packet-run")
+        decision = SimpleNamespace(
+            run=run,
+            candidate_selected=False,
+            fallback_reason="packet_or_assessment_unavailable",
+        )
+        response = "DJ Floppydisc is BARCODE's signal and audio engineer."
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=decision,
+            response=response,
+            prompt="context-rich baseline prompt",
+            prompt_source_bases=("canon-basis",),
+            candidate_active=False,
+            provider_call_count=0,
+            corrective_call_count=0,
+            block_reason="packet_or_assessment_unavailable",
+            legacy_baseline_active=True,
+            legacy_baseline_generation_provider_call_count=1,
+            legacy_fallback_reason="packet_or_assessment_unavailable",
+        )
+        guard = mock.AsyncMock(
+            return_value=(response, {"suppressed": False})
+        )
+        older_canary = mock.AsyncMock(
+            side_effect=AssertionError(
+                "legacy fallback invoked the older synthesis canary"
+            )
+        )
+        finalize = mock.AsyncMock(return_value=True)
+        with ExitStack() as stack:
+            for patcher in self.common_patches():
+                stack.enter_context(patcher)
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "apply_guarded_response_regeneration",
+                    new=guard,
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "maybe_generate_shared_brain_synthesis_canary",
+                    new=older_canary,
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "safely_finalize_shared_brain_synthesis",
+                    new=finalize,
+                )
+            )
+
+            await bnl01_bot.send_planned_conversation_response(
+                message,
+                response,
+                self.plan(),
+                prompt="context-rich baseline prompt",
+                prompt_source_bases=("canon-basis",),
+                source_context_available=True,
+                allow_model_save=False,
+                mark_recent_direct=False,
+                ordinary_chat_single_packet_execution=execution,
+            )
+
+        self.assertEqual(message.replies, [response])
+        older_canary.assert_not_awaited()
+        guard.assert_awaited_once()
+        self.assertTrue(guard.await_args.kwargs["regeneration_allowed"])
+        finalize.assert_awaited_once()
+        self.assertTrue(finalize.await_args.kwargs["response_sent"])
+        self.assertFalse(finalize.await_args.kwargs["candidate_live"])
+        self.assertEqual(
+            finalize.await_args.kwargs["guard_status"],
+            "single_packet_legacy_baseline_sent",
+        )
+
     async def test_single_packet_deterministic_clarification_bypasses_factual_guard_and_sends(self):
         message = FakeMessage()
         message.content = "Tell me about Jordan."

--- a/tests/test_unified_response_assessment_bot_paths.py
+++ b/tests/test_unified_response_assessment_bot_paths.py
@@ -312,6 +312,12 @@ class UnifiedResponseAssessmentBotPathTests(unittest.TestCase):
                 "- 2026-08-01 broadcast_memory_note: DJ Floppy Disc"
             )
         )
+        memory_builder = mock.Mock(
+            return_value=(
+                "Approved direct self-reports:\n"
+                "- Established memory sentinel: DJ Floppy Disc"
+            )
+        )
         with (
             mock.patch.dict(os.environ, flags, clear=False),
             mock.patch.object(
@@ -333,6 +339,11 @@ class UnifiedResponseAssessmentBotPathTests(unittest.TestCase):
                 bnl01_bot,
                 "build_conversation_prompt_source_basis",
                 return_value=None,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_user_memory_context",
+                new=memory_builder,
             ),
             mock.patch.object(
                 bnl01_bot,
@@ -359,6 +370,11 @@ class UnifiedResponseAssessmentBotPathTests(unittest.TestCase):
                 "build_ordinary_chat_basis",
                 return_value=ordinary_basis,
             ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_shared_brain_synthesis_basis",
+                return_value=None,
+            ),
         ):
             metadata = {}
             prompt, *_ = bnl01_bot.build_user_aware_prompt(
@@ -374,27 +390,58 @@ class UnifiedResponseAssessmentBotPathTests(unittest.TestCase):
                 prompt_metadata=metadata,
             )
 
-        broadcast_builder.assert_not_called()
-        self.assertEqual(len(assessment_calls), 1)
+            broadcast_builder.assert_not_called()
+            memory_builder.assert_not_called()
+            self.assertEqual(len(assessment_calls), 1)
+            self.assertFalse(
+                assessment_calls[0]["broadcast_memory_present"]
+            )
+            self.assertNotIn(
+                "broadcast_memory",
+                assessment_calls[0]["prompt_lanes"],
+            )
+            self.assertTrue(
+                metadata["ordinary_chat_single_packet_applied"]
+            )
+            self.assertIs(
+                metadata["ordinary_chat_single_packet_basis"],
+                ordinary_basis,
+            )
+            self.assertEqual(
+                metadata["ordinary_chat_single_packet_scope"].reason,
+                "eligible",
+            )
+            baseline_request = metadata[
+                "ordinary_chat_legacy_baseline_request"
+            ]
+            self.assertEqual(baseline_request["clean_content"], text)
+            self.assertEqual(baseline_request["user_id"], 202)
+            self.assertEqual(baseline_request["guild_id"], 1)
+            self.assertEqual(baseline_request["channel_id"], 303)
+            self.assertTrue(baseline_request["is_direct_interaction"])
+            self.assertNotIn("Broadcast memory context:", prompt)
+
+            rebuilt = bnl01_bot._build_ordinary_chat_legacy_baseline_prompt(
+                metadata,
+                payload_items=[],
+                request_text=text,
+                conversation_orchestration=None,
+            )
+
+        self.assertIsNotNone(rebuilt)
+        rebuilt_prompt, _allow, _style, rebuilt_metadata = rebuilt
+        self.assertIn("Durable memory context:", rebuilt_prompt)
+        self.assertIn("Established memory sentinel", rebuilt_prompt)
+        self.assertIn("Broadcast memory context:", rebuilt_prompt)
+        self.assertIn("DJ Floppy Disc", rebuilt_prompt)
         self.assertFalse(
-            assessment_calls[0]["broadcast_memory_present"]
+            rebuilt_metadata["ordinary_chat_single_packet_applied"]
         )
-        self.assertNotIn(
-            "broadcast_memory",
-            assessment_calls[0]["prompt_lanes"],
+        self.assertIsNone(
+            rebuilt_metadata["shared_brain_synthesis_canary_basis"]
         )
-        self.assertTrue(
-            metadata["ordinary_chat_single_packet_applied"]
-        )
-        self.assertIs(
-            metadata["ordinary_chat_single_packet_basis"],
-            ordinary_basis,
-        )
-        self.assertEqual(
-            metadata["ordinary_chat_single_packet_scope"].reason,
-            "eligible",
-        )
-        self.assertNotIn("Broadcast memory context:", prompt)
+        memory_builder.assert_called_once()
+        broadcast_builder.assert_called_once()
 
     def test_bot_recorder_persists_only_aggregate_receipt(self):
         with mock.patch.object(


### PR DESCRIPTION
## Summary

This draft now contains both repairs needed after the live acceptance failure:

- obey the narrow deterministic `reply/respond with exactly ... name(s), and no other words:` instruction with zero provider calls, save that exact BNL reply, and preserve it as the reply source for the next pronoun follow-up; and
- preserve BNL's established context-rich chat behavior when the ordinary-chat single-packet replacement fails locally **before** it makes a provider call.

The second repair restores the same eligible room context, durable memory, Relationship tone, canon/lore, Broadcast memory, and authorized source blocks that the established route used before packet cutover. Successful single-packet answers are unchanged.

## Root cause of the regression

The ordinary-chat cutover removed the established factual prompt lanes as soon as a turn became packet-eligible. If packet or assessment construction then failed locally, the replacement had no usable candidate and exposed a fixed hold/clarify template. That made a safety mechanism look like lost intelligence: basic BARCODE identities, relationships, and recent memory could be present in the established sources but absent from the packet-owned prompt.

The repair makes the cutover additive: BNL does not discard the working baseline until the replacement packet has actually crossed its prompt/provider boundary.

## Baseline-preservation boundary

A handoff to the established route is allowed only when all of these are true:

- the packet route produced no candidate;
- packet provider and corrective-call counts are both zero;
- no packet prompt was applied;
- the turn is stable and non-ambiguous; and
- the request is not live/current.

When allowed, the prompt is rebuilt with packet ownership disabled, one established-route generation runs, and the existing response guards and pre-send source/frame revalidation remain active. The older comparison canary is not stacked on top of this recovery generation. The original packet receipt is retained and finalized as `single_packet_legacy_baseline_sent`, with separate diagnostics for packet calls and baseline-generation calls.

The handoff is explicitly denied:

- after any packet provider/corrective call or packet prompt application;
- for live/current facts, including queue state and weather;
- for ambiguity or a required clarification;
- for changed/invalid pre-generation sources; and
- after a generated packet candidate is rejected.

Those cases continue to fail closed. There is no generated packet answer followed by a second model answer.

## Exact-reply continuity repair

The deterministic seed path:

1. recognizes only the bounded literal-name grammar;
2. sends and saves the exact requested names with zero provider calls;
3. makes the saved Discord reply available as the exact reply source; and
4. lets the subsequent singular/plural pronoun turn resolve against that source.

Normal factual, source, currentness, and ambiguity rules remain in place for every other instruction.

## Free-speaking channel scope

This PR does **not** alter whether BNL enters a conversation, response frequency, pacing, batching, or the primary-channel engagement policy. It improves the response path after the existing planner has selected a reply, so it applies equally to tagged and untagged turns that already qualify for an answer.

## Verification

Exact committed and published tree:

- Full repository suite: **2,287 tests passed** in 264.426 seconds.
- Final focused diagnostics/recovery module: **25 tests passed**.
- Python compile checks passed.
- `git diff --check` passed.
- GitHub CI run **#220** completed successfully.
- Local commit: `4d8f898857b8f366b0cbc37f3d5e3d7967cea8ea`.
- Remote PR head: `cee8d27663c7203190f4ab9fa1e8e2b1ac0d4946`.
- Remote parent: `ad56d6791585ba2be2b32359dd5a69fb4677f251`.
- Complete local and remote tree: `c02c7516a23a1d3e9e0c87a018928d5a20cbff59`.
- Every final published blob SHA matches its locally committed blob.

The new regressions cover stable zero-call recovery, prompt rebuilding with memory/Broadcast context, normal response guards, receipt/debug evidence, rebuild/provider failures, explicit denial for live facts, packet-started turns, ambiguity, and changed-source pre-generation failures, plus operator-visible route evidence.

## Merge and rollout boundary

Merged into GitHub `main` on 2026-08-21.

- Merge commit: `667f1fdf57497568d49971554903184c019d33fa`
- Verified complete tree: `c02c7516a23a1d3e9e0c87a018928d5a20cbff59`
- First parent: `bc22d28591abf9f52f8d34a3058e772764901c26`
- Verified PR-head second parent: `cee8d27663c7203190f4ab9fa1e8e2b1ac0d4946`

Production deployment remains pending. Deploy only the pinned merge commit/tree above and retain the pre-deployment environment and database backups.
