### PR TITLE
Expand shadow TikTok LIVE telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,10 @@ jobs:
       - name: Verify upstream transport import contract
         run: >-
           python -c "from piratetok_live import EventType, TikTokLiveClient;
-          assert EventType.chat == 'chat'; assert callable(TikTokLiveClient)"
+          expected = ('chat', 'like', 'room_user_seq', 'share', 'follow',
+          'gift', 'question_new', 'join', 'live_ended');
+          assert all(getattr(EventType, name, None) == name for name in expected);
+          assert callable(TikTokLiveClient)"
 
       - name: Verify shadow transport and adapter tests
         run: |

--- a/bnl_tiktok_live_chat.py
+++ b/bnl_tiktok_live_chat.py
@@ -1,9 +1,10 @@
-"""Ephemeral, read-only TikTok LIVE chat boundary for BNL.
+"""Ephemeral, read-only TikTok LIVE public telemetry boundary for BNL.
 
 The direct Webcast client lives in an isolated Python 3.11+ process. This
 standard-library-only module stays compatible with the bot's Python 3.9/3.12
-runtime, validates the transport's NDJSON, and keeps comments in bounded RAM.
-It does not start the collector, call Gemini, write a database, or post output.
+runtime, validates the transport's NDJSON, and keeps current-show observations
+in bounded RAM. It does not start the collector, call Gemini, write a database,
+or post output.
 """
 
 from __future__ import annotations
@@ -22,21 +23,40 @@ from typing import Any, Callable, Deque, Dict, List, Optional, Union
 SCHEMA_VERSION = 1
 SOURCE = "tiktok_live_webcast"
 VISIBILITY = "public_observation"
-AUTHORITY = "viewer_statement"
+COMMENT_AUTHORITY = "viewer_statement"
+INTERACTION_AUTHORITY = "public_interaction_event"
+METRIC_AUTHORITY = "platform_room_metric"
+AUTHORITY = COMMENT_AUTHORITY  # compatibility alias for comment context
 LIFECYCLE = "current_show_only"
 MEMORY_DEFAULT = "do_not_store"
 IDENTITY_DEFAULT = "tiktok_only_unlinked"
 
 COMMENT = "comment"
+LIKE = "like"
+VIEWER_SNAPSHOT = "viewer_snapshot"
+SHARE = "share"
+FOLLOW = "follow"
+GIFT = "gift"
+QUESTION = "question"
+JOIN = "join"
+
+OBSERVATION_EVENTS = frozenset(
+    {COMMENT, LIKE, VIEWER_SNAPSHOT, SHARE, FOLLOW, GIFT, QUESTION, JOIN}
+)
+RETAINED_EVENTS = frozenset(
+    {COMMENT, LIKE, VIEWER_SNAPSHOT, SHARE, FOLLOW, GIFT, QUESTION}
+)
 LIFECYCLE_EVENTS = frozenset(
     {"connected", "reconnecting", "disconnected", "live_ended", "transport_error"}
 )
-ALLOWED_EVENTS = frozenset({COMMENT, *LIFECYCLE_EVENTS})
+ALLOWED_EVENTS = frozenset({*OBSERVATION_EVENTS, *LIFECYCLE_EVENTS})
 
 MAX_LINE_BYTES = 32 * 1024
 MAX_COMMENT_CHARS = 1000
+MAX_QUESTION_CHARS = 1000
 MAX_TEXT_CHARS = 160
 MAX_CLOCK_SKEW_SECONDS = 5 * 60
+MAX_SOURCE_CLOCK_SKEW_SECONDS = 24 * 60 * 60
 _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 _SPACE_RE = re.compile(r"\s+")
 _CODE_RE = re.compile(r"[^A-Za-z0-9_.:-]+")
@@ -57,38 +77,127 @@ class LiveEvent:
     event_id: str
     room_id: str
     observed_at: float
+    source_at: float = 0.0
     unique_id: str = ""
     display_name: str = ""
     comment_text: str = ""
     moderator_flag: bool = False
+    like_count: int = 0
+    like_total: int = 0
+    viewer_count: int = 0
+    share_type: int = 0
+    gift_id: int = 0
+    gift_name: str = ""
+    gift_count: int = 0
+    diamond_count: int = 0
+    diamond_total: int = 0
+    combo: bool = False
+    streak_over: bool = False
+    question_id: str = ""
+    question_text: str = ""
+    answer_status: int = 0
+    join_count: int = 0
     error_code: str = ""
 
     @property
     def is_comment(self) -> bool:
         return self.event_type == COMMENT
 
+    @property
+    def is_observation(self) -> bool:
+        return self.event_type in OBSERVATION_EVENTS
+
+    @property
+    def event_time(self) -> float:
+        return self.source_at or self.observed_at
+
+    @property
+    def authority(self) -> str:
+        if self.event_type in {COMMENT, QUESTION}:
+            return COMMENT_AUTHORITY
+        if self.event_type == VIEWER_SNAPSHOT:
+            return METRIC_AUTHORITY
+        return INTERACTION_AUTHORITY
+
     def context_record(self) -> Dict[str, Any]:
         if not self.is_comment:
-            raise ValueError("only comments can become context")
+            raise ValueError("only comments can become conversation context")
         return {
             "event_id": self.event_id,
             "room_id": self.room_id,
             "observed_at": self.observed_at,
+            "source_at": self.source_at or None,
             "unique_id": self.unique_id,
             "display_name": self.display_name,
             "comment_text": self.comment_text,
             "moderator_flag": self.moderator_flag,
             "source": SOURCE,
             "visibility": VISIBILITY,
-            "authority": AUTHORITY,
+            "authority": COMMENT_AUTHORITY,
             "lifecycle": LIFECYCLE,
             "memory_default": MEMORY_DEFAULT,
             "identity_default": IDENTITY_DEFAULT,
         }
 
+    def telemetry_record(self) -> Dict[str, Any]:
+        if not self.is_observation:
+            raise ValueError("only public observations can become telemetry")
+        record: Dict[str, Any] = {
+            "event_type": self.event_type,
+            "event_id": self.event_id,
+            "room_id": self.room_id,
+            "observed_at": self.observed_at,
+            "source_at": self.source_at or None,
+            "source": SOURCE,
+            "visibility": VISIBILITY,
+            "authority": self.authority,
+            "lifecycle": LIFECYCLE,
+            "memory_default": MEMORY_DEFAULT,
+            "identity_default": IDENTITY_DEFAULT,
+        }
+        if self.unique_id:
+            record.update(
+                {
+                    "unique_id": self.unique_id,
+                    "display_name": self.display_name,
+                    "moderator_flag": self.moderator_flag,
+                }
+            )
+        if self.event_type == COMMENT:
+            record["comment_text"] = self.comment_text
+        elif self.event_type == LIKE:
+            record.update({"like_count": self.like_count, "like_total": self.like_total})
+        elif self.event_type == VIEWER_SNAPSHOT:
+            record["viewer_count"] = self.viewer_count
+        elif self.event_type == SHARE:
+            record["share_type"] = self.share_type
+        elif self.event_type == GIFT:
+            record.update(
+                {
+                    "gift_id": self.gift_id,
+                    "gift_name": self.gift_name,
+                    "gift_count": self.gift_count,
+                    "diamond_count": self.diamond_count,
+                    "diamond_total": self.diamond_total,
+                    "combo": self.combo,
+                    "streak_over": self.streak_over,
+                }
+            )
+        elif self.event_type == QUESTION:
+            record.update(
+                {
+                    "question_id": self.question_id,
+                    "question_text": self.question_text,
+                    "answer_status": self.answer_status,
+                }
+            )
+        elif self.event_type == JOIN:
+            record["join_count"] = self.join_count
+        return record
+
 
 class LiveChatBuffer:
-    """Current-show ring buffer with replay deduplication."""
+    """Current-show ring buffer with replay deduplication for public telemetry."""
 
     def __init__(
         self,
@@ -97,7 +206,9 @@ class LiveChatBuffer:
         time_fn: Callable[[], float] = time.time,
         max_seen_events: Optional[int] = None,
     ) -> None:
-        resolved_max_seen = (int(max_events) * 4) if max_seen_events is None else int(max_seen_events)
+        resolved_max_seen = (
+            int(max_events) * 4 if max_seen_events is None else int(max_seen_events)
+        )
         if max_events <= 0 or max_age_seconds <= 0 or resolved_max_seen <= 0:
             raise ValueError("buffer limits must be positive")
         self.max_events = int(max_events)
@@ -124,20 +235,22 @@ class LiveChatBuffer:
             self.seen.popitem(last=False)
 
     def add(self, event: LiveEvent, now: Optional[float] = None) -> bool:
-        if not event.is_comment:
+        if not event.is_observation:
             return False
         current = self.time_fn() if now is None else float(now)
         self.prune(current)
         if event.event_id in self.seen:
+            self.seen.move_to_end(event.event_id)
             self.duplicates += 1
             return False
         self.seen[event.event_id] = current
         while len(self.seen) > self.max_seen_events:
             self.seen.popitem(last=False)
-        self.events.append(event)
-        while len(self.events) > self.max_events:
-            self.events.popleft()
-            self.overflow += 1
+        if event.event_type in RETAINED_EVENTS:
+            self.events.append(event)
+            while len(self.events) > self.max_events:
+                self.events.popleft()
+                self.overflow += 1
         return True
 
     def snapshot(
@@ -145,19 +258,23 @@ class LiveChatBuffer:
         window_seconds: float = 5 * 60,
         limit: int = 100,
         now: Optional[float] = None,
+        event_types: Optional[frozenset] = None,
     ) -> List[LiveEvent]:
         current = self.time_fn() if now is None else float(now)
         self.prune(current)
         if window_seconds <= 0 or limit <= 0:
             return []
         cutoff = current - float(window_seconds)
-        return [event for event in self.events if event.observed_at >= cutoff][
-            -int(limit) :
-        ]
+        return [
+            event
+            for event in self.events
+            if event.observed_at >= cutoff
+            and (event_types is None or event.event_type in event_types)
+        ][-int(limit) :]
 
 
 class LiveChatAdapter:
-    """Protocol parser plus health counters; no persistence or generation."""
+    """Protocol parser plus bounded health/telemetry counters; no persistence."""
 
     def __init__(
         self,
@@ -173,10 +290,27 @@ class LiveChatAdapter:
             "room_id": "",
             "last_event_at": None,
             "last_comment_at": None,
+            "last_signal_at": None,
             "last_error_code": "",
             "received_lines": 0,
             "invalid_lines": 0,
+            "events_received": 0,
+            "events_accepted": 0,
             "comments_received": 0,
+            "comments_accepted": 0,
+            "like_events": 0,
+            "taps_observed": 0,
+            "latest_like_total": 0,
+            "viewer_snapshots": 0,
+            "viewer_count": 0,
+            "peak_viewers": 0,
+            "shares": 0,
+            "follows": 0,
+            "gift_events": 0,
+            "gift_units": 0,
+            "diamond_total": 0,
+            "questions": 0,
+            "joins": 0,
             "reconnect_count": 0,
             "transport_error_count": 0,
         }
@@ -184,8 +318,8 @@ class LiveChatAdapter:
     def ingest_line(self, line: Union[str, bytes]) -> Optional[LiveEvent]:
         """Parse one transport line and return only accepted events.
 
