### PR TITLE
Integrate audit PRs #472–#475 safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,10 @@ source-owned subject references may connect the same participant across episode
 surfaces, while name/handle resemblance and queue attribution alone never merge
 identities. Episode projections remain above Community Canon, follow Memory
 Ledger lineage/supersession, and are invalidated by the existing complete-delete
-path when a bound member exercises deletion.
+path when a bound member exercises deletion. When the configured owner appears
+in source evidence, public-safe episode projections and recall render that
+subject only as `6 Bit`; a retained private source label never enters public
+memory or prompt context.
 
 Declared TikTok owner handles `@six.bit` and `@pr0x60` resolve to the same BNL
 owner subject; `PR0X`/`Prox` is the side-account display identity. Other known

--- a/README.md
+++ b/README.md
@@ -130,16 +130,39 @@ reactions follows the ordinary conversation persistence path. Aggregate viewers,
 taps, gifts, joins, and other room metrics remain current-show-only and do not
 become personal memory or canon.
 
-The same one-minute read-model cycle automatically assembles a durable public
-show episode for every retained show. It preserves the website archive's full
-public-safe queue/broadcast milestone sequence and track roster, places every
-eligible TikTok comment/question on that clock, and pairs public Discord user
-rows only when BNL's stored response explicitly targets that member in the same
-channel within the bounded response window. Questions, answers, track state,
+The same one-minute read-model cycle may assemble a durable public show episode
+for a retained show only after the local queue gate, website queue capability,
+top-level public scope, and exact `queue_public_history_projection_v1` archive
+contract all pass. The archive must be available, `public_safe`, explicitly
+public, digest/revision-bearing, browser-personal-history-free, and free of test
+or simulation markers. Private, unavailable, malformed, capability-disabled,
+and local-gate-disabled projections create no show row or Memory Ledger
+projection. Each admitted episode carries a content-free
+`show_queue_evidence_authorization_v1` receipt in its source digest. Older rows
+without that receipt are preserved for audit but quarantined from show recall,
+packet selection, recurrence grouping, and source revalidation; an eligible
+public source refresh rewrites the matching row through the existing owner.
+
+An authorized episode preserves the website archive's full public-safe
+queue/broadcast milestone sequence and track roster, places every eligible
+TikTok comment/question on that clock, and pairs public Discord user rows only
+when BNL's stored response explicitly targets that member in the same channel
+within the bounded response window. Questions, answers, track state,
 Wheel/sponsor/signal-hold events, order, and outcomes therefore remain available
 after the live snapshot expires. Ordinary recall retrieves only the show and
 evidence slices relevant to the current question; the complete ledger is not
-dumped into every prompt.
+dumped into every prompt. The local queue gate is checked again for direct show
+context, packet selection, and send-time packet revalidation.
+
+Participant presence and Relationship proactive consent authorize continuity;
+they do not create show intent. A show/continuity request or an actual evidence
+match must exist before the selector may use the current member's episode
+participation. Relative-day words only select this owner when the request also
+names show scope, and historical analysis resolves the matching show date
+instead of falling through to the current show. Episode rebuilds are additive for public Discord exchanges
+already captured by this owner, so ordinary conversation pruning cannot erase
+an earlier request/BNL-response pair during finalization. The existing
+complete-delete path still removes the owning episode and its projections.
 
 This episode is a limited operational-memory exception, not a second queue
 owner. Website milestones and roster outcomes are authoritative operational
@@ -148,7 +171,10 @@ source-owned subject references may connect the same participant across episode
 surfaces, while name/handle resemblance and queue attribution alone never merge
 identities. Episode projections remain above Community Canon, follow Memory
 Ledger lineage/supersession, and are invalidated by the existing complete-delete
-path when a bound member exercises deletion.
+path when a bound member exercises deletion. When the configured owner appears
+in source evidence, public-safe episode projections and recall render that
+subject only as `6 Bit`; a retained private source label never enters public
+memory or prompt context.
 
 Declared TikTok owner handles `@six.bit` and `@pr0x60` resolve to the same BNL
 owner subject; `PR0X`/`Prox` is the side-account display identity. Other known

--- a/README.md
+++ b/README.md
@@ -130,16 +130,29 @@ reactions follows the ordinary conversation persistence path. Aggregate viewers,
 taps, gifts, joins, and other room metrics remain current-show-only and do not
 become personal memory or canon.
 
-The same one-minute read-model cycle automatically assembles a durable public
-show episode for every retained show. It preserves the website archive's full
-public-safe queue/broadcast milestone sequence and track roster, places every
-eligible TikTok comment/question on that clock, and pairs public Discord user
-rows only when BNL's stored response explicitly targets that member in the same
-channel within the bounded response window. Questions, answers, track state,
+The same one-minute read-model cycle may assemble a durable public show episode
+for a retained show only after the local queue gate, website queue capability,
+top-level public scope, and exact `queue_public_history_projection_v1` archive
+contract all pass. The archive must be available, `public_safe`, explicitly
+public, digest/revision-bearing, browser-personal-history-free, and free of test
+or simulation markers. Private, unavailable, malformed, capability-disabled,
+and local-gate-disabled projections create no show row or Memory Ledger
+projection. Each admitted episode carries a content-free
+`show_queue_evidence_authorization_v1` receipt in its source digest. Older rows
+without that receipt are preserved for audit but quarantined from show recall,
+packet selection, recurrence grouping, and source revalidation; an eligible
+public source refresh rewrites the matching row through the existing owner.
+
+An authorized episode preserves the website archive's full public-safe
+queue/broadcast milestone sequence and track roster, places every eligible
+TikTok comment/question on that clock, and pairs public Discord user rows only
+when BNL's stored response explicitly targets that member in the same channel
+within the bounded response window. Questions, answers, track state,
 Wheel/sponsor/signal-hold events, order, and outcomes therefore remain available
 after the live snapshot expires. Ordinary recall retrieves only the show and
 evidence slices relevant to the current question; the complete ledger is not
-dumped into every prompt.
+dumped into every prompt. The local queue gate is checked again for direct show
+context, packet selection, and send-time packet revalidation.
 
 This episode is a limited operational-memory exception, not a second queue
 owner. Website milestones and roster outcomes are authoritative operational

--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ after the live snapshot expires. Ordinary recall retrieves only the show and
 evidence slices relevant to the current question; the complete ledger is not
 dumped into every prompt.
 
+Participant presence and Relationship proactive consent authorize continuity;
+they do not create show intent. A show/continuity request or an actual evidence
+match must exist before the selector may use the current member's episode
+participation. Relative-day words only select this owner when the request also
+names show scope, and historical analysis resolves the matching show date
+instead of falling through to the current show. Episode rebuilds are additive for public Discord exchanges
+already captured by this owner, so ordinary conversation pruning cannot erase
+an earlier request/BNL-response pair during finalization. The existing
+complete-delete path still removes the owning episode and its projections.
+
 This episode is a limited operational-memory exception, not a second queue
 owner. Website milestones and roster outcomes are authoritative operational
 facts; TikTok and Discord text remains attributed observation evidence. Exact

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -21,6 +21,7 @@ from bnl_canon_source_contract import (
     CANON_SOURCE_CONTRACT_VERSION,
     build_claim_contract_inventory,
     diagnostics as canon_source_diagnostics,
+    env_queue_production_enabled,
     queue_usability,
     render_concise_public_schedule,
     render_founders,
@@ -3349,6 +3350,13 @@ def build_tiktok_show_evidence_context_for_turn(
     website_read_model_context: str = "",
 ) -> str:
     """Select finalized show evidence through the shared turn-level owner."""
+
+    if not env_queue_production_enabled():
+        logging.info(
+            "show_episode_evidence_context_skipped "
+            "reason=local_queue_production_gate_disabled"
+        )
+        return ""
 
     tiktok_subject_continuity_allowed = True
     if int(subject_user_id or 0) > 0 and os.path.exists(DB_FILE):
@@ -32575,6 +32583,7 @@ _tiktok_live_memory_runtime = {
     "show_ledger_last_discord_interactions": 0,
     "show_ledger_last_discord_exchanges": 0,
     "show_ledger_last_conversation_rows": 0,
+    "show_ledger_authorization_eligible": False,
     "show_ledger_last_error_type": "",
 }
 
@@ -32883,6 +32892,12 @@ async def queue_artist_memory_sync_task():
         return
     read_model = await asyncio.to_thread(fetch_bnl_read_model, True)
     if not read_model:
+        _tiktok_live_memory_runtime[
+            "show_ledger_authorization_eligible"
+        ] = False
+        _tiktok_live_memory_runtime[
+            "show_ledger_last_reason"
+        ] = "read_model_unavailable"
         logging.warning("queue_artist_memory_sync_skipped reason=read_model_unavailable")
         return
     guilds = list(iter_managed_guilds())
@@ -32941,10 +32956,14 @@ async def queue_artist_memory_sync_task():
                 guild_id=guild_id,
                 read_model=read_model,
                 artist_identity_index=artist_identity_index,
+                environ=os.environ,
             )
             _tiktok_live_memory_runtime["show_ledger_last_reason"] = str(
                 show_ledger_result.get("reason") or "unknown"
             )
+            _tiktok_live_memory_runtime[
+                "show_ledger_authorization_eligible"
+            ] = bool(show_ledger_result.get("authorizationEligible"))
             _tiktok_live_memory_runtime["show_ledger_last_written"] = int(
                 show_ledger_result.get("showsWritten") or 0
             )
@@ -32969,7 +32988,8 @@ async def queue_artist_memory_sync_task():
             _tiktok_live_memory_runtime["show_ledger_last_error_type"] = ""
             logging.info(
                 "barcode_show_episode_ledger_sync guild=%s status=%s "
-                "reason=%s shows_seen=%s shows_written=%s "
+                "reason=%s authorization_eligible=%s "
+                "shows_seen=%s shows_written=%s "
                 "shows_unchanged=%s shows_finalized=%s tiktok_events=%s "
                 "operational_events=%s track_roster=%s discord_interactions=%s "
                 "discord_exchanges=%s discord_participants=%s "
@@ -32979,6 +32999,7 @@ async def queue_artist_memory_sync_task():
                 guild_id,
                 show_ledger_result.get("status"),
                 show_ledger_result.get("reason"),
+                int(bool(show_ledger_result.get("authorizationEligible"))),
                 show_ledger_result.get("showsSeen", 0),
                 show_ledger_result.get("showsWritten", 0),
                 show_ledger_result.get("showsUnchanged", 0),
@@ -32996,6 +33017,9 @@ async def queue_artist_memory_sync_task():
                 show_ledger_result.get("projectionErrors", 0),
             )
         except Exception as exc:
+            _tiktok_live_memory_runtime[
+                "show_ledger_authorization_eligible"
+            ] = False
             _tiktok_live_memory_runtime[
                 "show_ledger_last_error_type"
             ] = type(exc).__name__
@@ -47052,7 +47076,7 @@ async def bnl_status(interaction: discord.Interaction):
         f"- tiktok_live_last_error_code: `{tiktok_live_diag.get('lastErrorCode')}` memory_default=`{tiktok_live_diag.get('memoryDefault')}`",
         f"- tiktok_live_memory_enabled: `{'yes' if BNL_TIKTOK_LIVE_MEMORY_ENABLED else 'no'}` placement=`above_community_canon`",
         f"- tiktok_live_memory_last_ingested: `{int(_tiktok_live_memory_runtime.get('last_ingested') or 0)}` total_since_start=`{int(_tiktok_live_memory_runtime.get('total_ingested') or 0)}` reason=`{_tiktok_live_memory_runtime.get('last_reason')}` error_type=`{_tiktok_live_memory_runtime.get('last_error_type') or 'none'}`",
