### PR TITLE
Enforce authorized show/queue evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,16 +130,29 @@ reactions follows the ordinary conversation persistence path. Aggregate viewers,
 taps, gifts, joins, and other room metrics remain current-show-only and do not
 become personal memory or canon.
 
-The same one-minute read-model cycle automatically assembles a durable public
-show episode for every retained show. It preserves the website archive's full
-public-safe queue/broadcast milestone sequence and track roster, places every
-eligible TikTok comment/question on that clock, and pairs public Discord user
-rows only when BNL's stored response explicitly targets that member in the same
-channel within the bounded response window. Questions, answers, track state,
+The same one-minute read-model cycle may assemble a durable public show episode
+for a retained show only after the local queue gate, website queue capability,
+top-level public scope, and exact `queue_public_history_projection_v1` archive
+contract all pass. The archive must be available, `public_safe`, explicitly
+public, digest/revision-bearing, browser-personal-history-free, and free of test
+or simulation markers. Private, unavailable, malformed, capability-disabled,
+and local-gate-disabled projections create no show row or Memory Ledger
+projection. Each admitted episode carries a content-free
+`show_queue_evidence_authorization_v1` receipt in its source digest. Older rows
+without that receipt are preserved for audit but quarantined from show recall,
+packet selection, recurrence grouping, and source revalidation; an eligible
+public source refresh rewrites the matching row through the existing owner.
+
+An authorized episode preserves the website archive's full public-safe
+queue/broadcast milestone sequence and track roster, places every eligible
+TikTok comment/question on that clock, and pairs public Discord user rows only
+when BNL's stored response explicitly targets that member in the same channel
+within the bounded response window. Questions, answers, track state,
 Wheel/sponsor/signal-hold events, order, and outcomes therefore remain available
 after the live snapshot expires. Ordinary recall retrieves only the show and
 evidence slices relevant to the current question; the complete ledger is not
-dumped into every prompt.
+dumped into every prompt. The local queue gate is checked again for direct show
+context, packet selection, and send-time packet revalidation.
 
 This episode is a limited operational-memory exception, not a second queue
 owner. Website milestones and roster outcomes are authoritative operational

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -21,6 +21,7 @@ from bnl_canon_source_contract import (
     CANON_SOURCE_CONTRACT_VERSION,
     build_claim_contract_inventory,
     diagnostics as canon_source_diagnostics,
+    env_queue_production_enabled,
     queue_usability,
     render_concise_public_schedule,
     render_founders,
@@ -3349,6 +3350,13 @@ def build_tiktok_show_evidence_context_for_turn(
     website_read_model_context: str = "",
 ) -> str:
     """Select finalized show evidence through the shared turn-level owner."""
+
+    if not env_queue_production_enabled():
+        logging.info(
+            "show_episode_evidence_context_skipped "
+            "reason=local_queue_production_gate_disabled"
+        )
+        return ""
 
     tiktok_subject_continuity_allowed = True
     if int(subject_user_id or 0) > 0 and os.path.exists(DB_FILE):
@@ -32575,6 +32583,7 @@ _tiktok_live_memory_runtime = {
     "show_ledger_last_discord_interactions": 0,
     "show_ledger_last_discord_exchanges": 0,
     "show_ledger_last_conversation_rows": 0,
+    "show_ledger_authorization_eligible": False,
     "show_ledger_last_error_type": "",
 }
 
@@ -32883,6 +32892,12 @@ async def queue_artist_memory_sync_task():
         return
     read_model = await asyncio.to_thread(fetch_bnl_read_model, True)
     if not read_model:
+        _tiktok_live_memory_runtime[
+            "show_ledger_authorization_eligible"
+        ] = False
+        _tiktok_live_memory_runtime[
+            "show_ledger_last_reason"
+        ] = "read_model_unavailable"
         logging.warning("queue_artist_memory_sync_skipped reason=read_model_unavailable")
         return
     guilds = list(iter_managed_guilds())
@@ -32941,10 +32956,14 @@ async def queue_artist_memory_sync_task():
                 guild_id=guild_id,
                 read_model=read_model,
                 artist_identity_index=artist_identity_index,
+                environ=os.environ,
             )
             _tiktok_live_memory_runtime["show_ledger_last_reason"] = str(
                 show_ledger_result.get("reason") or "unknown"
             )
+            _tiktok_live_memory_runtime[
+                "show_ledger_authorization_eligible"
+            ] = bool(show_ledger_result.get("authorizationEligible"))
             _tiktok_live_memory_runtime["show_ledger_last_written"] = int(
                 show_ledger_result.get("showsWritten") or 0
             )
