### PR TITLE
Distinguish show obligations from evidence refusals

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -10601,7 +10601,7 @@ def build_tiktok_show_analysis_correction_prompt(
 
 _SHOW_EPISODE_REFUSAL_PATTERNS = (
     r"\bdo not have (?:the )?(?:detailed |specific )?(?:incident |show )?logs\b",
-    r"\b(?:do not|don't) have.{0,100}\b(?:broadcast |show |chat )?(?:logs?|feed|recordings?)\b",
+    r"\b(?:do not|don't) have(?!\s+to\b).{0,100}\b(?:broadcast |show |chat )?(?:logs?|feed|recordings?)\b",
     r"\b(?:logs?|timeline|records?|telemetry) (?:is|are) not (?:active|available|loaded|piped)\b",
     r"\bnot piped directly into (?:this|my) (?:public )?(?:telemetry|feed|stream)\b",
     r"\bwhatever (?:happened|unfolded).{0,80}\bstays? between\b",

--- a/tests/test_tiktok_show_episode_response_guard.py
+++ b/tests/test_tiktok_show_episode_response_guard.py
@@ -86,6 +86,24 @@ class TikTokShowEpisodeResponseGuardTests(unittest.TestCase):
             "show_evidence_refused",
         )
 
+    def test_guard_accepts_grounded_no_obligation_language(self):
+        for response in (
+            "We don't have to show logs to establish the chronology: First "
+            "Signal opened the retained sequence, Alex discussed its green "
+            "visuals, and the Wheel later moved Queue Light next.",
+            "We do not have to dump the chat feed to answer this: First Signal "
+            "opened the retained sequence, Alex discussed its green visuals, "
+            "and the Wheel later moved Queue Light next.",
+        ):
+            with self.subTest(response=response):
+                self.assertEqual(
+                    bnl01_bot.tiktok_show_episode_response_failure(
+                        response,
+                        RAW_PROMPT,
+                    ),
+                    "",
+                )
+
     def test_guard_rejects_invented_clock_time(self):
         response = (
             "At 7:05 PM, Neon Fox's First Signal began, then Queue Light "


### PR DESCRIPTION
## Summary

- stop the finalized-show response guard from treating `don't have to ... logs` as a claim that show evidence is unavailable
- preserve the existing fail-closed classification for actual `don't have ... logs/feed/recordings` refusals
- cover both contracted and uncontracted no-obligation phrasing with grounded show evidence

No feature gates, prompt owners, storage, queue authority, deploys, or restarts change.

## Verification

- `python -m unittest tests.test_tiktok_show_episode_response_guard` — 14 passed
- `make check PYTHON=/workspace/scratch/eb3a66b1645f/BNL01-Bot/venv/bin/python` — 2,500 passed