-        f"- barcode_show_episode_ledger_last_sync: written=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_written') or 0)}` finalized=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_finalized') or 0)}` tiktok_events=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_events') or 0)}` operational_events=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_operational_events') or 0)}` discord_interactions=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_discord_interactions') or 0)}` discord_exchanges=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_discord_exchanges') or 0)}` conversation_rows=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_conversation_rows') or 0)}` reason=`{_tiktok_live_memory_runtime.get('show_ledger_last_reason')}` error_type=`{_tiktok_live_memory_runtime.get('show_ledger_last_error_type') or 'none'}`",
+        f"- barcode_show_episode_ledger_last_sync: authorized=`{'yes' if _tiktok_live_memory_runtime.get('show_ledger_authorization_eligible') else 'no'}` written=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_written') or 0)}` finalized=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_finalized') or 0)}` tiktok_events=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_events') or 0)}` operational_events=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_operational_events') or 0)}` discord_interactions=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_discord_interactions') or 0)}` discord_exchanges=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_discord_exchanges') or 0)}` conversation_rows=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_conversation_rows') or 0)}` reason=`{_tiktok_live_memory_runtime.get('show_ledger_last_reason')}` error_type=`{_tiktok_live_memory_runtime.get('show_ledger_last_error_type') or 'none'}`",
         f"- tiktok_live_identity_policy: `handle_display_correlated_v1` owner_handle_configured=`{'yes' if bool(BNL_TIKTOK_OWNER_HANDLES) else 'no'}`",
         f"- ambient_throttle: cooldown=`{AMBIENT_POST_COOLDOWN_MINUTES}m` daily_cap_today=`{ambient_cap_today}` normal_cap=`{AMBIENT_DAILY_POST_CAP}` high_activity_cap=`2` min_signal_messages=`{AMBIENT_MIN_SIGNAL_MESSAGES}` min_signal_users=`{AMBIENT_MIN_SIGNAL_UNIQUE_USERS}`",
         f"- ambient_posts_today: `{ambient_posts_today}`",

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -10601,7 +10601,7 @@ def build_tiktok_show_analysis_correction_prompt(
 
 _SHOW_EPISODE_REFUSAL_PATTERNS = (
     r"\bdo not have (?:the )?(?:detailed |specific )?(?:incident |show )?logs\b",
-    r"\b(?:do not|don't) have.{0,100}\b(?:broadcast |show |chat )?(?:logs?|feed|recordings?)\b",
+    r"\b(?:do not|don't) have(?!\s+to\b).{0,100}\b(?:broadcast |show |chat )?(?:logs?|feed|recordings?)\b",
     r"\b(?:logs?|timeline|records?|telemetry) (?:is|are) not (?:active|available|loaded|piped)\b",
     r"\bnot piped directly into (?:this|my) (?:public )?(?:telemetry|feed|stream)\b",
     r"\bwhatever (?:happened|unfolded).{0,80}\bstays? between\b",

--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -21,6 +21,7 @@ from bnl_canon_source_contract import (
     CANON_SOURCE_CONTRACT_VERSION,
     build_claim_contract_inventory,
     diagnostics as canon_source_diagnostics,
+    env_queue_production_enabled,
     queue_usability,
     render_concise_public_schedule,
     render_founders,
@@ -3350,8 +3351,15 @@ def build_tiktok_show_evidence_context_for_turn(
 ) -> str:
     """Select finalized show evidence through the shared turn-level owner."""
 
+    if not env_queue_production_enabled():
+        logging.info(
+            "show_episode_evidence_context_skipped "
+            "reason=local_queue_production_gate_disabled"
+        )
+        return ""
+
     tiktok_subject_continuity_allowed = int(subject_user_id or 0) <= 0
-    if int(subject_user_id or 0) > 0:
+    if int(subject_user_id or 0) > 0 and os.path.exists(DB_FILE):
         try:
             with sqlite3.connect(DB_FILE, timeout=0.5) as relationship_conn:
                 tiktok_subject_continuity_allowed = bool(
@@ -10601,7 +10609,7 @@ def build_tiktok_show_analysis_correction_prompt(
 
 _SHOW_EPISODE_REFUSAL_PATTERNS = (
     r"\bdo not have (?:the )?(?:detailed |specific )?(?:incident |show )?logs\b",
-    r"\b(?:do not|don't) have.{0,100}\b(?:broadcast |show |chat )?(?:logs?|feed|recordings?)\b",
+    r"\b(?:do not|don't) have(?!\s+to\b).{0,100}\b(?:broadcast |show |chat )?(?:logs?|feed|recordings?)\b",
     r"\b(?:logs?|timeline|records?|telemetry) (?:is|are) not (?:active|available|loaded|piped)\b",
     r"\bnot piped directly into (?:this|my) (?:public )?(?:telemetry|feed|stream)\b",
     r"\bwhatever (?:happened|unfolded).{0,80}\bstays? between\b",
@@ -32619,6 +32627,7 @@ _tiktok_live_memory_runtime = {
     "show_ledger_last_discord_interactions": 0,
     "show_ledger_last_discord_exchanges": 0,
     "show_ledger_last_conversation_rows": 0,
+    "show_ledger_authorization_eligible": False,
     "show_ledger_last_error_type": "",
 }
 
@@ -32927,6 +32936,12 @@ async def queue_artist_memory_sync_task():
         return
     read_model = await asyncio.to_thread(fetch_bnl_read_model, True)
     if not read_model:
+        _tiktok_live_memory_runtime[
+            "show_ledger_authorization_eligible"
+        ] = False
+        _tiktok_live_memory_runtime[
+            "show_ledger_last_reason"
+        ] = "read_model_unavailable"
         logging.warning("queue_artist_memory_sync_skipped reason=read_model_unavailable")
         return
     guilds = list(iter_managed_guilds())
@@ -32985,10 +33000,14 @@ async def queue_artist_memory_sync_task():
                 guild_id=guild_id,
                 read_model=read_model,
                 artist_identity_index=artist_identity_index,
+                environ=os.environ,
             )
             _tiktok_live_memory_runtime["show_ledger_last_reason"] = str(
                 show_ledger_result.get("reason") or "unknown"
             )
+            _tiktok_live_memory_runtime[
+                "show_ledger_authorization_eligible"
+            ] = bool(show_ledger_result.get("authorizationEligible"))
             _tiktok_live_memory_runtime["show_ledger_last_written"] = int(
                 show_ledger_result.get("showsWritten") or 0
             )
@@ -33013,7 +33032,8 @@ async def queue_artist_memory_sync_task():
             _tiktok_live_memory_runtime["show_ledger_last_error_type"] = ""
             logging.info(
                 "barcode_show_episode_ledger_sync guild=%s status=%s "
-                "reason=%s shows_seen=%s shows_written=%s "
+                "reason=%s authorization_eligible=%s "
+                "shows_seen=%s shows_written=%s "
                 "shows_unchanged=%s shows_finalized=%s tiktok_events=%s "
                 "operational_events=%s track_roster=%s discord_interactions=%s "
                 "discord_exchanges=%s discord_participants=%s "
@@ -33023,6 +33043,7 @@ async def queue_artist_memory_sync_task():
                 guild_id,
                 show_ledger_result.get("status"),
                 show_ledger_result.get("reason"),
+                int(bool(show_ledger_result.get("authorizationEligible"))),
                 show_ledger_result.get("showsSeen", 0),
                 show_ledger_result.get("showsWritten", 0),
                 show_ledger_result.get("showsUnchanged", 0),
@@ -33040,6 +33061,9 @@ async def queue_artist_memory_sync_task():
                 show_ledger_result.get("projectionErrors", 0),
             )
         except Exception as exc:
+            _tiktok_live_memory_runtime[
+                "show_ledger_authorization_eligible"
+            ] = False
             _tiktok_live_memory_runtime[
                 "show_ledger_last_error_type"
             ] = type(exc).__name__
@@ -47096,7 +47120,7 @@ async def bnl_status(interaction: discord.Interaction):
         f"- tiktok_live_last_error_code: `{tiktok_live_diag.get('lastErrorCode')}` memory_default=`{tiktok_live_diag.get('memoryDefault')}`",
         f"- tiktok_live_memory_enabled: `{'yes' if BNL_TIKTOK_LIVE_MEMORY_ENABLED else 'no'}` placement=`above_community_canon`",
         f"- tiktok_live_memory_last_ingested: `{int(_tiktok_live_memory_runtime.get('last_ingested') or 0)}` total_since_start=`{int(_tiktok_live_memory_runtime.get('total_ingested') or 0)}` reason=`{_tiktok_live_memory_runtime.get('last_reason')}` error_type=`{_tiktok_live_memory_runtime.get('last_error_type') or 'none'}`",
-        f"- barcode_show_episode_ledger_last_sync: written=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_written') or 0)}` finalized=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_finalized') or 0)}` tiktok_events=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_events') or 0)}` operational_events=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_operational_events') or 0)}` discord_interactions=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_discord_interactions') or 0)}` discord_exchanges=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_discord_exchanges') or 0)}` conversation_rows=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_conversation_rows') or 0)}` reason=`{_tiktok_live_memory_runtime.get('show_ledger_last_reason')}` error_type=`{_tiktok_live_memory_runtime.get('show_ledger_last_error_type') or 'none'}`",
+        f"- barcode_show_episode_ledger_last_sync: authorized=`{'yes' if _tiktok_live_memory_runtime.get('show_ledger_authorization_eligible') else 'no'}` written=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_written') or 0)}` finalized=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_finalized') or 0)}` tiktok_events=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_events') or 0)}` operational_events=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_operational_events') or 0)}` discord_interactions=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_discord_interactions') or 0)}` discord_exchanges=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_discord_exchanges') or 0)}` conversation_rows=`{int(_tiktok_live_memory_runtime.get('show_ledger_last_conversation_rows') or 0)}` reason=`{_tiktok_live_memory_runtime.get('show_ledger_last_reason')}` error_type=`{_tiktok_live_memory_runtime.get('show_ledger_last_error_type') or 'none'}`",
         f"- tiktok_live_identity_policy: `handle_display_correlated_v1` owner_handle_configured=`{'yes' if bool(BNL_TIKTOK_OWNER_HANDLES) else 'no'}`",
         f"- ambient_throttle: cooldown=`{AMBIENT_POST_COOLDOWN_MINUTES}m` daily_cap_today=`{ambient_cap_today}` normal_cap=`{AMBIENT_DAILY_POST_CAP}` high_activity_cap=`2` min_signal_messages=`{AMBIENT_MIN_SIGNAL_MESSAGES}` min_signal_users=`{AMBIENT_MIN_SIGNAL_UNIQUE_USERS}`",
         f"- ambient_posts_today: `{ambient_posts_today}`",

--- a/bnl_canon_source_contract.py
+++ b/bnl_canon_source_contract.py
@@ -30,6 +30,11 @@ ATOMIC_KNOWLEDGE_LIFECYCLE_SCHEMA_VERSION = (
 )
 PUBLIC_ASSESSMENT_EVIDENCE_VERSION = "public_assessment_evidence_v4"
 ENTITY_ACCOUNT_BINDING_CONTRACT_VERSION = "canon_entity_account_binding_v1"
+SHOW_QUEUE_EVIDENCE_AUTHORIZATION_VERSION = (
+    "show_queue_evidence_authorization_v1"
+)
+SHOW_QUEUE_ARCHIVE_SCHEMA_VERSION = "queue_public_history_projection_v1"
+SHOW_QUEUE_ARCHIVE_SOURCE = "queue_bnl_history_projection"
 
 
 class CanonStatus(str, Enum):
@@ -3240,6 +3245,168 @@ def queue_usability(
         "privateAllowed": bool(allow_private),
         "reason": reason,
     }
+
+
+def _show_queue_archive(read_model: dict | None) -> dict[str, Any]:
+    if not isinstance(read_model, dict):
+        return {}
+    sections = read_model.get("sections")
+    if not isinstance(sections, dict):
+        return {}
+    archive = sections.get("archive")
+    return dict(archive) if isinstance(archive, Mapping) else {}
+
+
+def _show_queue_archive_contains_test_evidence(value: Any) -> bool:
+    """Reject explicit simulation/test markers from a public projection."""
+
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            normalized_key = str(key or "").strip().casefold()
+            if normalized_key in {"issimulation", "istesttrack"} and item is True:
+                return True
+            if _show_queue_archive_contains_test_evidence(item):
+                return True
+        return False
+    if isinstance(value, (list, tuple)):
+        return any(_show_queue_archive_contains_test_evidence(item) for item in value)
+    if isinstance(value, str):
+        normalized = value.casefold()
+        return "[queue simulation track]" in normalized
+    return False
+
+
+def show_queue_evidence_authorization(
+    read_model: dict | None,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Validate the exact public-production archive admitted to show memory.
+
+    This is a narrow exception for the existing finalized-show owner. It does
+    not grant queue mutation, general queue persistence, Source File, dossier,
+    Relationship, or canon authority.
+    """
+
+    queue = queue_usability(
+        read_model,
+        environ=dict(environ) if environ is not None else None,
+        allow_private=False,
+    )
+    decision: dict[str, Any] = {
+        "usable": False,
+        "reason": str(queue.get("reason") or "queue_not_usable"),
+        "receipt": None,
+    }
+    if not queue.get("usable"):
+        return decision
+    if not isinstance(read_model, dict) or (
+        read_model.get("ok") is not True
+        or read_model.get("version") != 1
+        or read_model.get("source") != "barcode-network-site"
+        or read_model.get("publicOnly") is not True
+        or website_queue_access_scope(read_model) != "public"
+    ):
+        decision["reason"] = "read_model_public_contract_invalid"
+        return decision
+
+    archive = _show_queue_archive(read_model)
+    source_revision = archive.get("sourceRevision")
+    source_digest = str(archive.get("sourceDigest") or "").strip().casefold()
+    coverage_started_at = str(
+        archive.get("historyCoverageStartedAt") or ""
+    ).strip()
+    archive_contract_valid = bool(
+        archive.get("available") is True
+        and archive.get("reason") in {None, ""}
+        and archive.get("schemaVersion") == SHOW_QUEUE_ARCHIVE_SCHEMA_VERSION
+        and archive.get("source") == SHOW_QUEUE_ARCHIVE_SOURCE
+        and archive.get("visibility") == "public_safe"
+        and archive.get("accessScope") == "public"
+        and archive.get("memoryDefault") == "do_not_store"
+        and archive.get("sourceFileDefault") == "review_evidence_only"
+        and archive.get("publicDossierDefault") == "not_automatic"
+        and isinstance(source_revision, int)
+        and not isinstance(source_revision, bool)
+        and source_revision >= 0
+        and re.fullmatch(r"[a-f0-9]{64}", source_digest)
+        and re.fullmatch(r"20\d{2}-\d{2}-\d{2}", coverage_started_at)
+        and archive.get("personalHistory") is None
+        and not _show_queue_archive_contains_test_evidence(archive)
+    )
+    if not archive_contract_valid:
+        decision["reason"] = "archive_public_contract_invalid"
+        return decision
+
+    receipt = {
+        "contractVersion": SHOW_QUEUE_EVIDENCE_AUTHORIZATION_VERSION,
+        "readModelSource": "barcode-network-site",
+        "publicOnly": True,
+        "localQueueProduction": True,
+        "websiteQueueProduction": True,
+        "accessScope": "public",
+        "archiveSchemaVersion": SHOW_QUEUE_ARCHIVE_SCHEMA_VERSION,
+        "archiveSource": SHOW_QUEUE_ARCHIVE_SOURCE,
+        "archiveVisibility": "public_safe",
+        "archiveSourceRevision": source_revision,
+        "archiveSourceDigest": source_digest,
+        "historyCoverageStartedAt": coverage_started_at,
+    }
+    decision.update(
+        {
+            "usable": True,
+            "reason": "eligible_public_production_archive",
+            "receipt": receipt,
+        }
+    )
+    return decision
+
+
+def show_queue_evidence_authorization_receipt_valid(value: Any) -> bool:
+    """Validate a content-free receipt persisted with one show ledger."""
+
+    if not isinstance(value, Mapping):
+        return False
+    expected_keys = {
+        "contractVersion",
+        "readModelSource",
+        "publicOnly",
+        "localQueueProduction",
+        "websiteQueueProduction",
+        "accessScope",
+        "archiveSchemaVersion",
+        "archiveSource",
+        "archiveVisibility",
+        "archiveSourceRevision",
+        "archiveSourceDigest",
+        "historyCoverageStartedAt",
+    }
+    revision = value.get("archiveSourceRevision")
+    return bool(
+        set(value.keys()) == expected_keys
+        and value.get("contractVersion")
+        == SHOW_QUEUE_EVIDENCE_AUTHORIZATION_VERSION
+        and value.get("readModelSource") == "barcode-network-site"
+        and value.get("publicOnly") is True
+        and value.get("localQueueProduction") is True
+        and value.get("websiteQueueProduction") is True
+        and value.get("accessScope") == "public"
+        and value.get("archiveSchemaVersion")
+        == SHOW_QUEUE_ARCHIVE_SCHEMA_VERSION
+        and value.get("archiveSource") == SHOW_QUEUE_ARCHIVE_SOURCE
+        and value.get("archiveVisibility") == "public_safe"
+        and isinstance(revision, int)
+        and not isinstance(revision, bool)
+        and revision >= 0
+        and re.fullmatch(
+            r"[a-f0-9]{64}",
+            str(value.get("archiveSourceDigest") or "").strip().casefold(),
+        )
+        and re.fullmatch(
+            r"20\d{2}-\d{2}-\d{2}",
+            str(value.get("historyCoverageStartedAt") or "").strip(),
+        )
+    )
 
 def _looks_queue_derived(value: Any) -> bool:
     if isinstance(value, dict):

--- a/bnl_memory_ledger.py
+++ b/bnl_memory_ledger.py
@@ -31,6 +31,7 @@ from bnl_canon_source_contract import (
     is_public_usable,
     map_channel_policy_visibility,
     map_route_source_label,
+    show_queue_evidence_authorization_receipt_valid,
 )
 
 MEMORY_LEDGER_SCHEMA_VERSION = "memory_ledger_v1"
@@ -7580,6 +7581,9 @@ def _tiktok_show_occurrence_identity(
             != str(source_digest or "")
             or computed_digest != str(source_digest or "")
             or str(ledger.get("lifecycle") or "") != "finalized"
+            or not show_queue_evidence_authorization_receipt_valid(
+                ledger.get("sourceAuthorization")
+            )
         ):
             continue
         evidence_rows = [

--- a/bnl_tiktok_live_context.py
+++ b/bnl_tiktok_live_context.py
@@ -20,9 +20,10 @@ import stat
 import tempfile
 import time
 from collections.abc import Mapping, Sequence
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple
+from zoneinfo import ZoneInfo
 
 
 SCHEMA_VERSION = 2
@@ -56,6 +57,11 @@ _PUBLIC_EVENT_TYPES = frozenset({"comment", "question"})
 _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 _SPACE_RE = re.compile(r"\s+")
 _HANDLE_RE = re.compile(r"^[A-Za-z0-9._]+$")
+_PACIFIC_TZ = ZoneInfo("America/Los_Angeles")
+_SHOW_DATE_SCOPE_RE = re.compile(
+    r"\b(?:tiktok|tik tok|barcode radio|broadcast|show|episode|live|stream)\b",
+    re.IGNORECASE,
+)
 
 _LIVE_REACTION_PATTERNS = (
     r"\b(?:tiktok|tik tok)(?: live| stream)? (?:chat|comments?)\b",
@@ -511,6 +517,8 @@ def tiktok_show_records(archive: Any) -> list[Dict[str, Any]]:
 def select_show_for_tiktok_analysis(
     archive: Any,
     user_text: str,
+    *,
+    now: Any = None,
 ) -> Tuple[Dict[str, Any], str]:
     """Select the bounded public show record implied by one analytics request."""
 
@@ -523,7 +531,34 @@ def select_show_for_tiktok_analysis(
         for source_key, show in candidates:
             if _bounded_text(show.get("showDate"), 40) == explicit_date.group(0):
                 return dict(show), source_key
-    if re.search(r"\b(?:last|previous|prior) show\b", normalized):
+        return {}, "none"
+    relative_date = ""
+    if _SHOW_DATE_SCOPE_RE.search(normalized) and re.search(
+        r"\b(?:yesterday|last night)\b",
+        normalized,
+    ):
+        if isinstance(now, datetime):
+            current = now
+        elif now is not None:
+            try:
+                current = datetime.fromisoformat(
+                    str(now).replace("Z", "+00:00")
+                )
+            except (TypeError, ValueError):
+                current = datetime.now(timezone.utc)
+        else:
+            current = datetime.now(timezone.utc)
+        if current.tzinfo is None:
+            current = current.replace(tzinfo=timezone.utc)
+        relative_date = (
+            current.astimezone(_PACIFIC_TZ).date() - timedelta(days=1)
+        ).isoformat()
+    if relative_date:
+        for source_key, show in candidates:
+            if _bounded_text(show.get("showDate"), 40) == relative_date:
+                return dict(show), source_key
+        return {}, "none"
+    if re.search(r"\b(?:last|previous|prior|past) show\b", normalized):
         for source_key, show in candidates:
             if source_key in {"latestShow", "shows"}:
                 return dict(show), source_key

--- a/bnl_tiktok_show_ledger.py
+++ b/bnl_tiktok_show_ledger.py
@@ -19,7 +19,13 @@ import sqlite3
 from typing import Any, Mapping, Optional, Sequence
 from zoneinfo import ZoneInfo
 
-from bnl_canon_source_contract import Confidence, SourceClass, Visibility
+from bnl_canon_source_contract import (
+    Confidence,
+    SourceClass,
+    Visibility,
+    show_queue_evidence_authorization,
+    show_queue_evidence_authorization_receipt_valid,
+)
 from bnl_memory_ledger import (
     LINEAGE_TYPES,
     LedgerEntry,
@@ -45,7 +51,6 @@ TIKTOK_SHOW_EVIDENCE_RESPONSE_WINDOW_MS = 15 * 60 * 1000
 TIKTOK_SHOW_EVIDENCE_RECALL_SHOW_LIMIT = 2
 TIKTOK_SHOW_EVIDENCE_RECALL_MESSAGE_LIMIT = 10
 SHOW_EPISODE_CONTEXT_VERSION = "barcode_show_episode_context_v1"
-_LEGACY_SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION = "tiktok_show_evidence_ledger_v1"
 
 _SPACE_RE = re.compile(r"\s+")
 _QUERY_TERM_RE = re.compile(r"[a-z0-9][a-z0-9'’-]{2,}", re.IGNORECASE)
@@ -184,10 +189,7 @@ def _safe_document(value: Any) -> Optional[dict[str, Any]]:
     if not isinstance(value, Mapping):
         return None
     schema_version = value.get("schemaVersion")
-    if schema_version not in {
-        SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION,
-        _LEGACY_SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION,
-    }:
+    if schema_version != SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION:
         return None
     show_key = _safe_label(value.get("showKey"), 200)
     source_digest = _safe_label(value.get("sourceDigest"), 64).lower()
@@ -198,9 +200,12 @@ def _safe_document(value: Any) -> Optional[dict[str, Any]]:
         or not isinstance(value.get("participants"), list)
         or not isinstance(value.get("topics"), list)
         or not isinstance(value.get("trackMoments"), list)
+        or not show_queue_evidence_authorization_receipt_valid(
+            value.get("sourceAuthorization")
+        )
     ):
         return None
-    if schema_version == SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION and any(
+    if any(
         not isinstance(value.get(field), list)
         for field in (
             "trackRoster",
@@ -211,7 +216,36 @@ def _safe_document(value: Any) -> Optional[dict[str, Any]]:
         )
     ):
         return None
+    digest_payload = dict(value)
+    digest_payload.pop("sourceDigest", None)
+    computed_digest = hashlib.sha256(
+        _canonical_json(digest_payload).encode("utf-8")
+    ).hexdigest()
+    if computed_digest != source_digest:
+        return None
     return dict(value)
+
+
+def _seal_authorized_show_ledger(
+    ledger: Any,
+    authorization_receipt: Mapping[str, Any],
+) -> Optional[dict[str, Any]]:
+    """Bind one public show document to its validated source authorization."""
+
+    if (
+        not isinstance(ledger, Mapping)
+        or not show_queue_evidence_authorization_receipt_valid(
+            authorization_receipt
+        )
+    ):
+        return None
+    sealed = dict(ledger)
+    sealed.pop("sourceDigest", None)
+    sealed["sourceAuthorization"] = dict(authorization_receipt)
+    sealed["sourceDigest"] = hashlib.sha256(
+        _canonical_json(sealed).encode("utf-8")
+    ).hexdigest()
+    return _safe_document(sealed)
 
 
 def _context_digest(*values: Any) -> str:
@@ -1437,8 +1471,9 @@ def sync_tiktok_show_evidence_ledgers(
     artist_identity_index: Optional[
         Mapping[str, Sequence[Mapping[str, Any]]]
     ] = None,
+    environ: Optional[Mapping[str, str]] = None,
 ) -> dict[str, Any]:
-    """Idempotently assemble every available public show into memory."""
+    """Idempotently assemble every authorized public-production show."""
 
     result = {
         "status": "skipped",
@@ -1461,10 +1496,32 @@ def sync_tiktok_show_evidence_ledgers(
         "livingCanonSubjectsEvaluated": 0,
         "livingCanonCandidatesRefreshed": 0,
         "livingCanonFormationErrors": 0,
+        "authorizationEligible": False,
     }
+    authorization = show_queue_evidence_authorization(
+        read_model,
+        environ=environ,
+    )
+    if not authorization.get("usable"):
+        result["reason"] = str(
+            authorization.get("reason") or "archive_not_authorized"
+        )
+        return result
+    authorization_receipt = authorization.get("receipt")
+    if not show_queue_evidence_authorization_receipt_valid(
+        authorization_receipt
+    ):
+        result["reason"] = "archive_authorization_receipt_invalid"
+        return result
+    result["authorizationEligible"] = True
     archive = _archive_from_read_model(read_model)
     shows = tiktok_show_records(archive)
     if not shows or int(guild_id or 0) <= 0 or not db_file:
+        result["reason"] = (
+            "no_show_records"
+            if not shows
+            else "invalid_sync_target"
+        )
         return result
     result["showsSeen"] = len(shows)
     conn = sqlite3.connect(db_file, timeout=10.0)
@@ -1486,13 +1543,14 @@ def sync_tiktok_show_evidence_ledgers(
             )
             if discord_exchanges is None:
                 continue
-            ledger = _safe_document(
+            ledger = _seal_authorized_show_ledger(
                 build_tiktok_show_evidence_ledger(
                     show,
                     source_events,
                     artist_identity_index=artist_identity_index,
                     discord_exchanges=discord_exchanges,
-                )
+                ),
+                authorization_receipt,
             )
             if ledger is None:
                 continue

--- a/bnl_tiktok_show_ledger.py
+++ b/bnl_tiktok_show_ledger.py
@@ -19,7 +19,12 @@ import sqlite3
 from typing import Any, Mapping, Optional, Sequence
 from zoneinfo import ZoneInfo
 
-from bnl_canon_source_contract import Confidence, SourceClass, Visibility
+from bnl_canon_source_contract import (
+    SIX_BIT,
+    Confidence,
+    SourceClass,
+    Visibility,
+)
 from bnl_memory_ledger import (
     LINEAGE_TYPES,
     LedgerEntry,
@@ -178,6 +183,27 @@ def _canonical_json(value: Any) -> str:
 
 def _safe_label(value: Any, limit: int = 220) -> str:
     return _SPACE_RE.sub(" ", str(value or "")).strip()[:limit].rstrip()
+
+
+def _configured_owner_subject_ref() -> str:
+    try:
+        owner_user_id = int(os.getenv("BNL_OWNER_USER_ID", "0") or 0)
+    except (OverflowError, TypeError, ValueError):
+        return ""
+    return f"discord_user:{owner_user_id}" if owner_user_id > 0 else ""
+
+
+def _public_show_speaker_label(
+    subject_ref: Any,
+    value: Any,
+    fallback: str = "Show participant",
+    *,
+    limit: int = 160,
+) -> str:
+    owner_subject_ref = _configured_owner_subject_ref()
+    if owner_subject_ref and str(subject_ref or "") == owner_subject_ref:
+        return SIX_BIT.name
+    return _safe_label(value, limit) or fallback
 
 
 def _safe_document(value: Any) -> Optional[dict[str, Any]]:
@@ -1126,7 +1152,10 @@ def _project_finalized_show(
         if subject_ref:
             episode_subjects.setdefault(
                 subject_ref,
-                str(item.get("speakerLabel") or "Show participant")[:160],
+                _public_show_speaker_label(
+                    subject_ref,
+                    item.get("speakerLabel"),
+                ),
             )
     coverage = ledger.get("coverage") or {}
     episode_value = _canonical_json(
@@ -1152,9 +1181,24 @@ def _project_finalized_show(
             "operationalSummary": ledger.get("operationalSummary") or {},
             "topics": topics,
             "trackMoments": tracks,
-            "crossSourceBindings": list(
-                ledger.get("crossSourceBindings") or ()
-            )[:12],
+            "crossSourceBindings": [
+                {
+                    **binding,
+                    "tiktokSpeakerLabel": _public_show_speaker_label(
+                        binding.get("subjectRef"),
+                        binding.get("tiktokSpeakerLabel"),
+                        "TikTok viewer",
+                        limit=220,
+                    ),
+                    "discordSpeakerLabel": _public_show_speaker_label(
+                        binding.get("subjectRef"),
+                        binding.get("discordSpeakerLabel"),
+                        "Discord member",
+                    ),
+                }
+                for binding in ledger.get("crossSourceBindings") or ()
+                if isinstance(binding, Mapping)
+            ][:12],
             "sourceDigest": source_digest,
             "epistemicStatus": (
                 "authoritative public queue chronology plus source-linked "
@@ -1219,6 +1263,10 @@ def _project_finalized_show(
             or participant.get("handle")
             or "unknown-viewer"
         )[:240]
+        public_speaker_label = _public_show_speaker_label(
+            subject_ref,
+            participant.get("speakerLabel"),
+        )
         row_key = hashlib.sha256(subject_ref.encode("utf-8")).hexdigest()[:32]
         participant_value = _canonical_json(
             {
@@ -1226,7 +1274,7 @@ def _project_finalized_show(
                 "showKey": show_key,
                 "showDate": ledger.get("showDate"),
                 "surface": surface,
-                "speakerLabel": participant.get("speakerLabel"),
+                "speakerLabel": public_speaker_label,
                 "handle": participant.get("handle"),
                 "messageCount": participant.get("messageCount"),
                 "questionCount": participant.get("questionCount"),
@@ -1258,9 +1306,7 @@ def _project_finalized_show(
             source_role=f"{surface}_participant_episode_projection",
             entry_type="shared_moment",
             subject_key=subject_ref,
-            subject_display_name=str(
-                participant.get("speakerLabel") or "Show participant"
-            )[:160],
+            subject_display_name=public_speaker_label,
             predicate_key="barcode_radio.show_participation",
             value=participant_value,
             source_class=SourceClass.DERIVED_SUMMARY,
@@ -1287,9 +1333,7 @@ def _project_finalized_show(
             participants=(
                 LedgerParticipant(
                     subject_ref,
-                    str(
-                        participant.get("speakerLabel") or "Show participant"
-                    )[:160],
+                    public_speaker_label,
                     "author",
                     0,
                 ),
@@ -1732,16 +1776,25 @@ def _document_relevance(
     ]
     participant_matches = []
     for participant in participants:
+        participant_subject_ref = str(participant.get("subjectRef") or "")
         direct_subject = bool(
             allow_direct_subject
             and subject_ref
-            and str(participant.get("subjectRef") or "") == subject_ref
+            and participant_subject_ref == subject_ref
         )
         named = any(
             _phrase_in_query(query, value)
             for value in (
-                participant.get("speakerLabel"),
-                participant.get("displayName"),
+                _public_show_speaker_label(
+                    participant_subject_ref,
+                    participant.get("speakerLabel"),
+                    "",
+                ),
+                _public_show_speaker_label(
+                    participant_subject_ref,
+                    participant.get("displayName"),
+                    "",
+                ),
                 participant.get("handle"),
             )
         )
@@ -1797,7 +1850,11 @@ def _document_relevance(
             continue
         exchange_text = " ".join(
             [
-                str(exchange.get("speakerLabel") or ""),
+                _public_show_speaker_label(
+                    exchange.get("subjectRef"),
+                    exchange.get("speakerLabel"),
+                    "",
+                ),
                 *[
                     str(message.get("text") or "")
                     for message in exchange.get("userMessages") or ()
@@ -2106,8 +2163,9 @@ def _community_episode_context_item(
             if not subject_ref:
                 continue
             all_subjects.append(subject_ref)
-            participant_labels[subject_ref] = str(
-                participant.get("speakerLabel") or "Show participant"
+            participant_labels[subject_ref] = _public_show_speaker_label(
+                subject_ref,
+                participant.get("speakerLabel"),
             )
             participant_messages[subject_ref] = (
                 participant_messages.get(subject_ref, 0)
@@ -2405,7 +2463,15 @@ def _dialogue_episode_context_item(
             "showTitle": str(ledger.get("showTitle") or "BARCODE Radio"),
         }
         episode_messages = [
-            {**item, **episode, "surface": "TikTok"}
+            {
+                **item,
+                **episode,
+                "speakerLabel": _public_show_speaker_label(
+                    item.get("subjectRef"),
+                    item.get("speakerLabel"),
+                ),
+                "surface": "TikTok",
+            }
             for item in ledger.get("messages") or ()
             if isinstance(item, Mapping)
         ]
@@ -2422,8 +2488,10 @@ def _dialogue_episode_context_item(
                         "eventId": "discord_conversation:%s"
                         % str(message.get("conversationRowId") or ""),
                         "subjectRef": str(exchange.get("subjectRef") or ""),
-                        "speakerLabel": str(
-                            exchange.get("speakerLabel") or "Discord member"
+                        "speakerLabel": _public_show_speaker_label(
+                            exchange.get("subjectRef"),
+                            exchange.get("speakerLabel"),
+                            "Discord member",
                         ),
                         "surface": "Discord",
                     }
@@ -2458,8 +2526,10 @@ def _dialogue_episode_context_item(
                 str(message.get("showDate") or "unknown date"),
                 str(message.get("surface") or "show chat"),
                 float(message.get("minuteOffset") or 0.0),
-                _safe_label(message.get("speakerLabel"), 160)
-                or "Show participant",
+                _public_show_speaker_label(
+                    message.get("subjectRef"),
+                    message.get("speakerLabel"),
+                ),
                 moment,
                 json.dumps(
                     _safe_label(message.get("text"), 360),
@@ -2765,9 +2835,13 @@ def build_tiktok_show_evidence_context(
         if shown_participants:
             lines.append("People in this episode:")
             for participant in shown_participants[:8]:
+                public_speaker_label = _public_show_speaker_label(
+                    participant.get("subjectRef"),
+                    participant.get("speakerLabel"),
+                )
                 detail = (
                     f"- [{str(participant.get('surface') or 'tiktok')}] "
-                    f"{json.dumps(str(participant.get('speakerLabel') or 'Show participant'), ensure_ascii=False)}: "
+                    f"{json.dumps(public_speaker_label, ensure_ascii=False)}: "
                     f"{int(participant.get('messageCount') or 0)} authored messages, "
                     f"{int(participant.get('questionCount') or 0)} questions, "
                     f"{int(participant.get('bnlAddressCount') or 0)} addressed BNL, "
@@ -2908,7 +2982,14 @@ def build_tiktok_show_evidence_context(
             str(item.get("subjectRef") or "") for item in participant_matches
         }
         tiktok_messages = [
-            {**item, "surface": "tiktok"}
+            {
+                **item,
+                "speakerLabel": _public_show_speaker_label(
+                    item.get("subjectRef"),
+                    item.get("speakerLabel"),
+                ),
+                "surface": "tiktok",
+            }
             for item in ledger.get("messages") or ()
             if isinstance(item, Mapping)
         ]
@@ -2923,8 +3004,10 @@ def build_tiktok_show_evidence_context(
                 "eventId": "discord_conversation:"
                 + str(message.get("conversationRowId") or ""),
                 "subjectRef": str(exchange.get("subjectRef") or ""),
-                "speakerLabel": str(
-                    exchange.get("speakerLabel") or "Discord member"
+                "speakerLabel": _public_show_speaker_label(
+                    exchange.get("subjectRef"),
+                    exchange.get("speakerLabel"),
+                    "Discord member",
                 ),
                 "surface": "discord",
             }
@@ -2969,6 +3052,10 @@ def build_tiktok_show_evidence_context(
             lines.append("Source-linked authored examples:")
             for message in relevant_messages[:bounded_message_limit]:
                 track_label = str(message.get("trackLabel") or "")
+                public_speaker_label = _public_show_speaker_label(
+                    message.get("subjectRef"),
+                    message.get("speakerLabel"),
+                )
                 operational_context = (
                     message.get("operationalContext")
                     if isinstance(message.get("operationalContext"), Mapping)
@@ -2988,7 +3075,7 @@ def build_tiktok_show_evidence_context(
                 lines.append(
                     f"- [{str(message.get('surface') or 'tiktok')}] "
                     f"t+{float(message.get('minuteOffset') or 0.0):.1f}m "
-                    f"{json.dumps(str(message.get('speakerLabel') or 'Show participant'), ensure_ascii=False)}"
+                    f"{json.dumps(public_speaker_label, ensure_ascii=False)}"
                     f"{moment}{operation_suffix}: "
                     f"{json.dumps(str(message.get('text') or ''), ensure_ascii=False)}"
                 )
@@ -2998,7 +3085,11 @@ def build_tiktok_show_evidence_context(
             exchange_subject = str(exchange.get("subjectRef") or "")
             exchange_text = " ".join(
                 [
-                    str(exchange.get("speakerLabel") or ""),
+                    _public_show_speaker_label(
+                        exchange_subject,
+                        exchange.get("speakerLabel"),
+                        "",
+                    ),
                     *[
                         str(message.get("text") or "")
                         for message in exchange.get("userMessages") or ()
@@ -3027,12 +3118,17 @@ def build_tiktok_show_evidence_context(
         if relevant_exchanges:
             lines.append("Public Discord interactions with BNL during this episode:")
             for _exchange_score, exchange in relevant_exchanges[:6]:
+                public_speaker_label = _public_show_speaker_label(
+                    exchange.get("subjectRef"),
+                    exchange.get("speakerLabel"),
+                    "Discord member",
+                )
                 for message in (exchange.get("userMessages") or ())[-3:]:
                     if not isinstance(message, Mapping):
                         continue
                     lines.append(
                         f"- t+{float(message.get('minuteOffset') or 0.0):.1f}m "
-                        f"{json.dumps(str(exchange.get('speakerLabel') or 'Discord member'), ensure_ascii=False)}: "
+                        f"{json.dumps(public_speaker_label, ensure_ascii=False)}: "
                         f"{json.dumps(_safe_label(message.get('text'), 1200), ensure_ascii=False)}"
                     )
                 response = exchange.get("bnlResponse")

--- a/bnl_tiktok_show_ledger.py
+++ b/bnl_tiktok_show_ledger.py
@@ -19,7 +19,14 @@ import sqlite3
 from typing import Any, Mapping, Optional, Sequence
 from zoneinfo import ZoneInfo
 
-from bnl_canon_source_contract import Confidence, SourceClass, Visibility
+from bnl_canon_source_contract import (
+    SIX_BIT,
+    Confidence,
+    SourceClass,
+    Visibility,
+    show_queue_evidence_authorization,
+    show_queue_evidence_authorization_receipt_valid,
+)
 from bnl_memory_ledger import (
     LINEAGE_TYPES,
     LedgerEntry,
@@ -33,6 +40,7 @@ from bnl_tiktok_live_context import (
     SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION,
     build_tiktok_show_evidence_ledger,
     show_timeline_bounds_ms,
+    tiktok_show_evidence_key,
     tiktok_show_records,
 )
 
@@ -45,7 +53,6 @@ TIKTOK_SHOW_EVIDENCE_RESPONSE_WINDOW_MS = 15 * 60 * 1000
 TIKTOK_SHOW_EVIDENCE_RECALL_SHOW_LIMIT = 2
 TIKTOK_SHOW_EVIDENCE_RECALL_MESSAGE_LIMIT = 10
 SHOW_EPISODE_CONTEXT_VERSION = "barcode_show_episode_context_v1"
-_LEGACY_SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION = "tiktok_show_evidence_ledger_v1"
 
 _SPACE_RE = re.compile(r"\s+")
 _QUERY_TERM_RE = re.compile(r"[a-z0-9][a-z0-9'’-]{2,}", re.IGNORECASE)
@@ -53,7 +60,7 @@ _SHOW_QUERY_RE = re.compile(
     r"\b(?:tiktok|tik tok|barcode radio|broadcast|show|episode|live|chat|viewer|"
     r"audience|track|song|queue|wheel|submissions?|intake|sponsor|break|"
     r"signal hold|paused?|stalled?|resumed?|skipped?|removed?|returned?|"
-    r"restored?|started?|finished?|timeline|tonight|today|yesterday|last night|"
+    r"restored?|started?|finished?|timeline|"
     r"last show|previous show|past show|show chat|talked about)\b",
     re.IGNORECASE,
 )
@@ -83,6 +90,10 @@ _SUBJECT_CONTINUITY_QUERY_RE = re.compile(
     r"\b(?:remember me|know me|about me|my history|my activity|my messages?|"
     r"what did i|when did i|did i|have i|was i|where was i|"
     r"what do you think of me|your (?:read|opinion|impression) of me)\b",
+    re.IGNORECASE,
+)
+_RELATIVE_SHOW_DATE_SCOPE_RE = re.compile(
+    r"\b(?:tiktok|tik tok|barcode radio|broadcast|show|episode|live|stream)\b",
     re.IGNORECASE,
 )
 _MULTI_SHOW_QUERY_RE = re.compile(
@@ -180,14 +191,32 @@ def _safe_label(value: Any, limit: int = 220) -> str:
     return _SPACE_RE.sub(" ", str(value or "")).strip()[:limit].rstrip()
 
 
+def _configured_owner_subject_ref() -> str:
+    try:
+        owner_user_id = int(os.getenv("BNL_OWNER_USER_ID", "0") or 0)
+    except (OverflowError, TypeError, ValueError):
+        return ""
+    return f"discord_user:{owner_user_id}" if owner_user_id > 0 else ""
+
+
+def _public_show_speaker_label(
+    subject_ref: Any,
+    value: Any,
+    fallback: str = "Show participant",
+    *,
+    limit: int = 160,
+) -> str:
+    owner_subject_ref = _configured_owner_subject_ref()
+    if owner_subject_ref and str(subject_ref or "") == owner_subject_ref:
+        return SIX_BIT.name
+    return _safe_label(value, limit) or fallback
+
+
 def _safe_document(value: Any) -> Optional[dict[str, Any]]:
     if not isinstance(value, Mapping):
         return None
     schema_version = value.get("schemaVersion")
-    if schema_version not in {
-        SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION,
-        _LEGACY_SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION,
-    }:
+    if schema_version != SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION:
         return None
     show_key = _safe_label(value.get("showKey"), 200)
     source_digest = _safe_label(value.get("sourceDigest"), 64).lower()
@@ -198,9 +227,12 @@ def _safe_document(value: Any) -> Optional[dict[str, Any]]:
         or not isinstance(value.get("participants"), list)
         or not isinstance(value.get("topics"), list)
         or not isinstance(value.get("trackMoments"), list)
+        or not show_queue_evidence_authorization_receipt_valid(
+            value.get("sourceAuthorization")
+        )
     ):
         return None
-    if schema_version == SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION and any(
+    if any(
         not isinstance(value.get(field), list)
         for field in (
             "trackRoster",
@@ -211,7 +243,36 @@ def _safe_document(value: Any) -> Optional[dict[str, Any]]:
         )
     ):
         return None
+    digest_payload = dict(value)
+    digest_payload.pop("sourceDigest", None)
+    computed_digest = hashlib.sha256(
+        _canonical_json(digest_payload).encode("utf-8")
+    ).hexdigest()
+    if computed_digest != source_digest:
+        return None
     return dict(value)
+
+
+def _seal_authorized_show_ledger(
+    ledger: Any,
+    authorization_receipt: Mapping[str, Any],
+) -> Optional[dict[str, Any]]:
+    """Bind one public show document to its validated source authorization."""
+
+    if (
+        not isinstance(ledger, Mapping)
+        or not show_queue_evidence_authorization_receipt_valid(
+            authorization_receipt
+        )
+    ):
+        return None
+    sealed = dict(ledger)
+    sealed.pop("sourceDigest", None)
+    sealed["sourceAuthorization"] = dict(authorization_receipt)
+    sealed["sourceDigest"] = hashlib.sha256(
+        _canonical_json(sealed).encode("utf-8")
+    ).hexdigest()
+    return _safe_document(sealed)
 
 
 def _context_digest(*values: Any) -> str:
@@ -248,6 +309,8 @@ def _requested_show_date(user_text: str, *, now: Any = None) -> str:
     if explicit:
         return explicit.group(1)
     lowered = query.casefold()
+    if not _RELATIVE_SHOW_DATE_SCOPE_RE.search(lowered):
+        return ""
     current_date = _coerce_pacific_now(now).date()
     if re.search(r"\b(?:yesterday|last night)\b", lowered):
         return (current_date - timedelta(days=1)).isoformat()
@@ -1126,7 +1189,10 @@ def _project_finalized_show(
         if subject_ref:
             episode_subjects.setdefault(
                 subject_ref,
-                str(item.get("speakerLabel") or "Show participant")[:160],
+                _public_show_speaker_label(
+                    subject_ref,
+                    item.get("speakerLabel"),
+                ),
             )
     coverage = ledger.get("coverage") or {}
     episode_value = _canonical_json(
@@ -1152,9 +1218,24 @@ def _project_finalized_show(
             "operationalSummary": ledger.get("operationalSummary") or {},
             "topics": topics,
             "trackMoments": tracks,
-            "crossSourceBindings": list(
-                ledger.get("crossSourceBindings") or ()
-            )[:12],
+            "crossSourceBindings": [
+                {
+                    **binding,
+                    "tiktokSpeakerLabel": _public_show_speaker_label(
+                        binding.get("subjectRef"),
+                        binding.get("tiktokSpeakerLabel"),
+                        "TikTok viewer",
+                        limit=220,
+                    ),
+                    "discordSpeakerLabel": _public_show_speaker_label(
+                        binding.get("subjectRef"),
+                        binding.get("discordSpeakerLabel"),
+                        "Discord member",
+                    ),
+                }
+                for binding in ledger.get("crossSourceBindings") or ()
+                if isinstance(binding, Mapping)
+            ][:12],
             "sourceDigest": source_digest,
             "epistemicStatus": (
                 "authoritative public queue chronology plus source-linked "
@@ -1219,6 +1300,10 @@ def _project_finalized_show(
             or participant.get("handle")
             or "unknown-viewer"
         )[:240]
+        public_speaker_label = _public_show_speaker_label(
+            subject_ref,
+            participant.get("speakerLabel"),
+        )
         row_key = hashlib.sha256(subject_ref.encode("utf-8")).hexdigest()[:32]
         participant_value = _canonical_json(
             {
@@ -1226,7 +1311,7 @@ def _project_finalized_show(
                 "showKey": show_key,
                 "showDate": ledger.get("showDate"),
                 "surface": surface,
-                "speakerLabel": participant.get("speakerLabel"),
+                "speakerLabel": public_speaker_label,
                 "handle": participant.get("handle"),
                 "messageCount": participant.get("messageCount"),
                 "questionCount": participant.get("questionCount"),
@@ -1258,9 +1343,7 @@ def _project_finalized_show(
             source_role=f"{surface}_participant_episode_projection",
             entry_type="shared_moment",
             subject_key=subject_ref,
-            subject_display_name=str(
-                participant.get("speakerLabel") or "Show participant"
-            )[:160],
+            subject_display_name=public_speaker_label,
             predicate_key="barcode_radio.show_participation",
             value=participant_value,
             source_class=SourceClass.DERIVED_SUMMARY,
@@ -1287,9 +1370,7 @@ def _project_finalized_show(
             participants=(
                 LedgerParticipant(
                     subject_ref,
-                    str(
-                        participant.get("speakerLabel") or "Show participant"
-                    )[:160],
+                    public_speaker_label,
                     "author",
                     0,
                 ),
@@ -1362,6 +1443,183 @@ def _archive_from_read_model(read_model: Any) -> Mapping[str, Any]:
     if archive is None:
         archive = read_model.get("archive")
     return archive if isinstance(archive, Mapping) else {}
+
+
+def _stored_show_document(
+    raw_json: Any,
+    *,
+    show_key: str,
+    source_digest: Any,
+    lifecycle_status: Any,
+) -> Optional[dict[str, Any]]:
+    """Load one internally consistent prior show revision for additive rebuilds."""
+
+    try:
+        document = _safe_document(json.loads(str(raw_json or "{}")))
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    if document is None or (
+        str(document.get("showKey") or "") != str(show_key or "")
+        or str(document.get("sourceDigest") or "")
+        != str(source_digest or "")
+        or str(document.get("lifecycle") or "")
+        != str(lifecycle_status or "")
+    ):
+        return None
+    return document
+
+
+def _discord_message_identity(message: Any) -> str:
+    if not isinstance(message, Mapping):
+        return ""
+    for prefix, field in (
+        ("conversation", "conversationRowId"),
+        ("message", "messageId"),
+    ):
+        try:
+            value = int(message.get(field) or 0)
+        except (TypeError, ValueError, OverflowError):
+            value = 0
+        if value > 0:
+            return f"{prefix}:{value}"
+    return ""
+
+
+def _discord_exchange_message_keys(exchange: Any) -> set[str]:
+    if not isinstance(exchange, Mapping):
+        return set()
+    return {
+        identity
+        for identity in (
+            _discord_message_identity(message)
+            for message in exchange.get("userMessages") or ()
+        )
+        if identity
+    }
+
+
+def _merge_retained_discord_exchanges(
+    current: Sequence[Mapping[str, Any]],
+    prior_ledger: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Keep captured public exchanges when source conversation rows age out.
+
+    The existing show ledger remains the sole durable owner. Rebuilds are
+    additive for already-admitted Discord evidence; privacy deletion still
+    removes the owning show row before any later rebuild can consult it.
+    """
+
+    candidates: list[tuple[int, Mapping[str, Any]]] = []
+    if isinstance(prior_ledger, Mapping):
+        candidates.extend(
+            (0, exchange)
+            for exchange in prior_ledger.get("discordInteractions") or ()
+            if isinstance(exchange, Mapping)
+        )
+    candidates.extend(
+        (1, exchange)
+        for exchange in current or ()
+        if isinstance(exchange, Mapping)
+    )
+
+    groups: list[dict[str, Any]] = []
+    for source_priority, exchange in candidates:
+        subject_ref = str(exchange.get("subjectRef") or "")
+        message_keys = _discord_exchange_message_keys(exchange)
+        exchange_id = str(exchange.get("exchangeId") or "")
+        matching = [
+            index
+            for index, group in enumerate(groups)
+            if group["subjectRef"] == subject_ref
+            and (
+                bool(message_keys.intersection(group["messageKeys"]))
+                or bool(exchange_id and exchange_id in group["exchangeIds"])
+            )
+        ]
+        entry = (source_priority, exchange)
+        if not matching:
+            groups.append(
+                {
+                    "subjectRef": subject_ref,
+                    "messageKeys": set(message_keys),
+                    "exchangeIds": {exchange_id} if exchange_id else set(),
+                    "candidates": [entry],
+                }
+            )
+            continue
+        target = groups[matching[0]]
+        target["messageKeys"].update(message_keys)
+        if exchange_id:
+            target["exchangeIds"].add(exchange_id)
+        target["candidates"].append(entry)
+        for index in reversed(matching[1:]):
+            merged = groups.pop(index)
+            target["messageKeys"].update(merged["messageKeys"])
+            target["exchangeIds"].update(merged["exchangeIds"])
+            target["candidates"].extend(merged["candidates"])
+
+    merged_exchanges: list[dict[str, Any]] = []
+    for group in groups:
+        group_candidates = list(group["candidates"])
+
+        def candidate_rank(
+            candidate: tuple[int, Mapping[str, Any]],
+        ) -> tuple[int, int, int, str]:
+            source_priority, exchange = candidate
+            return (
+                int(isinstance(exchange.get("bnlResponse"), Mapping)),
+                int(source_priority),
+                len(exchange.get("userMessages") or ()),
+                str(exchange.get("exchangeId") or ""),
+            )
+
+        _base_priority, base_exchange = max(
+            group_candidates,
+            key=candidate_rank,
+        )
+        response_candidates = [
+            candidate
+            for candidate in group_candidates
+            if isinstance(candidate[1].get("bnlResponse"), Mapping)
+        ]
+        response = (
+            max(response_candidates, key=candidate_rank)[1].get("bnlResponse")
+            if response_candidates
+            else None
+        )
+        messages_by_key: dict[str, Mapping[str, Any]] = {}
+        for source_priority in (0, 1):
+            for candidate_priority, exchange in group_candidates:
+                if candidate_priority != source_priority:
+                    continue
+                for message in exchange.get("userMessages") or ():
+                    identity = _discord_message_identity(message)
+                    if identity and isinstance(message, Mapping):
+                        messages_by_key[identity] = message
+        user_messages = sorted(
+            messages_by_key.values(),
+            key=lambda message: (
+                int(message.get("occurredAtMs") or 0),
+                int(message.get("conversationRowId") or 0),
+                int(message.get("messageId") or 0),
+            ),
+        )
+        merged = dict(base_exchange)
+        merged["userMessages"] = [dict(message) for message in user_messages]
+        merged["bnlResponse"] = dict(response) if response is not None else None
+        merged_exchanges.append(merged)
+
+    merged_exchanges.sort(
+        key=lambda exchange: (
+            int(
+                ((exchange.get("userMessages") or [{}])[0]).get(
+                    "occurredAtMs", 0
+                )
+            ),
+            str(exchange.get("exchangeId") or ""),
+        )
+    )
+    return merged_exchanges
 
 
 def _projection_expectations(
@@ -1437,8 +1695,9 @@ def sync_tiktok_show_evidence_ledgers(
     artist_identity_index: Optional[
         Mapping[str, Sequence[Mapping[str, Any]]]
     ] = None,
+    environ: Optional[Mapping[str, str]] = None,
 ) -> dict[str, Any]:
-    """Idempotently assemble every available public show into memory."""
+    """Idempotently assemble every authorized public-production show."""
 
     result = {
         "status": "skipped",
@@ -1461,10 +1720,32 @@ def sync_tiktok_show_evidence_ledgers(
         "livingCanonSubjectsEvaluated": 0,
         "livingCanonCandidatesRefreshed": 0,
         "livingCanonFormationErrors": 0,
+        "authorizationEligible": False,
     }
+    authorization = show_queue_evidence_authorization(
+        read_model,
+        environ=environ,
+    )
+    if not authorization.get("usable"):
+        result["reason"] = str(
+            authorization.get("reason") or "archive_not_authorized"
+        )
+        return result
+    authorization_receipt = authorization.get("receipt")
+    if not show_queue_evidence_authorization_receipt_valid(
+        authorization_receipt
+    ):
+        result["reason"] = "archive_authorization_receipt_invalid"
+        return result
+    result["authorizationEligible"] = True
     archive = _archive_from_read_model(read_model)
     shows = tiktok_show_records(archive)
     if not shows or int(guild_id or 0) <= 0 or not db_file:
+        result["reason"] = (
+            "no_show_records"
+            if not shows
+            else "invalid_sync_target"
+        )
         return result
     result["showsSeen"] = len(shows)
     conn = sqlite3.connect(db_file, timeout=10.0)
@@ -1472,6 +1753,27 @@ def sync_tiktok_show_evidence_ledgers(
         ensure_tiktok_show_evidence_schema(conn)
         ensure_memory_ledger_schema(conn)
         for show in shows:
+            show_key = tiktok_show_evidence_key(show)
+            if not show_key:
+                continue
+            existing = conn.execute(
+                f"""
+                SELECT source_digest,lifecycle_status,ledger_json
+                FROM {TIKTOK_SHOW_EVIDENCE_TABLE}
+                WHERE guild_id=? AND show_key=?
+                """,
+                (int(guild_id), show_key),
+            ).fetchone()
+            prior_ledger = (
+                _stored_show_document(
+                    existing[2],
+                    show_key=show_key,
+                    source_digest=existing[0],
+                    lifecycle_status=existing[1],
+                )
+                if existing
+                else None
+            )
             source_events = _load_show_source_events(
                 conn,
                 guild_id=int(guild_id),
@@ -1486,13 +1788,18 @@ def sync_tiktok_show_evidence_ledgers(
             )
             if discord_exchanges is None:
                 continue
-            ledger = _safe_document(
+            discord_exchanges = _merge_retained_discord_exchanges(
+                discord_exchanges,
+                prior_ledger,
+            )
+            ledger = _seal_authorized_show_ledger(
                 build_tiktok_show_evidence_ledger(
                     show,
                     source_events,
                     artist_identity_index=artist_identity_index,
                     discord_exchanges=discord_exchanges,
-                )
+                ),
+                authorization_receipt,
             )
             if ledger is None:
                 continue
@@ -1520,14 +1827,6 @@ def sync_tiktok_show_evidence_ledgers(
             )
             show_key = str(ledger["showKey"])
             source_digest = str(ledger["sourceDigest"])
-            existing = conn.execute(
-                f"""
-                SELECT source_digest,lifecycle_status
-                FROM {TIKTOK_SHOW_EVIDENCE_TABLE}
-                WHERE guild_id=? AND show_key=?
-                """,
-                (int(guild_id), show_key),
-            ).fetchone()
             now = datetime.now(timezone.utc).isoformat()
             lifecycle = str(ledger.get("lifecycle") or "provisional")
             if existing and str(existing[0] or "") == source_digest:
@@ -1717,6 +2016,9 @@ def _document_relevance(
     requested_show_date: str = "",
 ) -> tuple[int, list[Mapping[str, Any]]]:
     query = str(user_text or "")
+    query_terms = _query_terms(query)
+    explicit_episode_scope = _show_episode_scope_requested(query)
+    evidence_query_overlap = False
     score = max(0, 20 - recency_rank)
     if requested_show_date:
         if requested_show_date != str(ledger.get("showDate") or ""):
@@ -1731,17 +2033,27 @@ def _document_relevance(
         if isinstance(item, Mapping)
     ]
     participant_matches = []
+    direct_subject_candidates = []
     for participant in participants:
+        participant_subject_ref = str(participant.get("subjectRef") or "")
         direct_subject = bool(
             allow_direct_subject
             and subject_ref
-            and str(participant.get("subjectRef") or "") == subject_ref
+            and participant_subject_ref == subject_ref
         )
         named = any(
             _phrase_in_query(query, value)
             for value in (
-                participant.get("speakerLabel"),
-                participant.get("displayName"),
+                _public_show_speaker_label(
+                    participant_subject_ref,
+                    participant.get("speakerLabel"),
+                    "",
+                ),
+                _public_show_speaker_label(
+                    participant_subject_ref,
+                    participant.get("displayName"),
+                    "",
+                ),
                 participant.get("handle"),
             )
         )
@@ -1750,14 +2062,18 @@ def _document_relevance(
             for attribution in participant.get("artistAttributions") or ()
             if isinstance(attribution, Mapping)
         )
-        if direct_subject or named or artist_named:
+        if direct_subject:
+            direct_subject_candidates.append(participant)
+        if named or artist_named:
             participant_matches.append(participant)
-            score += 120 if direct_subject else 90
+            evidence_query_overlap = True
+            score += 90
     for track in ledger.get("trackMoments") or ():
         if isinstance(track, Mapping) and _phrase_in_query(
             query,
             track.get("trackLabel"),
         ):
+            evidence_query_overlap = True
             score += 80
     for track in ledger.get("trackRoster") or ():
         if isinstance(track, Mapping) and any(
@@ -1769,11 +2085,12 @@ def _document_relevance(
                 track.get("submittedByTikTokHandle"),
             )
         ):
+            evidence_query_overlap = True
             score += 85
     for topic in ledger.get("showTopics") or ledger.get("topics") or ():
         if isinstance(topic, Mapping) and _phrase_in_query(query, topic.get("term")):
+            evidence_query_overlap = True
             score += 60
-    query_terms = _query_terms(query)
     for event in ledger.get("operationalEvents") or ():
         if not isinstance(event, Mapping):
             continue
@@ -1791,13 +2108,18 @@ def _document_relevance(
         ).replace("_", " ")
         overlap = query_terms.intersection(_query_terms(searchable))
         if overlap:
+            evidence_query_overlap = True
             score += min(60, 12 * len(overlap))
     for exchange in ledger.get("discordInteractions") or ():
         if not isinstance(exchange, Mapping):
             continue
         exchange_text = " ".join(
             [
-                str(exchange.get("speakerLabel") or ""),
+                _public_show_speaker_label(
+                    exchange.get("subjectRef"),
+                    exchange.get("speakerLabel"),
+                    "",
+                ),
                 *[
                     str(message.get("text") or "")
                     for message in exchange.get("userMessages") or ()
@@ -1812,7 +2134,15 @@ def _document_relevance(
         )
         overlap = query_terms.intersection(_query_terms(exchange_text))
         if overlap:
+            evidence_query_overlap = True
             score += min(70, 14 * len(overlap))
+    if direct_subject_candidates and (
+        explicit_episode_scope or evidence_query_overlap
+    ):
+        for participant in direct_subject_candidates:
+            if participant not in participant_matches:
+                participant_matches.append(participant)
+                score += 120
     if _SHOW_QUERY_RE.search(query):
         score += 30
     elif _COMMUNITY_BASELINE_QUERY_RE.search(query):
@@ -2106,8 +2436,9 @@ def _community_episode_context_item(
             if not subject_ref:
                 continue
             all_subjects.append(subject_ref)
-            participant_labels[subject_ref] = str(
-                participant.get("speakerLabel") or "Show participant"
+            participant_labels[subject_ref] = _public_show_speaker_label(
+                subject_ref,
+                participant.get("speakerLabel"),
             )
             participant_messages[subject_ref] = (
                 participant_messages.get(subject_ref, 0)
@@ -2405,7 +2736,15 @@ def _dialogue_episode_context_item(
             "showTitle": str(ledger.get("showTitle") or "BARCODE Radio"),
         }
         episode_messages = [
-            {**item, **episode, "surface": "TikTok"}
+            {
+                **item,
+                **episode,
+                "speakerLabel": _public_show_speaker_label(
+                    item.get("subjectRef"),
+                    item.get("speakerLabel"),
+                ),
+                "surface": "TikTok",
+            }
             for item in ledger.get("messages") or ()
             if isinstance(item, Mapping)
         ]
@@ -2422,8 +2761,10 @@ def _dialogue_episode_context_item(
                         "eventId": "discord_conversation:%s"
                         % str(message.get("conversationRowId") or ""),
                         "subjectRef": str(exchange.get("subjectRef") or ""),
-                        "speakerLabel": str(
-                            exchange.get("speakerLabel") or "Discord member"
+                        "speakerLabel": _public_show_speaker_label(
+                            exchange.get("subjectRef"),
+                            exchange.get("speakerLabel"),
+                            "Discord member",
                         ),
                         "surface": "Discord",
                     }
@@ -2458,8 +2799,10 @@ def _dialogue_episode_context_item(
                 str(message.get("showDate") or "unknown date"),
                 str(message.get("surface") or "show chat"),
                 float(message.get("minuteOffset") or 0.0),
-                _safe_label(message.get("speakerLabel"), 160)
-                or "Show participant",
+                _public_show_speaker_label(
+                    message.get("subjectRef"),
+                    message.get("speakerLabel"),
+                ),
                 moment,
                 json.dumps(
                     _safe_label(message.get("text"), 360),
@@ -2765,9 +3108,13 @@ def build_tiktok_show_evidence_context(
         if shown_participants:
             lines.append("People in this episode:")
             for participant in shown_participants[:8]:
+                public_speaker_label = _public_show_speaker_label(
+                    participant.get("subjectRef"),
+                    participant.get("speakerLabel"),
+                )
                 detail = (
                     f"- [{str(participant.get('surface') or 'tiktok')}] "
-                    f"{json.dumps(str(participant.get('speakerLabel') or 'Show participant'), ensure_ascii=False)}: "
+                    f"{json.dumps(public_speaker_label, ensure_ascii=False)}: "
                     f"{int(participant.get('messageCount') or 0)} authored messages, "
                     f"{int(participant.get('questionCount') or 0)} questions, "
                     f"{int(participant.get('bnlAddressCount') or 0)} addressed BNL, "
@@ -2908,7 +3255,14 @@ def build_tiktok_show_evidence_context(
             str(item.get("subjectRef") or "") for item in participant_matches
         }
         tiktok_messages = [
-            {**item, "surface": "tiktok"}
+            {
+                **item,
+                "speakerLabel": _public_show_speaker_label(
+                    item.get("subjectRef"),
+                    item.get("speakerLabel"),
+                ),
+                "surface": "tiktok",
+            }
             for item in ledger.get("messages") or ()
             if isinstance(item, Mapping)
         ]
@@ -2923,8 +3277,10 @@ def build_tiktok_show_evidence_context(
                 "eventId": "discord_conversation:"
                 + str(message.get("conversationRowId") or ""),
                 "subjectRef": str(exchange.get("subjectRef") or ""),
-                "speakerLabel": str(
-                    exchange.get("speakerLabel") or "Discord member"
+                "speakerLabel": _public_show_speaker_label(
+                    exchange.get("subjectRef"),
+                    exchange.get("speakerLabel"),
+                    "Discord member",
                 ),
                 "surface": "discord",
             }
@@ -2969,6 +3325,10 @@ def build_tiktok_show_evidence_context(
             lines.append("Source-linked authored examples:")
             for message in relevant_messages[:bounded_message_limit]:
                 track_label = str(message.get("trackLabel") or "")
+                public_speaker_label = _public_show_speaker_label(
+                    message.get("subjectRef"),
+                    message.get("speakerLabel"),
+                )
                 operational_context = (
                     message.get("operationalContext")
                     if isinstance(message.get("operationalContext"), Mapping)
@@ -2988,7 +3348,7 @@ def build_tiktok_show_evidence_context(
                 lines.append(
                     f"- [{str(message.get('surface') or 'tiktok')}] "
                     f"t+{float(message.get('minuteOffset') or 0.0):.1f}m "
-                    f"{json.dumps(str(message.get('speakerLabel') or 'Show participant'), ensure_ascii=False)}"
+                    f"{json.dumps(public_speaker_label, ensure_ascii=False)}"
                     f"{moment}{operation_suffix}: "
                     f"{json.dumps(str(message.get('text') or ''), ensure_ascii=False)}"
                 )
@@ -2998,7 +3358,11 @@ def build_tiktok_show_evidence_context(
             exchange_subject = str(exchange.get("subjectRef") or "")
             exchange_text = " ".join(
                 [
-                    str(exchange.get("speakerLabel") or ""),
+                    _public_show_speaker_label(
+                        exchange_subject,
+                        exchange.get("speakerLabel"),
+                        "",
+                    ),
                     *[
                         str(message.get("text") or "")
                         for message in exchange.get("userMessages") or ()
@@ -3027,12 +3391,17 @@ def build_tiktok_show_evidence_context(
         if relevant_exchanges:
             lines.append("Public Discord interactions with BNL during this episode:")
             for _exchange_score, exchange in relevant_exchanges[:6]:
+                public_speaker_label = _public_show_speaker_label(
+                    exchange.get("subjectRef"),
+                    exchange.get("speakerLabel"),
+                    "Discord member",
+                )
                 for message in (exchange.get("userMessages") or ())[-3:]:
                     if not isinstance(message, Mapping):
                         continue
                     lines.append(
                         f"- t+{float(message.get('minuteOffset') or 0.0):.1f}m "
-                        f"{json.dumps(str(exchange.get('speakerLabel') or 'Discord member'), ensure_ascii=False)}: "
+                        f"{json.dumps(public_speaker_label, ensure_ascii=False)}: "
                         f"{json.dumps(_safe_label(message.get('text'), 1200), ensure_ascii=False)}"
                     )
                 response = exchange.get("bnlResponse")

--- a/bnl_tiktok_show_ledger.py
+++ b/bnl_tiktok_show_ledger.py
@@ -33,6 +33,7 @@ from bnl_tiktok_live_context import (
     SHOW_EVIDENCE_LEDGER_SCHEMA_VERSION,
     build_tiktok_show_evidence_ledger,
     show_timeline_bounds_ms,
+    tiktok_show_evidence_key,
     tiktok_show_records,
 )
 
@@ -53,7 +54,7 @@ _SHOW_QUERY_RE = re.compile(
     r"\b(?:tiktok|tik tok|barcode radio|broadcast|show|episode|live|chat|viewer|"
     r"audience|track|song|queue|wheel|submissions?|intake|sponsor|break|"
     r"signal hold|paused?|stalled?|resumed?|skipped?|removed?|returned?|"
-    r"restored?|started?|finished?|timeline|tonight|today|yesterday|last night|"
+    r"restored?|started?|finished?|timeline|"
     r"last show|previous show|past show|show chat|talked about)\b",
     re.IGNORECASE,
 )
@@ -83,6 +84,10 @@ _SUBJECT_CONTINUITY_QUERY_RE = re.compile(
     r"\b(?:remember me|know me|about me|my history|my activity|my messages?|"
     r"what did i|when did i|did i|have i|was i|where was i|"
     r"what do you think of me|your (?:read|opinion|impression) of me)\b",
+    re.IGNORECASE,
+)
+_RELATIVE_SHOW_DATE_SCOPE_RE = re.compile(
+    r"\b(?:tiktok|tik tok|barcode radio|broadcast|show|episode|live|stream)\b",
     re.IGNORECASE,
 )
 _MULTI_SHOW_QUERY_RE = re.compile(
@@ -248,6 +253,8 @@ def _requested_show_date(user_text: str, *, now: Any = None) -> str:
     if explicit:
         return explicit.group(1)
     lowered = query.casefold()
+    if not _RELATIVE_SHOW_DATE_SCOPE_RE.search(lowered):
+        return ""
     current_date = _coerce_pacific_now(now).date()
     if re.search(r"\b(?:yesterday|last night)\b", lowered):
         return (current_date - timedelta(days=1)).isoformat()
@@ -1364,6 +1371,183 @@ def _archive_from_read_model(read_model: Any) -> Mapping[str, Any]:
     return archive if isinstance(archive, Mapping) else {}
 
 
+def _stored_show_document(
+    raw_json: Any,
+    *,
+    show_key: str,
+    source_digest: Any,
+    lifecycle_status: Any,
+) -> Optional[dict[str, Any]]:
+    """Load one internally consistent prior show revision for additive rebuilds."""
+
+    try:
+        document = _safe_document(json.loads(str(raw_json or "{}")))
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    if document is None or (
+        str(document.get("showKey") or "") != str(show_key or "")
+        or str(document.get("sourceDigest") or "")
+        != str(source_digest or "")
+        or str(document.get("lifecycle") or "")
+        != str(lifecycle_status or "")
+    ):
+        return None
+    return document
+
+
+def _discord_message_identity(message: Any) -> str:
+    if not isinstance(message, Mapping):
+        return ""
+    for prefix, field in (
+        ("conversation", "conversationRowId"),
+        ("message", "messageId"),
+    ):
+        try:
+            value = int(message.get(field) or 0)
+        except (TypeError, ValueError, OverflowError):
+            value = 0
+        if value > 0:
+            return f"{prefix}:{value}"
+    return ""
+
+
+def _discord_exchange_message_keys(exchange: Any) -> set[str]:
+    if not isinstance(exchange, Mapping):
+        return set()
+    return {
+        identity
+        for identity in (
+            _discord_message_identity(message)
+            for message in exchange.get("userMessages") or ()
+        )
+        if identity
+    }
+
+
+def _merge_retained_discord_exchanges(
+    current: Sequence[Mapping[str, Any]],
+    prior_ledger: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Keep captured public exchanges when source conversation rows age out.
+
+    The existing show ledger remains the sole durable owner. Rebuilds are
+    additive for already-admitted Discord evidence; privacy deletion still
+    removes the owning show row before any later rebuild can consult it.
+    """
+
+    candidates: list[tuple[int, Mapping[str, Any]]] = []
+    if isinstance(prior_ledger, Mapping):
+        candidates.extend(
+            (0, exchange)
+            for exchange in prior_ledger.get("discordInteractions") or ()
+            if isinstance(exchange, Mapping)
+        )
+    candidates.extend(
+        (1, exchange)
+        for exchange in current or ()
+        if isinstance(exchange, Mapping)
+    )
+
+    groups: list[dict[str, Any]] = []
+    for source_priority, exchange in candidates:
+        subject_ref = str(exchange.get("subjectRef") or "")
+        message_keys = _discord_exchange_message_keys(exchange)
+        exchange_id = str(exchange.get("exchangeId") or "")
+        matching = [
+            index
+            for index, group in enumerate(groups)
+            if group["subjectRef"] == subject_ref
+            and (
+                bool(message_keys.intersection(group["messageKeys"]))
+                or bool(exchange_id and exchange_id in group["exchangeIds"])
+            )
+        ]
+        entry = (source_priority, exchange)
+        if not matching:
+            groups.append(
+                {
+                    "subjectRef": subject_ref,
+                    "messageKeys": set(message_keys),
+                    "exchangeIds": {exchange_id} if exchange_id else set(),
+                    "candidates": [entry],
+                }
+            )
+            continue
+        target = groups[matching[0]]
+        target["messageKeys"].update(message_keys)
+        if exchange_id:
+            target["exchangeIds"].add(exchange_id)
+        target["candidates"].append(entry)
+        for index in reversed(matching[1:]):
+            merged = groups.pop(index)
+            target["messageKeys"].update(merged["messageKeys"])
+            target["exchangeIds"].update(merged["exchangeIds"])
+            target["candidates"].extend(merged["candidates"])
+
+    merged_exchanges: list[dict[str, Any]] = []
+    for group in groups:
+        group_candidates = list(group["candidates"])
+
+        def candidate_rank(
+            candidate: tuple[int, Mapping[str, Any]],
+        ) -> tuple[int, int, int, str]:
+            source_priority, exchange = candidate
+            return (
+                int(isinstance(exchange.get("bnlResponse"), Mapping)),
+                int(source_priority),
+                len(exchange.get("userMessages") or ()),
+                str(exchange.get("exchangeId") or ""),
+            )
+
+        _base_priority, base_exchange = max(
+            group_candidates,
+            key=candidate_rank,
+        )
+        response_candidates = [
+            candidate
+            for candidate in group_candidates
+            if isinstance(candidate[1].get("bnlResponse"), Mapping)
+        ]
+        response = (
+            max(response_candidates, key=candidate_rank)[1].get("bnlResponse")
+            if response_candidates
+            else None
+        )
+        messages_by_key: dict[str, Mapping[str, Any]] = {}
+        for source_priority in (0, 1):
+            for candidate_priority, exchange in group_candidates:
+                if candidate_priority != source_priority:
+                    continue
+                for message in exchange.get("userMessages") or ():
+                    identity = _discord_message_identity(message)
+                    if identity and isinstance(message, Mapping):
+                        messages_by_key[identity] = message
+        user_messages = sorted(
+            messages_by_key.values(),
+            key=lambda message: (
+                int(message.get("occurredAtMs") or 0),
+                int(message.get("conversationRowId") or 0),
+                int(message.get("messageId") or 0),
+            ),
+        )
+        merged = dict(base_exchange)
+        merged["userMessages"] = [dict(message) for message in user_messages]
+        merged["bnlResponse"] = dict(response) if response is not None else None
+        merged_exchanges.append(merged)
+
+    merged_exchanges.sort(
+        key=lambda exchange: (
+            int(
+                ((exchange.get("userMessages") or [{}])[0]).get(
+                    "occurredAtMs", 0
+                )
+            ),
+            str(exchange.get("exchangeId") or ""),
+        )
+    )
+    return merged_exchanges
+
+
 def _projection_expectations(
     conn: sqlite3.Connection,
     *,
@@ -1472,6 +1656,27 @@ def sync_tiktok_show_evidence_ledgers(
         ensure_tiktok_show_evidence_schema(conn)
         ensure_memory_ledger_schema(conn)
         for show in shows:
+            show_key = tiktok_show_evidence_key(show)
+            if not show_key:
+                continue
+            existing = conn.execute(
+                f"""
+                SELECT source_digest,lifecycle_status,ledger_json
+                FROM {TIKTOK_SHOW_EVIDENCE_TABLE}
+                WHERE guild_id=? AND show_key=?
+                """,
+                (int(guild_id), show_key),
+            ).fetchone()
+            prior_ledger = (
+                _stored_show_document(
+                    existing[2],
+                    show_key=show_key,
+                    source_digest=existing[0],
+                    lifecycle_status=existing[1],
+                )
+                if existing
+                else None
+            )
             source_events = _load_show_source_events(
                 conn,
                 guild_id=int(guild_id),
@@ -1486,6 +1691,10 @@ def sync_tiktok_show_evidence_ledgers(
             )
             if discord_exchanges is None:
                 continue
+            discord_exchanges = _merge_retained_discord_exchanges(
+                discord_exchanges,
+                prior_ledger,
+            )
             ledger = _safe_document(
                 build_tiktok_show_evidence_ledger(
                     show,
@@ -1520,14 +1729,6 @@ def sync_tiktok_show_evidence_ledgers(
             )
             show_key = str(ledger["showKey"])
             source_digest = str(ledger["sourceDigest"])
-            existing = conn.execute(
-                f"""
-                SELECT source_digest,lifecycle_status
-                FROM {TIKTOK_SHOW_EVIDENCE_TABLE}
-                WHERE guild_id=? AND show_key=?
-                """,
-                (int(guild_id), show_key),
-            ).fetchone()
             now = datetime.now(timezone.utc).isoformat()
             lifecycle = str(ledger.get("lifecycle") or "provisional")
             if existing and str(existing[0] or "") == source_digest:
@@ -1717,6 +1918,9 @@ def _document_relevance(
     requested_show_date: str = "",
 ) -> tuple[int, list[Mapping[str, Any]]]:
     query = str(user_text or "")
+    query_terms = _query_terms(query)
+    explicit_episode_scope = _show_episode_scope_requested(query)
+    evidence_query_overlap = False
     score = max(0, 20 - recency_rank)
     if requested_show_date:
         if requested_show_date != str(ledger.get("showDate") or ""):
@@ -1731,6 +1935,7 @@ def _document_relevance(
         if isinstance(item, Mapping)
     ]
     participant_matches = []
+    direct_subject_candidates = []
     for participant in participants:
         direct_subject = bool(
             allow_direct_subject
@@ -1750,14 +1955,18 @@ def _document_relevance(
             for attribution in participant.get("artistAttributions") or ()
             if isinstance(attribution, Mapping)
         )
-        if direct_subject or named or artist_named:
+        if direct_subject:
+            direct_subject_candidates.append(participant)
+        if named or artist_named:
             participant_matches.append(participant)
-            score += 120 if direct_subject else 90
+            evidence_query_overlap = True
+            score += 90
     for track in ledger.get("trackMoments") or ():
         if isinstance(track, Mapping) and _phrase_in_query(
             query,
             track.get("trackLabel"),
         ):
+            evidence_query_overlap = True
             score += 80
     for track in ledger.get("trackRoster") or ():
         if isinstance(track, Mapping) and any(
@@ -1769,11 +1978,12 @@ def _document_relevance(
                 track.get("submittedByTikTokHandle"),
             )
         ):
+            evidence_query_overlap = True
             score += 85
     for topic in ledger.get("showTopics") or ledger.get("topics") or ():
         if isinstance(topic, Mapping) and _phrase_in_query(query, topic.get("term")):
+            evidence_query_overlap = True
             score += 60
-    query_terms = _query_terms(query)
     for event in ledger.get("operationalEvents") or ():
         if not isinstance(event, Mapping):
             continue
@@ -1791,6 +2001,7 @@ def _document_relevance(
         ).replace("_", " ")
         overlap = query_terms.intersection(_query_terms(searchable))
         if overlap:
+            evidence_query_overlap = True
             score += min(60, 12 * len(overlap))
     for exchange in ledger.get("discordInteractions") or ():
         if not isinstance(exchange, Mapping):
@@ -1812,7 +2023,15 @@ def _document_relevance(
         )
         overlap = query_terms.intersection(_query_terms(exchange_text))
         if overlap:
+            evidence_query_overlap = True
             score += min(70, 14 * len(overlap))
+    if direct_subject_candidates and (
+        explicit_episode_scope or evidence_query_overlap
+    ):
+        for participant in direct_subject_candidates:
+            if participant not in participant_matches:
+                participant_matches.append(participant)
+                score += 120
     if _SHOW_QUERY_RE.search(query):
         score += 30
     elif _COMMUNITY_BASELINE_QUERY_RE.search(query):

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -38,6 +38,7 @@ from bnl_canon_source_contract import (
     adapt_legacy_canon_fact,
     adapt_living_atomic_claim,
     adapt_open_signal_claim,
+    env_queue_production_enabled,
     matching_canon_entity_identities,
     matching_canon_member_identities,
     normalize_canon_identity_label,
@@ -2992,6 +2993,8 @@ def _show_episode_items(
     request: IntelligencePacketRequest,
     diagnostics: IntelligencePacketDiagnostics,
     exclusions: list[IntelligencePacketExclusion],
+    *,
+    environ: Mapping[str, str] | None = None,
 ) -> list[IntelligencePacketItem]:
     """Adapt finalized BARCODE Radio evidence into the existing packet.
 
@@ -2999,6 +3002,17 @@ def _show_episode_items(
     deliberately keep first-party operations separate from projections over
     attributed Community Canon / Open Signal utterances.
     """
+
+    if not env_queue_production_enabled(
+        dict(environ) if environ is not None else None
+    ):
+        _add_exclusion(
+            diagnostics,
+            exclusions,
+            lane="show_episode",
+            reason="show_queue_evidence_local_gate_disabled",
+        )
+        return []
 
     allow_subject_continuity = bool(
         str(request.frame_subject_requirement or "").strip().lower()
@@ -5695,7 +5709,13 @@ def _show_episode_version(
     conn: sqlite3.Connection,
     packet: UnifiedIntelligencePacket,
     item: IntelligencePacketItem,
+    *,
+    environ: Mapping[str, str] | None = None,
 ) -> str:
+    if not env_queue_production_enabled(
+        dict(environ) if environ is not None else None
+    ):
+        return ""
     return tiktok_show_episode_context_item_version(
         conn,
         guild_id=int(packet.request.guild_id or 0),
@@ -6167,7 +6187,12 @@ def _revalidate_packet_in_snapshot(
             elif item.revalidation_kind == "episode":
                 current = _episode_version(conn, packet, item)
             elif item.revalidation_kind == "show_episode":
-                current = _show_episode_version(conn, packet, item)
+                current = _show_episode_version(
+                    conn,
+                    packet,
+                    item,
+                    environ=environ,
+                )
             elif item.revalidation_kind == "atomic":
                 current = (
                     _living_atomic_version(conn, item)
@@ -7137,6 +7162,7 @@ def build_packet(
                 request,
                 diagnostics,
                 exclusions,
+                environ=environ,
             )
         )
         candidates.extend(

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -38,6 +38,7 @@ from bnl_canon_source_contract import (
     adapt_legacy_canon_fact,
     adapt_living_atomic_claim,
     adapt_open_signal_claim,
+    env_queue_production_enabled,
     matching_canon_entity_identities,
     matching_canon_member_identities,
     normalize_canon_identity_label,
@@ -2992,6 +2993,8 @@ def _show_episode_items(
     request: IntelligencePacketRequest,
     diagnostics: IntelligencePacketDiagnostics,
     exclusions: list[IntelligencePacketExclusion],
+    *,
+    environ: Mapping[str, str] | None = None,
 ) -> list[IntelligencePacketItem]:
     """Adapt finalized BARCODE Radio evidence into the existing packet.
 
@@ -2999,6 +3002,17 @@ def _show_episode_items(
     deliberately keep first-party operations separate from projections over
     attributed Community Canon / Open Signal utterances.
     """
+
+    if not env_queue_production_enabled(
+        dict(environ) if environ is not None else None
+    ):
+        _add_exclusion(
+            diagnostics,
+            exclusions,
+            lane="show_episode",
+            reason="show_queue_evidence_local_gate_disabled",
+        )
+        return []
 
     requested_subject_user_id = int(request.subject_user_id or 0)
     subject_user_id = requested_subject_user_id
@@ -3019,6 +3033,7 @@ def _show_episode_items(
                 reason=consent_reason,
                 source_class="evidence_projection",
             )
+
     allow_subject_continuity = bool(
         consent_allowed
         and subject_user_id > 0
@@ -5716,7 +5731,14 @@ def _show_episode_version(
     conn: sqlite3.Connection,
     packet: UnifiedIntelligencePacket,
     item: IntelligencePacketItem,
+    *,
+    environ: Mapping[str, str] | None = None,
 ) -> str:
+    if not env_queue_production_enabled(
+        dict(environ) if environ is not None else None
+    ):
+        return ""
+
     requested_subject_user_id = int(packet.request.subject_user_id or 0)
     subject_user_id = requested_subject_user_id
     consent_allowed = requested_subject_user_id <= 0
@@ -6201,7 +6223,12 @@ def _revalidate_packet_in_snapshot(
             elif item.revalidation_kind == "episode":
                 current = _episode_version(conn, packet, item)
             elif item.revalidation_kind == "show_episode":
-                current = _show_episode_version(conn, packet, item)
+                current = _show_episode_version(
+                    conn,
+                    packet,
+                    item,
+                    environ=environ,
+                )
             elif item.revalidation_kind == "atomic":
                 current = (
                     _living_atomic_version(conn, item)
@@ -7171,6 +7198,7 @@ def build_packet(
                 request,
                 diagnostics,
                 exclusions,
+                environ=environ,
             )
         )
         candidates.extend(

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -1332,6 +1332,11 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         self._prime_flush(channel, request)
         with (
             self._flush_runtime(channel.id, generate),
+            mock.patch.dict(
+                os.environ,
+                {"BNL_QUEUE_PRODUCTION_ENABLED": "true"},
+                clear=False,
+            ),
             mock.patch.object(
                 bnl01_bot,
                 "resolve_channel_policy",

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -1332,6 +1332,11 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         self._prime_flush(channel, request)
         with (
             self._flush_runtime(channel.id, generate),
+            mock.patch.dict(
+                os.environ,
+                {"BNL_QUEUE_PRODUCTION_ENABLED": "true"},
+                clear=False,
+            ),
             mock.patch.object(
                 bnl01_bot,
                 "resolve_channel_policy",
@@ -1385,7 +1390,7 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
             "missing-public-show-batch-test.db",
             guild_id=channel.guild.id,
             user_text=request,
-            subject_user_id=100,
+            subject_user_id=0,
         )
         self.assertEqual(len(assessment_calls), 1)
         self.assertIn(

--- a/tests/test_living_canon_recurrence_v1.py
+++ b/tests/test_living_canon_recurrence_v1.py
@@ -218,6 +218,20 @@ class LivingCanonRecurrenceV1Tests(unittest.TestCase):
             "discordInteractions": [],
             "discordParticipants": [],
             "showTopics": [],
+            "sourceAuthorization": {
+                "contractVersion": "show_queue_evidence_authorization_v1",
+                "readModelSource": "barcode-network-site",
+                "publicOnly": True,
+                "localQueueProduction": True,
+                "websiteQueueProduction": True,
+                "accessScope": "public",
+                "archiveSchemaVersion": "queue_public_history_projection_v1",
+                "archiveSource": "queue_bnl_history_projection",
+                "archiveVisibility": "public_safe",
+                "archiveSourceRevision": 1,
+                "archiveSourceDigest": "a" * 64,
+                "historyCoverageStartedAt": "2026-08-24",
+            },
         }
         source_digest = hashlib.sha256(
             json.dumps(

--- a/tests/test_relationship_engine_v2.py
+++ b/tests/test_relationship_engine_v2.py
@@ -167,6 +167,7 @@ def _case_proactive_consent_owner_combines_settings_preferences_and_errors():
     )
 
 def _case_legacy_show_continuity_uses_effective_consent_and_fails_closed(monkeypatch):
+    monkeypatch.setenv('BNL_QUEUE_PRODUCTION_ENABLED','true')
     tmp=tempfile.NamedTemporaryFile(delete=False); tmp.close(); monkeypatch.setattr(bnl01_bot,'DB_FILE',tmp.name); bnl01_bot.init_db()
     selected=[]
     monkeypatch.setattr(

--- a/tests/test_tiktok_live_context_bridge.py
+++ b/tests/test_tiktok_live_context_bridge.py
@@ -238,6 +238,27 @@ class TikTokLiveContextBridgeTests(unittest.TestCase):
         self.assertEqual(show["sessionId"], "latest")
         self.assertEqual(source, "latestShow")
 
+        for query in (
+            "What happened during yesterday's BARCODE Radio show?",
+            "Give me the show timeline from last night.",
+            "Summarize the past show.",
+        ):
+            with self.subTest(query=query):
+                show, source = select_show_for_tiktok_analysis(
+                    archive,
+                    query,
+                    now="2026-08-29T12:00:00-07:00",
+                )
+                self.assertEqual(show["sessionId"], "latest")
+                self.assertEqual(source, "latestShow")
+
+        missing, source = select_show_for_tiktok_analysis(
+            archive,
+            "Give me the 2026-08-27 show timeline.",
+        )
+        self.assertEqual(missing, {})
+        self.assertEqual(source, "none")
+
     def test_whole_show_topics_receive_actual_chat_evidence_and_lexical_support(self):
         show = {
             "sessionId": "show-topic-evidence",

--- a/tests/test_tiktok_show_episode_response_guard.py
+++ b/tests/test_tiktok_show_episode_response_guard.py
@@ -86,6 +86,24 @@ class TikTokShowEpisodeResponseGuardTests(unittest.TestCase):
             "show_evidence_refused",
         )
 
+    def test_guard_accepts_grounded_no_obligation_language(self):
+        for response in (
+            "We don't have to show logs to establish the chronology: First "
+            "Signal opened the retained sequence, Alex discussed its green "
+            "visuals, and the Wheel later moved Queue Light next.",
+            "We do not have to dump the chat feed to answer this: First Signal "
+            "opened the retained sequence, Alex discussed its green visuals, "
+            "and the Wheel later moved Queue Light next.",
+        ):
+            with self.subTest(response=response):
+                self.assertEqual(
+                    bnl01_bot.tiktok_show_episode_response_failure(
+                        response,
+                        RAW_PROMPT,
+                    ),
+                    "",
+                )
+
     def test_guard_rejects_invented_clock_time(self):
         response = (
             "At 7:05 PM, Neon Fox's First Signal began, then Queue Light "

--- a/tests/test_tiktok_show_evidence_ledger.py
+++ b/tests/test_tiktok_show_evidence_ledger.py
@@ -3,6 +3,7 @@ import os
 import sqlite3
 import tempfile
 import unittest
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from unittest import mock
@@ -744,6 +745,98 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             self.assertEqual(second["showsUnchanged"], 1)
             self.assertEqual(second["projectionDeduplicated"], 0)
 
+    def test_sync_preserves_captured_exchange_after_conversation_pruning(self):
+        with tempfile.TemporaryDirectory() as directory:
+            db_file = str(Path(directory) / "bnl.db")
+            self.seed_source_and_memory(db_file)
+            provisional_show = json.loads(json.dumps(archived_show()))
+            provisional_show["status"] = "live"
+            provisional_show["milestones"] = [
+                event
+                for event in provisional_show["milestones"]
+                if event["eventType"] != "session_archived"
+            ]
+            provisional_model = {
+                "sections": {
+                    "archive": {
+                        "currentShow": provisional_show,
+                        "latestShow": None,
+                        "shows": [],
+                    }
+                }
+            }
+            first = sync_tiktok_show_evidence_ledgers(
+                db_file,
+                guild_id=77,
+                read_model=provisional_model,
+                artist_identity_index=artist_index(),
+            )
+            self.assertEqual(first["showsWritten"], 1)
+            self.assertEqual(first["showsFinalized"], 0)
+
+            conn = sqlite3.connect(db_file)
+            original_json = conn.execute(
+                f"SELECT ledger_json "
+                f"FROM {TIKTOK_SHOW_EVIDENCE_TABLE}"
+            ).fetchone()[0]
+            conn.execute("DELETE FROM conversations WHERE id IN (101,102)")
+            conn.commit()
+            conn.close()
+            original = json.loads(original_json)
+            self.assertEqual(original["lifecycle"], "provisional")
+            self.assertEqual(
+                sum(
+                    1
+                    for exchange in original["discordInteractions"]
+                    if isinstance(exchange.get("bnlResponse"), dict)
+                ),
+                1,
+            )
+
+            finalized_model = {
+                "sections": {
+                    "archive": {
+                        "currentShow": None,
+                        "latestShow": archived_show(),
+                        "shows": [],
+                    }
+                }
+            }
+
+            rebuilt = sync_tiktok_show_evidence_ledgers(
+                db_file,
+                guild_id=77,
+                read_model=finalized_model,
+                artist_identity_index=artist_index(),
+            )
+            self.assertEqual(rebuilt["showsWritten"], 1)
+            self.assertEqual(rebuilt["showsFinalized"], 1)
+            self.assertEqual(rebuilt["discordInteractions"], 2)
+            self.assertEqual(rebuilt["discordExchanges"], 1)
+
+            conn = sqlite3.connect(db_file)
+            rebuilt_json = conn.execute(
+                f"SELECT ledger_json "
+                f"FROM {TIKTOK_SHOW_EVIDENCE_TABLE}"
+            ).fetchone()[0]
+            conn.close()
+            stored = json.loads(rebuilt_json)
+            self.assertEqual(stored["lifecycle"], "finalized")
+            alex = next(
+                exchange
+                for exchange in stored["discordInteractions"]
+                if exchange["subjectRef"] == "discord_user:42"
+            )
+            self.assertEqual(len(alex["userMessages"]), 1)
+            self.assertEqual(
+                alex["userMessages"][0]["conversationRowId"],
+                101,
+            )
+            self.assertEqual(
+                alex["bnlResponse"]["text"],
+                "Yes—the Wheel confirmed Queue Light, and it is playing now.",
+            )
+
     def test_finalization_refreshes_existing_living_canon_owner_when_enabled(self):
         with tempfile.TemporaryDirectory() as directory:
             db_file = str(Path(directory) / "bnl.db")
@@ -1041,6 +1134,33 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 now="2026-08-29T12:00:00-07:00",
             )
             self.assertEqual(unrelated, ())
+            same_day_unrelated = select_tiktok_show_episode_context_items(
+                conn,
+                guild_id=77,
+                user_text="How are you doing today?",
+                subject_user_id=42,
+                allow_subject_continuity=True,
+                now="2026-08-28T12:00:00-07:00",
+            )
+            self.assertEqual(same_day_unrelated, ())
+            prior_day_unrelated = select_tiktok_show_episode_context_items(
+                conn,
+                guild_id=77,
+                user_text="What did you do yesterday?",
+                subject_user_id=42,
+                allow_subject_continuity=True,
+                now="2026-08-29T12:00:00-07:00",
+            )
+            self.assertEqual(prior_day_unrelated, ())
+            proactive_unrelated = select_tiktok_show_episode_context_items(
+                conn,
+                guild_id=77,
+                user_text="How do I make pasta?",
+                subject_user_id=42,
+                allow_subject_continuity=True,
+                now="2026-08-29T12:00:00-07:00",
+            )
+            self.assertEqual(proactive_unrelated, ())
             explicit_self = select_tiktok_show_episode_context_items(
                 conn,
                 guild_id=77,
@@ -1211,6 +1331,33 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             self.assertIn("nothing automatically becomes Legacy/Core", rendered)
             self.assertIn(("show_episode", 3), lane_counts)
             self.assertGreaterEqual(rendered_count, 3)
+
+            unrelated_packet = build_packet(
+                conn,
+                replace(
+                    request,
+                    user_text="How do I make pasta?",
+                    frame_subject_requirement="required",
+                ),
+                persist=False,
+                environ={
+                    "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+                    "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+                    "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+                    "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+                    "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED": "true",
+                    "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
+                    "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
+                    "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+                },
+            )
+            self.assertFalse(
+                unrelated_packet
+                and any(
+                    item.lane == "show_episode"
+                    for item in unrelated_packet.items
+                )
+            )
 
             conn.execute(
                 f"DELETE FROM {TIKTOK_SHOW_EVIDENCE_TABLE} WHERE guild_id=77"

--- a/tests/test_tiktok_show_evidence_ledger.py
+++ b/tests/test_tiktok_show_evidence_ledger.py
@@ -1,8 +1,11 @@
+import copy
+import hashlib
 import json
 import os
 import sqlite3
 import tempfile
 import unittest
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from unittest import mock
@@ -251,6 +254,38 @@ def archived_show():
                 "track": None,
             },
         ],
+    }
+
+
+ENABLED_QUEUE_ENV = {"BNL_QUEUE_PRODUCTION_ENABLED": "true"}
+
+
+def authorized_read_model(archive):
+    return {
+        "ok": True,
+        "version": 1,
+        "source": "barcode-network-site",
+        "publicOnly": True,
+        "accessScope": "public",
+        "capabilities": {"queueProduction": True},
+        "sections": {
+            "archive": {
+                "available": True,
+                "reason": None,
+                "schemaVersion": "queue_public_history_projection_v1",
+                "source": "queue_bnl_history_projection",
+                "visibility": "public_safe",
+                "accessScope": "public",
+                "historyCoverageStartedAt": "2026-08-24",
+                "sourceRevision": 42,
+                "sourceDigest": "a" * 64,
+                "memoryDefault": "do_not_store",
+                "sourceFileDefault": "review_evidence_only",
+                "publicDossierDefault": "not_automatic",
+                "personalHistory": None,
+                **archive,
+            }
+        },
     }
 
 
@@ -661,22 +696,17 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             db_file = str(Path(directory) / "bnl.db")
             self.seed_source_and_memory(db_file)
-            read_model = {
-                "ok": True,
-                "version": 1,
-                "sections": {
-                    "archive": {
-                        "currentShow": None,
-                        "latestShow": archived_show(),
-                        "shows": [],
-                    }
-                },
-            }
+            read_model = authorized_read_model({
+                "currentShow": None,
+                "latestShow": archived_show(),
+                "shows": [],
+            })
             first = sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
                 read_model=read_model,
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             self.assertEqual(first["status"], "completed")
             self.assertEqual(first["showsWritten"], 1)
@@ -740,24 +770,375 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 guild_id=77,
                 read_model=read_model,
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             self.assertEqual(second["showsWritten"], 0)
             self.assertEqual(second["showsUnchanged"], 1)
             self.assertEqual(second["projectionDeduplicated"], 0)
 
+    def test_sync_requires_exact_public_production_archive_authorization(self):
+        valid = authorized_read_model({
+            "currentShow": None,
+            "latestShow": archived_show(),
+            "shows": [],
+        })
+        cases = []
+
+        local_off = copy.deepcopy(valid)
+        cases.append(("local_off", local_off, {}, "local_gate_disabled"))
+
+        website_off = copy.deepcopy(valid)
+        website_off["capabilities"]["queueProduction"] = False
+        cases.append((
+            "website_off",
+            website_off,
+            ENABLED_QUEUE_ENV,
+            "website_capability_missing_or_false",
+        ))
+
+        private = copy.deepcopy(valid)
+        private["publicOnly"] = False
+        private["accessScope"] = "private"
+        private["sections"]["archive"]["accessScope"] = "private"
+        private["sections"]["archive"]["visibility"] = "bnl_private_safe"
+        cases.append((
+            "private_scope",
+            private,
+            ENABLED_QUEUE_ENV,
+            "private_access_not_allowed",
+        ))
+
+        unavailable = copy.deepcopy(valid)
+        unavailable["sections"]["archive"]["available"] = False
+        unavailable["sections"]["archive"]["reason"] = (
+            "queue_projection_unavailable"
+        )
+        cases.append((
+            "unavailable",
+            unavailable,
+            ENABLED_QUEUE_ENV,
+            "archive_public_contract_invalid",
+        ))
+
+        malformed = copy.deepcopy(valid)
+        malformed["sections"]["archive"]["sourceDigest"] = "not-a-digest"
+        cases.append((
+            "malformed",
+            malformed,
+            ENABLED_QUEUE_ENV,
+            "archive_public_contract_invalid",
+        ))
+
+        simulation = copy.deepcopy(valid)
+        simulation["sections"]["archive"]["latestShow"]["trackRoster"][0][
+            "isSimulation"
+        ] = True
+        cases.append((
+            "simulation",
+            simulation,
+            ENABLED_QUEUE_ENV,
+            "archive_public_contract_invalid",
+        ))
+
+        for label, model, environ, reason in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as directory:
+                db_file = str(Path(directory) / "bnl.db")
+                result = sync_tiktok_show_evidence_ledgers(
+                    db_file,
+                    guild_id=77,
+                    read_model=model,
+                    artist_identity_index=artist_index(),
+                    environ=environ,
+                )
+                self.assertEqual(result["status"], "skipped")
+                self.assertEqual(result["reason"], reason)
+                self.assertFalse(result["authorizationEligible"])
+                self.assertEqual(result["showsWritten"], 0)
+                self.assertFalse(Path(db_file).exists())
+
+    def test_authorization_receipt_quarantines_unreceipted_show_rows(self):
+        with tempfile.TemporaryDirectory() as directory:
+            db_file = str(Path(directory) / "bnl.db")
+            self.seed_source_and_memory(db_file)
+            read_model = authorized_read_model({
+                "currentShow": None,
+                "latestShow": archived_show(),
+                "shows": [],
+            })
+            result = sync_tiktok_show_evidence_ledgers(
+                db_file,
+                guild_id=77,
+                read_model=read_model,
+                artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
+            )
+            self.assertTrue(result["authorizationEligible"])
+
+            conn = sqlite3.connect(db_file)
+            stored = json.loads(conn.execute(
+                f"SELECT ledger_json FROM {TIKTOK_SHOW_EVIDENCE_TABLE}"
+            ).fetchone()[0])
+            receipt = stored["sourceAuthorization"]
+            self.assertEqual(
+                receipt["contractVersion"],
+                "show_queue_evidence_authorization_v1",
+            )
+            self.assertEqual(receipt["accessScope"], "public")
+            self.assertTrue(receipt["websiteQueueProduction"])
+
+            legacy = dict(stored)
+            legacy.pop("sourceAuthorization")
+            legacy.pop("sourceDigest")
+            legacy_digest = hashlib.sha256(
+                json.dumps(
+                    legacy,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            ).hexdigest()
+            legacy["sourceDigest"] = legacy_digest
+            conn.execute(
+                f"UPDATE {TIKTOK_SHOW_EVIDENCE_TABLE} "
+                "SET source_digest=?,ledger_json=?",
+                (
+                    legacy_digest,
+                    json.dumps(
+                        legacy,
+                        ensure_ascii=False,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                ),
+            )
+            conn.commit()
+            conn.close()
+
+            self.assertEqual(
+                build_tiktok_show_evidence_context(
+                    db_file,
+                    guild_id=77,
+                    user_text="Give me the 2026-08-28 show timeline.",
+                ),
+                "",
+            )
+
+            repaired = sync_tiktok_show_evidence_ledgers(
+                db_file,
+                guild_id=77,
+                read_model=read_model,
+                artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
+            )
+            self.assertEqual(repaired["showsWritten"], 1)
+            self.assertIn(
+                "Durable BARCODE Radio show episode memory:",
+                build_tiktok_show_evidence_context(
+                    db_file,
+                    guild_id=77,
+                    user_text="Give me the 2026-08-28 show timeline.",
+                ),
+            )
+
+    def test_sync_preserves_captured_exchange_after_conversation_pruning(self):
+        with tempfile.TemporaryDirectory() as directory:
+            db_file = str(Path(directory) / "bnl.db")
+            self.seed_source_and_memory(db_file)
+            provisional_show = json.loads(json.dumps(archived_show()))
+            provisional_show["status"] = "live"
+            provisional_show["milestones"] = [
+                event
+                for event in provisional_show["milestones"]
+                if event["eventType"] != "session_archived"
+            ]
+            provisional_model = authorized_read_model({
+                "currentShow": provisional_show,
+                "latestShow": None,
+                "shows": [],
+            })
+            first = sync_tiktok_show_evidence_ledgers(
+                db_file,
+                guild_id=77,
+                read_model=provisional_model,
+                artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
+            )
+            self.assertEqual(first["showsWritten"], 1)
+            self.assertEqual(first["showsFinalized"], 0)
+
+            conn = sqlite3.connect(db_file)
+            original_json = conn.execute(
+                f"SELECT ledger_json "
+                f"FROM {TIKTOK_SHOW_EVIDENCE_TABLE}"
+            ).fetchone()[0]
+            conn.execute("DELETE FROM conversations WHERE id IN (101,102)")
+            conn.commit()
+            conn.close()
+            original = json.loads(original_json)
+            self.assertEqual(original["lifecycle"], "provisional")
+            self.assertEqual(
+                sum(
+                    1
+                    for exchange in original["discordInteractions"]
+                    if isinstance(exchange.get("bnlResponse"), dict)
+                ),
+                1,
+            )
+
+            finalized_model = authorized_read_model({
+                "currentShow": None,
+                "latestShow": archived_show(),
+                "shows": [],
+            })
+
+            rebuilt = sync_tiktok_show_evidence_ledgers(
+                db_file,
+                guild_id=77,
+                read_model=finalized_model,
+                artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
+            )
+            self.assertEqual(rebuilt["showsWritten"], 1)
+            self.assertEqual(rebuilt["showsFinalized"], 1)
+            self.assertEqual(rebuilt["discordInteractions"], 2)
+            self.assertEqual(rebuilt["discordExchanges"], 1)
+
+            conn = sqlite3.connect(db_file)
+            rebuilt_json = conn.execute(
+                f"SELECT ledger_json "
+                f"FROM {TIKTOK_SHOW_EVIDENCE_TABLE}"
+            ).fetchone()[0]
+            conn.close()
+            stored = json.loads(rebuilt_json)
+            self.assertEqual(stored["lifecycle"], "finalized")
+            alex = next(
+                exchange
+                for exchange in stored["discordInteractions"]
+                if exchange["subjectRef"] == "discord_user:42"
+            )
+            self.assertEqual(len(alex["userMessages"]), 1)
+            self.assertEqual(
+                alex["userMessages"][0]["conversationRowId"],
+                101,
+            )
+            self.assertEqual(
+                alex["bnlResponse"]["text"],
+                "Yes—the Wheel confirmed Queue Light, and it is playing now.",
+            )
+    def test_public_show_boundaries_normalize_the_configured_owner_label(self):
+        with tempfile.TemporaryDirectory() as directory:
+            db_file = str(Path(directory) / "bnl.db")
+            ensure_journal_source_schema(db_file)
+            for event in durable_events():
+                result = record_source_event(
+                    db_file,
+                    guild_id=77,
+                    source_kind="tiktok_live_chat",
+                    source_key=event["event_id"],
+                    occurred_at_ms=event["occurred_at_ms"],
+                    raw_text=event["raw_text"],
+                    sanitized_summary=event["raw_text"],
+                    channel_policy="public_context",
+                    subject_ref=event["subject_ref"],
+                    private_display_name=(
+                        "Test Member"
+                        if event["subject_ref"] == "discord_user:42"
+                        else event["private_display_name"]
+                    ),
+                    public_usable=True,
+                    metadata=event["metadata"],
+                )
+                self.assertTrue(result.ok)
+            self.seed_conversations(db_file)
+            conn = sqlite3.connect(db_file)
+            conn.execute(
+                """
+                UPDATE conversations SET user_name='Test Member'
+                WHERE user_id=42 AND role='user'
+                """
+            )
+            conn.commit()
+            conn.close()
+            self.seed_shadow_memory(db_file)
+            read_model = authorized_read_model({
+                "currentShow": None,
+                "latestShow": archived_show(),
+                "shows": [],
+            })
+
+            with mock.patch.dict(
+                os.environ,
+                {"BNL_OWNER_USER_ID": "42"},
+                clear=False,
+            ):
+                result = sync_tiktok_show_evidence_ledgers(
+                    db_file,
+                    guild_id=77,
+                    read_model=read_model,
+                    artist_identity_index=artist_index(),
+                    environ=ENABLED_QUEUE_ENV,
+                )
+                self.assertEqual(result["status"], "completed")
+
+                conn = sqlite3.connect(db_file)
+                raw_ledger = conn.execute(
+                    f"SELECT ledger_json FROM {TIKTOK_SHOW_EVIDENCE_TABLE}"
+                ).fetchone()[0]
+                projection_rows = conn.execute(
+                    """
+                    SELECT subject_display_name,normalized_value
+                    FROM memory_ledger_entries
+                    WHERE source_table='tiktok_show_evidence'
+                      AND public_usable=1
+                    ORDER BY entry_id
+                    """
+                ).fetchall()
+                projection_participants = conn.execute(
+                    """
+                    SELECT participant.display_name
+                    FROM memory_ledger_participants AS participant
+                    JOIN memory_ledger_entries AS entry
+                      ON entry.entry_id=participant.entry_id
+                    WHERE entry.source_table='tiktok_show_evidence'
+                      AND entry.public_usable=1
+                    ORDER BY participant.entry_id,participant.order_index
+                    """
+                ).fetchall()
+                packet_items = select_tiktok_show_episode_context_items(
+                    conn,
+                    guild_id=77,
+                    user_text="What did 6 Bit say during yesterday's show?",
+                    now="2026-08-29T12:00:00-07:00",
+                )
+                conn.close()
+                legacy_context = build_tiktok_show_evidence_context(
+                    db_file,
+                    guild_id=77,
+                    user_text="What did 6 Bit say during the show?",
+                )
+
+            public_projection = json.dumps(
+                [projection_rows, projection_participants],
+                ensure_ascii=False,
+            )
+            packet_context = "\n".join(item.text for item in packet_items)
+            self.assertIn("Test Member", raw_ledger)
+            self.assertNotIn("Test Member", public_projection)
+            self.assertNotIn("Test Member", packet_context)
+            self.assertNotIn("Test Member", legacy_context)
+            self.assertIn("6 Bit", public_projection)
+            self.assertIn("6 Bit", packet_context)
+            self.assertIn("6 Bit", legacy_context)
+
     def test_finalization_refreshes_existing_living_canon_owner_when_enabled(self):
         with tempfile.TemporaryDirectory() as directory:
             db_file = str(Path(directory) / "bnl.db")
             self.seed_source_and_memory(db_file)
-            read_model = {
-                "sections": {
-                    "archive": {
-                        "currentShow": None,
-                        "latestShow": archived_show(),
-                        "shows": [],
-                    }
-                }
-            }
+            read_model = authorized_read_model({
+                "currentShow": None,
+                "latestShow": archived_show(),
+                "shows": [],
+            })
             with mock.patch.dict(
                 os.environ,
                 {
@@ -771,6 +1152,7 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                     guild_id=77,
                     read_model=read_model,
                     artist_identity_index=artist_index(),
+                    environ=ENABLED_QUEUE_ENV,
                 )
 
             self.assertEqual(result["livingCanonSubjectsEvaluated"], 1)
@@ -801,20 +1183,17 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 db_file,
                 include_shadow_memory=False,
             )
-            read_model = {
-                "sections": {
-                    "archive": {
-                        "currentShow": archived_show(),
-                        "latestShow": None,
-                        "shows": [],
-                    }
-                }
-            }
+            read_model = authorized_read_model({
+                "currentShow": archived_show(),
+                "latestShow": None,
+                "shows": [],
+            })
             first = sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
                 read_model=read_model,
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             self.assertEqual(first["projectionInserted"], 6)
             conn = sqlite3.connect(db_file)
@@ -838,6 +1217,7 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 guild_id=77,
                 read_model=read_model,
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             self.assertEqual(second["showsUnchanged"], 1)
             self.assertEqual(second["projectionInserted"], 0)
@@ -862,16 +1242,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": archived_show(),
-                            "latestShow": None,
-                            "shows": [],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": archived_show(),
+                    "latestShow": None,
+                    "shows": [],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
 
             broad = build_tiktok_show_evidence_context(
@@ -984,16 +1361,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": None,
-                            "latestShow": archived_show(),
-                            "shows": [],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": None,
+                    "latestShow": archived_show(),
+                    "shows": [],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             conn = sqlite3.connect(db_file)
             items = select_tiktok_show_episode_context_items(
@@ -1042,6 +1416,33 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 now="2026-08-29T12:00:00-07:00",
             )
             self.assertEqual(unrelated, ())
+            same_day_unrelated = select_tiktok_show_episode_context_items(
+                conn,
+                guild_id=77,
+                user_text="How are you doing today?",
+                subject_user_id=42,
+                allow_subject_continuity=True,
+                now="2026-08-28T12:00:00-07:00",
+            )
+            self.assertEqual(same_day_unrelated, ())
+            prior_day_unrelated = select_tiktok_show_episode_context_items(
+                conn,
+                guild_id=77,
+                user_text="What did you do yesterday?",
+                subject_user_id=42,
+                allow_subject_continuity=True,
+                now="2026-08-29T12:00:00-07:00",
+            )
+            self.assertEqual(prior_day_unrelated, ())
+            proactive_unrelated = select_tiktok_show_episode_context_items(
+                conn,
+                guild_id=77,
+                user_text="How do I make pasta?",
+                subject_user_id=42,
+                allow_subject_continuity=True,
+                now="2026-08-29T12:00:00-07:00",
+            )
+            self.assertEqual(proactive_unrelated, ())
             explicit_self = select_tiktok_show_episode_context_items(
                 conn,
                 guild_id=77,
@@ -1095,16 +1496,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": None,
-                            "latestShow": archived_show(),
-                            "shows": [older_show],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": None,
+                    "latestShow": archived_show(),
+                    "shows": [older_show],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             conn = sqlite3.connect(db_file)
             items = select_tiktok_show_episode_context_items(
@@ -1138,16 +1536,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": None,
-                            "latestShow": archived_show(),
-                            "shows": [],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": None,
+                    "latestShow": archived_show(),
+                    "shows": [],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             conn = sqlite3.connect(db_file)
             request = IntelligencePacketRequest(
@@ -1179,6 +1574,7 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                     "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
                     "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
                     "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+                    "BNL_QUEUE_PRODUCTION_ENABLED": "true",
                 },
             )
             self.assertIsNotNone(packet)
@@ -1198,7 +1594,16 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             self.assertTrue(all(not item.canon_status for item in show_items))
             self.assertTrue(all(not item.root_identities for item in show_items))
             self.assertEqual(packet.diagnostics.invalid_invariants, [])
-            self.assertTrue(revalidate_packet(conn, packet).valid)
+            self.assertTrue(
+                revalidate_packet(
+                    conn,
+                    packet,
+                    environ=ENABLED_QUEUE_ENV,
+                ).valid
+            )
+            self.assertFalse(
+                revalidate_packet(conn, packet, environ={}).valid
+            )
             rendered, lane_counts, rendered_count, _digests = (
                 render_packet_context(
                     packet,
@@ -1213,11 +1618,44 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             self.assertIn(("show_episode", 3), lane_counts)
             self.assertGreaterEqual(rendered_count, 3)
 
+            unrelated_packet = build_packet(
+                conn,
+                replace(
+                    request,
+                    user_text="How do I make pasta?",
+                    frame_subject_requirement="required",
+                ),
+                persist=False,
+                environ={
+                    "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+                    "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+                    "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+                    "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+                    "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED": "true",
+                    "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
+                    "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
+                    "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+                },
+            )
+            self.assertFalse(
+                unrelated_packet
+                and any(
+                    item.lane == "show_episode"
+                    for item in unrelated_packet.items
+                )
+            )
+
             conn.execute(
                 f"DELETE FROM {TIKTOK_SHOW_EVIDENCE_TABLE} WHERE guild_id=77"
             )
             conn.commit()
-            self.assertFalse(revalidate_packet(conn, packet).valid)
+            self.assertFalse(
+                revalidate_packet(
+                    conn,
+                    packet,
+                    environ=ENABLED_QUEUE_ENV,
+                ).valid
+            )
             conn.close()
 
     def test_packet_show_continuity_honors_member_proactive_opt_out(self):
@@ -1227,16 +1665,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": None,
-                            "latestShow": archived_show(),
-                            "shows": [],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": None,
+                    "latestShow": archived_show(),
+                    "shows": [],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             conn = sqlite3.connect(db_file)
             request = IntelligencePacketRequest(
@@ -1265,6 +1700,7 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
                 "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
                 "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+                "BNL_QUEUE_PRODUCTION_ENABLED": "true",
             }
             allowed_packet = build_packet(
                 conn,
@@ -1310,16 +1746,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": archived_show(),
-                            "latestShow": None,
-                            "shows": [],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": archived_show(),
+                    "latestShow": None,
+                    "shows": [],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             conn = sqlite3.connect(db_file)
             ensure_governance_schema(conn)

--- a/tests/test_tiktok_show_evidence_ledger.py
+++ b/tests/test_tiktok_show_evidence_ledger.py
@@ -744,6 +744,114 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             self.assertEqual(second["showsUnchanged"], 1)
             self.assertEqual(second["projectionDeduplicated"], 0)
 
+    def test_public_show_boundaries_normalize_the_configured_owner_label(self):
+        with tempfile.TemporaryDirectory() as directory:
+            db_file = str(Path(directory) / "bnl.db")
+            ensure_journal_source_schema(db_file)
+            for event in durable_events():
+                result = record_source_event(
+                    db_file,
+                    guild_id=77,
+                    source_kind="tiktok_live_chat",
+                    source_key=event["event_id"],
+                    occurred_at_ms=event["occurred_at_ms"],
+                    raw_text=event["raw_text"],
+                    sanitized_summary=event["raw_text"],
+                    channel_policy="public_context",
+                    subject_ref=event["subject_ref"],
+                    private_display_name=(
+                        "Test Member"
+                        if event["subject_ref"] == "discord_user:42"
+                        else event["private_display_name"]
+                    ),
+                    public_usable=True,
+                    metadata=event["metadata"],
+                )
+                self.assertTrue(result.ok)
+            self.seed_conversations(db_file)
+            conn = sqlite3.connect(db_file)
+            conn.execute(
+                """
+                UPDATE conversations SET user_name='Test Member'
+                WHERE user_id=42 AND role='user'
+                """
+            )
+            conn.commit()
+            conn.close()
+            self.seed_shadow_memory(db_file)
+            read_model = {
+                "sections": {
+                    "archive": {
+                        "currentShow": None,
+                        "latestShow": archived_show(),
+                        "shows": [],
+                    }
+                }
+            }
+
+            with mock.patch.dict(
+                os.environ,
+                {"BNL_OWNER_USER_ID": "42"},
+                clear=False,
+            ):
+                result = sync_tiktok_show_evidence_ledgers(
+                    db_file,
+                    guild_id=77,
+                    read_model=read_model,
+                    artist_identity_index=artist_index(),
+                )
+                self.assertEqual(result["status"], "completed")
+
+                conn = sqlite3.connect(db_file)
+                raw_ledger = conn.execute(
+                    f"SELECT ledger_json FROM {TIKTOK_SHOW_EVIDENCE_TABLE}"
+                ).fetchone()[0]
+                projection_rows = conn.execute(
+                    """
+                    SELECT subject_display_name,normalized_value
+                    FROM memory_ledger_entries
+                    WHERE source_table='tiktok_show_evidence'
+                      AND public_usable=1
+                    ORDER BY entry_id
+                    """
+                ).fetchall()
+                projection_participants = conn.execute(
+                    """
+                    SELECT participant.display_name
+                    FROM memory_ledger_participants AS participant
+                    JOIN memory_ledger_entries AS entry
+                      ON entry.entry_id=participant.entry_id
+                    WHERE entry.source_table='tiktok_show_evidence'
+                      AND entry.public_usable=1
+                    ORDER BY participant.entry_id,participant.order_index
+                    """
+                ).fetchall()
+                packet_items = select_tiktok_show_episode_context_items(
+                    conn,
+                    guild_id=77,
+                    user_text="What did 6 Bit say during yesterday's show?",
+                    now="2026-08-29T12:00:00-07:00",
+                )
+                conn.close()
+                legacy_context = build_tiktok_show_evidence_context(
+                    db_file,
+                    guild_id=77,
+                    user_text="What did 6 Bit say during the show?",
+                )
+
+            public_projection = json.dumps(
+                [projection_rows, projection_participants],
+                ensure_ascii=False,
+            )
+            packet_context = "\n".join(item.text for item in packet_items)
+            self.assertIn("Test Member", raw_ledger)
+            self.assertNotIn("Test Member", public_projection)
+            self.assertNotIn("Test Member", packet_context)
+            self.assertNotIn("Test Member", legacy_context)
+            self.assertIn("6 Bit", public_projection)
+            self.assertIn("6 Bit", packet_context)
+            self.assertIn("6 Bit", legacy_context)
+
     def test_finalization_refreshes_existing_living_canon_owner_when_enabled(self):
         with tempfile.TemporaryDirectory() as directory:
             db_file = str(Path(directory) / "bnl.db")

--- a/tests/test_tiktok_show_evidence_ledger.py
+++ b/tests/test_tiktok_show_evidence_ledger.py
@@ -1,3 +1,5 @@
+import copy
+import hashlib
 import json
 import os
 import sqlite3
@@ -250,6 +252,38 @@ def archived_show():
                 "track": None,
             },
         ],
+    }
+
+
+ENABLED_QUEUE_ENV = {"BNL_QUEUE_PRODUCTION_ENABLED": "true"}
+
+
+def authorized_read_model(archive):
+    return {
+        "ok": True,
+        "version": 1,
+        "source": "barcode-network-site",
+        "publicOnly": True,
+        "accessScope": "public",
+        "capabilities": {"queueProduction": True},
+        "sections": {
+            "archive": {
+                "available": True,
+                "reason": None,
+                "schemaVersion": "queue_public_history_projection_v1",
+                "source": "queue_bnl_history_projection",
+                "visibility": "public_safe",
+                "accessScope": "public",
+                "historyCoverageStartedAt": "2026-08-24",
+                "sourceRevision": 42,
+                "sourceDigest": "a" * 64,
+                "memoryDefault": "do_not_store",
+                "sourceFileDefault": "review_evidence_only",
+                "publicDossierDefault": "not_automatic",
+                "personalHistory": None,
+                **archive,
+            }
+        },
     }
 
 
@@ -660,22 +694,17 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             db_file = str(Path(directory) / "bnl.db")
             self.seed_source_and_memory(db_file)
-            read_model = {
-                "ok": True,
-                "version": 1,
-                "sections": {
-                    "archive": {
-                        "currentShow": None,
-                        "latestShow": archived_show(),
-                        "shows": [],
-                    }
-                },
-            }
+            read_model = authorized_read_model({
+                "currentShow": None,
+                "latestShow": archived_show(),
+                "shows": [],
+            })
             first = sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
                 read_model=read_model,
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             self.assertEqual(first["status"], "completed")
             self.assertEqual(first["showsWritten"], 1)
@@ -739,24 +768,185 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 guild_id=77,
                 read_model=read_model,
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             self.assertEqual(second["showsWritten"], 0)
             self.assertEqual(second["showsUnchanged"], 1)
             self.assertEqual(second["projectionDeduplicated"], 0)
 
+    def test_sync_requires_exact_public_production_archive_authorization(self):
+        valid = authorized_read_model({
+            "currentShow": None,
+            "latestShow": archived_show(),
+            "shows": [],
+        })
+        cases = []
+
+        local_off = copy.deepcopy(valid)
+        cases.append(("local_off", local_off, {}, "local_gate_disabled"))
+
+        website_off = copy.deepcopy(valid)
+        website_off["capabilities"]["queueProduction"] = False
+        cases.append((
+            "website_off",
+            website_off,
+            ENABLED_QUEUE_ENV,
+            "website_capability_missing_or_false",
+        ))
+
+        private = copy.deepcopy(valid)
+        private["publicOnly"] = False
+        private["accessScope"] = "private"
+        private["sections"]["archive"]["accessScope"] = "private"
+        private["sections"]["archive"]["visibility"] = "bnl_private_safe"
+        cases.append((
+            "private_scope",
+            private,
+            ENABLED_QUEUE_ENV,
+            "private_access_not_allowed",
+        ))
+
+        unavailable = copy.deepcopy(valid)
+        unavailable["sections"]["archive"]["available"] = False
+        unavailable["sections"]["archive"]["reason"] = (
+            "queue_projection_unavailable"
+        )
+        cases.append((
+            "unavailable",
+            unavailable,
+            ENABLED_QUEUE_ENV,
+            "archive_public_contract_invalid",
+        ))
+
+        malformed = copy.deepcopy(valid)
+        malformed["sections"]["archive"]["sourceDigest"] = "not-a-digest"
+        cases.append((
+            "malformed",
+            malformed,
+            ENABLED_QUEUE_ENV,
+            "archive_public_contract_invalid",
+        ))
+
+        simulation = copy.deepcopy(valid)
+        simulation["sections"]["archive"]["latestShow"]["trackRoster"][0][
+            "isSimulation"
+        ] = True
+        cases.append((
+            "simulation",
+            simulation,
+            ENABLED_QUEUE_ENV,
+            "archive_public_contract_invalid",
+        ))
+
+        for label, model, environ, reason in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as directory:
+                db_file = str(Path(directory) / "bnl.db")
+                result = sync_tiktok_show_evidence_ledgers(
+                    db_file,
+                    guild_id=77,
+                    read_model=model,
+                    artist_identity_index=artist_index(),
+                    environ=environ,
+                )
+                self.assertEqual(result["status"], "skipped")
+                self.assertEqual(result["reason"], reason)
+                self.assertFalse(result["authorizationEligible"])
+                self.assertEqual(result["showsWritten"], 0)
+                self.assertFalse(Path(db_file).exists())
+
+    def test_authorization_receipt_quarantines_unreceipted_show_rows(self):
+        with tempfile.TemporaryDirectory() as directory:
+            db_file = str(Path(directory) / "bnl.db")
+            self.seed_source_and_memory(db_file)
+            read_model = authorized_read_model({
+                "currentShow": None,
+                "latestShow": archived_show(),
+                "shows": [],
+            })
+            result = sync_tiktok_show_evidence_ledgers(
+                db_file,
+                guild_id=77,
+                read_model=read_model,
+                artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
+            )
+            self.assertTrue(result["authorizationEligible"])
+
+            conn = sqlite3.connect(db_file)
+            stored = json.loads(conn.execute(
+                f"SELECT ledger_json FROM {TIKTOK_SHOW_EVIDENCE_TABLE}"
+            ).fetchone()[0])
+            receipt = stored["sourceAuthorization"]
+            self.assertEqual(
+                receipt["contractVersion"],
+                "show_queue_evidence_authorization_v1",
+            )
+            self.assertEqual(receipt["accessScope"], "public")
+            self.assertTrue(receipt["websiteQueueProduction"])
+
+            legacy = dict(stored)
+            legacy.pop("sourceAuthorization")
+            legacy.pop("sourceDigest")
+            legacy_digest = hashlib.sha256(
+                json.dumps(
+                    legacy,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            ).hexdigest()
+            legacy["sourceDigest"] = legacy_digest
+            conn.execute(
+                f"UPDATE {TIKTOK_SHOW_EVIDENCE_TABLE} "
+                "SET source_digest=?,ledger_json=?",
+                (
+                    legacy_digest,
+                    json.dumps(
+                        legacy,
+                        ensure_ascii=False,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                ),
+            )
+            conn.commit()
+            conn.close()
+
+            self.assertEqual(
+                build_tiktok_show_evidence_context(
+                    db_file,
+                    guild_id=77,
+                    user_text="Give me the 2026-08-28 show timeline.",
+                ),
+                "",
+            )
+
+            repaired = sync_tiktok_show_evidence_ledgers(
+                db_file,
+                guild_id=77,
+                read_model=read_model,
+                artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
+            )
+            self.assertEqual(repaired["showsWritten"], 1)
+            self.assertIn(
+                "Durable BARCODE Radio show episode memory:",
+                build_tiktok_show_evidence_context(
+                    db_file,
+                    guild_id=77,
+                    user_text="Give me the 2026-08-28 show timeline.",
+                ),
+            )
+
     def test_finalization_refreshes_existing_living_canon_owner_when_enabled(self):
         with tempfile.TemporaryDirectory() as directory:
             db_file = str(Path(directory) / "bnl.db")
             self.seed_source_and_memory(db_file)
-            read_model = {
-                "sections": {
-                    "archive": {
-                        "currentShow": None,
-                        "latestShow": archived_show(),
-                        "shows": [],
-                    }
-                }
-            }
+            read_model = authorized_read_model({
+                "currentShow": None,
+                "latestShow": archived_show(),
+                "shows": [],
+            })
             with mock.patch.dict(
                 os.environ,
                 {
@@ -770,6 +960,7 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                     guild_id=77,
                     read_model=read_model,
                     artist_identity_index=artist_index(),
+                    environ=ENABLED_QUEUE_ENV,
                 )
 
             self.assertEqual(result["livingCanonSubjectsEvaluated"], 1)
@@ -800,20 +991,17 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 db_file,
                 include_shadow_memory=False,
             )
-            read_model = {
-                "sections": {
-                    "archive": {
-                        "currentShow": archived_show(),
-                        "latestShow": None,
-                        "shows": [],
-                    }
-                }
-            }
+            read_model = authorized_read_model({
+                "currentShow": archived_show(),
+                "latestShow": None,
+                "shows": [],
+            })
             first = sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
                 read_model=read_model,
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             self.assertEqual(first["projectionInserted"], 6)
             conn = sqlite3.connect(db_file)
@@ -837,6 +1025,7 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 guild_id=77,
                 read_model=read_model,
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             self.assertEqual(second["showsUnchanged"], 1)
             self.assertEqual(second["projectionInserted"], 0)
@@ -861,16 +1050,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": archived_show(),
-                            "latestShow": None,
-                            "shows": [],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": archived_show(),
+                    "latestShow": None,
+                    "shows": [],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
 
             broad = build_tiktok_show_evidence_context(
@@ -983,16 +1169,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": None,
-                            "latestShow": archived_show(),
-                            "shows": [],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": None,
+                    "latestShow": archived_show(),
+                    "shows": [],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             conn = sqlite3.connect(db_file)
             items = select_tiktok_show_episode_context_items(
@@ -1094,16 +1277,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": None,
-                            "latestShow": archived_show(),
-                            "shows": [older_show],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": None,
+                    "latestShow": archived_show(),
+                    "shows": [older_show],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             conn = sqlite3.connect(db_file)
             items = select_tiktok_show_episode_context_items(
@@ -1137,16 +1317,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": None,
-                            "latestShow": archived_show(),
-                            "shows": [],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": None,
+                    "latestShow": archived_show(),
+                    "shows": [],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             conn = sqlite3.connect(db_file)
             request = IntelligencePacketRequest(
@@ -1178,6 +1355,7 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                     "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
                     "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
                     "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+                    "BNL_QUEUE_PRODUCTION_ENABLED": "true",
                 },
             )
             self.assertIsNotNone(packet)
@@ -1197,7 +1375,16 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             self.assertTrue(all(not item.canon_status for item in show_items))
             self.assertTrue(all(not item.root_identities for item in show_items))
             self.assertEqual(packet.diagnostics.invalid_invariants, [])
-            self.assertTrue(revalidate_packet(conn, packet).valid)
+            self.assertTrue(
+                revalidate_packet(
+                    conn,
+                    packet,
+                    environ=ENABLED_QUEUE_ENV,
+                ).valid
+            )
+            self.assertFalse(
+                revalidate_packet(conn, packet, environ={}).valid
+            )
             rendered, lane_counts, rendered_count, _digests = (
                 render_packet_context(
                     packet,
@@ -1216,7 +1403,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 f"DELETE FROM {TIKTOK_SHOW_EVIDENCE_TABLE} WHERE guild_id=77"
             )
             conn.commit()
-            self.assertFalse(revalidate_packet(conn, packet).valid)
+            self.assertFalse(
+                revalidate_packet(
+                    conn,
+                    packet,
+                    environ=ENABLED_QUEUE_ENV,
+                ).valid
+            )
             conn.close()
 
     def test_complete_delete_removes_bound_sources_and_invalidates_episode(self):
@@ -1226,16 +1419,13 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             sync_tiktok_show_evidence_ledgers(
                 db_file,
                 guild_id=77,
-                read_model={
-                    "sections": {
-                        "archive": {
-                            "currentShow": archived_show(),
-                            "latestShow": None,
-                            "shows": [],
-                        }
-                    }
-                },
+                read_model=authorized_read_model({
+                    "currentShow": archived_show(),
+                    "latestShow": None,
+                    "shows": [],
+                }),
                 artist_identity_index=artist_index(),
+                environ=ENABLED_QUEUE_ENV,
             )
             conn = sqlite3.connect(db_file)
             ensure_governance_schema(conn)


### PR DESCRIPTION
## Purpose

Land the four overlapping, independently green audit PRs as one verified stack without dropping either side of their shared-file changes.

## Original PR heads preserved as parents

- #472 `0db0cccb80069dffab6c52266b40978a2e7b231c` — authorized show/queue evidence
- #473 `332474f98d19dbcc36d8abe0e17a1750bdea58a8` — show episode integrity and intent
- #474 `30fd2aad4c65a013f08a27857e103e0f15d28dad` — public show owner labels
- #475 `6b319360e7f031c7960cc0e0a584d6b5de9b00f2` — refusal/obligation language

## Reconciliation

- require local and website production authorization before show/queue evidence becomes usable
- apply proactive-consent decisions after that authorization gate and fail closed when consent lookup is unavailable
- preserve previously captured Discord exchanges when source conversations are later pruned, while sealing the rebuilt ledger with its authorization receipt
- normalize the configured owner label to canonical `6 Bit` only at public-safe projections; keep raw source evidence immutable
- retain actual missing-evidence refusal detection while allowing grounded “do not have to show logs” language
- update cross-PR tests to supply the now-required public production contract and to assert fail-closed participant continuity

## Verification

- final local tree: `eb70a2d1f86dac712ba522c0f2aad31deb046fc3`
- all seven conflict-resolution blobs matched their local Git object hashes after upload
- focused ledger, live-context, relationship, batching, and response-guard suites passed
- complete final bot suite passed: 2,509 tests
- this carrier must also pass fresh GitHub Python 3.9, Python 3.12, and TikTok transport checks before merge

No deployment, restart, production gate change, or new authority is included.