@@ -32969,7 +32988,8 @@ async def queue_artist_memory_sync_task():
             _tiktok_live_memory_runtime["show_ledger_last_error_type"] = ""
             logging.info(
                 "barcode_show_episode_ledger_sync guild=%s status=%s "
-                "reason=%s shows_seen=%s shows_written=%s "
+                "reason=%s authorization_eligible=%s "
+                "shows_seen=%s shows_written=%s "
                 "shows_unchanged=%s shows_finalized=%s tiktok_events=%s "
                 "operational_events=%s track_roster=%s discord_interactions=%s "
                 "discord_exchanges=%s discord_participants=%s "
@@ -32979,6 +32999,7 @@ async def queue_artist_memory_sync_task():
                 guild_id,
                 show_ledger_result.get("status"),
                 show_ledger_result.get("reason"),
+                int(bool(show_ledger_result.get("authorizationEligible"))),
                 show_ledger_result.get("showsSeen", 0),
                 show_ledger_result.get("showsWritten", 0),
                 show_ledger_result.get("showsUnchanged", 0),
@@ -32996,6 +33017,9 @@ async def queue_artist_memory_sync_task():
                 show_ledger_result.get("projectionErrors", 0),
             )
         except Exception as exc:
+            _tiktok_live_memory_runtime[
+                "show_ledger_authorization_eligible"
+            ] = False
             _tiktok_live_memory_runtime[
                 "show_ledger_last_error_type"
             ] = type(exc).__name__
@@ -47052,7 +47076,7 @@ async def bnl_status(interaction: discord.Interaction):
         f"- tiktok_live_last_error_code: `{tiktok_live_diag.get('lastErrorCode')}` memory_default=`{tiktok_live_diag.get('memoryDefault')}`",
         f"- tiktok_live_memory_enabled: `{'yes' if BNL_TIKTOK_LIVE_MEMORY_ENABLED else 'no'}` placement=`above_community_canon`",
         f"- tiktok_live_memory_last_ingested: `{int(_tiktok_live_memory_runtime.get('last_ingested') or 0)}` total_since_start=`{int(_tiktok_live_memory_runtime.get('total_ingested') or 0)}` reason=`{_tiktok_live_memory_runtime.get('last_reason')}` error_type=`{_tiktok_live_memory_runtime.get('last_error_type') or 'none'}`",
-        f"- barcode_show_episode_ledger_last_sync: written=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_written') or 0)}` finalized=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_finalized') or 0)}` tiktok_events=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_events') or 0)}` operational_events=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_operational_events') or 0)}` discord_interactions=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_discord_interactions') or 0)}` discord_exchanges=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_discord_exchanges') or 0)}` conversation_rows=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_conversation_rows') or 0)}` reason=`{_tiktok_live_memory_runtime.get('show_ledger_last_reason')}` error_type=`{_tiktok_live_memory_runtime.get('show_ledger_last_error_type') or 'none'}`",
+        f"- barcode_show_episode_ledger_last_sync: authorized=`{'yes' if _tiktok_live_memory_runtime.get('show_ledger_authorization_eligible') else 'no'}` written=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_written') or 0)}` finalized=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_finalized') or 0)}` tiktok_events=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_events') or 0)}` operational_events=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_operational_events') or 0)}` discord_interactions=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_discord_interactions') or 0)}` discord_exchanges=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_discord_exchanges') or 0)}` conversation_rows=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_conversation_rows') or 0)}` reason=`{_tiktok_live_memory_runtime.get('show_ledger_last_reason')}` error_type=`{_tiktok_live_memory_runtime.get('show_ledger_last_error_type') or 'none'}`",
         f"- tiktok_live_identity_policy: `handle_display_correlated_v1` owner_handle_configured=`{'yes' if bool(BNL_TIKTOK_OWNER_HANDLES) else 'no'}`",
         f"- ambient_throttle: cooldown=`{AMBIENT_POST_COOLDOWN_MINUTES}m` daily_cap_today=`{ambient_cap_today}` normal_cap=`{AMBIENT_DAILY_POST_CAP}` high_activity_cap=`2` min_signal_messages=`{AMBIENT_MIN_SIGNAL_MESSAGES}` min_signal_users=`{AMBIENT_MIN_SIGNAL_UNIQUE_USERS}`",
         f"- ambient_posts_today: `{ambient_posts_today}`",

--- a/bnl_canon_source_contract.py
+++ b/bnl_canon_source_contract.py
@@ -30,6 +30,11 @@ ATOMIC_KNOWLEDGE_LIFECYCLE_SCHEMA_VERSION = (
 )
 PUBLIC_ASSESSMENT_EVIDENCE_VERSION = "public_assessment_evidence_v4"
 ENTITY_ACCOUNT_BINDING_CONTRACT_VERSION = "canon_entity_account_binding_v1"
+SHOW_QUEUE_EVIDENCE_AUTHORIZATION_VERSION = (
+    "show_queue_evidence_authorization_v1"
+)
+SHOW_QUEUE_ARCHIVE_SCHEMA_VERSION = "queue_public_history_projection_v1"
+SHOW_QUEUE_ARCHIVE_SOURCE = "queue_bnl_history_projection"
 
 
 class CanonStatus(str, Enum):
