### PR TITLE
Preserve task-owned Journal evidence through ambiguous frames

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -27563,6 +27563,11 @@ def _build_unified_intelligence_packet_shadow(
             if isinstance(situation_frame, SituationFrameV1)
             else "not_provided"
         ),
+        frame_ambiguity_reasons=(
+            situation_frame.ambiguity_reasons
+            if isinstance(situation_frame, SituationFrameV1)
+            else ()
+        ),
         frame_subject_requirement=(
             situation_frame.subject_requirement
             if isinstance(situation_frame, SituationFrameV1)

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -362,7 +362,8 @@ _JOURNAL_LATEST_RE = re.compile(
 )
 _JOURNAL_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})\b")
 _JOURNAL_EXPLICIT_TITLE_START_RE = re.compile(
-    r"\b(?:journal(?:\s+entry)?|daily\s+entry|weekly\s+entry)\b\s+"
+    r"\b(?:journal(?:\s+entry)?|daily\s+entry|weekly\s+entry)\b"
+    r"\s*(?:[,;:‒–—]\s*)?"
     r"(?:(?:with|having)\s+(?:the\s+)?)?"
     r"(?:title(?:d)?|called|named)\s*(?::|=|is)?\s*"
     r"(?P<quote>[\"“'‘])",

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -363,7 +363,7 @@ _JOURNAL_LATEST_RE = re.compile(
 _JOURNAL_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})\b")
 _JOURNAL_EXPLICIT_TITLE_START_RE = re.compile(
     r"\b(?:journal(?:\s+entry)?|daily\s+entry|weekly\s+entry)\b"
-    r"\s*(?:[-,;:‒–—]\s*)?"
+    r"\s*(?:[-,;:‒–—(\[{]+\s*)?"
     r"(?:(?:with|having)\s+(?:the\s+)?)?"
     r"(?:title(?:d)?|called|named)\s*(?::|=|is)?\s*"
     r"(?P<quote>[\"“'‘])",

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -363,7 +363,8 @@ _JOURNAL_LATEST_RE = re.compile(
 _JOURNAL_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})\b")
 _JOURNAL_EXPLICIT_TITLE_RE = re.compile(
     r"\b(?:title(?:d)?|called|named)\s*(?::|=|is)?\s*"
-    r"[\"“](?P<title>[^\"”\n]{3,300})[\"”]",
+    r"(?:[\"“](?P<double_title>[^\"”\n]{3,300})[\"”]"
+    r"|['‘](?P<single_title>[^'’\n]{3,300})['’])",
     re.IGNORECASE,
 )
 _JOURNAL_QUERY_STOPWORDS = _CONTEXT_TOPIC_STOPWORDS | {
@@ -548,7 +549,10 @@ def _journal_query_identity(user_text: str) -> str:
 
 def _journal_query_title(user_text: str) -> str:
     match = _JOURNAL_EXPLICIT_TITLE_RE.search(str(user_text or ""))
-    return re.sub(r"\s+", " ", match.group("title")).strip() if match else ""
+    if not match:
+        return ""
+    title = match.group("double_title") or match.group("single_title") or ""
+    return re.sub(r"\s+", " ", title).strip()
 
 
 def _journal_query_terms(user_text: str) -> set[str]:
@@ -583,7 +587,7 @@ def _latest_published_journal_rows(
     entry_id: str = "",
     publication_date: str = "",
     exact_title: str = "",
-    limit: int = JOURNAL_PUBLICATION_TOPIC_SCAN_LIMIT,
+    limit: Optional[int] = JOURNAL_PUBLICATION_TOPIC_SCAN_LIMIT,
 ) -> list[dict[str, Any]]:
     if not table_exists(conn, "bnl_journal_entries"):
         return []
@@ -615,16 +619,18 @@ def _latest_published_journal_rows(
             "AND LOWER(TRIM(e.title))=LOWER(TRIM(?))"
         )
         params.append(exact_title)
-    params.append(max(1, min(int(limit or 1), 500)))
-    rows = conn.execute(
+    sql = (
         "SELECT "
         + ",".join("e." + name for name in _JOURNAL_PUBLICATION_COLUMNS)
         + " FROM bnl_journal_entries e WHERE "
         + " AND ".join(where)
         + " ORDER BY COALESCE(e.published_at,e.created_at) DESC,"
-        "e.entry_id ASC,e.revision DESC LIMIT ?",
-        tuple(params),
-    ).fetchall()
+        "e.entry_id ASC,e.revision DESC"
+    )
+    if limit is not None:
+        params.append(max(1, min(int(limit or 1), 500)))
+        sql += " LIMIT ?"
+    rows = conn.execute(sql, tuple(params)).fetchall()
     return [dict(zip(_JOURNAL_PUBLICATION_COLUMNS, row)) for row in rows]
 
 
@@ -821,7 +827,7 @@ def select_published_journal_entries_on_connection(
                 conn,
                 guild_id=guild_id,
                 exact_title=explicit_title,
-                limit=max(8, limit),
+                limit=None,
             )
         )
         if title_rows:
