### PR TITLE
Bind ordinary-chat support before generation

### DIFF
--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -79,7 +79,7 @@ PUBLIC_HOME_OWNER_CHANNEL_IDS_ENV = (
 )
 ORDINARY_CHAT_CAPABILITY_NAME = "ordinary_chat_single_packet_canary"
 ORDINARY_CHAT_CAPABILITY_CONTRACT_VERSION = (
-    "ordinary_chat_single_packet_v4"
+    "ordinary_chat_single_packet_v5"
 )
 ORDINARY_CHAT_ENABLED_ENV = "BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED"
 ORDINARY_CHAT_SCOPED_EXPANSION_ENABLED_ENV = (
@@ -1274,6 +1274,15 @@ class OrdinaryChatTaskResult:
 
     task_id: str
     text: str
+    support_kind: str
+    evidence_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class OrdinaryChatTaskSupportPlan:
+    """System-owned support binding for one ordinary-chat task."""
+
+    task_id: str
     support_kind: str
     evidence_ids: tuple[str, ...] = ()
 
@@ -3105,6 +3114,132 @@ def _ordinary_task_allowed_lanes(task: Any) -> frozenset[str]:
     return frozenset(_RENDERABLE_LANES)
 
 
+def ordinary_chat_task_support_plan(
+    basis: SharedBrainSynthesisBasis,
+) -> tuple[OrdinaryChatTaskSupportPlan, ...]:
+    """Bind every typed task to exact support before provider generation."""
+
+    evidence_scope = tuple(
+        (
+            evidence_id,
+            lane,
+            tuple(int(index) for index in subject_indexes),
+        )
+        for evidence_id, lane, _digest_value, subject_indexes in (
+            basis.rendered_evidence_refs
+        )
+    )
+    plans = []
+    for task in _ordinary_frame_tasks(basis):
+        task_id = str(getattr(task, "task_id", "") or "")
+        authority = str(getattr(task, "authority_scope", "") or "")
+        required_act = str(
+            getattr(task, "required_response_act", "") or "answer"
+        )
+        if required_act == "clarify":
+            plans.append(OrdinaryChatTaskSupportPlan(task_id, "clarify"))
+            continue
+        if required_act == "hold" or authority == "external_current":
+            plans.append(OrdinaryChatTaskSupportPlan(task_id, "hold"))
+            continue
+        if required_act == "refuse":
+            plans.append(
+                OrdinaryChatTaskSupportPlan(
+                    task_id,
+                    "current_request",
+                    ("REQUEST",),
+                )
+            )
+            continue
+        if authority == "external_public":
+            plans.append(
+                OrdinaryChatTaskSupportPlan(
+                    task_id,
+                    "external_public",
+                    ("PUBLIC",),
+                )
+            )
+            continue
+        if authority == "current_request":
+            plans.append(
+                OrdinaryChatTaskSupportPlan(
+                    task_id,
+                    "current_request",
+                    ("REQUEST",),
+                )
+            )
+            continue
+        if authority != "packet":
+            plans.append(OrdinaryChatTaskSupportPlan(task_id, ""))
+            continue
+
+        allowed_lanes = _ordinary_task_allowed_lanes(task)
+        required_subject_indexes = tuple(
+            dict.fromkeys(
+                int(subject_index)
+                for subject_index in getattr(task, "subject_indexes", ())
+            )
+        )
+        required_subject_set = set(required_subject_indexes)
+        allowed_refs = tuple(
+            (evidence_id, subject_indexes)
+            for evidence_id, lane, subject_indexes in evidence_scope
+            if lane in allowed_lanes
+            and (
+                not required_subject_set
+                or required_subject_set.intersection(subject_indexes)
+            )
+        )
+        covered_subjects = {
+            subject_index
+            for _evidence_id, subject_indexes in allowed_refs
+            for subject_index in subject_indexes
+            if subject_index in required_subject_set
+        }
+        if not allowed_refs or required_subject_set - covered_subjects:
+            plans.append(OrdinaryChatTaskSupportPlan(task_id, "hold"))
+            continue
+
+        selected_ids = []
+        for required_subject_index in required_subject_indexes:
+            evidence_id = next(
+                (
+                    candidate_id
+                    for candidate_id, subject_indexes in allowed_refs
+                    if required_subject_index in subject_indexes
+                ),
+                "",
+            )
+            if evidence_id and evidence_id not in selected_ids:
+                selected_ids.append(evidence_id)
+        if len(selected_ids) > 8:
+            plans.append(OrdinaryChatTaskSupportPlan(task_id, "hold"))
+            continue
+        for evidence_id, _subject_indexes in allowed_refs:
+            if len(selected_ids) >= 8:
+                break
+            if evidence_id not in selected_ids:
+                selected_ids.append(evidence_id)
+        selected_subjects = {
+            subject_index
+            for evidence_id, subject_indexes in allowed_refs
+            if evidence_id in selected_ids
+            for subject_index in subject_indexes
+            if subject_index in required_subject_set
+        }
+        if required_subject_set - selected_subjects:
+            plans.append(OrdinaryChatTaskSupportPlan(task_id, "hold"))
+            continue
+        plans.append(
+            OrdinaryChatTaskSupportPlan(
+                task_id,
+                "packet",
+                tuple(selected_ids),
+            )
+        )
+    return tuple(plans)
+
+
 def render_ordinary_chat_task_contract(
     basis: SharedBrainSynthesisBasis,
 ) -> str:
@@ -3113,9 +3248,10 @@ def render_ordinary_chat_task_contract(
     tasks = _ordinary_frame_tasks(basis)
     if not tasks:
         return ""
+    support_plans = ordinary_chat_task_support_plan(basis)
     task_lines = [
         "- %s | authority=%s | object=%s | currentness=%s | response=%s "
-        "| subjects=%s"
+        "| subjects=%s | supportKind=%s | evidenceIds=%s"
         % (
             str(getattr(task, "task_id", "") or ""),
             str(getattr(task, "authority_scope", "") or "unknown"),
@@ -3127,8 +3263,10 @@ def render_ordinary_chat_task_contract(
                 for subject_index in getattr(task, "subject_indexes", ())
             )
             or "none",
+            plan.support_kind or "invalid",
+            json.dumps(list(plan.evidence_ids), separators=(",", ":")),
         )
-        for task in tasks
+        for task, plan in zip(tasks, support_plans)
     ]
     evidence_lines = [
         "- %s | lane=%s | subjects=%s"
@@ -3148,6 +3286,20 @@ def render_ordinary_chat_task_contract(
             subject_indexes,
         ) in basis.rendered_evidence_refs
     ]
+    exact_template = json.dumps(
+        {
+            "tasks": [
+                {
+                    "taskId": plan.task_id,
+                    "text": "visible answer",
+                    "supportKind": plan.support_kind or "invalid",
+                    "evidenceIds": list(plan.evidence_ids),
+                }
+                for plan in support_plans
+            ]
+        },
+        separators=(",", ":"),
+    )
     return (
         "TYPED TURN TASK CONTRACT:\n"
         + "\n".join(task_lines)
@@ -3156,18 +3308,17 @@ def render_ordinary_chat_task_contract(
         + "\n- PUBLIC may support stable general public knowledge only.\n"
         + "- REQUEST may support a non-factual conversational response only.\n"
         + "PROVIDER OUTPUT CONTRACT:\n"
-        + "Return only one JSON object with exactly this shape: "
-        + '{"tasks":[{"taskId":"T1","text":"visible answer",'
-        + '"supportKind":"packet","evidenceIds":["E1"]}]}.\n'
-        + "Return every task exactly once and in order. Use supportKind packet "
-        + "with applicable E-identifiers for stored/BARCODE claims; "
-        + "external_public with PUBLIC for stable general knowledge; "
-        + "current_request with REQUEST for non-factual conversation; hold "
-        + "with no identifiers when current or selected evidence cannot be "
-        + "verified; clarify with no identifiers only when the typed task "
-        + "requires clarification. For a task with response=refuse, refuse "
-        + "the requested disclosure and use supportKind current_request with "
-        + "evidenceIds [\"REQUEST\"]. The text fields become the visible reply. "
+        + "Return only this exact JSON template, replacing each visible "
+        + "answer placeholder and no other value: "
+        + exact_template
+        + ".\nReturn every task exactly once and in order. Support metadata is "
+        + "system-owned: copy each task line's supportKind and evidenceIds "
+        + "values exactly into its JSON object. Do not choose, substitute, "
+        + "add, remove, or reorder support references. Generate only each "
+        + "task's visible text. For response=refuse, refuse the requested "
+        + "disclosure in that text. For supportKind=hold or clarify, make the "
+        + "visible text perform that act. The text fields become the visible "
+        + "reply. "
         + "Do not include Markdown fences, task labels, citations, internal "
         + "terms, or any text outside the JSON object."
     )
@@ -3265,109 +3416,44 @@ def validate_ordinary_chat_response_contract(
             status="task_coverage_mismatch",
             task_count=len(tasks),
         )
-    evidence_scope = {
-        evidence_id: (lane, tuple(subject_indexes))
-        for (
-            evidence_id,
-            lane,
-            _digest_value,
-            subject_indexes,
-        ) in basis.rendered_evidence_refs
-    }
+    support_plans = ordinary_chat_task_support_plan(basis)
     support_count = 0
-    for task, result in zip(tasks, contract.tasks):
+    for task, result, plan in zip(tasks, contract.tasks, support_plans):
         authority = str(getattr(task, "authority_scope", "") or "")
         required_act = str(
             getattr(task, "required_response_act", "") or "answer"
         )
-        if required_act == "clarify":
-            if result.support_kind != "clarify" or result.evidence_ids:
-                return OrdinaryChatContractValidation(
-                    status="clarification_contract_mismatch",
-                    task_count=len(tasks),
-                )
-            continue
-        if required_act == "hold" or authority == "external_current":
-            if result.support_kind != "hold" or result.evidence_ids:
-                return OrdinaryChatContractValidation(
-                    status="current_fact_not_held",
-                    task_count=len(tasks),
-                )
-            continue
-        if authority == "packet":
-            allowed_lanes = _ordinary_task_allowed_lanes(task)
-            required_subject_indexes = set(
-                int(subject_index)
-                for subject_index in getattr(task, "subject_indexes", ())
-            )
-            allowed_ids = {
-                evidence_id
-                for evidence_id, (
-                    lane,
-                    subject_indexes,
-                ) in evidence_scope.items()
-                if lane in allowed_lanes
-                and (
-                    not required_subject_indexes
-                    or required_subject_indexes.intersection(subject_indexes)
-                )
-            }
-            covered_subject_indexes = {
-                subject_index
-                for evidence_id in allowed_ids
-                for subject_index in evidence_scope[evidence_id][1]
-                if subject_index in required_subject_indexes
-            }
-            missing_subject_evidence = bool(
-                required_subject_indexes - covered_subject_indexes
-            )
-            if result.support_kind == "hold" and (
-                not allowed_ids or missing_subject_evidence
-            ):
-                if result.evidence_ids:
-                    return OrdinaryChatContractValidation(
-                        status="hold_has_support_reference",
-                        task_count=len(tasks),
-                    )
-                continue
-            if (
-                result.support_kind != "packet"
-                or not result.evidence_ids
-                or not set(result.evidence_ids).issubset(allowed_ids)
-                or missing_subject_evidence
-                or required_subject_indexes
-                - {
-                    subject_index
-                    for evidence_id in result.evidence_ids
-                    for subject_index in evidence_scope[evidence_id][1]
-                    if subject_index in required_subject_indexes
-                }
-            ):
-                return OrdinaryChatContractValidation(
-                    status="packet_support_invalid",
-                    task_count=len(tasks),
-                )
-        elif authority == "external_public":
-            if (
-                result.support_kind != "external_public"
-                or result.evidence_ids != ("PUBLIC",)
-            ):
-                return OrdinaryChatContractValidation(
-                    status="external_support_invalid",
-                    task_count=len(tasks),
-                )
-        elif authority == "current_request":
-            if (
-                result.support_kind != "current_request"
-                or result.evidence_ids != ("REQUEST",)
-            ):
-                return OrdinaryChatContractValidation(
-                    status="request_support_invalid",
-                    task_count=len(tasks),
-                )
-        else:
+        if not plan.support_kind:
             return OrdinaryChatContractValidation(
                 status="authority_scope_invalid",
+                task_count=len(tasks),
+            )
+        if (
+            result.support_kind != plan.support_kind
+            or result.evidence_ids != plan.evidence_ids
+        ):
+            if (
+                plan.support_kind == "hold"
+                and result.support_kind == "hold"
+                and result.evidence_ids
+            ):
+                status = "hold_has_support_reference"
+            elif required_act == "clarify":
+                status = "clarification_contract_mismatch"
+            elif required_act == "hold" or authority == "external_current":
+                status = "current_fact_not_held"
+            elif required_act == "refuse":
+                status = "request_support_invalid"
+            elif authority == "packet":
+                status = "packet_support_invalid"
+            elif authority == "external_public":
+                status = "external_support_invalid"
+            elif authority == "current_request":
+                status = "request_support_invalid"
+            else:
+                status = "authority_scope_invalid"
+            return OrdinaryChatContractValidation(
+                status=status,
                 task_count=len(tasks),
             )
         support_count += len(result.evidence_ids)
@@ -3387,51 +3473,14 @@ def ordinary_chat_deterministic_response_act(
     tasks = _ordinary_frame_tasks(basis)
     if not tasks:
         return ""
-    evidence_scope = {
-        evidence_id: (lane, tuple(subject_indexes))
-        for (
-            evidence_id,
-            lane,
-            _digest_value,
-            subject_indexes,
-        ) in basis.rendered_evidence_refs
-    }
+    support_plans = ordinary_chat_task_support_plan(basis)
     acts = []
-    for task in tasks:
+    for task, plan in zip(tasks, support_plans):
         act = str(
             getattr(task, "required_response_act", "") or "answer"
         )
-        if (
-            act == "answer"
-            and str(getattr(task, "authority_scope", "") or "")
-            == "packet"
-        ):
-            allowed_lanes = _ordinary_task_allowed_lanes(task)
-            required_subject_indexes = set(
-                int(subject_index)
-                for subject_index in getattr(task, "subject_indexes", ())
-            )
-            allowed_ids = {
-                evidence_id
-                for evidence_id, (lane, subject_indexes) in (
-                    evidence_scope.items()
-                )
-                if lane in allowed_lanes
-                and (
-                    not required_subject_indexes
-                    or required_subject_indexes.intersection(subject_indexes)
-                )
-            }
-            covered_subject_indexes = {
-                subject_index
-                for evidence_id in allowed_ids
-                for subject_index in evidence_scope[evidence_id][1]
-                if subject_index in required_subject_indexes
-            }
-            if not allowed_ids or (
-                required_subject_indexes - covered_subject_indexes
-            ):
-                act = "hold"
+        if act == "answer" and plan.support_kind == "hold":
+            act = "hold"
         acts.append(act)
     acts = tuple(acts)
     if any(act == "answer" for act in acts):

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -424,6 +424,16 @@ _CURRENT_REQUEST_TASK_RE = re.compile(
     r"thank\s+you|thanks|hello|hey)\b",
     re.I,
 )
+_CURRENT_REQUEST_SOCIAL_RE = re.compile(
+    r"^\s*(?:"
+    r"what(?:['’]?s|\s+is)\s+up|"
+    r"how(?:['’]?s|\s+is)\s+it\s+going|"
+    r"how(?:['’]?s|\s+are)\s+things|"
+    r"how\s+(?:are|have)\s+you\s+(?:been|doing)|"
+    r"you\s+good|sup"
+    r")\s*[?!.]*\s*$",
+    re.I,
+)
 _CURRENT_REQUEST_ADVICE_RE = re.compile(
     r"\b(?:"
     r"what|which|how)\b.{0,80}\b(?:should|could)\s+(?:i|we)\b|"
@@ -439,6 +449,11 @@ _CURRENT_REQUEST_TRANSFORM_CONTEXT_RE = re.compile(
     r"\b(?:this|that|these|those|above|following|chosen|selected|"
     r"open\s+question|settings?|options?|what\s+(?:i|we|you)\s+"
     r"(?:just\s+)?(?:said|gave|provided|chose|selected|decided))\b",
+    re.I,
+)
+_CURRENT_REQUEST_BARE_TRANSFORM_RE = re.compile(
+    r"^\s*(?:list|restate|repeat|recap|paraphrase|summari[sz]e)"
+    r"\s*[?!.]*\s*$",
     re.I,
 )
 _SENSITIVE_DISCLOSURE_REQUEST_RE = re.compile(
@@ -822,7 +837,9 @@ def _situation_tasks(
         )
         current_request = bool(
             _CURRENT_REQUEST_TASK_RE.search(segment)
+            or _CURRENT_REQUEST_SOCIAL_RE.search(segment)
             or _CURRENT_REQUEST_ADVICE_RE.search(segment)
+            or _CURRENT_REQUEST_BARE_TRANSFORM_RE.search(segment)
             or (
                 _CURRENT_REQUEST_TRANSFORM_RE.search(segment)
                 and _CURRENT_REQUEST_TRANSFORM_CONTEXT_RE.search(segment)

--- a/tests/test_ordinary_chat_acceptance_contract_matrix.py
+++ b/tests/test_ordinary_chat_acceptance_contract_matrix.py
@@ -61,6 +61,11 @@ class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
                 "should be narrow or wide. Briefly restate the chosen "
                 "settings and the open question.",
             ),
+            ("casual_whats_up", "whats up?"),
+            ("casual_apostrophe", "what's up?"),
+            ("casual_progress", "How’s it going?"),
+            ("casual_check_in", "You good?"),
+            ("bare_list", "List"),
         )
 
         for name, text in cases:
@@ -88,6 +93,14 @@ class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
         self.assertEqual(frame.tasks[0].authority_scope, "current_request")
         self.assertEqual(frame.tasks[0].required_response_act, "refuse")
         self.assertEqual(frame.tasks[0].subject_requirement, "not_applicable")
+
+    def test_casual_check_in_pattern_does_not_capture_live_weather(self):
+        frame = _frame("What's up with the weather today?")
+
+        self.assertEqual(frame.status, "resolved")
+        self.assertEqual(len(frame.tasks), 1)
+        self.assertEqual(frame.tasks[0].authority_scope, "external_current")
+        self.assertEqual(frame.tasks[0].required_response_act, "hold")
 
     def test_live_compound_pronouns_bind_per_task_without_authority_escape(self):
         frame = _frame(

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sqlite3
 import unittest
@@ -24,6 +25,7 @@ from bnl_shared_brain_synthesis import (
     ordinary_chat_configuration,
     ordinary_chat_deterministic_response_act,
     ordinary_chat_route_scope_decision,
+    ordinary_chat_task_support_plan,
     parse_ordinary_chat_response_contract,
     record_single_packet_block,
     render_ordinary_chat_task_contract,
@@ -43,6 +45,25 @@ from bnl_unified_response_assessment import (
     build_unified_response_assessment,
     revalidate_situation_frame,
 )
+
+
+def _contract_for_support_plan(basis, texts):
+    plans = ordinary_chat_task_support_plan(basis)
+    return parse_ordinary_chat_response_contract(
+        json.dumps(
+            {
+                "tasks": [
+                    {
+                        "taskId": plan.task_id,
+                        "text": text,
+                        "supportKind": plan.support_kind,
+                        "evidenceIds": list(plan.evidence_ids),
+                    }
+                    for plan, text in zip(plans, texts)
+                ]
+            }
+        )
+    )
 
 
 class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
@@ -520,7 +541,7 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertTrue(configured["effective"])
         self.assertEqual(
             configured["contract_version"],
-            "ordinary_chat_single_packet_v4",
+            "ordinary_chat_single_packet_v5",
         )
         self.assertEqual(configured["scope_mode"], "private_acceptance")
         self.assertFalse(
@@ -858,20 +879,9 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertIn("one shared mind with filtered surfaces", owned.prompt)
 
     def test_typed_response_contract_accepts_only_applicable_packet_refs(self):
-        evidence_id = next(
-            evidence_id
-            for (
-                evidence_id,
-                lane,
-                _digest,
-                _subject_indexes,
-            ) in self.basis.rendered_evidence_refs
-            if lane == "approved_fact"
-        )
-        contract = parse_ordinary_chat_response_contract(
-            '{"tasks":[{"taskId":"T1","text":"Your favorite movie is '
-            'Arrival.","supportKind":"packet","evidenceIds":["%s"]}]}'
-            % evidence_id
+        contract = _contract_for_support_plan(
+            self.basis,
+            ("Your favorite movie is Arrival.",),
         )
         validation = validate_ordinary_chat_response_contract(
             self.basis,
@@ -934,6 +944,34 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                     "typed_contract_%s" % expected,
                 )
 
+    def test_system_owned_support_plan_is_ordered_and_bounded(self):
+        crowded_basis = replace(
+            self.basis,
+            rendered_evidence_refs=tuple(
+                (
+                    "E%s" % index,
+                    "approved_fact",
+                    "%064x" % index,
+                    (0,),
+                )
+                for index in range(1, 10)
+            ),
+        )
+
+        plan = ordinary_chat_task_support_plan(crowded_basis)
+
+        self.assertEqual(len(plan), 1)
+        self.assertEqual(plan[0].support_kind, "packet")
+        self.assertEqual(
+            plan[0].evidence_ids,
+            tuple("E%s" % index for index in range(1, 9)),
+        )
+        rendered = render_ordinary_chat_task_contract(crowded_basis)
+        self.assertIn(
+            '"evidenceIds":["E1","E2","E3","E4","E5","E6","E7","E8"]',
+            rendered,
+        )
+
     def test_multi_subject_comparison_requires_support_for_every_subject(self):
         basis = self._multi_subject_basis(
             "Compare Cache Back and Mac Modem.",
@@ -951,11 +989,17 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         }
         cache_evidence = evidence_by_subject[(0,)]
         mac_evidence = evidence_by_subject[(1,)]
-        valid = parse_ordinary_chat_response_contract(
-            '{"tasks":[{"taskId":"T1","text":"Cache Back protects '
-            'archive continuity, while Mac Modem introduces unstable '
-            'distortions.","supportKind":"packet","evidenceIds":["%s",'
-            '"%s"]}]}' % (cache_evidence, mac_evidence)
+        support_plan = ordinary_chat_task_support_plan(basis)
+        self.assertEqual(len(support_plan), 1)
+        self.assertEqual(support_plan[0].support_kind, "packet")
+        self.assertIn(cache_evidence, support_plan[0].evidence_ids)
+        self.assertIn(mac_evidence, support_plan[0].evidence_ids)
+        valid = _contract_for_support_plan(
+            basis,
+            (
+                "Cache Back protects archive continuity, while Mac Modem "
+                "introduces unstable distortions.",
+            ),
         )
         incomplete = parse_ordinary_chat_response_contract(
             '{"tasks":[{"taskId":"T1","text":"They differ.",'
@@ -1212,7 +1256,7 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             "packet_support_invalid",
         )
 
-    def test_owner_declared_cache_bini_relationship_supports_live_three_way_packet(self):
+    def test_owner_declared_cache_bini_relationship_supports_live_compound_packets(self):
         authority = {
             "BNL_OWNER_USER_ID": "61",
             "BNL_PRIMARY_GUILD_ID": "1",
@@ -1266,6 +1310,14 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                     ("mac_modem", "Mac Modem"),
                 ),
             )
+            origin_basis = self._multi_subject_basis(
+                "Who is Cache Back, how did he come to be, and how is he "
+                "different from Call'em Bini?",
+                (
+                    ("cache_back", "Cache Back"),
+                    ("call_em_bini", "Call'em Bini"),
+                ),
+            )
 
         declared_refs = {
             subject_indexes: evidence_id
@@ -1296,16 +1348,19 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             ) in basis.rendered_evidence_refs
             if lane == "canon" and subject_indexes == (2,)
         )
-        contract = parse_ordinary_chat_response_contract(
-            '{"tasks":[{"taskId":"T1","text":"Cache Back has an '
-            "established canon origin connection to Call'em Bini while Mac "
-            'Modem has a different established role.","supportKind":'
-            '"packet","evidenceIds":["%s","%s","%s"]}]}'
-            % (
-                declared_refs[(0,)],
-                declared_refs[(1,)],
-                mac_evidence,
-            )
+        support_plan = ordinary_chat_task_support_plan(basis)
+        self.assertEqual(len(support_plan), 1)
+        self.assertEqual(support_plan[0].support_kind, "packet")
+        self.assertIn(declared_refs[(0,)], support_plan[0].evidence_ids)
+        self.assertIn(declared_refs[(1,)], support_plan[0].evidence_ids)
+        self.assertIn(mac_evidence, support_plan[0].evidence_ids)
+        contract = _contract_for_support_plan(
+            basis,
+            (
+                "Cache Back has an established canon origin connection to "
+                "Call'em Bini while Mac Modem has a different established "
+                "role.",
+            ),
         )
         self.assertTrue(
             validate_ordinary_chat_response_contract(
@@ -1314,6 +1369,48 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             ).valid
         )
         self.assertEqual(ordinary_chat_deterministic_response_act(basis), "")
+
+        origin_plan = ordinary_chat_task_support_plan(origin_basis)
+        self.assertEqual(
+            tuple(plan.task_id for plan in origin_plan),
+            ("T1", "T2", "T3"),
+        )
+        self.assertEqual(
+            tuple(plan.support_kind for plan in origin_plan),
+            ("packet", "packet", "packet"),
+        )
+        self.assertTrue(all(plan.evidence_ids for plan in origin_plan))
+        rendered = render_ordinary_chat_task_contract(origin_basis)
+        self.assertIn("Support metadata is system-owned", rendered)
+        for plan in origin_plan:
+            self.assertIn(
+                '"taskId":"%s"' % plan.task_id,
+                rendered,
+            )
+            self.assertIn(
+                '"evidenceIds":%s'
+                % json.dumps(list(plan.evidence_ids), separators=(",", ":")),
+                rendered,
+            )
+        origin_contract = _contract_for_support_plan(
+            origin_basis,
+            (
+                "Cache Back is BARCODE's archive specialist.",
+                "He emerged from cached project data during a cleanup.",
+                "Cache Back is a distinct Network member, while Call'em "
+                "Bini is the artist whose cached material was involved.",
+            ),
+        )
+        self.assertTrue(
+            validate_ordinary_chat_response_contract(
+                origin_basis,
+                origin_contract,
+            ).valid
+        )
+        self.assertEqual(
+            ordinary_chat_deterministic_response_act(origin_basis),
+            "",
+        )
 
     def test_typed_external_task_uses_public_not_packet_authority(self):
         external_packet = replace(
@@ -1513,27 +1610,16 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         rendered = render_ordinary_chat_task_contract(refusal_basis)
         self.assertIn("response=refuse", rendered)
         self.assertIn(
-            "use supportKind current_request with evidenceIds [\"REQUEST\"]",
+            'supportKind=current_request | evidenceIds=["REQUEST"]',
             rendered,
         )
 
     def test_receipt_is_content_free_and_counts_one_call(self):
         run = self._begin()
         self.assertTrue(run.prompt_applied)
-        evidence_id = next(
-            evidence_id
-            for (
-                evidence_id,
-                lane,
-                _digest,
-                _subject_indexes,
-            ) in self.basis.rendered_evidence_refs
-            if lane == "approved_fact"
-        )
-        contract = parse_ordinary_chat_response_contract(
-            '{"tasks":[{"taskId":"T1","text":"Your favorite movie is '
-            'Arrival.","supportKind":"packet","evidenceIds":["%s"]}]}'
-            % evidence_id
+        contract = _contract_for_support_plan(
+            self.basis,
+            ("Your favorite movie is Arrival.",),
         )
         decision = evaluate_single_packet_response(
             self.conn,
@@ -1605,7 +1691,10 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertEqual(report["ordinaryTypedContractViolationRuns"], 0)
         self.assertEqual(report["typedTaskTotal"], 1)
         self.assertEqual(report["typedTaskCoverageTotal"], 1)
-        self.assertEqual(report["typedSupportReferenceTotal"], 1)
+        self.assertEqual(
+            report["typedSupportReferenceTotal"],
+            len(ordinary_chat_task_support_plan(self.basis)[0].evidence_ids),
+        )
         self.assertEqual(report["invalidScopeRuns"], 0)
 
     def test_unsupported_packet_domain_claims_are_rejected_before_selection(self):


### PR DESCRIPTION
## Summary
- bind each typed ordinary-chat task to exact system-owned support metadata before the provider call
- render an exact JSON response template so the provider supplies only visible wording
- keep casual check-ins and bare transform prompts in current-request authority

## Live failures covered
- Cache Back origin/difference compound prompt
- `List`
- `whats up?` and apostrophe/check-in variants
- live weather remains an authoritative-current hold

## Verification
- focused ordinary-chat/bot-path suites: 88 tests passed
- `make check`: 2,528 tests passed