### PR TITLE
Honor proactive consent across BNL continuity

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,12 @@ currently present.
 without changing the shared cap. The selected basis is stored on the existing
 Ambient log as counts and source-row references, never as a second proactive
 engine or new memory authority. Memory/Governance/Relationship v2 live gates
-remain unchanged.
+remain unchanged. Dormant Echo selection and its final pre-send fence both read
+the existing member-owned Relationship v2 proactive preference; an opt-out or
+unreadable preference withholds the echo. The unified intelligence packet uses
+the same decision before adding member-bound show-episode continuity, while
+subject-neutral public show evidence remains available. No second consent store
+or new output authority is introduced.
 
 ## Relay accepted-history durability
 

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -133,11 +133,11 @@ from bnl_moment_engine import (
 from bnl_relationship_engine import (
     active_engagement_live_enabled as relationship_v2_active_engagement_live_enabled,
     ensure_relationship_v2_schema,
-    get_member_settings as get_relationship_v2_member_settings,
     governed_summary as governed_relationship_v2_summary,
     live_enabled as relationship_v2_live_enabled,
     observe_message as observe_relationship_v2_message,
     plan_engagement as plan_relationship_v2_engagement,
+    proactive_consent_decision as relationship_v2_proactive_consent_decision,
     refresh_moment_links as refresh_relationship_v2_moment_links,
     set_member_setting as set_relationship_v2_member_setting,
     settings_summary as relationship_v2_settings_summary,
@@ -3350,16 +3350,16 @@ def build_tiktok_show_evidence_context_for_turn(
 ) -> str:
     """Select finalized show evidence through the shared turn-level owner."""
 
-    tiktok_subject_continuity_allowed = True
-    if int(subject_user_id or 0) > 0 and os.path.exists(DB_FILE):
+    tiktok_subject_continuity_allowed = int(subject_user_id or 0) <= 0
+    if int(subject_user_id or 0) > 0:
         try:
             with sqlite3.connect(DB_FILE, timeout=0.5) as relationship_conn:
                 tiktok_subject_continuity_allowed = bool(
-                    get_relationship_v2_member_settings(
+                    relationship_v2_proactive_consent_decision(
                         relationship_conn,
                         guild_id=guild_id,
                         user_id=subject_user_id,
-                    ).get("proactive_enabled", True)
+                    )[0]
                 )
         except (OSError, sqlite3.DatabaseError, TypeError, ValueError):
             tiktok_subject_continuity_allowed = False
@@ -18009,9 +18009,21 @@ def select_dormant_echo_candidate(
         ),
     )
     rows = cursor.fetchall()
+    consent_rejections: set[str] = set()
+    consented_rows = []
+    for row in rows:
+        allowed, reason = relationship_v2_proactive_consent_decision(
+            conn,
+            guild_id=int(guild_id),
+            user_id=int(row[0] or 0),
+        )
+        if allowed:
+            consented_rows.append(row)
+        else:
+            consent_rejections.add(reason)
     conn.close()
 
-    for row in rows:
+    for row in consented_rows:
         (
             user_id,
             stored_display_name,
@@ -18069,6 +18081,10 @@ def select_dormant_echo_candidate(
             },
             "candidate_selected",
         )
+    if "proactive_consent_lookup_failed" in consent_rejections:
+        return None, "proactive_consent_lookup_failed"
+    if "member_opt_out" in consent_rejections:
+        return None, "member_opt_out"
     return None, "no_eligible_familiar_absent_member"
 
 
@@ -31480,6 +31496,34 @@ async def publish_prepared_dormant_echo(
 ) -> dict:
     if prepared.get("status") != "ready" or not prepared.get("message"):
         return {"status": "not_ready", "reason": "prepared_echo_missing"}
+    subject_user_id = int(prepared.get("subjectUserId") or 0)
+    try:
+        with sqlite3.connect(DB_FILE, timeout=0.5) as relationship_conn:
+            consent_allowed, consent_reason = (
+                relationship_v2_proactive_consent_decision(
+                    relationship_conn,
+                    guild_id=int(guild_id),
+                    user_id=subject_user_id,
+                )
+            )
+    except (OSError, sqlite3.DatabaseError, TypeError, ValueError):
+        consent_allowed = False
+        consent_reason = "proactive_consent_lookup_failed"
+    if not consent_allowed:
+        _set_dormant_echo_runtime_state(
+            guild_id,
+            status="withheld",
+            reason=consent_reason,
+            subject=prepared.get("subjectDisplayName") or "",
+            basis=prepared.get("basis") or {},
+        )
+        logging.info(
+            "dormant_echo_withheld_before_send guild=%s subject_user_id=%s reason=%s",
+            int(guild_id),
+            subject_user_id,
+            consent_reason,
+        )
+        return {"status": "withheld", "reason": consent_reason}
     now = now_pacific or datetime.now(PACIFIC_TZ)
     if now.tzinfo is None:
         now = PACIFIC_TZ.localize(now)

--- a/bnl_relationship_engine.py
+++ b/bnl_relationship_engine.py
@@ -235,6 +235,41 @@ def get_member_settings(conn: sqlite3.Connection, *, guild_id: int, user_id: int
     ensure_relationship_v2_schema(conn); row = conn.execute("SELECT proactive_enabled,playful_rivalry_enabled FROM relationship_member_settings_v2 WHERE guild_id=? AND subject_user_id=?", (guild_id,user_id)).fetchone()
     return {"proactive_enabled": bool(row[0]) if row else True, "playful_rivalry_enabled": bool(row[1]) if row else True}
 
+
+def proactive_consent_decision(
+    conn: sqlite3.Connection,
+    *,
+    guild_id: int,
+    user_id: int,
+) -> tuple[bool, str]:
+    """Resolve the existing member-owned proactive preference, fail closed.
+
+    The slash-command setting and the latest typed opt-in/opt-out preference are
+    two views of the same Relationship v2 control. Callers outside the planner
+    use this adapter instead of reading either table independently or creating
+    a second consent store.
+    """
+
+    if int(guild_id or 0) <= 0 or int(user_id or 0) <= 0:
+        return False, "proactive_consent_subject_invalid"
+    try:
+        settings = get_member_settings(
+            conn,
+            guild_id=int(guild_id),
+            user_id=int(user_id),
+        )
+        preference = _latest_pref(
+            conn,
+            guild_id=int(guild_id),
+            user_id=int(user_id),
+            key="proactive",
+        )
+    except (sqlite3.Error, TypeError, ValueError):
+        return False, "proactive_consent_lookup_failed"
+    if not settings.get("proactive_enabled", True) or preference == "disabled":
+        return False, "member_opt_out"
+    return True, "proactive_consent_allowed"
+
 def rebuild_state(conn: sqlite3.Connection, *, guild_id: int, subject_user_id: int, evaluated_at: str = "") -> dict[str, Any]:
     ensure_relationship_v2_schema(conn); eval_dt = parse_utc(evaluated_at or _now())
     settings = get_member_settings(conn, guild_id=guild_id, user_id=subject_user_id)
@@ -439,7 +474,17 @@ def plan_engagement(conn: sqlite3.Connection, *, guild_id: int, user_id: int, ca
     ensure_relationship_v2_schema(conn); now_dt=parse_utc(now or _now()); settings=get_member_settings(conn,guild_id=guild_id,user_id=user_id); withheld=[]; errors=[]
     state=rebuild_state(conn,guild_id=guild_id,subject_user_id=user_id,evaluated_at=now_dt.isoformat())
     open_loops = _open_loop_count(conn, guild_id=guild_id, user_id=user_id, channel_policy=channel_policy); moments = _compatible_moment_count(conn, guild_id=guild_id, user_id=user_id, channel_policy=channel_policy)
-    if not settings["proactive_enabled"] or state.get("engagement_opt_out"): withheld.append("member_opt_out")
+    proactive_allowed, proactive_reason = proactive_consent_decision(
+        conn,
+        guild_id=guild_id,
+        user_id=user_id,
+    )
+    if not proactive_allowed or state.get("engagement_opt_out"):
+        withheld.append(
+            proactive_reason
+            if proactive_reason == "proactive_consent_lookup_failed"
+            else "member_opt_out"
+        )
     if not settings["playful_rivalry_enabled"] and candidate_type == "playful_rivalry": withheld.append("playful_rivalry_disabled")
     if channel_policy not in PUBLIC_POLICIES: withheld.append("channel_policy_ineligible")
     if route_mode not in RELATIONSHIP_LIVE_ROUTES: withheld.append("route_ineligible")

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -84,7 +84,7 @@ from bnl_moment_engine import (
     select_situation_aware_episode_gists,
 )
 from bnl_profile_points import material_profile_point_map
-from bnl_relationship_engine import shadow_packet_posture
+from bnl_relationship_engine import proactive_consent_decision, shadow_packet_posture
 from bnl_tiktok_show_ledger import (
     select_tiktok_show_episode_context_items,
     tiktok_show_episode_context_item_version,
@@ -3000,15 +3000,36 @@ def _show_episode_items(
     attributed Community Canon / Open Signal utterances.
     """
 
+    requested_subject_user_id = int(request.subject_user_id or 0)
+    subject_user_id = requested_subject_user_id
+    consent_allowed = requested_subject_user_id <= 0
+    consent_reason = "proactive_consent_allowed"
+    if requested_subject_user_id > 0:
+        consent_allowed, consent_reason = proactive_consent_decision(
+            conn,
+            guild_id=int(request.guild_id or 0),
+            user_id=requested_subject_user_id,
+        )
+        if not consent_allowed:
+            subject_user_id = 0
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane="show_episode",
+                reason=consent_reason,
+                source_class="evidence_projection",
+            )
     allow_subject_continuity = bool(
-        str(request.frame_subject_requirement or "").strip().lower()
+        consent_allowed
+        and subject_user_id > 0
+        and str(request.frame_subject_requirement or "").strip().lower()
         == "required"
     )
     selected = select_tiktok_show_episode_context_items(
         conn,
         guild_id=int(request.guild_id or 0),
         user_text=str(request.user_text or "")[:8000],
-        subject_user_id=int(request.subject_user_id or 0),
+        subject_user_id=subject_user_id,
         allow_subject_continuity=allow_subject_continuity,
         now=request.now or None,
     )
@@ -5696,14 +5717,27 @@ def _show_episode_version(
     packet: UnifiedIntelligencePacket,
     item: IntelligencePacketItem,
 ) -> str:
+    requested_subject_user_id = int(packet.request.subject_user_id or 0)
+    subject_user_id = requested_subject_user_id
+    consent_allowed = requested_subject_user_id <= 0
+    if requested_subject_user_id > 0:
+        consent_allowed, _reason = proactive_consent_decision(
+            conn,
+            guild_id=int(packet.request.guild_id or 0),
+            user_id=requested_subject_user_id,
+        )
+        if not consent_allowed:
+            subject_user_id = 0
     return tiktok_show_episode_context_item_version(
         conn,
         guild_id=int(packet.request.guild_id or 0),
         user_text=str(packet.request.user_text or "")[:8000],
-        subject_user_id=int(packet.request.subject_user_id or 0),
+        subject_user_id=subject_user_id,
         source_ref=str(item.revalidation_key or item.source_ref or ""),
         allow_subject_continuity=bool(
-            str(packet.request.frame_subject_requirement or "")
+            consent_allowed
+            and subject_user_id > 0
+            and str(packet.request.frame_subject_requirement or "")
             .strip()
             .lower()
             == "required"

--- a/tests/test_dormant_signal_echo.py
+++ b/tests/test_dormant_signal_echo.py
@@ -226,6 +226,25 @@ class DormantSignalEchoTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(candidate)
         self.assertEqual(reason, "no_eligible_familiar_absent_member")
 
+    def test_member_proactive_opt_out_blocks_candidate_selection(self):
+        self.seed_familiar_member()
+        with sqlite3.connect(self.db_path) as conn:
+            bnl01_bot.set_relationship_v2_member_setting(
+                conn,
+                guild_id=77,
+                user_id=42,
+                proactive_enabled=False,
+            )
+
+        candidate, reason = bnl01_bot.select_dormant_echo_candidate(
+            77,
+            now_pacific=self.now,
+            guild=self.guild,
+        )
+
+        self.assertIsNone(candidate)
+        self.assertEqual(reason, "member_opt_out")
+
         with sqlite3.connect(self.db_path) as conn:
             conn.execute(
                 """
@@ -488,6 +507,49 @@ class DormantSignalEchoTests(unittest.IsolatedAsyncioTestCase):
                 """
             ).fetchone()[0]
         self.assertEqual(remaining, 0)
+
+    async def test_publish_rechecks_consent_and_withholds_after_opt_out(self):
+        prepared = {
+            "status": "ready",
+            "message": "An Emerald-shaped harmonic still fits this synth thread.",
+            "subjectUserId": 42,
+            "subjectDisplayName": "Emerald",
+            "basis": {"subjectUserId": 42},
+        }
+        with sqlite3.connect(self.db_path) as conn:
+            bnl01_bot.set_relationship_v2_member_setting(
+                conn,
+                guild_id=77,
+                user_id=42,
+                proactive_enabled=False,
+            )
+        with mock.patch.object(
+            bnl01_bot,
+            "schedule_after_ambient_post",
+            side_effect=AssertionError("withheld echo must not consume capacity"),
+        ):
+            result = await bnl01_bot.publish_prepared_dormant_echo(
+                77,
+                222,
+                self.channel,
+                prepared,
+                capacity_used_before_send=0,
+                now_pacific=self.now,
+            )
+
+        self.assertEqual(
+            result,
+            {"status": "withheld", "reason": "member_opt_out"},
+        )
+        self.assertEqual(self.channel.sent, [])
+        with sqlite3.connect(self.db_path) as conn:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM ambient_log WHERE guild_id=77"
+            ).fetchone()[0]
+        self.assertEqual(count, 0)
+        runtime = bnl01_bot._get_ambient_runtime_state(77)
+        self.assertEqual(runtime["last_dormant_echo_status"], "withheld")
+        self.assertEqual(runtime["last_dormant_echo_reason"], "member_opt_out")
 
     async def test_global_cooldown_prevents_repeat_before_candidate_lookup(self):
         with sqlite3.connect(self.db_path) as conn:

--- a/tests/test_relationship_engine_v2.py
+++ b/tests/test_relationship_engine_v2.py
@@ -142,6 +142,48 @@ def _case_settings_view_live_off_and_toggle_controls():
     set_member_setting(c,guild_id=1,user_id=2,proactive_enabled=True,playful_rivalry_enabled=True)
     assert 'proactive=enabled' in settings_summary(c,guild_id=1,user_id=2) and 'playful_rivalry=enabled' in settings_summary(c,guild_id=1,user_id=2)
 
+def _case_proactive_consent_owner_combines_settings_preferences_and_errors():
+    c=conn()
+    assert proactive_consent_decision(c,guild_id=1,user_id=2) == (
+        True,
+        'proactive_consent_allowed',
+    )
+    obs(c,"don't follow up",1)
+    assert proactive_consent_decision(c,guild_id=1,user_id=2) == (
+        False,
+        'member_opt_out',
+    )
+    set_member_setting(c,guild_id=1,user_id=2,proactive_enabled=True)
+    assert proactive_consent_decision(c,guild_id=1,user_id=2)[0]
+    set_member_setting(c,guild_id=1,user_id=2,proactive_enabled=False)
+    assert proactive_consent_decision(c,guild_id=1,user_id=2) == (
+        False,
+        'member_opt_out',
+    )
+    c.close()
+    assert proactive_consent_decision(c,guild_id=1,user_id=2) == (
+        False,
+        'proactive_consent_lookup_failed',
+    )
+
+def _case_legacy_show_continuity_uses_effective_consent_and_fails_closed(monkeypatch):
+    tmp=tempfile.NamedTemporaryFile(delete=False); tmp.close(); monkeypatch.setattr(bnl01_bot,'DB_FILE',tmp.name); bnl01_bot.init_db()
+    selected=[]
+    monkeypatch.setattr(
+        bnl01_bot,
+        'build_tiktok_show_evidence_context',
+        lambda _db, **kwargs: selected.append(kwargs['subject_user_id']) or 'context',
+    )
+    assert bnl01_bot.build_tiktok_show_evidence_context_for_turn(guild_id=1,user_text='What happened?',subject_user_id=2) == 'context'
+    assert selected[-1] == 2
+    with sqlite3.connect(tmp.name) as c:
+        set_member_setting(c,guild_id=1,user_id=2,proactive_enabled=False)
+    bnl01_bot.build_tiktok_show_evidence_context_for_turn(guild_id=1,user_text='What happened?',subject_user_id=2)
+    assert selected[-1] == 0
+    monkeypatch.setattr(bnl01_bot,'DB_FILE',os.path.join(tmp.name,'unavailable.db'))
+    bnl01_bot.build_tiktok_show_evidence_context_for_turn(guild_id=1,user_text='What happened?',subject_user_id=2)
+    assert selected[-1] == 0
+
 def _case_correction_forget_deactivates_underlying_event_and_delete_removes_projection():
     c=conn(); eid=obs(c,'thank you',1); assert state(c)['rapport'] > 0
     led=c.execute('select ledger_entry_id from relationship_event_ledger_links_v2 where event_id=?',(eid,)).fetchone()[0]

--- a/tests/test_tiktok_show_evidence_ledger.py
+++ b/tests/test_tiktok_show_evidence_ledger.py
@@ -23,6 +23,7 @@ from bnl_memory_governance import (
     complete_delete_member_data,
     ensure_governance_schema,
 )
+from bnl_relationship_engine import set_member_setting
 from bnl_tiktok_live_context import build_tiktok_show_evidence_ledger
 from bnl_shared_brain_synthesis import render_packet_context
 from bnl_tiktok_show_ledger import (
@@ -1217,6 +1218,89 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             )
             conn.commit()
             self.assertFalse(revalidate_packet(conn, packet).valid)
+            conn.close()
+
+    def test_packet_show_continuity_honors_member_proactive_opt_out(self):
+        with tempfile.TemporaryDirectory() as directory:
+            db_file = str(Path(directory) / "bnl.db")
+            self.seed_source_and_memory(db_file)
+            sync_tiktok_show_evidence_ledgers(
+                db_file,
+                guild_id=77,
+                read_model={
+                    "sections": {
+                        "archive": {
+                            "currentShow": None,
+                            "latestShow": archived_show(),
+                            "shows": [],
+                        }
+                    }
+                },
+                artist_identity_index=artist_index(),
+            )
+            conn = sqlite3.connect(db_file)
+            request = IntelligencePacketRequest(
+                guild_id=77,
+                subject_user_id=42,
+                route_mode="normal_chat",
+                conversation_surface="mention_or_reply",
+                subject_display_name="Alex",
+                channel_id=9001,
+                channel_name="barcode-bot",
+                channel_policy="public_home",
+                visibility_allowance="public_safe",
+                user_text="What happened next?",
+                participant_user_ids=(42,),
+                direct_state="direct",
+                budget_chars=6000,
+                frame_subject_requirement="required",
+                now="2026-08-29T12:00:00-07:00",
+            )
+            flags = {
+                "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+                "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+                "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+                "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+                "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED": "true",
+                "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
+                "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
+                "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+            }
+            allowed_packet = build_packet(
+                conn,
+                request,
+                persist=False,
+                environ=flags,
+            )
+            self.assertTrue(
+                any(item.lane == "show_episode" for item in allowed_packet.items)
+            )
+
+            set_member_setting(
+                conn,
+                guild_id=77,
+                user_id=42,
+                proactive_enabled=False,
+            )
+            conn.commit()
+            blocked_packet = build_packet(
+                conn,
+                request,
+                persist=False,
+                environ=flags,
+            )
+            self.assertFalse(
+                any(item.lane == "show_episode" for item in blocked_packet.items)
+            )
+            self.assertEqual(
+                blocked_packet.diagnostics.excluded_by_reason.get(
+                    "member_opt_out"
+                ),
+                1,
+            )
+            self.assertFalse(
+                revalidate_packet(conn, allowed_packet, environ=flags).valid
+            )
             conn.close()
 
     def test_complete_delete_removes_bound_sources_and_invalidates_episode(self):


### PR DESCRIPTION
Merge carrier for draft PR #471. This PR points to the exact already-reviewed and CI-green head SHA `90247ba787cc9b3043818d3054c63cc957dda978`; it contains no additional source changes.

## Why

Dormant Echo and the unified show-packet path could project member-bound continuity after that member disabled the existing Relationship v2 proactive preference. The older finalized-show wrapper also read only one view of that preference.

## What changed

- Added one fail-closed Relationship v2 consent decision over the existing slash setting and typed preference.
- Applied it during Dormant Echo selection and again immediately before delivery.
- Applied it to legacy and unified finalized-show continuity.
- Revalidation now invalidates previously selected subject-bound show items after an opt-out.
- Kept subject-neutral public show evidence available.

## Preserved boundaries

- No second consent store, proactive engine, output authority, queue owner, memory owner, or packet owner.
- Relationship, Active Engagement, memory, and queue live gates/defaults are unchanged.
- No restart, environment-variable change, or merge.

## Verification

- Focused: 41 tests passed.
- Full repository gate: `make check PYTHON=/workspace/scratch/eb3a66b1645f/BNL01-Bot/venv/bin/python` — 2,504 tests passed.
- `git diff --check` passed.
- Remote tree SHA matches the locally verified tree: `696efa353887c22351763c87a9c59f1f8420fae5`.