### PR TITLE
Add shadow-only direct TikTok LIVE chat transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,33 @@ jobs:
 
       - name: Verify source and tests
         run: make check PYTHON=python
+
+  tiktok-live-transport-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Use isolated transport Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: tools/tiktok-live-ingest/requirements.txt
+
+      - name: Install pinned signerless transport dependency
+        run: >-
+          python -m pip install --disable-pip-version-check
+          -r tools/tiktok-live-ingest/requirements.txt
+
+      - name: Verify upstream transport import contract
+        run: >-
+          python -c "from piratetok_live import EventType, TikTokLiveClient;
+          assert EventType.chat == 'chat'; assert callable(TikTokLiveClient)"
+
+      - name: Verify shadow transport and adapter tests
+        run: |
+          python -m compileall -q bnl_tiktok_live_chat.py scripts tests
+          python -m unittest discover -s tests -p 'test_*tiktok_live*.py'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 venv/
 .venv/
+.venv-tiktok-live/
 venv_backup/
 __pycache__/
 *.db

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 .PHONY: compile test check
 
 compile:
-	$(PYTHON) -m compileall -q bnl01_bot.py bnl_*.py tests
+	$(PYTHON) -m compileall -q bnl01_bot.py bnl_*.py scripts tests
 
 test:
 	$(PYTHON) -m unittest discover -s tests -p 'test_*.py'

