### PR TITLE
Run website Relay hourly at :10 with protected budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Dollar-aware budget controls default to:
 - `BNL_GEMINI_BILLING_LAG_BUFFER_USD=0.50`
 - `BNL_GEMINI_INTERACTIVE_RESERVE_USD=2.00`
 - `BNL_GEMINI_JOURNAL_RESERVE_USD=1.00`
+- `BNL_GEMINI_RELAY_PACE_ALLOWANCE_USD=5.50`
 - `BNL_GEMINI_BACKGROUND_MAX_OUTPUT_TOKENS=4096`
 - `BNL_GEMINI_PROVIDER_TIMEOUT_SECONDS=120` (clamped to 10–240 seconds)
 - `BNL_GEMINI_BUDGET_RESERVATION_TTL_MINUTES=30` (minimum 30 minutes)
@@ -73,10 +74,22 @@ reports provider-returned input, visible-output, thinking, cached, and total
 tokens; estimated daily/monthly cost; pace/projection; attempts; and route
 restrictions. Daily and monthly accounting boundaries use Pacific Time.
 
-The website Relay still inspects fresh public signal every
-`BNL_WEBSITE_RELAY_INTERVAL_MINUTES` (default 20). Non-fresh, approved quiet
-sources are generated at most every `BNL_WEBSITE_QUIET_RELAY_INTERVAL_MINUTES`
-(default 60); manual and force-pull requests retain the quiet-source cascade.
+The website Relay makes one scheduled decision every
+`BNL_WEBSITE_RELAY_INTERVAL_MINUTES` (default and minimum 60), aligned to
+`BNL_WEBSITE_RELAY_MINUTE_OFFSET` (default 10, so the normal run is at `:10`
+each hour). Fresh eligible public signal and the existing approved quiet-source
+cascade use that same scheduled window; `BNL_WEBSITE_QUIET_RELAY_INTERVAL_MINUTES`
+defaults to 60 and may be raised independently. Manual and force-pull requests
+remain immediate and retain the same quiet-source cascade, validator, history,
+and cursor rules. Website presence heartbeat remains independent at five
+minutes.
+
+Relay keeps its background one-attempt/no-fallback provider policy, but may use
+the small configured pace allowance when generic background work is restricted.
+The allowance never bypasses the effective hard limit or the Journal and
+interactive dollar reserves. Show-day generation remains background-shaped but
+time-sensitive, so the generic monthly/daily pace gate cannot suppress a
+claimed show phase while those harder limits still permit it.
 
 Native queue context has two independent production gates plus one website-owned access scope. The local bot variable `BNL_QUEUE_PRODUCTION_ENABLED` defaults off and accepts only `true` (case-insensitive); the website read model must also report `capabilities.queueProduction=true`. The website then declares `accessScope=none`, `private`, or `public`. `none` is always stripped. `private` is accepted only from an authenticated response obtained with the existing `BNL_API_KEY`, and only `sealed_test` and `internal_controlled` channel policies may retain its queue/history fields. Those Discord channels are permission-locked for owner/admin test operators; regular members are not BNL testers. Discord access is the authorization boundary, so the bot deliberately does not add a second owner-only requester check inside those already restricted channels. `public` may support public queue context. Merging queue-aware code does not enable either production gate or change a site's session access choice.
 

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -497,7 +497,20 @@ try:
     )
 except (TypeError, ValueError):
     DORMANT_ECHO_SELECTION_CHANCE = 0.05
