### PR TITLE
Repair ordinary-chat live acceptance seams

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -34729,16 +34729,19 @@ def _classify_batch_engagement(items, bot_user=None, pending_request_intent=Fals
 
     if multiline_payload_detected:
         return "answer", "single_message_multiline_request_payload"
-    if pending_request_intent and len(texts) == 1 and _is_single_payload_like_item(texts[0]):
-        return "answer", "pending_request_single_payload_continuation"
-    if pending_request_intent and _is_payload_like_cluster(items):
-        return "answer", "pending_request_payload_continuation"
+    # A complete current-turn request owns its own frame. A short-lived
+    # pending list anchor may collect otherwise unframed payload fragments,
+    # but it must not reinterpret the next self-contained question as payload.
     if question_like or request_like or bot_named:
         if request_intent:
             return "answer", f"request_intent:{request_reason}"
         if payload_expected:
             return "answer", f"request_payload_expected:{payload_reason}"
         return "answer", "question_request_or_addressed"
+    if pending_request_intent and len(texts) == 1 and _is_single_payload_like_item(texts[0]):
+        return "answer", "pending_request_single_payload_continuation"
+    if pending_request_intent and _is_payload_like_cluster(items):
+        return "answer", "pending_request_payload_continuation"
     if media_context_present:
         media_labels = []
         for t in texts:
@@ -34804,7 +34807,9 @@ def _detect_request_action(text: str):
 
 def _build_active_response_packet(channel_id: int, items, pending_state, pending_anchor=None, bot_user=None, *, guild_id: int = 0, channel_policy: str = "unknown", recent_bnl_reply_context: bool = False, consume_retransmission: bool = False):
     original_items = list(items or [])
-    payload_items = _collect_batch_request_payload_items(original_items, pending_state=bool(pending_state), pending_anchor=pending_anchor)
+    # First collect only payload structure present in this batch. Pending state
+    # is consulted after classification proves this is a continuation.
+    payload_items = _collect_batch_request_payload_items(original_items)
     collapsed_items = _collapse_consecutive_batch_fragments(original_items)
     combined_text = " ".join(
         (content or "") for (_name, content, _user_id) in original_items
@@ -34847,8 +34852,23 @@ def _build_active_response_packet(channel_id: int, items, pending_state, pending
     if repair_intent:
         decision, reason = "answer", "repair_intent_contextual_generation"
     is_single_payload_continuation = reason == "pending_request_single_payload_continuation"
+    pending_payload_continuation = reason in {
+        "pending_request_payload_continuation",
+        "pending_request_single_payload_continuation",
+    }
+    if pending_payload_continuation:
+        payload_items = _collect_batch_request_payload_items(
+            original_items,
+            pending_state=bool(pending_state),
+            pending_anchor=pending_anchor,
+        )
     has_request_payload = bool(payload_items)
-    if (not has_request_payload) and pending_request and decision == "answer":
+    if (
+        not has_request_payload
+        and pending_request
+        and pending_payload_continuation
+        and decision == "answer"
+    ):
         payload_items = [
             (content or "").strip()
             for (_name, content, _uid) in collapsed_items
@@ -35663,6 +35683,14 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 ),
             )
             orchestration_decision = orchestration_state["decision"]
+            batch_route_mode = str(
+                getattr(
+                    orchestration_decision.situation_frame,
+                    "route_mode",
+                    "",
+                )
+                or ROUTE_MODE_NORMAL_CHAT
+            )
             if orchestration_decision.influences_response:
                 if orchestration_decision.response_act in {"answer", "clarify"}:
                     decision = "answer"
@@ -35804,7 +35832,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 guild_id=guild_id,
                 user_id=first_uid,
                 channel_id=channel_id,
-                route_mode=ROUTE_MODE_NORMAL_CHAT,
+                route_mode=batch_route_mode,
                 channel_policy=channel_policy,
                 current_direct=batch_current_direct,
                 user_text=combined_text,
@@ -35908,7 +35936,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     source_safe_recall_synthesis_enabled(
                         guild_id=guild_id,
                         user_id=first_uid,
-                        route_mode=ROUTE_MODE_NORMAL_CHAT,
+                        route_mode=batch_route_mode,
                         channel_policy=channel_policy,
                         user_text=combined_text,
                         current_direct=bool(
@@ -35922,7 +35950,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 batch_memory_context = build_user_memory_context(
                     first_uid,
                     guild_id,
-                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    route_mode=batch_route_mode,
                     channel_policy=channel_policy,
                     user_text=combined_text,
                     is_owner_or_mod=batch_member_is_privileged,
@@ -35978,7 +36006,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     batch_memory_context,
                     user_id=first_uid,
                     guild_id=guild_id,
-                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    route_mode=batch_route_mode,
                     channel_policy=channel_policy,
                     user_text=combined_text,
                     is_owner_or_mod=batch_member_is_privileged,
@@ -36105,7 +36133,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 and unified_moment_canary_enabled(
                     guild_id=guild_id,
                     channel_id=channel_id,
-                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    route_mode=batch_route_mode,
                     channel_policy=channel_policy,
                 )
             )
@@ -36113,7 +36141,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             batch_unified_assessment = (
                 build_unified_response_assessment_shadow(
                     guild_id=guild_id,
-                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    route_mode=batch_route_mode,
                     channel_policy=channel_policy,
                     conversation_surface=(
                         conversation_surface_for_channel_policy(
@@ -36188,7 +36216,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     guild_id=guild_id,
                     channel_id=channel_id,
                     channel_policy=channel_policy,
-                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    route_mode=batch_route_mode,
                     topic_text=combined_text,
                     participant_user_ids=(
                         batch_unified_assessment.participant_user_ids
@@ -36211,7 +36239,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     guild_id=guild_id,
                     user_id=first_uid,
                     channel_id=channel_id,
-                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    route_mode=batch_route_mode,
                     channel_policy=channel_policy,
                     current_direct=batch_current_direct,
                     user_text=combined_text,
@@ -36233,7 +36261,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     guild_id=guild_id,
                     user_id=first_uid,
                     channel_id=channel_id,
-                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    route_mode=batch_route_mode,
                     channel_policy=channel_policy,
                     current_direct=bool(
                         active_packet.get("addressed_to_bot")
@@ -36277,7 +36305,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     source_safe_recall_synthesis_contract(
                         guild_id=guild_id,
                         user_id=first_uid,
-                        route_mode=ROUTE_MODE_NORMAL_CHAT,
+                        route_mode=batch_route_mode,
                         channel_policy=channel_policy,
                         user_text=combined_text,
                         current_direct=bool(
@@ -36380,7 +36408,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                         orchestration_state["decision"].situation_frame
                     ),
                     situation_frame_current_text=combined_text,
-                    route_mode=ROUTE_MODE_NORMAL_CHAT,
+                    route_mode=batch_route_mode,
                     channel_policy=channel_policy,
                     conversation_surface=(
                         conversation_surface_for_channel_policy(
@@ -36941,7 +36969,8 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             and batch_ordinary_chat_execution.block_reason
             and str(response or "")
             == _ordinary_chat_single_packet_block_response(
-                batch_ordinary_chat_execution.block_reason
+                batch_ordinary_chat_execution.block_reason,
+                orchestration_state["decision"].situation_frame,
             )
         )
         batch_typed_single_packet_candidate = bool(
@@ -41837,13 +41866,50 @@ class OrdinaryChatLegacyBaselineExecution:
     provider_call_count: int
 
 
-def _ordinary_chat_single_packet_block_response(reason: str) -> str:
+def _ordinary_chat_ambiguous_subject_labels(
+    situation_frame: SituationFrameV1 | None,
+) -> tuple[str, ...]:
+    if str(getattr(situation_frame, "status", "") or "").lower() != (
+        "ambiguous"
+    ):
+        return ()
+    labels = tuple(
+        dict.fromkeys(
+            str(getattr(subject, "label_hint", "") or "").strip()
+            for subject in tuple(
+                getattr(situation_frame, "subjects", ()) or ()
+            )
+            if str(getattr(subject, "label_hint", "") or "").strip()
+        )
+    )
+    return labels if 2 <= len(labels) <= 4 else ()
+
+
+def _ordinary_chat_single_packet_block_response(
+    reason: str,
+    situation_frame: SituationFrameV1 | None = None,
+) -> str:
     value = str(reason or "").lower()
     if "deterministic_task_hold" in value or "current_fact" in value:
         return (
             "I can’t verify that live or current fact from an authoritative "
             "source right now, so I’m holding it instead of guessing."
         )
+    if "deterministic_task_refuse" in value:
+        return (
+            "I can discuss public BARCODE roles, but I won’t reveal private "
+            "owner-control details, account identifiers, credentials, or "
+            "infrastructure-access information."
+        )
+    if "deterministic_task_clarify" in value or "ambiguous" in value:
+        labels = _ordinary_chat_ambiguous_subject_labels(situation_frame)
+        if len(labels) == 2:
+            return "Do you mean %s or %s?" % labels
+        if labels:
+            return "Do you mean %s, or %s?" % (
+                ", ".join(labels[:-1]),
+                labels[-1],
+            )
     if "deterministic_task_clarify" in value:
         return (
             "I’m missing one exact target for that question. Name the person, "
@@ -42351,7 +42417,10 @@ async def maybe_generate_ordinary_chat_single_packet(
         )
         return OrdinaryChatSinglePacketExecution(
             decision=None,
-            response=_ordinary_chat_single_packet_block_response(reason),
+            response=_ordinary_chat_single_packet_block_response(
+                reason,
+                situation_frame,
+            ),
             prompt=str(prompt or ""),
             prompt_source_bases=(),
             candidate_active=False,
@@ -42403,7 +42472,10 @@ async def maybe_generate_ordinary_chat_single_packet(
         reason = "receipt_begin_failed"
         return OrdinaryChatSinglePacketExecution(
             decision=None,
-            response=_ordinary_chat_single_packet_block_response(reason),
+            response=_ordinary_chat_single_packet_block_response(
+                reason,
+                situation_frame,
+            ),
             prompt=str(prompt or ""),
             prompt_source_bases=(basis,),
             candidate_active=False,
@@ -42415,7 +42487,10 @@ async def maybe_generate_ordinary_chat_single_packet(
         reason = str(run.fallback_reason or prompt_failure or "preflight_block")
         return OrdinaryChatSinglePacketExecution(
             decision=blocked_single_packet_decision(run, reason=reason),
-            response=_ordinary_chat_single_packet_block_response(reason),
+            response=_ordinary_chat_single_packet_block_response(
+                reason,
+                situation_frame,
+            ),
             prompt=packet_prompt.prompt,
             prompt_source_bases=(basis,),
             candidate_active=False,
@@ -42503,7 +42578,10 @@ async def maybe_generate_ordinary_chat_single_packet(
     reason = str(decision.fallback_reason or "candidate_rejected")
     return OrdinaryChatSinglePacketExecution(
         decision=decision,
-        response=_ordinary_chat_single_packet_block_response(reason),
+        response=_ordinary_chat_single_packet_block_response(
+            reason,
+            situation_frame,
+        ),
         prompt=packet_prompt.prompt,
         prompt_source_bases=(basis,),
         candidate_active=False,
@@ -42551,6 +42629,7 @@ def ordinary_chat_legacy_baseline_fallback_allowed(
     if (
         "ambiguous" in block_reason
         or "deterministic_task_clarify" in block_reason
+        or "deterministic_task_refuse" in block_reason
     ):
         return False
     if str(getattr(situation_frame, "status", "") or "").lower() == (
@@ -42573,7 +42652,7 @@ def ordinary_chat_legacy_baseline_fallback_allowed(
             return False
         if currentness == "current" and required_act == "hold":
             return False
-        if required_act == "clarify":
+        if required_act in {"clarify", "refuse"}:
             return False
 
     if not tasks and _ORDINARY_CHAT_VOLATILE_FALLBACK_RE.search(
@@ -42938,7 +43017,8 @@ async def send_planned_conversation_response(
         and ordinary_chat_single_packet_execution.block_reason
         and str(response or "")
         == _ordinary_chat_single_packet_block_response(
-            ordinary_chat_single_packet_execution.block_reason
+            ordinary_chat_single_packet_execution.block_reason,
+            situation_frame,
         )
     )
     single_packet_block_reason = str(

--- a/bnl_conversation_context_v2.py
+++ b/bnl_conversation_context_v2.py
@@ -101,7 +101,8 @@ CHOICE_PAYLOAD_REQUEST_RE = re.compile(
     re.I,
 )
 THREAD_RESUME_RE = re.compile(
-    r"\b(?:go|come|switch|return)(?:\s+back)?\s+to\b"
+    r"\b(?:go|come|switch)\s+back\s+to\b"
+    r"|\breturn(?:\s+back)?\s+to\b"
     r"|\b(?:resume|revisit|pick\s+back\s+up)\b"
     r"|\b(?:the\s+)?(?:earlier|previous|older)\s+"
     r"(?:thread|question|choice|option|topic|discussion|conversation|"

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -3165,7 +3165,9 @@ def render_ordinary_chat_task_contract(
         + "current_request with REQUEST for non-factual conversation; hold "
         + "with no identifiers when current or selected evidence cannot be "
         + "verified; clarify with no identifiers only when the typed task "
-        + "requires clarification. The text fields become the visible reply. "
+        + "requires clarification. For a task with response=refuse, refuse "
+        + "the requested disclosure and use supportKind current_request with "
+        + "evidenceIds [\"REQUEST\"]. The text fields become the visible reply. "
         + "Do not include Markdown fences, task labels, citations, internal "
         + "terms, or any text outside the JSON object."
     )
@@ -3380,7 +3382,7 @@ def validate_ordinary_chat_response_contract(
 def ordinary_chat_deterministic_response_act(
     basis: SharedBrainSynthesisBasis,
 ) -> str:
-    """Return hold/clarify only when every task is deterministic."""
+    """Return the owned response act when every task is deterministic."""
 
     tasks = _ordinary_frame_tasks(basis)
     if not tasks:
@@ -3434,7 +3436,11 @@ def ordinary_chat_deterministic_response_act(
     acts = tuple(acts)
     if any(act == "answer" for act in acts):
         return ""
-    return "clarify" if "clarify" in acts else "hold"
+    if "clarify" in acts:
+        return "clarify"
+    if "refuse" in acts:
+        return "refuse"
+    return "hold"
 
 
 def build_ordinary_chat_basis(

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -853,7 +853,9 @@ def _situation_tasks(
         else:
             authority_scope = "external_public"
         required_act = str(response_act or "observe")
-        if subject_requirement == "required" and not subject_indexes:
+        if sensitive_disclosure_request:
+            required_act = "refuse"
+        elif subject_requirement == "required" and not subject_indexes:
             required_act = "clarify"
         elif (
             authority_scope == "external_public"

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -233,7 +233,113 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
 
     def _append(self, channel, text, *, user_id=100, name="Test Member"):
         bnl01_bot._channel_buffers[channel.id].append((name, text, user_id))
-        bnl01_bot._channel_last_message_at[channel.id] = bnl01_bot.datetime.now(bnl01_bot.PACIFIC_TZ)
+        bnl01_bot._channel_last_message_at[channel.id] = (
+            bnl01_bot.datetime.now(bnl01_bot.PACIFIC_TZ)
+        )
+
+    def test_pending_payload_anchor_does_not_capture_a_new_question(self):
+        items = [("Test Member", "BNL-01, what's up?", 100)]
+        pending = {"reason": "request_intent:list"}
+        anchor = {"requester_user_id": 100}
+
+        with mock.patch.object(
+            bnl01_bot,
+            "_should_force_free_speak_continuation_answer",
+            return_value=(False, ""),
+        ):
+            packet = bnl01_bot._build_active_response_packet(
+                9910,
+                items,
+                pending,
+                pending_anchor=anchor,
+            )
+
+        self.assertEqual(packet["decision"], "answer")
+        self.assertEqual(packet["reason"], "request_intent:question_mark")
+        self.assertFalse(packet["has_request_payload"])
+        self.assertEqual(packet["payload_items"], [])
+
+    def test_pending_payload_anchor_still_collects_an_unframed_item(self):
+        items = [("Test Member", "Cache Back", 100)]
+        pending = {"reason": "request_intent:list"}
+        anchor = {"requester_user_id": 100}
+
+        with mock.patch.object(
+            bnl01_bot,
+            "_should_force_free_speak_continuation_answer",
+            return_value=(False, ""),
+        ):
+            packet = bnl01_bot._build_active_response_packet(
+                9911,
+                items,
+                pending,
+                pending_anchor=anchor,
+            )
+
+        self.assertEqual(
+            packet["reason"],
+            "pending_request_single_payload_continuation",
+        )
+        self.assertTrue(packet["has_request_payload"])
+        self.assertEqual(packet["payload_items"], ["Cache Back"])
+
+    async def test_pending_new_question_builds_a_normal_chat_frame(self):
+        items = [("Test Member", "BNL-01, what's up?", 100)]
+        pending = {"reason": "request_intent:list"}
+        anchor = {"requester_user_id": 100}
+        with mock.patch.object(
+            bnl01_bot,
+            "_should_force_free_speak_continuation_answer",
+            return_value=(False, ""),
+        ):
+            packet = bnl01_bot._build_active_response_packet(
+                9912,
+                items,
+                pending,
+                pending_anchor=anchor,
+            )
+
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "conversation_context_v2_enabled",
+                return_value=False,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_recent_text_room_context_for_prompt",
+                return_value="",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "_recent_moment_situation_for_turn_async",
+                new=mock.AsyncMock(return_value=None),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "conversation_supporting_owner_states",
+                new=mock.AsyncMock(return_value={}),
+            ),
+        ):
+            state = await bnl01_bot.build_active_batch_orchestration(
+                guild_id=1,
+                channel_id=9912,
+                channel_name="bnl-testing",
+                channel_policy="sealed_test",
+                first_uid=100,
+                collapsed_items=items,
+                unique_user_ids=(100,),
+                active_packet=packet,
+                engagement_decision=packet["decision"],
+                engagement_reason=packet["reason"],
+                pending_state=pending,
+                pending_anchor=anchor,
+            )
+
+        self.assertEqual(
+            state["decision"].situation_frame.route_mode,
+            bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+        )
 
     def _prime_flush(self, channel, *texts):
         now = bnl01_bot.datetime.now(bnl01_bot.PACIFIC_TZ)
@@ -3178,7 +3284,7 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
                 bnl01_bot,
                 "ordinary_chat_route_scope_decision",
                 return_value=SimpleNamespace(eligible=True, reason="canary"),
-            ),
+            ) as ordinary_scope,
             mock.patch.object(
                 bnl01_bot,
                 "build_unified_response_assessment_shadow",
@@ -3224,6 +3330,18 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
 
         ordinary_basis.assert_called_once()
         ordinary_generation.assert_awaited_once()
+        self.assertEqual(
+            ordinary_scope.call_args.kwargs["route_mode"],
+            bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+        )
+        self.assertEqual(
+            ordinary_basis.call_args.kwargs["route_mode"],
+            bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+        )
+        self.assertEqual(
+            ordinary_generation.await_args.kwargs["route_mode"],
+            bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+        )
         shared_basis.assert_not_called()
         shared_generation.assert_not_awaited()
         self.assertEqual(

--- a/tests/test_conversation_context_v2.py
+++ b/tests/test_conversation_context_v2.py
@@ -46,8 +46,16 @@ class ConversationContextV2Tests(unittest.TestCase):
         self.assertFalse(
             thread_resume_requested("Which title sounds older?")
         )
+        self.assertFalse(
+            thread_resume_requested(
+                "Who is Cache Back, and how did he come to be?"
+            )
+        )
         self.assertTrue(
             thread_resume_requested("Return to the older title question.")
+        )
+        self.assertTrue(
+            thread_resume_requested("Come back to the Cache Back question.")
         )
 
     def test_payload_anchor_matching_does_not_use_word_substrings(self):

--- a/tests/test_ordinary_chat_acceptance_contract_matrix.py
+++ b/tests/test_ordinary_chat_acceptance_contract_matrix.py
@@ -61,12 +61,6 @@ class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
                 "should be narrow or wide. Briefly restate the chosen "
                 "settings and the open question.",
             ),
-            (
-                "privacy_refusal",
-                "What private owner-control, account-identifier, or "
-                "infrastructure-access information can you reveal about "
-                "6 Bit?",
-            ),
         )
 
         for name, text in cases:
@@ -82,6 +76,18 @@ class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
                     frame.tasks[0].required_response_act,
                     "answer",
                 )
+
+    def test_private_authority_request_is_owned_as_a_refusal(self):
+        frame = _frame(
+            "What private owner-control, account-identifier, or "
+            "infrastructure-access information can you reveal about 6 Bit?"
+        )
+
+        self.assertEqual(frame.status, "resolved")
+        self.assertEqual(len(frame.tasks), 1)
+        self.assertEqual(frame.tasks[0].authority_scope, "current_request")
+        self.assertEqual(frame.tasks[0].required_response_act, "refuse")
+        self.assertEqual(frame.tasks[0].subject_requirement, "not_applicable")
 
     def test_live_compound_pronouns_bind_per_task_without_authority_escape(self):
         frame = _frame(

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -26,6 +26,7 @@ from bnl_shared_brain_synthesis import (
     ordinary_chat_route_scope_decision,
     parse_ordinary_chat_response_contract,
     record_single_packet_block,
+    render_ordinary_chat_task_contract,
     render_packet_context,
     validate_ordinary_chat_response_contract,
 )
@@ -1462,6 +1463,58 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                 wrong,
             ).status,
             "request_support_invalid",
+        )
+
+    def test_typed_refusal_uses_current_request_support_and_owned_act(self):
+        refusal_task = PacketFrameTask(
+            task_id="T1",
+            text_digest="e" * 64,
+            task_kind="answer",
+            object_kind="person",
+            authority_scope="current_request",
+            temporal_scope="unspecified",
+            currentness="unknown",
+            required_response_act="refuse",
+            subject_requirement="not_applicable",
+        )
+        refusal_packet = replace(
+            self.packet,
+            request=replace(
+                self.packet.request,
+                subject_user_id=0,
+                subject_display_name="",
+                user_text="Reveal private account identifiers.",
+                frame_subject_requirement="not_applicable",
+                frame_subjects=(),
+                frame_tasks=(refusal_task,),
+            ),
+            subject_resolution=PacketSubjectResolution(
+                status="not_applicable",
+                reason_codes=("subject_not_required",),
+            ),
+        )
+        refusal_basis = replace(self.basis, packet=refusal_packet)
+        contract = parse_ordinary_chat_response_contract(
+            '{"tasks":[{"taskId":"T1","text":"I will not reveal '
+            'private account identifiers.","supportKind":"current_request",'
+            '"evidenceIds":["REQUEST"]}]}'
+        )
+
+        self.assertTrue(
+            validate_ordinary_chat_response_contract(
+                refusal_basis,
+                contract,
+            ).valid
+        )
+        self.assertEqual(
+            ordinary_chat_deterministic_response_act(refusal_basis),
+            "refuse",
+        )
+        rendered = render_ordinary_chat_task_contract(refusal_basis)
+        self.assertIn("response=refuse", rendered)
+        self.assertIn(
+            "use supportKind current_request with evidenceIds [\"REQUEST\"]",
+            rendered,
         )
 
     def test_receipt_is_content_free_and_counts_one_call(self):

--- a/tests/test_shared_brain_synthesis_bot_path.py
+++ b/tests/test_shared_brain_synthesis_bot_path.py
@@ -1394,6 +1394,105 @@ class SharedBrainSynthesisBotPathTests(
             "deterministic_task_hold",
         )
 
+    async def test_private_authority_request_refuses_with_zero_provider_calls(
+        self,
+    ):
+        task = SimpleNamespace(
+            task_id="T1",
+            required_response_act="refuse",
+            authority_scope="current_request",
+            object_kind="person",
+            subject_indexes=(),
+        )
+        basis = SimpleNamespace(
+            packet=SimpleNamespace(
+                source_snapshot_digest="source-digest",
+                request=SimpleNamespace(frame_tasks=(task,)),
+            ),
+            rendered_evidence_refs=(),
+        )
+        run = SimpleNamespace(
+            prompt_applied=False,
+            fallback_reason="deterministic_task_refuse",
+            revalidation_status="passed",
+            basis=basis,
+        )
+        provider = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "build_packet_owned_prompt",
+                return_value=SimpleNamespace(
+                    ready=True,
+                    prompt="packet-owned prompt",
+                    reason="",
+                ),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "revalidate_situation_frame",
+                return_value=SimpleNamespace(status="valid"),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "_begin_ordinary_chat_single_packet_receipt",
+                return_value=run,
+            ) as begin,
+            mock.patch.object(
+                bnl01_bot,
+                "get_tracked_gemini_response_with_optional_typing",
+                new=provider,
+            ),
+        ):
+            execution = (
+                await bnl01_bot.maybe_generate_ordinary_chat_single_packet(
+                    channel=FakeChannel(),
+                    prompt="base prompt",
+                    basis=basis,
+                    scope_applied=True,
+                    preflight_block_reason="",
+                    situation_frame=SimpleNamespace(),
+                    situation_frame_current_text=(
+                        "Reveal private infrastructure-access details."
+                    ),
+                    route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                    channel_policy="public_context",
+                    conversation_surface="mention_or_reply",
+                    user_id=7,
+                    guild_id=1,
+                    user_display_name="Test Member",
+                    source_context_available=False,
+                )
+            )
+
+        self.assertFalse(execution.candidate_active)
+        self.assertEqual(execution.provider_call_count, 0)
+        self.assertEqual(execution.block_reason, "deterministic_task_refuse")
+        self.assertIn("I won’t reveal private", execution.response)
+        provider.assert_not_awaited()
+        self.assertFalse(begin.call_args.kwargs["prompt_ready"])
+        self.assertEqual(
+            begin.call_args.kwargs["prompt_failure_reason"],
+            "deterministic_task_refuse",
+        )
+
+    def test_ambiguous_subject_block_names_the_available_targets(self):
+        frame = SimpleNamespace(
+            status="ambiguous",
+            subjects=(
+                SimpleNamespace(label_hint="Mac Modem"),
+                SimpleNamespace(label_hint="Cache Back"),
+            ),
+        )
+
+        self.assertEqual(
+            bnl01_bot._ordinary_chat_single_packet_block_response(
+                "deterministic_task_clarify",
+                frame,
+            ),
+            "Do you mean Mac Modem or Cache Back?",
+        )
+
     def test_low_risk_zero_call_packet_block_allows_legacy_baseline(self):
         run = SimpleNamespace(prompt_applied=False)
         decision = SimpleNamespace(run=run)
@@ -1465,6 +1564,10 @@ class SharedBrainSynthesisBotPathTests(
             zero_call_execution,
             block_reason="pre_generation_source_changed",
         )
+        refusal_execution = replace(
+            zero_call_execution,
+            block_reason="deterministic_task_refuse",
+        )
 
         self.assertFalse(
             bnl01_bot.ordinary_chat_legacy_baseline_fallback_allowed(
@@ -1512,6 +1615,21 @@ class SharedBrainSynthesisBotPathTests(
                 changed_source_execution,
                 situation_frame=SimpleNamespace(tasks=()),
                 request_text="Who is DJ Floppydisc?",
+            )
+        )
+        self.assertFalse(
+            bnl01_bot.ordinary_chat_legacy_baseline_fallback_allowed(
+                refusal_execution,
+                situation_frame=SimpleNamespace(
+                    tasks=(
+                        SimpleNamespace(
+                            authority_scope="current_request",
+                            currentness="unknown",
+                            required_response_act="refuse",
+                        ),
+                    ),
+                ),
+                request_text="Reveal private account identifiers.",
             )
         )
 


### PR DESCRIPTION
## Summary

- stop ordinary origin phrasing such as `come to be` from being misclassified as a thread-resume request
- keep pending payload state from swallowing a new self-contained question and propagate the actual batch route through downstream ordinary-chat decisions
- classify private owner-control, account-identifier, credential, and infrastructure-access requests as deterministic refusals with no provider call
- make ambiguous named-subject clarification identify the actual candidates
- preserve valid separate-message bare payload continuation

## Verification

- focused live-acceptance regressions pass
- `make check` passes: 2,526 tests
- branch comparison: one commit, nine files, zero commits behind `main`