--- a/bnl_tiktok_live_chat.py
+++ b/bnl_tiktok_live_chat.py
@@ -1,0 +1,358 @@
+"""Ephemeral, read-only TikTok LIVE chat boundary for BNL.
+
+The direct Webcast client lives in an isolated Python 3.11+ process. This
+standard-library-only module stays compatible with the bot's Python 3.9/3.12
+runtime, validates the transport's NDJSON, and keeps comments in bounded RAM.
+It does not start the collector, call Gemini, write a database, or post output.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import time
+from collections import OrderedDict, deque
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Deque, Dict, List, Optional, Union
+
+SCHEMA_VERSION = 1
+SOURCE = "tiktok_live_webcast"
+VISIBILITY = "public_observation"
+AUTHORITY = "viewer_statement"
+LIFECYCLE = "current_show_only"
+MEMORY_DEFAULT = "do_not_store"
+IDENTITY_DEFAULT = "tiktok_only_unlinked"
+
+COMMENT = "comment"
+LIFECYCLE_EVENTS = frozenset(
+    {"connected", "reconnecting", "disconnected", "live_ended", "transport_error"}
+)
+ALLOWED_EVENTS = frozenset({COMMENT, *LIFECYCLE_EVENTS})
+
+MAX_LINE_BYTES = 32 * 1024
+MAX_COMMENT_CHARS = 1000
+MAX_TEXT_CHARS = 160
+MAX_CLOCK_SKEW_SECONDS = 5 * 60
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_SPACE_RE = re.compile(r"\s+")
+_CODE_RE = re.compile(r"[^A-Za-z0-9_.:-]+")
+_HANDLE_RE = re.compile(r"^[A-Za-z0-9._]+$")
+
+
+class ProtocolError(ValueError):
+    """Bounded parse failure that never includes the raw transport line."""
+
+    def __init__(self, code: str) -> None:
+        self.code = _code(code, "protocol_error")
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True)
+class LiveEvent:
+    event_type: str
+    event_id: str
+    room_id: str
+    observed_at: float
+    unique_id: str = ""
+    display_name: str = ""
+    comment_text: str = ""
+    moderator_flag: bool = False
+    error_code: str = ""
+
+    @property
+    def is_comment(self) -> bool:
+        return self.event_type == COMMENT
+
+    def context_record(self) -> Dict[str, Any]:
+        if not self.is_comment:
+            raise ValueError("only comments can become context")
+        return {
+            "event_id": self.event_id,
+            "room_id": self.room_id,
+            "observed_at": self.observed_at,
+            "unique_id": self.unique_id,
+            "display_name": self.display_name,
+            "comment_text": self.comment_text,
+            "moderator_flag": self.moderator_flag,
+            "source": SOURCE,
+            "visibility": VISIBILITY,
+            "authority": AUTHORITY,
+            "lifecycle": LIFECYCLE,
+            "memory_default": MEMORY_DEFAULT,
+            "identity_default": IDENTITY_DEFAULT,
+        }
+
+
+class LiveChatBuffer:
+    """Current-show ring buffer with replay deduplication."""
+
+    def __init__(
+        self,
+        max_events: int = 1000,
+        max_age_seconds: float = 15 * 60,
+        time_fn: Callable[[], float] = time.time,
+    ) -> None:
+        if max_events <= 0 or max_age_seconds <= 0:
+            raise ValueError("buffer limits must be positive")
+        self.max_events = int(max_events)
+        self.max_age_seconds = float(max_age_seconds)
+        self.time_fn = time_fn
+        self.events: Deque[LiveEvent] = deque()
+        self.seen: "OrderedDict[str, float]" = OrderedDict()
+        self.duplicates = 0
+        self.expired = 0
+        self.overflow = 0
+
+    def clear(self) -> None:
+        self.events.clear()
+        self.seen.clear()
+
+    def prune(self, now: Optional[float] = None) -> None:
+        current = self.time_fn() if now is None else float(now)
+        cutoff = current - self.max_age_seconds
+        while self.events and self.events[0].observed_at < cutoff:
+            self.events.popleft()
+            self.expired += 1
+        while self.seen and next(iter(self.seen.values())) < cutoff:
+            self.seen.popitem(last=False)
+
+    def add(self, event: LiveEvent, now: Optional[float] = None) -> bool:
+        if not event.is_comment:
+            return False
+        current = self.time_fn() if now is None else float(now)
+        self.prune(current)
+        if event.event_id in self.seen:
+            self.duplicates += 1
+            return False
+        self.seen[event.event_id] = current
+        self.events.append(event)
+        while len(self.events) > self.max_events:
+            self.events.popleft()
+            self.overflow += 1
+        return True
+
+    def snapshot(
+        self,
+        window_seconds: float = 5 * 60,
+        limit: int = 100,
+        now: Optional[float] = None,
+    ) -> List[LiveEvent]:
+        current = self.time_fn() if now is None else float(now)
+        self.prune(current)
+        if window_seconds <= 0 or limit <= 0:
+            return []
+        cutoff = current - float(window_seconds)
+        return [event for event in self.events if event.observed_at >= cutoff][
+            -int(limit) :
+        ]
+
+
+class LiveChatAdapter:
+    """Protocol parser plus health counters; no persistence or generation."""
+
+    def __init__(
+        self,
+        buffer: Optional[LiveChatBuffer] = None,
+        time_fn: Callable[[], float] = time.time,
+        clear_on_live_end: bool = True,
+    ) -> None:
+        self.time_fn = time_fn
+        self.buffer = buffer if buffer is not None else LiveChatBuffer(time_fn=time_fn)
+        self.clear_on_live_end = clear_on_live_end
+        self.health: Dict[str, Any] = {
+            "state": "stopped",
+            "room_id": "",
+            "last_event_at": None,
+            "last_comment_at": None,
+            "last_error_code": "",
+            "received_lines": 0,
+            "invalid_lines": 0,
+            "comments_received": 0,
+            "reconnect_count": 0,
+            "transport_error_count": 0,
+        }
+
+    def ingest_line(self, line: Union[str, bytes]) -> Optional[LiveEvent]:
+        self.health["received_lines"] += 1
+        try:
+            event = parse_line(line, now=self.time_fn())
+        except ProtocolError as exc:
+            self.health["invalid_lines"] += 1
+            self.health["last_error_code"] = exc.code
+            return None
+        self.ingest_event(event)
+        return event
+
+    def ingest_event(self, event: LiveEvent) -> bool:
+        now = self.time_fn()
+        old_room = self.health["room_id"]
+        if event.room_id and old_room and event.room_id != old_room:
+            self.buffer.clear()
+        if event.room_id:
+            self.health["room_id"] = event.room_id
+        self.health["last_event_at"] = now
+
+        if event.event_type == "connected":
+            self.health["state"] = "connected"
+            self.health["last_error_code"] = ""
+        elif event.event_type == "reconnecting":
+            self.health["state"] = "reconnecting"
+            self.health["reconnect_count"] += 1
+        elif event.event_type == "disconnected":
+            if self.health["state"] != "ended":
+                self.health["state"] = "disconnected"
+        elif event.event_type == "live_ended":
+            self.health["state"] = "ended"
+            if self.clear_on_live_end:
+                self.buffer.clear()
+        elif event.event_type == "transport_error":
+            self.health["state"] = "error"
+            self.health["transport_error_count"] += 1
+            self.health["last_error_code"] = event.error_code or "transport_error"
+        elif event.is_comment:
+            self.health["comments_received"] += 1
+            self.health["last_comment_at"] = now
+            return self.buffer.add(event, now=now)
+        return False
+
+    def context_snapshot(self, window_seconds: float = 300, limit: int = 100):
+        return [
+            event.context_record()
+            for event in self.buffer.snapshot(window_seconds, limit, self.time_fn())
+        ]
+
+    def health_snapshot(self) -> Dict[str, Any]:
+        self.buffer.prune(self.time_fn())
+        return {
+            **self.health,
+            "comments_buffered": len(self.buffer.events),
+            "duplicate_count": self.buffer.duplicates,
+            "expired_count": self.buffer.expired,
+            "overflow_count": self.buffer.overflow,
+            "source": SOURCE,
+            "lifecycle": LIFECYCLE,
+            "memory_default": MEMORY_DEFAULT,
+        }
+
+
+def parse_line(line: Union[str, bytes], now: Optional[float] = None) -> LiveEvent:
+    current = time.time() if now is None else float(now)
+    if isinstance(line, bytes):
+        if len(line) > MAX_LINE_BYTES:
+            raise ProtocolError("line_too_long")
+        try:
+            text = line.decode("utf-8")
+        except UnicodeDecodeError:
+            raise ProtocolError("invalid_utf8")
+    elif isinstance(line, str):
+        if len(line.encode("utf-8")) > MAX_LINE_BYTES:
+            raise ProtocolError("line_too_long")
+        text = line
+    else:
+        raise ProtocolError("invalid_line_type")
+
+    try:
+        payload = json.loads(text)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        raise ProtocolError("invalid_json")
+    if not isinstance(payload, Mapping):
+        raise ProtocolError("payload_not_object")
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ProtocolError("unsupported_schema_version")
+
+    event_type = _code(payload.get("event_type"), "")
+    if event_type not in ALLOWED_EVENTS:
+        raise ProtocolError("unsupported_event_type")
+    observed_at = _timestamp(payload.get("observed_at"), current)
+    room_id = _text(payload.get("room_id"), 80)
+    event_id = _text(payload.get("event_id"), MAX_TEXT_CHARS)
+
+    if event_type == COMMENT:
+        unique_id = _text(payload.get("unique_id"), 80).lstrip("@")
+        if unique_id and not _HANDLE_RE.fullmatch(unique_id):
+            raise ProtocolError("invalid_unique_id")
+        display_name = _text(payload.get("display_name"), 120)
+        comment_text = _text(payload.get("comment_text"), MAX_COMMENT_CHARS)
+        if not comment_text:
+            raise ProtocolError("empty_comment")
+        event_id = event_id or _fallback_id(
+            event_type, room_id, unique_id, comment_text, observed_at
+        )
+        return LiveEvent(
+            event_type=event_type,
+            event_id=event_id,
+            room_id=room_id,
+            observed_at=observed_at,
+            unique_id=unique_id,
+            display_name=display_name or unique_id or "TikTok viewer",
+            comment_text=comment_text,
+            moderator_flag=_bool(payload.get("moderator_flag")),
+        )
+
+    event_id = event_id or _fallback_id(event_type, room_id, "", "", observed_at)
+    return LiveEvent(
+        event_type=event_type,
+        event_id=event_id,
+        room_id=room_id,
+        observed_at=observed_at,
+        error_code=(
+            _code(payload.get("error_code"), "transport_error")
+            if event_type == "transport_error"
+            else ""
+        ),
+    )
+
+
+def _text(value: Any, limit: int) -> str:
+    if not isinstance(value, (str, int, float, bool)):
+        return ""
+    text = _SPACE_RE.sub(" ", _CONTROL_RE.sub(" ", str(value))).strip()
+    return text[:limit].rstrip()
+
+
+def _code(value: Any, fallback: str) -> str:
+    return _CODE_RE.sub("_", _text(value, 80)).strip("_") or fallback
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return isinstance(value, str) and value.lower().strip() in {"1", "true", "yes"}
+
+
+def _timestamp(value: Any, now: float) -> float:
+    parsed: Optional[float] = None
+    try:
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            parsed = float(value)
+        elif isinstance(value, str):
+            text = value.strip().replace("Z", "+00:00")
+            try:
+                parsed = float(text)
+            except ValueError:
+                dt = datetime.fromisoformat(text)
+                parsed = (dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)).timestamp()
+    except (TypeError, ValueError, OverflowError):
+        parsed = None
+    if parsed is None or not math.isfinite(parsed):
+        return now
+    return parsed if abs(parsed - now) <= MAX_CLOCK_SKEW_SECONDS else now
+
+
+def _fallback_id(
+    event_type: str,
+    room_id: str,
+    unique_id: str,
+    comment_text: str,
+    observed_at: float,
+) -> str:
+    raw = "\x1f".join(
+        [event_type, room_id, unique_id, comment_text, "{:.3f}".format(observed_at)]
+    ).encode("utf-8", errors="replace")
+    return "local:" + hashlib.sha256(raw).hexdigest()[:32]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Operational helper scripts that are not imported by the main BNL runtime."""

