### PR TITLE
Enforce three-state BNL queue access contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,16 +78,19 @@ The website Relay still inspects fresh public signal every
 sources are generated at most every `BNL_WEBSITE_QUIET_RELAY_INTERVAL_MINUTES`
 (default 60); manual and force-pull requests retain the quiet-source cascade.
 
-Native queue context has two independent production gates. The local bot variable `BNL_QUEUE_PRODUCTION_ENABLED` defaults off and accepts only `true` (case-insensitive); the website read model must also report `capabilities.queueProduction=true`. Queue/session/track context is stripped unless both gates agree. Merging queue-aware code does not enable either gate.
+Native queue context has two independent production gates plus one website-owned access scope. The local bot variable `BNL_QUEUE_PRODUCTION_ENABLED` defaults off and accepts only `true` (case-insensitive); the website read model must also report `capabilities.queueProduction=true`. The website then declares `accessScope=none`, `private`, or `public`. `none` is always stripped. `private` is accepted only from an authenticated response obtained with the existing `BNL_API_KEY`, and only `sealed_test` and `internal_controlled` channel policies may retain its queue/history fields. `public` may support public queue context. Merging queue-aware code does not enable either production gate or change a site's session access choice.
+
+Private and public responses use the website's same explicit sanitized operational DTO. The bot does not receive payment/checkout, contact, raw upload, legal-acceptance, moderation, browser-capability, or admin-only fields, and it never gains queue mutation or playback control. Private data is temporary prompt context only: it may answer an owner/admin inside an approved private channel, but it cannot drive public/show-day output, public recaps, Broadcast Memory, dossiers, Source Files, Relay, Journal, or any persistence path.
 
 Activation order is site first, bot second:
 
 1. Keep the bot gate disabled while the website native-queue cutover is verified.
-2. Confirm the website capability is true and its public queue state is sanitized and accurate.
-3. Only after explicit owner approval, set `BNL_QUEUE_PRODUCTION_ENABLED=true` and restart the bot.
-4. Roll back the bot first by unsetting the variable or changing it away from `true`; the website can then be rolled back independently.
+2. Confirm the website capability is true and test all three session choices: no access, authenticated private access, and public access for a live broadcast.
+3. Confirm private queue data is visible only in private test/operator channels and cannot drive public or show-day output.
+4. Only after explicit owner approval, set `BNL_QUEUE_PRODUCTION_ENABLED=true` and restart the bot.
+5. Roll back the bot first by unsetting the variable or changing it away from `true`; the website can then be rolled back independently.
 
