### PR TITLE
Repair ordinary chat single-packet acceptance

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -26706,6 +26706,15 @@ def _typed_canon_subject_references(
 
     text = unicodedata.normalize("NFKC", str(current_text or ""))
     text = text.replace("’", "'").casefold()
+    singular_pronoun = re.search(
+        r"\b(?:he|him|his|she|her|hers|that\s+(?:person|member|"
+        r"character|entity))\b",
+        text,
+        re.I,
+    )
+    pronoun_antecedent_limit = (
+        singular_pronoun.start() if singular_pronoun is not None else -1
+    )
     factual_subject_cue_re = re.compile(
         r"\b(?:tell\s+me\s+about|what\s+do\s+you\s+"
         r"(?:know|remember)\s+about|what\s+happened\s+with|"
@@ -26757,10 +26766,34 @@ def _typed_canon_subject_references(
                 r"(?:connected|related)\s+to\b" % escaped,
                 r"\b(?:connected|related)\s+to\s+(?:the\s+)?"
                 r"(?P<alias>%s)(?![a-z0-9])" % escaped,
+                r"\b(?:different\s+from|differs?\s+from|versus|vs\.?)\s+"
+                r"(?:the\s+)?(?P<alias>%s)(?![a-z0-9])" % escaped,
             )
             for pattern in subject_patterns:
                 for match in re.finditer(pattern, text, re.I):
                     start, end = match.span("alias")
+                    candidates.add(
+                        (start, end, subject.key, subject.name)
+                    )
+            if (
+                pronoun_antecedent_limit > 0
+                and subject.key
+                not in {
+                    "barcode",
+                    "barcode_network",
+                    "barcode_radio",
+                    "bnl_01",
+                }
+            ):
+                for match in re.finditer(
+                    r"(?<![a-z0-9])(?P<alias>%s)(?![a-z0-9])"
+                    % escaped,
+                    text[:pronoun_antecedent_limit],
+                    re.I,
+                ):
+                    start, end = match.span("alias")
+                    if text[end : end + 2] == "'s":
+                        continue
                     candidates.add(
                         (start, end, subject.key, subject.name)
                     )
@@ -26829,6 +26862,63 @@ _EXACT_REPLY_CANON_IDENTITY_QUERY_RE = re.compile(
     r"connection))\b",
     re.I,
 )
+
+
+def _exact_reply_canon_discourse_focus_keys(
+    reply_text: str,
+    eligible_identities,
+) -> tuple[str, ...]:
+    """Return canon aliases used as grammatical sentence subjects.
+
+    This is identity-only discourse binding.  It does not promote prior model
+    prose into factual evidence, and it deliberately ignores possessives,
+    prepositional mentions, predicate complements, and coordinated subjects.
+    """
+
+    normalized = unicodedata.normalize(
+        "NFKC",
+        str(reply_text or ""),
+    ).replace("’", "'")
+    sentences = tuple(
+        sentence.strip(" \t\r\n\"'()[]{}")
+        for sentence in re.split(r"(?<=[.!?;])\s+|[\r\n]+", normalized)
+        if sentence.strip()
+    )
+    focus_keys = []
+    subject_verb_re = re.compile(
+        r"^\s+(?:is|was|are|were|serves?|served|handles?|handled|"
+        r"maintains?|maintained|recovers?|recovered|protects?|protected|"
+        r"manages?|managed|keeps?|kept|became|remains?|remained|"
+        r"emerged|originated|works?|worked|helps?|helped|does|did|has|"
+        r"had)\b",
+        re.I,
+    )
+    for sentence in sentences:
+        for identity in eligible_identities:
+            matched = False
+            for alias in (identity.name, *identity.aliases):
+                value = unicodedata.normalize(
+                    "NFKC",
+                    str(alias or ""),
+                ).replace("’", "'").strip()
+                if not value:
+                    continue
+                match = re.match(
+                    r"^%s(?![a-z0-9])" % re.escape(value),
+                    sentence,
+                    re.I,
+                )
+                if match is None:
+                    continue
+                tail = sentence[match.end() :]
+                if tail.startswith("'s") or not subject_verb_re.match(tail):
+                    continue
+                focus_keys.append(identity.key)
+                matched = True
+                break
+            if matched:
+                break
+    return tuple(dict.fromkeys(focus_keys))
 
 
 def _exact_reply_canon_subject_references(
@@ -26935,6 +27025,15 @@ def _exact_reply_canon_subject_references(
                 if len(remaining) == 1:
                     return remaining, "resolved"
                 return (), "ambiguous"
+        focus_keys = _exact_reply_canon_discourse_focus_keys(
+            reply_text,
+            eligible,
+        )
+        focused = tuple(
+            identity for identity in resolved if identity[0] in focus_keys
+        )
+        if len(focused) == 1:
+            return focused, "resolved"
         if len(resolved) == 1:
             return tuple(resolved), "resolved"
         return (), "ambiguous"
@@ -35462,6 +35561,32 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
         post_generation_regeneration_pending = None
         payload_completion_regenerated = False
         response = ""
+        batch_ordinary_chat_execution = None
+        batch_single_packet_cutover = False
+
+        async def _finalize_stale_batch_single_packet(
+            execution: OrdinaryChatSinglePacketExecution | None,
+            *,
+            stale_reason: str,
+            final_response: str,
+        ) -> None:
+            if execution is None or execution.decision is None:
+                return
+            stale_decision = (
+                await safely_record_ordinary_chat_single_packet_block(
+                    execution.decision,
+                    reason=stale_reason,
+                )
+                or execution.decision
+            )
+            await safely_finalize_shared_brain_synthesis(
+                stale_decision,
+                final_response=final_response,
+                response_sent=False,
+                candidate_live=False,
+                guard_status=stale_reason,
+            )
+
         while True:
             if (
                 batch_exclusively_targets_other_people(items)
@@ -35654,6 +35779,45 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 batch_website_read_model_context
                 or batch_tiktok_show_evidence_context
             )
+            community_visual_basis = build_community_visual_basis(
+                guild_id,
+                (
+                    tuple(
+                        content
+                        for _name, content, _uid in collapsed_items
+                    )
+                    if len(unique_user_ids) == 1
+                    else ""
+                ),
+                channel_policy=channel_policy,
+            )
+            community_visual_prompt = (
+                render_community_visual_basis_for_prompt(
+                    community_visual_basis
+                )
+            )
+            batch_current_direct = bool(
+                active_packet.get("addressed_to_bot")
+                or is_broad_personal_recall_request(combined_text)
+            )
+            batch_ordinary_chat_scope = ordinary_chat_route_scope_decision(
+                guild_id=guild_id,
+                user_id=first_uid,
+                channel_id=channel_id,
+                route_mode=ROUTE_MODE_NORMAL_CHAT,
+                channel_policy=channel_policy,
+                current_direct=batch_current_direct,
+                user_text=combined_text,
+                has_media=bool(active_packet.get("media_present")),
+                specialized_owner_present=bool(
+                    batch_source_context_available
+                    or community_visual_prompt
+                ),
+            )
+            batch_ordinary_chat_single_packet = bool(
+                len(unique_user_ids) == 1
+                and batch_ordinary_chat_scope.eligible
+            )
             batch_source_no_store_reason = (
                 "finalized_show_evidence_no_store"
                 if batch_tiktok_show_evidence_context
@@ -35713,7 +35877,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     + batch_attribution_contract.prompt_block
                     + "\n"
                 )
-            if recent_room_prompt:
+            if recent_room_prompt and not batch_ordinary_chat_single_packet:
                 prompt += "\n\n" + recent_room_prompt + "\n"
             orchestration_prompt_block = str(
                 orchestration_state.get("prompt_block") or ""
@@ -35724,7 +35888,11 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             batch_memory_source_metadata: dict = {}
             batch_member_is_privileged = False
             batch_memory_target_user_id = 0
-            if len(unique_user_ids) == 1:
+            batch_source_safe_recall = False
+            if (
+                len(unique_user_ids) == 1
+                and not batch_ordinary_chat_single_packet
+            ):
                 member = channel.guild.get_member(first_uid)
                 batch_member_is_privileged = is_privileged_member(
                     member,
@@ -35932,8 +36100,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     if present
                 )
             )
-            batch_unified_moment_canary_scope = (
-                unified_moment_canary_enabled(
+            batch_unified_moment_canary_scope = bool(
+                not batch_ordinary_chat_single_packet
+                and unified_moment_canary_enabled(
                     guild_id=guild_id,
                     channel_id=channel_id,
                     route_mode=ROUTE_MODE_NORMAL_CHAT,
@@ -36037,6 +36206,28 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 batch_prompt_source_bases.append(
                     batch_unified_moment_canary_basis
                 )
+            batch_ordinary_chat_basis = (
+                build_ordinary_chat_basis(
+                    guild_id=guild_id,
+                    user_id=first_uid,
+                    channel_id=channel_id,
+                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy=channel_policy,
+                    current_direct=batch_current_direct,
+                    user_text=combined_text,
+                    packet=batch_intelligence_packet_out.get("packet"),
+                    assessment=batch_unified_assessment,
+                    has_media=bool(active_packet.get("media_present")),
+                )
+                if batch_ordinary_chat_single_packet
+                else None
+            )
+            batch_ordinary_chat_preflight_block_reason = (
+                "packet_or_assessment_unavailable"
+                if batch_ordinary_chat_single_packet
+                and batch_ordinary_chat_basis is None
+                else ""
+            )
             batch_shared_brain_synthesis_basis = (
                 build_shared_brain_synthesis_basis(
                     guild_id=guild_id,
@@ -36067,6 +36258,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 )
                 if len(unique_user_ids) == 1
                 and not batch_source_context_available
+                and not batch_ordinary_chat_single_packet
                 else None
             )
             continuity_contract = build_general_conversation_continuity_contract(
@@ -36077,7 +36269,10 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             )
             if continuity_contract:
                 prompt += "\n\n" + continuity_contract
-            if len(unique_user_ids) == 1:
+            if (
+                len(unique_user_ids) == 1
+                and not batch_ordinary_chat_single_packet
+            ):
                 batch_recall_synthesis_contract = (
                     source_safe_recall_synthesis_contract(
                         guild_id=guild_id,
@@ -36112,18 +36307,6 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     "\n\n"
                     + batch_unified_moment_canary_basis.rendered_context
                 )
-            community_visual_basis = build_community_visual_basis(
-                guild_id,
-                (
-                    tuple(content for _name, content, _uid in collapsed_items)
-                    if len(unique_user_ids) == 1
-                    else ""
-                ),
-                channel_policy=channel_policy,
-            )
-            community_visual_prompt = render_community_visual_basis_for_prompt(
-                community_visual_basis
-            )
             if community_visual_prompt:
                 prompt += "\n\n" + community_visual_prompt + "\n"
             recent_media_prompt = ""
@@ -36184,22 +36367,71 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 len(collapsed_items),
                 f"payload_count={len(active_packet['payload_items'])};elapsed_seconds={generation_elapsed:.2f};selected_wait_seconds={selected_wait_seconds:.2f};indicator_active={int(typing_active)}",
             )
-            response = await get_gemini_response(
-                prompt,
-                user_id=first_uid,
-                guild_id=channel.guild.id,
-                route=generation_route,
-                source_context_available=batch_source_context_available,
+            batch_ordinary_chat_execution = (
+                await maybe_generate_ordinary_chat_single_packet(
+                    channel=channel,
+                    prompt=prompt,
+                    basis=batch_ordinary_chat_basis,
+                    scope_applied=batch_ordinary_chat_single_packet,
+                    preflight_block_reason=(
+                        batch_ordinary_chat_preflight_block_reason
+                    ),
+                    situation_frame=(
+                        orchestration_state["decision"].situation_frame
+                    ),
+                    situation_frame_current_text=combined_text,
+                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy=channel_policy,
+                    conversation_surface=(
+                        conversation_surface_for_channel_policy(
+                            channel_policy,
+                            channel_id == get_guild_config(guild_id),
+                        )
+                    ),
+                    user_id=first_uid,
+                    guild_id=guild_id,
+                    user_display_name=(
+                        collapsed_items[-1][0]
+                        if collapsed_items
+                        else ""
+                    ),
+                    source_context_available=bool(
+                        batch_ordinary_chat_basis
+                        or batch_source_context_available
+                    ),
+                )
             )
+            batch_single_packet_cutover = bool(
+                batch_ordinary_chat_execution is not None
+                and not batch_ordinary_chat_execution.legacy_baseline_active
+            )
+            if batch_ordinary_chat_execution is not None:
+                response = batch_ordinary_chat_execution.response
+                prompt = batch_ordinary_chat_execution.prompt
+                batch_prompt_source_bases = list(
+                    batch_ordinary_chat_execution.prompt_source_bases
+                )
+                generation_route = ORDINARY_CHAT_SINGLE_PACKET_ROUTE
+            else:
+                response = await get_gemini_response(
+                    prompt,
+                    user_id=first_uid,
+                    guild_id=channel.guild.id,
+                    route=generation_route,
+                    source_context_available=batch_source_context_available,
+                )
 
-            response = suppress_stale_media_fallback(
-                response,
-                current_text=combined_text,
-                current_has_media=bool(active_packet.get("media_present")),
-                user_id=first_uid,
-                guild_id=guild_id,
-                channel_id=channel_id,
-            )
+            if not batch_single_packet_cutover:
+                response = suppress_stale_media_fallback(
+                    response,
+                    current_text=combined_text,
+                    current_has_media=bool(
+                        active_packet.get("media_present")
+                    ),
+                    user_id=first_uid,
+                    guild_id=guild_id,
+                    channel_id=channel_id,
+                )
 
             if not response:
                 latest_result = GenerationResult(
@@ -36230,7 +36462,10 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 _log_batch_event(logging.INFO, "active_packet_completion_check", guild_id, channel_id, len(collapsed_items), f"payload_count={len(payload_items)};missing_count={len(missing_items)};decision={decision};reason={reason}")
                 if missing_items:
                     _log_batch_event(logging.INFO, "request_payload_items_missing", guild_id, channel_id, len(missing_items), f"missing_items={len(missing_items)}")
-                    if not payload_completion_regenerated:
+                    if (
+                        not payload_completion_regenerated
+                        and not batch_single_packet_cutover
+                    ):
                         correction_prompt = (
                             prompt
                             + "\n\nCORRECTION REQUIRED: Your last draft omitted required payload items. "
@@ -36346,6 +36581,24 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     }
                     _channel_preempted_generation_id[channel_id] = 0
                     _channel_message_interrupt_generation_id[channel_id] = 0
+                    if batch_single_packet_cutover:
+                        _channel_interrupt_handoff[channel_id] = list(
+                            items
+                        )
+                        _channel_first_seen[channel_id] = datetime.now(
+                            PACIFIC_TZ
+                        )
+                        _channel_last_message_at[channel_id] = (
+                            datetime.now(PACIFIC_TZ)
+                        )
+                        await _finalize_stale_batch_single_packet(
+                            batch_ordinary_chat_execution,
+                            stale_reason=(
+                                "stale_after_batch_single_packet_generation"
+                            ),
+                            final_response=response,
+                        )
+                        return
                     continue
 
             late_count = len(_channel_buffers[channel_id])
@@ -36354,6 +36607,21 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 _channel_preempted_generation_id[channel_id] = local_generation_id
                 _channel_message_interrupt_generation_id[channel_id] = local_generation_id
                 _log_batch_event(logging.INFO, "stale_generation_interrupted", guild_id, channel_id, late_count, "late_message_arrived")
+                if batch_single_packet_cutover:
+                    _channel_interrupt_handoff[channel_id] = list(items)
+                    _channel_first_seen[channel_id] = datetime.now(
+                        PACIFIC_TZ
+                    )
+                    await _finalize_stale_batch_single_packet(
+                        batch_ordinary_chat_execution,
+                        stale_reason=(
+                            "stale_after_batch_single_packet_generation"
+                        ),
+                        final_response=response,
+                    )
+                    _channel_preempted_generation_id[channel_id] = 0
+                    _channel_message_interrupt_generation_id[channel_id] = 0
+                    return
                 if (not regenerated_once) and datetime.now(PACIFIC_TZ) < cycle_deadline:
                     late_items = list(_channel_buffers[channel_id])
                     _channel_buffers[channel_id].clear()
@@ -36400,6 +36668,14 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             if pending_after_discard > 0 or interrupted_by_message:
                 _log_batch_event(logging.INFO, "stale_response_discarded", guild_id, channel_id, len(items), "interrupted_preempted")
             if pending_after_discard > 0:
+                if batch_single_packet_cutover:
+                    await _finalize_stale_batch_single_packet(
+                        batch_ordinary_chat_execution,
+                        stale_reason=(
+                            "stale_before_batch_single_packet_send"
+                        ),
+                        final_response=response,
+                    )
                 # The generated response covered ``items`` but cannot be sent after a
                 # newer fragment arrived. Preserve that full packet for the successor
                 # flush; requeueing only the newest buffer loses the conversation that
@@ -36452,6 +36728,14 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
         )
         if stale_response:
             _log_batch_event(logging.INFO, "stale_response_blocked_before_send", guild_id, channel_id, buffered_count, "hard_message_interrupt")
+            if batch_single_packet_cutover:
+                await _finalize_stale_batch_single_packet(
+                    batch_ordinary_chat_execution,
+                    stale_reason=(
+                        "stale_before_batch_single_packet_send"
+                    ),
+                    final_response=response,
+                )
             if hard_interrupt:
                 pause_seconds = random.uniform(HARD_INTERRUPT_REEVALUATE_PAUSE_MIN_SECONDS, HARD_INTERRUPT_REEVALUATE_PAUSE_MAX_SECONDS)
                 await asyncio.sleep(pause_seconds)
@@ -36507,9 +36791,17 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             batch_bypass_reason="none",
             deterministic_response=False,
             simple_greeting_detected=is_simple_greeting_to_bnl(combined_text),
-            memory_context_injected=True,
-            memory_context_source_count=1,
-            memory_injection_decision="batch_prompt_public_safe",
+            memory_context_injected=bool(batch_memory_context),
+            memory_context_source_count=(
+                1 if batch_memory_context else 0
+            ),
+            memory_injection_decision=(
+                "single_packet_owner"
+                if batch_single_packet_cutover
+                else "batch_prompt_public_safe"
+                if batch_memory_context
+                else "none"
+            ),
             memory_write_decision=(
                 get_route_mode_contract(
                     ROUTE_MODE_NORMAL_CHAT
@@ -36523,8 +36815,12 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             ),
             source_analysis_context_injected=(
                 batch_source_context_available
+                or batch_single_packet_cutover
             ),
-            source_context_allowed=batch_source_context_available,
+            source_context_allowed=bool(
+                batch_source_context_available
+                or batch_single_packet_cutover
+            ),
             community_scouting_ran=False,
             entity_subjects_detected_count=0,
             subject_extraction_ran=False,
@@ -36549,6 +36845,26 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             canned_ack_suppressed=bool(locals().get("ack_diag", {}).get("canned_ack_suppressed", False)),
             ack_converted_to_observe=bool(locals().get("ack_diag", {}).get("ack_converted_to_observe", False)),
             ack_escalated_to_generation=bool(locals().get("ack_diag", {}).get("ack_escalated_to_generation", False)),
+            ordinary_chat_single_packet_applied=(
+                batch_single_packet_cutover
+            ),
+            ordinary_chat_legacy_baseline_fallback=False,
+            ordinary_chat_single_packet_provider_call_count=(
+                batch_ordinary_chat_execution.provider_call_count
+                if batch_ordinary_chat_execution is not None
+                else 0
+            ),
+            ordinary_chat_single_packet_corrective_call_count=(
+                batch_ordinary_chat_execution.corrective_call_count
+                if batch_ordinary_chat_execution is not None
+                else 0
+            ),
+            ordinary_chat_single_packet_block_reason=(
+                batch_ordinary_chat_execution.block_reason
+                if batch_ordinary_chat_execution is not None
+                else ""
+            ),
+            ordinary_chat_legacy_baseline_generation_provider_call_count=0,
         )
 
         batch_baseline_response = response or ""
@@ -36556,75 +36872,223 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
         batch_baseline_source_bases = tuple(
             batch_prompt_source_bases
         )
-        batch_synthesis_execution = (
-            await maybe_generate_shared_brain_synthesis_canary(
-                channel=channel,
-                baseline_response=batch_baseline_response,
-                prompt=batch_baseline_prompt,
-                prompt_source_bases=batch_baseline_source_bases,
-                basis=batch_shared_brain_synthesis_basis,
-                user_id=first_uid,
-                guild_id=guild_id,
-                user_display_name=(
-                    collapsed_items[-1][0] if collapsed_items else ""
-                ),
-                source_context_available=batch_source_context_available,
+        batch_synthesis_execution = None
+        if batch_ordinary_chat_execution is None:
+            batch_synthesis_execution = (
+                await maybe_generate_shared_brain_synthesis_canary(
+                    channel=channel,
+                    baseline_response=batch_baseline_response,
+                    prompt=batch_baseline_prompt,
+                    prompt_source_bases=batch_baseline_source_bases,
+                    basis=batch_shared_brain_synthesis_basis,
+                    user_id=first_uid,
+                    guild_id=guild_id,
+                    user_display_name=(
+                        collapsed_items[-1][0]
+                        if collapsed_items
+                        else ""
+                    ),
+                    source_context_available=(
+                        batch_source_context_available
+                    ),
+                )
+                if not batch_source_context_available
+                else None
             )
-            if not batch_source_context_available
-            else None
-        )
         batch_synthesis_decision = (
-            batch_synthesis_execution.decision
+            batch_ordinary_chat_execution.decision
+            if batch_ordinary_chat_execution is not None
+            else batch_synthesis_execution.decision
             if batch_synthesis_execution is not None
             else None
         )
         batch_synthesis_candidate_active = bool(
-            batch_synthesis_execution is not None
+            batch_ordinary_chat_execution.candidate_active
+            if batch_ordinary_chat_execution is not None
+            else batch_synthesis_execution is not None
             and batch_synthesis_execution.candidate_active
         )
-        if batch_synthesis_execution is not None:
+        if batch_single_packet_cutover:
+            response = batch_ordinary_chat_execution.response
+            prompt = batch_ordinary_chat_execution.prompt
+            batch_prompt_source_bases = list(
+                batch_ordinary_chat_execution.prompt_source_bases
+            )
+        elif batch_synthesis_execution is not None:
             response = batch_synthesis_execution.response
             prompt = batch_synthesis_execution.prompt
             batch_prompt_source_bases = list(
                 batch_synthesis_execution.prompt_source_bases
             )
         batch_canary_guard_fallback_triggered = False
-        archive_guard_triggered = bool(_contains_unsupported_source_authority_claim(response or ""))
-        response, guard_diagnostics = await apply_guarded_response_regeneration(
-            response or "",
-            prompt=prompt,
-            user_id=first_uid,
-            guild_id=guild_id,
-            route_mode=ROUTE_MODE_NORMAL_CHAT,
-            channel_policy=channel_policy,
-            directness=batch_directness,
-            user_display_name=collapsed_items[-1][0] if collapsed_items else "",
-            current_user_text=combined_text,
-            has_media=bool(active_packet.get("media_present", False)),
-            is_reply=False,
-            generation_route=generation_route if 'generation_route' in locals() else "get_gemini_response",
-            channel=channel,
-            source_context_available=batch_source_context_available,
-            batch_generation_id=local_generation_id,
-            conversation_continuity_required=batch_continuity_required,
-            community_visual_basis=community_visual_basis,
-            exact_quote_requested=(
-                batch_attribution_contract.exact_quote_requested
-            ),
-            exact_quote_authority=(
-                batch_attribution_contract.exact_quote_authority
-            ),
-            third_party_attribution_requested=(
-                batch_attribution_contract.third_party_attribution_requested
-            ),
-            prompt_source_bases=tuple(batch_prompt_source_bases),
-            regeneration_allowed=not batch_synthesis_candidate_active,
-            situation_frame=(
-                orchestration_state["decision"].situation_frame
-            ),
+        batch_response_source_context_available = bool(
+            batch_source_context_available or batch_single_packet_cutover
         )
+        archive_guard_triggered = bool(
+            not batch_response_source_context_available
+            and _contains_unsupported_source_authority_claim(
+                response or ""
+            )
+        )
+        batch_single_packet_selected_response = (
+            str(response or "") if batch_single_packet_cutover else ""
+        )
+        batch_deterministic_single_packet_block = bool(
+            batch_single_packet_cutover
+            and batch_ordinary_chat_execution is not None
+            and not batch_synthesis_candidate_active
+            and batch_ordinary_chat_execution.provider_call_count == 0
+            and batch_ordinary_chat_execution.block_reason
+            and str(response or "")
+            == _ordinary_chat_single_packet_block_response(
+                batch_ordinary_chat_execution.block_reason
+            )
+        )
+        batch_typed_single_packet_candidate = bool(
+            batch_single_packet_cutover
+            and batch_synthesis_candidate_active
+            and batch_synthesis_decision is not None
+            and str(
+                getattr(
+                    batch_synthesis_decision,
+                    "typed_contract_status",
+                    "",
+                )
+                or ""
+            )
+            == "valid"
+        )
+        if batch_deterministic_single_packet_block:
+            guard_diagnostics = {
+                "suppressed": False,
+                "deterministic_single_packet_block": True,
+                "_revalidated_prompt_source_bases": tuple(
+                    batch_prompt_source_bases
+                ),
+            }
+        elif batch_typed_single_packet_candidate:
+            guard_diagnostics = {
+                "suppressed": False,
+                "typed_single_packet_selection_boundary": True,
+                "_revalidated_prompt_source_bases": tuple(
+                    batch_prompt_source_bases
+                ),
+            }
+        else:
+            response, guard_diagnostics = (
+                await apply_guarded_response_regeneration(
+                    response or "",
+                    prompt=prompt,
+                    user_id=first_uid,
+                    guild_id=guild_id,
+                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy=channel_policy,
+                    directness=batch_directness,
+                    user_display_name=(
+                        collapsed_items[-1][0]
+                        if collapsed_items
+                        else ""
+                    ),
+                    current_user_text=combined_text,
+                    has_media=bool(
+                        active_packet.get("media_present", False)
+                    ),
+                    is_reply=False,
+                    generation_route=(
+                        generation_route
+                        if "generation_route" in locals()
+                        else "get_gemini_response"
+                    ),
+                    channel=channel,
+                    source_context_available=(
+                        batch_response_source_context_available
+                    ),
+                    batch_generation_id=local_generation_id,
+                    conversation_continuity_required=(
+                        batch_continuity_required
+                    ),
+                    community_visual_basis=community_visual_basis,
+                    exact_quote_requested=(
+                        batch_attribution_contract.exact_quote_requested
+                    ),
+                    exact_quote_authority=(
+                        batch_attribution_contract.exact_quote_authority
+                    ),
+                    third_party_attribution_requested=(
+                        batch_attribution_contract
+                        .third_party_attribution_requested
+                    ),
+                    prompt_source_bases=tuple(
+                        batch_prompt_source_bases
+                    ),
+                    regeneration_allowed=bool(
+                        not batch_synthesis_candidate_active
+                        and not batch_single_packet_cutover
+                    ),
+                    situation_frame=(
+                        orchestration_state["decision"].situation_frame
+                    ),
+                )
+            )
         if (
-            batch_synthesis_candidate_active
+            batch_single_packet_cutover
+            and batch_synthesis_candidate_active
+            and batch_synthesis_decision is not None
+            and (
+                guard_diagnostics.get("suppressed")
+                or str(response or "")
+                != batch_single_packet_selected_response
+            )
+        ):
+            batch_single_packet_guard_reason = (
+                "single_packet_guard_suppressed"
+                if guard_diagnostics.get("suppressed")
+                else "single_packet_guard_modified_response"
+            )
+            batch_synthesis_decision = (
+                await safely_record_ordinary_chat_single_packet_block(
+                    batch_synthesis_decision,
+                    reason=batch_single_packet_guard_reason,
+                )
+                or batch_synthesis_decision
+            )
+            if not guard_diagnostics.get("suppressed"):
+                guard_diagnostics.update(
+                    {
+                        "suppressed": True,
+                        "suppression_reason": (
+                            batch_single_packet_guard_reason
+                        ),
+                    }
+                )
+            response = recover_guarded_response_obligation(
+                response,
+                baseline_response=batch_baseline_response,
+                prompt=prompt,
+                current_user_text=combined_text,
+                diagnostics=guard_diagnostics,
+                route_mode=ROUTE_MODE_NORMAL_CHAT,
+                channel_policy=channel_policy,
+                source_context_available=(
+                    batch_response_source_context_available
+                ),
+                exact_quote_requested=(
+                    batch_attribution_contract.exact_quote_requested
+                ),
+                exact_quote_authority=(
+                    batch_attribution_contract.exact_quote_authority
+                ),
+                third_party_attribution_requested=(
+                    batch_attribution_contract
+                    .third_party_attribution_requested
+                ),
+            )
+            batch_synthesis_candidate_active = False
+            if guard_diagnostics.get("source_neutral_recovery"):
+                batch_prompt_source_bases = []
+        if (
+            not batch_single_packet_cutover
+            and batch_synthesis_candidate_active
             and batch_synthesis_decision is not None
         ):
             batch_fallback_reason = ""
@@ -36772,18 +37236,33 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             _channel_preempted_generation_id[channel_id] = 0
             _channel_message_interrupt_generation_id[channel_id] = 0
             if batch_synthesis_decision is not None:
-                batch_synthesis_decision = (
-                    await safely_fallback_shared_brain_synthesis(
-                        batch_synthesis_decision,
-                        "stale_after_batch_candidate_guard",
+                if batch_single_packet_cutover:
+                    batch_synthesis_decision = (
+                        await safely_record_ordinary_chat_single_packet_block(
+                            batch_synthesis_decision,
+                            reason=(
+                                "stale_after_batch_single_packet_guard"
+                            ),
+                        )
+                        or batch_synthesis_decision
                     )
-                )
+                else:
+                    batch_synthesis_decision = (
+                        await safely_fallback_shared_brain_synthesis(
+                            batch_synthesis_decision,
+                            "stale_after_batch_candidate_guard",
+                        )
+                    )
                 await safely_finalize_shared_brain_synthesis(
                     batch_synthesis_decision,
-                    final_response=batch_baseline_response,
+                    final_response=response,
                     response_sent=False,
                     candidate_live=False,
-                    guard_status="stale_after_batch_candidate_guard",
+                    guard_status=(
+                        "stale_after_batch_single_packet_guard"
+                        if batch_single_packet_cutover
+                        else "stale_after_batch_candidate_guard"
+                    ),
                 )
             return
         if guard_diagnostics.get("suppressed"):
@@ -36838,6 +37317,20 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     presend_quote_failure,
                     channel_id,
                 )
+                if (
+                    batch_single_packet_cutover
+                    and batch_synthesis_decision is not None
+                ):
+                    batch_synthesis_decision = (
+                        await safely_record_ordinary_chat_single_packet_block(
+                            batch_synthesis_decision,
+                            reason=(
+                                "single_packet_exact_quote_%s"
+                                % presend_quote_failure
+                            ),
+                        )
+                        or batch_synthesis_decision
+                    )
                 guard_diagnostics.update(
                     {
                         "suppressed": True,
@@ -36855,7 +37348,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     route_mode=ROUTE_MODE_NORMAL_CHAT,
                     channel_policy=channel_policy,
                     source_context_available=(
-                        batch_source_context_available
+                        batch_response_source_context_available
                     ),
                     exact_quote_requested=(
                         batch_attribution_contract.exact_quote_requested
@@ -36871,8 +37364,54 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
         batch_source_failure = prompt_source_basis_failure(
             batch_presend_source_bases
         )
+        if batch_source_failure and batch_single_packet_cutover:
+            if batch_synthesis_decision is not None:
+                batch_synthesis_decision = (
+                    await safely_record_ordinary_chat_single_packet_block(
+                        batch_synthesis_decision,
+                        reason=(
+                            "single_packet_presend_%s"
+                            % batch_source_failure
+                        ),
+                        source_revalidation_status=(
+                            batch_source_failure
+                        ),
+                    )
+                    or batch_synthesis_decision
+                )
+            guard_diagnostics.update(
+                {
+                    "suppressed": True,
+                    "suppression_reason": batch_source_failure,
+                    "prompt_source_basis_changed": True,
+                }
+            )
+            response = recover_guarded_response_obligation(
+                response,
+                baseline_response=batch_baseline_response,
+                prompt=prompt,
+                current_user_text=combined_text,
+                diagnostics=guard_diagnostics,
+                route_mode=ROUTE_MODE_NORMAL_CHAT,
+                channel_policy=channel_policy,
+                source_context_available=(
+                    batch_response_source_context_available
+                ),
+                exact_quote_requested=(
+                    batch_attribution_contract.exact_quote_requested
+                ),
+                exact_quote_authority=None,
+                third_party_attribution_requested=(
+                    batch_attribution_contract
+                    .third_party_attribution_requested
+                ),
+            )
+            batch_presend_source_bases = ()
+            batch_synthesis_candidate_active = False
+            batch_source_failure = ""
         if (
             batch_source_failure
+            and not batch_single_packet_cutover
             and batch_synthesis_candidate_active
             and batch_synthesis_decision is not None
         ):
@@ -37040,7 +37579,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 diagnostics=guard_diagnostics,
                 route_mode=ROUTE_MODE_NORMAL_CHAT,
                 channel_policy=channel_policy,
-                source_context_available=batch_source_context_available,
+                source_context_available=(
+                    batch_response_source_context_available
+                ),
                 exact_quote_requested=(
                     batch_attribution_contract.exact_quote_requested
                 ),
@@ -37054,6 +37595,16 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             batch_synthesis_candidate_active = False
         batch_frame = orchestration_state["decision"].situation_frame
         if isinstance(batch_frame, SituationFrameV1):
+            batch_packet_basis = getattr(
+                getattr(batch_synthesis_decision, "run", None),
+                "basis",
+                None,
+            )
+            batch_packet = getattr(batch_packet_basis, "packet", None)
+            batch_packet_snapshot_digest = str(
+                getattr(batch_packet, "source_snapshot_digest", "")
+                or ""
+            )
             batch_frame_revalidation = revalidate_situation_frame(
                 batch_frame,
                 current_text=combined_text,
@@ -37065,6 +37616,11 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     )
                 ),
                 channel_policy=channel_policy,
+                packet_source_snapshot_digest=(
+                    batch_packet_snapshot_digest
+                    if batch_single_packet_cutover
+                    else ""
+                ),
             )
             guard_diagnostics.update(
                 {
@@ -37088,6 +37644,75 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 batch_frame_revalidation.status,
                 len(batch_frame_revalidation.reason_codes),
             )
+            batch_single_packet_block_reason = str(
+                batch_ordinary_chat_execution.block_reason
+                if batch_ordinary_chat_execution is not None
+                else ""
+            ).lower()
+            batch_deterministic_frame_clarification = bool(
+                batch_deterministic_single_packet_block
+                and batch_frame_revalidation.status == "ambiguous"
+                and (
+                    "frame_ambiguous"
+                    in batch_single_packet_block_reason
+                    or "deterministic_task_clarify"
+                    in batch_single_packet_block_reason
+                )
+            )
+            if (
+                batch_single_packet_cutover
+                and batch_frame_revalidation.status != "valid"
+                and not batch_deterministic_frame_clarification
+            ):
+                if batch_synthesis_decision is not None:
+                    batch_synthesis_decision = (
+                        await safely_record_ordinary_chat_single_packet_block(
+                            batch_synthesis_decision,
+                            reason=(
+                                "single_packet_frame_%s"
+                                % batch_frame_revalidation.status
+                            ),
+                            frame_revalidation_status=(
+                                batch_frame_revalidation.status
+                            ),
+                        )
+                        or batch_synthesis_decision
+                    )
+                guard_diagnostics.update(
+                    {
+                        "suppressed": True,
+                        "suppression_reason": (
+                            "source_revalidation_frame_"
+                            + batch_frame_revalidation.status
+                        ),
+                    }
+                )
+                response = recover_guarded_response_obligation(
+                    response,
+                    baseline_response=batch_baseline_response,
+                    prompt=prompt,
+                    current_user_text=combined_text,
+                    diagnostics=guard_diagnostics,
+                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy=channel_policy,
+                    source_context_available=(
+                        batch_response_source_context_available
+                    ),
+                    exact_quote_requested=(
+                        batch_attribution_contract.exact_quote_requested
+                    ),
+                    exact_quote_authority=None,
+                    third_party_attribution_requested=(
+                        batch_attribution_contract
+                        .third_party_attribution_requested
+                    ),
+                )
+                batch_presend_source_bases = ()
+                batch_synthesis_candidate_active = False
+            if batch_deterministic_frame_clarification:
+                guard_diagnostics[
+                    "deterministic_frame_clarification"
+                ] = True
         _log_batch_event(
             logging.INFO,
             "response_send_commit_start",
@@ -37123,6 +37748,17 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             logging.info("response_send_succeeded route=%s channel_id=%s message_length=%s", generation_route if 'generation_route' in locals() else "get_gemini_response", channel_id, len(response or ""))
         except Exception as exc:
             logging.error("response_send_failed route=%s channel_id=%s discord_error_type=%s", generation_route if 'generation_route' in locals() else "get_gemini_response", channel_id, type(exc).__name__)
+            if (
+                batch_single_packet_cutover
+                and batch_synthesis_decision is not None
+            ):
+                batch_synthesis_decision = (
+                    await safely_record_ordinary_chat_single_packet_block(
+                        batch_synthesis_decision,
+                        reason="single_packet_discord_send_failed",
+                    )
+                    or batch_synthesis_decision
+                )
             await safely_finalize_shared_brain_synthesis(
                 batch_synthesis_decision,
                 final_response=response,
@@ -37153,6 +37789,13 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             guard_status=(
                 "batch_guard_recovery_sent"
                 if guard_diagnostics.get("response_obligation_recovered")
+                else "batch_single_packet_candidate_sent"
+                if (
+                    batch_single_packet_cutover
+                    and batch_synthesis_candidate_active
+                )
+                else "batch_single_packet_deterministic_block_sent"
+                if batch_single_packet_cutover
                 else "batch_candidate_sent"
                 if batch_synthesis_candidate_active
                 else "batch_established_path_sent"

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -4996,6 +4996,14 @@ def _filter_frame_applicable_candidates(
         str(request.frame_subject_requirement or "").strip().lower()
         == "required"
     )
+    unscoped_conversation_task = any(
+        str(task.authority_scope or "").strip().lower() == "packet"
+        and str(task.subject_requirement or "").strip().lower()
+        != "required"
+        and str(task.object_kind or "unknown").strip().lower()
+        in {"unknown", "multiple"}
+        for task in request.frame_tasks
+    )
     accepted_subject_keys = {
         value
         for value in (
@@ -5031,6 +5039,10 @@ def _filter_frame_applicable_candidates(
             subject_required
             and item.lane in subject_scoped_lanes
             and item.subject_key not in accepted_subject_keys
+            and not (
+                item.lane == "conversation_context"
+                and unscoped_conversation_task
+            )
         ):
             exclude(item, "frame_subject_mismatch")
             continue

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -378,8 +378,14 @@ _BNL_SELF_SUBJECT_CUE_RE = re.compile(
 )
 _TASK_LEAD_RE = re.compile(
     r"(?:what|which|who|where|when|why|how|tell|explain|summari[sz]e|"
-    r"compare(?:s|d)?|describe|give|show|help|check|find|is|are|do|does|did|can|"
-    r"could|would|should)\b",
+    r"restate|repeat|recap|paraphrase|recommend|suggest|list|"
+    r"compare(?:s|d)?|describe|give|show|help|check|find|choose|try|test|"
+    r"is|are|do|does|did|can|could|would|should)\b",
+    re.I,
+)
+_TASK_SEGMENT_START_RE = re.compile(
+    r"^(?:(?:briefly|please|quickly|first)\s+)*(?:%s)"
+    % _TASK_LEAD_RE.pattern,
     re.I,
 )
 _VOLATILE_EXTERNAL_RE = re.compile(
@@ -416,6 +422,49 @@ _CURRENT_REQUEST_TASK_RE = re.compile(
     r"do\s+you\s+(?:like|prefer|want)|can\s+you\s+(?:help|write|make|"
     r"create|explain)|please\s+(?:help|write|make|create)|"
     r"thank\s+you|thanks|hello|hey)\b",
+    re.I,
+)
+_CURRENT_REQUEST_ADVICE_RE = re.compile(
+    r"\b(?:"
+    r"what|which|how)\b.{0,80}\b(?:should|could)\s+(?:i|we)\b|"
+    r"\b(?:what|which)\s+(?:would\s+you\s+)?(?:recommend|suggest)\b|"
+    r"\b(?:recommend|suggest)\s+(?:a|an|the|what|which|how)\b",
+    re.I,
+)
+_CURRENT_REQUEST_TRANSFORM_RE = re.compile(
+    r"\b(?:restate|repeat|recap|paraphrase|summari[sz]e|list)\b",
+    re.I,
+)
+_CURRENT_REQUEST_TRANSFORM_CONTEXT_RE = re.compile(
+    r"\b(?:this|that|these|those|above|following|chosen|selected|"
+    r"open\s+question|settings?|options?|what\s+(?:i|we|you)\s+"
+    r"(?:just\s+)?(?:said|gave|provided|chose|selected|decided))\b",
+    re.I,
+)
+_SENSITIVE_DISCLOSURE_REQUEST_RE = re.compile(
+    r"\b(?:reveal|share|disclose|expose|provide|give|tell|show)\b"
+    r".{0,140}\b(?:private|sensitive|secret|credential|password|token|"
+    r"api\s*key|account[-\s]?identifier|owner[-\s]?control|"
+    r"infrastructure[-\s]?access|admin(?:istrator)?\s+access|"
+    r"operator\s+access|private\s+identity)\b|"
+    r"\b(?:private|sensitive|secret|credential|password|token|"
+    r"api\s*key|account[-\s]?identifier|owner[-\s]?control|"
+    r"infrastructure[-\s]?access|admin(?:istrator)?\s+access|"
+    r"operator\s+access|private\s+identity)\b"
+    r".{0,140}\b(?:reveal|share|disclose|expose|provide|give|tell|show)\b",
+    re.I,
+)
+_CONVERSATION_CONTEXT_TASK_RE = re.compile(
+    r"\b(?:what|which|why|how)(?:\s+[a-z0-9'’-]+){0,8}\s+did\s+"
+    r"(?:i|you|we)\s+(?:say|tell|give|ask|mean|call|choose|select|"
+    r"decide|prefer|agree|set|pick)\b|"
+    r"\b(?:i|you|we)\s+(?:said|told|gave|asked|meant|called|chose|"
+    r"selected|decided|preferred|agreed|set|picked)\b",
+    re.I,
+)
+_CANON_SINGULAR_DEICTIC_RE = re.compile(
+    r"\b(?:he|him|his|she|her|hers|that\s+(?:person|member|"
+    r"character|entity))\b",
     re.I,
 )
 _PACKET_AUTHORITY_OBJECTS = frozenset(
@@ -611,19 +660,35 @@ def _situation_task_segments(text: str) -> Tuple[str, ...]:
     if not value:
         return ()
     value = re.sub(
-        r"[?!]+\s+(?=%s)" % _TASK_LEAD_RE.pattern,
+        r"[?!.]+\s+(?=(?:(?:briefly|please|quickly|first)\s+)*%s)"
+        % _TASK_LEAD_RE.pattern,
         "\n",
         value,
         flags=re.I,
     )
     value = re.sub(
-        r",?\s+(?:and|also|plus|then)\s+(?=%s)" % _TASK_LEAD_RE.pattern,
+        r",?\s+(?:and|also|plus|then)\s+"
+        r"(?=(?:(?:briefly|please|quickly|first)\s+)*%s)"
+        % _TASK_LEAD_RE.pattern,
+        "\n",
+        value,
+        flags=re.I,
+    )
+    value = re.sub(
+        r",\s+(?=(?:(?:briefly|please|quickly|first)\s+)*%s)"
+        % _TASK_LEAD_RE.pattern,
         "\n",
         value,
         flags=re.I,
     )
     parts = tuple(part.strip(" ,;.!?") for part in value.split("\n"))
-    return tuple(part for part in parts if part) or (str(text or ""),)
+    parts = tuple(part for part in parts if part)
+    explicit_tasks = tuple(
+        part for part in parts if _TASK_SEGMENT_START_RE.search(part)
+    )
+    if explicit_tasks and len(parts) > 1:
+        return explicit_tasks
+    return parts or (str(text or ""),)
 
 
 def _task_subject_indexes(
@@ -692,6 +757,7 @@ def _situation_tasks(
     exact_reply_resolved: bool = False,
 ) -> Tuple[SituationTaskReference, ...]:
     tasks = []
+    prior_unique_subject_index = None
     for index, segment in enumerate(_situation_task_segments(text), start=1):
         phase = _situation_phase(segment)
         object_kind = _situation_object(segment)
@@ -713,6 +779,15 @@ def _situation_tasks(
             objective_kind=objective_kind,
         )
         subject_indexes = _task_subject_indexes(segment, subjects)
+        singular_deictic = bool(
+            _CANON_SINGULAR_DEICTIC_RE.search(segment or "")
+        )
+        if singular_deictic and prior_unique_subject_index is not None:
+            subject_indexes = tuple(
+                dict.fromkeys(
+                    (prior_unique_subject_index, *subject_indexes)
+                )
+            )
         if (
             exact_reply_resolved
             and _EXACT_REPLY_DEICTIC_SUBJECT_RE.search(segment)
@@ -737,16 +812,37 @@ def _situation_tasks(
                 and not external_role_query
             )
             or (object_kind == "person" and not external_role_query)
+            or (singular_deictic and subjects)
         )
         subject_requirement = (
             "required" if subject_indexes or subject_cue else "not_applicable"
         )
-        if subject_requirement == "required" or (
+        sensitive_disclosure_request = bool(
+            _SENSITIVE_DISCLOSURE_REQUEST_RE.search(segment)
+        )
+        current_request = bool(
+            _CURRENT_REQUEST_TASK_RE.search(segment)
+            or _CURRENT_REQUEST_ADVICE_RE.search(segment)
+            or (
+                _CURRENT_REQUEST_TRANSFORM_RE.search(segment)
+                and _CURRENT_REQUEST_TRANSFORM_CONTEXT_RE.search(segment)
+            )
+        )
+        conversation_context_task = bool(
+            _CONVERSATION_CONTEXT_TASK_RE.search(segment)
+        )
+        if sensitive_disclosure_request:
+            authority_scope = "current_request"
+            subject_requirement = "not_applicable"
+            subject_indexes = ()
+        elif subject_requirement == "required" or (
             object_kind in _PACKET_AUTHORITY_OBJECTS
             and not external_role_query
         ):
             authority_scope = "packet"
-        elif _CURRENT_REQUEST_TASK_RE.search(segment):
+        elif conversation_context_task:
+            authority_scope = "packet"
+        elif current_request:
             authority_scope = "current_request"
         elif (
             exact_reply_resolved
@@ -780,6 +876,10 @@ def _situation_tasks(
                 subject_indexes=subject_indexes,
             )
         )
+        if len(subject_indexes) == 1:
+            prior_unique_subject_index = subject_indexes[0]
+        elif subject_indexes:
+            prior_unique_subject_index = None
     return tuple(tasks)
 
 

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -3138,6 +3138,327 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(checked_bases, [(refreshed_basis,)])
 
+    async def test_plain_name_batch_uses_ordinary_single_packet_cutover(self):
+        channel = self._channel(8132)
+        basis = object()
+        packet = object()
+        assessment = object()
+        decision = SimpleNamespace(
+            candidate_selected=True,
+            typed_contract_status="valid",
+        )
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=decision,
+            response="Cache Back is BARCODE's archive specialist.",
+            prompt="packet-owned prompt",
+            prompt_source_bases=(basis,),
+            candidate_active=True,
+            provider_call_count=1,
+            corrective_call_count=0,
+        )
+        ordinary_generation = mock.AsyncMock(return_value=execution)
+        shared_generation = mock.AsyncMock()
+        shared_basis = mock.Mock(return_value=object())
+        finalize = mock.AsyncMock(return_value=decision)
+
+        def build_assessment(*_args, **kwargs):
+            kwargs["intelligence_packet_out"]["packet"] = packet
+            return assessment
+
+        async def legacy_generation(*_args, **_kwargs):
+            raise AssertionError(
+                "plain-name batch must not call the established provider "
+                "before the ordinary single-packet route"
+            )
+
+        self._prime_flush(channel, "BNL, who is Cache Back?")
+        with (
+            self._flush_runtime(channel.id, legacy_generation),
+            mock.patch.object(
+                bnl01_bot,
+                "ordinary_chat_route_scope_decision",
+                return_value=SimpleNamespace(eligible=True, reason="canary"),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_unified_response_assessment_shadow",
+                side_effect=build_assessment,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_ordinary_chat_basis",
+                return_value=basis,
+            ) as ordinary_basis,
+            mock.patch.object(
+                bnl01_bot,
+                "build_shared_brain_synthesis_basis",
+                new=shared_basis,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_ordinary_chat_single_packet",
+                new=ordinary_generation,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_shared_brain_synthesis_canary",
+                new=shared_generation,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "safely_finalize_shared_brain_synthesis",
+                new=finalize,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "prompt_source_basis_failure",
+                return_value="",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "record_unified_response_assessment_shadow_after_send",
+                new=mock.AsyncMock(),
+            ),
+        ):
+            await bnl01_bot._flush_channel_buffer(channel)
+
+        ordinary_basis.assert_called_once()
+        ordinary_generation.assert_awaited_once()
+        shared_basis.assert_not_called()
+        shared_generation.assert_not_awaited()
+        self.assertEqual(
+            channel.sent,
+            ["Cache Back is BARCODE's archive specialist."],
+        )
+        finalize.assert_awaited_once()
+        self.assertTrue(finalize.await_args.kwargs["response_sent"])
+        self.assertTrue(finalize.await_args.kwargs["candidate_live"])
+        self.assertEqual(
+            finalize.await_args.kwargs["guard_status"],
+            "batch_single_packet_candidate_sent",
+        )
+
+    async def test_late_fragment_stales_batch_single_packet_without_second_call(
+        self,
+    ):
+        channel = self._channel(8133)
+        basis = object()
+        packet = object()
+        assessment = object()
+        decision = SimpleNamespace(
+            candidate_selected=True,
+            typed_contract_status="valid",
+        )
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=decision,
+            response="Cache Back is BARCODE's archive specialist.",
+            prompt="packet-owned prompt",
+            prompt_source_bases=(basis,),
+            candidate_active=True,
+            provider_call_count=1,
+            corrective_call_count=0,
+        )
+        finalize = mock.AsyncMock(return_value=True)
+        block = mock.AsyncMock(return_value=decision)
+
+        def build_assessment(*_args, **kwargs):
+            kwargs["intelligence_packet_out"]["packet"] = packet
+            return assessment
+
+        async def ordinary_generation(**_kwargs):
+            self._append(
+                channel,
+                "And which BARCODE member handles signal recovery?",
+            )
+            return execution
+
+        async def legacy_generation(*_args, **_kwargs):
+            raise AssertionError(
+                "stale single-packet work must be handed off, not regenerated "
+                "through the legacy provider"
+            )
+
+        self._prime_flush(channel, "BNL, who is Cache Back?")
+        with (
+            self._flush_runtime(channel.id, legacy_generation),
+            mock.patch.object(
+                bnl01_bot,
+                "ordinary_chat_route_scope_decision",
+                return_value=SimpleNamespace(
+                    eligible=True,
+                    reason="canary",
+                ),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_unified_response_assessment_shadow",
+                side_effect=build_assessment,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_ordinary_chat_basis",
+                return_value=basis,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_shared_brain_synthesis_basis",
+            ) as shared_basis,
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_ordinary_chat_single_packet",
+                new=mock.AsyncMock(side_effect=ordinary_generation),
+            ) as ordinary,
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_shared_brain_synthesis_canary",
+                new=mock.AsyncMock(),
+            ) as shared_generation,
+            mock.patch.object(
+                bnl01_bot,
+                "safely_record_ordinary_chat_single_packet_block",
+                new=block,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "safely_finalize_shared_brain_synthesis",
+                new=finalize,
+            ),
+        ):
+            await bnl01_bot._flush_channel_buffer(channel)
+
+        ordinary.assert_awaited_once()
+        shared_basis.assert_not_called()
+        shared_generation.assert_not_awaited()
+        self.assertEqual(channel.sent, [])
+        self.assertEqual(
+            len(bnl01_bot._channel_interrupt_handoff[channel.id]),
+            2,
+        )
+        block.assert_awaited_once_with(
+            decision,
+            reason="stale_after_batch_single_packet_generation",
+        )
+        finalize.assert_awaited_once()
+        self.assertFalse(finalize.await_args.kwargs["response_sent"])
+        self.assertFalse(finalize.await_args.kwargs["candidate_live"])
+        self.assertEqual(
+            finalize.await_args.kwargs["guard_status"],
+            "stale_after_batch_single_packet_generation",
+        )
+
+    async def test_batch_single_packet_send_failure_never_marks_candidate_live(
+        self,
+    ):
+        channel = self._channel(8134)
+        basis = object()
+        packet = object()
+        assessment = object()
+        decision = SimpleNamespace(
+            candidate_selected=True,
+            typed_contract_status="valid",
+        )
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=decision,
+            response="Cache Back is BARCODE's archive specialist.",
+            prompt="packet-owned prompt",
+            prompt_source_bases=(basis,),
+            candidate_active=True,
+            provider_call_count=1,
+            corrective_call_count=0,
+        )
+        ordinary = mock.AsyncMock(return_value=execution)
+        finalize = mock.AsyncMock(return_value=True)
+        block = mock.AsyncMock(return_value=decision)
+
+        def build_assessment(*_args, **kwargs):
+            kwargs["intelligence_packet_out"]["packet"] = packet
+            return assessment
+
+        async def legacy_generation(*_args, **_kwargs):
+            raise AssertionError(
+                "single-packet send failure must not invoke the legacy provider"
+            )
+
+        self._prime_flush(channel, "BNL, who is Cache Back?")
+        with (
+            self._flush_runtime(channel.id, legacy_generation),
+            mock.patch.object(
+                channel,
+                "send",
+                new=mock.AsyncMock(
+                    side_effect=RuntimeError("discord unavailable")
+                ),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "ordinary_chat_route_scope_decision",
+                return_value=SimpleNamespace(
+                    eligible=True,
+                    reason="canary",
+                ),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_unified_response_assessment_shadow",
+                side_effect=build_assessment,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_ordinary_chat_basis",
+                return_value=basis,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_shared_brain_synthesis_basis",
+            ) as shared_basis,
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_ordinary_chat_single_packet",
+                new=ordinary,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_shared_brain_synthesis_canary",
+                new=mock.AsyncMock(),
+            ) as shared_generation,
+            mock.patch.object(
+                bnl01_bot,
+                "prompt_source_basis_failure",
+                return_value="",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "safely_record_ordinary_chat_single_packet_block",
+                new=block,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "safely_finalize_shared_brain_synthesis",
+                new=finalize,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "record_unified_response_assessment_shadow_after_send",
+                new=mock.AsyncMock(),
+            ),
+        ):
+            await bnl01_bot._flush_channel_buffer(channel)
+
+        ordinary.assert_awaited_once()
+        shared_basis.assert_not_called()
+        shared_generation.assert_not_awaited()
+        block.assert_awaited_once_with(
+            decision,
+            reason="single_packet_discord_send_failed",
+        )
+        finalize.assert_awaited_once()
+        self.assertFalse(finalize.await_args.kwargs["response_sent"])
+        self.assertFalse(finalize.await_args.kwargs["candidate_live"])
+        self.assertEqual(
+            finalize.await_args.kwargs["guard_status"],
+            "batch_discord_send_failed",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ordinary_chat_acceptance_contract_matrix.py
+++ b/tests/test_ordinary_chat_acceptance_contract_matrix.py
@@ -44,6 +44,105 @@ def _frame(text):
 
 
 class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
+    def test_live_current_turn_requests_keep_current_request_authority(self):
+        cases = (
+            (
+                "violet_lantern_advice",
+                "We are starting a sealed continuity test called Violet "
+                "Lantern. The goal is to calibrate a fictional beacon, and "
+                "the open question is whether its pulse should be slow or "
+                "fast. What should we test first?",
+            ),
+            (
+                "amber_compass_restate",
+                "We are starting a sealed continuity test called Amber "
+                "Compass. The signal color is amber, and we have chosen a "
+                "slow pulse. The only open question is whether the beam "
+                "should be narrow or wide. Briefly restate the chosen "
+                "settings and the open question.",
+            ),
+            (
+                "privacy_refusal",
+                "What private owner-control, account-identifier, or "
+                "infrastructure-access information can you reveal about "
+                "6 Bit?",
+            ),
+        )
+
+        for name, text in cases:
+            with self.subTest(name=name):
+                frame = _frame(text)
+                self.assertEqual(frame.status, "resolved")
+                self.assertEqual(len(frame.tasks), 1)
+                self.assertEqual(
+                    frame.tasks[0].authority_scope,
+                    "current_request",
+                )
+                self.assertEqual(
+                    frame.tasks[0].required_response_act,
+                    "answer",
+                )
+
+    def test_live_compound_pronouns_bind_per_task_without_authority_escape(self):
+        frame = _frame(
+            "Who is Cache Back, how did he come to be, and how is he "
+            "different from Call'em Bini?"
+        )
+        subject_keys = tuple(
+            subject.entity_ref for subject in frame.subjects
+        )
+        task_subjects = tuple(
+            tuple(subject_keys[index] for index in task.subject_indexes)
+            for task in frame.tasks
+        )
+
+        self.assertEqual(frame.status, "resolved")
+        self.assertEqual(
+            tuple(task.authority_scope for task in frame.tasks),
+            ("packet", "packet", "packet"),
+        )
+        self.assertEqual(
+            task_subjects,
+            (
+                ("cache_back",),
+                ("cache_back",),
+                ("cache_back", "call_em_bini"),
+            ),
+        )
+
+    def test_named_singular_pronoun_ambiguity_requires_clarification(self):
+        frame = _frame(
+            "Mac Modem and Cache Back are both part of BARCODE. "
+            "What is his role in the Network?"
+        )
+
+        self.assertEqual(frame.status, "ambiguous")
+        self.assertEqual(
+            set(subject.entity_ref for subject in frame.subjects),
+            {"mac_modem", "cache_back"},
+        )
+        self.assertEqual(len(frame.tasks), 1)
+        self.assertEqual(frame.tasks[0].authority_scope, "packet")
+        self.assertEqual(frame.tasks[0].required_response_act, "clarify")
+        self.assertEqual(frame.tasks[0].subject_indexes, ())
+
+    def test_prior_conversation_choice_is_packet_owned_in_mixed_request(self):
+        frame = _frame(
+            "Who is Cache Back, and what beam width did we choose for "
+            "Amber Compass?"
+        )
+
+        self.assertEqual(frame.status, "resolved")
+        self.assertEqual(
+            tuple(task.authority_scope for task in frame.tasks),
+            ("packet", "packet"),
+        )
+        self.assertEqual(frame.tasks[0].subject_requirement, "required")
+        self.assertEqual(
+            frame.tasks[1].subject_requirement,
+            "not_applicable",
+        )
+
     def test_exact_name_seed_reply_chain_resolves_without_seed_facts(self):
         cases = (
             (
@@ -466,6 +565,43 @@ class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
         )
         self.assertEqual(frame.tasks[0].authority_scope, "packet")
         self.assertEqual(frame.tasks[0].subject_indexes, (0, 1))
+
+    def test_exact_bnl_reply_uses_repeated_grammatical_focus_for_pronoun(self):
+        reply_text = (
+            "Cache Back is BARCODE's archive specialist. He emerged when "
+            "a laptop cache containing Call'em Bini's project files was "
+            "cleared. Cache Back remains a distinct Network member."
+        )
+        context = bnl01_bot.ConversationContextResult(
+            rendered_context=(
+                "BNL-01 (exact Discord reply source): " + reply_text
+            ),
+            selected_row_ids=(77,),
+            same_room_paired_turn_count=0,
+            unpaired_row_count=1,
+            cross_channel_paired_turn_count=0,
+            current_message_duplicates_removed=0,
+            visibility_policy_exclusions=0,
+            selection_reasons=("discord_reply_source",),
+            final_char_count=len(reply_text),
+            referent_status="resolved",
+            referent_candidate_count=1,
+            referent_selected_row_ids=(77,),
+            referent_reason="discord_reply_source",
+        )
+
+        identity_subjects, identity_status = (
+            bnl01_bot._exact_reply_canon_subject_references(
+                context,
+                "What did he believe he was at first?",
+            )
+        )
+
+        self.assertEqual(identity_status, "resolved")
+        self.assertEqual(
+            identity_subjects,
+            (("cache_back", "Cache Back"),),
+        )
 
     def test_exact_bnl_reply_pronoun_identity_ambiguity_fails_closed(self):
         question = "How is he connected to Call'em Bini?"

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -976,6 +976,134 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertTrue(prompt.ready)
         self.assertIn("subjects=S1,S2", prompt.prompt)
 
+    def test_subject_task_does_not_evict_unscoped_conversation_task_evidence(self):
+        text = (
+            "Who is Cache Back, and what beam width did we choose for "
+            "Amber Compass?"
+        )
+        prior_text = (
+            "For Amber Compass, we chose a narrow beam and a slow pulse."
+        )
+        self.conn.execute(
+            """
+            INSERT INTO conversations(
+                id,guild_id,user_id,user_name,role,content,channel_id,
+                channel_policy,route_mode,timestamp
+            ) VALUES(902,1,7,'Test Member','user',?,10,
+                     'public_context','normal_chat',?)
+            """,
+            (prior_text, "2026-08-10T12:00:30+00:00"),
+        )
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            channel_policy="public_context",
+            current_text=text,
+            current_speaker_user_ids=(7,),
+            current_speaker_labels=("Test Member",),
+            addressee_kinds=("discord_mention",),
+            source_message_ids=(402,),
+            explicit_mention_count=1,
+            subject_entity_refs=("cache_back",),
+            subject_label_hints=("Cache Back",),
+            referent_status="resolved",
+            response_act="answer",
+            packet_revision="turn_mixed_subject_context_01",
+        )
+        request = IntelligencePacketRequest(
+            guild_id=1,
+            subject_user_id=0,
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            channel_id=10,
+            channel_name="bnl-testing",
+            channel_policy="public_context",
+            visibility_allowance="public_safe",
+            user_text=text,
+            participant_user_ids=(7,),
+            direct_state="direct",
+            budget_chars=5000,
+            conversation_evidence=(
+                PacketConversationEvidence(
+                    text=prior_text,
+                    source_id=902,
+                    speaker_user_id=7,
+                    speaker_label="Test Member",
+                ),
+                PacketConversationEvidence(
+                    text=text,
+                    speaker_user_id=7,
+                    speaker_label="Test Member",
+                    current_turn=True,
+                ),
+            ),
+            declared_canon_authorized=True,
+            frame_schema_version=frame.schema_version,
+            frame_revision=frame.frame_revision,
+            frame_input_evidence_digest=frame.input_evidence_digest,
+            frame_status=frame.status,
+            frame_subject_requirement=frame.subject_requirement,
+            frame_subjects=tuple(
+                PacketFrameSubject(
+                    user_id=subject.user_id,
+                    entity_ref=subject.entity_ref,
+                    label_hint=subject.label_hint,
+                    binding_method=subject.binding_method,
+                    confidence=subject.confidence,
+                    role_hints=subject.role_hints,
+                    domain_hints=subject.domain_hints,
+                )
+                for subject in frame.subjects
+            ),
+            frame_tasks=tuple(
+                PacketFrameTask(
+                    task_id=task.task_id,
+                    text_digest=task.text_digest,
+                    task_kind=task.task_kind,
+                    object_kind=task.object_kind,
+                    authority_scope=task.authority_scope,
+                    temporal_scope=task.temporal_scope,
+                    currentness=task.currentness,
+                    required_response_act=task.required_response_act,
+                    subject_requirement=task.subject_requirement,
+                    subject_indexes=task.subject_indexes,
+                )
+                for task in frame.tasks
+            ),
+            frame_role_hints=frame.role_hints,
+            frame_domain_hints=frame.domain_hints,
+            frame_event_ref=frame.event_ref,
+            frame_event_relation=frame.event_relation,
+            frame_task_kind=frame.task_kind,
+            frame_object_kind=frame.object_kind,
+            frame_phase=frame.phase,
+            frame_temporal_scope=frame.temporal_scope,
+            frame_currentness=frame.currentness,
+            now="2026-08-10T12:02:00+00:00",
+        )
+
+        packet = build_packet(
+            self.conn,
+            request,
+            persist=True,
+            environ=self.flags,
+        )
+
+        self.assertEqual(frame.status, "resolved")
+        self.assertEqual(
+            tuple(task.authority_scope for task in frame.tasks),
+            ("packet", "packet"),
+        )
+        self.assertTrue(
+            any(
+                item.lane == "conversation_context"
+                and "narrow beam" in item.text
+                for item in packet.items
+            )
+        )
+        self.assertEqual(packet.diagnostics.invalid_invariants, [])
+
     def test_multi_subject_render_reserves_evidence_for_each_subject(self):
         basis = self._multi_subject_basis(
             "Compare Cache Back and Mac Modem.",
@@ -1279,6 +1407,61 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                 answered,
             ).status,
             "current_fact_not_held",
+        )
+
+    def test_typed_current_request_uses_request_authority(self):
+        request_packet = replace(
+            self.packet,
+            request=replace(
+                self.packet.request,
+                subject_user_id=0,
+                subject_display_name="",
+                user_text="What should we test first?",
+                frame_subject_requirement="not_applicable",
+                frame_subjects=(),
+                frame_tasks=(
+                    PacketFrameTask(
+                        task_id="T1",
+                        text_digest="d" * 64,
+                        task_kind="answer",
+                        object_kind="unknown",
+                        authority_scope="current_request",
+                        temporal_scope="unspecified",
+                        currentness="unknown",
+                        required_response_act="answer",
+                        subject_requirement="not_applicable",
+                    ),
+                ),
+            ),
+            subject_resolution=PacketSubjectResolution(
+                status="not_applicable",
+                reason_codes=("subject_not_required",),
+            ),
+        )
+        request_basis = replace(self.basis, packet=request_packet)
+        valid = parse_ordinary_chat_response_contract(
+            '{"tasks":[{"taskId":"T1","text":"Test the slow pulse '
+            'first.","supportKind":"current_request","evidenceIds":'
+            '["REQUEST"]}]}'
+        )
+        wrong = parse_ordinary_chat_response_contract(
+            '{"tasks":[{"taskId":"T1","text":"Test the slow pulse '
+            'first.","supportKind":"external_public","evidenceIds":'
+            '["PUBLIC"]}]}'
+        )
+
+        self.assertTrue(
+            validate_ordinary_chat_response_contract(
+                request_basis,
+                valid,
+            ).valid
+        )
+        self.assertEqual(
+            validate_ordinary_chat_response_contract(
+                request_basis,
+                wrong,
+            ).status,
+            "request_support_invalid",
         )
 
     def test_receipt_is_content_free_and_counts_one_call(self):


### PR DESCRIPTION
## Summary

- routes simple ordinary-chat prompts through the existing single-packet shared-brain acceptance path, including plain-name questions, pronouns, restatements, advice, and privacy requests
- preserves specialist owners, production gates, public/private identity boundaries, and BNL's intended signal/glitch presentation behavior
- makes batched ordinary-chat handling consume the already-selected packet candidate instead of falling through to a second legacy provider path
- strengthens task-authority resolution, ambiguity handling, stale-candidate checks, and response/send receipts without adding another memory store, selector, brain, or authority layer

## Root cause

Simple natural requests were losing authority during route classification and batching. Structured or operational prompts happened to carry markers that reached the correct owner, while shorter prompts could bypass the packet candidate and enter legacy fallback behavior.

## Verification

- 107 focused ordinary-chat, batching, assessment, and canary tests passed
- full `make check` passed: compile verification plus 2,519 tests
- `git diff --check` passed
- GitHub tree exactly matches the locally tested commit tree (`ab1da24dd743075159afdc505412b328b7b536ff`)

## Deployment safety

This change does not alter `.env`, the bounded canary allowlists, or any global production authority gate. Deployment should retain the existing `ordinary_chat_single_packet_canary` scope and use the documented database-backup/restart verification sequence.