### PR TITLE
Route public TikTok chat and current-track link questions

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -2142,6 +2142,12 @@ def fetch_bnl_read_model(force: bool = False) -> dict:
 _PRIVATE_BNL_QUEUE_POLICIES = frozenset({"sealed_test", "internal_controlled"})
 
 _QUEUE_READ_MODEL_PATTERNS = (
+    r"\bwhat(?:['’]s| is|s) (?:the )?(?:link|url) (?:to|for) "
+    r"(?:the )?(?:current|now playing|playing|loaded|this) (?:track|song)\b",
+    r"\b(?:send|give|drop)(?: me)? (?:the )?(?:link|url) (?:to|for) "
+    r"(?:the )?(?:current|now playing|playing|loaded|this) (?:track|song)\b",
+    r"\b(?:current|now playing|playing|loaded) (?:track|song)(?:['’]s)? "
+    r"(?:link|url)\b",
     r"\bwho(?:['’]s| is) playing(?: (?:now|currently|right now))?\b",
     r"\bnow playing\b",
     r"\bwhat(?:['’]s| is) playing(?: (?:now|currently|right now))?\b",
@@ -2188,7 +2194,14 @@ def _queue_query_focus(text: str) -> dict:
     """Classify which slice of the complete queue snapshot this request needs."""
 
     normalized = re.sub(r"\s+", " ", str(text or "")).strip().lower()
-    now_playing = bool(re.search(
+    track_link = bool(re.search(
+        r"\b(?:link|url) (?:to|for) (?:the )?"
+        r"(?:current|now playing|playing|loaded|this) (?:track|song)\b|"
+        r"\b(?:current|now playing|playing|loaded) "
+        r"(?:track|song)(?:['’]s)? (?:link|url)\b",
+        normalized,
+    ))
+    now_playing = track_link or bool(re.search(
         r"\b(?:now playing|whats playing|what(?:['’]s| is) playing|"
         r"what (?:song|track) is on|what (?:are we|am i) listening to|"
         r"what(?:['’]s| is|s) (?:currently )?(?:pulled|loaded) up|"
@@ -2234,6 +2247,7 @@ def _queue_query_focus(text: str) -> dict:
     ))
     return {
         "now_playing": now_playing,
+        "track_link": track_link,
         "up_next": up_next,
         "full_lineup": full_lineup,
         "wheel": wheel,
@@ -2448,6 +2462,7 @@ def _track_label(
     include_lane: bool = True,
     include_source: bool = False,
     include_queue_details: bool = False,
+    include_public_source_url: bool = False,
 ) -> str:
     if not isinstance(track, dict):
         return ""
@@ -2517,6 +2532,15 @@ def _track_label(
                     duration_label = f"est. {duration_label}"
         if duration_label:
             extras.append(f"duration={duration_label}")
+    if include_public_source_url:
+        source_url = _compact_public_text(track.get("publicSourceUrl"), 500)
+        parsed_source_url = urllib.parse.urlparse(source_url)
+        if (
+            source_url
+            and parsed_source_url.scheme in {"http", "https"}
+            and parsed_source_url.netloc
+        ):
+            extras.append(f"publicSourceUrl={source_url}")
     if label and extras:
         label = f"{label} ({', '.join(extras)})"
     return label
@@ -2566,7 +2590,14 @@ def _queue_request_focus_lines(focus: dict, queue_url: str) -> list:
             "- Full-lineup request: do not reproduce the complete lineup in Discord; "
             f"direct the user to {destination}."
         )
-    if focus.get("now_playing"):
+    if focus.get("track_link"):
+        lines.append(
+            "- Current-track-link request: reply with the exact publicSourceUrl "
+            "from Now playing and no unrelated statistics. If it is absent, say "
+            "that no public source link is available; never deflect a readable link "
+            "request to the DJ, host, or production team."
+        )
+    elif focus.get("now_playing"):
         lines.append("- Now-playing request: answer with the current loaded track and playback state only unless the user asks for more.")
     if focus.get("up_next"):
         lines.append("- Up-next request: answer with Up next only unless the user asks for more.")
@@ -2685,7 +2716,11 @@ def build_bnl_read_model_context(read_model: dict, user_text: str, channel_polic
         revision = _first_present_value(queue, ("revision",))
         if revision is not None:
             lines.append(f"- Queue revision: {_compact_public_text(revision, 30)}")
-        now_label = _track_label(now_playing, include_queue_details=True)
+        now_label = _track_label(
+            now_playing,
+            include_queue_details=True,
+            include_public_source_url=bool(queue_focus.get("track_link")),
+        )
         if now_label:
             lines.append(f"- Now playing: {now_label}")
         else:

--- a/bnl_tiktok_live_context.py
+++ b/bnl_tiktok_live_context.py
@@ -56,6 +56,9 @@ _SPACE_RE = re.compile(r"\s+")
 _HANDLE_RE = re.compile(r"^[A-Za-z0-9._]+$")
 
 _LIVE_REACTION_PATTERNS = (
+    r"\b(?:tiktok|tik tok)(?: live| stream)? (?:chat|comments?)\b",
+    r"\bwhat(?:['’]s| is|s) (?:the )?chat talking (?:about|bout)\b",
+    r"\bwhat did (?:the )?(?:live |stream )?chat (?:just )?say\b",
     r"\bwhat(?:['’]s| is|s) (?:the )?(?:tiktok )?chat (?:saying|thinking|doing)\b",
     r"\bwhat (?:does|do) (?:the )?(?:tiktok )?chat think\b",
     r"\bhow(?:['’]s| is) (?:the )?(?:tiktok )?chat (?:reacting|feeling|doing)\b",

--- a/tests/test_bnl_live_context_bridge.py
+++ b/tests/test_bnl_live_context_bridge.py
@@ -150,6 +150,11 @@ class BNLLiveContextBridgeTests(unittest.TestCase):
                     "How is TikTok chat reacting to the show?",
                     "public_home",
                 )
+                exact_live_chat_context = bnl01_bot.build_bnl_read_model_context(
+                    public_read_model(),
+                    "What did TikTok chat just say?",
+                    "public_home",
+                )
 
         self.assertIn("Now playing: 6 Bit — Training Module One", context)
         self.assertIn("track_play_started", context)
@@ -157,6 +162,11 @@ class BNLLiveContextBridgeTests(unittest.TestCase):
         self.assertNotIn("Do Not Dump Me", context)
         self.assertIn("queue snapshot as authoritative show state", context)
         self.assertIn("above Community Canon", context)
+        self.assertIn("This track is wild.", exact_live_chat_context)
+        self.assertIn(
+            "Current TikTok LIVE public reaction context",
+            exact_live_chat_context,
+        )
 
     def test_private_queue_scope_cannot_feed_public_live_reaction_context(self):
         model = public_read_model()

--- a/tests/test_showday_queue_alignment.py
+++ b/tests/test_showday_queue_alignment.py
@@ -293,12 +293,62 @@ class ShowdayQueueAlignmentTests(unittest.IsolatedAsyncioTestCase):
             "what are we listening to",
             "what did you pull up",
             "what's pulled up in now playing",
+            "Whats the link to the current track?",
+            "Drop me the URL for the loaded song",
             "whats next",
             "who won the wheel",
         )
         for phrase in phrases:
             with self.subTest(phrase=phrase):
                 self.assertTrue(bnl01_bot._queue_read_model_query(phrase))
+
+    def test_current_track_link_request_includes_only_the_public_source_url(self):
+        model = read_model(True)
+        model["sections"]["queue"]["nowPlaying"] = {
+            "submittedArtistName": "Current Artist",
+            "submittedSongTitle": "Current Track",
+            "publicSourceUrl": "https://www.youtube.com/watch?v=abcdefghijk",
+        }
+
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_QUEUE_PRODUCTION_ENABLED": "true"},
+            clear=False,
+        ):
+            context = bnl01_bot.build_bnl_read_model_context(
+                model,
+                "Whats the link to the current track?",
+                "public_home",
+            )
+
+        self.assertIn("Current-track-link request", context)
+        self.assertIn(
+            "publicSourceUrl=https://www.youtube.com/watch?v=abcdefghijk",
+            context,
+        )
+        self.assertIn("never deflect", context)
+
+    def test_current_track_link_request_drops_an_invalid_source_url(self):
+        model = private_read_model()
+        model["sections"]["queue"]["nowPlaying"] = {
+            "submittedArtistName": "Current Artist",
+            "submittedSongTitle": "Current Track",
+            "publicSourceUrl": "javascript:alert(1)",
+        }
+
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_QUEUE_PRODUCTION_ENABLED": "true"},
+            clear=False,
+        ):
+            context = bnl01_bot.build_bnl_read_model_context(
+                model,
+                "Whats the link to the current track?",
+                "sealed_test",
+            )
+
+        self.assertIn("Current-track-link request", context)
+        self.assertNotIn("javascript:alert", context)
 
     def test_complete_queue_is_searched_beyond_position_eight_without_dumping_it(self):
         model = private_read_model()

--- a/tests/test_tiktok_live_context_bridge.py
+++ b/tests/test_tiktok_live_context_bridge.py
@@ -93,6 +93,10 @@ class TikTokLiveContextBridgeTests(unittest.TestCase):
         positives = (
             "What's TikTok chat saying?",
             "whats chat thinking about the show",
+            "What did TikTok chat just say?",
+            "What is the chat talking about right now?",
+            "Nice. What is the chat talking bout?",
+            "No, BNL, the TikTok chat.",
             "How are the viewers reacting?",
             "How's the live going?",
             "What is happening during the show?",


### PR DESCRIPTION
## Summary

Follow-up hotfix to #457 for two live public Discord misses observed during the show:

- Route direct and natural TikTok chat wording, including `what did TikTok chat just say?`, into the existing authorized live-context snapshot.
- Route current-track link/URL requests into the queue read model.
- Expose only the validated HTTP(S) `publicSourceUrl` for that focused request and explicitly prevent DJ/host/production-team deflection.
- Keep the TikTok collector, queue mutation authority, and storage policy unchanged.

## Verification

- `make check PYTHON=./venv/bin/python` — 2,449 tests passed.
- Focused live-context/queue suite — 36 tests passed.
- `tests.test_conversation_batching` — 46 tests passed.
- Python compilation and `git diff --check` passed.

The tested tree is `d76fcac3e9418edb9c38268df22119a788794e0a`.