--- a/scripts/tiktok_live_chat_transport.py
+++ b/scripts/tiktok_live_chat_transport.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Emit a read-only TikTok LIVE comment stream as versioned NDJSON.
+
+This script is intentionally isolated from the main BNL environment. It imports
+``piratetok_live`` only after argument validation, listens only for comments and
+connection lifecycle events, writes protocol objects to stdout, and writes only
+bounded diagnostic codes to stderr. It cannot post, moderate, gift, follow, or
+change BARCODE show state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import signal
+import sys
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+SCHEMA_VERSION = 1
+MAX_ROOM_ID_CHARS = 80
+MAX_UNIQUE_ID_CHARS = 80
+MAX_DISPLAY_NAME_CHARS = 120
+MAX_COMMENT_CHARS = 1000
+MAX_ERROR_CODE_CHARS = 80
+
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_WHITESPACE_RE = re.compile(r"\s+")
+_SAFE_CODE_RE = re.compile(r"[^A-Za-z0-9_.:-]+")
+_USERNAME_RE = re.compile(r"^[A-Za-z0-9._]+$")
+
+
+def _bounded_text(value: Any, max_chars: int) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, (str, int, float, bool)):
+        text = str(value)
+    else:
+        return ""
+    text = _CONTROL_CHAR_RE.sub(" ", text)
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+    return text[:max_chars].rstrip()
+
+
+def _bounded_code(value: Any, fallback: str) -> str:
+    text = _bounded_text(value, MAX_ERROR_CODE_CHARS)
+    text = _SAFE_CODE_RE.sub("_", text).strip("_")
+    return text or fallback
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _mapping(value: Any) -> Mapping:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _first_nonempty(*values: Any) -> str:
+    for value in values:
+        text = _bounded_text(value, MAX_DISPLAY_NAME_CHARS)
+        if text:
+            return text
+    return ""
+
+
+def _coerce_int(value: Any, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def normalize_username(value: str) -> str:
+    username = _bounded_text(value, MAX_UNIQUE_ID_CHARS).lstrip("@").strip()
+    if not username:
+        raise argparse.ArgumentTypeError("TikTok username is required")
+    if not _USERNAME_RE.fullmatch(username):
+        raise argparse.ArgumentTypeError(
+            "TikTok username may contain letters, numbers, periods, and underscores"
+        )
+    return username
+
+
+def _event_room_id(event: Any, data: Mapping) -> str:
+    common = _mapping(data.get("common"))
+    return _bounded_text(
+        _first_nonempty(
+            getattr(event, "room_id", ""),
+            data.get("roomId"),
+            data.get("room_id"),
+            common.get("roomId"),
+            common.get("room_id"),
+        ),
+        MAX_ROOM_ID_CHARS,
+    )
+
+
+def _event_message_id(data: Mapping) -> str:
+    common = _mapping(data.get("common"))
+    return _first_nonempty(
+        common.get("msgId"),
+        common.get("msg_id"),
+        data.get("msgId"),
+        data.get("msg_id"),
+        common.get("logId"),
+        common.get("log_id"),
+    )
+
+
+def _moderator_flag(user: Mapping) -> bool:
+    identity = _mapping(user.get("identity"))
+    user_attr = _mapping(user.get("userAttr"))
+    if not user_attr:
+        user_attr = _mapping(user.get("user_attr"))
+    return any(
+        bool(value)
+        for value in (
+            identity.get("isModeratorOfAnchor"),
+            identity.get("is_moderator_of_anchor"),
+            user_attr.get("isAdmin"),
+            user_attr.get("is_admin"),
+            user_attr.get("isSuperAdmin"),
+            user_attr.get("is_super_admin"),
+        )
+    )
+
+
+def _fallback_event_id(
+    room_id: str,
+    unique_id: str,
+    comment_text: str,
+    observed_at: str,
+) -> str:
+    material = "\x1f".join(
+        [room_id, unique_id, comment_text, observed_at]
+    ).encode("utf-8", errors="replace")
+    return "local:{}".format(hashlib.sha256(material).hexdigest()[:32])
+
+
+def build_comment_payload(event: Any) -> Optional[Dict[str, Any]]:
+    data = _mapping(getattr(event, "data", {}))
+    user = _mapping(data.get("user"))
+    comment_text = _bounded_text(data.get("content"), MAX_COMMENT_CHARS)
+    if not comment_text:
+        return None
+
+    unique_id = _bounded_text(
+        _first_nonempty(user.get("uniqueId"), user.get("unique_id")),
+        MAX_UNIQUE_ID_CHARS,
+    ).lstrip("@")
+    display_name = _bounded_text(
+        _first_nonempty(user.get("nickname"), unique_id, "TikTok viewer"),
+        MAX_DISPLAY_NAME_CHARS,
+    )
+    room_id = _event_room_id(event, data)
+    observed_at = _utc_now()
+    message_id = _bounded_text(_event_message_id(data), 120)
+    event_id = (
+        "tiktok:{}:{}".format(room_id or "room", message_id)
+        if message_id
+        else _fallback_event_id(room_id, unique_id, comment_text, observed_at)
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "event_type": "comment",
+        "event_id": event_id,
+        "room_id": room_id,
+        "observed_at": observed_at,
+        "unique_id": unique_id,
+        "display_name": display_name,
+        "comment_text": comment_text,
+        "moderator_flag": _moderator_flag(user),
+    }
+
+
+def build_lifecycle_payload(event_type: str, event: Any) -> Dict[str, Any]:
+    data = _mapping(getattr(event, "data", {}))
+    room_id = _event_room_id(event, data)
+    payload: Dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "event_type": event_type,
+        "event_id": "{}:{}:{}".format(
+            event_type, room_id or "room", datetime.now(timezone.utc).timestamp()
+        ),
+        "room_id": room_id,
+        "observed_at": _utc_now(),
+    }
+    if event_type == "reconnecting":
+        payload.update(
+            {
+                "attempt": max(0, _coerce_int(data.get("attempt"))),
+                "max_retries": max(0, _coerce_int(data.get("max_retries"))),
+                "delay_seconds": max(0, _coerce_int(data.get("delay"))),
+            }
+        )
+    return payload
+
+
+def build_transport_error_payload(error: Any) -> Dict[str, Any]:
+    error_code = _bounded_code(
+        error.__class__.__name__ if isinstance(error, BaseException) else error,
+        "transport_error",
+    )
+    observed_at = _utc_now()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "event_type": "transport_error",
+        "event_id": "transport_error:{}".format(observed_at),
+        "room_id": "",
+        "observed_at": observed_at,
+        "error_code": error_code,
+    }
+
+
+def emit_payload(payload: Mapping) -> None:
+    sys.stdout.write(json.dumps(dict(payload), separators=(",", ":"), sort_keys=True))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def emit_diagnostic(code: str) -> None:
+    sys.stderr.write(_bounded_code(code, "transport_diagnostic") + "\n")
+    sys.stderr.flush()
+
+
+def run_transport(args: argparse.Namespace) -> int:
+    try:
+        from piratetok_live import EventType, TikTokLiveClient
+    except ImportError:
+        emit_payload(build_transport_error_payload("missing_dependency"))
+        emit_diagnostic("missing_dependency")
+        return 2
+
+    client = TikTokLiveClient(args.username)
+    if args.cdn == "us":
+        client.cdn_us()
+    elif args.cdn == "eu":
+        client.cdn_eu()
+    client.max_retries(args.max_retries)
+    client.stale_timeout(args.stale_timeout)
+
+    @client.on(EventType.connected)
+    def on_connected(event: Any) -> None:
+        emit_payload(build_lifecycle_payload("connected", event))
+
+    @client.on(EventType.chat)
+    def on_chat(event: Any) -> None:
+        payload = build_comment_payload(event)
+        if payload is not None:
+            emit_payload(payload)
+
+    @client.on(EventType.reconnecting)
+    def on_reconnecting(event: Any) -> None:
+        emit_payload(build_lifecycle_payload("reconnecting", event))
+
+    @client.on(EventType.live_ended)
+    def on_live_ended(event: Any) -> None:
+        emit_payload(build_lifecycle_payload("live_ended", event))
+
+    @client.on(EventType.disconnected)
+    def on_disconnected(event: Any) -> None:
+        emit_payload(build_lifecycle_payload("disconnected", event))
+
+    @client.on("error")
+    def on_error(event: Any) -> None:
+        emit_payload(build_transport_error_payload(getattr(event, "data", event)))
+
+    def request_stop(_signum: int, _frame: Any) -> None:
+        emit_diagnostic("stop_requested")
+        client.disconnect()
+
+    for signal_name in (signal.SIGINT, signal.SIGTERM):
+        try:
+            signal.signal(signal_name, request_stop)
+        except (AttributeError, OSError, ValueError):
+            pass
+
+    try:
+        client.run()
+    except KeyboardInterrupt:
+        client.disconnect()
+        return 130
+    except Exception as exc:
+        emit_payload(build_transport_error_payload(exc))
+        emit_diagnostic(exc.__class__.__name__)
+        return 1
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read TikTok LIVE comments and emit BARCODE shadow NDJSON"
+    )
+    parser.add_argument("--username", required=True, type=normalize_username)
+    parser.add_argument(
+        "--cdn",
+        choices=("default", "us", "eu"),
+        default="us",
+        help="TikTok Webcast CDN preference",
+    )
+    parser.add_argument("--max-retries", type=int, default=5)
+    parser.add_argument("--stale-timeout", type=float, default=60.0)
+    return parser
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.max_retries < 0 or args.max_retries > 100:
+        parser.error("--max-retries must be between 0 and 100")
+    if args.stale_timeout < 10 or args.stale_timeout > 600:
+        parser.error("--stale-timeout must be between 10 and 600 seconds")
+    return run_transport(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bnl_tiktok_live_chat.py
+++ b/tests/test_bnl_tiktok_live_chat.py
@@ -1,0 +1,136 @@
+import json
+import unittest
+
+from bnl_tiktok_live_chat import (
+    AUTHORITY,
+    IDENTITY_DEFAULT,
+    MEMORY_DEFAULT,
+    SOURCE,
+    VISIBILITY,
+    LiveChatAdapter,
+    LiveChatBuffer,
+    ProtocolError,
+    parse_line,
+)
+
+
+class Clock:
+    def __init__(self):
+        self.value = 1_700_000_000.0
+
+    def __call__(self):
+        return self.value
+
+
+def payload(**changes):
+    value = {
+        "schema_version": 1,
+        "event_type": "comment",
+        "event_id": "message-1",
+        "room_id": "room-1",
+        "observed_at": 1_700_000_000.0,
+        "unique_id": "test.viewer",
+        "display_name": "Test Viewer",
+        "comment_text": "This track is wild.",
+        "moderator_flag": False,
+    }
+    value.update(changes)
+    return value
+
+
+class ParseTests(unittest.TestCase):
+    def test_adapter_owns_source_and_no_store_semantics(self):
+        event = parse_line(
+            json.dumps(payload(source="spoof", memory_default="store")),
+            now=1_700_000_000.0,
+        )
+        record = event.context_record()
+        self.assertEqual(record["source"], SOURCE)
+        self.assertEqual(record["visibility"], VISIBILITY)
+        self.assertEqual(record["authority"], AUTHORITY)
+        self.assertEqual(record["memory_default"], MEMORY_DEFAULT)
+        self.assertEqual(record["identity_default"], IDENTITY_DEFAULT)
+
+    def test_sanitizes_and_bounds_comment(self):
+        event = parse_line(
+            json.dumps(payload(comment_text="hello\u0000\nworld " + "x" * 2000)),
+            now=1_700_000_000.0,
+        )
+        self.assertTrue(event.comment_text.startswith("hello world"))
+        self.assertLessEqual(len(event.comment_text), 1000)
+
+    def test_failures_are_bounded(self):
+        with self.assertRaises(ProtocolError) as invalid:
+            parse_line("{secret-token", now=1.0)
+        self.assertEqual(invalid.exception.code, "invalid_json")
+        self.assertNotIn("secret-token", str(invalid.exception))
+        with self.assertRaises(ProtocolError) as handle:
+            parse_line(json.dumps(payload(unique_id="bad handle;secret")), now=1.0)
+        self.assertEqual(handle.exception.code, "invalid_unique_id")
+
+    def test_missing_id_gets_deterministic_fallback(self):
+        value = json.dumps(payload(event_id=""))
+        first = parse_line(value, now=1_700_000_000.0)
+        second = parse_line(value, now=1_700_000_000.0)
+        self.assertEqual(first.event_id, second.event_id)
+        self.assertTrue(first.event_id.startswith("local:"))
+
+
+class BufferTests(unittest.TestCase):
+    def setUp(self):
+        self.clock = Clock()
+        self.buffer = LiveChatBuffer(2, 30, self.clock)
+        self.adapter = LiveChatAdapter(self.buffer, self.clock)
+
+    def add(self, event_id, text="comment"):
+        return self.adapter.ingest_line(
+            json.dumps(
+                payload(
+                    event_id=event_id,
+                    comment_text=text,
+                    observed_at=self.clock(),
+                )
+            )
+        )
+
+    def test_dedupes_and_caps(self):
+        self.add("a")
+        self.add("a", "replay")
+        self.add("b")
+        self.add("c")
+        self.assertEqual(
+            [row["event_id"] for row in self.adapter.context_snapshot()], ["b", "c"]
+        )
+        health = self.adapter.health_snapshot()
+        self.assertEqual(health["duplicate_count"], 1)
+        self.assertEqual(health["overflow_count"], 1)
+
+    def test_expires_and_clears_at_live_end(self):
+        self.add("a")
+        self.clock.value += 31
+        self.assertEqual(self.adapter.context_snapshot(), [])
+        self.add("b")
+        self.adapter.ingest_line(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "event_type": "live_ended",
+                    "event_id": "end",
+                    "room_id": "room-1",
+                    "observed_at": self.clock(),
+                }
+            )
+        )
+        self.assertEqual(self.adapter.context_snapshot(), [])
+        self.assertEqual(self.adapter.health_snapshot()["state"], "ended")
+
+    def test_invalid_line_changes_health_not_storage(self):
+        self.assertIsNone(self.adapter.ingest_line("not-json secret"))
+        health = self.adapter.health_snapshot()
+        self.assertEqual(health["invalid_lines"], 1)
+        self.assertEqual(health["last_error_code"], "invalid_json")
+        self.assertNotIn("secret", json.dumps(health))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tiktok_live_chat_transport.py
+++ b/tests/test_tiktok_live_chat_transport.py
@@ -1,0 +1,189 @@
+import argparse
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import ModuleType, SimpleNamespace
+from unittest import mock
+
+from scripts import tiktok_live_chat_transport as transport
+
+
+class TransportPayloadTests(unittest.TestCase):
+    def test_comment_payload_contains_only_normalized_comment_fields(self):
+        event = SimpleNamespace(
+            room_id="room-1",
+            data={
+                "common": {"msgId": "message-9"},
+                "content": "  hello\u0000\nworld  ",
+                "user": {
+                    "uniqueId": "@test.viewer",
+                    "nickname": "Test Viewer",
+                    "avatarThumb": {"urlList": ["private-avatar-url"]},
+                    "bioDescription": "should not leave transport",
+                    "identity": {"isModeratorOfAnchor": True},
+                },
+            },
+        )
+        payload = transport.build_comment_payload(event)
+
+        self.assertEqual(payload["event_type"], "comment")
+        self.assertEqual(payload["event_id"], "tiktok:room-1:message-9")
+        self.assertEqual(payload["comment_text"], "hello world")
+        self.assertEqual(payload["unique_id"], "test.viewer")
+        self.assertTrue(payload["moderator_flag"])
+        serialized = json.dumps(payload)
+        self.assertNotIn("avatar", serialized.lower())
+        self.assertNotIn("bioDescription", serialized)
+        self.assertNotIn("private-avatar-url", serialized)
+
+    def test_empty_comment_is_not_emitted(self):
+        event = SimpleNamespace(room_id="room", data={"content": "\u0000\n"})
+        self.assertIsNone(transport.build_comment_payload(event))
+
+    def test_transport_error_uses_class_only(self):
+        payload = transport.build_transport_error_payload(
+            RuntimeError("https://example.invalid/?token=secret")
+        )
+        self.assertEqual(payload["error_code"], "RuntimeError")
+        self.assertNotIn("secret", json.dumps(payload))
+        self.assertNotIn("example.invalid", json.dumps(payload))
+
+    def test_reconnecting_payload_bounds_numeric_fields(self):
+        event = SimpleNamespace(
+            room_id="room",
+            data={"attempt": "3", "max_retries": "5", "delay": "8"},
+        )
+        payload = transport.build_lifecycle_payload("reconnecting", event)
+        self.assertEqual(payload["attempt"], 3)
+        self.assertEqual(payload["max_retries"], 5)
+        self.assertEqual(payload["delay_seconds"], 8)
+
+    def test_emit_payload_is_one_compact_json_line(self):
+        output = io.StringIO()
+        with redirect_stdout(output):
+            transport.emit_payload({"schema_version": 1, "event_type": "connected"})
+        lines = output.getvalue().splitlines()
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(json.loads(lines[0])["event_type"], "connected")
+
+
+class TransportCliTests(unittest.TestCase):
+    def test_username_validation(self):
+        self.assertEqual(transport.normalize_username("@six.bit"), "six.bit")
+        with self.assertRaises(argparse.ArgumentTypeError):
+            transport.normalize_username("six bit; rm -rf")
+
+    def test_missing_dependency_returns_bounded_error(self):
+        # The dependency is intentionally absent from the main test environment.
+        args = argparse.Namespace(
+            username="six.bit",
+            cdn="us",
+            max_retries=0,
+            stale_timeout=60.0,
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with mock.patch.dict(sys.modules, {"piratetok_live": None}):
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                result = transport.run_transport(args)
+        self.assertEqual(result, 2)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["event_type"], "transport_error")
+        self.assertEqual(payload["error_code"], "missing_dependency")
+        self.assertEqual(stderr.getvalue().strip(), "missing_dependency")
+
+    def test_run_transport_registers_read_only_callbacks(self):
+        class FakeEventType:
+            connected = "connected"
+            chat = "chat"
+            reconnecting = "reconnecting"
+            live_ended = "live_ended"
+            disconnected = "disconnected"
+
+        class FakeClient:
+            last_instance = None
+
+            def __init__(self, username):
+                self.username = username
+                self.listeners = {}
+                self.settings = {}
+                FakeClient.last_instance = self
+
+            def cdn_us(self):
+                self.settings["cdn"] = "us"
+                return self
+
+            def cdn_eu(self):
+                self.settings["cdn"] = "eu"
+                return self
+
+            def max_retries(self, value):
+                self.settings["max_retries"] = value
+                return self
+
+            def stale_timeout(self, value):
+                self.settings["stale_timeout"] = value
+                return self
+
+            def on(self, event_type):
+                def register(callback):
+                    self.listeners.setdefault(event_type, []).append(callback)
+                    return callback
+                return register
+
+            def disconnect(self):
+                self.settings["disconnected"] = True
+
+            def run(self):
+                events = [
+                    ("connected", SimpleNamespace(room_id="room", data={"room_id": "room"})),
+                    (
+                        "chat",
+                        SimpleNamespace(
+                            room_id="room",
+                            data={
+                                "common": {"msgId": "1"},
+                                "content": "hello",
+                                "user": {"uniqueId": "viewer", "nickname": "Viewer"},
+                            },
+                        ),
+                    ),
+                    ("live_ended", SimpleNamespace(room_id="room", data={})),
+                    ("disconnected", SimpleNamespace(room_id="room", data={})),
+                ]
+                for event_type, event in events:
+                    for callback in self.listeners.get(event_type, []):
+                        callback(event)
+
+        fake_module = ModuleType("piratetok_live")
+        fake_module.EventType = FakeEventType
+        fake_module.TikTokLiveClient = FakeClient
+        args = argparse.Namespace(
+            username="six.bit",
+            cdn="us",
+            max_retries=4,
+            stale_timeout=75.0,
+        )
+        stdout = io.StringIO()
+        with mock.patch.dict(sys.modules, {"piratetok_live": fake_module}):
+            with redirect_stdout(stdout):
+                result = transport.run_transport(args)
+
+        self.assertEqual(result, 0)
+        emitted = [json.loads(line) for line in stdout.getvalue().splitlines()]
+        self.assertEqual(
+            [event["event_type"] for event in emitted],
+            ["connected", "comment", "live_ended", "disconnected"],
+        )
+        self.assertEqual(FakeClient.last_instance.settings["cdn"], "us")
+        self.assertEqual(FakeClient.last_instance.settings["max_retries"], 4)
+        self.assertEqual(FakeClient.last_instance.settings["stale_timeout"], 75.0)
+        self.assertNotIn("gift", FakeClient.last_instance.listeners)
+        self.assertNotIn("follow", FakeClient.last_instance.listeners)
+        self.assertNotIn("join", FakeClient.last_instance.listeners)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tiktok-live-ingest/README.md
+++ b/tools/tiktok-live-ingest/README.md
@@ -1,0 +1,101 @@
+# TikTok LIVE chat transport (shadow-only)
+
+This directory documents the optional transport used by
+`scripts/tiktok_live_chat_transport.py`. It connects directly to TikTok's
+public LIVE Webcast stream through the signerless `piratetok-live-py` client
+and writes a small versioned NDJSON event stream to stdout.
+
+## Boundary
+
+This is **not** part of the main BNL Python environment. The production bot
+supports Python 3.9 and 3.12; `piratetok-live-py` requires Python 3.11 or newer.
+Keep the transport in its own virtual environment. A later bot integration may
+consume stdout through a local process pipe after the shadow proof passes.
+
+The transport:
+
+- reads public comments and stream lifecycle events only;
+- does not use EulerStream, an API key, a signing service, or TikTok account
+  cookies;
+- cannot post comments, gift, follow, moderate, or mutate the show;
+- emits no profile biography, avatar, follower count, gift, like, join, or
+  payment data;
+- sends human diagnostics to stderr and reserves stdout for NDJSON;
+- does not write a database or log file.
+
+The BNL adapter hard-codes every accepted comment as:
+
+```text
+source=tiktok_live_webcast
+visibility=public_observation
+authority=viewer_statement
+lifecycle=current_show_only
+memory_default=do_not_store
+identity_default=tiktok_only_unlinked
+```
+
+A TikTok handle is not a Discord identity, website account, queue submitter,
+artist profile, Source File subject, or dossier identity.
+
+## Isolated setup for a connection proof
+
+No setup is performed by the repository or by importing BNL. In an isolated
+test environment with Python 3.11+:
+
+```bash
+python3.11 -m venv .venv-tiktok-live
+.venv-tiktok-live/bin/python -m pip install --upgrade pip
+.venv-tiktok-live/bin/python -m pip install \
+  -r tools/tiktok-live-ingest/requirements.txt
+```
+
+Run the transport by itself only during an explicitly approved shadow proof:
+
+```bash
+.venv-tiktok-live/bin/python -u \
+  scripts/tiktok_live_chat_transport.py \
+  --username six.bit \
+  --cdn us
+```
+
+Do not redirect stdout to a durable file. The intended consumer is the local
+in-memory adapter, not a transcript archive.
+
+## NDJSON contract
+
+Each line is one JSON object with `schema_version=1`.
+
+Comment fields:
+
+```text
+event_type=comment
+event_id
+room_id
+observed_at
+unique_id
+display_name
+comment_text
+moderator_flag
+```
+
+Lifecycle types:
+
+```text
+connected
+reconnecting
+disconnected
+live_ended
+transport_error
+```
+
+`transport_error` carries only a bounded error class/code. Raw exception text,
+URLs, cookies, and request headers are not emitted.
+
+## Current stop point
+
+This PR provides the replaceable transport, parser, bounded in-memory buffer,
+deduplication, and lifecycle health. It does not start the collector or wire
+TikTok comments into `bnl01_bot.py`, Gemini, Discord output, Relay, Journal,
+Moments, Relationship, Source Files, dossiers, queue actions, or the website.
+Those are separate approval and implementation decisions after a real-length
+shadow connection proves the upstream transport.

