### PR TITLE
Route historical show timelines to durable evidence

### DIFF
--- a/bnl_tiktok_live_context.py
+++ b/bnl_tiktok_live_context.py
@@ -108,6 +108,11 @@ _SHOW_ANALYSIS_PATTERNS = (
     r"(?:said|talked about|discussed|mentioned|asked)\b.*"
     r"\b(?:during|throughout|on|in|from) (?:the )?"
     r"(?:live|show|stream|broadcast)\b",
+    r"\bwhat happened (?:during|throughout|at|in|on) (?:the )?"
+    r"(?:(?:(?:yesterday|last night)(?:['’]s)?|last|previous|past) "
+    r"(?:(?:barcode radio|tiktok) )?(?:live|show|stream|broadcast)|"
+    r"(?:(?:barcode radio|tiktok) )?(?:live|show|stream|broadcast) "
+    r"(?:yesterday|last night))\b",
 )
 
 _SHOW_ANALYSIS_FOLLOWUP_PATTERNS = (

--- a/tests/test_bnl_live_context_bridge.py
+++ b/tests/test_bnl_live_context_bridge.py
@@ -427,6 +427,35 @@ class BNLLiveContextBridgeTests(unittest.TestCase):
         self.assertNotIn("Now playing:", context)
         self.assertNotIn("Ranking by public chat messages", context)
 
+    def test_historical_multisource_timeline_reloads_durable_show_owner(self):
+        question = (
+            "BNL, what happened during yesterday's BARCODE Radio show? "
+            "Give me a chronological timeline using the show chat, queue "
+            "events, tracks, and your Discord conversations."
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"BNL_QUEUE_PRODUCTION_ENABLED": "true"},
+            clear=False,
+        ), mock.patch.object(
+            bnl01_bot,
+            "fetch_bnl_read_model",
+            return_value=public_read_model_with_show_archive(),
+        ) as fetch, mock.patch.object(
+            bnl01_bot,
+            "_load_durable_tiktok_show_events",
+            return_value=[],
+        ) as archive_load:
+            context = bnl01_bot.maybe_build_bnl_read_model_context(
+                question,
+                "public_home",
+            )
+
+        fetch.assert_called_once_with(force=True)
+        archive_load.assert_called_once()
+        self.assertIn("Durable TikTok show analysis context", context)
+        self.assertIn("Analysis intent=show_recap", context)
+
     def test_each_explicit_chat_analysis_turn_reloads_its_durable_owner(self):
         questions = (
             "Any recurring topics from TikTok chat during the show?",

--- a/tests/test_tiktok_live_context_bridge.py
+++ b/tests/test_tiktok_live_context_bridge.py
@@ -124,6 +124,9 @@ class TikTokLiveContextBridgeTests(unittest.TestCase):
             "Give me a quick rundown on what people talked about throughout the live",
             "What recurring topics came up in chat during the show?",
             "How did the broadcast go?",
+            "BNL, what happened during yesterday's BARCODE Radio show? "
+            "Give me a chronological timeline using the show chat, queue "
+            "events, tracks, and your Discord conversations.",
         )
         for value in positives:
             with self.subTest(value=value):

--- a/tests/test_tiktok_show_episode_response_guard.py
+++ b/tests/test_tiktok_show_episode_response_guard.py
@@ -56,6 +56,22 @@ class TikTokShowEpisodeResponseGuardTests(unittest.TestCase):
             "unsupported_show_lore_cliff",
         )
 
+    def test_guard_rejects_public_surface_snapshot_refusal(self):
+        refusal = (
+            "I can't give you a minute-by-minute timeline of the chat or "
+            "Discord exchanges from yesterday, 6 Bit—that level of granular "
+            "conversation logging isn't available in my current surface "
+            "snapshot. I can, however, confirm the high-level metrics from "
+            "the broadcast."
+        )
+        self.assertEqual(
+            bnl01_bot.tiktok_show_episode_response_failure(
+                refusal,
+                RAW_PROMPT,
+            ),
+            "show_evidence_refused",
+        )
+
     def test_guard_rejects_invented_clock_time(self):
         response = (
             "At 7:05 PM, Neon Fox's First Signal began, then Queue Light "


### PR DESCRIPTION
## Summary

- Recognize historical BARCODE Radio “what happened” requests with explicit past-show wording as durable show-analysis requests.
- Route the exact failed public prompt through the existing archived show owner with `show_analysis=1`, so queue chronology, TikTok show chat, tracks, and paired Discord exchanges are supplied together.
- Keep the existing finalized-episode response guard active so a draft claiming the available timeline is unavailable is regenerated or suppressed.

## Confirmed root cause

The deployed VPS was healthy on `ec37f921b1b9c3395a51e3abb9bcb594f53ae432`. Its finalized ledger contained 1,704 episode events and the existing builder produced a 14,955-character evidence packet. The actual public request logged `show_analysis=0` and loaded only the generic 1,310-character read-model packet. Reproduction on the deployed source confirmed the exact prompt returned `False` from both the historical-analysis and live-reaction classifiers.

## Verification

- Exact failed wording now resolves as explicit `show_recap` and forces the durable owner reload.
- Exact public “surface snapshot” refusal is rejected by the existing finalized-show guard.
- Focused show, live-context, ledger, guard, and layered-canon suite: 80 passed.
- `make PYTHON=venv/bin/python check`: 2,489 passed.
- `git diff --check`: passed.
- Published Git tree matches the locally tested tree exactly: `625bd1ddc508ff81a5f34838dc212c7a68811f60`.

## Boundaries

- Reuses the existing show episode, queue authority, Open Signal, recurrence, and response-guard owners.
- No website, schema, migration, environment, queue operation, canon promotion, or feature-gate changes.
- Global memory, Relationship, Active Engagement, and production gates are unchanged.

## Post-merge deployment

Bot runtime only. Deploy the merged `main` commit with the standard bot pull/restart procedure, then repeat the exact historical timeline prompt and verify `tiktok_show_analysis_request_resolved mode=explicit`, `show_analysis=1`, and `show_episode_evidence_context_loaded` before judging the answer.