-        Invalid lines and replayed comments return ``None``. Lifecycle events are
-        returned after their health state is applied.
+        Invalid lines and replayed public observations return ``None``.
+        Lifecycle events are returned after their health state is applied.
         """
 
         self.health["received_lines"] += 1
@@ -196,7 +330,7 @@ class LiveChatAdapter:
             self.health["last_error_code"] = exc.code
             return None
         accepted = self.ingest_event(event)
-        if event.is_comment and not accepted:
+        if event.is_observation and not accepted:
             return None
         return event
 
@@ -205,6 +339,8 @@ class LiveChatAdapter:
         old_room = self.health["room_id"]
         if event.room_id and old_room and event.room_id != old_room:
             self.buffer.clear()
+            self.health["viewer_count"] = 0
+            self.health["latest_like_total"] = 0
         if event.room_id:
             self.health["room_id"] = event.room_id
         self.health["last_event_at"] = now
@@ -226,23 +362,74 @@ class LiveChatAdapter:
             self.health["state"] = "error"
             self.health["transport_error_count"] += 1
             self.health["last_error_code"] = event.error_code or "transport_error"
-        elif event.is_comment:
-            self.health["comments_received"] += 1
-            self.health["last_comment_at"] = now
-            return self.buffer.add(event, now=now)
+        elif event.is_observation:
+            self.health["events_received"] += 1
+            if event.is_comment:
+                self.health["comments_received"] += 1
+            accepted = self.buffer.add(event, now=now)
+            if not accepted:
+                return False
+            self.health["events_accepted"] += 1
+            self.health["last_signal_at"] = now
+            if event.event_type == COMMENT:
+                self.health["comments_accepted"] += 1
+                self.health["last_comment_at"] = now
+            elif event.event_type == LIKE:
+                self.health["like_events"] += 1
+                self.health["taps_observed"] += event.like_count
+                if event.like_total:
+                    self.health["latest_like_total"] = event.like_total
+            elif event.event_type == VIEWER_SNAPSHOT:
+                self.health["viewer_snapshots"] += 1
+                self.health["viewer_count"] = event.viewer_count
+                self.health["peak_viewers"] = max(
+                    self.health["peak_viewers"], event.viewer_count
+                )
+            elif event.event_type == SHARE:
+                self.health["shares"] += 1
+            elif event.event_type == FOLLOW:
+                self.health["follows"] += 1
+            elif event.event_type == GIFT:
+                self.health["gift_events"] += 1
+                self.health["gift_units"] += event.gift_count
+                self.health["diamond_total"] += event.diamond_total
+            elif event.event_type == QUESTION:
+                self.health["questions"] += 1
+            elif event.event_type == JOIN:
+                self.health["joins"] += max(1, event.join_count)
+            return True
         return False
 
     def context_snapshot(self, window_seconds: float = 300, limit: int = 100):
         return [
             event.context_record()
-            for event in self.buffer.snapshot(window_seconds, limit, self.time_fn())
+            for event in self.buffer.snapshot(
+                window_seconds,
+                limit,
+                self.time_fn(),
+                event_types=frozenset({COMMENT}),
+            )
+        ]
+
+    def telemetry_snapshot(self, window_seconds: float = 300, limit: int = 500):
+        return [
+            event.telemetry_record()
+            for event in self.buffer.snapshot(
+                window_seconds,
+                limit,
+                self.time_fn(),
+                event_types=RETAINED_EVENTS,
+            )
         ]
 
     def health_snapshot(self) -> Dict[str, Any]:
         self.buffer.prune(self.time_fn())
         return {
             **self.health,
-            "comments_buffered": len(self.buffer.events),
+            "events_buffered": len(self.buffer.events),
+            "comments_buffered": sum(
+                1 for event in self.buffer.events if event.event_type == COMMENT
+            ),
             "seen_event_ids": len(self.buffer.seen),
             "duplicate_count": self.buffer.duplicates,
             "expired_count": self.buffer.expired,
@@ -282,30 +469,82 @@ def parse_line(line: Union[str, bytes], now: Optional[float] = None) -> LiveEven
     if event_type not in ALLOWED_EVENTS:
         raise ProtocolError("unsupported_event_type")
     observed_at = _timestamp(payload.get("observed_at"), current)
+    source_at = _optional_timestamp(
+        payload.get("source_at"), observed_at, MAX_SOURCE_CLOCK_SKEW_SECONDS
+    )
     room_id = _text(payload.get("room_id"), 80)
     event_id = _text(payload.get("event_id"), MAX_TEXT_CHARS)
 
-    if event_type == COMMENT:
-        unique_id = _text(payload.get("unique_id"), 80).lstrip("@")
-        if unique_id and not _HANDLE_RE.fullmatch(unique_id):
-            raise ProtocolError("invalid_unique_id")
-        display_name = _text(payload.get("display_name"), 120)
-        comment_text = _text(payload.get("comment_text"), MAX_COMMENT_CHARS)
-        if not comment_text:
-            raise ProtocolError("empty_comment")
-        event_id = event_id or _fallback_id(
-            event_type, room_id, unique_id, comment_text, observed_at
-        )
-        return LiveEvent(
-            event_type=event_type,
-            event_id=event_id,
-            room_id=room_id,
-            observed_at=observed_at,
-            unique_id=unique_id,
-            display_name=display_name or unique_id or "TikTok viewer",
-            comment_text=comment_text,
-            moderator_flag=_bool(payload.get("moderator_flag")),
-        )
+    if event_type in OBSERVATION_EVENTS:
+        unique_id, display_name, moderator_flag = _identity_fields(payload)
+        kwargs: Dict[str, Any] = {
+            "event_type": event_type,
+            "event_id": event_id,
+            "room_id": room_id,
+            "observed_at": observed_at,
+            "source_at": source_at,
+            "unique_id": unique_id,
+            "display_name": display_name,
+            "moderator_flag": moderator_flag,
+        }
+
+        if event_type == COMMENT:
+            comment_text = _text(payload.get("comment_text"), MAX_COMMENT_CHARS)
+            if not comment_text:
+                raise ProtocolError("empty_comment")
+            kwargs["comment_text"] = comment_text
+        elif event_type == LIKE:
+            like_count = _nonnegative_int(payload.get("like_count"), 10**9)
+            like_total = _nonnegative_int(payload.get("like_total"), 10**12)
+            if like_count <= 0 and like_total <= 0:
+                raise ProtocolError("empty_like_event")
+            kwargs.update({"like_count": like_count, "like_total": like_total})
+        elif event_type == VIEWER_SNAPSHOT:
+            kwargs["viewer_count"] = _nonnegative_int(
+                payload.get("viewer_count"), 10**9
+            )
+        elif event_type == SHARE:
+            kwargs["share_type"] = _nonnegative_int(payload.get("share_type"), 1000)
+        elif event_type == GIFT:
+            gift_count = max(1, _nonnegative_int(payload.get("gift_count"), 10**9))
+            kwargs.update(
+                {
+                    "gift_id": _nonnegative_int(payload.get("gift_id"), 10**12),
+                    "gift_name": _text(payload.get("gift_name"), 160) or "Gift",
+                    "gift_count": gift_count,
+                    "diamond_count": _nonnegative_int(
+                        payload.get("diamond_count"), 10**9
+                    ),
+                    "diamond_total": _nonnegative_int(
+                        payload.get("diamond_total"), 10**12
+                    ),
+                    "combo": _bool(payload.get("combo")),
+                    "streak_over": _bool(payload.get("streak_over")),
+                }
+            )
+        elif event_type == QUESTION:
+            question_text = _text(payload.get("question_text"), MAX_QUESTION_CHARS)
+            if not question_text:
+                raise ProtocolError("empty_question")
+            kwargs.update(
+                {
+                    "question_id": _text(payload.get("question_id"), 120),
+                    "question_text": question_text,
+                    "answer_status": _nonnegative_int(
+                        payload.get("answer_status"), 1000
+                    ),
+                }
+            )
+        elif event_type == JOIN:
+            kwargs["join_count"] = max(
+                1, _nonnegative_int(payload.get("join_count"), 10**6)
+            )
+
+        if not event_id:
+            kwargs["event_id"] = _fallback_observation_id(
+                event_type, room_id, payload, source_at or observed_at
+            )
+        return LiveEvent(**kwargs)
 
     event_id = event_id or _fallback_id(event_type, room_id, "", "", observed_at)
     return LiveEvent(
@@ -313,12 +552,23 @@ def parse_line(line: Union[str, bytes], now: Optional[float] = None) -> LiveEven
         event_id=event_id,
         room_id=room_id,
         observed_at=observed_at,
+        source_at=source_at,
         error_code=(
             _code(payload.get("error_code"), "transport_error")
             if event_type == "transport_error"
             else ""
         ),
     )
+
+
+def _identity_fields(payload: Mapping) -> tuple:
+    unique_id = _text(payload.get("unique_id"), 80).lstrip("@")
+    if unique_id and not _HANDLE_RE.fullmatch(unique_id):
+        raise ProtocolError("invalid_unique_id")
+    display_name = _text(payload.get("display_name"), 120)
+    if unique_id or display_name:
+        display_name = display_name or unique_id or "TikTok viewer"
+    return unique_id, display_name, _bool(payload.get("moderator_flag"))
 
 
 def _text(value: Any, limit: int) -> str:
@@ -340,23 +590,87 @@ def _bool(value: Any) -> bool:
     return isinstance(value, str) and value.lower().strip() in {"1", "true", "yes"}
 
 
-def _timestamp(value: Any, now: float) -> float:
-    parsed: Optional[float] = None
+def _nonnegative_int(value: Any, maximum: int) -> int:
+    if isinstance(value, bool):
+        return 0
     try:
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
-            parsed = float(value)
-        elif isinstance(value, str):
-            text = value.strip().replace("Z", "+00:00")
-            try:
-                parsed = float(text)
-            except ValueError:
-                dt = datetime.fromisoformat(text)
-                parsed = (dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)).timestamp()
+        numeric = int(value)
     except (TypeError, ValueError, OverflowError):
-        parsed = None
+        return 0
+    return min(maximum, max(0, numeric))
+
+
+def _timestamp(value: Any, now: float) -> float:
+    parsed = _parse_timestamp(value)
     if parsed is None or not math.isfinite(parsed):
         return now
     return parsed if abs(parsed - now) <= MAX_CLOCK_SKEW_SECONDS else now
+
+
+def _optional_timestamp(value: Any, reference: float, max_skew: float) -> float:
+    parsed = _parse_timestamp(value)
+    if parsed is None or not math.isfinite(parsed):
+        return 0.0
+    return parsed if abs(parsed - reference) <= max_skew else 0.0
+
+
+def _parse_timestamp(value: Any) -> Optional[float]:
+    try:
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            numeric = float(value)
+            if numeric > 10**15:
+                numeric /= 1_000_000.0
+            elif numeric > 10**11:
+                numeric /= 1_000.0
+            return numeric
+        if isinstance(value, str):
+            text = value.strip().replace("Z", "+00:00")
+            try:
+                numeric = float(text)
+                if numeric > 10**15:
+                    numeric /= 1_000_000.0
+                elif numeric > 10**11:
+                    numeric /= 1_000.0
+                return numeric
+            except ValueError:
+                dt = datetime.fromisoformat(text)
+                return (dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)).timestamp()
+    except (TypeError, ValueError, OverflowError, OSError):
+        return None
+    return None
+
+
+def _fallback_observation_id(
+    event_type: str,
+    room_id: str,
+    payload: Mapping,
+    event_time: float,
+) -> str:
+    safe: Dict[str, Any] = {
+        "event_type": event_type,
+        "room_id": room_id,
+        "unique_id": _text(payload.get("unique_id"), 80),
+        "event_time": "{:.3f}".format(event_time),
+    }
+    for key in (
+        "comment_text",
+        "like_count",
+        "like_total",
+        "viewer_count",
+        "share_type",
+        "gift_id",
+        "gift_count",
+        "diamond_total",
+        "question_id",
+        "question_text",
+        "join_count",
+    ):
+        if key in payload:
+            safe[key] = payload.get(key)
+    raw = json.dumps(safe, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8", errors="replace"
+    )
+    return "local:" + hashlib.sha256(raw).hexdigest()[:32]
 
 
 def _fallback_id(

--- a/scripts/tiktok_live_chat_shadow_window.py
+++ b/scripts/tiktok_live_chat_shadow_window.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Supervise the read-only TikTok LIVE collector for one weekly show window.
+"""Supervise the read-only TikTok LIVE telemetry collector for one show window.
 
 The supervisor keeps replay suppression across child-process reconnects, stops
 an ended Webcast connection immediately, and starts a fresh connection until
@@ -12,12 +12,8 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import os
-import re
-import signal
 import sys