--- a/tools/tiktok-live-ingest/requirements.txt
+++ b/tools/tiktok-live-ingest/requirements.txt
@@ -1,0 +1,2 @@
+# Isolated Python 3.11+ transport dependency. Do not add this to the main bot venv.
+piratetok-live-py==0.2.0


### PR DESCRIPTION
## Result

Adds the first bounded TikTok LIVE chat ingestion layer without EulerStream and without changing BNL’s live behavior.

The PR provides a direct, signerless TikTok Webcast transport plus a standard-library BNL-side NDJSON adapter. It is intentionally stopped before runtime wiring, model use, Discord output, or persistence.

## Changed behavior

- Adds an isolated Python 3.11+ transport using `piratetok-live-py==0.2.0`.
- Connects directly to the configured public TikTok LIVE room and listens only for comments and connection lifecycle events.
- Emits a small versioned NDJSON contract through stdout.
- Normalizes and bounds comment text, handle, display name, room ID, event ID, timestamps, moderator indication, and error codes.
- Adds an in-memory BNL adapter with age/count caps, replay deduplication, room/live-end clearing, and health counters.
- Hard-codes every accepted comment as:
  - `source=tiktok_live_webcast`
  - `visibility=public_observation`
  - `authority=viewer_statement`
  - `lifecycle=current_show_only`
  - `memory_default=do_not_store`
  - `identity_default=tiktok_only_unlinked`