-Show-day copy follows the same boundary. The 6:40 PM Pacific intake message names the native queue only when both gates are usable; otherwise it uses provider-neutral public-intake wording. The 7:00 PM message describes the scheduled broadcast window without claiming unverified live state, and the later sponsor message remains optional and host-controlled.
+Show-day copy follows the same boundary and accepts only public queue scope. A private test response cannot drive an intake, live, sponsor, recap, or public-current-state message. The 6:40 PM Pacific intake message names the native queue only when both production gates and public access are usable; otherwise it uses provider-neutral public-intake wording. The 7:00 PM message describes the scheduled broadcast window without claiming unverified live state, and the later sponsor message remains optional and host-controlled.
 
 Holiday and occasion reflections extend the existing Ambient coordinator and
 active liaison channel. The maintained calendar targets 10:00 AM Pacific,

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -27,6 +27,7 @@ from bnl_canon_source_contract import (
     render_key_personnel_canon_block,
     render_prompt_canon_block,
     strip_queue_sections,
+    website_queue_access_scope,
 )
 from bnl_occasion import (
     OCCASION_CALENDAR_VERSION,
@@ -1986,7 +1987,11 @@ def get_bnl_control_flags(force_refresh: bool = False) -> dict:
 
 def fetch_bnl_read_model(force: bool = False) -> dict:
     """
-    Fetch the public website read model as temporary prompt context only.
+    Fetch the website read model as temporary prompt context only.
+
+    The existing BNL service key authenticates the private queue projection.
+    A private response is accepted only when that key is configured; public
+    responses remain compatible with the original public-only contract.
     This helper never writes to SQLite, broadcast memory, website relay, or site state.
     """
     global _bnl_read_model_cache, _bnl_read_model_cached_at
@@ -2000,7 +2005,10 @@ def fetch_bnl_read_model(force: bool = False) -> dict:
         if age < BNL_READ_MODEL_TTL_SECONDS:
             return _bnl_read_model_cache
 
-    req = urllib.request.Request(BNL_READ_MODEL_URL, method="GET", headers={"Accept": "application/json"})
+    headers = {"Accept": "application/json"}
+    if BNL_API_KEY:
+        headers["x-api-key"] = BNL_API_KEY
+    req = urllib.request.Request(BNL_READ_MODEL_URL, method="GET", headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=3) as response:
             code = getattr(response, "status", None) or response.getcode()
@@ -2016,19 +2024,46 @@ def fetch_bnl_read_model(force: bool = False) -> dict:
     if not isinstance(data, dict):
         logging.warning("bnl_read_model_invalid_shape")
         return {}
-    if data.get("ok") is not True or data.get("version") != 1 or data.get("publicOnly") is not True or not isinstance(data.get("sections"), dict):
+    public_only = data.get("publicOnly")
+    access_scope = str(data.get("accessScope") or "").strip().lower()
+    public_response = public_only is True and access_scope in {"", "none", "public"}
+    private_response = bool(BNL_API_KEY) and public_only is False and access_scope == "private"
+    if (
+        data.get("ok") is not True
+        or data.get("version") != 1
+        or not isinstance(data.get("sections"), dict)
+        or not (public_response or private_response)
+    ):
         logging.warning("bnl_read_model_invalid_shape")
         return {}
 
     _bnl_read_model_cache = data
     _bnl_read_model_cached_at = now
-    logging.info(f"bnl_read_model_fetch_success sections={len(data.get('sections') or {})}")
+    logging.info(
+        "bnl_read_model_fetch_success sections=%s access_scope=%s",
+        len(data.get("sections") or {}),
+        website_queue_access_scope(data),
+    )
     return data
 
 
-def safe_bnl_read_model_for_consumption(read_model: dict) -> dict:
-    """Return the queue-gated read-model view for all normal consumers."""
-    return strip_queue_sections(read_model)
+_PRIVATE_BNL_QUEUE_POLICIES = frozenset({"sealed_test", "internal_controlled"})
+
+
+def _channel_allows_private_bnl_queue(channel_policy: str = "") -> bool:
+    return str(channel_policy or "").strip().lower() in _PRIVATE_BNL_QUEUE_POLICIES
+
+
+def safe_bnl_read_model_for_consumption(
+    read_model: dict,
+    channel_policy: str = "",
+) -> dict:
+    """Return the queue-gated view allowed for this exact channel policy."""
+
+    return strip_queue_sections(
+        read_model,
+        allow_private=_channel_allows_private_bnl_queue(channel_policy),
+    )
 
 
 def is_bnl_read_model_relevant(text: str, channel_policy: str = "") -> bool:
@@ -2185,8 +2220,11 @@ def _track_label(track: dict, include_lane: bool = True, include_source: bool = 
 
 
 def build_bnl_read_model_context(read_model: dict, user_text: str, channel_policy: str) -> str:
-    """Build a compact, public-only prompt block from a validated read model."""
-    read_model = safe_bnl_read_model_for_consumption(read_model)
+    """Build a compact prompt block from the channel-authorized read model."""
+
+    declared_access_scope = website_queue_access_scope(read_model)
+    private_queue_allowed = _channel_allows_private_bnl_queue(channel_policy)
+    read_model = safe_bnl_read_model_for_consumption(read_model, channel_policy)
     if not read_model:
         return ""
     sections = _read_model_sections(read_model)
@@ -2199,9 +2237,22 @@ def build_bnl_read_model_context(read_model: dict, user_text: str, channel_polic
     rules_section = sections.get("rules") if sections.get("rules") is not None else read_model.get("rules")
     source_context_items = _public_source_context_items(read_model)
 
+    # A private website response still contains independently public-safe site
+    # context. Once its queue/history sections have been stripped for a public
+    # consumer, label that prompt view as having no queue access rather than
+    # suppressing the unrelated public site material.
+    access_scope = (
+        "none"
+        if declared_access_scope == "private" and not private_queue_allowed
+        else website_queue_access_scope(read_model)
+    )
+    private_access = access_scope == "private"
     lines = [
-        "Website public read model context:",
-        f"Source: {_compact_public_text(read_model.get('source') or 'barcode-network-site', 80)} / publicOnly=true / version=1",
+        "Website private queue read model context:" if private_access else "Website public read model context:",
+        (
+            f"Source: {_compact_public_text(read_model.get('source') or 'barcode-network-site', 80)} "
+            f"/ publicOnly={'false' if private_access else 'true'} / accessScope={access_scope} / version=1"
+        ),
     ]
     schema_revision = _compact_public_text(read_model.get("schemaRevision"), 40)
     if schema_revision:
@@ -2349,14 +2400,26 @@ def build_bnl_read_model_context(read_model: dict, user_text: str, channel_polic
         lines.append("\nSite lane rules:")
         for rule in lane_rules[:5]:
             lines.append(f"- {rule}")
-    lines.extend([
-        "- This is public website context only.",
-        "- Do not treat this as durable memory.",
-        "- Do not write, merge, promote, or persist this context.",
-        "- Do not claim private account/payment/user data.",
-        "- Do not claim simulation/test tracks are present; the read model excludes them.",
-        "- Do not expose raw JSON directly; answer naturally from the compact public fields above.",
-    ])
+    if private_access:
+        lines.extend([
+            "- This is private owner/admin test and operator context only.",
+            "- Do not use this queue data in public output.",
+            "- Do not use it for public replies, public announcements, public recaps, the public Broadcast Deck, or the public Broadcast Archive.",
+            "- Simulation/test tracks may be present and must remain private test evidence.",
+            "- Do not treat this as durable memory.",
+            "- Do not write, merge, promote, or persist this context.",
+            "- Do not claim payment, checkout, contact, upload, legal-acceptance, private account, or admin-only data.",
+            "- Do not expose raw JSON directly; answer naturally from the compact operational fields above.",
+        ])
+    else:
+        lines.extend([
+            "- This is public website context only.",
+            "- Do not treat this as durable memory.",
+            "- Do not write, merge, promote, or persist this context.",
+            "- Do not claim private account/payment/user data.",
+            "- Do not claim simulation/test tracks are present; the read model excludes them.",
+            "- Do not expose raw JSON directly; answer naturally from the compact public fields above.",
+        ])
     logging.info(f"bnl_read_model_context_loaded reason=relevant_prompt channel_policy={channel_policy}")
     return "\n".join(lines[:80])
 
@@ -2369,7 +2432,10 @@ def maybe_build_bnl_read_model_context(user_text: str, channel_policy: str) -> s
         return ""
     if (
         _current_queue_state_query(user_text)
-        and not queue_usability(read_model)["usable"]
+        and not queue_usability(
+            read_model,
+            allow_private=_channel_allows_private_bnl_queue(channel_policy),
+        )["usable"]
     ):
         logging.info(
             "bnl_read_model_context_skipped "

--- a/bnl_canon_source_contract.py
+++ b/bnl_canon_source_contract.py
@@ -1700,7 +1700,8 @@ QUEUE_KEYS = {
     "queue", "session", "payment", "payments", "availability", "nowPlaying", "currentTrack", "upNext", "nextTrack",
     "queuedTracks", "activeTracks", "completedTracks", "queueOpen", "activeCount", "completedCount", "removedCount",
     "capacity", "pressure", "broadcastPhase", "prioritySignal", "priority", "priorityUpgradesEnabled", "priorityUpgradeLabel",
-    "wheelSpinsOwed", "artists", "queueStatus", "currentSession",
+    "wheelSpinsOwed", "artists", "queueStatus", "currentSession", "archive", "stats", "playbackTiming",
+    "wheelTiming", "playbackDiagnostics", "wheelEligibleArtists",
 }
 _QUEUE_KEY_LOWER = {k.lower() for k in QUEUE_KEYS}
 _QUEUE_PROVENANCE_TERMS = ("queue", "queue_public_snapshot", "session", "track", "payment", "priority", "wheel", "now_playing", "up_next")
@@ -3188,12 +3189,53 @@ def website_queue_production_capability(read_model: dict | None) -> bool | None:
     caps = (read_model or {}).get("capabilities") if isinstance(read_model, dict) else None
     return caps.get("queueProduction") if isinstance(caps, dict) and isinstance(caps.get("queueProduction"), bool) else None
 
-def queue_usability(read_model: dict | None, *, environ: dict[str, str] | None = None) -> dict[str, Any]:
+def website_queue_access_scope(read_model: dict | None) -> str:
+    """Return the validated queue access scope declared by the website read model."""
+
+    if not isinstance(read_model, dict):
+        return "none"
+    scope = str(read_model.get("accessScope") or "").strip().lower()
+    public_only = read_model.get("publicOnly")
+    if scope == "private" and public_only is False:
+        return "private"
+    if scope == "public" and public_only is True:
+        return "public"
+    if scope == "none":
+        return "none"
+    # Compatibility for the original public-only website contract.
+    if not scope and public_only is True:
+        return "public"
+    return "none"
+
+def queue_usability(
+    read_model: dict | None,
+    *,
+    environ: dict[str, str] | None = None,
+    allow_private: bool = False,
+) -> dict[str, Any]:
     local = env_queue_production_enabled(environ)
     remote = website_queue_production_capability(read_model)
-    usable = bool(local and remote is True)
-    reason = "eligible" if usable else ("local_gate_disabled" if not local else "website_capability_missing_or_false")
-    return {"usable": usable, "local": local, "website": remote, "reason": reason}
+    access_scope = website_queue_access_scope(read_model)
+    scope_allowed = access_scope == "public" or (access_scope == "private" and allow_private)
+    usable = bool(local and remote is True and scope_allowed)
+    if usable:
+        reason = "eligible"
+    elif not local:
+        reason = "local_gate_disabled"
+    elif remote is not True:
+        reason = "website_capability_missing_or_false"
+    elif access_scope == "private":
+        reason = "private_access_not_allowed"
+    else:
+        reason = "website_queue_access_none_or_invalid"
+    return {
+        "usable": usable,
+        "local": local,
+        "website": remote,
+        "accessScope": access_scope,
+        "privateAllowed": bool(allow_private),
+        "reason": reason,
+    }
 
 def _looks_queue_derived(value: Any) -> bool:
     if isinstance(value, dict):
@@ -3279,13 +3321,22 @@ def _strip_queue_recursive(value: Any, *, in_sections: bool = False) -> Any:
         return [_strip_queue_recursive(v) for v in value]
     return value
 
-def strip_queue_sections(read_model: dict | None, *, environ: dict[str, str] | None = None) -> dict:
+def strip_queue_sections(
+    read_model: dict | None,
+    *,
+    environ: dict[str, str] | None = None,
+    allow_private: bool = False,
+) -> dict:
     if not isinstance(read_model, dict):
         return {}
-    if queue_usability(read_model, environ=environ)["usable"]:
+    if queue_usability(
+        read_model,
+        environ=environ,
+        allow_private=allow_private,
+    )["usable"]:
         return read_model
     return _strip_queue_recursive(read_model)
 
 def diagnostics(read_model: dict | None = None, *, environ: dict[str, str] | None = None) -> dict[str, Any]:
     q = queue_usability(read_model, environ=environ)
-    return {"contractVersion": CANON_SOURCE_CONTRACT_VERSION, "compatibilityAdaptersActive": True, "localQueueProductionCapability": q["local"], "websiteQueueProductionCapability": q["website"], "effectiveQueueUsable": q["usable"], "queueReason": q["reason"]}
+    return {"contractVersion": CANON_SOURCE_CONTRACT_VERSION, "compatibilityAdaptersActive": True, "localQueueProductionCapability": q["local"], "websiteQueueProductionCapability": q["website"], "websiteQueueAccessScope": q["accessScope"], "effectiveQueueUsable": q["usable"], "queueReason": q["reason"]}

--- a/docs/canon_source_contract_v1.md
+++ b/docs/canon_source_contract_v1.md
@@ -29,11 +29,17 @@ owner, controller, admin, operator, or infrastructure facts.
 
 ## Central sanitized read-model boundary
 
-`fetch_bnl_read_model()` may retain the raw validated payload in its private cache for capability checks, cache metadata, and privacy-safe diagnostics. Normal consumers use the sanitized consumption view through the bot boundary before prompt assembly or intent dispatch.
+`fetch_bnl_read_model()` sends the existing `BNL_API_KEY` when configured and may retain the raw validated payload in its private cache for capability checks, cache metadata, and privacy-safe diagnostics. It accepts either the original/explicit public response (`publicOnly=true`, scope absent/`public`/`none`) or an authenticated private response (`publicOnly=false`, `accessScope=private`). A private response is rejected when the service key is not configured. Normal consumers use the channel-scoped sanitized consumption view before prompt assembly or intent dispatch.
 
 When queue production is disabled, the contract strips queue/session/payment/availability/now-playing/up-next/active/completed track/count/Priority/Wheel/queue-derived artist fields. It also filters `operatorLanes` by provenance: queue-public snapshots and queue/session/track/payment/priority/wheel-derived entries are removed from temporary runtime context, recap candidates, broadcast-memory candidates, dossier seed candidates, and public-safe copy candidates. Non-queue public dossier material and non-queue boundary/do-not-store rules remain available.
 
-Queue production remains disabled unless both gates are explicit: local `BNL_QUEUE_PRODUCTION_ENABLED=true` and website `capabilities.queueProduction=true`. Missing or malformed capability data fails closed.
+Queue production remains disabled unless both gates are explicit: local `BNL_QUEUE_PRODUCTION_ENABLED=true` and website `capabilities.queueProduction=true`. Queue use then follows exactly three website scopes:
+
+- `none`: no queue/history data is usable;
+- `private`: queue/history data is usable only in `sealed_test` and `internal_controlled`;
+- `public`: queue/history data is usable in public consumers.
+
+Missing, contradictory, or malformed scope/`publicOnly` combinations fail closed. Public and show-day consumers cannot receive private queue data, and Broadcast Memory, dossier, Source File, Relay, Journal, or any other persistence/publication path cannot retain it. An approved private channel may answer the owner/admin from private queue context, including a transient test recap, but the prompt carries an explicit instruction not to use that data in public output and remains non-persistent.
 
 The website's bounded `sections.sourceContext` list remains public site canon, not live queue state. BNL may load those public summaries for an explicit site/read-model question even while live queue context is disabled. Queue/session/track values are still removed before prompt assembly.
 
@@ -66,7 +72,7 @@ Static approved canon and schedule facts cannot prove live/open/current/now stat
 
 ## Native queue and show-day alignment
 
-Show-day announcement canon consumes the same two-gate decision without persisting queue data. The scheduled 6:40 PM Pacific intake message names the native BARCODE Radio queue only when the local bot gate and website capability are both true. Otherwise it uses provider-neutral public-intake wording; stock and generated announcements may not fall back to Auxchord-specific copy or imply BNL operates submissions.
+Show-day announcement canon consumes the same gate decision without persisting queue data. The scheduled 6:40 PM Pacific intake message names the native BARCODE Radio queue only when the local bot gate, website capability, and public queue access are all true. Private access is intentionally insufficient. Otherwise it uses provider-neutral public-intake wording; stock and generated announcements may not fall back to Auxchord-specific copy or imply BNL operates submissions.
 
 The 7:00 PM Pacific announcement is deliberately restrained: the schedule proves the broadcast window, not a current live/on-air state. The optional later-show sponsor reminder does not claim that a commercial break is active, due, required, or already called. Current state still requires fresh public runtime evidence and host control.
 

--- a/tests/test_canon_source_contract.py
+++ b/tests/test_canon_source_contract.py
@@ -250,8 +250,52 @@ class CanonSourceContractTests(unittest.TestCase):
             self.assertFalse(c.queue_usability(rm, environ={"BNL_QUEUE_PRODUCTION_ENABLED": "true"})["usable"])
 
     def test_queue_eligible_only_when_both_true(self):
-        rm = {"capabilities": {"queueProduction": True}, "sections": {"queue": {"nowPlaying": {"title": "X"}}}}
+        rm = {
+            "publicOnly": True,
+            "accessScope": "public",
+            "capabilities": {"queueProduction": True},
+            "sections": {"queue": {"nowPlaying": {"title": "X"}}},
+        }
         self.assertTrue(c.queue_usability(rm, environ={"BNL_QUEUE_PRODUCTION_ENABLED": "TrUe"})["usable"])
+
+    def test_private_queue_scope_requires_explicit_private_consumer(self):
+        rm = {
+            "publicOnly": False,
+            "accessScope": "private",
+            "capabilities": {"queueProduction": True},
+            "sections": {
+                "queue": {"nowPlaying": {"title": SECRET_NOW}},
+                "archive": {"latestTitle": SECRET_RECAP},
+                "rules": ["Private operational context only."],
+            },
+        }
+        env = {"BNL_QUEUE_PRODUCTION_ENABLED": "true"}
+
+        public_use = c.queue_usability(rm, environ=env)
+        private_use = c.queue_usability(rm, environ=env, allow_private=True)
+        public_view = c.strip_queue_sections(rm, environ=env)
+        private_view = c.strip_queue_sections(rm, environ=env, allow_private=True)
+
+        self.assertFalse(public_use["usable"])
+        self.assertEqual(public_use["reason"], "private_access_not_allowed")
+        self.assertTrue(private_use["usable"])
+        self.assertNotIn(SECRET_NOW, str(public_view))
+        self.assertNotIn(SECRET_RECAP, str(public_view))
+        self.assertIn(SECRET_NOW, str(private_view))
+        self.assertIn(SECRET_RECAP, str(private_view))
+
+    def test_malformed_queue_access_scope_fails_closed(self):
+        env = {"BNL_QUEUE_PRODUCTION_ENABLED": "true"}
+        malformed = {
+            "publicOnly": False,
+            "accessScope": "public",
+            "capabilities": {"queueProduction": True},
+            "sections": {"queue": {"nowPlaying": {"title": SECRET_NOW}}},
+        }
+
+        self.assertEqual(c.website_queue_access_scope(malformed), "none")
+        self.assertFalse(c.queue_usability(malformed, environ=env, allow_private=True)["usable"])
+        self.assertNotIn(SECRET_NOW, str(c.strip_queue_sections(malformed, environ=env, allow_private=True)))
 
     def test_non_queue_context_remains(self):
         rm = {"capabilities": {"queueProduction": False}, "sections": {"rules": ["Public rule"]}, "sourceContext": {"source": "site"}}

--- a/tests/test_showday_queue_alignment.py
+++ b/tests/test_showday_queue_alignment.py
@@ -1,4 +1,5 @@
 import os
+import json
 import unittest
 from unittest import mock
 
@@ -31,7 +32,152 @@ def read_model(queue_production: bool, *, radio_summary: str = "") -> dict:
     }
 
 
+def private_read_model() -> dict:
+    model = read_model(True)
+    model["publicOnly"] = False
+    model["accessScope"] = "private"
+    model["sections"]["sourceContext"] = [{
+        "id": "public_site_summary",
+        "title": "Public Site Summary",
+        "summary": "PUBLIC_SITE_CONTEXT_REMAINS_AVAILABLE",
+    }]
+    model["sections"]["queue"] = {
+        "available": True,
+        "accessScope": "private",
+        "nowPlaying": {"title": "PRIVATE_TEST_QUEUE_TITLE"},
+        "queue": [{"title": "PRIVATE_SIMULATION_TRACK", "isSimulation": True}],
+    }
+    model["sections"]["archive"] = {
+        "available": True,
+        "latestTitle": "PRIVATE_TEST_ARCHIVE_TITLE",
+    }
+    return model
+
+
 class ShowdayQueueAlignmentTests(unittest.IsolatedAsyncioTestCase):
+    def test_authenticated_private_read_model_is_accepted_and_sends_existing_api_key(self):
+        payload = private_read_model()
+        captured = {}
+
+        class Response:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def getcode(self):
+                return 200
+
+            def read(self):
+                return json.dumps(payload).encode("utf-8")
+
+        def open_request(request, timeout):
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return Response()
+
+        with mock.patch.object(bnl01_bot, "BNL_READ_MODEL_ENABLED", True), \
+             mock.patch.object(bnl01_bot, "BNL_READ_MODEL_URL", "https://example.test/api/bnl/read-model"), \
+             mock.patch.object(bnl01_bot, "BNL_API_KEY", "shared-bnl-key"), \
+             mock.patch.object(bnl01_bot.urllib.request, "urlopen", side_effect=open_request), \
+             mock.patch.object(bnl01_bot, "_bnl_read_model_cache", None), \
+             mock.patch.object(bnl01_bot, "_bnl_read_model_cached_at", None):
+            result = bnl01_bot.fetch_bnl_read_model(force=True)
+
+        self.assertEqual(result["accessScope"], "private")
+        self.assertEqual(captured["request"].get_header("X-api-key"), "shared-bnl-key")
+        self.assertEqual(captured["timeout"], 3)
+
+    def test_private_read_model_is_rejected_without_service_key(self):
+        payload = private_read_model()
+
+        class Response:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def getcode(self):
+                return 200
+
+            def read(self):
+                return json.dumps(payload).encode("utf-8")
+
+        with mock.patch.object(bnl01_bot, "BNL_READ_MODEL_ENABLED", True), \
+             mock.patch.object(bnl01_bot, "BNL_READ_MODEL_URL", "https://example.test/api/bnl/read-model"), \
+             mock.patch.object(bnl01_bot, "BNL_API_KEY", ""), \
+             mock.patch.object(bnl01_bot.urllib.request, "urlopen", return_value=Response()), \
+             mock.patch.object(bnl01_bot, "_bnl_read_model_cache", None), \
+             mock.patch.object(bnl01_bot, "_bnl_read_model_cached_at", None):
+            result = bnl01_bot.fetch_bnl_read_model(force=True)
+
+        self.assertEqual(result, {})
+
+    def test_private_queue_data_is_visible_only_in_private_test_and_operator_channels(self):
+        model = private_read_model()
+        with mock.patch.dict(os.environ, {"BNL_QUEUE_PRODUCTION_ENABLED": "true"}, clear=False):
+            public_contexts = [
+                bnl01_bot.build_bnl_read_model_context(
+                    model,
+                    "what is playing right now?",
+                    policy,
+                )
+                for policy in (
+                    "public_home",
+                    "public_context",
+                    "public_selective",
+                    "broadcast_memory",
+                )
+            ]
+            sealed_context = bnl01_bot.build_bnl_read_model_context(
+                model,
+                "what is playing right now?",
+                "sealed_test",
+            )
+            operator_context = bnl01_bot.build_bnl_read_model_context(
+                model,
+                "what is playing right now?",
+                "internal_controlled",
+            )
+
+        for public_context in public_contexts:
+            self.assertNotIn("PRIVATE_TEST_QUEUE_TITLE", public_context)
+            self.assertNotIn("PRIVATE_SIMULATION_TRACK", public_context)
+            self.assertNotIn("PRIVATE_TEST_ARCHIVE_TITLE", public_context)
+            self.assertIn("PUBLIC_SITE_CONTEXT_REMAINS_AVAILABLE", public_context)
+        self.assertIn("PRIVATE_TEST_QUEUE_TITLE", sealed_context)
+        self.assertIn("PRIVATE_SIMULATION_TRACK", sealed_context)
+        self.assertIn("PRIVATE_TEST_QUEUE_TITLE", operator_context)
+        self.assertIn("private", operator_context.lower())
+        self.assertIn("Do not use this queue data in public output", operator_context)
+
+    def test_private_queue_cannot_drive_public_current_state_or_showday_output(self):
+        model = private_read_model()
+        with mock.patch.dict(os.environ, {"BNL_QUEUE_PRODUCTION_ENABLED": "true"}, clear=False), \
+             mock.patch.object(bnl01_bot, "fetch_bnl_read_model", return_value=model):
+            public_context = bnl01_bot.maybe_build_bnl_read_model_context(
+                "what is playing right now?",
+                "public_home",
+            )
+            operator_context = bnl01_bot.maybe_build_bnl_read_model_context(
+                "what is playing right now?",
+                "internal_controlled",
+            )
+            intake = bnl01_bot.showday_submission_canon(model)
+
+        self.assertNotIn("PRIVATE_TEST_QUEUE_TITLE", public_context)
+        self.assertNotIn("PRIVATE_SIMULATION_TRACK", public_context)
+        self.assertNotIn("PRIVATE_TEST_ARCHIVE_TITLE", public_context)
+        self.assertIn("PUBLIC_SITE_CONTEXT_REMAINS_AVAILABLE", public_context)
+        self.assertIn("PRIVATE_TEST_QUEUE_TITLE", operator_context)
+        self.assertEqual(intake["mode"], "public_intake")
+
     def test_native_announcement_canon_requires_local_and_site_gates(self):
         remote_true = read_model(True)
         remote_false = read_model(False)


### PR DESCRIPTION
## Summary

- honor the website-owned three-state BNL queue access contract: `none`, `private`, or `public`
- reuse the existing `BNL_API_KEY` to authenticate the site's private sanitized read model
- allow private queue/history data only in `sealed_test` and `internal_controlled` channel policies
- strip private queue/history data from public, show-day, recap, Relay, Journal, dossier, Source File, Broadcast Memory, and persistence consumers
- preserve independently public-safe site context when a private queue response is stripped

## Behavior

- **none**: queue/history is unusable everywhere
- **private**: sanitized read-only queue/history may answer the owner/admin transiently in approved private channels only
- **public**: sanitized read-only queue context may support normal public consumers
- malformed or contradictory `accessScope` / `publicOnly` combinations fail closed
- show-day native-queue wording requires the local production gate, the website production capability, and **public** access
- BNL receives no queue mutation or playback-control authority

The bot does not receive payment/checkout, contact, raw upload, legal-acceptance, moderation, browser-capability, or admin-only fields from this contract. Private test data cannot be stored or published.

## Files changed

- `README.md`
- `bnl01_bot.py`
- `bnl_canon_source_contract.py`
- `docs/canon_source_contract_v1.md`
- `tests/test_canon_source_contract.py`
- `tests/test_showday_queue_alignment.py`

## Verification

- rebased focused queue access / show-day suite: **49/49 passed**
- rebased `make check`: **2,362/2,362 tests passed**
- patch whitespace check: passed
- owner/privacy review: no new personal identity; only the established public owner label is used
- hosted GitHub CI [run #226](https://github.com/6-Bit-01/BNL01-Bot/actions/runs/32821053874): **passed** on Python 3.9 and 3.12 for the exact rebased head

## Tested and published tree

- rebased base: `0cfd84b7ede710ce81009da240c89025c98f778e` (merged Gemini cost controls, #444)
- published head: `46b6e4e3fe7367ca1a6c72f5859054eb3ea15742`
- tested/published tree: `509b9866a22b8b0d49681b83a068cd094a6d6333`
- exact local/remote tree match: **yes**

## Defaults and runtime uncertainty

- `BNL_QUEUE_PRODUCTION_ENABLED` remains disabled unless explicitly set to `true`
- the website's independent queue-production gate and per-session access choice must also permit access
- no environment variable, secret, deployment, restart, production test, or feature activation is included
- the existing `BNL_API_KEY` is reused; no new secret is introduced

## Protected systems left untouched

No queue mutation, payment, Stripe, Signal Hold, Priority, Wheel, playback, Archive writing, memory, dossier, Source File, Relay, Journal, account, identity, or canon write path was added or enabled.

## Rollback

Revert this PR's merge commit. The local and website production gates remain independent and default-safe.

## Post-merge runtime evidence still required — not executed

1. Verify website responses for no access, authenticated private access, and public access.
2. Confirm private simulation/rehearsal data appears only in an approved owner/admin channel and never in public output or the public Archive.
3. Confirm the public path excludes simulation/test data.
4. Only after explicit approval, enable/restart the bot gate and capture runtime evidence.
