### PR TITLE
Compose ordinary-chat tasks without repetition

### DIFF
--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -52,6 +52,7 @@ from bnl_unified_response_assessment import (
     UnifiedResponseAssessment,
     assess_response_coherence,
     shadow_enabled as assessment_shadow_enabled,
+    situation_task_texts,
 )
 
 
@@ -79,7 +80,7 @@ PUBLIC_HOME_OWNER_CHANNEL_IDS_ENV = (
 )
 ORDINARY_CHAT_CAPABILITY_NAME = "ordinary_chat_single_packet_canary"
 ORDINARY_CHAT_CAPABILITY_CONTRACT_VERSION = (
-    "ordinary_chat_single_packet_v5"
+    "ordinary_chat_single_packet_v6"
 )
 ORDINARY_CHAT_ENABLED_ENV = "BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED"
 ORDINARY_CHAT_SCOPED_EXPANSION_ENABLED_ENV = (
@@ -1296,9 +1297,18 @@ class OrdinaryChatResponseContract:
 
     @property
     def response(self) -> str:
-        return "\n\n".join(
-            task.text.strip() for task in self.tasks if task.text.strip()
-        ).strip()
+        parts = []
+        seen = set()
+        for task in self.tasks:
+            text = task.text.strip()
+            if not text:
+                continue
+            normalized = re.sub(r"\s+", " ", text).strip().casefold()
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            parts.append(text)
+        return "\n\n".join(parts).strip()
 
 
 @dataclass(frozen=True)
@@ -3248,12 +3258,21 @@ def render_ordinary_chat_task_contract(
     tasks = _ordinary_frame_tasks(basis)
     if not tasks:
         return ""
+    frame = getattr(basis.assessment, "situation_frame", None)
+    task_requests = situation_task_texts(
+        frame,
+        current_text=str(basis.packet.request.user_text or ""),
+    )
+    if len(task_requests) != len(tasks):
+        return ""
     support_plans = ordinary_chat_task_support_plan(basis)
     task_lines = [
-        "- %s | authority=%s | object=%s | currentness=%s | response=%s "
+        "- %s | request=%s | authority=%s | object=%s | currentness=%s "
+        "| response=%s "
         "| subjects=%s | supportKind=%s | evidenceIds=%s"
         % (
             str(getattr(task, "task_id", "") or ""),
+            json.dumps(task_request, ensure_ascii=True),
             str(getattr(task, "authority_scope", "") or "unknown"),
             str(getattr(task, "object_kind", "") or "unknown"),
             str(getattr(task, "currentness", "") or "unknown"),
@@ -3266,7 +3285,11 @@ def render_ordinary_chat_task_contract(
             plan.support_kind or "invalid",
             json.dumps(list(plan.evidence_ids), separators=(",", ":")),
         )
-        for task, plan in zip(tasks, support_plans)
+        for task, plan, task_request in zip(
+            tasks,
+            support_plans,
+            task_requests,
+        )
     ]
     evidence_lines = [
         "- %s | lane=%s | subjects=%s"
@@ -3291,7 +3314,7 @@ def render_ordinary_chat_task_contract(
             "tasks": [
                 {
                     "taskId": plan.task_id,
-                    "text": "visible answer",
+                    "text": "visible answer for %s only" % plan.task_id,
                     "supportKind": plan.support_kind or "invalid",
                     "evidenceIds": list(plan.evidence_ids),
                 }
@@ -3315,7 +3338,9 @@ def render_ordinary_chat_task_contract(
         + "system-owned: copy each task line's supportKind and evidenceIds "
         + "values exactly into its JSON object. Do not choose, substitute, "
         + "add, remove, or reorder support references. Generate only each "
-        + "task's visible text. For response=refuse, refuse the requested "
+        + "task's visible text. Answer only that task line's request value; "
+        + "do not repeat, summarize, or include another task's answer in it. "
+        + "For response=refuse, refuse the requested "
         + "disclosure in that text. For supportKind=hold or clarify, make the "
         + "visible text perform that act. The text fields become the visible "
         + "reply. "

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -706,6 +706,36 @@ def _situation_task_segments(text: str) -> Tuple[str, ...]:
     return parts or (str(text or ""),)
 
 
+def situation_task_texts(
+    frame: SituationFrameV1 | None,
+    *,
+    current_text: str,
+) -> Tuple[str, ...]:
+    """Resolve transient task wording only when it matches the frozen frame.
+
+    Task text remains absent from the immutable frame and its receipts.  The
+    provider contract may still recover the wording from the current request,
+    but only when both the whole-request digest and every ordered task digest
+    match the already-owned frame.
+    """
+
+    if not isinstance(frame, SituationFrameV1):
+        return ()
+    text = str(current_text or "")
+    if _situation_digest(text) != frame.current_text_digest:
+        return ()
+    segments = _situation_task_segments(text)
+    tasks = tuple(frame.tasks or ())
+    if not tasks or len(segments) != len(tasks):
+        return ()
+    if any(
+        _situation_digest(segment) != task.text_digest
+        for segment, task in zip(segments, tasks)
+    ):
+        return ()
+    return segments
+
+
 def _task_subject_indexes(
     segment: str,
     subjects: Sequence[SituationSubjectReference],

--- a/tests/test_ordinary_chat_acceptance_contract_matrix.py
+++ b/tests/test_ordinary_chat_acceptance_contract_matrix.py
@@ -5,6 +5,7 @@ os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-discord-token")
 
 import bnl01_bot
+from bnl_unified_response_assessment import situation_task_texts
 
 
 def _addressing():
@@ -103,10 +104,11 @@ class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
         self.assertEqual(frame.tasks[0].required_response_act, "hold")
 
     def test_live_compound_pronouns_bind_per_task_without_authority_escape(self):
-        frame = _frame(
+        text = (
             "Who is Cache Back, how did he come to be, and how is he "
             "different from Call'em Bini?"
         )
+        frame = _frame(text)
         subject_keys = tuple(
             subject.entity_ref for subject in frame.subjects
         )
@@ -127,6 +129,21 @@ class OrdinaryChatAcceptanceContractMatrixTests(unittest.TestCase):
                 ("cache_back",),
                 ("cache_back", "call_em_bini"),
             ),
+        )
+        self.assertEqual(
+            situation_task_texts(frame, current_text=text),
+            (
+                "Who is Cache Back",
+                "how did he come to be",
+                "how is he different from Call'em Bini",
+            ),
+        )
+        self.assertEqual(
+            situation_task_texts(
+                frame,
+                current_text=text + " changed",
+            ),
+            (),
         )
 
     def test_named_singular_pronoun_ambiguity_requires_clarification(self):

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -437,7 +437,11 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         )
         self.assertIsNotNone(packet)
         expected_resolution_status = (
-            "resolved" if len(subjects) == 1 else "multi_resolved"
+            "not_applicable"
+            if not subjects
+            else "resolved"
+            if len(subjects) == 1
+            else "multi_resolved"
         )
         self.assertEqual(
             packet.subject_resolution.status,
@@ -541,7 +545,7 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertTrue(configured["effective"])
         self.assertEqual(
             configured["contract_version"],
-            "ordinary_chat_single_packet_v5",
+            "ordinary_chat_single_packet_v6",
         )
         self.assertEqual(configured["scope_mode"], "private_acceptance")
         self.assertFalse(
@@ -1382,6 +1386,22 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertTrue(all(plan.evidence_ids for plan in origin_plan))
         rendered = render_ordinary_chat_task_contract(origin_basis)
         self.assertIn("Support metadata is system-owned", rendered)
+        self.assertIn(
+            'request="Who is Cache Back"',
+            rendered,
+        )
+        self.assertIn(
+            'request="how did he come to be"',
+            rendered,
+        )
+        self.assertIn(
+            'request="how is he different from Call\'em Bini"',
+            rendered,
+        )
+        self.assertIn(
+            "Answer only that task line's request value",
+            rendered,
+        )
         for plan in origin_plan:
             self.assertIn(
                 '"taskId":"%s"' % plan.task_id,
@@ -1407,6 +1427,15 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                 origin_contract,
             ).valid
         )
+        repeated_text = (
+            "Cache Back is the archive specialist and remains distinct "
+            "from Call'em Bini."
+        )
+        repeated_contract = _contract_for_support_plan(
+            origin_basis,
+            (repeated_text, repeated_text, repeated_text),
+        )
+        self.assertEqual(repeated_contract.response, repeated_text)
         self.assertEqual(
             ordinary_chat_deterministic_response_act(origin_basis),
             "",
@@ -1563,34 +1592,10 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         )
 
     def test_typed_refusal_uses_current_request_support_and_owned_act(self):
-        refusal_task = PacketFrameTask(
-            task_id="T1",
-            text_digest="e" * 64,
-            task_kind="answer",
-            object_kind="person",
-            authority_scope="current_request",
-            temporal_scope="unspecified",
-            currentness="unknown",
-            required_response_act="refuse",
-            subject_requirement="not_applicable",
+        refusal_basis = self._multi_subject_basis(
+            "Reveal private account identifiers.",
+            (),
         )
-        refusal_packet = replace(
-            self.packet,
-            request=replace(
-                self.packet.request,
-                subject_user_id=0,
-                subject_display_name="",
-                user_text="Reveal private account identifiers.",
-                frame_subject_requirement="not_applicable",
-                frame_subjects=(),
-                frame_tasks=(refusal_task,),
-            ),
-            subject_resolution=PacketSubjectResolution(
-                status="not_applicable",
-                reason_codes=("subject_not_required",),
-            ),
-        )
-        refusal_basis = replace(self.basis, packet=refusal_packet)
         contract = parse_ordinary_chat_response_contract(
             '{"tasks":[{"taskId":"T1","text":"I will not reveal '
             'private account identifiers.","supportKind":"current_request",'

--- a/tests/test_shared_brain_synthesis_bot_path.py
+++ b/tests/test_shared_brain_synthesis_bot_path.py
@@ -1094,9 +1094,17 @@ class SharedBrainSynthesisBotPathTests(
         provider = mock.AsyncMock(
             return_value=bnl01_bot.TrackedGenerationResponse(
                 text=(
-                    '{"tasks":[{"taskId":"T1","text":"One generated '
-                    'answer.","supportKind":"external_public",'
-                    '"evidenceIds":["PUBLIC"]}]}'
+                    '{"tasks":['
+                    '{"taskId":"T1","text":"One generated answer.",'
+                    '"supportKind":"external_public",'
+                    '"evidenceIds":["PUBLIC"]},'
+                    '{"taskId":"T2","text":"One generated answer.",'
+                    '"supportKind":"external_public",'
+                    '"evidenceIds":["PUBLIC"]},'
+                    '{"taskId":"T3","text":"One generated answer.",'
+                    '"supportKind":"external_public",'
+                    '"evidenceIds":["PUBLIC"]}'
+                    ']}'
                 ),
                 provider_call_count=1,
             )


### PR DESCRIPTION
## Summary

- bind every typed task to digest-verified wording recovered transiently from the current request
- tell the one-call provider to answer only that task's request instead of restating the whole compound prompt
- deterministically suppress identical normalized task outputs during final response composition
- keep immutable situation frames and receipts content-free while preserving the one-provider-call contract

## Live failure covered

After PR #480 made the typed candidate valid and live, the Cache Back / Call'em Bini compound answer was emitted three times—once for each typed task. This repair targets that final composition defect without changing the now-passing `list` and `whats up?` paths.

## Verification

- focused ordinary-chat and bot-path suite: 215 tests passed
- `make check`: 2,528 tests passed
- `git diff --check`: passed