-from dataclasses import dataclass
-from datetime import datetime, time as clock_time, timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional, Sequence, Set
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -26,322 +22,32 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from bnl_tiktok_live_chat import LiveChatAdapter, LiveChatBuffer, LiveEvent
-
-DEFAULT_TIMEZONE = "America/Los_Angeles"
-DEFAULT_WEEKDAY = 4  # Monday=0, Friday=4
-DEFAULT_WINDOW_START = clock_time(18, 50)
-DEFAULT_WINDOW_END = clock_time(2, 0)
-DEFAULT_RETRY_SECONDS = 20.0
-DEFAULT_BUFFER_EVENTS = 5000
-DEFAULT_DEDUPE_SECONDS = 8 * 60 * 60
-
-_CLOCK_RE = re.compile(r"^(?:[01]\d|2[0-3]):[0-5]\d$")
-_USERNAME_RE = re.compile(r"^[A-Za-z0-9._]+$")
-_SAFE_CODE_RE = re.compile(r"[^A-Za-z0-9_.:-]+")
-_WEEKDAYS = {
-    "monday": 0,
-    "mon": 0,
-    "tuesday": 1,
-    "tue": 1,
-    "wednesday": 2,
-    "wed": 2,
-    "thursday": 3,
-    "thu": 3,
-    "friday": 4,
-    "fri": 4,
-    "saturday": 5,
-    "sat": 5,
-    "sunday": 6,
-    "sun": 6,
-}
-
-
-@dataclass(frozen=True)
-class ActiveWindow:
-    start: datetime
-    end: datetime
-
-
-@dataclass
-class CycleState:
-    saw_connected: bool = False
-    saw_live_end: bool = False
-    comments_emitted: int = 0
-    duplicate_replays_suppressed: int = 0
-    invalid_lines: int = 0
-
-
-@dataclass(frozen=True)
-class CycleResult:
-    return_code: int
-    state: CycleState
-    stop_reason: str
-
-
-def parse_clock(value: str) -> clock_time:
-    text = str(value).strip()
-    if not _CLOCK_RE.fullmatch(text):
-        raise argparse.ArgumentTypeError("time must use 24-hour HH:MM format")
-    hour, minute = (int(part) for part in text.split(":", 1))
-    return clock_time(hour, minute)
-
-
-def parse_weekday(value: str) -> int:
-    text = str(value).strip().lower()
-    if text.isdigit():
-        numeric = int(text)
-        if 0 <= numeric <= 6:
-            return numeric
-    if text in _WEEKDAYS:
-        return _WEEKDAYS[text]
-    raise argparse.ArgumentTypeError("weekday must be monday-sunday or 0-6")
-
-
-def normalize_username(value: str) -> str:
-    username = str(value).strip().lstrip("@")
-    if not username or not _USERNAME_RE.fullmatch(username):
-        raise argparse.ArgumentTypeError(
-            "TikTok username may contain letters, numbers, periods, and underscores"
-        )
-    return username
-
-
-def resolve_active_window(
-    now: datetime,
-    weekday: int,
-    start_time: clock_time,
-    end_time: clock_time,
-) -> Optional[ActiveWindow]:
-    """Return the current scheduled window, including a cross-midnight tail."""
-
-    if now.tzinfo is None or now.utcoffset() is None:
-        raise ValueError("now must be timezone-aware")
-    if start_time == end_time:
-        raise ValueError("window start and end must differ")
-    if not 0 <= weekday <= 6:
-        raise ValueError("weekday must be between 0 and 6")
-
-    local_date = now.date()
-    local_clock = now.timetz().replace(tzinfo=None)
-
-    if start_time < end_time:
-        if now.weekday() != weekday or not (start_time <= local_clock < end_time):
-            return None
-        start = datetime.combine(local_date, start_time, tzinfo=now.tzinfo)
-        end = datetime.combine(local_date, end_time, tzinfo=now.tzinfo)
-        return ActiveWindow(start=start, end=end)
-
-    next_weekday = (weekday + 1) % 7
-    if now.weekday() == weekday and local_clock >= start_time:
-        start = datetime.combine(local_date, start_time, tzinfo=now.tzinfo)
-        end = datetime.combine(local_date + timedelta(days=1), end_time, tzinfo=now.tzinfo)
-        return ActiveWindow(start=start, end=end)
-    if now.weekday() == next_weekday and local_clock < end_time:
-        start = datetime.combine(local_date - timedelta(days=1), start_time, tzinfo=now.tzinfo)
-        end = datetime.combine(local_date, end_time, tzinfo=now.tzinfo)
-        return ActiveWindow(start=start, end=end)
-    return None
-
-
-def format_event(event: LiveEvent, timezone: ZoneInfo) -> str:
-    stamp = datetime.fromtimestamp(event.observed_at, tz=timezone).strftime("%H:%M:%S")
-    if event.is_comment:
-        handle = event.unique_id or event.display_name or "viewer"
-        moderator = " [MOD]" if event.moderator_flag else ""
-        return "{} @{}{}: {}".format(stamp, handle, moderator, event.comment_text)
-
-    room_id = event.room_id or "-"
-    suffix = ""
-    if event.event_type == "transport_error" and event.error_code:
-        suffix = " error={}".format(event.error_code)
-    return "[{}] {} room={}{}".format(stamp, event.event_type, room_id, suffix)
-
-
-def _safe_code(value: object, fallback: str = "transport_diagnostic") -> str:
-    text = str(value).strip()[:120]
-    return _SAFE_CODE_RE.sub("_", text).strip("_") or fallback
-
-
-def build_transport_command(args: argparse.Namespace) -> list[str]:
-    return [
-        str(args.python),
-        "-u",
-        str(args.transport_script),
-        "--username",
-        args.username,
-        "--cdn",
-        args.cdn,
-        "--max-retries",
-        str(args.max_retries),
-        "--stale-timeout",
-        str(args.stale_timeout),
-        "--dedupe-capacity",
-        str(args.transport_dedupe_capacity),
-    ]
-
-
-async def _drain_stderr(reader: asyncio.StreamReader) -> None:
-    async for raw in reader:
-        try:
-            text = raw.decode("utf-8", errors="replace")
-        except AttributeError:
-            text = str(raw)
-        code = _safe_code(text)
-        if code:
-            print("[transport] {}".format(code), flush=True)
-
-
-async def _consume_stdout(
-    reader: asyncio.StreamReader,
-    process: asyncio.subprocess.Process,
-    adapter: LiveChatAdapter,
-    timezone: ZoneInfo,
-    ended_rooms: Set[str],
-    state: CycleState,
-) -> None:
-    async for raw in reader:
-        duplicates_before = adapter.buffer.duplicates
-        invalid_before = int(adapter.health["invalid_lines"])
-        event = adapter.ingest_line(raw)
-        state.duplicate_replays_suppressed += (
-            adapter.buffer.duplicates - duplicates_before
-        )
-        state.invalid_lines += int(adapter.health["invalid_lines"]) - invalid_before
-        if event is None:
-            continue
-
-        if event.event_type == "connected":
-            state.saw_connected = True
-            if not event.room_id or event.room_id not in ended_rooms:
-                print(format_event(event, timezone), flush=True)
-            continue
-
-        if event.is_comment:
-            state.comments_emitted += 1
-            print(format_event(event, timezone), flush=True)
-            continue
-
-        if event.event_type == "live_ended":
-            state.saw_live_end = True
-            first_end_for_room = not event.room_id or event.room_id not in ended_rooms
-            if event.room_id:
-                ended_rooms.add(event.room_id)
-            if first_end_for_room:
-                print(format_event(event, timezone), flush=True)
-            if process.returncode is None:
-                try:
-                    process.terminate()
-                except ProcessLookupError:
-                    pass
-            return
-
-        if event.event_type == "reconnecting" and event.room_id in ended_rooms:
-            continue
-        print(format_event(event, timezone), flush=True)
-
-
-async def _terminate_process(process: asyncio.subprocess.Process) -> None:
-    if process.returncode is not None:
-        return
-    try:
-        process.terminate()
-    except ProcessLookupError:
-        return
-    try:
-        await asyncio.wait_for(process.wait(), timeout=5.0)
-    except asyncio.TimeoutError:
-        try:
-            process.kill()
-        except ProcessLookupError:
-            return
-        await process.wait()
-
-
-async def run_transport_cycle(
-    args: argparse.Namespace,
-    adapter: LiveChatAdapter,
-    timezone: ZoneInfo,
-    ended_rooms: Set[str],
-    stop_event: asyncio.Event,
-    deadline: datetime,
-) -> CycleResult:
-    command = build_transport_command(args)
-    env = os.environ.copy()
-    env["PYTHONUNBUFFERED"] = "1"
-    env["PYTHONDONTWRITEBYTECODE"] = "1"
-    process = await asyncio.create_subprocess_exec(
-        *command,
-        cwd=str(REPO_ROOT),
-        env=env,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    assert process.stdout is not None
-    assert process.stderr is not None
-
-    state = CycleState()
-    stdout_task = asyncio.create_task(
-        _consume_stdout(
-            process.stdout,
-            process,
-            adapter,
-            timezone,
-            ended_rooms,
-            state,
-        )
-    )
-    stderr_task = asyncio.create_task(_drain_stderr(process.stderr))
-    process_task = asyncio.create_task(process.wait())
-    stop_task = asyncio.create_task(stop_event.wait())
-
-    remaining = max(0.0, (deadline - datetime.now(timezone)).total_seconds())
-    done, _pending = await asyncio.wait(
-        {process_task, stop_task},
-        timeout=remaining,
-        return_when=asyncio.FIRST_COMPLETED,
-    )
-
-    stop_reason = "process_exit"
-    if not done:
-        stop_reason = "window_closed"
-        await _terminate_process(process)
-    elif stop_task in done and stop_event.is_set():
-        stop_reason = "stop_requested"
-        await _terminate_process(process)
-
-    return_code = await process.wait()
-    await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
-    for task in (process_task, stop_task):
-        if not task.done():
-            task.cancel()
-    return CycleResult(return_code=return_code, state=state, stop_reason=stop_reason)
-
-
-async def _sleep_until_retry(
-    seconds: float,
-    stop_event: asyncio.Event,
-    deadline: datetime,
-    timezone: ZoneInfo,
-) -> None:
-    remaining = max(0.0, (deadline - datetime.now(timezone)).total_seconds())
-    delay = min(float(seconds), remaining)
-    if delay <= 0:
-        return
-    try:
-        await asyncio.wait_for(stop_event.wait(), timeout=delay)
-    except asyncio.TimeoutError:
-        pass
-
-
-def _install_signal_handlers(stop_event: asyncio.Event) -> None:
-    loop = asyncio.get_running_loop()
-    for signal_name in (signal.SIGINT, signal.SIGTERM):
-        try:
-            loop.add_signal_handler(signal_name, stop_event.set)
-        except (NotImplementedError, RuntimeError, ValueError):
-            pass
-
+from bnl_tiktok_live_chat import LiveChatAdapter, LiveChatBuffer  # noqa: E402
+from scripts.tiktok_live_shadow_model import (
+    DEFAULT_BUFFER_EVENTS,
+    DEFAULT_DEDUPE_SECONDS,
+    DEFAULT_RETRY_SECONDS,
+    DEFAULT_TIMEZONE,
+    DEFAULT_WEEKDAY,
+    DEFAULT_WINDOW_END,
+    DEFAULT_WINDOW_START,
+    REPO_ROOT,
+    ActiveWindow,
+    CycleResult,
+    CycleState,
+    build_transport_command,
+    format_event,
+    normalize_username,
+    parse_clock,
+    parse_weekday,
+    resolve_active_window,
+)
+from scripts.tiktok_live_shadow_runtime import (
+    _install_signal_handlers,
+    _sleep_until_retry,
+    format_summary,
+    run_transport_cycle,
+)
 
 async def run_window(args: argparse.Namespace) -> int:
     try:
@@ -380,7 +86,7 @@ async def run_window(args: argparse.Namespace) -> int:
     ended_rooms: Set[str] = set()
     cycle_count = 0
 
-    print("[shadow] BARCODE TikTok LIVE chat monitor", flush=True)
+    print("[shadow] BARCODE TikTok LIVE telemetry monitor", flush=True)
     print("[shadow] Target: @{}".format(args.username), flush=True)
     print(
         "[shadow] Window: {} to {} {}".format(
@@ -391,6 +97,10 @@ async def run_window(args: argparse.Namespace) -> int:
         flush=True,
     )
     print("[shadow] Waiting for the account to become LIVE...", flush=True)
+    print(
+        "[shadow] Signals: comments, taps, viewers, shares, follows, gifts, questions, joins",
+        flush=True,
+    )
     print("[shadow] Replay suppression: active", flush=True)
     print(flush=True)
 
@@ -409,7 +119,7 @@ async def run_window(args: argparse.Namespace) -> int:
 
         if result.state.duplicate_replays_suppressed:
             print(
-                "[shadow] Suppressed {} replayed comment(s).".format(
+                "[shadow] Suppressed {} replayed event(s).".format(
                     result.state.duplicate_replays_suppressed
                 ),
                 flush=True,
@@ -447,15 +157,7 @@ async def run_window(args: argparse.Namespace) -> int:
 
     health = adapter.health_snapshot()
     print(flush=True)
-    print(
-        "[shadow] Window closed. comments={} duplicates_suppressed={} reconnects={} cycles={}".format(
-            health["comments_received"] - health["duplicate_count"],
-            health["duplicate_count"],
-            health["reconnect_count"],
-            cycle_count,
-        ),
-        flush=True,
-    )
+    print(format_summary(health, cycle_count), flush=True)
     return 0
 
 
@@ -530,7 +232,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         parser.error("--max-retries must be between 0 and 100")
     if args.stale_timeout < 10 or args.stale_timeout > 600:
         parser.error("--stale-timeout must be between 10 and 600")
-    if args.run_for_seconds is not None and not (1 <= args.run_for_seconds <= 24 * 60 * 60):
+    if args.run_for_seconds is not None and not (
+        1 <= args.run_for_seconds <= 24 * 60 * 60
+    ):
         parser.error("--run-for-seconds must be between 1 and 86400")
     if not args.transport_script.is_file():
         parser.error("transport script does not exist")

--- a/scripts/tiktok_live_chat_transport.py
+++ b/scripts/tiktok_live_chat_transport.py
@@ -1,275 +1,43 @@
 #!/usr/bin/env python3
-"""Emit a read-only TikTok LIVE comment stream as versioned NDJSON.
+"""Emit read-only TikTok LIVE public telemetry as versioned NDJSON.
 
 This script is intentionally isolated from the main BNL environment. It imports
-``piratetok_live`` only after argument validation, listens only for comments and
-connection lifecycle events, writes protocol objects to stdout, and writes only
-bounded diagnostic codes to stderr. It cannot post, moderate, gift, follow, or
-change BARCODE show state.
+``piratetok_live`` only after argument validation, listens only for public LIVE
+observations and connection lifecycle events, writes protocol objects to
+stdout, and writes only bounded diagnostic codes to stderr. It cannot post,
+moderate, gift, follow, or change BARCODE show state.
 """
 
 from __future__ import annotations
 
 import argparse
-import hashlib
-import json
-import re
 import signal
 import sys
-from collections import OrderedDict
-from collections.abc import Mapping
-from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
 
-SCHEMA_VERSION = 1
-MAX_ROOM_ID_CHARS = 80
-MAX_UNIQUE_ID_CHARS = 80
-MAX_DISPLAY_NAME_CHARS = 120
-MAX_COMMENT_CHARS = 1000
-MAX_ERROR_CODE_CHARS = 80
-DEFAULT_DEDUPE_CAPACITY = 20_000
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
-_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
-_WHITESPACE_RE = re.compile(r"\s+")
-_SAFE_CODE_RE = re.compile(r"[^A-Za-z0-9_.:-]+")
-_USERNAME_RE = re.compile(r"^[A-Za-z0-9._]+$")
-
-
-class EventIdDeduper:
-    """Bound replay suppression without retaining comment text."""
-
-    def __init__(self, capacity: int = DEFAULT_DEDUPE_CAPACITY) -> None:
-        if capacity <= 0:
-            raise ValueError("dedupe capacity must be positive")
-        self.capacity = int(capacity)
-        self._event_ids: "OrderedDict[str, None]" = OrderedDict()
-        self.duplicates = 0
-
-    def accept(self, event_id: str) -> bool:
-        if not event_id:
-            return True
-        if event_id in self._event_ids:
-            self._event_ids.move_to_end(event_id)
-            self.duplicates += 1
-            return False
-        self._event_ids[event_id] = None
-        while len(self._event_ids) > self.capacity:
-            self._event_ids.popitem(last=False)
-        return True
-
-
-def _bounded_text(value: Any, max_chars: int) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, (str, int, float, bool)):
-        text = str(value)
-    else:
-        return ""
-    text = _CONTROL_CHAR_RE.sub(" ", text)
-    text = _WHITESPACE_RE.sub(" ", text).strip()
-    return text[:max_chars].rstrip()
-
-
-def _bounded_code(value: Any, fallback: str) -> str:
-    text = _bounded_text(value, MAX_ERROR_CODE_CHARS)
-    text = _SAFE_CODE_RE.sub("_", text).strip("_")
-    return text or fallback
-
-
-def _utc_now() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def _mapping(value: Any) -> Mapping:
-    return value if isinstance(value, Mapping) else {}
-
-
-def _first_nonempty(*values: Any) -> str:
-    for value in values:
-        text = _bounded_text(value, MAX_DISPLAY_NAME_CHARS)
-        if text:
-            return text
-    return ""
-
-
-def _coerce_int(value: Any, default: int = 0) -> int:
-    if isinstance(value, bool):
-        return default
-    try:
-        return int(value)
-    except (TypeError, ValueError, OverflowError):
-        return default
-
-
-def normalize_username(value: str) -> str:
-    username = _bounded_text(value, MAX_UNIQUE_ID_CHARS).lstrip("@").strip()
-    if not username:
-        raise argparse.ArgumentTypeError("TikTok username is required")
-    if not _USERNAME_RE.fullmatch(username):
-        raise argparse.ArgumentTypeError(
-            "TikTok username may contain letters, numbers, periods, and underscores"
-        )
-    return username
-
-
-def _event_room_id(event: Any, data: Mapping) -> str:
-    common = _mapping(data.get("common"))
-    return _bounded_text(
-        _first_nonempty(
-            getattr(event, "room_id", ""),
-            data.get("roomId"),
-            data.get("room_id"),
-            common.get("roomId"),
-            common.get("room_id"),
-        ),
-        MAX_ROOM_ID_CHARS,
-    )
-
-
-def _event_message_id(data: Mapping) -> str:
-    common = _mapping(data.get("common"))
-    return _first_nonempty(
-        common.get("msgId"),
-        common.get("msg_id"),
-        data.get("msgId"),
-        data.get("msg_id"),
-        common.get("logId"),
-        common.get("log_id"),
-    )
-
-
-def _event_source_time(data: Mapping) -> str:
-    common = _mapping(data.get("common"))
-    return _first_nonempty(
-        common.get("createTime"),
-        common.get("create_time"),
-        common.get("clientSendTime"),
-        common.get("client_send_time"),
-        data.get("createTime"),
-        data.get("create_time"),
-    )
-
-
-def _moderator_flag(user: Mapping) -> bool:
-    identity = _mapping(user.get("identity"))
-    user_attr = _mapping(user.get("userAttr"))
-    if not user_attr:
-        user_attr = _mapping(user.get("user_attr"))
-    return any(
-        bool(value)
-        for value in (
-            identity.get("isModeratorOfAnchor"),
-            identity.get("is_moderator_of_anchor"),
-            user_attr.get("isAdmin"),
-            user_attr.get("is_admin"),
-            user_attr.get("isSuperAdmin"),
-            user_attr.get("is_super_admin"),
-        )
-    )
-
-
-def _fallback_event_id(
-    room_id: str,
-    unique_id: str,
-    comment_text: str,
-    source_marker: str,
-) -> str:
-    material = "\x1f".join(
-        [room_id, unique_id, comment_text, source_marker]
-    ).encode("utf-8", errors="replace")
-    return "local:{}".format(hashlib.sha256(material).hexdigest()[:32])
-
-
-def build_comment_payload(event: Any) -> Optional[Dict[str, Any]]:
-    data = _mapping(getattr(event, "data", {}))
-    user = _mapping(data.get("user"))
-    comment_text = _bounded_text(data.get("content"), MAX_COMMENT_CHARS)
-    if not comment_text:
-        return None
-
-    unique_id = _bounded_text(
-        _first_nonempty(user.get("uniqueId"), user.get("unique_id")),
-        MAX_UNIQUE_ID_CHARS,
-    ).lstrip("@")
-    display_name = _bounded_text(
-        _first_nonempty(user.get("nickname"), unique_id, "TikTok viewer"),
-        MAX_DISPLAY_NAME_CHARS,
-    )
-    room_id = _event_room_id(event, data)
-    observed_at = _utc_now()
-    message_id = _bounded_text(_event_message_id(data), 120)
-    event_id = (
-        "tiktok:{}:{}".format(room_id or "room", message_id)
-        if message_id
-        else _fallback_event_id(
-            room_id,
-            unique_id,
-            comment_text,
-            _event_source_time(data) or observed_at,
-        )
-    )
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "event_type": "comment",
-        "event_id": event_id,
-        "room_id": room_id,
-        "observed_at": observed_at,
-        "unique_id": unique_id,
-        "display_name": display_name,
-        "comment_text": comment_text,
-        "moderator_flag": _moderator_flag(user),
-    }
-
-
-def build_lifecycle_payload(event_type: str, event: Any) -> Dict[str, Any]:
-    data = _mapping(getattr(event, "data", {}))
-    room_id = _event_room_id(event, data)
-    payload: Dict[str, Any] = {
-        "schema_version": SCHEMA_VERSION,
-        "event_type": event_type,
-        "event_id": "{}:{}:{}".format(
-            event_type, room_id or "room", datetime.now(timezone.utc).timestamp()
-        ),
-        "room_id": room_id,
-        "observed_at": _utc_now(),
-    }
-    if event_type == "reconnecting":
-        payload.update(
-            {
-                "attempt": max(0, _coerce_int(data.get("attempt"))),
-                "max_retries": max(0, _coerce_int(data.get("max_retries"))),
-                "delay_seconds": max(0, _coerce_int(data.get("delay"))),
-            }
-        )
-    return payload
-
-
-def build_transport_error_payload(error: Any) -> Dict[str, Any]:
-    error_code = _bounded_code(
-        error.__class__.__name__ if isinstance(error, BaseException) else error,
-        "transport_error",
-    )
-    observed_at = _utc_now()
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "event_type": "transport_error",
-        "event_id": "transport_error:{}".format(observed_at),
-        "room_id": "",
-        "observed_at": observed_at,
-        "error_code": error_code,
-    }
-
-
-def emit_payload(payload: Mapping) -> None:
-    sys.stdout.write(json.dumps(dict(payload), separators=(",", ":"), sort_keys=True))
-    sys.stdout.write("\n")
-    sys.stdout.flush()
-
-
-def emit_diagnostic(code: str) -> None:
-    sys.stderr.write(_bounded_code(code, "transport_diagnostic") + "\n")
-    sys.stderr.flush()
-
+from scripts.tiktok_live_telemetry_common import (  # noqa: E402
+    DEFAULT_DEDUPE_CAPACITY,
+    EventIdDeduper,
+    build_lifecycle_payload,
+    build_transport_error_payload,
+    emit_diagnostic,
+    emit_payload,
+    normalize_username,
+)
+from scripts.tiktok_live_telemetry_payloads import (  # noqa: E402
+    build_comment_payload,
+    build_gift_payload,
+    build_join_payload,
+    build_like_payload,
+    build_question_payload,
+    build_social_payload,
+    build_viewer_snapshot_payload,
+)
 
 def run_transport(args: argparse.Namespace) -> int:
     try:
@@ -287,9 +55,21 @@ def run_transport(args: argparse.Namespace) -> int:
     client.max_retries(args.max_retries)
     client.stale_timeout(args.stale_timeout)
 
-    comment_deduper = EventIdDeduper(args.dedupe_capacity)
+    event_deduper = EventIdDeduper(args.dedupe_capacity)
     stream_ended = False
     disconnected_emitted = False
+
+    def emit_observation(builder: Callable[[Any], Optional[Dict[str, Any]]], event: Any) -> None:
+        if stream_ended:
+            return
+        payload = builder(event)
+        if payload is not None and event_deduper.accept(payload["event_id"]):
+            emit_payload(payload)
+
+    def register_optional(name: str, callback: Callable[[Any], None]) -> None:
+        event_value = getattr(EventType, name, None)
+        if event_value is not None:
+            client.on(event_value)(callback)
 
     @client.on(EventType.connected)
     def on_connected(event: Any) -> None:
@@ -298,11 +78,36 @@ def run_transport(args: argparse.Namespace) -> int:
 
     @client.on(EventType.chat)
     def on_chat(event: Any) -> None:
-        if stream_ended:
-            return
-        payload = build_comment_payload(event)
-        if payload is not None and comment_deduper.accept(payload["event_id"]):
-            emit_payload(payload)
+        emit_observation(build_comment_payload, event)
+
+    def on_like(event: Any) -> None:
+        emit_observation(build_like_payload, event)
+
+    def on_viewer_snapshot(event: Any) -> None:
+        emit_observation(build_viewer_snapshot_payload, event)
+
+    def on_share(event: Any) -> None:
+        emit_observation(lambda value: build_social_payload("share", value), event)
+
+    def on_follow(event: Any) -> None:
+        emit_observation(lambda value: build_social_payload("follow", value), event)
+
+    def on_gift(event: Any) -> None:
+        emit_observation(build_gift_payload, event)
+
+    def on_question(event: Any) -> None:
+        emit_observation(build_question_payload, event)
+
+    def on_join(event: Any) -> None:
+        emit_observation(build_join_payload, event)
+
+    register_optional("like", on_like)
+    register_optional("room_user_seq", on_viewer_snapshot)
+    register_optional("share", on_share)
+    register_optional("follow", on_follow)
+    register_optional("gift", on_gift)
+    register_optional("question_new", on_question)
+    register_optional("join", on_join)
 
     @client.on(EventType.reconnecting)
     def on_reconnecting(event: Any) -> None:
@@ -355,7 +160,7 @@ def run_transport(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Read TikTok LIVE comments and emit BARCODE shadow NDJSON"
+        description="Read TikTok LIVE public telemetry and emit BARCODE shadow NDJSON"
     )
     parser.add_argument("--username", required=True, type=normalize_username)
     parser.add_argument(
@@ -370,7 +175,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--dedupe-capacity",
         type=int,
         default=DEFAULT_DEDUPE_CAPACITY,
-        help="Maximum recent TikTok message IDs retained for replay suppression",
+        help="Maximum recent TikTok event IDs retained for replay suppression",
     )
     return parser
 

--- a/scripts/tiktok_live_shadow_model.py
+++ b/scripts/tiktok_live_shadow_model.py
@@ -1,0 +1,225 @@
+"""Schedule, formatting, and immutable models for TikTok LIVE shadow monitoring."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import signal
+import sys
+from dataclasses import dataclass
+from datetime import datetime, time as clock_time, timedelta
+from pathlib import Path
+from typing import Optional, Sequence, Set
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from bnl_tiktok_live_chat import (  # noqa: E402
+    FOLLOW,
+    GIFT,
+    JOIN,
+    LIKE,
+    QUESTION,
+    SHARE,
+    VIEWER_SNAPSHOT,
+    LiveChatAdapter,
+    LiveChatBuffer,
+    LiveEvent,
+)
+
+DEFAULT_TIMEZONE = "America/Los_Angeles"
+DEFAULT_WEEKDAY = 4  # Monday=0, Friday=4
+DEFAULT_WINDOW_START = clock_time(18, 50)
+DEFAULT_WINDOW_END = clock_time(2, 0)
+DEFAULT_RETRY_SECONDS = 20.0
+DEFAULT_BUFFER_EVENTS = 5000
+DEFAULT_DEDUPE_SECONDS = 8 * 60 * 60
+
+_CLOCK_RE = re.compile(r"^(?:[01]\d|2[0-3]):[0-5]\d$")
+_USERNAME_RE = re.compile(r"^[A-Za-z0-9._]+$")
+_SAFE_CODE_RE = re.compile(r"[^A-Za-z0-9_.:-]+")
+_WEEKDAYS = {
+    "monday": 0,
+    "mon": 0,
+    "tuesday": 1,
+    "tue": 1,
+    "wednesday": 2,
+    "wed": 2,
+    "thursday": 3,
+    "thu": 3,
+    "friday": 4,
+    "fri": 4,
+    "saturday": 5,
+    "sat": 5,
+    "sunday": 6,
+    "sun": 6,
+}
+
+
+@dataclass(frozen=True)
+class ActiveWindow:
+    start: datetime
+    end: datetime
+
+
+@dataclass
+class CycleState:
+    saw_connected: bool = False
+    saw_live_end: bool = False
+    events_emitted: int = 0
+    comments_emitted: int = 0
+    duplicate_replays_suppressed: int = 0
+    invalid_lines: int = 0
+    last_viewer_count: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class CycleResult:
+    return_code: int
+    state: CycleState
+    stop_reason: str
+
+
+def parse_clock(value: str) -> clock_time:
+    text = str(value).strip()
+    if not _CLOCK_RE.fullmatch(text):
+        raise argparse.ArgumentTypeError("time must use 24-hour HH:MM format")
+    hour, minute = (int(part) for part in text.split(":", 1))
+    return clock_time(hour, minute)
+
+
+def parse_weekday(value: str) -> int:
+    text = str(value).strip().lower()
+    if text.isdigit():
+        numeric = int(text)
+        if 0 <= numeric <= 6:
+            return numeric
+    if text in _WEEKDAYS:
+        return _WEEKDAYS[text]
+    raise argparse.ArgumentTypeError("weekday must be monday-sunday or 0-6")
+
+
+def normalize_username(value: str) -> str:
+    username = str(value).strip().lstrip("@")
+    if not username or not _USERNAME_RE.fullmatch(username):
+        raise argparse.ArgumentTypeError(
+            "TikTok username may contain letters, numbers, periods, and underscores"
+        )
+    return username
+
+
+def resolve_active_window(
+    now: datetime,
+    weekday: int,
+    start_time: clock_time,
+    end_time: clock_time,
+) -> Optional[ActiveWindow]:
+    """Return the current scheduled window, including a cross-midnight tail."""
+
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise ValueError("now must be timezone-aware")
+    if start_time == end_time:
+        raise ValueError("window start and end must differ")
+    if not 0 <= weekday <= 6:
+        raise ValueError("weekday must be between 0 and 6")
+
+    local_date = now.date()
+    local_clock = now.timetz().replace(tzinfo=None)
+
+    if start_time < end_time:
+        if now.weekday() != weekday or not (start_time <= local_clock < end_time):
+            return None
+        start = datetime.combine(local_date, start_time, tzinfo=now.tzinfo)
+        end = datetime.combine(local_date, end_time, tzinfo=now.tzinfo)
+        return ActiveWindow(start=start, end=end)
+
+    next_weekday = (weekday + 1) % 7
+    if now.weekday() == weekday and local_clock >= start_time:
+        start = datetime.combine(local_date, start_time, tzinfo=now.tzinfo)
+        end = datetime.combine(
+            local_date + timedelta(days=1), end_time, tzinfo=now.tzinfo
+        )
+        return ActiveWindow(start=start, end=end)
+    if now.weekday() == next_weekday and local_clock < end_time:
+        start = datetime.combine(
+            local_date - timedelta(days=1), start_time, tzinfo=now.tzinfo
+        )
+        end = datetime.combine(local_date, end_time, tzinfo=now.tzinfo)
+        return ActiveWindow(start=start, end=end)
+    return None
+
+
+def _handle(event: LiveEvent) -> str:
+    return event.unique_id or event.display_name or "viewer"
+
+
+def format_event(event: LiveEvent, timezone: ZoneInfo) -> str:
+    stamp = datetime.fromtimestamp(event.event_time, tz=timezone).strftime("%H:%M:%S")
+    if event.is_comment:
+        moderator = " [MOD]" if event.moderator_flag else ""
+        return "{} @{}{}: {}".format(
+            stamp, _handle(event), moderator, event.comment_text
+        )
+    if event.event_type == LIKE:
+        total = " (total {:,})".format(event.like_total) if event.like_total else ""
+        return "{} [TAPS] +{:,}{}".format(stamp, event.like_count, total)
+    if event.event_type == VIEWER_SNAPSHOT:
+        return "{} [VIEWERS] {:,}".format(stamp, event.viewer_count)
+    if event.event_type == SHARE:
+        return "{} [SHARE] @{} shared the LIVE".format(stamp, _handle(event))
+    if event.event_type == FOLLOW:
+        return "{} [FOLLOW] @{} followed".format(stamp, _handle(event))
+    if event.event_type == GIFT:
+        diamonds = (
+            " · {:,} diamonds".format(event.diamond_total)
+            if event.diamond_total
+            else ""
+        )
+        return "{} [GIFT] @{} sent {} x{:,}{}".format(
+            stamp,
+            _handle(event),
+            event.gift_name or "Gift",
+            max(1, event.gift_count),
+            diamonds,
+        )
+    if event.event_type == QUESTION:
+        return "{} [QUESTION] @{}: {}".format(
+            stamp, _handle(event), event.question_text
+        )
+    if event.event_type == JOIN:
+        return "{} [JOIN] @{}".format(stamp, _handle(event))
+
+    room_id = event.room_id or "-"
+    suffix = ""
+    if event.event_type == "transport_error" and event.error_code:
+        suffix = " error={}".format(event.error_code)
+    return "[{}] {} room={}{}".format(stamp, event.event_type, room_id, suffix)
+
+
+def _safe_code(value: object, fallback: str = "transport_diagnostic") -> str:
+    text = str(value).strip()[:120]
+    return _SAFE_CODE_RE.sub("_", text).strip("_") or fallback
+
+
+def build_transport_command(args: argparse.Namespace) -> list[str]:
+    return [
+        str(args.python),
+        "-u",
+        str(args.transport_script),
+        "--username",
+        args.username,
+        "--cdn",
+        args.cdn,
+        "--max-retries",
+        str(args.max_retries),
+        "--stale-timeout",
+        str(args.stale_timeout),
+        "--dedupe-capacity",
+        str(args.transport_dedupe_capacity),
+    ]
+
+

--- a/scripts/tiktok_live_shadow_runtime.py
+++ b/scripts/tiktok_live_shadow_runtime.py
@@ -1,0 +1,218 @@
+"""Async process supervision for the isolated TikTok LIVE shadow collector."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import signal
+from datetime import datetime
+from typing import Set
+from zoneinfo import ZoneInfo
+
+from bnl_tiktok_live_chat import JOIN, VIEWER_SNAPSHOT, LiveChatAdapter
+from scripts.tiktok_live_shadow_model import (
+    REPO_ROOT,
+    CycleResult,
+    CycleState,
+    _safe_code,
+    build_transport_command,
+    format_event,
+)
+
+async def _drain_stderr(reader: asyncio.StreamReader) -> None:
+    async for raw in reader:
+        try:
+            text = raw.decode("utf-8", errors="replace")
+        except AttributeError:
+            text = str(raw)
+        code = _safe_code(text)
+        if code:
+            print("[transport] {}".format(code), flush=True)
+
+
+async def _consume_stdout(
+    reader: asyncio.StreamReader,
+    process: asyncio.subprocess.Process,
+    adapter: LiveChatAdapter,
+    timezone: ZoneInfo,
+    ended_rooms: Set[str],
+    state: CycleState,
+) -> None:
+    async for raw in reader:
+        duplicates_before = adapter.buffer.duplicates
+        invalid_before = int(adapter.health["invalid_lines"])
+        event = adapter.ingest_line(raw)
+        state.duplicate_replays_suppressed += (
+            adapter.buffer.duplicates - duplicates_before
+        )
+        state.invalid_lines += int(adapter.health["invalid_lines"]) - invalid_before
+        if event is None:
+            continue
+
+        if event.event_type == "connected":
+            state.saw_connected = True
+            if not event.room_id or event.room_id not in ended_rooms:
+                print(format_event(event, timezone), flush=True)
+            continue
+
+        if event.is_observation:
+            state.events_emitted += 1
+            if event.is_comment:
+                state.comments_emitted += 1
+            if event.event_type == JOIN:
+                # Joins are counted in the final summary but not printed one-by-one.
+                continue
+            if event.event_type == VIEWER_SNAPSHOT:
+                if state.last_viewer_count == event.viewer_count:
+                    continue
+                state.last_viewer_count = event.viewer_count
+            print(format_event(event, timezone), flush=True)
+            continue
+
+        if event.event_type == "live_ended":
+            state.saw_live_end = True
+            first_end_for_room = not event.room_id or event.room_id not in ended_rooms
+            if event.room_id:
+                ended_rooms.add(event.room_id)
+            if first_end_for_room:
+                print(format_event(event, timezone), flush=True)
+            if process.returncode is None:
+                try:
+                    process.terminate()
+                except ProcessLookupError:
+                    pass
+            return
+
+        if event.event_type == "reconnecting" and event.room_id in ended_rooms:
+            continue
+        print(format_event(event, timezone), flush=True)
+
+
+async def _terminate_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+    try:
+        process.terminate()
+    except ProcessLookupError:
+        return
+    try:
+        await asyncio.wait_for(process.wait(), timeout=5.0)
+    except asyncio.TimeoutError:
+        try:
+            process.kill()
+        except ProcessLookupError:
+            return
+        await process.wait()
+
+
+async def run_transport_cycle(
+    args: argparse.Namespace,
+    adapter: LiveChatAdapter,
+    timezone: ZoneInfo,
+    ended_rooms: Set[str],
+    stop_event: asyncio.Event,
+    deadline: datetime,
+) -> CycleResult:
+    command = build_transport_command(args)
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        cwd=str(REPO_ROOT),
+        env=env,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    assert process.stdout is not None
+    assert process.stderr is not None
+
+    state = CycleState()
+    stdout_task = asyncio.create_task(
+        _consume_stdout(
+            process.stdout,
+            process,
+            adapter,
+            timezone,
+            ended_rooms,
+            state,
+        )
+    )
+    stderr_task = asyncio.create_task(_drain_stderr(process.stderr))
+    process_task = asyncio.create_task(process.wait())
+    stop_task = asyncio.create_task(stop_event.wait())
+
+    remaining = max(0.0, (deadline - datetime.now(timezone)).total_seconds())
+    done, _pending = await asyncio.wait(
+        {process_task, stop_task},
+        timeout=remaining,
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    stop_reason = "process_exit"
+    if not done:
+        stop_reason = "window_closed"
+        await _terminate_process(process)
+    elif stop_task in done and stop_event.is_set():
+        stop_reason = "stop_requested"
+        await _terminate_process(process)
+
+    return_code = await process.wait()
+    await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
+    for task in (process_task, stop_task):
+        if not task.done():
+            task.cancel()
+    return CycleResult(return_code=return_code, state=state, stop_reason=stop_reason)
+
+
+async def _sleep_until_retry(
+    seconds: float,
+    stop_event: asyncio.Event,
+    deadline: datetime,
+    timezone: ZoneInfo,
+) -> None:
+    remaining = max(0.0, (deadline - datetime.now(timezone)).total_seconds())
+    delay = min(float(seconds), remaining)
+    if delay <= 0:
+        return
+    try:
+        await asyncio.wait_for(stop_event.wait(), timeout=delay)
+    except asyncio.TimeoutError:
+        pass
+
+
+def _install_signal_handlers(stop_event: asyncio.Event) -> None:
+    loop = asyncio.get_running_loop()
+    for signal_name in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(signal_name, stop_event.set)
+        except (NotImplementedError, RuntimeError, ValueError):
+            pass
+
+
+def format_summary(health: dict, cycle_count: int) -> str:
+    return (
+        "[shadow] Window closed. comments={comments:,} taps={taps:,} "
+        "latest_tap_total={latest:,} peak_viewers={peak:,} shares={shares:,} "
+        "follows={follows:,} gifts={gifts:,}/{gift_units:,} diamonds={diamonds:,} "
+        "questions={questions:,} joins={joins:,} duplicates_suppressed={duplicates:,} "
+        "reconnects={reconnects:,} cycles={cycles:,}"
+    ).format(
+        comments=health["comments_accepted"],
+        taps=health["taps_observed"],
+        latest=health["latest_like_total"],
+        peak=health["peak_viewers"],
+        shares=health["shares"],
+        follows=health["follows"],
+        gifts=health["gift_events"],
+        gift_units=health["gift_units"],
+        diamonds=health["diamond_total"],
+        questions=health["questions"],
+        joins=health["joins"],
+        duplicates=health["duplicate_count"],
+        reconnects=health["reconnect_count"],
+        cycles=cycle_count,
+    )
+
+

--- a/scripts/tiktok_live_telemetry_common.py
+++ b/scripts/tiktok_live_telemetry_common.py
@@ -1,0 +1,323 @@
+"""Shared bounded helpers for the isolated TikTok LIVE telemetry transport."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import signal
+import sys
+from collections import OrderedDict
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Optional, Sequence
+
+SCHEMA_VERSION = 1
+MAX_ROOM_ID_CHARS = 80
+MAX_UNIQUE_ID_CHARS = 80
+MAX_DISPLAY_NAME_CHARS = 120
+MAX_COMMENT_CHARS = 1000
+MAX_QUESTION_CHARS = 1000
+MAX_GIFT_NAME_CHARS = 160
+MAX_ERROR_CODE_CHARS = 80
+DEFAULT_DEDUPE_CAPACITY = 20_000
+
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_WHITESPACE_RE = re.compile(r"\s+")
+_SAFE_CODE_RE = re.compile(r"[^A-Za-z0-9_.:-]+")
+_USERNAME_RE = re.compile(r"^[A-Za-z0-9._]+$")
+
+
+class EventIdDeduper:
+    """Bound replay suppression without retaining comment or event content."""
+
+    def __init__(self, capacity: int = DEFAULT_DEDUPE_CAPACITY) -> None:
+        if capacity <= 0:
+            raise ValueError("dedupe capacity must be positive")
+        self.capacity = int(capacity)
+        self._event_ids: "OrderedDict[str, None]" = OrderedDict()
+        self.duplicates = 0
+
+    def accept(self, event_id: str) -> bool:
+        if not event_id:
+            return True
+        if event_id in self._event_ids:
+            self._event_ids.move_to_end(event_id)
+            self.duplicates += 1
+            return False
+        self._event_ids[event_id] = None
+        while len(self._event_ids) > self.capacity:
+            self._event_ids.popitem(last=False)
+        return True
+
+
+def _bounded_text(value: Any, max_chars: int) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, (str, int, float, bool)):
+        text = str(value)
+    else:
+        return ""
+    text = _CONTROL_CHAR_RE.sub(" ", text)
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+    return text[:max_chars].rstrip()
+
+
+def _bounded_code(value: Any, fallback: str) -> str:
+    text = _bounded_text(value, MAX_ERROR_CODE_CHARS)
+    text = _SAFE_CODE_RE.sub("_", text).strip("_")
+    return text or fallback
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _mapping(value: Any) -> Mapping:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _first_nonempty(*values: Any, max_chars: int = MAX_DISPLAY_NAME_CHARS) -> str:
+    for value in values:
+        text = _bounded_text(value, max_chars)
+        if text:
+            return text
+    return ""
+
+
+def _coerce_int(value: Any, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def _nonnegative_int(value: Any, default: int = 0, maximum: int = 10**12) -> int:
+    return min(maximum, max(0, _coerce_int(value, default)))
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return isinstance(value, str) and value.strip().lower() in {"1", "true", "yes"}
+
+
+def normalize_username(value: str) -> str:
+    username = _bounded_text(value, MAX_UNIQUE_ID_CHARS).lstrip("@").strip()
+    if not username:
+        raise argparse.ArgumentTypeError("TikTok username is required")
+    if not _USERNAME_RE.fullmatch(username):
+        raise argparse.ArgumentTypeError(
+            "TikTok username may contain letters, numbers, periods, and underscores"
+        )
+    return username
+
+
+def _event_room_id(event: Any, data: Mapping) -> str:
+    common = _mapping(data.get("common"))
+    return _bounded_text(
+        _first_nonempty(
+            getattr(event, "room_id", ""),
+            data.get("roomId"),
+            data.get("room_id"),
+            common.get("roomId"),
+            common.get("room_id"),
+            max_chars=MAX_ROOM_ID_CHARS,
+        ),
+        MAX_ROOM_ID_CHARS,
+    )
+
+
+def _event_message_id(data: Mapping) -> str:
+    common = _mapping(data.get("common"))
+    return _first_nonempty(
+        common.get("msgId"),
+        common.get("msg_id"),
+        data.get("msgId"),
+        data.get("msg_id"),
+        common.get("logId"),
+        common.get("log_id"),
+        max_chars=120,
+    )
+
+
+def _event_source_time(data: Mapping) -> str:
+    common = _mapping(data.get("common"))
+    return _first_nonempty(
+        common.get("createTime"),
+        common.get("create_time"),
+        common.get("clientSendTime"),
+        common.get("client_send_time"),
+        data.get("createTime"),
+        data.get("create_time"),
+        max_chars=80,
+    )
+
+
+def _source_at(data: Mapping) -> str:
+    raw = _event_source_time(data)
+    if not raw:
+        return ""
+    try:
+        numeric = float(raw)
+    except (TypeError, ValueError, OverflowError):
+        return ""
+    if numeric > 10**15:
+        numeric /= 1_000_000.0
+    elif numeric > 10**11:
+        numeric /= 1_000.0
+    if not (946684800 <= numeric <= 4102444800):
+        return ""
+    try:
+        return datetime.fromtimestamp(numeric, tz=timezone.utc).isoformat().replace(
+            "+00:00", "Z"
+        )
+    except (OSError, OverflowError, ValueError):
+        return ""
+
+
+def _moderator_flag(user: Mapping) -> bool:
+    identity = _mapping(user.get("identity"))
+    user_attr = _mapping(user.get("userAttr"))
+    if not user_attr:
+        user_attr = _mapping(user.get("user_attr"))
+    return any(
+        bool(value)
+        for value in (
+            identity.get("isModeratorOfAnchor"),
+            identity.get("is_moderator_of_anchor"),
+            user_attr.get("isAdmin"),
+            user_attr.get("is_admin"),
+            user_attr.get("isSuperAdmin"),
+            user_attr.get("is_super_admin"),
+        )
+    )
+
+
+def _user_fields(user: Mapping) -> Dict[str, Any]:
+    unique_id = _bounded_text(
+        _first_nonempty(
+            user.get("uniqueId"),
+            user.get("unique_id"),
+            max_chars=MAX_UNIQUE_ID_CHARS,
+        ),
+        MAX_UNIQUE_ID_CHARS,
+    ).lstrip("@")
+    display_name = _bounded_text(
+        _first_nonempty(
+            user.get("nickname"),
+            unique_id,
+            "TikTok viewer",
+            max_chars=MAX_DISPLAY_NAME_CHARS,
+        ),
+        MAX_DISPLAY_NAME_CHARS,
+    )
+    return {
+        "unique_id": unique_id,
+        "display_name": display_name,
+        "moderator_flag": _moderator_flag(user),
+    }
+
+
+def _fallback_event_id(
+    event_type: str,
+    room_id: str,
+    parts: Sequence[Any],
+    source_marker: str,
+) -> str:
+    material = "\x1f".join(
+        [event_type, room_id, *(_bounded_text(part, 1000) for part in parts), source_marker]
+    ).encode("utf-8", errors="replace")
+    return "local:{}".format(hashlib.sha256(material).hexdigest()[:32])
+
+
+def _observation_base(
+    event_type: str,
+    event: Any,
+    data: Mapping,
+    fallback_parts: Sequence[Any],
+) -> Dict[str, Any]:
+    room_id = _event_room_id(event, data)
+    observed_at = _utc_now()
+    source_at = _source_at(data)
+    message_id = _bounded_text(_event_message_id(data), 120)
+    event_id = (
+        "tiktok:{}:{}".format(room_id or "room", message_id)
+        if message_id
+        else _fallback_event_id(
+            event_type,
+            room_id,
+            fallback_parts,
+            _event_source_time(data) or source_at or observed_at,
+        )
+    )
+    payload: Dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "event_type": event_type,
+        "event_id": event_id,
+        "room_id": room_id,
+        "observed_at": observed_at,
+    }
+    if source_at:
+        payload["source_at"] = source_at
+    return payload
+
+
+def build_lifecycle_payload(event_type: str, event: Any) -> Dict[str, Any]:
+    data = _mapping(getattr(event, "data", {}))
+    room_id = _event_room_id(event, data)
+    payload: Dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "event_type": event_type,
+        "event_id": "{}:{}:{}".format(
+            event_type, room_id or "room", datetime.now(timezone.utc).timestamp()
+        ),
+        "room_id": room_id,
+        "observed_at": _utc_now(),
+    }
+    source_at = _source_at(data)
+    if source_at:
+        payload["source_at"] = source_at
+    if event_type == "reconnecting":
+        payload.update(
+            {
+                "attempt": max(0, _coerce_int(data.get("attempt"))),
+                "max_retries": max(0, _coerce_int(data.get("max_retries"))),
+                "delay_seconds": max(0, _coerce_int(data.get("delay"))),
+            }
+        )
+    return payload
+
+
+def build_transport_error_payload(error: Any) -> Dict[str, Any]:
+    error_code = _bounded_code(
+        error.__class__.__name__ if isinstance(error, BaseException) else error,
+        "transport_error",
+    )
+    observed_at = _utc_now()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "event_type": "transport_error",
+        "event_id": "transport_error:{}".format(observed_at),
+        "room_id": "",
+        "observed_at": observed_at,
+        "error_code": error_code,
+    }
+
+
+def emit_payload(payload: Mapping) -> None:
+    sys.stdout.write(json.dumps(dict(payload), separators=(",", ":"), sort_keys=True))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def emit_diagnostic(code: str) -> None:
+    sys.stderr.write(_bounded_code(code, "transport_diagnostic") + "\n")
+    sys.stderr.flush()
+
+

--- a/scripts/tiktok_live_telemetry_payloads.py
+++ b/scripts/tiktok_live_telemetry_payloads.py
@@ -1,0 +1,206 @@
+"""Normalize public TikTok LIVE Webcast observations into bounded NDJSON payloads."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from scripts.tiktok_live_telemetry_common import (
+    MAX_COMMENT_CHARS,
+    MAX_GIFT_NAME_CHARS,
+    MAX_QUESTION_CHARS,
+    _bounded_text,
+    _coerce_bool,
+    _first_nonempty,
+    _mapping,
+    _nonnegative_int,
+    _observation_base,
+    _user_fields,
+)
+
+def build_comment_payload(event: Any) -> Optional[Dict[str, Any]]:
+    data = _mapping(getattr(event, "data", {}))
+    user = _mapping(data.get("user"))
+    comment_text = _bounded_text(data.get("content"), MAX_COMMENT_CHARS)
+    if not comment_text:
+        return None
+    user_fields = _user_fields(user)
+    payload = _observation_base(
+        "comment",
+        event,
+        data,
+        [user_fields["unique_id"], comment_text],
+    )
+    payload.update(user_fields)
+    payload["comment_text"] = comment_text
+    return payload
+
+
+def build_like_payload(event: Any) -> Optional[Dict[str, Any]]:
+    data = _mapping(getattr(event, "data", {}))
+    like_count = _nonnegative_int(data.get("count"), maximum=10**9)
+    like_total = _nonnegative_int(data.get("total"), maximum=10**12)
+    if like_count <= 0 and like_total <= 0:
+        return None
+    user_fields = _user_fields(_mapping(data.get("user")))
+    payload = _observation_base(
+        "like",
+        event,
+        data,
+        [user_fields["unique_id"], like_count, like_total],
+    )
+    payload.update(user_fields)
+    payload.update({"like_count": like_count, "like_total": like_total})
+    return payload
+
+
+def build_viewer_snapshot_payload(event: Any) -> Optional[Dict[str, Any]]:
+    data = _mapping(getattr(event, "data", {}))
+    viewer_count = _nonnegative_int(
+        data.get("viewerCount", data.get("viewer_count")), maximum=10**9
+    )
+    payload = _observation_base(
+        "viewer_snapshot",
+        event,
+        data,
+        [viewer_count, data.get("popStr"), data.get("pop_str")],
+    )
+    payload["viewer_count"] = viewer_count
+    return payload
+
+
+def build_social_payload(event_type: str, event: Any) -> Optional[Dict[str, Any]]:
+    if event_type not in {"share", "follow"}:
+        raise ValueError("unsupported social event type")
+    data = _mapping(getattr(event, "data", {}))
+    user_fields = _user_fields(_mapping(data.get("user")))
+    payload = _observation_base(
+        event_type,
+        event,
+        data,
+        [
+            user_fields["unique_id"],
+            data.get("action"),
+            data.get("shareType"),
+            data.get("share_type"),
+        ],
+    )
+    payload.update(user_fields)
+    if event_type == "share":
+        payload["share_type"] = _nonnegative_int(
+            data.get("shareType", data.get("share_type")), maximum=1000
+        )
+    return payload
+
+
+def build_gift_payload(event: Any) -> Optional[Dict[str, Any]]:
+    data = _mapping(getattr(event, "data", {}))
+    is_combo = _coerce_bool(data.get("is_combo", data.get("isCombo")))
+    is_streak_over = _coerce_bool(
+        data.get("is_streak_over", data.get("isStreakOver"))
+    )
+    if is_combo and not is_streak_over:
+        return None
+
+    gift = _mapping(data.get("gift"))
+    user_fields = _user_fields(_mapping(data.get("user")))
+    gift_id = _nonnegative_int(
+        data.get("giftId", data.get("gift_id", gift.get("id"))), maximum=10**12
+    )
+    gift_name = _bounded_text(
+        _first_nonempty(
+            gift.get("name"),
+            data.get("giftName"),
+            data.get("gift_name"),
+            "Gift",
+            max_chars=MAX_GIFT_NAME_CHARS,
+        ),
+        MAX_GIFT_NAME_CHARS,
+    )
+    gift_count = max(
+        1,
+        _nonnegative_int(
+            data.get("repeatCount", data.get("repeat_count", 1)), maximum=10**9
+        ),
+    )
+    diamond_count = _nonnegative_int(
+        gift.get("diamondCount", gift.get("diamond_count")), maximum=10**9
+    )
+    diamond_total = _nonnegative_int(
+        data.get("diamond_total", data.get("diamondTotal")), maximum=10**12
+    )
+    if diamond_total <= 0 and diamond_count > 0:
+        diamond_total = min(10**12, diamond_count * gift_count)
+
+    payload = _observation_base(
+        "gift",
+        event,
+        data,
+        [user_fields["unique_id"], gift_id, gift_count, diamond_total],
+    )
+    payload.update(user_fields)
+    payload.update(
+        {
+            "gift_id": gift_id,
+            "gift_name": gift_name,
+            "gift_count": gift_count,
+            "diamond_count": diamond_count,
+            "diamond_total": diamond_total,
+            "combo": is_combo,
+            "streak_over": is_streak_over or not is_combo,
+        }
+    )
+    return payload
+
+
+def build_question_payload(event: Any) -> Optional[Dict[str, Any]]:
+    data = _mapping(getattr(event, "data", {}))
+    details = _mapping(data.get("details"))
+    question_text = _bounded_text(
+        details.get("questionText", details.get("question_text")),
+        MAX_QUESTION_CHARS,
+    )
+    if not question_text:
+        return None
+    user_fields = _user_fields(_mapping(details.get("user")))
+    question_id = _bounded_text(
+        _first_nonempty(
+            details.get("questionId"),
+            details.get("question_id"),
+            max_chars=120,
+        ),
+        120,
+    )
+    payload = _observation_base(
+        "question",
+        event,
+        data,
+        [question_id, user_fields["unique_id"], question_text],
+    )
+    payload.update(user_fields)
+    payload.update(
+        {
+            "question_id": question_id,
+            "question_text": question_text,
+            "answer_status": _nonnegative_int(
+                details.get("answerStatus", details.get("answer_status")),
+                maximum=1000,
+            ),
+        }
+    )
+    return payload
+
+
+def build_join_payload(event: Any) -> Optional[Dict[str, Any]]:
+    data = _mapping(getattr(event, "data", {}))
+    user_fields = _user_fields(_mapping(data.get("user")))
+    payload = _observation_base(
+        "join",
+        event,
+        data,
+        [user_fields["unique_id"], data.get("action")],
+    )
+    payload.update(user_fields)
+    payload["join_count"] = 1
+    return payload
+
+

--- a/tests/test_bnl_tiktok_live_chat.py
+++ b/tests/test_bnl_tiktok_live_chat.py
@@ -3,8 +3,11 @@ import unittest
 
 from bnl_tiktok_live_chat import (
     AUTHORITY,
+    COMMENT_AUTHORITY,
     IDENTITY_DEFAULT,
+    INTERACTION_AUTHORITY,
     MEMORY_DEFAULT,
+    METRIC_AUTHORITY,
     SOURCE,
     VISIBILITY,
     LiveChatAdapter,
@@ -29,6 +32,7 @@ def payload(**changes):
         "event_id": "message-1",
         "room_id": "room-1",
         "observed_at": 1_700_000_000.0,
+        "source_at": 1_700_000_000.0,
         "unique_id": "test.viewer",
         "display_name": "Test Viewer",
         "comment_text": "This track is wild.",
@@ -48,6 +52,7 @@ class ParseTests(unittest.TestCase):
         self.assertEqual(record["source"], SOURCE)
         self.assertEqual(record["visibility"], VISIBILITY)
         self.assertEqual(record["authority"], AUTHORITY)
+        self.assertEqual(record["authority"], COMMENT_AUTHORITY)
         self.assertEqual(record["memory_default"], MEMORY_DEFAULT)
         self.assertEqual(record["identity_default"], IDENTITY_DEFAULT)
 
@@ -58,6 +63,35 @@ class ParseTests(unittest.TestCase):
         )
         self.assertTrue(event.comment_text.startswith("hello world"))
         self.assertLessEqual(len(event.comment_text), 1000)
+
+    def test_parses_all_shadow_telemetry_types(self):
+        cases = [
+            (payload(event_type="like", comment_text=None, like_count="25", like_total="500"), "like"),
+            (payload(event_type="viewer_snapshot", comment_text=None, unique_id="", display_name="", viewer_count="37"), "viewer_snapshot"),
+            (payload(event_type="share", comment_text=None, share_type="2"), "share"),
+            (payload(event_type="follow", comment_text=None), "follow"),
+            (payload(event_type="gift", comment_text=None, gift_id="10", gift_name="Rose", gift_count="3", diamond_count="1", diamond_total="3", combo=True, streak_over=True), "gift"),
+            (payload(event_type="question", comment_text=None, question_id="7", question_text="Where do I submit?", answer_status="0"), "question"),
+            (payload(event_type="join", comment_text=None, join_count="1"), "join"),
+        ]
+        parsed = [parse_line(json.dumps(value), now=1_700_000_000.0) for value, _ in cases]
+        self.assertEqual([event.event_type for event in parsed], [expected for _, expected in cases])
+        self.assertEqual(parsed[0].like_count, 25)
+        self.assertEqual(parsed[1].viewer_count, 37)
+        self.assertEqual(parsed[4].diamond_total, 3)
+        self.assertEqual(parsed[5].question_text, "Where do I submit?")
+        self.assertEqual(parsed[0].telemetry_record()["authority"], INTERACTION_AUTHORITY)
+        self.assertEqual(parsed[1].telemetry_record()["authority"], METRIC_AUTHORITY)
+        self.assertEqual(parsed[5].telemetry_record()["authority"], COMMENT_AUTHORITY)
+
+    def test_source_timestamp_is_preserved_separately_from_receipt_time(self):
+        event = parse_line(
+            json.dumps(payload(observed_at=1_700_000_010.0, source_at=1_700_000_000.0)),
+            now=1_700_000_010.0,
+        )
+        self.assertEqual(event.observed_at, 1_700_000_010.0)
+        self.assertEqual(event.source_at, 1_700_000_000.0)
+        self.assertEqual(event.event_time, 1_700_000_000.0)
 
     def test_failures_are_bounded(self):
         with self.assertRaises(ProtocolError) as invalid:
@@ -79,7 +113,7 @@ class ParseTests(unittest.TestCase):
 class BufferTests(unittest.TestCase):
     def setUp(self):
         self.clock = Clock()
-        self.buffer = LiveChatBuffer(2, 30, self.clock)
+        self.buffer = LiveChatBuffer(3, 30, self.clock)
         self.adapter = LiveChatAdapter(self.buffer, self.clock)
 
     def add(self, event_id, text="comment"):
@@ -89,6 +123,18 @@ class BufferTests(unittest.TestCase):
                     event_id=event_id,
                     comment_text=text,
                     observed_at=self.clock(),
+                    source_at=self.clock(),
+                )
+            )
+        )
+
+    def ingest(self, **changes):
+        return self.adapter.ingest_line(
+            json.dumps(
+                payload(
+                    observed_at=self.clock(),
+                    source_at=self.clock(),
+                    **changes,
                 )
             )
         )
@@ -98,14 +144,17 @@ class BufferTests(unittest.TestCase):
         self.assertIsNone(self.add("a", "replay"))
         self.add("b")
         self.add("c")
+        self.add("d")
         self.assertEqual(
-            [row["event_id"] for row in self.adapter.context_snapshot()], ["b", "c"]
+            [row["event_id"] for row in self.adapter.context_snapshot()],
+            ["b", "c", "d"],
         )
         health = self.adapter.health_snapshot()
         self.assertEqual(health["duplicate_count"], 1)
         self.assertEqual(health["overflow_count"], 1)
+        self.assertEqual(health["comments_accepted"], 4)
 
-    def test_seen_ids_are_bounded_separately_from_comment_buffer(self):
+    def test_seen_ids_are_bounded_separately_from_event_buffer(self):
         buffer = LiveChatBuffer(2, 300, self.clock, max_seen_events=3)
         adapter = LiveChatAdapter(buffer, self.clock)
         for event_id in ("a", "b", "c", "d"):
@@ -119,8 +168,37 @@ class BufferTests(unittest.TestCase):
                 )
             )
         health = adapter.health_snapshot()
-        self.assertEqual(health["comments_buffered"], 2)
+        self.assertEqual(health["events_buffered"], 2)
         self.assertEqual(health["seen_event_ids"], 3)
+
+    def test_metrics_are_deduped_and_aggregated_without_join_retention(self):
+        self.ingest(event_type="like", event_id="like-1", comment_text=None, like_count=100, like_total=1000)
+        self.assertIsNone(
+            self.ingest(event_type="like", event_id="like-1", comment_text=None, like_count=100, like_total=1000)
+        )
+        self.ingest(event_type="viewer_snapshot", event_id="view-1", comment_text=None, unique_id="", display_name="", viewer_count=25)
+        self.ingest(event_type="viewer_snapshot", event_id="view-2", comment_text=None, unique_id="", display_name="", viewer_count=41)
+        self.ingest(event_type="share", event_id="share-1", comment_text=None)
+        self.ingest(event_type="follow", event_id="follow-1", comment_text=None)
+        self.ingest(event_type="gift", event_id="gift-1", comment_text=None, gift_name="Rose", gift_count=3, diamond_total=3, streak_over=True)
+        self.ingest(event_type="question", event_id="question-1", comment_text=None, question_text="Where?", question_id="1")
+        self.ingest(event_type="join", event_id="join-1", comment_text=None, join_count=1)
+
+        health = self.adapter.health_snapshot()
+        self.assertEqual(health["taps_observed"], 100)
+        self.assertEqual(health["latest_like_total"], 1000)
+        self.assertEqual(health["viewer_count"], 41)
+        self.assertEqual(health["peak_viewers"], 41)
+        self.assertEqual(health["shares"], 1)
+        self.assertEqual(health["follows"], 1)
+        self.assertEqual(health["gift_events"], 1)
+        self.assertEqual(health["gift_units"], 3)
+        self.assertEqual(health["diamond_total"], 3)
+        self.assertEqual(health["questions"], 1)
+        self.assertEqual(health["joins"], 1)
+        self.assertEqual(health["duplicate_count"], 1)
+        self.assertFalse(any(row["event_type"] == "join" for row in self.adapter.telemetry_snapshot()))
+        self.assertEqual(self.adapter.context_snapshot(), [])
 
     def test_expires_and_clears_at_live_end(self):
         self.add("a")

--- a/tests/test_tiktok_live_chat_shadow_window.py
+++ b/tests/test_tiktok_live_chat_shadow_window.py
@@ -11,6 +11,7 @@ from scripts import tiktok_live_chat_shadow_window as shadow
 class ShadowWindowTests(unittest.TestCase):
     def setUp(self):
         self.timezone = ZoneInfo("America/Los_Angeles")
+        self.timestamp = datetime(2026, 8, 28, 23, 15, tzinfo=self.timezone).timestamp()
 
     def test_default_window_runs_until_two_am(self):
         self.assertEqual(shadow.DEFAULT_WINDOW_START, clock_time(18, 50))
@@ -65,7 +66,8 @@ class ShadowWindowTests(unittest.TestCase):
             event_type="comment",
             event_id="event-1",
             room_id="room-1",
-            observed_at=datetime(2026, 8, 28, 23, 15, tzinfo=self.timezone).timestamp(),
+            observed_at=self.timestamp,
+            source_at=self.timestamp,
             unique_id="test.mod",
             display_name="Test Mod",
             comment_text="BNL CHAT TEST 740",
@@ -75,6 +77,55 @@ class ShadowWindowTests(unittest.TestCase):
             shadow.format_event(event, self.timezone),
             "23:15:00 @test.mod [MOD]: BNL CHAT TEST 740",
         )
+
+    def test_telemetry_formatters_are_plain_and_testable(self):
+        events = [
+            LiveEvent("like", "1", "room", self.timestamp, source_at=self.timestamp, like_count=125, like_total=8420),
+            LiveEvent("viewer_snapshot", "2", "room", self.timestamp, source_at=self.timestamp, viewer_count=37),
+            LiveEvent("share", "3", "room", self.timestamp, source_at=self.timestamp, unique_id="sharer"),
+            LiveEvent("follow", "4", "room", self.timestamp, source_at=self.timestamp, unique_id="follower"),
+            LiveEvent("gift", "5", "room", self.timestamp, source_at=self.timestamp, unique_id="giver", gift_name="Rose", gift_count=3, diamond_total=3),
+            LiveEvent("question", "6", "room", self.timestamp, source_at=self.timestamp, unique_id="asker", question_text="Where do I submit?"),
+        ]
+        lines = [shadow.format_event(event, self.timezone) for event in events]
+        self.assertEqual(lines[0], "23:15:00 [TAPS] +125 (total 8,420)")
+        self.assertEqual(lines[1], "23:15:00 [VIEWERS] 37")
+        self.assertIn("@sharer shared", lines[2])
+        self.assertIn("@follower followed", lines[3])
+        self.assertIn("Rose x3 · 3 diamonds", lines[4])
+        self.assertIn("Where do I submit?", lines[5])
+
+    def test_summary_includes_all_current_show_metrics(self):
+        health = {
+            "comments_accepted": 12,
+            "taps_observed": 8420,
+            "latest_like_total": 9000,
+            "peak_viewers": 41,
+            "shares": 3,
+            "follows": 2,
+            "gift_events": 1,
+            "gift_units": 3,
+            "diamond_total": 3,
+            "questions": 4,
+            "joins": 27,
+            "duplicate_count": 6,
+            "reconnect_count": 1,
+        }
+        summary = shadow.format_summary(health, 2)
+        for expected in (
+            "comments=12",
+            "taps=8,420",
+            "peak_viewers=41",
+            "shares=3",
+            "follows=2",
+            "gifts=1/3",
+            "diamonds=3",
+            "questions=4",
+            "joins=27",
+            "duplicates_suppressed=6",
+            "cycles=2",
+        ):
+            self.assertIn(expected, summary)
 
     def test_transport_command_is_read_only_collector_contract(self):
         args = argparse.Namespace(

--- a/tests/test_tiktok_live_chat_transport.py
+++ b/tests/test_tiktok_live_chat_transport.py
@@ -10,93 +10,6 @@ from unittest import mock
 from scripts import tiktok_live_chat_transport as transport
 
 
-class TransportPayloadTests(unittest.TestCase):
-    def test_comment_payload_contains_only_normalized_comment_fields(self):
-        event = SimpleNamespace(
-            room_id="room-1",
-            data={
-                "common": {"msgId": "message-9"},
-                "content": "  hello\u0000\nworld  ",
-                "user": {
-                    "uniqueId": "@test.viewer",
-                    "nickname": "Test Viewer",
-                    "avatarThumb": {"urlList": ["private-avatar-url"]},
-                    "bioDescription": "should not leave transport",
-                    "identity": {"isModeratorOfAnchor": True},
-                },
-            },
-        )
-        payload = transport.build_comment_payload(event)
-
-        self.assertEqual(payload["event_type"], "comment")
-        self.assertEqual(payload["event_id"], "tiktok:room-1:message-9")
-        self.assertEqual(payload["comment_text"], "hello world")
-        self.assertEqual(payload["unique_id"], "test.viewer")
-        self.assertTrue(payload["moderator_flag"])
-        serialized = json.dumps(payload)
-        self.assertNotIn("avatar", serialized.lower())
-        self.assertNotIn("bioDescription", serialized)
-        self.assertNotIn("private-avatar-url", serialized)
-
-    def test_empty_comment_is_not_emitted(self):
-        event = SimpleNamespace(room_id="room", data={"content": "\u0000\n"})
-        self.assertIsNone(transport.build_comment_payload(event))
-
-    def test_fallback_event_id_uses_stable_source_time(self):
-        event = SimpleNamespace(
-            room_id="room-1",
-            data={
-                "common": {"createTime": "1787931000000"},
-                "content": "same replayed comment",
-                "user": {"uniqueId": "viewer", "nickname": "Viewer"},
-            },
-        )
-        with mock.patch.object(
-            transport,
-            "_utc_now",
-            side_effect=["2026-08-28T23:30:00Z", "2026-08-28T23:31:00Z"],
-        ):
-            first = transport.build_comment_payload(event)
-            second = transport.build_comment_payload(event)
-        self.assertEqual(first["event_id"], second["event_id"])
-        self.assertNotEqual(first["observed_at"], second["observed_at"])
-
-    def test_transport_error_uses_class_only(self):
-        payload = transport.build_transport_error_payload(
-            RuntimeError("https://example.invalid/?token=secret")
-        )
-        self.assertEqual(payload["error_code"], "RuntimeError")
-        self.assertNotIn("secret", json.dumps(payload))
-        self.assertNotIn("example.invalid", json.dumps(payload))
-
-    def test_reconnecting_payload_bounds_numeric_fields(self):
-        event = SimpleNamespace(
-            room_id="room",
-            data={"attempt": "3", "max_retries": "5", "delay": "8"},
-        )
-        payload = transport.build_lifecycle_payload("reconnecting", event)
-        self.assertEqual(payload["attempt"], 3)
-        self.assertEqual(payload["max_retries"], 5)
-        self.assertEqual(payload["delay_seconds"], 8)
-
-    def test_emit_payload_is_one_compact_json_line(self):
-        output = io.StringIO()
-        with redirect_stdout(output):
-            transport.emit_payload({"schema_version": 1, "event_type": "connected"})
-        lines = output.getvalue().splitlines()
-        self.assertEqual(len(lines), 1)
-        self.assertEqual(json.loads(lines[0])["event_type"], "connected")
-
-    def test_event_id_deduper_is_bounded(self):
-        deduper = transport.EventIdDeduper(capacity=2)
-        self.assertTrue(deduper.accept("one"))
-        self.assertFalse(deduper.accept("one"))
-        self.assertTrue(deduper.accept("two"))
-        self.assertTrue(deduper.accept("three"))
-        self.assertTrue(deduper.accept("one"))
-        self.assertEqual(deduper.duplicates, 1)
-
-
 class TransportCliTests(unittest.TestCase):
     def test_username_validation(self):
         self.assertEqual(transport.normalize_username("@six.bit"), "six.bit")
@@ -122,10 +35,17 @@ class TransportCliTests(unittest.TestCase):
         self.assertEqual(payload["error_code"], "missing_dependency")
         self.assertEqual(stderr.getvalue().strip(), "missing_dependency")
 
-    def test_run_transport_stops_at_live_end_and_suppresses_replay(self):
+    def test_run_transport_emits_public_telemetry_and_stops_at_live_end(self):
         class FakeEventType:
             connected = "connected"
             chat = "chat"
+            like = "like"
+            room_user_seq = "room_user_seq"
+            share = "share"
+            follow = "follow"
+            gift = "gift"
+            question_new = "question_new"
+            join = "join"
             reconnecting = "reconnecting"
             live_ended = "live_ended"
             disconnected = "disconnected"
@@ -169,20 +89,101 @@ class TransportCliTests(unittest.TestCase):
                     callback(event)
 
             def run(self):
-                connected = SimpleNamespace(room_id="room", data={"room_id": "room"})
+                common = lambda msg: {"msgId": msg}
+                self.emit("connected", SimpleNamespace(room_id="room", data={}))
                 comment = SimpleNamespace(
                     room_id="room",
                     data={
-                        "common": {"msgId": "1"},
+                        "common": common("comment-1"),
                         "content": "hello",
                         "user": {"uniqueId": "viewer", "nickname": "Viewer"},
                     },
                 )
-                self.emit("connected", connected)
                 self.emit("chat", comment)
                 self.emit("chat", comment)
+                self.emit(
+                    "like",
+                    SimpleNamespace(
+                        room_id="room",
+                        data={"common": common("like-1"), "count": 25, "total": 500},
+                    ),
+                )
+                self.emit(
+                    "room_user_seq",
+                    SimpleNamespace(
+                        room_id="room",
+                        data={"common": common("view-1"), "viewerCount": 33},
+                    ),
+                )
+                social = SimpleNamespace(
+                    room_id="room",
+                    data={
+                        "common": common("social-1"),
+                        "user": {"uniqueId": "social", "nickname": "Social"},
+                    },
+                )
+                self.emit("share", social)
+                social2 = SimpleNamespace(
+                    room_id="room",
+                    data={
+                        "common": common("social-2"),
+                        "user": {"uniqueId": "follower", "nickname": "Follower"},
+                    },
+                )
+                self.emit("follow", social2)
+                self.emit(
+                    "gift",
+                    SimpleNamespace(
+                        room_id="room",
+                        data={
+                            "common": common("gift-progress"),
+                            "is_combo": True,
+                            "is_streak_over": False,
+                            "repeatCount": 2,
+                            "gift": {"name": "Rose", "diamondCount": 1},
+                        },
+                    ),
+                )
+                self.emit(
+                    "gift",
+                    SimpleNamespace(
+                        room_id="room",
+                        data={
+                            "common": common("gift-final"),
+                            "is_combo": True,
+                            "is_streak_over": True,
+                            "repeatCount": 2,
+                            "diamond_total": 2,
+                            "gift": {"name": "Rose", "diamondCount": 1},
+                            "user": {"uniqueId": "giver", "nickname": "Giver"},
+                        },
+                    ),
+                )
+                self.emit(
+                    "question_new",
+                    SimpleNamespace(
+                        room_id="room",
+                        data={
+                            "common": common("question-1"),
+                            "details": {
+                                "questionId": "7",
+                                "questionText": "Where do I submit?",
+                                "user": {"uniqueId": "asker", "nickname": "Asker"},
+                            },
+                        },
+                    ),
+                )
+                self.emit(
+                    "join",
+                    SimpleNamespace(
+                        room_id="room",
+                        data={
+                            "common": common("join-1"),
+                            "user": {"uniqueId": "new.viewer", "nickname": "New Viewer"},
+                        },
+                    ),
+                )
                 self.emit("live_ended", SimpleNamespace(room_id="room", data={}))
-                # Simulate the upstream library trying to deliver a stale frame after end.
                 self.emit("reconnecting", SimpleNamespace(room_id="room", data={}))
                 self.emit("chat", comment)
                 self.emit("disconnected", SimpleNamespace(room_id="room", data={}))
@@ -206,15 +207,36 @@ class TransportCliTests(unittest.TestCase):
         emitted = [json.loads(line) for line in stdout.getvalue().splitlines()]
         self.assertEqual(
             [event["event_type"] for event in emitted],
-            ["connected", "comment", "live_ended", "disconnected"],
+            [
+                "connected",
+                "comment",
+                "like",
+                "viewer_snapshot",
+                "share",
+                "follow",
+                "gift",
+                "question",
+                "join",
+                "live_ended",
+                "disconnected",
+            ],
         )
         self.assertTrue(FakeClient.last_instance.settings["disconnected"])
         self.assertEqual(FakeClient.last_instance.settings["cdn"], "us")
         self.assertEqual(FakeClient.last_instance.settings["max_retries"], 4)
         self.assertEqual(FakeClient.last_instance.settings["stale_timeout"], 75.0)
-        self.assertNotIn("gift", FakeClient.last_instance.listeners)
-        self.assertNotIn("follow", FakeClient.last_instance.listeners)
-        self.assertNotIn("join", FakeClient.last_instance.listeners)
+        for event_name in (
+            "like",
+            "room_user_seq",
+            "share",
+            "follow",
+            "gift",
+            "question_new",
+            "join",
+        ):
+            self.assertIn(event_name, FakeClient.last_instance.listeners)
+        self.assertNotIn("post", FakeClient.last_instance.listeners)
+        self.assertNotIn("moderate", FakeClient.last_instance.listeners)
 
 
 if __name__ == "__main__":

--- a/tests/test_tiktok_live_telemetry_payloads.py
+++ b/tests/test_tiktok_live_telemetry_payloads.py
@@ -1,0 +1,186 @@
+import argparse
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import ModuleType, SimpleNamespace
+from unittest import mock
+
+from scripts import tiktok_live_chat_transport as transport
+from scripts import tiktok_live_telemetry_common as telemetry_common
+
+
+class TransportPayloadTests(unittest.TestCase):
+    def test_comment_payload_contains_only_normalized_comment_fields(self):
+        event = SimpleNamespace(
+            room_id="room-1",
+            data={
+                "common": {"msgId": "message-9", "createTime": "1787931000000"},
+                "content": "  hello\u0000\nworld  ",
+                "user": {
+                    "uniqueId": "@test.viewer",
+                    "nickname": "Test Viewer",
+                    "avatarThumb": {"urlList": ["private-avatar-url"]},
+                    "bioDescription": "should not leave transport",
+                    "identity": {"isModeratorOfAnchor": True},
+                },
+            },
+        )
+        payload = transport.build_comment_payload(event)
+
+        self.assertEqual(payload["event_type"], "comment")
+        self.assertEqual(payload["event_id"], "tiktok:room-1:message-9")
+        self.assertEqual(payload["comment_text"], "hello world")
+        self.assertEqual(payload["unique_id"], "test.viewer")
+        self.assertTrue(payload["moderator_flag"])
+        self.assertTrue(payload["source_at"].startswith("2026-"))
+        serialized = json.dumps(payload)
+        self.assertNotIn("avatar", serialized.lower())
+        self.assertNotIn("bioDescription", serialized)
+        self.assertNotIn("private-avatar-url", serialized)
+
+    def test_empty_comment_is_not_emitted(self):
+        event = SimpleNamespace(room_id="room", data={"content": "\u0000\n"})
+        self.assertIsNone(transport.build_comment_payload(event))
+
+    def test_like_and_viewer_payloads_are_bounded_metrics(self):
+        like = transport.build_like_payload(
+            SimpleNamespace(
+                room_id="room",
+                data={
+                    "common": {"msgId": "like-1"},
+                    "count": "42",
+                    "total": "9001",
+                    "user": {"uniqueId": "tapper", "nickname": "Tapper"},
+                },
+            )
+        )
+        viewers = transport.build_viewer_snapshot_payload(
+            SimpleNamespace(
+                room_id="room",
+                data={"common": {"msgId": "view-1"}, "viewerCount": "37"},
+            )
+        )
+        self.assertEqual(like["like_count"], 42)
+        self.assertEqual(like["like_total"], 9001)
+        self.assertEqual(like["unique_id"], "tapper")
+        self.assertEqual(viewers["viewer_count"], 37)
+
+    def test_follow_share_and_question_payloads_keep_public_fields_only(self):
+        social = SimpleNamespace(
+            room_id="room",
+            data={
+                "common": {"msgId": "social-1"},
+                "action": "2",
+                "shareType": "3",
+                "shareTarget": "should-not-leave",
+                "user": {
+                    "uniqueId": "viewer",
+                    "nickname": "Viewer",
+                    "bioDescription": "private-profile-text",
+                },
+            },
+        )
+        share = transport.build_social_payload("share", social)
+        follow = transport.build_social_payload("follow", social)
+        question = transport.build_question_payload(
+            SimpleNamespace(
+                room_id="room",
+                data={
+                    "common": {"msgId": "question-1"},
+                    "details": {
+                        "questionId": "77",
+                        "questionText": "Where do I submit?",
+                        "answerStatus": "0",
+                        "user": {"uniqueId": "asker", "nickname": "Asker"},
+                    },
+                },
+            )
+        )
+        self.assertEqual(share["event_type"], "share")
+        self.assertEqual(share["share_type"], 3)
+        self.assertEqual(follow["event_type"], "follow")
+        self.assertEqual(question["question_text"], "Where do I submit?")
+        serialized = json.dumps([share, follow, question])
+        self.assertNotIn("private-profile-text", serialized)
+        self.assertNotIn("shareTarget", serialized)
+
+    def test_gift_emits_only_completed_combo_and_never_currency(self):
+        base = {
+            "common": {"msgId": "gift-1"},
+            "giftId": "5655",
+            "repeatCount": "3",
+            "gift": {"id": "5655", "name": "Rose", "diamondCount": "1"},
+            "user": {"uniqueId": "giver", "nickname": "Giver"},
+            "is_combo": True,
+            "diamond_total": 3,
+        }
+        in_progress = transport.build_gift_payload(
+            SimpleNamespace(room_id="room", data={**base, "is_streak_over": False})
+        )
+        completed = transport.build_gift_payload(
+            SimpleNamespace(room_id="room", data={**base, "is_streak_over": True})
+        )
+        self.assertIsNone(in_progress)
+        self.assertEqual(completed["gift_name"], "Rose")
+        self.assertEqual(completed["gift_count"], 3)
+        self.assertEqual(completed["diamond_total"], 3)
+        self.assertNotIn("usd", json.dumps(completed).lower())
+        self.assertNotIn("dollar", json.dumps(completed).lower())
+
+    def test_fallback_event_id_uses_stable_source_time(self):
+        event = SimpleNamespace(
+            room_id="room-1",
+            data={
+                "common": {"createTime": "1787931000000"},
+                "content": "same replayed comment",
+                "user": {"uniqueId": "viewer", "nickname": "Viewer"},
+            },
+        )
+        with mock.patch.object(
+            telemetry_common,
+            "_utc_now",
+            side_effect=["2026-08-28T23:30:00Z", "2026-08-28T23:31:00Z"],
+        ):
+            first = transport.build_comment_payload(event)
+            second = transport.build_comment_payload(event)
+        self.assertEqual(first["event_id"], second["event_id"])
+        self.assertNotEqual(first["observed_at"], second["observed_at"])
+
+    def test_transport_error_uses_class_only(self):
+        payload = transport.build_transport_error_payload(
+            RuntimeError("https://example.invalid/?token=secret")
+        )
+        self.assertEqual(payload["error_code"], "RuntimeError")
+        self.assertNotIn("secret", json.dumps(payload))
+        self.assertNotIn("example.invalid", json.dumps(payload))
+
+    def test_reconnecting_payload_bounds_numeric_fields(self):
+        event = SimpleNamespace(
+            room_id="room",
+            data={"attempt": "3", "max_retries": "5", "delay": "8"},
+        )
+        payload = transport.build_lifecycle_payload("reconnecting", event)
+        self.assertEqual(payload["attempt"], 3)
+        self.assertEqual(payload["max_retries"], 5)
+        self.assertEqual(payload["delay_seconds"], 8)
+
+    def test_emit_payload_is_one_compact_json_line(self):
+        output = io.StringIO()
+        with redirect_stdout(output):
+            transport.emit_payload({"schema_version": 1, "event_type": "connected"})
+        lines = output.getvalue().splitlines()
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(json.loads(lines[0])["event_type"], "connected")
+
+    def test_event_id_deduper_is_bounded(self):
+        deduper = transport.EventIdDeduper(capacity=2)
+        self.assertTrue(deduper.accept("one"))
+        self.assertFalse(deduper.accept("one"))
+        self.assertTrue(deduper.accept("two"))
+        self.assertTrue(deduper.accept("three"))
+        self.assertTrue(deduper.accept("one"))
+        self.assertEqual(deduper.duplicates, 1)
+
+

--- a/tools/tiktok-live-ingest/README.md
+++ b/tools/tiktok-live-ingest/README.md
@@ -1,4 +1,4 @@
-# TikTok LIVE chat transport (shadow-only)
+# TikTok LIVE public telemetry transport (shadow-only)
 
 This directory documents the optional transport used by
 `scripts/tiktok_live_chat_transport.py`. It connects directly to TikTok's
@@ -13,25 +13,35 @@ Keep the transport in its own virtual environment.
 
 The transport and weekly shadow supervisor:
 
-- read public comments and stream lifecycle events only;
+- read public comments, taps/likes, viewer snapshots, shares, follows, gifts,
+  TikTok Q&A questions, joins, and stream lifecycle events;
 - do not use EulerStream, an API key, a signing service, or TikTok account
   cookies;
 - cannot post comments, gift, follow, moderate, or mutate the show;
-- emit no profile biography, avatar, follower count, gift, like, join, or
-  payment data;
+- emit no profile biography, avatar, follower count, private profile fields,
+  payment/customer data, or currency conversion;
+- treat TikTok gift diamonds only as platform-provided engagement units, not
+  BARCODE payment truth and not a cash value;
 - do not write a database or durable transcript;
 - do not call Gemini, Discord, the website, Relay, Journal, Moments,
   Relationship, Source Files, dossiers, queue actions, or payment owners.
 
-The BNL adapter hard-codes every accepted comment as:
+Every accepted event is hard-coded as:
 
 ```text
 source=tiktok_live_webcast
 visibility=public_observation
-authority=viewer_statement
 lifecycle=current_show_only
 memory_default=do_not_store
 identity_default=tiktok_only_unlinked
+```
+
+Authority varies by event type:
+
+```text
+comment/question=viewer_statement
+like/share/follow/gift/join=public_interaction_event
+viewer_snapshot=platform_room_metric
 ```
 
 A TikTok handle is not a Discord identity, website account, queue submitter,
@@ -60,17 +70,21 @@ Run the raw transport only for a short connection proof:
 
 Do not redirect stdout to a durable file.
 
-## Replay and LIVE-end handling
+## Replay, gift-streak, and LIVE-end handling
 
-TikTok can replay recent Webcast messages after a reconnect. The transport now
-retains only a bounded set of recent event IDs and suppresses duplicate comment
-IDs. When TikTok emits `live_ended`, the transport emits it once, blocks later
-stale-frame comments, and requests a clean disconnect instead of reconnecting
-to the ended room.
+TikTok can replay recent Webcast messages after a reconnect. The transport
+retains only a bounded set of recent event IDs and suppresses duplicates across
+all emitted telemetry types. The window supervisor adds a second deduplication
+boundary across fresh child processes.
 
-The window supervisor adds a second deduplication boundary across fresh child
-processes. It can therefore stop an ended connection and keep checking for a
-new LIVE without printing the same comments again.
+Combo-gift progress frames are not emitted as completed gifts. The transport
+waits for TikTok's streak-over signal and emits the final gift count/diamond
+total once, preventing intermediate combo frames from inflating analytics.
+
+When TikTok emits `live_ended`, the transport emits it once, blocks later stale
+frames, and requests a clean disconnect instead of reconnecting to the ended
+room. The weekly supervisor then keeps checking for a new LIVE until the show
+window closes.
 
 ## Weekly unattended shadow window
 
@@ -92,11 +106,15 @@ that window it:
 - connects automatically when the account becomes LIVE;
 - restarts after a connection failure;
 - keeps watching after a LIVE ends in case the stream restarts;
+- prints comments, batched tap events, changed viewer counts, shares, follows,
+  completed gifts, and TikTok Q&A questions;
+- counts joins without printing every join line;
+- prints a bounded end-of-window telemetry summary;
 - stops and destroys its terminal scrollback at 2:00 AM;
 - restarts the tmux terminal if the supervisor process crashes.
 
-Raw comments remain only in a dedicated tmux terminal. Routine systemd logs
-contain scheduler health, not the comment transcript.
+Raw public observations remain only in a dedicated tmux terminal. Routine
+systemd logs contain scheduler health, not the transcript or telemetry stream.
 
 After the unit files are installed and enabled, attach with:
 
@@ -116,23 +134,35 @@ systemctl list-timers bnl-tiktok-chat-shadow.timer --no-pager
 
 The service/timer are a shadow reliability tool only. Enabling them does not
 authorize BNL to consume, answer, store, summarize, publish, or act on TikTok
-comments.
+telemetry.
 
 ## NDJSON contract
 
 Each line is one JSON object with `schema_version=1`.
 
-Comment fields:
+Common fields:
 
 ```text
-event_type=comment
+event_type
 event_id
 room_id
-observed_at
-unique_id
-display_name
-comment_text
-moderator_flag
+observed_at      # VPS receipt time
+source_at        # TikTok source time when available
+```
+
+Public observation types:
+
+```text
+comment          unique_id, display_name, comment_text, moderator_flag
+like             unique_id/display_name when supplied, like_count, like_total
+viewer_snapshot  viewer_count
+share            unique_id, display_name, share_type
+follow           unique_id, display_name
+gift             unique_id, display_name, gift_id, gift_name, gift_count,
+                  diamond_count, diamond_total, combo, streak_over
+question         unique_id, display_name, question_id, question_text,
+                  answer_status
+join             unique_id, display_name, join_count
 ```
 
 Lifecycle types:
@@ -151,7 +181,11 @@ URLs, cookies, and request headers are not emitted.
 ## Current stop point
 
 The direct connection has been observed receiving real public LIVE comments,
-moderator status, and the LIVE-end event. This code hardens and automates the
-shadow collection window. It still does not wire TikTok comments into
-`bnl01_bot.py`, Gemini, Discord output, durable memory, or any public surface.
-Private BNL awareness remains a separate implementation and activation gate.
+moderator status, and the LIVE-end event. This phase expands the same shadow
+transport to additional public engagement telemetry so the next full show can
+validate availability, volume, timing, and replay behavior.
+
+It still does not wire any TikTok event into `bnl01_bot.py`, Gemini, Discord
+output, durable memory, the queue, the website, or a public surface. Private BNL
+awareness and queue/track correlation remain separate implementation and
+activation gates.


### PR DESCRIPTION
## Result

Extends the proven direct TikTok LIVE shadow collector beyond comments so the next show can test public engagement telemetry without introducing EulerStream, a second BNL mind, a database, or any public behavior.

## Added public shadow signals

- comments and moderator markers
- tap/like deltas and reported total likes
- viewer-count snapshots and peak-viewer tracking
- shares
- follows
- completed gifts, gift units, and TikTok-provided diamond units
- TikTok Q&A questions
- joins, counted in the final summary without printing every join line
- stream lifecycle and reconnect health

## Data contract and safeguards

Every accepted observation remains:

```text
source=tiktok_live_webcast
visibility=public_observation
lifecycle=current_show_only
memory_default=do_not_store
identity_default=tiktok_only_unlinked
```

Authority remains source-specific:

```text
comment/question=viewer_statement
like/share/follow/gift/join=public_interaction_event
viewer_snapshot=platform_room_metric
```

The transport preserves both VPS receipt time and TikTok source time when available. It bounds text and numeric fields, strips profile biography/avatar/private profile data, does not convert diamonds into money, and emits only final combo-gift frames so progress messages do not inflate gift totals.

Replay suppression now covers every telemetry event across ordinary reconnects and fresh child collector processes during the same show window. Joins are counted but not retained in the current-show event buffer.

## Operator terminal behavior

The unattended Friday shadow window still runs from 6:50 PM Friday through 2:00 AM Saturday in `America/Los_Angeles`. During the window it prints compact public telemetry lines, suppresses unchanged viewer snapshots, and emits one bounded end-of-window summary.

## Explicitly unchanged

- no `bnl01_bot.py` integration
- no Gemini calls or per-event generation
- no Discord output
- no website, queue, payment, overlay, Journal, Relay, Moment, Relationship, Source File, dossier, or durable-memory write
- no TikTok posting, gifting, following, or moderation
- no account, artist, queue-submit, or Discord identity linking
- no change to `#welcome`, `#episode-tracker`, conversation routing, or show-control authority
- no VPS unit activation or configuration change in this PR

## Main files

- `bnl_tiktok_live_chat.py`
- `scripts/tiktok_live_chat_transport.py`
- `scripts/tiktok_live_telemetry_common.py`
- `scripts/tiktok_live_telemetry_payloads.py`
- `scripts/tiktok_live_chat_shadow_window.py`
- `scripts/tiktok_live_shadow_model.py`
- `scripts/tiktok_live_shadow_runtime.py`
- focused transport, adapter, payload, and schedule tests

## Local verification

- 33 focused TikTok tests passed
- Python compilation passed for the adapter, transport, supervisor, and tests
- Python 3.9 syntax compatibility passed for all changed Python files
- transport and supervisor `--help` entrypoints passed

GitHub CI additionally runs the existing full bot `make check` on Python 3.9 and 3.12, plus the isolated Python 3.11 direct-transport import and TikTok-focused test contract.

## Runtime uncertainty

The direct path is already observed receiving real comments, moderator markers, room connection, and LIVE-end events. This PR does not claim that every newly registered telemetry type will be delivered by TikTok at useful frequency or with stable field shapes. One real shadow LIVE is still required to verify taps, viewer snapshots, shares, follows, gifts, questions, joins, event volume, latency, and replay behavior.

## Rollback

Revert this PR. It creates no database, schema, secret, environment-variable, payment, queue, website, or public-state migration.