- Adds a Python 3.11 CI job that installs the isolated transport dependency and checks its import/event contract.

## Explicitly not changed

- No `bnl01_bot.py` integration or collector startup.
- No Gemini calls or per-comment generation.
- No Discord output, TikTok posting, moderation, gifts, follows, likes, or joins.
- No database, Redis, transcript, Moment, Relationship, Journal, Relay, Source File, dossier, queue, payment, or website writes.
- No TikTok-to-Discord/account/artist identity linking.
- No changes to protected `#welcome` or `#episode-tracker` behavior.
- No runtime environment variables, systemd configuration, deployment, rehearsal, or public gate changes.

## Files

- `bnl_tiktok_live_chat.py`
- `scripts/tiktok_live_chat_transport.py`
- `scripts/__init__.py`
- `tests/test_bnl_tiktok_live_chat.py`
- `tests/test_tiktok_live_chat_transport.py`
- `tools/tiktok-live-ingest/README.md`
- `tools/tiktok-live-ingest/requirements.txt`
- `.github/workflows/ci.yml`
- `Makefile`
- `.gitignore`

## Verification

Local focused verification on the exact published file contents:

- `python3 -m compileall -q bnl_tiktok_live_chat.py scripts tests`
- `python3 -W error -m unittest discover -s tests -p 'test_*.py' -v`
- 15 tests passed.
- New Python files parsed successfully against Python 3.9 grammar.
- Local file Git blob hashes match the blobs committed to the branch.

GitHub CI additionally runs:

- Existing `make check` on Python 3.9 and 3.12.
- Isolated Python 3.11 dependency installation.
- Upstream `TikTokLiveClient` / `EventType.chat` import contract.
- TikTok adapter and transport tests.

## Runtime uncertainty and risk

This PR does not prove that the direct connection will survive a real BARCODE-length LIVE. TikTok does not expose this as an official public LIVE-comment API; the Webcast protocol can change, throttle, or block the collector. A separately approved isolated shadow run is still required to measure message coverage, latency, reconnect behavior, duplicate replay, CPU/memory use, and stream-end handling.

## Rollback

Revert this PR. It creates no schema, persisted data, secret, configuration, deployment, or public-state migration.
