### PR TITLE
Fix private queue context in batched BNL replies

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -33343,6 +33343,30 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             style_key, style_rule = choose_response_style(channel.guild.id, first_uid, len(collapsed_items), combined_text)
             log_response_style(channel.guild.id, first_uid, style_key)
             prompt = _format_batched_prompt(collapsed_items, style_key, style_rule)
+            batch_website_read_model_context = maybe_build_bnl_read_model_context(
+                combined_text,
+                channel_policy,
+            )
+            batch_source_context_available = bool(
+                batch_website_read_model_context
+            )
+            if batch_website_read_model_context:
+                prompt += (
+                    "\n\nAuthoritative current website queue context for this "
+                    "request:\n"
+                    + batch_website_read_model_context
+                    + "\nAnswer current queue questions directly from this context. "
+                    "Do not replace the current readout with the normal Friday "
+                    "schedule or claim that the queue is unavailable.\n"
+                )
+                _log_batch_event(
+                    logging.INFO,
+                    "website_read_model_context_used",
+                    guild_id,
+                    channel_id,
+                    len(collapsed_items),
+                    f"channel_policy={channel_policy}",
+                )
             batch_attribution_contract = build_batch_attribution_contract(
                 collapsed_items,
                 guild_id=guild_id,
@@ -33570,6 +33594,10 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                             "canon",
                             _canon_relevant_to_response(combined_text),
                         ),
+                        (
+                            "website_read_model",
+                            batch_source_context_available,
+                        ),
                     )
                     if present
                 )
@@ -33636,6 +33664,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     exact_quote_authority_present=(
                         batch_attribution_contract.exact_quote_authority
                         is not None
+                    ),
+                    website_read_model_present=(
+                        batch_source_context_available
                     ),
                     current_direct=bool(
                         active_packet.get("addressed_to_bot")
@@ -33824,6 +33855,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 user_id=first_uid,
                 guild_id=channel.guild.id,
                 route=generation_route,
+                source_context_available=batch_source_context_available,
             )
 
             response = suppress_stale_media_fallback(
@@ -33879,6 +33911,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                             user_id=first_uid,
                             guild_id=channel.guild.id,
                             route=generation_route,
+                            source_context_available=(
+                                batch_source_context_available
+                            ),
                         )
                         if regenerated:
                             response = regenerated
@@ -34142,8 +34177,10 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             memory_context_source_count=1,
             memory_injection_decision="batch_prompt_public_safe",
             memory_write_decision=get_route_mode_contract(ROUTE_MODE_NORMAL_CHAT).save_behavior,
-            source_analysis_context_injected=False,
-            source_context_allowed=False,
+            source_analysis_context_injected=(
+                batch_source_context_available
+            ),
+            source_context_allowed=batch_source_context_available,
             community_scouting_ran=False,
             entity_subjects_detected_count=0,
             subject_extraction_ran=False,
@@ -34181,7 +34218,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 user_display_name=(
                     collapsed_items[-1][0] if collapsed_items else ""
                 ),
-                source_context_available=False,
+                source_context_available=batch_source_context_available,
             )
         )
         batch_synthesis_decision = (
@@ -34215,7 +34252,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             is_reply=False,
             generation_route=generation_route if 'generation_route' in locals() else "get_gemini_response",
             channel=channel,
-            source_context_available=False,
+            source_context_available=batch_source_context_available,
             batch_generation_id=local_generation_id,
             conversation_continuity_required=batch_continuity_required,
             community_visual_basis=community_visual_basis,
@@ -34290,7 +34327,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                             else "get_gemini_response"
                         ),
                         channel=channel,
-                        source_context_available=False,
+                        source_context_available=(
+                            batch_source_context_available
+                        ),
                         batch_generation_id=local_generation_id,
                         conversation_continuity_required=(
                             batch_continuity_required
@@ -34476,7 +34515,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                         else "get_gemini_response"
                     ),
                     channel=channel,
-                    source_context_available=False,
+                    source_context_available=(
+                        batch_source_context_available
+                    ),
                     batch_generation_id=local_generation_id,
                     conversation_continuity_required=(
                         batch_continuity_required

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -747,6 +747,51 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("and why do they blink?", prompts[0])
         self.assertEqual(channel.sent, ["One combined response."])
 
+    async def test_sealed_batch_queue_question_receives_private_read_model_context(self):
+        channel = self._channel(8150)
+        generation_calls = []
+        queue_context = (
+            "Website private queue read model context:\n"
+            "Queue:\n"
+            "- Session=Private rehearsal, queueOpen=False\n"
+            "Queued tracks:\n"
+            "- Rehearsal Artist — Waiting Track"
+        )
+
+        async def generate(prompt, **kwargs):
+            generation_calls.append((prompt, kwargs))
+            return "Submissions are closed. Rehearsal Artist — Waiting Track is waiting."
+
+        self._prime_flush(
+            channel,
+            "BNL, read the current BARCODE Radio rehearsal queue. "
+            "Is submissions access open or closed, and what tracks are currently waiting?",
+        )
+        with (
+            self._flush_runtime(channel.id, generate),
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_build_bnl_read_model_context",
+                return_value=queue_context,
+            ) as context_builder,
+        ):
+            await bnl01_bot._flush_channel_buffer(channel)
+
+        context_builder.assert_called_once()
+        self.assertEqual(context_builder.call_args.args[1], "sealed_test")
+        self.assertEqual(len(generation_calls), 1)
+        prompt, kwargs = generation_calls[0]
+        self.assertIn(queue_context, prompt)
+        self.assertIn(
+            "Answer current queue questions directly from this context",
+            prompt,
+        )
+        self.assertTrue(kwargs["source_context_available"])
+        self.assertEqual(
+            channel.sent,
+            ["Submissions are closed. Rehearsal Artist — Waiting Track is waiting."],
+        )
+
     async def test_active_batch_guard_receives_typed_gist_attribution_contract(self):
         channel = self._channel(8136)
         prompts = []


### PR DESCRIPTION
## Summary

- inject the governed BNL website read model into authorized batched replies
- preserve the existing sealed/private versus public queue access boundary
- carry source-context authority through batch generation and response guards
- add a regression test using the exact failed rehearsal queue question

## Production smoke diagnosis

Production successfully fetched the private read model, but the plain-name `#bnl-testing` request entered the batched response path. That path did not attach the fetched queue context, so the model substituted the normal Friday schedule.

## Verification

- focused batching regression: passed
- show-day queue alignment suite: passed
- full `make check`: passed (exit 0)
- private owner identity policy scan: clear