@@ -833,7 +839,7 @@ def select_published_journal_entries_on_connection(
                 conn,
                 guild_id=guild_id,
                 publication_date=publication_date,
-                limit=max(8, limit),
+                limit=None,
             )
         else:
             query_mode = (
@@ -934,6 +940,7 @@ def revalidate_published_journal_entry_on_connection(
     control_snapshot: JournalControlSnapshot | None,
     user_text: str = "",
     now: Any = None,
+    require_unique_selection: bool = False,
 ) -> str:
     if (
         journal_control_snapshot_status(control_snapshot, now=now) != "valid"
@@ -947,6 +954,30 @@ def revalidate_published_journal_entry_on_connection(
         and entry_id in set(control_snapshot.memory_excluded_entry_ids)
     ):
         return ""
+    if require_unique_selection:
+        if not str(user_text or "").strip():
+            return ""
+        selection = select_published_journal_entries_on_connection(
+            conn,
+            guild_id=guild_id,
+            user_text=user_text,
+            control_snapshot=control_snapshot,
+            now=now,
+            limit=2,
+        )
+        if (
+            selection.status != "eligible"
+            or selection.query_mode != query_mode
+            or len(selection.publications) != 1
+        ):
+            return ""
+        publication = selection.publications[0]
+        if (
+            publication.entry_id != entry_id
+            or publication.revision != int(revision)
+        ):
+            return ""
+        return publication.source_digest
     if query_mode == "latest":
         if not str(user_text or "").strip():
             return ""

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -363,8 +363,11 @@ _JOURNAL_LATEST_RE = re.compile(
 _JOURNAL_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})\b")
 _JOURNAL_EXPLICIT_TITLE_RE = re.compile(
     r"\b(?:title(?:d)?|called|named)\s*(?::|=|is)?\s*"
-    r"(?:[\"“](?P<double_title>[^\"”\n]{3,300})[\"”]"
-    r"|['‘](?P<single_title>[^'’\n]{3,300})['’])",
+    r'(?:"(?P<straight_double_title>[^"\n]{3,300})"'
+    r"|“(?P<curly_double_title>[^”\n]{3,300})”"
+    r"|'(?P<straight_single_title>(?:[^'\n]|'(?=\w)){3,300})'"
+    r"|‘(?P<curly_single_title>(?:[^’\n]|’(?=\w)){3,300})’)"
+    r"(?=\s|[.,;:!?)]|$)",
     re.IGNORECASE,
 )
 _JOURNAL_QUERY_STOPWORDS = _CONTEXT_TOPIC_STOPWORDS | {
@@ -551,7 +554,19 @@ def _journal_query_title(user_text: str) -> str:
     match = _JOURNAL_EXPLICIT_TITLE_RE.search(str(user_text or ""))
     if not match:
         return ""
-    title = match.group("double_title") or match.group("single_title") or ""
+    title = next(
+        (
+            value
+            for value in (
+                match.group("straight_double_title"),
+                match.group("curly_double_title"),
+                match.group("straight_single_title"),
+                match.group("curly_single_title"),
+            )
+            if value
+        ),
+        "",
+    )
     return re.sub(r"\s+", " ", title).strip()
 
 
@@ -822,7 +837,7 @@ def select_published_journal_entries_on_connection(
     else:
         title_rows = (
             []
-            if requested_mode == "latest" or not explicit_title
+            if not explicit_title
             else _latest_published_journal_rows(
                 conn,
                 guild_id=guild_id,
@@ -830,7 +845,7 @@ def select_published_journal_entries_on_connection(
                 limit=None,
             )
         )
-        if title_rows:
+        if explicit_title:
             query_mode = "exact_title"
             rows = title_rows
         elif publication_date:

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -362,7 +362,9 @@ _JOURNAL_LATEST_RE = re.compile(
 )
 _JOURNAL_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})\b")
 _JOURNAL_EXPLICIT_TITLE_START_RE = re.compile(
-    r"\b(?:title(?:d)?|called|named)\s*(?::|=|is)?\s*"
+    r"\b(?:journal(?:\s+entry)?|daily\s+entry|weekly\s+entry)\b\s+"
+    r"(?:(?:with|having)\s+(?:the\s+)?)?"
+    r"(?:title(?:d)?|called|named)\s*(?::|=|is)?\s*"
     r"(?P<quote>[\"“'‘])",
     re.IGNORECASE,
 )

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -550,11 +550,11 @@ def _journal_query_identity(user_text: str) -> str:
     return ""
 
 
-def _journal_query_title(user_text: str) -> str:
+def _journal_query_title_candidates(user_text: str) -> tuple[str, ...]:
     text = str(user_text or "")
     match = _JOURNAL_EXPLICIT_TITLE_START_RE.search(text)
     if not match:
-        return ""
+        return ()
     opener = match.group("quote")
     closer = _JOURNAL_TITLE_QUOTE_PAIRS[opener]
     title_start = match.end()
@@ -562,28 +562,19 @@ def _journal_query_title(user_text: str) -> str:
     line_end = len(text) if newline_at < 0 else newline_at
     scan_end = min(line_end, title_start + 300)
     close_at = text.find(closer, title_start + 3, scan_end + 1)
+    candidates: list[str] = []
     while close_at >= 0:
         suffix = text[close_at + 1 : line_end]
         if _JOURNAL_TITLE_CLOSE_BOUNDARY_RE.match(suffix):
-            later_close = text.find(closer, close_at + 1, scan_end + 1)
-            # With single quotes, a prior candidate can be a possessive
-            # apostrophe. Scan onward only when the next same-style mark
-            # can itself close; a mark followed by title text is an opener.
-            if (
-                opener not in {"'", "‘"}
-                or later_close < 0
-                or not _JOURNAL_TITLE_CLOSE_BOUNDARY_RE.match(
-                    text[later_close + 1 : line_end]
-                )
-            ):
+            title = re.sub(
+                r"\s+", " ", text[title_start:close_at]
+            ).strip()
+            if title and title not in candidates:
+                candidates.append(title)
+            if opener not in {"'", "‘"}:
                 break
         close_at = text.find(closer, close_at + 1, scan_end + 1)
-    if close_at < 0:
-        return ""
-    title = text[title_start:close_at]
-    return re.sub(r"\s+", " ", title).strip()
-
-
+    return tuple(candidates)
 def _journal_query_terms(user_text: str) -> set[str]:
     return {
         token
@@ -835,7 +826,10 @@ def select_published_journal_entries_on_connection(
         return JournalPublicationSelection("source_unavailable", requested_mode)
 
     identity = _journal_query_identity(user_text)
-    explicit_title = _journal_query_title(user_text)
+    explicit_title_candidates = _journal_query_title_candidates(user_text)
+    explicit_title = (
+        explicit_title_candidates[-1] if explicit_title_candidates else ""
+    )
     publication_date_match = _JOURNAL_DATE_RE.search(str(user_text or ""))
     publication_date = (
         publication_date_match.group(1) if publication_date_match else ""
@@ -849,16 +843,18 @@ def select_published_journal_entries_on_connection(
             limit=max(1, limit),
         )
     else:
-        title_rows = (
-            []
-            if not explicit_title
-            else _latest_published_journal_rows(
+        title_rows: list[dict[str, Any]] = []
+        for candidate in reversed(explicit_title_candidates):
+            candidate_rows = _latest_published_journal_rows(
                 conn,
                 guild_id=guild_id,
-                exact_title=explicit_title,
+                exact_title=candidate,
                 limit=None,
             )
-        )
+            if candidate_rows:
+                explicit_title = candidate
+                title_rows = candidate_rows
+                break
         if explicit_title:
             query_mode = "exact_title"
             rows = title_rows

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -370,15 +370,6 @@ _JOURNAL_TITLE_QUOTE_PAIRS = {"\"": "\"", "“": "”", "'": "'", "‘": "’"}
 _JOURNAL_TITLE_CLOSE_BOUNDARY_RE = re.compile(
     r"^(?:\s|[.,;:!?)}\]]|$)"
 )
-_JOURNAL_TITLE_STRONG_CLOSE_BOUNDARY_RE = re.compile(
-    r"^\s*(?:[.,;:!?)}\]]|20\d{2}-\d{2}-\d{2}\b|"
-    r"(?:from|on)\s+(?:20\d{2}-\d{2}-\d{2}|today|tonight|"
-    r"yesterday|tomorrow)\b|"
-    r"(?:and|but|or|then)\s+(?:compare|explain|give|read|show|"
-    r"summarize|tell|what|when|where|which|who|why|how)\b|"
-    r"(?:please|what|when|where|which|who|why|how)\b)",
-    re.IGNORECASE,
-)
 _JOURNAL_QUERY_STOPWORDS = _CONTEXT_TOPIC_STOPWORDS | {
     "article",
     "called",
@@ -576,12 +567,14 @@ def _journal_query_title(user_text: str) -> str:
         if _JOURNAL_TITLE_CLOSE_BOUNDARY_RE.match(suffix):
             later_close = text.find(closer, close_at + 1, scan_end + 1)
             # With single quotes, a prior candidate can be a possessive
-            # apostrophe. Scan onward unless this is the last candidate or
-            # the suffix clearly begins a new clause.
+            # apostrophe. Scan onward only when the next same-style mark
+            # can itself close; a mark followed by title text is an opener.
             if (
                 opener not in {"'", "‘"}
                 or later_close < 0
-                or _JOURNAL_TITLE_STRONG_CLOSE_BOUNDARY_RE.match(suffix)
+                or not _JOURNAL_TITLE_CLOSE_BOUNDARY_RE.match(
+                    text[later_close + 1 : line_end]
+                )
             ):
                 break
         close_at = text.find(closer, close_at + 1, scan_end + 1)

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -368,8 +368,68 @@ _JOURNAL_EXPLICIT_TITLE_START_RE = re.compile(
 )
 _JOURNAL_TITLE_QUOTE_PAIRS = {"\"": "\"", "“": "”", "'": "'", "‘": "’"}
 _JOURNAL_TITLE_CLOSE_BOUNDARY_RE = re.compile(
-    r"^(?:\s|[.,;:!?)}\]]|$)"
+    r"^(?:\s|[.,;:!?)}\]‒–—]|$)"
 )
+_JOURNAL_TITLE_TRAILING_CLAUSE_STARTERS = {
+    "about",
+    "after",
+    "against",
+    "alongside",
+    "among",
+    "around",
+    "as",
+    "at",
+    "before",
+    "behind",
+    "below",
+    "beneath",
+    "beside",
+    "between",
+    "beyond",
+    "by",
+    "concerning",
+    "despite",
+    "during",
+    "except",
+    "for",
+    "from",
+    "how",
+    "in",
+    "inside",
+    "into",
+    "like",
+    "near",
+    "of",
+    "off",
+    "on",
+    "onto",
+    "outside",
+    "over",
+    "past",
+    "please",
+    "regarding",
+    "since",
+    "than",
+    "through",
+    "throughout",
+    "to",
+    "toward",
+    "under",
+    "underneath",
+    "until",
+    "up",
+    "upon",
+    "via",
+    "what",
+    "when",
+    "where",
+    "which",
+    "who",
+    "why",
+    "with",
+    "within",
+    "without",
+}
 _JOURNAL_QUERY_STOPWORDS = _CONTEXT_TOPIC_STOPWORDS | {
     "article",
     "called",
@@ -562,19 +622,49 @@ def _journal_query_title_candidates(user_text: str) -> tuple[str, ...]:
     line_end = len(text) if newline_at < 0 else newline_at
     scan_end = min(line_end, title_start + 300)
     close_at = text.find(closer, title_start + 3, scan_end + 1)
-    candidates: list[str] = []
+    candidates: list[tuple[str, int]] = []
     while close_at >= 0:
         suffix = text[close_at + 1 : line_end]
         if _JOURNAL_TITLE_CLOSE_BOUNDARY_RE.match(suffix):
             title = re.sub(
                 r"\s+", " ", text[title_start:close_at]
             ).strip()
-            if title and title not in candidates:
-                candidates.append(title)
+            if title and all(title != item[0] for item in candidates):
+                candidates.append((title, close_at))
             if opener not in {"'", "‘"}:
                 break
         close_at = text.find(closer, close_at + 1, scan_end + 1)
-    return tuple(candidates)
+    if not candidates:
+        return ()
+    if opener not in {"'", "‘"}:
+        return (candidates[0][0],)
+
+    # A plural possessive inside a single-quoted title produces a possible
+    # close before the real outer quote. Advance only when the current word
+    # can be possessive and the text before the next candidate still looks
+    # like title text. Once an authoritative outer boundary is found, never
+    # weaken the explicit title to a shorter stored publication.
+    selected_index = 0
+    while selected_index + 1 < len(candidates):
+        _, current_close = candidates[selected_index]
+        _, next_close = candidates[selected_index + 1]
+        between = text[current_close + 1 : next_close]
+        if closer in between:
+            break
+        current_word = re.search(
+            r"([A-Za-z0-9]+)$", text[title_start:current_close]
+        )
+        next_word = re.match(r"\s*([A-Za-z0-9]+)", between)
+        if (
+            current_word is None
+            or not current_word.group(1).lower().endswith("s")
+            or next_word is None
+            or next_word.group(1).lower()
+            in _JOURNAL_TITLE_TRAILING_CLAUSE_STARTERS
+        ):
+            break
+        selected_index += 1
+    return (candidates[selected_index][0],)
 def _journal_query_terms(user_text: str) -> set[str]:
     return {
         token

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -361,6 +361,11 @@ _JOURNAL_LATEST_RE = re.compile(
     re.IGNORECASE,
 )
 _JOURNAL_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})\b")
+_JOURNAL_EXPLICIT_TITLE_RE = re.compile(
+    r"\b(?:title(?:d)?|called|named)\s*(?::|=|is)?\s*"
+    r"[\"“](?P<title>[^\"”\n]{3,300})[\"”]",
+    re.IGNORECASE,
+)
 _JOURNAL_QUERY_STOPWORDS = _CONTEXT_TOPIC_STOPWORDS | {
     "article",
     "called",
@@ -541,6 +546,11 @@ def _journal_query_identity(user_text: str) -> str:
     return ""
 
 
+def _journal_query_title(user_text: str) -> str:
+    match = _JOURNAL_EXPLICIT_TITLE_RE.search(str(user_text or ""))
+    return re.sub(r"\s+", " ", match.group("title")).strip() if match else ""
+
+
 def _journal_query_terms(user_text: str) -> set[str]:
     return {
         token
@@ -572,7 +582,7 @@ def _latest_published_journal_rows(
     guild_id: int,
     entry_id: str = "",
     publication_date: str = "",
-    containing_title_in: str = "",
+    exact_title: str = "",
     limit: int = JOURNAL_PUBLICATION_TOPIC_SCAN_LIMIT,
 ) -> list[dict[str, Any]]:
     if not table_exists(conn, "bnl_journal_entries"):
@@ -599,12 +609,12 @@ def _latest_published_journal_rows(
             "SUBSTR(COALESCE(e.published_at,e.created_at),1,10)=?"
         )
         params.append(publication_date)
-    if containing_title_in:
+    if exact_title:
         where.append(
             "LENGTH(TRIM(e.title))>=3 "
-            "AND INSTR(LOWER(?),LOWER(TRIM(e.title)))>0"
+            "AND LOWER(TRIM(e.title))=LOWER(TRIM(?))"
         )
-        params.append(containing_title_in)
+        params.append(exact_title)
     params.append(max(1, min(int(limit or 1), 500)))
     rows = conn.execute(
         "SELECT "
@@ -790,6 +800,7 @@ def select_published_journal_entries_on_connection(
         return JournalPublicationSelection("source_unavailable", requested_mode)
 
     identity = _journal_query_identity(user_text)
+    explicit_title = _journal_query_title(user_text)
     publication_date_match = _JOURNAL_DATE_RE.search(str(user_text or ""))
     publication_date = (
         publication_date_match.group(1) if publication_date_match else ""
@@ -805,11 +816,11 @@ def select_published_journal_entries_on_connection(
     else:
         title_rows = (
             []
-            if requested_mode == "latest"
+            if requested_mode == "latest" or not explicit_title
             else _latest_published_journal_rows(
                 conn,
                 guild_id=guild_id,
-                containing_title_in=str(user_text or ""),
+                exact_title=explicit_title,
                 limit=max(8, limit),
             )
         )

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -363,7 +363,7 @@ _JOURNAL_LATEST_RE = re.compile(
 _JOURNAL_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})\b")
 _JOURNAL_EXPLICIT_TITLE_START_RE = re.compile(
     r"\b(?:journal(?:\s+entry)?|daily\s+entry|weekly\s+entry)\b"
-    r"\s*(?:[,;:‒–—]\s*)?"
+    r"\s*(?:[-,;:‒–—]\s*)?"
     r"(?:(?:with|having)\s+(?:the\s+)?)?"
     r"(?:title(?:d)?|called|named)\s*(?::|=|is)?\s*"
     r"(?P<quote>[\"“'‘])",

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -361,13 +361,22 @@ _JOURNAL_LATEST_RE = re.compile(
     re.IGNORECASE,
 )
 _JOURNAL_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})\b")
-_JOURNAL_EXPLICIT_TITLE_RE = re.compile(
+_JOURNAL_EXPLICIT_TITLE_START_RE = re.compile(
     r"\b(?:title(?:d)?|called|named)\s*(?::|=|is)?\s*"
-    r'(?:"(?P<straight_double_title>[^"\n]{3,300})"'
-    r"|“(?P<curly_double_title>[^”\n]{3,300})”"
-    r"|'(?P<straight_single_title>(?:[^'\n]|'(?=\w)){3,300})'"
-    r"|‘(?P<curly_single_title>(?:[^’\n]|’(?=\w)){3,300})’)"
-    r"(?=\s|[.,;:!?)]|$)",
+    r"(?P<quote>[\"“'‘])",
+    re.IGNORECASE,
+)
+_JOURNAL_TITLE_QUOTE_PAIRS = {"\"": "\"", "“": "”", "'": "'", "‘": "’"}
+_JOURNAL_TITLE_CLOSE_BOUNDARY_RE = re.compile(
+    r"^(?:\s|[.,;:!?)}\]]|$)"
+)
+_JOURNAL_TITLE_STRONG_CLOSE_BOUNDARY_RE = re.compile(
+    r"^\s*(?:[.,;:!?)}\]]|20\d{2}-\d{2}-\d{2}\b|"
+    r"(?:from|on)\s+(?:20\d{2}-\d{2}-\d{2}|today|tonight|"
+    r"yesterday|tomorrow)\b|"
+    r"(?:and|but|or|then)\s+(?:compare|explain|give|read|show|"
+    r"summarize|tell|what|when|where|which|who|why|how)\b|"
+    r"(?:please|what|when|where|which|who|why|how)\b)",
     re.IGNORECASE,
 )
 _JOURNAL_QUERY_STOPWORDS = _CONTEXT_TOPIC_STOPWORDS | {
@@ -551,22 +560,34 @@ def _journal_query_identity(user_text: str) -> str:
 
 
 def _journal_query_title(user_text: str) -> str:
-    match = _JOURNAL_EXPLICIT_TITLE_RE.search(str(user_text or ""))
+    text = str(user_text or "")
+    match = _JOURNAL_EXPLICIT_TITLE_START_RE.search(text)
     if not match:
         return ""
-    title = next(
-        (
-            value
-            for value in (
-                match.group("straight_double_title"),
-                match.group("curly_double_title"),
-                match.group("straight_single_title"),
-                match.group("curly_single_title"),
-            )
-            if value
-        ),
-        "",
-    )
+    opener = match.group("quote")
+    closer = _JOURNAL_TITLE_QUOTE_PAIRS[opener]
+    title_start = match.end()
+    newline_at = text.find("\n", title_start)
+    line_end = len(text) if newline_at < 0 else newline_at
+    scan_end = min(line_end, title_start + 300)
+    close_at = text.find(closer, title_start + 3, scan_end + 1)
+    while close_at >= 0:
+        suffix = text[close_at + 1 : line_end]
+        if _JOURNAL_TITLE_CLOSE_BOUNDARY_RE.match(suffix):
+            later_close = text.find(closer, close_at + 1, scan_end + 1)
+            # With single quotes, a prior candidate can be a possessive
+            # apostrophe. Scan onward unless this is the last candidate or
+            # the suffix clearly begins a new clause.
+            if (
+                opener not in {"'", "‘"}
+                or later_close < 0
+                or _JOURNAL_TITLE_STRONG_CLOSE_BOUNDARY_RE.match(suffix)
+            ):
+                break
+        close_at = text.find(closer, close_at + 1, scan_end + 1)
+    if close_at < 0:
+        return ""
+    title = text[title_start:close_at]
     return re.sub(r"\s+", " ", title).strip()
 
 

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -4964,8 +4964,9 @@ def _relay_publication_items(
 def _subject_independent_publication_lanes(
     request: IntelligencePacketRequest,
     diagnostics: IntelligencePacketDiagnostics,
+    candidates: Sequence[IntelligencePacketItem],
 ) -> frozenset[str]:
-    """Return uniquely resolved publication lanes outside subject ambiguity."""
+    """Return concretely selected publication lanes outside subject ambiguity."""
 
     ambiguity_reasons = frozenset(
         str(reason or "").strip().lower()
@@ -4990,18 +4991,49 @@ def _subject_independent_publication_lanes(
         "journal": (
             str(diagnostics.journal_query_status or "").strip().lower(),
             int(diagnostics.journal_candidate_count or 0),
+            frozenset({"exact_identity", "exact_title", "exact_date"}),
         ),
         "relay": (
             str(diagnostics.relay_query_status or "").strip().lower(),
             int(diagnostics.relay_candidate_count or 0),
+            frozenset({"exact_identity", "exact_date"}),
         ),
     }
+    publication_items_by_lane: dict[
+        str,
+        dict[tuple[str, str, str], IntelligencePacketItem],
+    ] = {}
+    for item in candidates:
+        if item.lane not in {"journal_publication", "relay_publication"}:
+            continue
+        publication_items_by_lane.setdefault(item.lane, {})[
+            (item.source_ref, item.source_digest, item.revalidation_key)
+        ] = item
     lanes: set[str] = set()
     for task in request.frame_tasks:
         object_kind = str(task.object_kind or "").strip().lower()
-        query_status, candidate_count = publication_queries.get(
-            object_kind,
-            ("not_requested", 0),
+        query_status, candidate_count, concrete_query_modes = (
+            publication_queries.get(
+                object_kind,
+                ("not_requested", 0, frozenset()),
+            )
+        )
+        lane = "%s_publication" % object_kind
+        publication_items = tuple(
+            publication_items_by_lane.get(lane, {}).values()
+        )
+        query_mode = (
+            str(
+                _publication_revalidation_payload(publication_items[0]).get(
+                    "queryMode"
+                )
+                or ""
+            )
+            .strip()
+            .lower()
+            if len(publication_items) == 1
+            and publication_items[0].revalidation_kind == lane
+            else ""
         )
         if (
             str(task.authority_scope or "").strip().lower() == "packet"
@@ -5013,8 +5045,9 @@ def _subject_independent_publication_lanes(
             and object_kind in {"journal", "relay"}
             and query_status == "eligible"
             and candidate_count == 1
+            and query_mode in concrete_query_modes
         ):
-            lanes.add("%s_publication" % object_kind)
+            lanes.add(lane)
     return frozenset(lanes)
 
 
@@ -5044,7 +5077,11 @@ def _filter_frame_applicable_candidates(
         kept = []
         reason = "frame_subject_%s" % subject_resolution.status
         subject_independent_publication_lanes = (
-            _subject_independent_publication_lanes(request, diagnostics)
+            _subject_independent_publication_lanes(
+                request,
+                diagnostics,
+                candidates,
+            )
             if subject_resolution.status == "ambiguous"
             else frozenset()
         )
@@ -6206,6 +6243,7 @@ def _revalidate_packet_in_snapshot(
         _subject_independent_publication_lanes(
             packet.request,
             packet.diagnostics,
+            packet.items,
         )
     )
     subject_independent_publication_content = bool(
@@ -6463,6 +6501,7 @@ def _packet_invariants(
         _subject_independent_publication_lanes(
             packet.request,
             packet.diagnostics,
+            packet.items,
         )
         if packet.subject_resolution.status == "ambiguous"
         else frozenset()

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -298,23 +298,19 @@ _TERM_RE = re.compile(r"[a-z0-9][a-z0-9'’-]*", re.I)
 _PUBLICATION_DATE_LITERAL = r"20\d{2}-\d{2}-\d{2}"
 _PUBLICATION_DATE_SELECTOR_RE = {
     "journal": re.compile(
-        r"(?:\bjournal(?:\s+entry)?\b\s+"
+        r"\bjournal(?:\s+entry)?\b\s+"
         r"(?:(?:was\s+)?(?:publish(?:ed)?|post(?:ed)?|release(?:d)?)"
         r"\s+(?:(?:on|for)\s+)?|(?:dated|from|for|on)\s+)"
         + _PUBLICATION_DATE_LITERAL
-        + r"\b|\b"
-        + _PUBLICATION_DATE_LITERAL
-        + r"\s+journal(?:\s+entry)?\b)",
+        + r"\b",
         re.I,
     ),
     "relay": re.compile(
-        r"(?:\b(?:relay|website\s+(?:message|signal|status))\b\s+"
+        r"\b(?:relay|website\s+(?:message|signal|status))\b\s+"
         r"(?:(?:was\s+)?(?:publish(?:ed)?|post(?:ed)?|release(?:d)?)"
         r"\s+(?:(?:on|for)\s+)?|(?:dated|from|for|on)\s+)"
         + _PUBLICATION_DATE_LITERAL
-        + r"\b|\b"
-        + _PUBLICATION_DATE_LITERAL
-        + r"\s+(?:relay|website\s+(?:message|signal|status))\b)",
+        + r"\b",
         re.I,
     ),
 }

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -4990,12 +4990,10 @@ def _subject_independent_publication_lanes(
     publication_queries = {
         "journal": (
             str(diagnostics.journal_query_status or "").strip().lower(),
-            int(diagnostics.journal_candidate_count or 0),
             frozenset({"exact_identity", "exact_title", "exact_date"}),
         ),
         "relay": (
             str(diagnostics.relay_query_status or "").strip().lower(),
-            int(diagnostics.relay_candidate_count or 0),
             frozenset({"exact_identity", "exact_date"}),
         ),
     }
@@ -5012,10 +5010,10 @@ def _subject_independent_publication_lanes(
     lanes: set[str] = set()
     for task in request.frame_tasks:
         object_kind = str(task.object_kind or "").strip().lower()
-        query_status, candidate_count, concrete_query_modes = (
+        query_status, concrete_query_modes = (
             publication_queries.get(
                 object_kind,
-                ("not_requested", 0, frozenset()),
+                ("not_requested", frozenset()),
             )
         )
         lane = "%s_publication" % object_kind
@@ -5044,7 +5042,7 @@ def _subject_independent_publication_lanes(
             and not task.subject_indexes
             and object_kind in {"journal", "relay"}
             and query_status == "eligible"
-            and candidate_count == 1
+            and len(publication_items) == 1
             and query_mode in concrete_query_modes
         ):
             lanes.add(lane)

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -303,7 +303,8 @@ _PUBLICATION_DATE_FOLLOWUP_LITERAL = (
 _PUBLICATION_DATE_SELECTOR_BOUNDARY = (
     r"(?=\s*(?:$|[.?!;:)\]}‒–—]|"
     r"(?:,\s*(?:(?:and|but)\s+)?|(?:and|but)\s+)?"
-    r"(?:(?:then|please|also|just|briefly|quickly)\s+){0,2}"
+    r"(?:(?:then|please|also|just|briefly|quickly|kindly|now)\b"
+    r"\s*(?:[,;:]\s*)?){0,3}"
     + _PUBLICATION_DATE_FOLLOWUP_LITERAL
     + r"))"
 )

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -4960,6 +4960,26 @@ def _relay_publication_items(
     return items
 
 
+def _subject_independent_publication_lanes(
+    request: IntelligencePacketRequest,
+) -> frozenset[str]:
+    """Return task-owned publication lanes that need no person subject."""
+
+    lanes: set[str] = set()
+    for task in request.frame_tasks:
+        object_kind = str(task.object_kind or "").strip().lower()
+        if (
+            str(task.authority_scope or "").strip().lower() == "packet"
+            and str(task.task_kind or "").strip().lower()
+            == "retrieve_publication"
+            and str(task.subject_requirement or "").strip().lower()
+            != "required"
+            and object_kind in {"journal", "relay"}
+        ):
+            lanes.add("%s_publication" % object_kind)
+    return frozenset(lanes)
+
+
 def _filter_frame_applicable_candidates(
     request: IntelligencePacketRequest,
     subject_resolution: PacketSubjectResolution,
@@ -4985,8 +5005,16 @@ def _filter_frame_applicable_candidates(
     if not subject_resolution.applicable:
         kept = []
         reason = "frame_subject_%s" % subject_resolution.status
+        subject_independent_publication_lanes = (
+            _subject_independent_publication_lanes(request)
+            if subject_resolution.status == "ambiguous"
+            else frozenset()
+        )
         for item in candidates:
-            if item.lane == "current_intent":
+            if (
+                item.lane == "current_intent"
+                or item.lane in subject_independent_publication_lanes
+            ):
                 kept.append(item)
             else:
                 exclude(item, reason)
@@ -6136,6 +6164,26 @@ def _revalidate_packet_in_snapshot(
         packet.request,
         environ=environ,
     )
+    subject_independent_publication_lanes = (
+        _subject_independent_publication_lanes(packet.request)
+    )
+    subject_independent_publication_content = bool(
+        current_subject_resolution.status == "ambiguous"
+        and subject_independent_publication_lanes
+        and any(
+            item.lane in subject_independent_publication_lanes
+            for item in packet.items
+        )
+        and all(
+            item.lane == "current_intent"
+            or item.lane in subject_independent_publication_lanes
+            for item in packet.items
+        )
+        and all(
+            item.lane in subject_independent_publication_lanes
+            for item in packet.validation_items
+        )
+    )
     legacy_resolution_unspecified = bool(
         not str(packet.request.frame_revision or "").strip()
         and packet.subject_resolution.status == "unresolved"
@@ -6312,7 +6360,10 @@ def _revalidate_packet_in_snapshot(
         status = "processing_error"
     elif subject_changed:
         status = "subject_binding_changed"
-    elif not current_subject_resolution.applicable:
+    elif (
+        not current_subject_resolution.applicable
+        and not subject_independent_publication_content
+    ):
         status = "subject_%s" % current_subject_resolution.status
     elif changed:
         status = "source_changed"
@@ -6367,6 +6418,11 @@ def _packet_invariants(
     packet: UnifiedIntelligencePacket,
 ) -> tuple[str, ...]:
     invalid = []
+    subject_independent_publication_lanes = (
+        _subject_independent_publication_lanes(packet.request)
+        if packet.subject_resolution.status == "ambiguous"
+        else frozenset()
+    )
     accepted_subject_keys = {
         value for value in packet_subject_keys(packet) if value
     }
@@ -6419,7 +6475,11 @@ def _packet_invariants(
     if (
         str(packet.request.frame_revision or "").strip()
         and not packet.subject_resolution.applicable
-        and any(item.lane != "current_intent" for item in packet.items)
+        and any(
+            item.lane != "current_intent"
+            and item.lane not in subject_independent_publication_lanes
+            for item in packet.items
+        )
     ):
         invalid.append("unresolved_frame_subject_selected_content")
     if str(packet.request.frame_revision or "").strip() and not (

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -303,6 +303,7 @@ _PUBLICATION_DATE_FOLLOWUP_LITERAL = (
 _PUBLICATION_DATE_SELECTOR_BOUNDARY = (
     r"(?=\s*(?:$|[.?!;:)\]}‒–—]|"
     r"(?:,\s*(?:(?:and|but)\s+)?|(?:and|but)\s+)?"
+    r"(?:(?:then|please|also|just|briefly|quickly)\s+){0,2}"
     + _PUBLICATION_DATE_FOLLOWUP_LITERAL
     + r"))"
 )

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -4988,10 +4988,20 @@ def _publication_date_selector_is_bound(
     user_text: str,
     object_kind: str,
 ) -> bool:
+    text = str(user_text or "")
     pattern = _PUBLICATION_DATE_SELECTOR_RE.get(
         str(object_kind or "").strip().lower()
     )
-    return bool(pattern and pattern.search(str(user_text or "")))
+    selected_date = re.search(
+        r"\b" + _PUBLICATION_DATE_LITERAL + r"\b",
+        text,
+    )
+    if pattern is None or selected_date is None:
+        return False
+    return any(
+        selected_date.group(0) in match.group(0)
+        for match in pattern.finditer(text)
+    )
 
 
 def _subject_independent_publication_lanes(

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -296,21 +296,33 @@ _EPISODE_QUERY_RE = re.compile(
 )
 _TERM_RE = re.compile(r"[a-z0-9][a-z0-9'’-]*", re.I)
 _PUBLICATION_DATE_LITERAL = r"20\d{2}-\d{2}-\d{2}"
+_PUBLICATION_DATE_FOLLOWUP_LITERAL = (
+    r"(?:what|when|where|why|how|tell|show|give|summarize|explain|compare|"
+    r"does|did|is|was|can|could|would|should)\b"
+)
+_PUBLICATION_DATE_SELECTOR_BOUNDARY = (
+    r"(?=\s*(?:$|[.?!;:)\]}‒–—]|"
+    r"(?:,\s*|(?:and|but)\s+)?"
+    + _PUBLICATION_DATE_FOLLOWUP_LITERAL
+    + r"))"
+)
 _PUBLICATION_DATE_SELECTOR_RE = {
     "journal": re.compile(
         r"\bjournal(?:\s+entry)?\b\s+"
         r"(?:(?:was\s+)?(?:publish(?:ed)?|post(?:ed)?|release(?:d)?)"
-        r"\s+(?:(?:on|for)\s+)?|(?:dated|from|for|on)\s+)"
+        r"\s+(?:(?:on|for)\s+)?|dated\s+)"
         + _PUBLICATION_DATE_LITERAL
-        + r"\b",
+        + r"\b"
+        + _PUBLICATION_DATE_SELECTOR_BOUNDARY,
         re.I,
     ),
     "relay": re.compile(
         r"\b(?:relay|website\s+(?:message|signal|status))\b\s+"
         r"(?:(?:was\s+)?(?:publish(?:ed)?|post(?:ed)?|release(?:d)?)"
-        r"\s+(?:(?:on|for)\s+)?|(?:dated|from|for|on)\s+)"
+        r"\s+(?:(?:on|for)\s+)?|dated\s+)"
         + _PUBLICATION_DATE_LITERAL
-        + r"\b",
+        + r"\b"
+        + _PUBLICATION_DATE_SELECTOR_BOUNDARY,
         re.I,
     ),
 }

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -295,6 +295,29 @@ _EPISODE_QUERY_RE = re.compile(
     re.I,
 )
 _TERM_RE = re.compile(r"[a-z0-9][a-z0-9'’-]*", re.I)
+_PUBLICATION_DATE_LITERAL = r"20\d{2}-\d{2}-\d{2}"
+_PUBLICATION_DATE_SELECTOR_RE = {
+    "journal": re.compile(
+        r"(?:\bjournal(?:\s+entry)?\b\s+"
+        r"(?:(?:was\s+)?(?:publish(?:ed)?|post(?:ed)?|release(?:d)?)"
+        r"\s+(?:(?:on|for)\s+)?|(?:dated|from|for|on)\s+)"
+        + _PUBLICATION_DATE_LITERAL
+        + r"\b|\b"
+        + _PUBLICATION_DATE_LITERAL
+        + r"\s+journal(?:\s+entry)?\b)",
+        re.I,
+    ),
+    "relay": re.compile(
+        r"(?:\b(?:relay|website\s+(?:message|signal|status))\b\s+"
+        r"(?:(?:was\s+)?(?:publish(?:ed)?|post(?:ed)?|release(?:d)?)"
+        r"\s+(?:(?:on|for)\s+)?|(?:dated|from|for|on)\s+)"
+        + _PUBLICATION_DATE_LITERAL
+        + r"\b|\b"
+        + _PUBLICATION_DATE_LITERAL
+        + r"\s+(?:relay|website\s+(?:message|signal|status))\b)",
+        re.I,
+    ),
+}
 _TERM_STOPWORDS = {
     "a",
     "about",
@@ -4961,6 +4984,16 @@ def _relay_publication_items(
     return items
 
 
+def _publication_date_selector_is_bound(
+    user_text: str,
+    object_kind: str,
+) -> bool:
+    pattern = _PUBLICATION_DATE_SELECTOR_RE.get(
+        str(object_kind or "").strip().lower()
+    )
+    return bool(pattern and pattern.search(str(user_text or "")))
+
+
 def _subject_independent_publication_lanes(
     request: IntelligencePacketRequest,
     diagnostics: IntelligencePacketDiagnostics,
@@ -5044,6 +5077,13 @@ def _subject_independent_publication_lanes(
             and query_status == "eligible"
             and len(publication_items) == 1
             and query_mode in concrete_query_modes
+            and (
+                query_mode != "exact_date"
+                or _publication_date_selector_is_bound(
+                    request.user_text,
+                    object_kind,
+                )
+            )
         ):
             lanes.add(lane)
     return frozenset(lanes)

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -6415,6 +6415,10 @@ def _revalidate_packet_in_snapshot(
                     control_snapshot=current_journal_control,
                     user_text=packet.request.user_text,
                     now=packet.request.now or None,
+                    require_unique_selection=(
+                        item.lane
+                        in subject_independent_publication_lanes
+                    ),
                 )
             elif item.revalidation_kind == "relay_publication":
                 payload = _publication_revalidation_payload(item)
@@ -6424,6 +6428,10 @@ def _revalidate_packet_in_snapshot(
                     relay_id=str(payload.get("relayId") or ""),
                     query_mode=str(payload.get("queryMode") or ""),
                     user_text=packet.request.user_text,
+                    require_unique_selection=(
+                        item.lane
+                        in subject_independent_publication_lanes
+                    ),
                 )
             elif item.revalidation_kind in {"current", "snapshot"}:
                 current = item.revalidation_key

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -487,6 +487,7 @@ class IntelligencePacketRequest:
     frame_revision: str = ""
     frame_input_evidence_digest: str = ""
     frame_status: str = "not_provided"
+    frame_ambiguity_reasons: tuple[str, ...] = ()
     frame_subject_requirement: str = "legacy"
     frame_subjects: tuple[PacketFrameSubject, ...] = ()
     frame_tasks: tuple[PacketFrameTask, ...] = ()
@@ -4966,6 +4967,11 @@ def _subject_independent_publication_lanes(
 ) -> frozenset[str]:
     """Return uniquely resolved publication lanes outside subject ambiguity."""
 
+    ambiguity_reasons = frozenset(
+        str(reason or "").strip().lower()
+        for reason in request.frame_ambiguity_reasons
+        if str(reason or "").strip()
+    )
     concrete_subjects = tuple(
         subject
         for subject in request.frame_subjects
@@ -4974,6 +4980,7 @@ def _subject_independent_publication_lanes(
     )
     if (
         str(request.frame_status or "").strip().lower() != "ambiguous"
+        or ambiguity_reasons != frozenset({"multiple_subject_candidates"})
         or str(request.frame_subject_requirement or "").strip().lower()
         != "required"
         or len(concrete_subjects) < 2

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -302,7 +302,7 @@ _PUBLICATION_DATE_FOLLOWUP_LITERAL = (
 )
 _PUBLICATION_DATE_SELECTOR_BOUNDARY = (
     r"(?=\s*(?:$|[.?!;:)\]}‒–—]|"
-    r"(?:,\s*|(?:and|but)\s+)?"
+    r"(?:,\s*(?:(?:and|but)\s+)?|(?:and|but)\s+)?"
     + _PUBLICATION_DATE_FOLLOWUP_LITERAL
     + r"))"
 )

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -4962,19 +4962,50 @@ def _relay_publication_items(
 
 def _subject_independent_publication_lanes(
     request: IntelligencePacketRequest,
+    diagnostics: IntelligencePacketDiagnostics,
 ) -> frozenset[str]:
-    """Return task-owned publication lanes that need no person subject."""
+    """Return uniquely resolved publication lanes outside subject ambiguity."""
 
+    concrete_subjects = tuple(
+        subject
+        for subject in request.frame_subjects
+        if int(subject.user_id or 0) > 0
+        or str(subject.entity_ref or "").strip()
+    )
+    if (
+        str(request.frame_status or "").strip().lower() != "ambiguous"
+        or str(request.frame_subject_requirement or "").strip().lower()
+        != "required"
+        or len(concrete_subjects) < 2
+    ):
+        return frozenset()
+    publication_queries = {
+        "journal": (
+            str(diagnostics.journal_query_status or "").strip().lower(),
+            int(diagnostics.journal_candidate_count or 0),
+        ),
+        "relay": (
+            str(diagnostics.relay_query_status or "").strip().lower(),
+            int(diagnostics.relay_candidate_count or 0),
+        ),
+    }
     lanes: set[str] = set()
     for task in request.frame_tasks:
         object_kind = str(task.object_kind or "").strip().lower()
+        query_status, candidate_count = publication_queries.get(
+            object_kind,
+            ("not_requested", 0),
+        )
         if (
             str(task.authority_scope or "").strip().lower() == "packet"
             and str(task.task_kind or "").strip().lower()
             == "retrieve_publication"
             and str(task.subject_requirement or "").strip().lower()
             != "required"
+            and not task.subject_indexes
             and object_kind in {"journal", "relay"}
+            and query_status == "eligible"
+            and candidate_count == 1
         ):
             lanes.add("%s_publication" % object_kind)
     return frozenset(lanes)
@@ -5006,7 +5037,7 @@ def _filter_frame_applicable_candidates(
         kept = []
         reason = "frame_subject_%s" % subject_resolution.status
         subject_independent_publication_lanes = (
-            _subject_independent_publication_lanes(request)
+            _subject_independent_publication_lanes(request, diagnostics)
             if subject_resolution.status == "ambiguous"
             else frozenset()
         )
@@ -6165,7 +6196,10 @@ def _revalidate_packet_in_snapshot(
         environ=environ,
     )
     subject_independent_publication_lanes = (
-        _subject_independent_publication_lanes(packet.request)
+        _subject_independent_publication_lanes(
+            packet.request,
+            packet.diagnostics,
+        )
     )
     subject_independent_publication_content = bool(
         current_subject_resolution.status == "ambiguous"
@@ -6419,7 +6453,10 @@ def _packet_invariants(
 ) -> tuple[str, ...]:
     invalid = []
     subject_independent_publication_lanes = (
-        _subject_independent_publication_lanes(packet.request)
+        _subject_independent_publication_lanes(
+            packet.request,
+            packet.diagnostics,
+        )
         if packet.subject_resolution.status == "ambiguous"
         else frozenset()
     )

--- a/bnl_website_relay_state.py
+++ b/bnl_website_relay_state.py
@@ -6,7 +6,7 @@ import re
 import sqlite3
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Optional
 
 from bnl_journal_source_store import record_source_event, timestamp_to_epoch_ms
 
@@ -399,7 +399,7 @@ def _relay_publication_rows(
     guild_id: int,
     relay_id: str = "",
     publication_date: str = "",
-    limit: int = RELAY_PUBLICATION_TOPIC_SCAN_LIMIT,
+    limit: Optional[int] = RELAY_PUBLICATION_TOPIC_SCAN_LIMIT,
 ) -> list[dict[str, Any]]:
     if not _relay_table_exists(conn, "website_relay_history"):
         return []
@@ -414,15 +414,17 @@ def _relay_publication_rows(
     if publication_date:
         where.append("SUBSTR(published_timestamp,1,10)=?")
         params.append(publication_date)
-    params.append(max(1, min(int(limit or 1), 500)))
-    rows = conn.execute(
+    sql = (
         "SELECT "
         + ",".join(_RELAY_PUBLICATION_COLUMNS)
         + " FROM website_relay_history WHERE "
         + " AND ".join(where)
-        + " ORDER BY published_timestamp DESC,relay_id DESC LIMIT ?",
-        tuple(params),
-    ).fetchall()
+        + " ORDER BY published_timestamp DESC,relay_id DESC"
+    )
+    if limit is not None:
+        params.append(max(1, min(int(limit or 1), 500)))
+        sql += " LIMIT ?"
+    rows = conn.execute(sql, tuple(params)).fetchall()
     return [dict(zip(_RELAY_PUBLICATION_COLUMNS, row)) for row in rows]
 
 
@@ -614,7 +616,7 @@ def select_accepted_relay_publications_on_connection(
             conn,
             guild_id=guild_id,
             publication_date=publication_date,
-            limit=max(8, limit),
+            limit=None,
         )
     else:
         query_mode = (
@@ -715,7 +717,27 @@ def revalidate_accepted_relay_publication_on_connection(
     relay_id: str,
     query_mode: str,
     user_text: str = "",
+    require_unique_selection: bool = False,
 ) -> str:
+    if require_unique_selection:
+        if not str(user_text or "").strip():
+            return ""
+        selection = select_accepted_relay_publications_on_connection(
+            conn,
+            guild_id=guild_id,
+            user_text=user_text,
+            limit=2,
+        )
+        if (
+            selection.status != "eligible"
+            or selection.query_mode != query_mode
+            or len(selection.publications) != 1
+        ):
+            return ""
+        publication = selection.publications[0]
+        if publication.relay_id != relay_id:
+            return ""
+        return publication.source_digest
     if query_mode == "latest":
         if not str(user_text or "").strip():
             return ""

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -301,6 +301,7 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             frame_revision=self.frame.frame_revision,
             frame_input_evidence_digest=self.frame.input_evidence_digest,
             frame_status=self.frame.status,
+            frame_ambiguity_reasons=self.frame.ambiguity_reasons,
             frame_subject_requirement=self.frame.subject_requirement,
             frame_subjects=frame_subjects,
             frame_tasks=tuple(
@@ -390,6 +391,7 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             frame_revision=frame.frame_revision,
             frame_input_evidence_digest=frame.input_evidence_digest,
             frame_status=frame.status,
+            frame_ambiguity_reasons=frame.ambiguity_reasons,
             frame_subject_requirement=frame.subject_requirement,
             frame_subjects=tuple(
                 PacketFrameSubject(
@@ -1092,6 +1094,7 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             frame_revision=frame.frame_revision,
             frame_input_evidence_digest=frame.input_evidence_digest,
             frame_status=frame.status,
+            frame_ambiguity_reasons=frame.ambiguity_reasons,
             frame_subject_requirement=frame.subject_requirement,
             frame_subjects=tuple(
                 PacketFrameSubject(

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -76,6 +76,7 @@ class PublicationReadAdapterTests(unittest.TestCase):
             section_values,
             sort_keys=True,
             separators=(",", ":"),
+            ensure_ascii=False,
         )
         content_hash = hashlib.sha256(
             "|".join((title, excerpt, sections)).encode()
@@ -103,6 +104,7 @@ class PublicationReadAdapterTests(unittest.TestCase):
             public_payload,
             sort_keys=True,
             separators=(",", ":"),
+            ensure_ascii=False,
         )
         self.conn.execute(
             """
@@ -299,6 +301,89 @@ class PublicationReadAdapterTests(unittest.TestCase):
                         for publication in selected.publications
                     ),
                 )
+
+    def test_journal_exact_title_keeps_embedded_apostrophes(self):
+        self.add_journal("journal_short_artist", title="Artist")
+        self.add_journal(
+            "journal_straight_apostrophe",
+            title="Artist's Notes",
+        )
+        self.add_journal(
+            "journal_curly_apostrophe",
+            title="Artist’s Notes",
+        )
+        snapshot = control_snapshot()
+
+        cases = (
+            ("'Artist's Notes'", "journal_straight_apostrophe"),
+            ("‘Artist’s Notes’", "journal_curly_apostrophe"),
+        )
+        for quoted_title, expected_entry_id in cases:
+            with self.subTest(quoted_title=quoted_title):
+                selected = (
+                    journal.select_published_journal_entries_on_connection(
+                        self.conn,
+                        guild_id=1,
+                        user_text=(
+                            "show the Journal entry titled "
+                            + quoted_title
+                            + " from 2026-08-02"
+                        ),
+                        control_snapshot=snapshot,
+                        now=NOW,
+                    )
+                )
+                self.assertEqual("eligible", selected.status)
+                self.assertEqual("exact_title", selected.query_mode)
+                self.assertEqual(
+                    (expected_entry_id,),
+                    tuple(
+                        publication.entry_id
+                        for publication in selected.publications
+                    ),
+                )
+
+        followed_by_another_quote = (
+            journal.select_published_journal_entries_on_connection(
+                self.conn,
+                guild_id=1,
+                user_text=(
+                    "show the Journal entry titled 'Artist's Notes'. "
+                    "Compare it with 'Artist'."
+                ),
+                control_snapshot=snapshot,
+                now=NOW,
+            )
+        )
+        self.assertEqual("eligible", followed_by_another_quote.status)
+        self.assertEqual(
+            ("journal_straight_apostrophe",),
+            tuple(
+                publication.entry_id
+                for publication in followed_by_another_quote.publications
+            ),
+        )
+
+    def test_missing_explicit_journal_title_does_not_fall_back_to_date(self):
+        self.add_journal(
+            "journal_same_date_other_title",
+            title="Different Entry",
+        )
+
+        selected = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text=(
+                'show the Journal entry titled "Missing Entry" '
+                "from 2026-08-02"
+            ),
+            control_snapshot=control_snapshot(),
+            now=NOW,
+        )
+
+        self.assertEqual("not_found", selected.status)
+        self.assertEqual("exact_title", selected.query_mode)
+        self.assertEqual((), selected.publications)
 
     def test_explicit_latest_journal_prefers_publication_time_over_topic_density(self):
         self.add_journal(
@@ -747,6 +832,29 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
                     "passed",
                     single_quoted.diagnostics.revalidation_status,
                 )
+
+    def test_ambiguous_missing_explicit_title_does_not_project_date_match(self):
+        self.add_journal(
+            "journal_same_date_unrequested",
+            title="Different Entry",
+            published_at="2026-08-04T01:00:00Z",
+        )
+        packet = build_packet(
+            self.conn,
+            self.framed_request(
+                'Show me the Journal entry titled "Missing Entry" '
+                "from 2026-08-04. What did it say?",
+                snapshot=control_snapshot(),
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertEqual("ambiguous", packet.subject_resolution.status)
+        self.assertEqual("not_found", packet.diagnostics.journal_query_status)
+        self.assertFalse(
+            any(item.lane == "journal_publication" for item in packet.items)
+        )
 
     def test_ambiguous_exact_date_uses_one_eligible_publication(self):
         self.add_journal(

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -312,11 +312,37 @@ class PublicationReadAdapterTests(unittest.TestCase):
             "journal_curly_apostrophe",
             title="Artist’s Notes",
         )
+        self.add_journal("journal_short_artists", title="Artists")
+        self.add_journal(
+            "journal_straight_plural_possessive",
+            title="Artists' Notes",
+        )
+        self.add_journal(
+            "journal_curly_plural_possessive",
+            title="Artists’ Notes",
+        )
+        self.add_journal("journal_short_cats", title="Cats")
+        self.add_journal(
+            "journal_coordinated_possessive",
+            title="Cats' and Dogs",
+        )
         snapshot = control_snapshot()
 
         cases = (
             ("'Artist's Notes'", "journal_straight_apostrophe"),
             ("‘Artist’s Notes’", "journal_curly_apostrophe"),
+            (
+                "'Artists' Notes'",
+                "journal_straight_plural_possessive",
+            ),
+            (
+                "‘Artists’ Notes’",
+                "journal_curly_plural_possessive",
+            ),
+            (
+                "'Cats' and Dogs'",
+                "journal_coordinated_possessive",
+            ),
         )
         for quoted_title, expected_entry_id in cases:
             with self.subTest(quoted_title=quoted_title):
@@ -361,6 +387,28 @@ class PublicationReadAdapterTests(unittest.TestCase):
             tuple(
                 publication.entry_id
                 for publication in followed_by_another_quote.publications
+            ),
+        )
+
+        plural_title_before_another_quote = (
+            journal.select_published_journal_entries_on_connection(
+                self.conn,
+                guild_id=1,
+                user_text=(
+                    "show the Journal entry titled 'Artists' and "
+                    "compare it with 'Artist'."
+                ),
+                control_snapshot=snapshot,
+                now=NOW,
+            )
+        )
+        self.assertEqual(
+            ("journal_short_artists",),
+            tuple(
+                publication.entry_id
+                for publication in (
+                    plural_title_before_another_quote.publications
+                )
             ),
         )
 

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -284,6 +284,19 @@ class PublicationReadAdapterTests(unittest.TestCase):
             tuple(item.entry_id for item in scoped.publications),
         )
 
+        punctuated = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text='show the Journal entry, titled "Legacy Entry"',
+            control_snapshot=snapshot,
+            now=NOW,
+        )
+        self.assertEqual("exact_title", punctuated.query_mode)
+        self.assertEqual(
+            ("journal_legacy_entry",),
+            tuple(item.entry_id for item in punctuated.publications),
+        )
+
         deictic = journal.select_published_journal_entries_on_connection(
             self.conn,
             guild_id=1,
@@ -1082,6 +1095,25 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
         self.assertEqual("passed", packet.diagnostics.revalidation_status)
         self.assertFalse(packet.diagnostics.invalid_invariants)
 
+        coordinated_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "Show the Journal published on 2026-08-04, and "
+                "summarize it.",
+                snapshot=snapshot,
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertEqual(
+            ("journal:journal_date_visible:1",),
+            tuple(
+                item.source_ref
+                for item in coordinated_packet.items
+                if item.lane == "journal_publication"
+            ),
+        )
+
     def test_ambiguous_topic_date_is_not_a_publication_date_selector(self):
         self.add_journal(
             "journal_same_date_topic",
@@ -1421,6 +1453,21 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
             any(
                 item.lane == "relay_publication"
                 for item in relay_packet.items
+            )
+        )
+
+        relay_coordinated_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "Show the Relay published on 2026-08-05, and summarize it.",
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertTrue(
+            any(
+                item.lane == "relay_publication"
+                for item in relay_coordinated_packet.items
             )
         )
 

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -1064,6 +1064,56 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
         self.assertEqual("passed", packet.diagnostics.revalidation_status)
         self.assertFalse(packet.diagnostics.invalid_invariants)
 
+    def test_ambiguous_topic_date_is_not_a_publication_date_selector(self):
+        self.add_journal(
+            "journal_same_date_topic",
+            title="Unrelated Same-Date Entry",
+            published_at="2026-08-04T01:00:00Z",
+        )
+        journal_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "What did the Journal say about the 2026-08-04 event?",
+                snapshot=control_snapshot(),
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertEqual("ambiguous", journal_packet.subject_resolution.status)
+        self.assertEqual(
+            "eligible", journal_packet.diagnostics.journal_query_status
+        )
+        self.assertFalse(
+            any(
+                item.lane == "journal_publication"
+                for item in journal_packet.items
+            )
+        )
+
+        self.add_relay(
+            "bnl-same-date-topic",
+            published_at="2026-08-05T01:00:00Z",
+        )
+        relay_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "What did the Relay say about the 2026-08-05 event?",
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertEqual("ambiguous", relay_packet.subject_resolution.status)
+        self.assertEqual(
+            "eligible", relay_packet.diagnostics.relay_query_status
+        )
+        self.assertFalse(
+            any(
+                item.lane == "relay_publication" for item in relay_packet.items
+            )
+        )
+
     def test_ambiguous_exact_date_scans_complete_journal_match_set(self):
         hidden_ids = []
         for index in range(9):

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -4,6 +4,7 @@ import os
 import sqlite3
 import tempfile
 import unittest
+from dataclasses import replace
 from unittest import mock
 
 import bnl_journal as journal
@@ -14,10 +15,13 @@ import bnl_website_relay_state as relay
 from bnl_shared_brain_synthesis import render_packet_context
 from bnl_unified_intelligence_packet import (
     IntelligencePacketRequest,
+    PacketFrameSubject,
+    PacketFrameTask,
     build_evaluation_report,
     build_packet,
     revalidate_packet,
 )
+from bnl_unified_response_assessment import build_situation_frame_v1
 
 
 NOW = "2026-08-10T10:01:00Z"
@@ -243,6 +247,31 @@ class PublicationReadAdapterTests(unittest.TestCase):
         )
         self.assertEqual("exact_date", by_date.query_mode)
         self.assertEqual(entry_id, by_date.publications[0].entry_id)
+
+    def test_journal_exact_title_requires_explicit_selector_syntax(self):
+        self.add_journal("journal_old_entry", title="Old Entry")
+        snapshot = control_snapshot()
+        explicit = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text='show the Journal titled "Old Entry"',
+            control_snapshot=snapshot,
+            now=NOW,
+        )
+        self.assertEqual("exact_title", explicit.query_mode)
+        self.assertEqual(
+            ("journal_old_entry",),
+            tuple(item.entry_id for item in explicit.publications),
+        )
+
+        deictic = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text="What did that old entry in the Journal say?",
+            control_snapshot=snapshot,
+            now=NOW,
+        )
+        self.assertEqual("topic", deictic.query_mode)
 
     def test_explicit_latest_journal_prefers_publication_time_over_topic_density(self):
         self.add_journal(
@@ -552,6 +581,155 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
             journal_control_snapshot=snapshot,
             journal_control_status=control_status,
         )
+
+    def framed_request(self, text, *, snapshot=None, control_status="valid"):
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text=text,
+            current_speaker_user_ids=(7,),
+            subject_entity_refs=("cache_back", "call_em_bini"),
+            response_act="answer",
+        )
+        self.assertEqual("ambiguous", frame.status)
+        self.assertEqual(
+            ("multiple_subject_candidates",),
+            frame.ambiguity_reasons,
+        )
+        return replace(
+            self.request(
+                text,
+                snapshot=snapshot,
+                control_status=control_status,
+            ),
+            frame_schema_version=frame.schema_version,
+            frame_revision=frame.frame_revision,
+            frame_input_evidence_digest=frame.input_evidence_digest,
+            frame_status=frame.status,
+            frame_ambiguity_reasons=frame.ambiguity_reasons,
+            frame_subject_requirement=frame.subject_requirement,
+            frame_subjects=tuple(
+                PacketFrameSubject(
+                    user_id=subject.user_id,
+                    entity_ref=subject.entity_ref,
+                    label_hint=subject.label_hint,
+                    binding_method=subject.binding_method,
+                    confidence=subject.confidence,
+                    role_hints=subject.role_hints,
+                    domain_hints=subject.domain_hints,
+                )
+                for subject in frame.subjects
+            ),
+            frame_tasks=tuple(
+                PacketFrameTask(
+                    task_id=task.task_id,
+                    text_digest=task.text_digest,
+                    task_kind=task.task_kind,
+                    object_kind=task.object_kind,
+                    authority_scope=task.authority_scope,
+                    temporal_scope=task.temporal_scope,
+                    currentness=task.currentness,
+                    required_response_act=task.required_response_act,
+                    subject_requirement=task.subject_requirement,
+                    subject_indexes=task.subject_indexes,
+                )
+                for task in frame.tasks
+            ),
+            frame_role_hints=frame.role_hints,
+            frame_domain_hints=frame.domain_hints,
+            frame_event_ref=frame.event_ref,
+            frame_event_relation=frame.event_relation,
+            frame_task_kind=frame.task_kind,
+            frame_object_kind=frame.object_kind,
+            frame_phase=frame.phase,
+            frame_temporal_scope=frame.temporal_scope,
+            frame_currentness=frame.currentness,
+        )
+
+    def test_ambiguous_frame_exception_uses_production_title_selector(self):
+        entry_id = "journal_legacy_entry"
+        self.add_journal(entry_id, title="Legacy Entry")
+        snapshot = control_snapshot()
+        exact = build_packet(
+            self.conn,
+            self.framed_request(
+                'Show me the Journal entry titled "Legacy Entry". '
+                "What did it say?",
+                snapshot=snapshot,
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertEqual("ambiguous", exact.subject_resolution.status)
+        self.assertEqual(
+            ("journal:%s:1" % entry_id,),
+            tuple(
+                item.source_ref
+                for item in exact.items
+                if item.lane == "journal_publication"
+            ),
+        )
+        self.assertEqual("passed", exact.diagnostics.revalidation_status)
+        self.assertFalse(exact.diagnostics.invalid_invariants)
+
+        deictic = build_packet(
+            self.conn,
+            self.framed_request(
+                "What did that Legacy Entry in the Journal say?",
+                snapshot=snapshot,
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertEqual("ambiguous", deictic.subject_resolution.status)
+        self.assertEqual("eligible", deictic.diagnostics.journal_query_status)
+        self.assertFalse(
+            any(item.lane == "journal_publication" for item in deictic.items)
+        )
+        self.assertGreaterEqual(
+            deictic.diagnostics.excluded_by_reason.get(
+                "frame_subject_ambiguous",
+                0,
+            ),
+            1,
+        )
+
+    def test_ambiguous_exact_date_uses_one_eligible_publication(self):
+        self.add_journal(
+            "journal_date_visible",
+            title="Visible Date Entry",
+            published_at="2026-08-04T01:00:00Z",
+        )
+        self.add_journal(
+            "journal_date_hidden",
+            title="Hidden Date Entry",
+            published_at="2026-08-04T02:00:00Z",
+        )
+        snapshot = control_snapshot(
+            public_excluded=("journal_date_hidden",),
+        )
+        packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "What did the Journal publish on 2026-08-04?",
+                snapshot=snapshot,
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertEqual(2, packet.diagnostics.journal_candidate_count)
+        self.assertEqual(
+            ("journal:journal_date_visible:1",),
+            tuple(
+                item.source_ref
+                for item in packet.items
+                if item.lane == "journal_publication"
+            ),
+        )
+        self.assertEqual("passed", packet.diagnostics.revalidation_status)
+        self.assertFalse(packet.diagnostics.invalid_invariants)
 
     def test_packet_adapters_are_publication_only_and_revalidate_mutation(self):
         journal_id = "journal_packet_001"

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -273,6 +273,33 @@ class PublicationReadAdapterTests(unittest.TestCase):
         )
         self.assertEqual("topic", deictic.query_mode)
 
+    def test_journal_exact_title_accepts_paired_single_quotes(self):
+        self.add_journal("journal_single_quote", title="Legacy Entry")
+        snapshot = control_snapshot()
+
+        for quoted_title in ("'Legacy Entry'", "‘Legacy Entry’"):
+            with self.subTest(quoted_title=quoted_title):
+                selected = (
+                    journal.select_published_journal_entries_on_connection(
+                        self.conn,
+                        guild_id=1,
+                        user_text=(
+                            "show the Journal entry titled " + quoted_title
+                        ),
+                        control_snapshot=snapshot,
+                        now=NOW,
+                    )
+                )
+                self.assertEqual("eligible", selected.status)
+                self.assertEqual("exact_title", selected.query_mode)
+                self.assertEqual(
+                    ("journal_single_quote",),
+                    tuple(
+                        publication.entry_id
+                        for publication in selected.publications
+                    ),
+                )
+
     def test_explicit_latest_journal_prefers_publication_time_over_topic_density(self):
         self.add_journal(
             "journal_older_dense",
@@ -696,6 +723,31 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
             1,
         )
 
+        for quoted_title in ("'Legacy Entry'", "‘Legacy Entry’"):
+            with self.subTest(quoted_title=quoted_title):
+                single_quoted = build_packet(
+                    self.conn,
+                    self.framed_request(
+                        "Show me the Journal entry titled %s. "
+                        "What did it say?" % quoted_title,
+                        snapshot=snapshot,
+                    ),
+                    persist=False,
+                    environ=self.flags,
+                )
+                self.assertEqual(
+                    ("journal:%s:1" % entry_id,),
+                    tuple(
+                        item.source_ref
+                        for item in single_quoted.items
+                        if item.lane == "journal_publication"
+                    ),
+                )
+                self.assertEqual(
+                    "passed",
+                    single_quoted.diagnostics.revalidation_status,
+                )
+
     def test_ambiguous_exact_date_uses_one_eligible_publication(self):
         self.add_journal(
             "journal_date_visible",
@@ -730,6 +782,173 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
         )
         self.assertEqual("passed", packet.diagnostics.revalidation_status)
         self.assertFalse(packet.diagnostics.invalid_invariants)
+
+    def test_ambiguous_exact_date_scans_complete_journal_match_set(self):
+        hidden_ids = []
+        for index in range(9):
+            entry_id = "journal_dense_date_%02d" % index
+            self.add_journal(
+                entry_id,
+                title="Dense Date Entry %02d" % index,
+                published_at="2026-08-04T%02d:00:00Z" % (9 - index),
+            )
+            if index < 7:
+                hidden_ids.append(entry_id)
+
+        packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "What did the Journal publish on 2026-08-04?",
+                snapshot=control_snapshot(public_excluded=hidden_ids),
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertEqual(9, packet.diagnostics.journal_candidate_count)
+        self.assertFalse(
+            any(item.lane == "journal_publication" for item in packet.items)
+        )
+        self.assertGreaterEqual(
+            packet.diagnostics.excluded_by_reason.get(
+                "frame_subject_ambiguous",
+                0,
+            ),
+            2,
+        )
+
+    def test_ambiguous_exact_title_scans_complete_journal_match_set(self):
+        hidden_ids = []
+        for index in range(9):
+            entry_id = "journal_duplicate_title_%02d" % index
+            self.add_journal(
+                entry_id,
+                title="Shared Carrier Title",
+                published_at="2026-08-04T%02d:00:00Z" % (9 - index),
+            )
+            if index < 7:
+                hidden_ids.append(entry_id)
+
+        packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "Show me the Journal entry titled 'Shared Carrier Title'. "
+                "What did it say?",
+                snapshot=control_snapshot(public_excluded=hidden_ids),
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertEqual(9, packet.diagnostics.journal_candidate_count)
+        self.assertFalse(
+            any(item.lane == "journal_publication" for item in packet.items)
+        )
+        self.assertGreaterEqual(
+            packet.diagnostics.excluded_by_reason.get(
+                "frame_subject_ambiguous",
+                0,
+            ),
+            2,
+        )
+
+    def test_ambiguous_exact_date_scans_complete_relay_match_set(self):
+        for index in range(9):
+            self.add_relay(
+                "bnl-dense-date-%02d" % index,
+                message="Dense date Relay %02d." % index,
+                lane="presence" if index < 7 else "current_signal",
+                event_type="online" if index < 7 else "public_discord_activity",
+                published_at="2026-08-04T%02d:00:00Z" % (9 - index),
+            )
+
+        packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "What Relay was published on 2026-08-04?",
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertEqual(9, packet.diagnostics.relay_candidate_count)
+        self.assertFalse(
+            any(item.lane == "relay_publication" for item in packet.items)
+        )
+        self.assertGreaterEqual(
+            packet.diagnostics.excluded_by_reason.get(
+                "frame_subject_ambiguous",
+                0,
+            ),
+            2,
+        )
+
+    def test_ambiguous_publication_revalidation_rejects_new_match(self):
+        snapshot = control_snapshot()
+        self.add_journal(
+            "journal_unique_date",
+            title="Initially Unique Date Entry",
+            published_at="2026-08-04T01:00:00Z",
+        )
+        packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "What did the Journal publish on 2026-08-04?",
+                snapshot=snapshot,
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertTrue(
+            any(item.lane == "journal_publication" for item in packet.items)
+        )
+
+        self.add_journal(
+            "journal_competing_date",
+            title="Competing Date Entry",
+            published_at="2026-08-04T02:00:00Z",
+        )
+        changed = revalidate_packet(
+            self.conn,
+            packet,
+            environ=self.flags,
+            journal_control_snapshot=snapshot,
+            journal_control_snapshot_provided=True,
+        )
+
+        self.assertFalse(changed.valid)
+        self.assertEqual("source_changed", changed.status)
+
+        self.add_relay(
+            "bnl-unique-date",
+            published_at="2026-08-05T01:00:00Z",
+        )
+        relay_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "What Relay was published on 2026-08-05?",
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertTrue(
+            any(
+                item.lane == "relay_publication"
+                for item in relay_packet.items
+            )
+        )
+
+        self.add_relay(
+            "bnl-competing-date",
+            published_at="2026-08-05T02:00:00Z",
+        )
+        relay_changed = revalidate_packet(
+            self.conn,
+            relay_packet,
+            environ=self.flags,
+        )
+        self.assertFalse(relay_changed.valid)
+        self.assertEqual("source_changed", relay_changed.status)
 
     def test_packet_adapters_are_publication_only_and_revalidate_mutation(self):
         journal_id = "journal_packet_001"

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -310,6 +310,19 @@ class PublicationReadAdapterTests(unittest.TestCase):
             tuple(item.entry_id for item in ascii_hyphen.publications),
         )
 
+        double_hyphen = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text='show the Journal entry -- titled "Legacy Entry"',
+            control_snapshot=snapshot,
+            now=NOW,
+        )
+        self.assertEqual("exact_title", double_hyphen.query_mode)
+        self.assertEqual(
+            ("journal_legacy_entry",),
+            tuple(item.entry_id for item in double_hyphen.publications),
+        )
+
         deictic = journal.select_published_journal_entries_on_connection(
             self.conn,
             guild_id=1,
@@ -1146,6 +1159,25 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
             ),
         )
 
+        punctuated_modifier_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "Show the Journal published on 2026-08-04, and then, "
+                "please summarize it.",
+                snapshot=snapshot,
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertEqual(
+            ("journal:journal_date_visible:1",),
+            tuple(
+                item.source_ref
+                for item in punctuated_modifier_packet.items
+                if item.lane == "journal_publication"
+            ),
+        )
+
     def test_ambiguous_topic_date_is_not_a_publication_date_selector(self):
         self.add_journal(
             "journal_same_date_topic",
@@ -1516,6 +1548,22 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
             any(
                 item.lane == "relay_publication"
                 for item in relay_adverb_packet.items
+            )
+        )
+
+        relay_punctuated_modifier_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "Show the Relay published on 2026-08-05, and then, "
+                "please summarize it.",
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertTrue(
+            any(
+                item.lane == "relay_publication"
+                for item in relay_punctuated_modifier_packet.items
             )
         )
 

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -303,6 +303,7 @@ class PublicationReadAdapterTests(unittest.TestCase):
                 )
 
     def test_journal_exact_title_keeps_embedded_apostrophes(self):
+        self.add_journal("journal_legacy_entry", title="Legacy Entry")
         self.add_journal("journal_short_artist", title="Artist")
         self.add_journal(
             "journal_straight_apostrophe",
@@ -433,6 +434,49 @@ class PublicationReadAdapterTests(unittest.TestCase):
                 )
             ),
         )
+
+        trailing_possessive_cases = (
+            (
+                "show the Journal entry titled 'Legacy Entry' "
+                "from the Artists' Guild",
+                "journal_legacy_entry",
+            ),
+            (
+                "show the Journal entry titled 'Artists' Notes' "
+                "from the Artists' Guild",
+                "journal_straight_plural_possessive",
+            ),
+            (
+                "show the Journal entry titled ‘Legacy Entry’ "
+                "from the Artists’ Guild",
+                "journal_legacy_entry",
+            ),
+            (
+                "show the Journal entry titled ‘Artists’ Notes’ "
+                "from the Artists’ Guild",
+                "journal_curly_plural_possessive",
+            ),
+        )
+        for user_text, expected_entry_id in trailing_possessive_cases:
+            with self.subTest(user_text=user_text):
+                selected = (
+                    journal.select_published_journal_entries_on_connection(
+                        self.conn,
+                        guild_id=1,
+                        user_text=user_text,
+                        control_snapshot=snapshot,
+                        now=NOW,
+                    )
+                )
+                self.assertEqual("eligible", selected.status)
+                self.assertEqual("exact_title", selected.query_mode)
+                self.assertEqual(
+                    (expected_entry_id,),
+                    tuple(
+                        publication.entry_id
+                        for publication in selected.publications
+                    ),
+                )
 
     def test_missing_explicit_journal_title_does_not_fall_back_to_date(self):
         self.add_journal(

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -252,6 +252,8 @@ class PublicationReadAdapterTests(unittest.TestCase):
 
     def test_journal_exact_title_requires_explicit_selector_syntax(self):
         self.add_journal("journal_old_entry", title="Old Entry")
+        self.add_journal("journal_noise", title="Noise")
+        self.add_journal("journal_legacy_entry", title="Legacy Entry")
         snapshot = control_snapshot()
         explicit = journal.select_published_journal_entries_on_connection(
             self.conn,
@@ -264,6 +266,22 @@ class PublicationReadAdapterTests(unittest.TestCase):
         self.assertEqual(
             ("journal_old_entry",),
             tuple(item.entry_id for item in explicit.publications),
+        )
+
+        scoped = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text=(
+                "Regarding the project called 'Noise', show the Journal "
+                "titled 'Legacy Entry'"
+            ),
+            control_snapshot=snapshot,
+            now=NOW,
+        )
+        self.assertEqual("exact_title", scoped.query_mode)
+        self.assertEqual(
+            ("journal_legacy_entry",),
+            tuple(item.entry_id for item in scoped.publications),
         )
 
         deictic = journal.select_published_journal_entries_on_connection(
@@ -1113,6 +1131,28 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
             )
         )
 
+        journal_object_topic_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "What did the Journal say about the Journal on "
+                "2026-08-04 event?",
+                snapshot=control_snapshot(),
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertEqual(
+            "eligible",
+            journal_object_topic_packet.diagnostics.journal_query_status,
+        )
+        self.assertFalse(
+            any(
+                item.lane == "journal_publication"
+                for item in journal_object_topic_packet.items
+            )
+        )
+
         self.add_relay(
             "bnl-same-date-topic",
             published_at="2026-08-05T01:00:00Z",
@@ -1153,6 +1193,27 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
             any(
                 item.lane == "relay_publication"
                 for item in relay_topic_packet.items
+            )
+        )
+
+        relay_object_topic_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "What did the Relay say about the Relay on "
+                "2026-08-05 event?",
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertEqual(
+            "eligible",
+            relay_object_topic_packet.diagnostics.relay_query_status,
+        )
+        self.assertFalse(
+            any(
+                item.lane == "relay_publication"
+                for item in relay_object_topic_packet.items
             )
         )
 

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -1091,6 +1091,28 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
             )
         )
 
+        journal_topic_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "What did the Journal say about the 2026-08-04 "
+                "Journal event?",
+                snapshot=control_snapshot(),
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertEqual(
+            "eligible",
+            journal_topic_packet.diagnostics.journal_query_status,
+        )
+        self.assertFalse(
+            any(
+                item.lane == "journal_publication"
+                for item in journal_topic_packet.items
+            )
+        )
+
         self.add_relay(
             "bnl-same-date-topic",
             published_at="2026-08-05T01:00:00Z",
@@ -1111,6 +1133,26 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
         self.assertFalse(
             any(
                 item.lane == "relay_publication" for item in relay_packet.items
+            )
+        )
+
+        relay_topic_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "What did the Relay say about the 2026-08-05 Relay event?",
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertEqual(
+            "eligible",
+            relay_topic_packet.diagnostics.relay_query_status,
+        )
+        self.assertFalse(
+            any(
+                item.lane == "relay_publication"
+                for item in relay_topic_packet.items
             )
         )
 

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -302,6 +302,38 @@ class PublicationReadAdapterTests(unittest.TestCase):
                     ),
                 )
 
+        for quoted_title in (
+            '"Legacy Entry"',
+            "“Legacy Entry”",
+            "'Legacy Entry'",
+            "‘Legacy Entry’",
+        ):
+            for dash in ("–", "—"):
+                with self.subTest(quoted_title=quoted_title, dash=dash):
+                    selected = (
+                        journal.select_published_journal_entries_on_connection(
+                            self.conn,
+                            guild_id=1,
+                            user_text=(
+                                "show the Journal entry titled "
+                                + quoted_title
+                                + dash
+                                + "what did it say?"
+                            ),
+                            control_snapshot=snapshot,
+                            now=NOW,
+                        )
+                    )
+                    self.assertEqual("eligible", selected.status)
+                    self.assertEqual("exact_title", selected.query_mode)
+                    self.assertEqual(
+                        ("journal_single_quote",),
+                        tuple(
+                            publication.entry_id
+                            for publication in selected.publications
+                        ),
+                    )
+
     def test_journal_exact_title_keeps_embedded_apostrophes(self):
         self.add_journal("journal_legacy_entry", title="Legacy Entry")
         self.add_journal("journal_short_artist", title="Artist")
@@ -477,6 +509,33 @@ class PublicationReadAdapterTests(unittest.TestCase):
                         for publication in selected.publications
                     ),
                 )
+
+    def test_missing_possessive_title_does_not_use_shorter_title(self):
+        self.add_journal("journal_short_artists", title="Artists")
+        self.add_journal("journal_short_cats", title="Cats")
+
+        missing_titles = (
+            "'Artists' Notes'",
+            "‘Artists’ Notes’",
+            "'Cats' and Dogs'",
+        )
+        for missing_title in missing_titles:
+            with self.subTest(missing_title=missing_title):
+                selected = (
+                    journal.select_published_journal_entries_on_connection(
+                        self.conn,
+                        guild_id=1,
+                        user_text=(
+                            "show the Journal entry titled " + missing_title
+                        ),
+                        control_snapshot=control_snapshot(),
+                        now=NOW,
+                    )
+                )
+
+                self.assertEqual("not_found", selected.status)
+                self.assertEqual("exact_title", selected.query_mode)
+                self.assertEqual((), selected.publications)
 
     def test_missing_explicit_journal_title_does_not_fall_back_to_date(self):
         self.add_journal(

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -1114,6 +1114,58 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
             )
         )
 
+    def test_ambiguous_date_binding_must_match_selected_date(self):
+        self.add_journal(
+            "journal_first_unbound_date",
+            title="First Unbound Date Entry",
+            published_at="2026-08-04T01:00:00Z",
+        )
+        journal_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "What did the Journal say about the 2026-08-04 event, "
+                "if the Journal was published on 2026-08-05?",
+                snapshot=control_snapshot(),
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertEqual("ambiguous", journal_packet.subject_resolution.status)
+        self.assertEqual(
+            "eligible", journal_packet.diagnostics.journal_query_status
+        )
+        self.assertFalse(
+            any(
+                item.lane == "journal_publication"
+                for item in journal_packet.items
+            )
+        )
+
+        self.add_relay(
+            "bnl-first-unbound-date",
+            published_at="2026-08-05T01:00:00Z",
+        )
+        relay_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "What did the Relay say about the 2026-08-05 event, "
+                "if the Relay was published on 2026-08-06?",
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertEqual("ambiguous", relay_packet.subject_resolution.status)
+        self.assertEqual(
+            "eligible", relay_packet.diagnostics.relay_query_status
+        )
+        self.assertFalse(
+            any(
+                item.lane == "relay_publication" for item in relay_packet.items
+            )
+        )
+
     def test_ambiguous_exact_date_scans_complete_journal_match_set(self):
         hidden_ids = []
         for index in range(9):

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -412,6 +412,28 @@ class PublicationReadAdapterTests(unittest.TestCase):
             ),
         )
 
+        arbitrary_clause_before_another_quote = (
+            journal.select_published_journal_entries_on_connection(
+                self.conn,
+                guild_id=1,
+                user_text=(
+                    "show the Journal entry titled 'Artists' Notes' "
+                    "alongside 'Artist'"
+                ),
+                control_snapshot=snapshot,
+                now=NOW,
+            )
+        )
+        self.assertEqual(
+            ("journal_straight_plural_possessive",),
+            tuple(
+                publication.entry_id
+                for publication in (
+                    arbitrary_clause_before_another_quote.publications
+                )
+            ),
+        )
+
     def test_missing_explicit_journal_title_does_not_fall_back_to_date(self):
         self.add_journal(
             "journal_same_date_other_title",

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -297,6 +297,19 @@ class PublicationReadAdapterTests(unittest.TestCase):
             tuple(item.entry_id for item in punctuated.publications),
         )
 
+        ascii_hyphen = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text='show the Journal entry - titled "Legacy Entry"',
+            control_snapshot=snapshot,
+            now=NOW,
+        )
+        self.assertEqual("exact_title", ascii_hyphen.query_mode)
+        self.assertEqual(
+            ("journal_legacy_entry",),
+            tuple(item.entry_id for item in ascii_hyphen.publications),
+        )
+
         deictic = journal.select_published_journal_entries_on_connection(
             self.conn,
             guild_id=1,
@@ -1114,6 +1127,25 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
             ),
         )
 
+        coordinated_adverb_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "Show the Journal published on 2026-08-04, and then "
+                "summarize it.",
+                snapshot=snapshot,
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertEqual(
+            ("journal:journal_date_visible:1",),
+            tuple(
+                item.source_ref
+                for item in coordinated_adverb_packet.items
+                if item.lane == "journal_publication"
+            ),
+        )
+
     def test_ambiguous_topic_date_is_not_a_publication_date_selector(self):
         self.add_journal(
             "journal_same_date_topic",
@@ -1468,6 +1500,22 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
             any(
                 item.lane == "relay_publication"
                 for item in relay_coordinated_packet.items
+            )
+        )
+
+        relay_adverb_packet = build_packet(
+            self.conn,
+            self.framed_request(
+                "Show the Relay published on 2026-08-05, and please "
+                "summarize it.",
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertTrue(
+            any(
+                item.lane == "relay_publication"
+                for item in relay_adverb_packet.items
             )
         )
 

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -18,9 +18,11 @@ from bnl_shadow_acceptance import (
 )
 from bnl_shared_brain_synthesis import render_packet_context
 from bnl_unified_intelligence_packet import (
+    IntelligencePacketItem,
     IntelligencePacketRequest,
     PacketConversationEvidence,
     PacketFrameSubject,
+    PacketFrameTask,
     _safe_atomic_supporting_observation,
     build_evaluation_report,
     build_packet,
@@ -2773,6 +2775,219 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
             projected.entry_id,
             {item.source_ref for item in packet.items},
         )
+
+    def test_subject_free_journal_task_survives_ambiguous_frame_subjects(
+        self,
+    ):
+        publication = IntelligencePacketItem(
+            lane="journal_publication",
+            source_class=packet_module.JOURNAL_PUBLICATION_SOURCE_CLASS,
+            source_type="canonical_published_journal",
+            source_ref="journal:journal_weekly_2026-08-24_7489c3d9:1",
+            source_digest="f" * 64,
+            subject_key="bnl_01",
+            predicate_key="published_journal_entry",
+            text=(
+                "Backend Queue Runs, Soundstage Experiments, and "
+                "Post-Show Echoes: published entry text."
+            ),
+            visibility="public",
+            confidence=Confidence.APPROVED.value,
+            lifecycle="published",
+            authority=0,
+            usage="publication_projection",
+            score=155.0,
+            revalidation_kind="journal_publication",
+            revalidation_key=(
+                '{"entryId":"journal_weekly_2026-08-24_7489c3d9",'
+                '"queryMode":"exact_title","revision":1}'
+            ),
+            attribution_mode="publication_only",
+            uncertainty_status="derived_publication_zero_fact_weight",
+        )
+        request = replace(
+            self.public_request(
+                text=(
+                    "Show me the published Journal entry titled "
+                    '"Backend Queue Runs, Soundstage Experiments, and '
+                    'Post-Show Echoes." What did it say?'
+                )
+            ),
+            frame_schema_version="situation_frame_v1",
+            frame_revision="sf_journal_exact_title",
+            frame_input_evidence_digest="d" * 64,
+            frame_status="ambiguous",
+            frame_subject_requirement="required",
+            frame_subjects=(
+                PacketFrameSubject(
+                    user_id=7,
+                    binding_method="conversation_candidate",
+                    confidence="medium",
+                ),
+                PacketFrameSubject(
+                    entity_ref="cache_back",
+                    binding_method="conversation_candidate",
+                    confidence="medium",
+                ),
+            ),
+            frame_tasks=(
+                PacketFrameTask(
+                    task_id="T1",
+                    text_digest="e" * 64,
+                    task_kind="retrieve_publication",
+                    object_kind="journal",
+                    authority_scope="packet",
+                    temporal_scope="historical",
+                    currentness="historical",
+                    required_response_act="answer",
+                    subject_requirement="not_applicable",
+                ),
+            ),
+            frame_task_kind="retrieve_publication",
+            frame_object_kind="journal",
+            frame_phase="request",
+        )
+
+        def journal_candidates(
+            _conn,
+            _request,
+            diagnostics,
+            _exclusions,
+        ):
+            diagnostics.journal_query_status = "eligible"
+            diagnostics.journal_control_status = "valid"
+            diagnostics.journal_candidate_count = 1
+            diagnostics.candidates_by_lane["journal_publication"] = 1
+            diagnostics.publication_projection_count += 1
+            return [publication]
+
+        with (
+            mock.patch.object(
+                packet_module,
+                "_journal_publication_items",
+                side_effect=journal_candidates,
+            ),
+            mock.patch.object(
+                packet_module,
+                "revalidate_published_journal_entry_on_connection",
+                return_value=publication.source_digest,
+            ),
+        ):
+            packet = build_packet(
+                self.conn,
+                request,
+                persist=False,
+                environ=self.flags,
+            )
+
+        self.assertEqual(packet.subject_resolution.status, "ambiguous")
+        self.assertEqual(
+            tuple(
+                item.source_ref
+                for item in packet.items
+                if item.lane == "journal_publication"
+            ),
+            (publication.source_ref,),
+        )
+        self.assertTrue(
+            all(
+                item.lane in {"current_intent", "journal_publication"}
+                for item in packet.items
+            )
+        )
+        self.assertEqual(packet.diagnostics.revalidation_status, "passed")
+        self.assertNotIn(
+            "journal_publication",
+            packet.diagnostics.missing_lanes,
+        )
+        self.assertFalse(packet.diagnostics.invalid_invariants)
+
+    def test_publication_task_does_not_unblock_unrelated_or_blocked_content(
+        self,
+    ):
+        request = replace(
+            self.public_request(text="What did the Journal say?"),
+            frame_schema_version="situation_frame_v1",
+            frame_revision="sf_journal_ambiguous_guard",
+            frame_input_evidence_digest="a" * 64,
+            frame_status="ambiguous",
+            frame_subject_requirement="required",
+            frame_tasks=(
+                PacketFrameTask(
+                    task_id="T1",
+                    text_digest="b" * 64,
+                    task_kind="retrieve_publication",
+                    object_kind="journal",
+                    authority_scope="packet",
+                    temporal_scope="historical",
+                    currentness="historical",
+                    required_response_act="answer",
+                    subject_requirement="not_applicable",
+                ),
+            ),
+        )
+        publication = IntelligencePacketItem(
+            lane="journal_publication",
+            source_class=packet_module.JOURNAL_PUBLICATION_SOURCE_CLASS,
+            source_type="canonical_published_journal",
+            source_ref="journal:allowed:1",
+            source_digest="c" * 64,
+            subject_key="bnl_01",
+            predicate_key="published_journal_entry",
+            text="Allowed publication.",
+            visibility="public",
+            confidence=Confidence.APPROVED.value,
+            lifecycle="published",
+            authority=0,
+            usage="publication_projection",
+            revalidation_kind="journal_publication",
+            attribution_mode="publication_only",
+            uncertainty_status="derived_publication_zero_fact_weight",
+        )
+        unrelated = replace(
+            publication,
+            lane="canon",
+            source_class=SourceClass.APPROVED_CANON.value,
+            source_type="canon_fact",
+            source_ref="canon:unrelated",
+            subject_key="cache_back",
+            predicate_key="role",
+            text="Unrelated subject-bound canon.",
+            usage="content",
+            revalidation_kind="canon",
+            attribution_mode="",
+            uncertainty_status="",
+        )
+        diagnostics = packet_module.IntelligencePacketDiagnostics()
+        exclusions = []
+
+        kept = packet_module._filter_frame_applicable_candidates(
+            request,
+            packet_module.PacketSubjectResolution(status="ambiguous"),
+            [publication, unrelated],
+            diagnostics,
+            exclusions,
+        )
+
+        self.assertEqual(kept, [publication])
+        self.assertEqual(
+            diagnostics.excluded_by_reason,
+            {"frame_subject_ambiguous": 1},
+        )
+        blocked_diagnostics = packet_module.IntelligencePacketDiagnostics()
+        blocked = packet_module._filter_frame_applicable_candidates(
+            request,
+            packet_module.PacketSubjectResolution(status="blocked"),
+            [publication],
+            blocked_diagnostics,
+            [],
+        )
+        self.assertEqual(blocked, [])
+        self.assertEqual(
+            blocked_diagnostics.excluded_by_reason,
+            {"frame_subject_blocked": 1},
+        )
+
 
     def test_gate_requires_all_shadows_and_rejects_live_authority(self):
         enabled = shadow_configuration(self.flags)

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -30,6 +30,7 @@ from bnl_unified_intelligence_packet import (
     shadow_configuration,
 )
 from bnl_unified_response_assessment import (
+    build_situation_frame_v1,
     build_unified_response_assessment,
 )
 
@@ -2955,6 +2956,10 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
             authority=0,
             usage="publication_projection",
             revalidation_kind="journal_publication",
+            revalidation_key=(
+                '{"entryId":"allowed","queryMode":"exact_title",'
+                '"revision":1}'
+            ),
             attribution_mode="publication_only",
             uncertainty_status="derived_publication_zero_fact_weight",
         )
@@ -3044,6 +3049,134 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
         self.assertEqual(deictic, [])
         self.assertEqual(
             deictic_diagnostics.excluded_by_reason,
+            {"frame_subject_ambiguous": 1},
+        )
+
+    def test_publication_exception_uses_production_frame_and_concrete_selector(
+        self,
+    ):
+        def production_request(text):
+            frame = build_situation_frame_v1(
+                route_allowed=True,
+                route_mode="normal_chat",
+                conversation_surface="public_home",
+                channel_policy="public_home",
+                current_text=text,
+                current_speaker_user_ids=(7,),
+                subject_entity_refs=("cache_back", "call_em_bini"),
+                response_act="answer",
+            )
+            self.assertEqual(frame.status, "ambiguous")
+            self.assertEqual(
+                frame.ambiguity_reasons,
+                ("multiple_subject_candidates",),
+            )
+            return replace(
+                self.public_request(text=text),
+                frame_schema_version=frame.schema_version,
+                frame_revision=frame.frame_revision,
+                frame_input_evidence_digest=frame.input_evidence_digest,
+                frame_status=frame.status,
+                frame_ambiguity_reasons=frame.ambiguity_reasons,
+                frame_subject_requirement=frame.subject_requirement,
+                frame_subjects=tuple(
+                    PacketFrameSubject(
+                        user_id=subject.user_id,
+                        entity_ref=subject.entity_ref,
+                        label_hint=subject.label_hint,
+                        binding_method=subject.binding_method,
+                        confidence=subject.confidence,
+                        role_hints=subject.role_hints,
+                        domain_hints=subject.domain_hints,
+                    )
+                    for subject in frame.subjects
+                ),
+                frame_tasks=tuple(
+                    PacketFrameTask(
+                        task_id=task.task_id,
+                        text_digest=task.text_digest,
+                        task_kind=task.task_kind,
+                        object_kind=task.object_kind,
+                        authority_scope=task.authority_scope,
+                        temporal_scope=task.temporal_scope,
+                        currentness=task.currentness,
+                        required_response_act=task.required_response_act,
+                        subject_requirement=task.subject_requirement,
+                        subject_indexes=task.subject_indexes,
+                    )
+                    for task in frame.tasks
+                ),
+                frame_task_kind=frame.task_kind,
+                frame_object_kind=frame.object_kind,
+                frame_phase=frame.phase,
+                frame_temporal_scope=frame.temporal_scope,
+                frame_currentness=frame.currentness,
+            )
+
+        exact_request = production_request(
+            "Show me the published Journal entry titled "
+            '"Backend Queue Runs, Soundstage Experiments, and '
+            'Post-Show Echoes." What did it say?'
+        )
+        vague_request = production_request(
+            "What did that Journal entry say?"
+        )
+        publication = IntelligencePacketItem(
+            lane="journal_publication",
+            source_class=packet_module.JOURNAL_PUBLICATION_SOURCE_CLASS,
+            source_type="canonical_published_journal",
+            source_ref="journal:journal_weekly_2026-08-24_7489c3d9:1",
+            source_digest="f" * 64,
+            subject_key="bnl_01",
+            predicate_key="published_journal_entry",
+            text="Published entry text.",
+            visibility="public",
+            confidence=Confidence.APPROVED.value,
+            lifecycle="published",
+            authority=0,
+            usage="publication_projection",
+            revalidation_kind="journal_publication",
+            revalidation_key=(
+                '{"entryId":"journal_weekly_2026-08-24_7489c3d9",'
+                '"queryMode":"exact_title","revision":1}'
+            ),
+            attribution_mode="publication_only",
+            uncertainty_status="derived_publication_zero_fact_weight",
+        )
+
+        exact_diagnostics = packet_module.IntelligencePacketDiagnostics()
+        exact_diagnostics.journal_query_status = "eligible"
+        exact_diagnostics.journal_candidate_count = 1
+        exact = packet_module._filter_frame_applicable_candidates(
+            exact_request,
+            packet_module.PacketSubjectResolution(status="ambiguous"),
+            [publication],
+            exact_diagnostics,
+            [],
+        )
+        self.assertEqual(exact, [publication])
+
+        vague_publication = replace(
+            publication,
+            revalidation_key=(
+                '{"entryId":"journal_weekly_2026-08-24_7489c3d9",'
+                '"queryMode":"topic","revision":1}'
+            ),
+        )
+        vague_diagnostics = packet_module.IntelligencePacketDiagnostics()
+        vague_diagnostics.journal_query_status = "eligible"
+        vague_diagnostics.journal_candidate_count = 1
+        vague_exclusions = []
+        vague = packet_module._filter_frame_applicable_candidates(
+            vague_request,
+            packet_module.PacketSubjectResolution(status="ambiguous"),
+            [vague_publication],
+            vague_diagnostics,
+            vague_exclusions,
+        )
+        self.assertEqual(vague, [])
+        self.assertEqual(
+            vague_diagnostics.excluded_by_reason,
             {"frame_subject_ambiguous": 1},
         )
 

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -2817,6 +2817,7 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
             frame_revision="sf_journal_exact_title",
             frame_input_evidence_digest="d" * 64,
             frame_status="ambiguous",
+            frame_ambiguity_reasons=("multiple_subject_candidates",),
             frame_subject_requirement="required",
             frame_subjects=(
                 PacketFrameSubject(
@@ -2911,6 +2912,7 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
             frame_revision="sf_journal_ambiguous_guard",
             frame_input_evidence_digest="a" * 64,
             frame_status="ambiguous",
+            frame_ambiguity_reasons=("multiple_subject_candidates",),
             frame_subject_requirement="required",
             frame_subjects=(
                 PacketFrameSubject(
@@ -3020,6 +3022,28 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
         self.assertEqual(unresolved, [])
         self.assertEqual(
             unresolved_diagnostics.excluded_by_reason,
+            {"frame_subject_ambiguous": 1},
+        )
+        deictic_reference_request = replace(
+            request,
+            frame_ambiguity_reasons=(
+                "referent_ambiguous",
+                "multiple_subject_candidates",
+            ),
+        )
+        deictic_diagnostics = packet_module.IntelligencePacketDiagnostics()
+        deictic_diagnostics.journal_query_status = "eligible"
+        deictic_diagnostics.journal_candidate_count = 1
+        deictic = packet_module._filter_frame_applicable_candidates(
+            deictic_reference_request,
+            packet_module.PacketSubjectResolution(status="ambiguous"),
+            [publication],
+            deictic_diagnostics,
+            [],
+        )
+        self.assertEqual(deictic, [])
+        self.assertEqual(
+            deictic_diagnostics.excluded_by_reason,
             {"frame_subject_ambiguous": 1},
         )
 

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -2912,6 +2912,18 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
             frame_input_evidence_digest="a" * 64,
             frame_status="ambiguous",
             frame_subject_requirement="required",
+            frame_subjects=(
+                PacketFrameSubject(
+                    user_id=7,
+                    binding_method="conversation_candidate",
+                    confidence="medium",
+                ),
+                PacketFrameSubject(
+                    entity_ref="cache_back",
+                    binding_method="conversation_candidate",
+                    confidence="medium",
+                ),
+            ),
             frame_tasks=(
                 PacketFrameTask(
                     task_id="T1",
@@ -2959,6 +2971,8 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
             uncertainty_status="",
         )
         diagnostics = packet_module.IntelligencePacketDiagnostics()
+        diagnostics.journal_query_status = "eligible"
+        diagnostics.journal_candidate_count = 1
         exclusions = []
 
         kept = packet_module._filter_frame_applicable_candidates(
@@ -2986,6 +3000,27 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
         self.assertEqual(
             blocked_diagnostics.excluded_by_reason,
             {"frame_subject_blocked": 1},
+        )
+        unresolved_reference_request = replace(
+            request,
+            frame_subjects=(),
+        )
+        unresolved_diagnostics = (
+            packet_module.IntelligencePacketDiagnostics()
+        )
+        unresolved_diagnostics.journal_query_status = "eligible"
+        unresolved_diagnostics.journal_candidate_count = 4
+        unresolved = packet_module._filter_frame_applicable_candidates(
+            unresolved_reference_request,
+            packet_module.PacketSubjectResolution(status="ambiguous"),
+            [publication],
+            unresolved_diagnostics,
+            [],
+        )
+        self.assertEqual(unresolved, [])
+        self.assertEqual(
+            unresolved_diagnostics.excluded_by_reason,
+            {"frame_subject_ambiguous": 1},
         )
 
 


### PR DESCRIPTION
## Summary
- preserve a validated Journal or Relay publication lane when an explicit subject-free `retrieve_publication` task names a concrete publication, even if unrelated conversational subject candidates make the global frame ambiguous
- require positive proof from the production selector: exact identity, an explicitly quoted exact Journal title, or an exact date
- accept paired straight or curly single quotes as well as double quotes for explicit Journal title selection
- prove uniqueness across the complete exact-match set after Journal visibility/integrity and Relay provenance/presence filtering, rather than the selector's returned-result window
- re-run that unique selection during packet revalidation so a newly eligible competing publication suppresses the stale packet before send
- keep topic/latest/deictic requests, blocked or unresolved frames, eligible multi-match selectors, and unrelated canon/member content fail-closed

## Live failure addressed
The exact-title Journal lookup found and validated the published entry, then frame filtering discarded it as `frame_subject_ambiguous`. The repair preserves only the publication lane owned by the typed retrieval task and only after its production selector resolves one concrete eligible publication.

This does not add a general conversational response guard. It restores an answer that the existing frame filter incorrectly discarded. The remaining fail-closed behavior is confined to ambiguous Journal/Relay retrieval when no concrete unique publication is proven.

## Review follow-up
- exact-title and exact-date Journal scans now inspect the complete matching set
- exact-date Relay scans now inspect the complete matching set
- more-than-eight regressions cover hidden Journal rows, duplicate Journal titles, and presence-only Relay rows with a second eligible result beyond the old scan cap
- straight and curly single-quoted title selectors are covered through both the adapter and production frame/packet path
- Journal and Relay packet revalidation reject a competing eligible match added after packet construction

## Latest review follow-up
- a parsed explicit Journal title remains authoritative even when it has no matching row; it returns `exact_title` / `not_found` instead of weakening to date or topic selection
- straight and curly single-quoted titles preserve contraction and plural-possessive apostrophes, including `Artist's Notes`, `Artist’s Notes`, `Artists' Notes`, and `Artists’ Notes`
- quote parsing uses the next same-style mark structurally rather than a clause-word allowlist, so arbitrary trailing clauses and later separately quoted phrases stop at the actual outer quote
- quote-boundary regressions also cover coordinated possessives (`Cats' and Dogs`)
- adapter and production packet regressions prove that a missing title cannot project an unrelated same-date publication

## Final review follow-up
- single-quoted selectors now enumerate plausible closing boundaries and resolve them against exact stored Journal titles, preferring the longest exact match
- trailing possessives after the requested title can no longer extend the title, while contractions and possessives inside the title remain intact
- straight and curly regressions cover both a simple title and a plural-possessive title followed by trailing possessive prose

## Final correctness follow-up
- the single-quote parser now chooses one authoritative syntactic title boundary before database selection, so an absent full title cannot weaken to a shorter stored title
- en/em dash punctuation is accepted immediately after a quoted title
- straight/curly missing-title regressions cover plural and coordinated possessives; all four quote styles are covered with both dash forms

## Publication-date binding follow-up
- the ambiguous-frame exception now treats `exact_date` as concrete only when the exact first date consumed by the selector is explicitly bound through Journal/Relay publication syntax (for example, “Journal published on” or “Relay dated”)
- date-first topical noun phrases such as `2026-08-04 Journal event` do not qualify, and a later bound date cannot legitimize an earlier unbound selector date
- production packet regressions cover single-date topical phrases and multi-date Journal/Relay requests while preserving explicit publication-date selection, complete-set uniqueness, and send-time revalidation

## Selector-scope follow-up
- an explicit title cue must belong directly to a Journal/daily-entry/weekly-entry phrase; an earlier unrelated `called`/`named` quoted phrase cannot steal the Journal title
- ambiguous-frame publication dates require `published`/`posted`/`released`/`dated` syntax and a valid end or question-follow-up boundary after the date
- bounded repeated appositive punctuation—including single/double ASCII hyphens, typographic dashes, and opening brackets—between the Journal phrase and its title cue is accepted
- comma-plus-conjunction follow-ups and up to three bounded common modifiers (`then`, `please`, `also`, `just`, `briefly`, `quickly`, `kindly`, `now`) accept normal comma/semicolon/colon punctuation after a valid publication date
- adapter and production packet regressions cover the unrelated-title-cue, trailing-topical-noun, appositive-title, and coordinated-follow-up cases for Journal and Relay

## Verification
- focused title/date/uniqueness/revalidation slice: 15 passed
- `make check PYTHON=.venv/bin/python`: 2,550 tests passed
- `git diff --check`: passed
- published Git tree matches the locally tested tree: `491c911be1aac96a031bdcf2d6840dcc3406ee67`

## Protected boundaries
No production gate, environment, schema, scheduler, generation path, Journal cadence/release owner, Relay publication owner, queue, website, deployment, or service change.