-BNL_WEBSITE_RELAY_INTERVAL_MINUTES = max(1, int(os.getenv("BNL_WEBSITE_RELAY_INTERVAL_MINUTES", "20")))
+BNL_WEBSITE_RELAY_INTERVAL_MINUTES = max(
+    60,
+    int(os.getenv("BNL_WEBSITE_RELAY_INTERVAL_MINUTES", "60") or 60),
+)
+try:
+    _configured_relay_minute_offset = int(
+        os.getenv("BNL_WEBSITE_RELAY_MINUTE_OFFSET", "10") or 10
+    )
+except (TypeError, ValueError):
+    _configured_relay_minute_offset = 10
+BNL_WEBSITE_RELAY_MINUTE_OFFSET = max(
+    0,
+    min(59, _configured_relay_minute_offset),
+)
 try:
     _configured_quiet_relay_interval = int(
         os.getenv("BNL_WEBSITE_QUIET_RELAY_INTERVAL_MINUTES", "60") or 60
@@ -4679,6 +4692,22 @@ def _build_source_decision_prompt(decision: RelaySourceDecision, mode: str, guil
     )
 
 
+def _website_relay_generation_failure_reason(
+    exc: Exception,
+) -> str:
+    """Return an operator-safe, truthful reason for a failed Relay draft."""
+
+    if isinstance(exc, BackgroundGenerationUnavailable):
+        result = exc.result
+        if result.error_category == GENERATION_ERROR_LOCAL_MODEL_BUDGET:
+            reason = str(
+                result.provider_error_code
+                or GENERATION_ERROR_LOCAL_MODEL_BUDGET
+            ).strip()
+            return f"budget_restricted:{reason}"
+    return "provider_failure"
+
+
 async def _generate_quiet_website_relay(guild_id: int, *, source_cursor: int, highest: int, reason: str = "approved_quiet_source") -> WebsiteRelayDecision:
     quiet_source = _select_approved_quiet_relay_source(guild_id, source_cursor, highest, allow_continuity=(reason != "bootstrap_no_publish"))
     if quiet_source.skip_reason:
@@ -4688,7 +4717,21 @@ async def _generate_quiet_website_relay(guild_id: int, *, source_cursor: int, hi
     relay_lane = _select_quiet_relay_lane(guild_id, quiet_source.source_class)
     prompt = _build_source_decision_prompt(quiet_source, mode, guild_id, relay_lane)
     try:
-        generated = await get_gemini_response(prompt, user_id=0, guild_id=guild_id, route="website_relay_event") or ""
+        generated = await get_gemini_response(
+            prompt,
+            user_id=0,
+            guild_id=guild_id,
+            route="website_relay_event",
+            raise_on_generation_failure=True,
+        ) or ""
+    except BackgroundGenerationUnavailable as exc:
+        failure_reason = _website_relay_generation_failure_reason(exc)
+        logging.warning(
+            "website_relay_no_publish guild=%s reason=%s",
+            guild_id,
+            failure_reason,
+        )
+        return WebsiteRelayDecision(False, skipReason=failure_reason, sourceCursor=source_cursor, metadata={"reason": failure_reason, "source_class": quiet_source.source_class, "aggregate_source_counts": quiet_source.aggregate_counts})
     except Exception as exc:
         logging.warning("website_relay_no_publish guild=%s reason=provider_failure error=%s", guild_id, _safe_force_pull_error(exc))
         return WebsiteRelayDecision(False, skipReason="provider_failure", sourceCursor=source_cursor, metadata={"reason": "provider_failure", "source_class": quiet_source.source_class, "aggregate_source_counts": quiet_source.aggregate_counts})
@@ -4776,7 +4819,21 @@ async def generate_dynamic_website_relay(guild_id: int, *, allow_quiet_sources: 
         f"Fresh public context:\n{relay_context}\n"
     )
     try:
-        generated = await get_gemini_response(prompt, user_id=0, guild_id=guild_id, route="website_relay_event") or ""
+        generated = await get_gemini_response(
+            prompt,
+            user_id=0,
+            guild_id=guild_id,
+            route="website_relay_event",
+            raise_on_generation_failure=True,
+        ) or ""
+    except BackgroundGenerationUnavailable as exc:
+        failure_reason = _website_relay_generation_failure_reason(exc)
+        logging.warning(
+            "website_relay_no_publish guild=%s reason=%s",
+            guild_id,
+            failure_reason,
+        )
+        return WebsiteRelayDecision(False, skipReason=failure_reason, sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, metadata={"reason": failure_reason, "source_class": "fresh_discord"})
     except Exception as exc:
         logging.warning("website_relay_no_publish guild=%s reason=provider_failure error=%s", guild_id, _safe_force_pull_error(exc))
         return WebsiteRelayDecision(False, skipReason="provider_failure", sourceConversationIds=[int(r[0]) for r in rows], sourceCursor=source_cursor, metadata={"reason": "provider_failure"})
@@ -4892,7 +4949,22 @@ async def _execute_website_relay_transaction(
         highest = int(decision.metadata.get("highest_eligible_conversation_id") or max(decision.sourceConversationIds or [decision.sourceCursor or 0]))
         if not decision.publish:
             reason = decision.skipReason or "no_safe_source"
-            outcome = "disabled" if reason == "website_relay_disabled" else ("provider_failed" if reason in {"provider_failure", "relay_generation_timeout"} else ("no_safe_source" if reason in {"no_new_public_signal", "bootstrap_no_publish", "fresh_context_expired"} else "rejected"))
+            outcome = (
+                "disabled"
+                if reason == "website_relay_disabled"
+                else "budget_restricted"
+                if reason.startswith("budget_restricted:")
+                else "provider_failed"
+                if reason in {"provider_failure", "relay_generation_timeout"}
+                else "no_safe_source"
+                if reason
+                in {
+                    "no_new_public_signal",
+                    "bootstrap_no_publish",
+                    "fresh_context_expired",
+                }
+                else "rejected"
+            )
             relay_complete_attempt(DB_FILE, attempt_id, source_class=source_class, outcome=outcome, reason=reason, aggregate_source_counts=counts, cursor=decision.sourceCursor, highest_eligible_conversation_id=highest)
             return decision
         if BNL_WEBSITE_CONTRACT_VERSION == "1":
@@ -8843,9 +8915,14 @@ def classify_generation_error(exc: Exception | None = None, *, empty_response: b
     if empty_response:
         return GENERATION_ERROR_PROVIDER_EMPTY, "", ""
     if isinstance(exc, LocalModelBudgetExhausted):
+        budget_reason = re.sub(
+            r"[^a-z0-9_:-]+",
+            "_",
+            str(exc or GENERATION_ERROR_LOCAL_MODEL_BUDGET).strip().lower(),
+        ).strip("_")
         return (
             GENERATION_ERROR_LOCAL_MODEL_BUDGET,
-            GENERATION_ERROR_LOCAL_MODEL_BUDGET,
+            budget_reason or GENERATION_ERROR_LOCAL_MODEL_BUDGET,
             "BNL's local model budget is exhausted.",
         )
     provider_kind = provider_failure_kind(exc)
@@ -20959,6 +21036,10 @@ def _dollar_budget_decision(
         "BNL_GEMINI_INTERACTIVE_RESERVE_USD",
         "2.00",
     )
+    relay_pace_allowance = _budget_env_usd(
+        "BNL_GEMINI_RELAY_PACE_ALLOWANCE_USD",
+        "5.50",
+    )
     effective_hard = max(
         Decimal("0"),
         config.monthly_hard_limit_usd - billing_lag_buffer,
@@ -21001,6 +21082,13 @@ def _dollar_budget_decision(
     if projected_month > background_limit:
         return False, "interactive_and_journal_reserve"
 
+    # Show-day generation is low-frequency, atomically claimed, and tied to a
+    # real broadcast window. Keep its background one-attempt/no-fallback
+    # provider policy while preventing the generic pace gate from suppressing
+    # time-sensitive copy. The hard limit and both dollar reserves still win.
+    if policy.showday_protected:
+        return True, "showday_protected"
+
     pace = calculate_monthly_budget_pace(
         _nanos_to_usd(guarded_month_nanos),
         _nanos_to_usd(guarded_today_nanos),
@@ -21008,6 +21096,19 @@ def _dollar_budget_decision(
         at=now_pacific,
     )
     expected_nanos = _usd_to_nanos(pace.expected_cost_to_date_usd)
+    if policy.relay_protected:
+        # Relay remains operational slightly ahead of the generic target pace,
+        # but only inside a small configured headroom and never at the expense
+        # of Journal/interactive reserves or the effective hard limit. Hourly
+        # cadence plus the existing one-attempt/no-fallback policy bounds the
+        # route itself without introducing another scheduler or budget owner.
+        relay_pace_limit = min(
+            background_limit,
+            expected_nanos + _usd_to_nanos(relay_pace_allowance),
+        )
+        if projected_month > relay_pace_limit:
+            return False, "relay_pace_allowance"
+        return True, "relay_protected"
     if guarded_month_nanos >= expected_nanos:
         return False, "monthly_target_pace"
 
@@ -21480,7 +21581,9 @@ def get_usage_breakdown() -> dict:
     )
     restrictions = {}
     for route_class, sample_route in (
-        ("background", "website_relay_event"),
+        ("background", "ambient_generation"),
+        ("relay", "website_relay_event"),
+        ("showday", "showday_generation"),
         ("ordinary", ORDINARY_CHAT_SINGLE_PACKET_ROUTE),
         ("journal", JOURNAL_ROUTE),
     ):
@@ -21585,6 +21688,10 @@ def get_usage_breakdown() -> dict:
         "effective_hard_limit_usd": effective_hard_limit_usd,
         "remaining_effective_hard_usd": remaining_effective_hard_usd,
         "daily_soft_limit_usd": config.daily_soft_limit_usd,
+        "relay_pace_allowance_usd": _budget_env_usd(
+            "BNL_GEMINI_RELAY_PACE_ALLOWANCE_USD",
+            "5.50",
+        ),
         "budget_enforcement_enabled": config.enforcement_enabled,
         "remaining_target_usd": pace.remaining_target_usd,
         "remaining_hard_limit_usd": pace.remaining_hard_limit_usd,
@@ -31236,12 +31343,52 @@ async def website_presence_heartbeat_task():
     await asyncio.to_thread(publish_website_presence_v2, source="heartbeat", status="ONLINE", mode="OBSERVATION")
 
 
+def _relay_schedule_minute_index(now_pacific: datetime) -> int:
+    return (
+        now_pacific.date().toordinal() * 24 * 60
+        + now_pacific.hour * 60
+        + now_pacific.minute
+    )
+
+
+def _scheduled_relay_due(
+    now_pacific: datetime,
+    *,
+    interval_minutes: int | None = None,
+) -> bool:
+    """Return whether a Pacific wall-clock minute owns a Relay period."""
+
+    interval = max(
+        1,
+        int(interval_minutes or BNL_WEBSITE_RELAY_INTERVAL_MINUTES),
+    )
+    offset = BNL_WEBSITE_RELAY_MINUTE_OFFSET % interval
+    return (
+        _relay_schedule_minute_index(now_pacific) - offset
+    ) % interval == 0
+
+
+def _next_scheduled_relay_at(now_pacific: datetime) -> datetime:
+    """Return the next scheduled Relay evaluation after ``now_pacific``."""
+
+    interval = max(1, BNL_WEBSITE_RELAY_INTERVAL_MINUTES)
+    candidate = now_pacific.replace(second=0, microsecond=0) + timedelta(
+        minutes=1
+    )
+    offset = BNL_WEBSITE_RELAY_MINUTE_OFFSET % interval
+    delta = (
+        offset - _relay_schedule_minute_index(candidate)
+    ) % interval
+    return candidate + timedelta(minutes=delta)
+
+
 def _scheduled_quiet_relay_due(now_pacific: datetime) -> bool:
     """Return whether this scheduled tick may use a non-fresh relay source."""
-    minutes_since_midnight = now_pacific.hour * 60 + now_pacific.minute
-    return (
-        minutes_since_midnight % BNL_WEBSITE_QUIET_RELAY_INTERVAL_MINUTES
-    ) == 0
+
+    return _scheduled_relay_due(
+        now_pacific,
+        interval_minutes=BNL_WEBSITE_QUIET_RELAY_INTERVAL_MINUTES,
+    )
 
 
 @tasks.loop(minutes=1)
@@ -31252,8 +31399,7 @@ async def website_relay_task():
     if not flags.get("websiteRelayEnabled", True):
         return
     now_pt = datetime.now(PACIFIC_TZ)
-    interval = max(1, BNL_WEBSITE_RELAY_INTERVAL_MINUTES)
-    if (now_pt.minute % interval) != 0:
+    if not _scheduled_relay_due(now_pt):
         return
 
     for guild in iter_managed_guilds():
@@ -42734,6 +42880,7 @@ async def usage(interaction: discord.Interaction):
         name="Protected Token Capacity",
         value=(
             f"Journal reserve: **{diagnostics['journal_protected_tokens']:,} tokens**\n"
+            f"Relay reserve: **{diagnostics['relay_protected_tokens']:,} tokens**\n"
             f"Ordinary-route capacity remaining: "
             f"**{diagnostics['ordinary_route_remaining']:,} tokens**"
         ),
@@ -42753,6 +42900,7 @@ async def usage(interaction: discord.Interaction):
             f"spendable hard headroom: "
             f"**${diagnostics['remaining_effective_hard_usd']:.4f}**\n"
             f"Daily soft floor: **${diagnostics['daily_soft_limit_usd']:.2f}** · "
+            f"Relay pace allowance: **${diagnostics['relay_pace_allowance_usd']:.2f}**\n"
             f"Target pace to date: **${diagnostics['expected_cost_to_date_usd']:.4f}** · "
             f"projected month end: **${diagnostics['projected_month_end_cost_usd']:.4f}**\n"
             f"Average/day: **${diagnostics['average_cost_per_elapsed_day_usd']:.4f}** · "
@@ -43012,7 +43160,8 @@ async def bnl_source_check(interaction: discord.Interaction):
         f"- community_presence_last_top_withheld_reason: `{dossier_diag['community_presence_last_top_withheld_reason']}`",
         f"- community_presence_last_error_status: `{dossier_diag['community_presence_last_error_status']}`",
         f"- _bnl_control_flags_last_source_url: `{flags_source}`",
-        f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` every `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}` min",
+        f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` every `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}` min at offset `:{BNL_WEBSITE_RELAY_MINUTE_OFFSET:02d}`",
+        f"- website_relay_next_scheduled_at: `{_next_scheduled_relay_at(datetime.now(PACIFIC_TZ)).isoformat(timespec='minutes')}`",
     ]
     await send_safe_ephemeral_chunks(interaction, "\n".join(lines), limit=1700)
 
@@ -44192,7 +44341,9 @@ async def bnl_status(interaction: discord.Interaction):
         f"- occasion_next_name: `{occasion_next.get('occasionName', 'none')}`",
         f"- occasion_next_scheduled_for: `{occasion_next.get('scheduledFor', 'none')}`",
         f"- website_contract_version: `{BNL_WEBSITE_CONTRACT_VERSION}`",
-        f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` (interval `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}m`)",
+        f"- website_relay_enabled: `{BNL_WEBSITE_RELAY_ENABLED}` (interval `{BNL_WEBSITE_RELAY_INTERVAL_MINUTES}m`, offset `:{BNL_WEBSITE_RELAY_MINUTE_OFFSET:02d}`)",
+        f"- website_relay_quiet_interval: `{BNL_WEBSITE_QUIET_RELAY_INTERVAL_MINUTES}m`",
+        f"- website_relay_next_scheduled_at: `{_next_scheduled_relay_at(datetime.now(PACIFIC_TZ)).isoformat(timespec='minutes')}`",
         f"- website_heartbeat_interval: `{BNL_WEBSITE_HEARTBEAT_INTERVAL_MINUTES}m`",
         f"- website_heartbeat_task_running: `{'yes' if website_presence_heartbeat_task.is_running() else 'no'}`",
         f"- website_presence_last: `{_last_website_presence_result}`",

--- a/bnl_gemini_routing.py
+++ b/bnl_gemini_routing.py
@@ -33,6 +33,7 @@ class GeminiRoutePolicy:
     allow_fallback: bool
     journal_protected: bool = False
     relay_protected: bool = False
+    showday_protected: bool = False
 
 
 def _bounded_env_int(
@@ -213,6 +214,7 @@ def policy_for_route(route: str) -> GeminiRoutePolicy:
             provider_retries=0,
             allow_fallback=False,
             relay_protected="relay" in normalized_route,
+            showday_protected="showday" in normalized_route,
         )
     return GeminiRoutePolicy(
         lane=lane,

--- a/tests/test_cost_control_schedulers.py
+++ b/tests/test_cost_control_schedulers.py
@@ -45,25 +45,39 @@ class CostControlSchedulerTests(unittest.IsolatedAsyncioTestCase):
             "glitch_rewrite",
         )
 
-    def test_quiet_cadence_reduces_snapshot_periodic_slots_by_two_thirds(self):
-        with mock.patch.object(
+    def test_hourly_relay_and_quiet_cascade_share_the_ten_minute_offset(self):
+        with mock.patch.multiple(
             bnl01_bot,
-            "BNL_WEBSITE_QUIET_RELAY_INTERVAL_MINUTES",
-            60,
+            BNL_WEBSITE_RELAY_INTERVAL_MINUTES=60,
+            BNL_WEBSITE_QUIET_RELAY_INTERVAL_MINUTES=60,
+            BNL_WEBSITE_RELAY_MINUTE_OFFSET=10,
         ):
-            scheduled = [
+            at_ten = bnl01_bot.PACIFIC_TZ.localize(
+                datetime(2026, 8, 22, 17, 10)
+            )
+            at_hour = bnl01_bot.PACIFIC_TZ.localize(
+                datetime(2026, 8, 22, 18, 0)
+            )
+            self.assertTrue(bnl01_bot._scheduled_relay_due(at_ten))
+            self.assertTrue(bnl01_bot._scheduled_quiet_relay_due(at_ten))
+            self.assertFalse(bnl01_bot._scheduled_relay_due(at_hour))
+            self.assertFalse(bnl01_bot._scheduled_quiet_relay_due(at_hour))
+
+    def test_next_hourly_relay_is_reported_at_ten_past(self):
+        with mock.patch.multiple(
+            bnl01_bot,
+            BNL_WEBSITE_RELAY_INTERVAL_MINUTES=60,
+            BNL_WEBSITE_RELAY_MINUTE_OFFSET=10,
+        ):
+            now = bnl01_bot.PACIFIC_TZ.localize(
+                datetime(2026, 8, 22, 17, 40, 30)
+            )
+            self.assertEqual(
+                bnl01_bot._next_scheduled_relay_at(now),
                 bnl01_bot.PACIFIC_TZ.localize(
-                    datetime(2026, 8, 22, minute // 60, minute % 60)
-                )
-                for minute in range(0, 17 * 60 + 41, 20)
-            ]
-            quiet_eligible = [
-                at
-                for at in scheduled
-                if bnl01_bot._scheduled_quiet_relay_due(at)
-            ]
-        self.assertEqual(len(scheduled), 54)
-        self.assertEqual(len(quiet_eligible), 18)
+                    datetime(2026, 8, 22, 18, 10)
+                ),
+            )
 
     async def run_relay_tick(self, at, *, claimed=True):
         guild = SimpleNamespace(id=42, get_channel=lambda _channel_id: None)
@@ -101,7 +115,12 @@ class CostControlSchedulerTests(unittest.IsolatedAsyncioTestCase):
             mock.patch.object(
                 bnl01_bot,
                 "BNL_WEBSITE_RELAY_INTERVAL_MINUTES",
-                20,
+                60,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "BNL_WEBSITE_RELAY_MINUTE_OFFSET",
+                10,
             ),
             mock.patch.object(
                 bnl01_bot,
@@ -112,25 +131,25 @@ class CostControlSchedulerTests(unittest.IsolatedAsyncioTestCase):
             await bnl01_bot.website_relay_task.coro()
         return claim, execute
 
-    async def test_regular_tick_checks_fresh_signal_without_quiet_generation(self):
-        at = bnl01_bot.PACIFIC_TZ.localize(datetime(2026, 8, 22, 17, 40))
+    async def test_hourly_tick_checks_fresh_signal_and_quiet_cascade(self):
+        at = bnl01_bot.PACIFIC_TZ.localize(datetime(2026, 8, 22, 17, 10))
         claim, execute = await self.run_relay_tick(at)
         claim.assert_called_once_with(
             bnl01_bot.DB_FILE,
             42,
-            "2026-08-22T17:40-07:00",
+            "2026-08-22T17:10-07:00",
         )
-        execute.assert_awaited_once()
-        self.assertFalse(execute.await_args.kwargs["allow_quiet_sources"])
-
-    async def test_hourly_tick_retains_scheduled_quiet_relay_behavior(self):
-        at = bnl01_bot.PACIFIC_TZ.localize(datetime(2026, 8, 22, 18, 0))
-        _claim, execute = await self.run_relay_tick(at)
         execute.assert_awaited_once()
         self.assertTrue(execute.await_args.kwargs["allow_quiet_sources"])
 
+    async def test_top_of_hour_is_not_a_relay_tick(self):
+        at = bnl01_bot.PACIFIC_TZ.localize(datetime(2026, 8, 22, 18, 0))
+        claim, execute = await self.run_relay_tick(at)
+        claim.assert_not_called()
+        execute.assert_not_awaited()
+
     async def test_duplicate_worker_claim_makes_no_generation_call(self):
-        at = bnl01_bot.PACIFIC_TZ.localize(datetime(2026, 8, 22, 18, 20))
+        at = bnl01_bot.PACIFIC_TZ.localize(datetime(2026, 8, 22, 18, 10))
         _claim, execute = await self.run_relay_tick(at, claimed=False)
         execute.assert_not_awaited()
 
@@ -518,6 +537,11 @@ class CostControlSchedulerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             bnl01_bot.policy_for_route(seen[0]["route"]).lane,
             "background",
+        )
+        self.assertTrue(
+            bnl01_bot.policy_for_route(
+                seen[0]["route"]
+            ).showday_protected
         )
 
     async def test_ambient_generation_is_labeled_as_background(self):

--- a/tests/test_gemini_budget_enforcement.py
+++ b/tests/test_gemini_budget_enforcement.py
@@ -75,6 +75,7 @@ class GeminiBudgetEnforcementTests(unittest.TestCase):
             "BNL_GEMINI_BILLING_LAG_BUFFER_USD": "0.50",
             "BNL_GEMINI_JOURNAL_RESERVE_USD": "1.00",
             "BNL_GEMINI_INTERACTIVE_RESERVE_USD": "2.00",
+            "BNL_GEMINI_RELAY_PACE_ALLOWANCE_USD": "5.50",
         }
         values.update(overrides)
         return values
@@ -117,7 +118,7 @@ class GeminiBudgetEnforcementTests(unittest.TestCase):
     def test_daily_soft_limit_stops_optional_background_work(self):
         with mock.patch.dict(os.environ, self.default_budget_env(), clear=False):
             allowed, reason = self.decision(
-                "website_relay_event",
+                "ambient_generation",
                 request="0.02",
                 month="19.99",
                 today="0.64",
@@ -141,6 +142,49 @@ class GeminiBudgetEnforcementTests(unittest.TestCase):
             )
         self.assertEqual(background, (False, "monthly_target_pace"))
         self.assertEqual(interactive, (True, "interactive_available"))
+
+    def test_relay_uses_bounded_pace_allowance_while_ambient_stays_restricted(self):
+        with mock.patch.dict(os.environ, self.default_budget_env(), clear=False):
+            relay = self.decision(
+                "website_relay_event",
+                request="0.01",
+                month="20.01",
+                today="0.70",
+            )
+            ambient = self.decision(
+                "ambient_generation",
+                request="0.01",
+                month="20.01",
+                today="0.70",
+            )
+        self.assertEqual(relay, (True, "relay_protected"))
+        self.assertEqual(ambient, (False, "monthly_target_pace"))
+
+    def test_relay_pace_allowance_cannot_expand_into_unreserved_hard_headroom(self):
+        env = self.default_budget_env(
+            BNL_GEMINI_MONTHLY_HARD_LIMIT_USD="30.00",
+            BNL_GEMINI_BILLING_LAG_BUFFER_USD="0",
+            BNL_GEMINI_JOURNAL_RESERVE_USD="0",
+            BNL_GEMINI_INTERACTIVE_RESERVE_USD="0",
+        )
+        with mock.patch.dict(os.environ, env, clear=False):
+            relay = self.decision(
+                "website_relay_event",
+                request="0.01",
+                month="25.50",
+                today="0.10",
+            )
+        self.assertEqual(relay, (False, "relay_pace_allowance"))
+
+    def test_showday_bypasses_soft_pace_but_not_harder_reserves(self):
+        with mock.patch.dict(os.environ, self.default_budget_env(), clear=False):
+            showday = self.decision(
+                "showday_generation",
+                request="0.01",
+                month="20.01",
+                today="0.70",
+            )
+        self.assertEqual(showday, (True, "showday_protected"))
 
     def test_background_yields_to_interactive_and_journal_reserves(self):
         with mock.patch.dict(os.environ, self.default_budget_env(), clear=False):
@@ -203,6 +247,16 @@ class GeminiBudgetEnforcementTests(unittest.TestCase):
                         ),
                         (False, "monthly_hard_limit"),
                     )
+
+    def test_budget_failure_classification_preserves_exact_guard_reason(self):
+        category, code, _message = bnl01_bot.classify_generation_error(
+            bnl01_bot.LocalModelBudgetExhausted("monthly_target_pace")
+        )
+        self.assertEqual(
+            category,
+            bnl01_bot.GENERATION_ERROR_LOCAL_MODEL_BUDGET,
+        )
+        self.assertEqual(code, "monthly_target_pace")
 
     def test_unpriced_history_restricts_background_without_monthlong_journal_outage(self):
         with mock.patch.dict(os.environ, self.default_budget_env(), clear=False):

--- a/tests/test_gemini_routing_policy.py
+++ b/tests/test_gemini_routing_policy.py
@@ -92,6 +92,17 @@ class GeminiRoutingPolicyTests(unittest.TestCase):
             policy = routing.policy_for_route("website_relay_event")
         self.assertEqual(policy.max_output_tokens, 4_096)
 
+    def test_relay_and_showday_keep_distinct_background_protection_flags(self):
+        relay = routing.policy_for_route("website_relay_event")
+        showday = routing.policy_for_route("showday_generation")
+        ambient = routing.policy_for_route("ambient_generation")
+        self.assertTrue(relay.relay_protected)
+        self.assertFalse(relay.showday_protected)
+        self.assertTrue(showday.showday_protected)
+        self.assertFalse(showday.relay_protected)
+        self.assertFalse(ambient.relay_protected)
+        self.assertFalse(ambient.showday_protected)
+
     def test_background_output_limit_remains_environment_configurable(self):
         with mock.patch.dict(
             "os.environ",

--- a/tests/test_website_contract_v2.py
+++ b/tests/test_website_contract_v2.py
@@ -343,7 +343,8 @@ class ContractV2Tests(unittest.TestCase):
             self.assertFalse(bnl01_bot.update_website_status_controlled("OBSERVATION", "msg", source="relay"))
 
     def test_flags_gate_only_expected_tasks_and_cadence_constant(self):
-        self.assertEqual(bnl01_bot.BNL_WEBSITE_RELAY_INTERVAL_MINUTES, 20)
+        self.assertEqual(bnl01_bot.BNL_WEBSITE_RELAY_INTERVAL_MINUTES, 60)
+        self.assertEqual(bnl01_bot.BNL_WEBSITE_RELAY_MINUTE_OFFSET, 10)
         self.assertEqual(bnl01_bot.BNL_WEBSITE_HEARTBEAT_INTERVAL_MINUTES, 5)
         self.assertTrue(hasattr(bnl01_bot, "website_presence_heartbeat_task"))
 

--- a/tests/test_website_relay_event_driven.py
+++ b/tests/test_website_relay_event_driven.py
@@ -318,7 +318,7 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
         self.add_row("Can BNL compare the public BARCODE Radio release notes with the Transmission topic people mentioned? #barcode", user="a")
         self.add_row("There is also a public dossier question about credits for that music release discussion?", user="b")
         prompts = []
-        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route="", **_kwargs):
             prompts.append(prompt)
             return "Fresh Discord discussion connects BARCODE Radio, a release-credit question, a dossier angle, and a Transmission topic without confirming any live state.\nFollow the public thread for confirmed credits or links before treating the topic as indexed."
         with mock.patch.object(bnl01_bot, "fetch_bnl_read_model", side_effect=AssertionError("read model called")), \
@@ -341,7 +341,7 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
             post_count += 1
             await asyncio.sleep(0.02)
             return True
-        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route="", **_kwargs):
             await asyncio.sleep(0.02)
             return "Two fresh Discord questions compare broadcast submissions with track context for tonight's show thread.\nFollow the public thread for confirmed submission details or links before indexing the answer."
         async def run_two():
@@ -366,7 +366,7 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
             nonlocal post_count
             post_count += 1
             return True
-        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route="", **_kwargs):
             await asyncio.sleep(0.01)
             return "Two fresh Discord questions compare broadcast submissions with track context for tonight's show thread.\nFollow the public thread for confirmed submission details or links before indexing the answer."
         async def run_two():
@@ -385,7 +385,7 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
         state.bootstrap_cursor(self.db, 42, 0)
         self.add_row("Can BNL explain how tonight's public broadcast track submissions work? #barcode", user="a")
         self.add_row("I have a public question about the show and which track context matters?", user="b")
-        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route="", **_kwargs):
             return "Two fresh Discord questions compare broadcast submissions with track context for tonight's show thread.\nFollow the public thread for confirmed submission details or links before indexing the answer."
         async def run_one():
             with mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=fake_gemini), \
@@ -536,6 +536,55 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
         self.assertEqual(decision.skipReason, "provider_failure")
         self.assertEqual(state.stock_directive_reason("Continue monitoring."), "stock_directive_rejected")
 
+    def test_budget_restriction_is_not_misreported_as_invalid_output(self):
+        state.bootstrap_cursor(self.db, 42, 0)
+        self.add_row("Can BNL explain how tonight's public broadcast track submissions work? #barcode", user="a")
+        self.add_row("I have a public question about the show and which track context matters?", user="b")
+        failure = bnl01_bot.BackgroundGenerationUnavailable(
+            bnl01_bot.GenerationResult(
+                False,
+                error_category=bnl01_bot.GENERATION_ERROR_LOCAL_MODEL_BUDGET,
+                provider_error_code="monthly_target_pace",
+                route="website_relay_event",
+            )
+        )
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "get_gemini_response",
+                side_effect=failure,
+            ) as generate,
+            mock.patch.object(
+                bnl01_bot,
+                "get_bnl_control_flags",
+                return_value={"websiteRelayEnabled": True},
+            ),
+        ):
+            decision = asyncio.run(
+                bnl01_bot._execute_website_relay_transaction(
+                    42,
+                    source="relay",
+                )
+            )
+        self.assertFalse(decision.publish)
+        self.assertEqual(
+            decision.skipReason,
+            "budget_restricted:monthly_target_pace",
+        )
+        self.assertEqual(
+            decision.metadata["reason"],
+            "budget_restricted:monthly_target_pace",
+        )
+        self.assertTrue(
+            generate.await_args.kwargs["raise_on_generation_failure"]
+        )
+        attempt = state.last_attempt(self.db, 42)
+        self.assertEqual(attempt["outcome"], "budget_restricted")
+        self.assertEqual(
+            attempt["reason"],
+            "budget_restricted:monthly_target_pace",
+        )
+
     def test_website_relay_route_bypasses_glitch_and_cross_universe_rewrites(self):
         async def base_result(contents, route):
             return bnl01_bot.GenerationResult(True, "Line one.\nLine two directive with enough detail.", route=route)
@@ -573,7 +622,7 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
             state.bootstrap_cursor(self.db, 42, 0)
             self.add_row("Can BNL explain how tonight's public broadcast track submissions work? #barcode", user="a")
             self.add_row("I have a public question about the show and which track context matters?", user="b")
-            async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+            async def fake_gemini(prompt, user_id=0, guild_id=0, route="", **_kwargs):
                 return output
             async def run_one():
                 with mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=fake_gemini), \
@@ -594,7 +643,7 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
         for i in range(30):
             self.add_row(f"Public row {i:02d} asks about broadcast track submissions and show context? #barcode", user=str(i % 3))
         prompts = []
-        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route="", **_kwargs):
             prompts.append(prompt)
             return "Fresh Discord rows focus on broadcast track submissions across the newest selected context.\nFollow the public thread for confirmed submission details or links before indexing the answer."
         with mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=fake_gemini):
@@ -614,7 +663,7 @@ class WebsiteRelayEventDrivenTests(unittest.TestCase):
             self.add_row(f"weak prefix {i}", user="a")
         self.add_row("Can BNL explain how tonight's public broadcast track submissions work? #barcode", user="b")
         self.add_row("I have a public question about the show and which track context matters?", user="c")
-        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route="", **_kwargs):
             return "Newer Discord questions focus the relay on broadcast submissions despite the weak prefix.\nFollow the public thread for confirmed submission details or links before indexing the answer."
         with mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=fake_gemini):
             decision = self.generate()
@@ -682,7 +731,7 @@ class WebsiteRelayRecoveryTests(unittest.TestCase):
 
     def test_quiet_manual_transaction_publishes_from_canon_without_cursor_advance(self):
         state.bootstrap_cursor(self.db, 42, 7)
-        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route="", **_kwargs):
             self.assertIn("selected approved source class: canon", prompt)
             self.assertNotIn("queue counts", prompt.lower().split("approved source context:", 1)[-1])
             return ("BARCODE canon keeps the relay trained on the broadcast corridor and its unresolved archive questions without claiming fresh movement.\n"
@@ -701,7 +750,7 @@ class WebsiteRelayRecoveryTests(unittest.TestCase):
         state.bootstrap_cursor(self.db, 42, 0)
         self.add_row("Can BNL explain how public broadcast track submissions work? #barcode", user="a")
         self.add_row("I have a public question about the show and which track context matters?", user="b")
-        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route="", **_kwargs):
             return ("Two fresh public questions compare broadcast submissions with track context in the public corridor.\n"
                     "Follow the public questions for confirmed submission details before indexing the answer.")
         with mock.patch.object(bnl01_bot, "BNL_API_KEY", "test-api-key"), \
@@ -717,7 +766,7 @@ class WebsiteRelayRecoveryTests(unittest.TestCase):
         state.bootstrap_cursor(self.db, 42, 0)
         self.add_row("Can BNL explain how public broadcast track submissions work? #barcode", user="a")
         self.add_row("I have a public question about the show and which track context matters?", user="b")
-        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route="", **_kwargs):
             return ("Two fresh public questions compare broadcast submissions with track context in the public corridor.\n"
                     "Follow the public questions for confirmed submission details before indexing the answer.")
         with mock.patch.object(bnl01_bot, "BNL_API_KEY", "test-api-key"), \
@@ -875,7 +924,7 @@ class WebsiteRelayRecoveryTests(unittest.TestCase):
 
     def test_bootstrap_transaction_publishes_quiet_without_replaying_history(self):
         self.add_row("Old historical Discord row from ArchivistName should not be replayed as fresh current content.", user="ArchivistName")
-        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route="", **_kwargs):
             self.assertIn("selected approved source class", prompt)
             self.assertNotIn("ArchivistName", prompt)
             self.assertNotIn("Old historical Discord row", prompt)
@@ -919,7 +968,7 @@ class WebsiteRelayRecoveryTests(unittest.TestCase):
     def test_weak_fresh_rows_quiet_fallback_preserves_cursor_until_strong_delivery(self):
         state.bootstrap_cursor(self.db, 42, 0)
         self.add_row("too small", user="weak")
-        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route="", **_kwargs):
             return ("BARCODE canon gives BNL a stable archive question without consuming weak public chatter.\n"
                     "Ask which archive thread should be clarified before weak chatter becomes evidence.")
         with mock.patch.object(bnl01_bot, "get_gemini_response", side_effect=fake_gemini), \
@@ -933,7 +982,7 @@ class WebsiteRelayRecoveryTests(unittest.TestCase):
 
     def test_canon_temporal_validation_rejects_unsupported_live_claim(self):
         source = state.RelaySourceDecision("canon", "[approved_barcode_canon:0] BNL-01 serves as the BARCODE Network liaison voice.", {"canon": 1}, source_cursor=0)
-        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route="", **_kwargs):
             return ("BARCODE Radio is currently live and on-air tonight for the current show.\n"
                     "Ask listeners to join the live BARCODE Radio window right now.")
         with mock.patch.object(bnl01_bot, "_select_approved_quiet_relay_source", return_value=source), \
@@ -950,7 +999,7 @@ class WebsiteRelayRecoveryTests(unittest.TestCase):
 
     def test_timeless_barcode_radio_canon_fact_can_remain(self):
         source = state.RelaySourceDecision("canon", "[approved_barcode_canon:0] BARCODE Radio is the Network broadcast corridor.", {"canon": 1}, source_cursor=0)
-        async def fake_gemini(prompt, user_id=0, guild_id=0, route=""):
+        async def fake_gemini(prompt, user_id=0, guild_id=0, route="", **_kwargs):
             return ("BARCODE Radio remains the Network broadcast corridor for confirmed public transmissions and archive questions.\n"
                     "Ask which BARCODE archive question should be clarified for the public corridor next.")
         with mock.patch.object(bnl01_bot, "_select_approved_quiet_relay_source", return_value=source), \


### PR DESCRIPTION
## Summary
- move the existing Website Relay scheduler to a minimum 60-minute cadence at `:10` Pacific, with normal and quiet-source eligibility aligned to the same window
- keep the five-minute heartbeat and immediate/manual force-pull path unchanged
- let Relay use a bounded `$5.50` pace allowance while still honoring the effective hard limit plus Journal and interactive reserves
- keep show-day generation background-shaped but protect atomically claimed, time-sensitive phases from generic soft pace suppression
- record exact budget skips such as `budget_restricted:monthly_target_pace` instead of misreporting an empty result as `output_shape_invalid`
- expose Relay cadence, offset, next scheduled evaluation, and separate Relay/show-day budget status in owner diagnostics

No website, queue, payment, memory/canon, accepted-history, cursor, or publication-contract changes are included.

## Verification
- focused Relay/scheduler/budget/contract diagnostics suite: 128 tests passed
- `make check`: 2,391 tests passed, compile check passed

## Deployment behavior
- a stale `BNL_WEBSITE_RELAY_INTERVAL_MINUTES=20` value is clamped to 60 after restart
- `BNL_WEBSITE_RELAY_MINUTE_OFFSET` defaults to `10`
- `BNL_GEMINI_RELAY_PACE_ALLOWANCE_USD` defaults to `5.50`
- no database migration or site deployment is required

Owner review remains the release gate; this PR is not merged.