@@ -3240,6 +3245,168 @@ def queue_usability(
         "privateAllowed": bool(allow_private),
         "reason": reason,
     }
+
+
+def _show_queue_archive(read_model: dict | None) -> dict[str, Any]:
+    if not isinstance(read_model, dict):
+        return {}
+    sections = read_model.get("sections")
+    if not isinstance(sections, dict):
+        return {}
+    archive = sections.get("archive")
+    return dict(archive) if isinstance(archive, Mapping) else {}
+
+
+def _show_queue_archive_contains_test_evidence(value: Any) -> bool:
+    """Reject explicit simulation/test markers from a public projection."""
+
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            normalized_key = str(key or "").strip().casefold()
+            if normalized_key in {"issimulation", "istesttrack"} and item is True:
+                return True
+            if _show_queue_archive_contains_test_evidence(item):
+                return True
+        return False
+    if isinstance(value, (list, tuple)):
+        return any(_show_queue_archive_contains_test_evidence(item) for item in value)
+    if isinstance(value, str):
+        normalized = value.casefold()
+        return "[queue simulation track]" in normalized
+    return False
+
+
+def show_queue_evidence_authorization(
+    read_model: dict | None,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Validate the exact public-production archive admitted to show memory.
+
+    This is a narrow exception for the existing finalized-show owner. It does
+    not grant queue mutation, general queue persistence, Source File, dossier,
+    Relationship, or canon authority.
+    """
+
+    queue = queue_usability(
+        read_model,
+        environ=dict(environ) if environ is not None else None,
+        allow_private=False,
+    )
+    decision: dict[str, Any] = {
+        "usable": False,
+        "reason": str(queue.get("reason") or "queue_not_usable"),
+        "receipt": None,
+    }
+    if not queue.get("usable"):
+        return decision
+    if not isinstance(read_model, dict) or (
+        read_model.get("ok") is not True
+        or read_model.get("version") != 1
+        or read_model.get("source") != "barcode-network-site"
+        or read_model.get("publicOnly") is not True
+        or website_queue_access_scope(read_model) != "public"
+    ):
+        decision["reason"] = "read_model_public_contract_invalid"
+        return decision
+
+    archive = _show_queue_archive(read_model)
+    source_revision = archive.get("sourceRevision")
+    source_digest = str(archive.get("sourceDigest") or "").strip().casefold()
+    coverage_started_at = str(
+        archive.get("historyCoverageStartedAt") or ""
+    ).strip()
+    archive_contract_valid = bool(
+        archive.get("available") is True
+        and archive.get("reason") in {None, ""}
+        and archive.get("schemaVersion") == SHOW_QUEUE_ARCHIVE_SCHEMA_VERSION
+        and archive.get("source") == SHOW_QUEUE_ARCHIVE_SOURCE
+        and archive.get("visibility") == "public_safe"
+        and archive.get("accessScope") == "public"
+        and archive.get("memoryDefault") == "do_not_store"
+        and archive.get("sourceFileDefault") == "review_evidence_only"
+        and archive.get("publicDossierDefault") == "not_automatic"
+        and isinstance(source_revision, int)
+        and not isinstance(source_revision, bool)
+        and source_revision >= 0
+        and re.fullmatch(r"[a-f0-9]{64}", source_digest)
+        and re.fullmatch(r"20\d{2}-\d{2}-\d{2}", coverage_started_at)
+        and archive.get("personalHistory") is None
+        and not _show_queue_archive_contains_test_evidence(archive)
+    )
+    if not archive_contract_valid:
+        decision["reason"] = "archive_public_contract_invalid"
+        return decision
+
+    receipt = {
+        "contractVersion": SHOW_QUEUE_EVIDENCE_AUTHORIZATION_VERSION,
+        "readModelSource": "barcode-network-site",
+        "publicOnly": True,
+        "localQueueProduction": True,
+        "websiteQueueProduction": True,
+        "accessScope": "public",
+        "archiveSchemaVersion": SHOW_QUEUE_ARCHIVE_SCHEMA_VERSION,
+        "archiveSource": SHOW_QUEUE_ARCHIVE_SOURCE,
+        "archiveVisibility": "public_safe",
+        "archiveSourceRevision": source_revision,
+        "archiveSourceDigest": source_digest,
+        "historyCoverageStartedAt": coverage_started_at,
+    }
+    decision.update(
+        {
+            "usable": True,
+            "reason": "eligible_public_production_archive",
+            "receipt": receipt,
+        }
+    )
+    return decision
+
+
+def show_queue_evidence_authorization_receipt_valid(value: Any) -> bool:
+    """Validate a content-free receipt persisted with one show ledger."""
+
+    if not isinstance(value, Mapping):
+        return False
+    expected_keys = {
+        "contractVersion",
+        "readModelSource",
+        "publicOnly",
+        "localQueueProduction",
+        "websiteQueueProduction",
+        "accessScope",
+        "archiveSchemaVersion",
+        "archiveSource",
+        "archiveVisibility",
+        "archiveSourceRevision",
+        "archiveSourceDigest",
+        "historyCoverageStartedAt",
+    }
+    revision = value.get("archiveSourceRevision")
+    return bool(
+        set(value.keys()) == expected_keys
+        and value.get("contractVersion")
+        == SHOW_QUEUE_EVIDENCE_AUTHORIZATION_VERSION
+        and value.get("readModelSource") == "barcode-network-site"
+        and value.get("publicOnly") is True
+        and value.get("localQueueProduction") is True
+        and value.get("websiteQueueProduction") is True
+        and value.get("accessScope") == "public"
+        and value.get("archiveSchemaVersion")
+        == SHOW_QUEUE_ARCHIVE_SCHEMA_VERSION
+        and value.get("archiveSource") == SHOW_QUEUE_ARCHIVE_SOURCE
+        and value.get("archiveVisibility") == "public_safe"
+        and isinstance(revision, int)
+        and not isinstance(revision, bool)
+        and revision >= 0
+        and re.fullmatch(
+            r"[a-f0-9]{64}",
+            str(value.get("archiveSourceDigest") or "").strip().casefold(),
+        )
+        and re.fullmatch(
+            r"20\d{2}-\d{2}-\d{2}",
+            str(value.get("historyCoverageStartedAt") or "").strip(),
+        )
+    )
 
 def _looks_queue_derived(value: Any) -> bool:
     if isinstance(value, dict):

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -31,6 +31,7 @@ from bnl_canon_source_contract import (
     is_public_usable,
     map_channel_policy_visibility,
     map_route_source_label,
+    show_queue_evidence_authorization_receipt_valid,
 )
 
 MEMORY_LEDGER_SCHEMA_VERSION = "memory_ledger_v1"
@@ -7580,6 +7581,9 @@ def _tiktok_show_occurrence_identity(
             != str(source_digest or "")
             or computed_digest != str(source_digest or "")
             or str(ledger.get("lifecycle") or "") != "finalized"
+            or not show_queue_evidence_authorization_receipt_valid(
+                ledger.get("sourceAuthorization")
+            )
         ):
             continue
         evidence_rows = [

--- a/bnl_tiktok_show_ledger.py
+++ b/bnl_tiktok_show_ledger.py
@@ -19,7 +19,13 @@ import sqlite3
 from typing import Any, Mapping, Optional, Sequence
 from zoneinfo import ZoneInfo
 
-from bnl_canon_source_contract import Confidence, SourceClass, Visibility
+from bnl_canon_source_contract import (
+    Confidence,
+    SourceClass,
+    Visibility,
+    show_queue_evidence_authorization,
+    show_queue_evidence_authorization_receipt_valid,
+)
 from bnl_memory_ledger import (
     LINEAGE_TYPES,
     LedgerEntry,
@@ -45,7 +51,6 @@ TIKTOK_SHOW_EVIDENCE_RESPONSE_WINDOW_MS = 15 * 60 * 1000
 TIKTOK_SHOW_EVIDENCE_RECALL_SHOW_LIMIT = 2
 TIKTOK_SHOW_EVIDENCE_RECALL_MESSAGE_LIMIT = 10
 SHOW_EPISODE_CONTEXT_VERSION = "barcode_show_episode_context_v1"
-_LEGACY_SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION = "tiktok_show_evidence_ledger_v1"
 
 _SPACE_RE = re.compile(r"\s+")
 _QUERY_TERM_RE = re.compile(r"[a-z0-9][a-z0-9'’-]{2,}", re.IGNORECASE)
@@ -184,10 +189,7 @@ def _safe_document(value: Any) -> Optional[dict[str, Any]]:
     if not isinstance(value, Mapping):
         return None
     schema_version = value.get("schemaVersion")
-    if schema_version not in {
-        SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION,
-        _LEGACY_SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION,
-    }:
+    if schema_version != SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION:
         return None
     show_key = _safe_label(value.get("showKey"), 200)
     source_digest = _safe_label(value.get("sourceDigest"), 64).lower()
@@ -198,9 +200,12 @@ def _safe_document(value: Any) -> Optional[dict[str, Any]]:
         or not isinstance(value.get("participants"), list)
         or not isinstance(value.get("topics"), list)
         or not isinstance(value.get("trackMoments"), list)
+        or not show_queue_evidence_authorization_receipt_valid(
+            value.get("sourceAuthorization")
+        )
     ):
         return None
-    if schema_version == SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION and any(
+    if any(
         not isinstance(value.get(field), list)
         for field in (
             "trackRoster",
@@ -211,7 +216,36 @@ def _safe_document(value: Any) -> Optional[dict[str, Any]]:
         )
     ):
         return None
+    digest_payload = dict(value)
+    digest_payload.pop("sourceDigest", None)
+    computed_digest = hashlib.sha256(
+        _canonical_json(digest_payload).encode("utf-8")
+    ).hexdigest()
+    if computed_digest != source_digest:
+        return None
     return dict(value)
+
+
+def _seal_authorized_show_ledger(
+    ledger: Any,
+    authorization_receipt: Mapping[str, Any],
+) -> Optional[dict[str, Any]]:
+    """Bind one public show document to its validated source authorization."""
+
+    if (
+        not isinstance(ledger, Mapping)
+        or not show_queue_evidence_authorization_receipt_valid(
+            authorization_receipt
+        )
+    ):
+        return None
+    sealed = dict(ledger)
+    sealed.pop("sourceDigest", None)
+    sealed["sourceAuthorization"] = dict(authorization_receipt)
+    sealed["sourceDigest"] = hashlib.sha256(
+        _canonical_json(sealed).encode("utf-8")
+    ).hexdigest()
+    return _safe_document(sealed)
 
 
 def _context_digest(*values: Any) -> str:
@@ -1437,8 +1471,9 @@ def sync_tiktok_show_evidence_ledgers(
     artist_identity_index: Optional[
         Mapping[str, Sequence[Mapping[str, Any]]]
     ] = None,
+    environ: Optional[Mapping[str, str]] = None,
 ) -> dict[str, Any]:
-    """Idempotently assemble every available public show into memory."""
+    """Idempotently assemble every authorized public-production show."""
 
     result = {
         "status": "skipped",
@@ -1461,10 +1496,32 @@ def sync_tiktok_show_evidence_ledgers(
         "livingCanonSubjectsEvaluated": 0,
         "livingCanonCandidatesRefreshed": 0,
         "livingCanonFormationErrors": 0,
+        "authorizationEligible": False,
     }
+    authorization = show_queue_evidence_authorization(
+        read_model,
+        environ=environ,
+    )
+    if not authorization.get("usable"):
+        result["reason"] = str(
+            authorization.get("reason") or "archive_not_authorized"
+        )
+        return result
+    authorization_receipt = authorization.get("receipt")
+    if not show_queue_evidence_authorization_receipt_valid(
+        authorization_receipt
+    ):
+        result["reason"] = "archive_authorization_receipt_invalid"
+        return result
+    result["authorizationEligible"] = True
     archive = _archive_from_read_model(read_model)
     shows = tiktok_show_records(archive)
     if not shows or int(guild_id or 0) <= 0 or not db_file:
+        result["reason"] = (
+            "no_show_records"
+            if not shows
+            else "invalid_sync_target"
+        )
         return result
     result["showsSeen"] = len(shows)
     conn = sqlite3.connect(db_file, timeout=10.0)
@@ -1486,13 +1543,14 @@ def sync_tiktok_show_evidence_ledgers(
             )
             if discord_exchanges is None:
                 continue
-            ledger = _safe_document(
+            ledger = _seal_authorized_show_ledger(
                 build_tiktok_show_evidence_ledger(
                     show,
                     source_events,
                     artist_identity_index=artist_identity_index,
                     discord_exchanges=discord_exchanges,
-                )
+                ),
+                authorization_receipt,
             )
             if ledger is None:
                 continue

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -38,6 +38,7 @@ from bnl_canon_source_contract import (
     adapt_legacy_canon_fact,
     adapt_living_atomic_claim,
     adapt_open_signal_claim,
+    env_queue_production_enabled,
     matching_canon_entity_identities,
     matching_canon_member_identities,
     normalize_canon_identity_label,
@@ -2992,6 +2993,8 @@ def _show_episode_items(
     request: IntelligencePacketRequest,
     diagnostics: IntelligencePacketDiagnostics,
     exclusions: list[IntelligencePacketExclusion],
+    *,
+    environ: Mapping[str, str] | None = None,
 ) -> list[IntelligencePacketItem]:
     """Adapt finalized BARCODE Radio evidence into the existing packet.
 
@@ -2999,6 +3002,17 @@ def _show_episode_items(
     deliberately keep first-party operations separate from projections over
     attributed Community Canon / Open Signal utterances.
     """
+
+    if not env_queue_production_enabled(
+        dict(environ) if environ is not None else None
+    ):
+        _add_exclusion(
+            diagnostics,
+            exclusions,
+            lane="show_episode",
+            reason="show_queue_evidence_local_gate_disabled",
+        )
+        return []
 
     allow_subject_continuity = bool(
         str(request.frame_subject_requirement or "").strip().lower()
@@ -5695,7 +5709,13 @@ def _show_episode_version(
     conn: sqlite3.Connection,
     packet: UnifiedIntelligencePacket,
     item: IntelligencePacketItem,
+    *,
+    environ: Mapping[str, str] | None = None,
 ) -> str:
+    if not env_queue_production_enabled(
+        dict(environ) if environ is not None else None
+    ):
+        return ""
     return tiktok_show_episode_context_item_version(
         conn,
         guild_id=int(packet.request.guild_id or 0),
@@ -6167,7 +6187,12 @@ def _revalidate_packet_in_snapshot(
             elif item.revalidation_kind == "episode":
                 current = _episode_version(conn, packet, item)
             elif item.revalidation_kind == "show_episode":
-                current = _show_episode_version(conn, packet, item)
+                current = _show_episode_version(
+                    conn,
+                    packet,
+                    item,
+                    environ=environ,
+                )
             elif item.revalidation_kind == "atomic":
                 current = (
                     _living_atomic_version(conn, item)
@@ -7137,6 +7162,7 @@ def build_packet(
                 request,
                 diagnostics,
                 exclusions,
+                environ=environ,
             )
         )
         candidates.extend(

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -1332,6 +1332,11 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         self._prime_flush(channel, request)
         with (
             self._flush_runtime(channel.id, generate),
+            mock.patch.dict(
+                os.environ,
+                {"BNL_QUEUE_PRODUCTION_ENABLED": "true"},
+                clear=False,
+            ),
             mock.patch.object(
                 bnl01_bot,
                 "resolve_channel_policy",

--- a/tests/test_living_canon_recurrence_v1.py
+++ b/tests/test_living_canon_recurrence_v1.py
@@ -218,6 +218,20 @@ class LivingCanonRecurrenceV1Tests(unittest.TestCase):
             "discordInteractions": [],
             "discordParticipants": [],
             "showTopics": [],
+            "sourceAuthorization": {
+                "contractVersion": "show_queue_evidence_authorization_v1",
+                "readModelSource": "barcode-network-site",
+                "publicOnly": True,
+                "localQueueProduction": True,
+                "websiteQueueProduction": True,
+                "accessScope": "public",
+                "archiveSchemaVersion": "queue_public_history_projection_v1",
+                "archiveSource": "queue_bnl_history_projection",
+                "archiveVisibility": "public_safe",
+                "archiveSourceRevision": 1,
+                "archiveSourceDigest": "a" * 64,
+                "historyCoverageStartedAt": "2026-08-24",
+            },
         }
         source_digest = hashlib.sha256(
             json.dumps(

--- a/tests/test_tiktok_show_evidence_ledger.py
+++ b/tests/test_tiktok_show_evidence_ledger.py
@@ -1,3 +1,5 @@
+import copy
+import hashlib
 import json
 import os
 import sqlite3
@@ -250,6 +252,38 @@ def archived_show():
                 "track": None,
             },
         ],
+    }
+
+
+ENABLED_QUEUE_ENV = {"BNL_QUEUE_PRODUCTION_ENABLED": "true"}
+
+
+def authorized_read_model(archive):
+    return {
+        "ok": True,
+        "version": 1,
+        "source": "barcode-network-site",
+        "publicOnly": True,
+        "accessScope": "public",
+        "capabilities": {"queueProduction": True},
+        "sections": {
+            "archive": {
+                "available": True,
+                "reason": None,
+                "schemaVersion": "queue_public_history_projection_v1",
+                "source": "queue_bnl_history_projection",
+                "visibility": "public_safe",
+                "accessScope": "public",
+                "historyCoverageStartedAt": "2026-08-24",
+                "sourceRevision": 42,
+                "sourceDigest": "a" * 64,
+                "memoryDefault": "do_not_store",
+                "sourceFileDefault": "review_evidence_only",
+                "publicDossierDefault": "not_automatic",
+                "personalHistory": None,
+                **archive,
+            }
+        },
     }
 
 
@@ -660,22 +694,17 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             db_file = str(Path(directory) / "bnl.db")
             self.seed_source_and_memory(db_file)
-            read_model = {
-                "ok": True,
-                "version": 1,
-                "sections": {
-                    "archive": {
-                        "currentShow": None,
-                        "latestShow": archived_show(),
-                        "shows": [],
-                    }
-                },
-            }
+            read_model = authorized_read_model({
+                "currentShow": None,
+                "latestShow": archived_show(),
+                "shows": [],
+            })
             first = sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
                 read_model=read_model,
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             self.assertEqual(first["status"], "completed")
             self.assertEqual(first["showsWritten"], 1)
@@ -739,24 +768,185 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 guild_id=77,
                 read_model=read_model,
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             self.assertEqual(second["showsWritten"], 0)
             self.assertEqual(second["showsUnchanged"], 1)
             self.assertEqual(second["projectionDeduplicated"], 0)
 
+    def test_sync_requires_exact_public_production_archive_authorization(self):
+        valid = authorized_read_model({
+            "currentShow": None,
+            "latestShow": archived_show(),
+            "shows": [],
+        })
+        cases = []
+
+        local_off = copy.deepcopy(valid)
+        cases.append(("local_off", local_off, {}, "local_gate_disabled"))
+
+        website_off = copy.deepcopy(valid)
+        website_off["capabilities"]["queueProduction"] = False
+        cases.append((
+            "website_off",
+            website_off,
+            ENABLED_QUEUE_ENV,
+            "website_capability_missing_or_false",
+        ))
+
+        private = copy.deepcopy(valid)
+        private["publicOnly"] = False
+        private["accessScope"] = "private"
+        private["sections"]["archive"]["accessScope"] = "private"
+        private["sections"]["archive"]["visibility"] = "bnl_private_safe"
+        cases.append((
+            "private_scope",
+            private,
+            ENABLED_QUEUE_ENV,
+            "private_access_not_allowed",
+        ))
+
+        unavailable = copy.deepcopy(valid)
+        unavailable["sections"]["archive"]["available"] = False
+        unavailable["sections"]["archive"]["reason"] = (
+            "queue_projection_unavailable"
+        )
+        cases.append((
+            "unavailable",
+            unavailable,
+            ENABLED_QUEUE_ENV,
+            "archive_public_contract_invalid",
+        ))
+
+        malformed = copy.deepcopy(valid)
+        malformed["sections"]["archive"]["sourceDigest"] = "not-a-digest"
+        cases.append((
+            "malformed",
+            malformed,
+            ENABLED_QUEUE_ENV,
+            "archive_public_contract_invalid",
+        ))
+
+        simulation = copy.deepcopy(valid)
+        simulation["sections"]["archive"]["latestShow"]["trackRoster"][0][
+            "isSimulation"
+        ] = True
+        cases.append((
+            "simulation",
+            simulation,
+            ENABLED_QUEUE_ENV,
+            "archive_public_contract_invalid",
+        ))
+
+        for label, model, environ, reason in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as directory:
+                db_file = str(Path(directory) / "bnl.db")
+                result = sync_tiktok_show_evidence_ledgers(
+                    db_file,
+                    guild_id=77,
+                    read_model=model,
+                    artist_identity_index=artist_index(),
+                    environ=environ,
+                )
+                self.assertEqual(result["status"], "skipped")
+                self.assertEqual(result["reason"], reason)
+                self.assertFalse(result["authorizationEligible"])
+                self.assertEqual(result["showsWritten"], 0)
+                self.assertFalse(Path(db_file).exists())
+
+    def test_authorization_receipt_quarantines_unreceipted_show_rows(self):
+        with tempfile.TemporaryDirectory() as directory:
+            db_file = str(Path(directory) / "bnl.db")
+            self.seed_source_and_memory(db_file)
+            read_model = authorized_read_model({
+                "currentShow": None,
+                "latestShow": archived_show(),
+                "shows": [],
+            })
+            result = sync_tiktok_show_evidence_ledgers(
+                db_file,
+                guild_id=77,
+                read_model=read_model,
+                artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
+            )
+            self.assertTrue(result["authorizationEligible"])
+
+            conn = sqlite3.connect(db_file)
+            stored = json.loads(conn.execute(
+                f"SELECT ledger_json FROM {TIKTOK_SHOW_EVIDENCE_TABLE}"
+            ).fetchone()[0])
+            receipt = stored["sourceAuthorization"]
+            self.assertEqual(
+                receipt["contractVersion"],
+                "show_queue_evidence_authorization_v1",
+            )
+            self.assertEqual(receipt["accessScope"], "public")
+            self.assertTrue(receipt["websiteQueueProduction"])
+
+            legacy = dict(stored)
+            legacy.pop("sourceAuthorization")
+            legacy.pop("sourceDigest")
+            legacy_digest = hashlib.sha256(
+                json.dumps(
+                    legacy,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            ).hexdigest()
+            legacy["sourceDigest"] = legacy_digest
+            conn.execute(
+                f"UPDATE {TIKTOK_SHOW_EVIDENCE_TABLE} "
+                "SET source_digest=?,ledger_json=?",
+                (
+                    legacy_digest,
+                    json.dumps(
+                        legacy,
+                        ensure_ascii=False,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                ),
+            )
+            conn.commit()
+            conn.close()
+
+            self.assertEqual(
+                build_tiktok_show_evidence_context(
+                    db_file,
+                    guild_id=77,
+                    user_text="Give me the 2026-08-28 show timeline.",
+                ),
+                "",
+            )
+
+            repaired = sync_tiktok_show_evidence_ledgers(
+                db_file,
+                guild_id=77,
+                read_model=read_model,
+                artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
+            )
+            self.assertEqual(repaired["showsWritten"], 1)
+            self.assertIn(
+                "Durable BARCODE Radio show episode memory:",
+                build_tiktok_show_evidence_context(
+                    db_file,
+                    guild_id=77,
+                    user_text="Give me the 2026-08-28 show timeline.",
+                ),
+            )
+
     def test_finalization_refreshes_existing_living_canon_owner_when_enabled(self):
         with tempfile.TemporaryDirectory() as directory:
             db_file = str(Path(directory) / "bnl.db")
             self.seed_source_and_memory(db_file)
-            read_model = {
-                "sections": {
-                    "archive": {
-                        "currentShow": None,
-                        "latestShow": archived_show(),
-                        "shows": [],
-                    }
-                }
-            }
+            read_model = authorized_read_model({
+                "currentShow": None,
+                "latestShow": archived_show(),
+                "shows": [],
+            })
             with mock.patch.dict(
                 os.environ,
                 {
@@ -770,6 +960,7 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                     guild_id=77,
                     read_model=read_model,
                     artist_identity_index=artist_index(),
+                    environ=ENABLED_QUEUE_ENV,
                 )
 
             self.assertEqual(result["livingCanonSubjectsEvaluated"], 1)
@@ -800,20 +991,17 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 db_file,
                 include_shadow_memory=False,
             )
-            read_model = {
-                "sections": {
-                    "archive": {
-                        "currentShow": archived_show(),
-                        "latestShow": None,
-                        "shows": [],
-                    }
-                }
-            }
+            read_model = authorized_read_model({
+                "currentShow": archived_show(),
+                "latestShow": None,
+                "shows": [],
+            })
             first = sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
                 read_model=read_model,
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             self.assertEqual(first["projectionInserted"], 6)
             conn = sqlite3.connect(db_file)
@@ -837,6 +1025,7 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 guild_id=77,
                 read_model=read_model,
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             self.assertEqual(second["showsUnchanged"], 1)
             self.assertEqual(second["projectionInserted"], 0)
@@ -861,16 +1050,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": archived_show(),
-                            "latestShow": None,
-                            "shows": [],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": archived_show(),
+                    "latestShow": None,
+                    "shows": [],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
 
             broad = build_tiktok_show_evidence_context(
@@ -983,16 +1169,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": None,
-                            "latestShow": archived_show(),
-                            "shows": [],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": None,
+                    "latestShow": archived_show(),
+                    "shows": [],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             conn = sqlite3.connect(db_file)
             items = select_tiktok_show_episode_context_items(
@@ -1094,16 +1277,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": None,
-                            "latestShow": archived_show(),
-                            "shows": [older_show],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": None,
+                    "latestShow": archived_show(),
+                    "shows": [older_show],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             conn = sqlite3.connect(db_file)
             items = select_tiktok_show_episode_context_items(
@@ -1137,16 +1317,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": None,
-                            "latestShow": archived_show(),
-                            "shows": [],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": None,
+                    "latestShow": archived_show(),
+                    "shows": [],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             conn = sqlite3.connect(db_file)
             request = IntelligencePacketRequest(
@@ -1178,6 +1355,7 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                     "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
                     "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
                     "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+                    "BNL_QUEUE_PRODUCTION_ENABLED": "true",
                 },
             )
             self.assertIsNotNone(packet)
@@ -1197,7 +1375,16 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             self.assertTrue(all(not item.canon_status for item in show_items))
             self.assertTrue(all(not item.root_identities for item in show_items))
             self.assertEqual(packet.diagnostics.invalid_invariants, [])
-            self.assertTrue(revalidate_packet(conn, packet).valid)
+            self.assertTrue(
+                revalidate_packet(
+                    conn,
+                    packet,
+                    environ=ENABLED_QUEUE_ENV,
+                ).valid
+            )
+            self.assertFalse(
+                revalidate_packet(conn, packet, environ={}).valid
+            )
             rendered, lane_counts, rendered_count, _digests = (
                 render_packet_context(
                     packet,
@@ -1216,7 +1403,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 f"DELETE FROM {TIKTOK_SHOW_EVIDENCE_TABLE} WHERE guild_id=77"
             )
             conn.commit()
-            self.assertFalse(revalidate_packet(conn, packet).valid)
+            self.assertFalse(
+                revalidate_packet(
+                    conn,
+                    packet,
+                    environ=ENABLED_QUEUE_ENV,
+                ).valid
+            )
             conn.close()
 
     def test_complete_delete_removes_bound_sources_and_invalidates_episode(self):
@@ -1226,16 +1419,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": archived_show(),
-                            "latestShow": None,
-                            "shows": [],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": archived_show(),
+                    "latestShow": None,
+                    "shows": [],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             conn = sqlite3.connect(db_file)
             ensure_governance_schema(conn)


### PR DESCRIPTION
## Summary

- require both the local production gate and the website's public queue capability before the existing finalized-show owner may persist evidence
- validate the exact public archive contract, reject private/unavailable/malformed/simulation projections, and bind admitted rows to a content-free authorization receipt
- preserve legacy rows for audit/deletion while quarantining unreceipted rows from show recall, unified packets, recurrence grouping, and source revalidation
- recheck the local gate during direct recall, packet selection, and send-time revalidation; expose authorization state in existing diagnostics

## Boundaries

- no queue mutation authority
- no new queue, memory, ledger, packet, or context owner
- no production gate activation, environment change, restart, deployment, or merge

## Verification

- focused authorization/ledger/recurrence/contract/bridge/show-alignment slice: 112 tests passed
- packet/response/conversation/queue-memory slice: 147 tests passed
- `make check`: compile passed; 2,501 tests passed
- `git diff --check` passed
