### PR TITLE
Converge Journal context through ordinary chat

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -191,6 +191,7 @@ from bnl_shared_brain_synthesis import (
     ordinary_chat_configuration,
     ordinary_chat_deterministic_response_act,
     ordinary_chat_route_scope_decision,
+    publication_packet_owns_turn,
     parse_ordinary_chat_response_contract,
     record_fallback as record_shared_brain_synthesis_fallback,
     record_single_packet_block,
@@ -27563,6 +27564,11 @@ def _build_unified_intelligence_packet_shadow(
             if isinstance(situation_frame, SituationFrameV1)
             else "not_provided"
         ),
+        frame_ambiguity_reasons=(
+            situation_frame.ambiguity_reasons
+            if isinstance(situation_frame, SituationFrameV1)
+            else ()
+        ),
         frame_subject_requirement=(
             situation_frame.subject_requirement
             if isinstance(situation_frame, SituationFrameV1)
@@ -35807,6 +35813,12 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 batch_website_read_model_context
                 or batch_tiktok_show_evidence_context
             )
+            batch_situation_frame = (
+                orchestration_state["decision"].situation_frame
+            )
+            batch_publication_packet_owns_turn = (
+                publication_packet_owns_turn(batch_situation_frame)
+            )
             community_visual_basis = build_community_visual_basis(
                 guild_id,
                 (
@@ -35838,7 +35850,10 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 user_text=combined_text,
                 has_media=bool(active_packet.get("media_present")),
                 specialized_owner_present=bool(
-                    batch_source_context_available
+                    (
+                        batch_source_context_available
+                        and not batch_publication_packet_owns_turn
+                    )
                     or community_visual_prompt
                 ),
             )
@@ -35858,7 +35873,10 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     batch_website_read_model_context,
                 )
             )
-            if batch_website_read_model_context:
+            if (
+                batch_website_read_model_context
+                and not batch_publication_packet_owns_turn
+            ):
                 prompt += (
                     "\n\nAuthoritative current live-show context for this "
                     "request:\n"
@@ -35878,7 +35896,10 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     len(collapsed_items),
                     f"channel_policy={channel_policy}",
                 )
-            if batch_tiktok_show_evidence_context:
+            if (
+                batch_tiktok_show_evidence_context
+                and not batch_publication_packet_owns_turn
+            ):
                 prompt += (
                     "\n\n"
                     + batch_tiktok_show_evidence_context
@@ -36118,11 +36139,15 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                             bool(
                                 batch_website_read_model_context
                                 and not batch_finalized_show_packet_owner
+                                and not batch_publication_packet_owns_turn
                             ),
                         ),
                         (
                             "show_episode",
-                            bool(batch_tiktok_show_evidence_context),
+                            bool(
+                                batch_tiktok_show_evidence_context
+                                and not batch_publication_packet_owns_turn
+                            ),
                         ),
                     )
                     if present
@@ -36196,6 +36221,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                         bool(
                             batch_website_read_model_context
                             and not batch_finalized_show_packet_owner
+                            and not batch_publication_packet_owns_turn
                         )
                     ),
                     current_direct=bool(
@@ -36206,7 +36232,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                         batch_intelligence_packet_out
                     ),
                     situation_frame=(
-                        orchestration_state["decision"].situation_frame
+                        batch_situation_frame
                     ),
                 )
             )
@@ -38396,11 +38422,23 @@ def build_user_aware_prompt(
         clean_content,
         tiktok_show_evidence_context,
     )
+    publication_packet_owns_current_turn = publication_packet_owns_turn(
+        conversation_orchestration.situation_frame
+        if isinstance(
+            conversation_orchestration,
+            ConversationOrchestrationDecision,
+        )
+        else None
+    )
     assessment_broadcast_context_present = bool(
-        broadcast_context and not finalized_show_packet_owner
+        broadcast_context
+        and not finalized_show_packet_owner
+        and not publication_packet_owns_current_turn
     )
     assessment_website_read_model_present = bool(
-        website_read_model_context and not finalized_show_packet_owner
+        website_read_model_context
+        and not finalized_show_packet_owner
+        and not publication_packet_owns_current_turn
     )
     community_visual_basis = build_community_visual_basis(
         guild_id,
@@ -38414,9 +38452,15 @@ def build_user_aware_prompt(
         community_visual_prompt_block += "\n"
     specialized_owner_present = bool(
         (assessment_broadcast_context_present and broadcast_specialized_owner)
-        or show_state_context
+        or (
+            show_state_context
+            and not publication_packet_owns_current_turn
+        )
         or assessment_website_read_model_present
-        or queue_artist_memory_context
+        or (
+            queue_artist_memory_context
+            and not publication_packet_owns_current_turn
+        )
         or community_visual_prompt_block
     )
     if ordinary_chat_single_packet and specialized_owner_present:
@@ -38460,15 +38504,30 @@ def build_user_aware_prompt(
                     "broadcast_memory",
                     assessment_broadcast_context_present,
                 ),
-                ("show_state", bool(show_state_context)),
+                (
+                    "show_state",
+                    bool(
+                        show_state_context
+                        and not publication_packet_owns_current_turn
+                    ),
+                ),
                 (
                     "website_read_model",
                     assessment_website_read_model_present,
                 ),
-                ("queue_artist_memory", bool(queue_artist_memory_context)),
+                (
+                    "queue_artist_memory",
+                    bool(
+                        queue_artist_memory_context
+                        and not publication_packet_owns_current_turn
+                    ),
+                ),
                 (
                     "show_episode",
-                    bool(tiktok_show_evidence_context),
+                    bool(
+                        tiktok_show_evidence_context
+                        and not publication_packet_owns_current_turn
+                    ),
                 ),
             )
             if present
@@ -38504,15 +38563,30 @@ def build_user_aware_prompt(
                         "broadcast_memory",
                         assessment_broadcast_context_present,
                     ),
-                    ("show_state", bool(show_state_context)),
+                    (
+                        "show_state",
+                        bool(
+                            show_state_context
+                            and not publication_packet_owns_current_turn
+                        ),
+                    ),
                     (
                         "website_read_model",
                         assessment_website_read_model_present,
                     ),
-                    ("queue_artist_memory", bool(queue_artist_memory_context)),
+                    (
+                        "queue_artist_memory",
+                        bool(
+                            queue_artist_memory_context
+                            and not publication_packet_owns_current_turn
+                        ),
+                    ),
                     (
                         "show_episode",
-                        bool(tiktok_show_evidence_context),
+                        bool(
+                            tiktok_show_evidence_context
+                            and not publication_packet_owns_current_turn
+                        ),
                     ),
                     ("source_context", bool(source_context_block)),
                     ("canon", _canon_relevant_to_response(clean_content)),
@@ -38552,7 +38626,10 @@ def build_user_aware_prompt(
         continuity_required=continuity_required_state,
         exact_quote_requested=exact_quote_requested,
         exact_quote_authority_present=exact_quote_authority is not None,
-        show_state_present=bool(show_state_context),
+        show_state_present=bool(
+            show_state_context
+            and not publication_packet_owns_current_turn
+        ),
         website_read_model_present=(
             assessment_website_read_model_present
         ),
@@ -38853,6 +38930,7 @@ def build_user_aware_prompt(
         broadcast_prompt_block = ""
         show_state_prompt_block = ""
         website_read_model_prompt_block = ""
+        queue_artist_memory_prompt_block = ""
         tiktok_show_evidence_prompt_block = ""
         tiktok_show_analysis_turn_contract = ""
         tiktok_show_episode_turn_contract = ""

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -1881,6 +1881,50 @@ def ordinary_chat_route_scope_decision(
     )
 
 
+def publication_packet_owns_turn(situation_frame: Any) -> bool:
+    """Return whether typed Journal/Relay tasks own this factual turn.
+
+    Specialized context can be discovered from topic words inside a
+    publication question.  That discovery must not divert the requested
+    Journal/Relay task to the legacy prompt.  A genuinely requested
+    specialized-owner task still keeps its existing route.
+    """
+
+    tasks = tuple(getattr(situation_frame, "tasks", ()) or ())
+    if not tasks:
+        return False
+    publication_task_present = False
+    for task in tasks:
+        authority_scope = str(
+            getattr(task, "authority_scope", "") or ""
+        ).strip().lower()
+        object_kind = str(
+            getattr(task, "object_kind", "") or ""
+        ).strip().lower()
+        task_kind = str(
+            getattr(task, "task_kind", "") or ""
+        ).strip().lower()
+        subject_requirement = str(
+            getattr(task, "subject_requirement", "") or ""
+        ).strip().lower()
+        publication_task = bool(
+            authority_scope == "packet"
+            and task_kind == "retrieve_publication"
+            and object_kind in {"journal", "relay"}
+            and subject_requirement != "required"
+        )
+        if publication_task:
+            publication_task_present = True
+            continue
+        if authority_scope == "packet" or object_kind in {
+            "queue",
+            "website",
+            "broadcast",
+        }:
+            return False
+    return publication_task_present
+
+
 def ordinary_chat_route_scope_enabled(**kwargs: Any) -> bool:
     return ordinary_chat_route_scope_decision(**kwargs).eligible
 

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -487,6 +487,7 @@ class IntelligencePacketRequest:
     frame_revision: str = ""
     frame_input_evidence_digest: str = ""
     frame_status: str = "not_provided"
+    frame_ambiguity_reasons: tuple[str, ...] = ()
     frame_subject_requirement: str = "legacy"
     frame_subjects: tuple[PacketFrameSubject, ...] = ()
     frame_tasks: tuple[PacketFrameTask, ...] = ()
@@ -4960,6 +4961,47 @@ def _relay_publication_items(
     return items
 
 
+def _subject_independent_publication_lanes(
+    request: IntelligencePacketRequest,
+) -> frozenset[str]:
+    """Keep publication tasks separate from unrelated subject ambiguity."""
+
+    ambiguity_reasons = frozenset(
+        str(reason or "").strip().lower()
+        for reason in request.frame_ambiguity_reasons
+        if str(reason or "").strip()
+    )
+    concrete_subjects = tuple(
+        subject
+        for subject in request.frame_subjects
+        if int(subject.user_id or 0) > 0
+        or str(subject.entity_ref or "").strip()
+    )
+    if (
+        str(request.frame_status or "").strip().lower() != "ambiguous"
+        or ambiguity_reasons != frozenset({"multiple_subject_candidates"})
+        or str(request.frame_subject_requirement or "").strip().lower()
+        != "required"
+        or len(concrete_subjects) < 2
+    ):
+        return frozenset()
+
+    lanes = set()
+    for task in request.frame_tasks:
+        object_kind = str(task.object_kind or "").strip().lower()
+        if (
+            str(task.authority_scope or "").strip().lower() == "packet"
+            and str(task.task_kind or "").strip().lower()
+            == "retrieve_publication"
+            and str(task.subject_requirement or "").strip().lower()
+            != "required"
+            and not task.subject_indexes
+            and object_kind in {"journal", "relay"}
+        ):
+            lanes.add("%s_publication" % object_kind)
+    return frozenset(lanes)
+
+
 def _filter_frame_applicable_candidates(
     request: IntelligencePacketRequest,
     subject_resolution: PacketSubjectResolution,
@@ -4985,8 +5027,16 @@ def _filter_frame_applicable_candidates(
     if not subject_resolution.applicable:
         kept = []
         reason = "frame_subject_%s" % subject_resolution.status
+        subject_independent_publication_lanes = (
+            _subject_independent_publication_lanes(request)
+            if subject_resolution.status == "ambiguous"
+            else frozenset()
+        )
         for item in candidates:
-            if item.lane == "current_intent":
+            if (
+                item.lane == "current_intent"
+                or item.lane in subject_independent_publication_lanes
+            ):
                 kept.append(item)
             else:
                 exclude(item, reason)
@@ -6136,6 +6186,26 @@ def _revalidate_packet_in_snapshot(
         packet.request,
         environ=environ,
     )
+    subject_independent_publication_lanes = (
+        _subject_independent_publication_lanes(packet.request)
+    )
+    subject_independent_publication_content = bool(
+        current_subject_resolution.status == "ambiguous"
+        and subject_independent_publication_lanes
+        and any(
+            item.lane in subject_independent_publication_lanes
+            for item in packet.items
+        )
+        and all(
+            item.lane == "current_intent"
+            or item.lane in subject_independent_publication_lanes
+            for item in packet.items
+        )
+        and all(
+            item.lane in subject_independent_publication_lanes
+            for item in packet.validation_items
+        )
+    )
     legacy_resolution_unspecified = bool(
         not str(packet.request.frame_revision or "").strip()
         and packet.subject_resolution.status == "unresolved"
@@ -6312,7 +6382,10 @@ def _revalidate_packet_in_snapshot(
         status = "processing_error"
     elif subject_changed:
         status = "subject_binding_changed"
-    elif not current_subject_resolution.applicable:
+    elif (
+        not current_subject_resolution.applicable
+        and not subject_independent_publication_content
+    ):
         status = "subject_%s" % current_subject_resolution.status
     elif changed:
         status = "source_changed"
@@ -6367,6 +6440,11 @@ def _packet_invariants(
     packet: UnifiedIntelligencePacket,
 ) -> tuple[str, ...]:
     invalid = []
+    subject_independent_publication_lanes = (
+        _subject_independent_publication_lanes(packet.request)
+        if packet.subject_resolution.status == "ambiguous"
+        else frozenset()
+    )
     accepted_subject_keys = {
         value for value in packet_subject_keys(packet) if value
     }
@@ -6419,7 +6497,11 @@ def _packet_invariants(
     if (
         str(packet.request.frame_revision or "").strip()
         and not packet.subject_resolution.applicable
-        and any(item.lane != "current_intent" for item in packet.items)
+        and any(
+            item.lane != "current_intent"
+            and item.lane not in subject_independent_publication_lanes
+            for item in packet.items
+        )
     ):
         invalid.append("unresolved_frame_subject_selected_content")
     if str(packet.request.frame_revision or "").strip() and not (

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -482,6 +482,16 @@ _CANON_SINGULAR_DEICTIC_RE = re.compile(
     r"character|entity))\b",
     re.I,
 )
+_PUBLICATION_DEICTIC_RE = re.compile(
+    r"\b(?:this|that|these|those)\s+"
+    r"(?:(?:last|previous|earlier)\s+)?"
+    r"(?:journal(?:\s+entr(?:y|ies))?|daily\s+entr(?:y|ies)|"
+    r"weekly\s+entr(?:y|ies)|relay(?:\s+(?:message|publication))?)\b|"
+    r"\b(?:this|that|these|those)\s+"
+    r"(?:entr(?:y|ies)|publication|message)\b.{0,40}"
+    r"\b(?:journal|relay)\b",
+    re.I,
+)
 _PACKET_AUTHORITY_OBJECTS = frozenset(
     {
         "journal",
@@ -1170,6 +1180,12 @@ def build_situation_frame_v1(
     if normalized_referent in {"ambiguous", "unresolved"}:
         ambiguity.append("referent_%s" % normalized_referent)
         competing.append("nearby_referent_candidates")
+    if (
+        _PUBLICATION_DEICTIC_RE.search(text)
+        and normalized_referent != "resolved"
+    ):
+        ambiguity.append("publication_referent_unresolved")
+        competing.append("publication_referent_candidates")
     referenced_subject_indexes = {
         subject_index
         for task in tasks

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -26,6 +26,7 @@ from bnl_shared_brain_synthesis import (
     ordinary_chat_deterministic_response_act,
     ordinary_chat_route_scope_decision,
     ordinary_chat_task_support_plan,
+    publication_packet_owns_turn,
     parse_ordinary_chat_response_contract,
     record_single_packet_block,
     render_ordinary_chat_task_contract,
@@ -801,6 +802,34 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                 )
                 self.assertFalse(decision.eligible)
                 self.assertEqual(decision.reason, reason)
+
+    def test_publication_task_owns_topic_overlap_but_not_queue_task(self):
+        journal_topic = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text="What did the Journal say about the queue?",
+            current_speaker_user_ids=(7,),
+            response_act="answer",
+        )
+        mixed_current_queue = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text=(
+                "What did the Journal say about the queue, and is the "
+                "queue open right now?"
+            ),
+            current_speaker_user_ids=(7,),
+            response_act="answer",
+        )
+
+        self.assertTrue(publication_packet_owns_turn(journal_topic))
+        self.assertFalse(
+            publication_packet_owns_turn(mixed_current_queue)
+        )
 
     def test_packet_owned_prompt_rejects_legacy_and_nonpacket_owners(self):
         base_prompt = (

--- a/tests/test_situation_frame_v1.py
+++ b/tests/test_situation_frame_v1.py
@@ -332,6 +332,47 @@ class SituationFrameV1Tests(unittest.TestCase):
                 self.assertEqual(frame.task_kind, "retrieve_publication")
                 self.assertEqual(frame.status, "resolved")
 
+    def test_unresolved_publication_deictic_is_not_treated_as_a_topic(self):
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="public_home",
+            channel_policy="public_home",
+            current_text="What did that Journal entry say?",
+            current_speaker_user_ids=(101,),
+            subject_entity_refs=("cache_back", "call_em_bini"),
+            response_act="answer",
+        )
+
+        self.assertEqual(frame.status, "ambiguous")
+        self.assertIn(
+            "publication_referent_unresolved",
+            frame.ambiguity_reasons,
+        )
+        self.assertIn(
+            "multiple_subject_candidates",
+            frame.ambiguity_reasons,
+        )
+
+        resolved = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            channel_policy="sealed_test",
+            current_text="What did that Journal entry say?",
+            current_speaker_user_ids=(101,),
+            subject_entity_refs=("cache_back", "call_em_bini"),
+            reply_message_ids=(700,),
+            exact_source_row_ids=(77,),
+            referent_status="resolved",
+            response_act="answer",
+        )
+
+        self.assertNotIn(
+            "publication_referent_unresolved",
+            resolved.ambiguity_reasons,
+        )
+
     def test_mixed_request_is_split_into_ordered_authority_tasks(self):
         frame = build_situation_frame_v1(
             route_allowed=True,

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -18,8 +18,10 @@ from bnl_shadow_acceptance import (
 )
 from bnl_shared_brain_synthesis import render_packet_context
 from bnl_unified_intelligence_packet import (
+    IntelligencePacketItem,
     IntelligencePacketRequest,
     PacketConversationEvidence,
+    PacketFrameTask,
     PacketFrameSubject,
     _safe_atomic_supporting_observation,
     build_evaluation_report,
@@ -2773,6 +2775,138 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
             projected.entry_id,
             {item.source_ref for item in packet.items},
         )
+
+    def test_publication_task_survives_only_unrelated_subject_ambiguity(self):
+        publication = IntelligencePacketItem(
+            lane="journal_publication",
+            source_class=packet_module.JOURNAL_PUBLICATION_SOURCE_CLASS,
+            source_type="canonical_published_journal",
+            source_ref="journal:journal_weekly_queue:1",
+            source_digest="f" * 64,
+            subject_key="bnl_01",
+            predicate_key="published_journal_entry",
+            text="The Journal connected the queue run to the last show.",
+            visibility="public",
+            confidence=Confidence.APPROVED.value,
+            lifecycle="published",
+            authority=0,
+            usage="publication_projection",
+            score=135.0,
+            revalidation_kind="journal_publication",
+            revalidation_key=(
+                '{"entryId":"journal_weekly_queue",'
+                '"queryMode":"topic","revision":1}'
+            ),
+            attribution_mode="publication_only",
+            uncertainty_status="derived_publication_zero_fact_weight",
+        )
+        request = replace(
+            self.public_request(
+                text="What did the Journal say about the queue?"
+            ),
+            frame_schema_version="situation_frame_v1",
+            frame_revision="sf_journal_topic",
+            frame_input_evidence_digest="d" * 64,
+            frame_status="ambiguous",
+            frame_ambiguity_reasons=("multiple_subject_candidates",),
+            frame_subject_requirement="required",
+            frame_subjects=(
+                PacketFrameSubject(
+                    entity_ref="cache_back",
+                    binding_method="conversation_candidate",
+                    confidence="medium",
+                ),
+                PacketFrameSubject(
+                    entity_ref="call_em_bini",
+                    binding_method="conversation_candidate",
+                    confidence="medium",
+                ),
+            ),
+            frame_tasks=(
+                PacketFrameTask(
+                    task_id="T1",
+                    text_digest="e" * 64,
+                    task_kind="retrieve_publication",
+                    object_kind="journal",
+                    authority_scope="packet",
+                    temporal_scope="historical",
+                    currentness="historical",
+                    required_response_act="answer",
+                    subject_requirement="not_applicable",
+                ),
+            ),
+            frame_task_kind="retrieve_publication",
+            frame_object_kind="journal",
+            frame_phase="request",
+        )
+
+        def journal_candidates(
+            _conn,
+            _request,
+            diagnostics,
+            _exclusions,
+        ):
+            diagnostics.journal_query_status = "eligible"
+            diagnostics.journal_control_status = "valid"
+            diagnostics.journal_candidate_count = 1
+            diagnostics.candidates_by_lane["journal_publication"] = 1
+            diagnostics.publication_projection_count += 1
+            return [publication]
+
+        with (
+            mock.patch.object(
+                packet_module,
+                "_journal_publication_items",
+                side_effect=journal_candidates,
+            ),
+            mock.patch.object(
+                packet_module,
+                "revalidate_published_journal_entry_on_connection",
+                return_value=publication.source_digest,
+            ),
+        ):
+            packet = build_packet(
+                self.conn,
+                request,
+                persist=False,
+                environ=self.flags,
+            )
+
+        self.assertEqual(packet.subject_resolution.status, "ambiguous")
+        self.assertEqual(
+            tuple(
+                item.source_ref
+                for item in packet.items
+                if item.lane == "journal_publication"
+            ),
+            (publication.source_ref,),
+        )
+        self.assertTrue(
+            all(
+                item.lane in {"current_intent", "journal_publication"}
+                for item in packet.items
+            )
+        )
+        self.assertEqual(packet.diagnostics.revalidation_status, "passed")
+        self.assertFalse(packet.diagnostics.invalid_invariants)
+
+        deictic_request = replace(
+            request,
+            frame_ambiguity_reasons=(
+                "publication_referent_unresolved",
+                "multiple_subject_candidates",
+            ),
+        )
+        deictic_diagnostics = packet_module.IntelligencePacketDiagnostics()
+        deictic_diagnostics.journal_query_status = "eligible"
+        excluded = packet_module._filter_frame_applicable_candidates(
+            deictic_request,
+            packet_module.PacketSubjectResolution(status="ambiguous"),
+            [publication],
+            deictic_diagnostics,
+            [],
+        )
+        self.assertEqual(excluded, [])
 
     def test_gate_requires_all_shadows_and_rejects_live_authority(self):
         enabled = shadow_configuration(self.flags)

--- a/tests/test_unified_response_assessment_bot_paths.py
+++ b/tests/test_unified_response_assessment_bot_paths.py
@@ -443,6 +443,182 @@ class UnifiedResponseAssessmentBotPathTests(unittest.TestCase):
         memory_builder.assert_called_once()
         broadcast_builder.assert_called_once()
 
+    def test_journal_topic_keeps_packet_owner_over_queue_context(self):
+        text = "What did the Journal say about the queue?"
+        frame = bnl01_bot.build_situation_frame_v1(
+            route_allowed=True,
+            route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            conversation_surface="sealed_test",
+            channel_policy="sealed_test",
+            current_text=text,
+            current_speaker_user_ids=(101,),
+            response_act="answer",
+        )
+        orchestration = bnl01_bot.ConversationOrchestrationDecision(
+            response_act="answer",
+            reason="direct_request",
+            response_required=True,
+            address_kind="discord_mention",
+            continuity_required=False,
+            referent_status="not_requested",
+            referent_candidate_count=0,
+            referent_candidate_labels=(),
+            moment_situation_state="none",
+            moment_topic_coherent=False,
+            moment_participant_overlap=False,
+            moment_human_entry_count=0,
+            moment_model_entry_count=0,
+            engagement_decision="respond",
+            engagement_reason="direct_request",
+            influence_mode="sealed_canary",
+            packet_version="test",
+            packet_revision="test",
+            governed_memory_state="owner_not_requested",
+            relationship_state="owner_tone_only",
+            canon_state="owner_not_requested",
+            source_control_state="route_policy_only",
+            situation_frame=frame,
+        )
+        flags = {
+            "BNL_MEMORY_LEDGER_SHADOW_ENABLED": "true",
+            "BNL_MOMENT_ENGINE_SHADOW_ENABLED": "true",
+            "BNL_MEMORY_GOVERNANCE_SHADOW_ENABLED": "true",
+            "BNL_RELATIONSHIP_V2_SHADOW_ENABLED": "true",
+            "BNL_UNIFIED_RESPONSE_ASSESSMENT_SHADOW_ENABLED": "true",
+            "BNL_UNIFIED_INTELLIGENCE_PACKET_SHADOW_ENABLED": "true",
+            "BNL_SHARED_BRAIN_SYNTHESIS_CANARY_ENABLED": "false",
+            "BNL_PUBLIC_HOME_BROAD_RECALL_OWNER_ENABLED": "false",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED": "true",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_GUILD_IDS": "1",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_USER_IDS": "101",
+            "BNL_ORDINARY_CHAT_SINGLE_PACKET_CHANNEL_IDS": "303",
+            "BNL_MEMORY_GOVERNANCE_LIVE_ENABLED": "false",
+            "BNL_RELATIONSHIP_V2_LIVE_ENABLED": "false",
+            "BNL_ACTIVE_ENGAGEMENT_V2_LIVE_ENABLED": "false",
+        }
+        packet = object()
+        assessment = SimpleNamespace()
+        ordinary_basis = object()
+        visual_basis = SimpleNamespace(status="not_requested")
+        assessment_calls = []
+
+        def assessment_builder(**kwargs):
+            assessment_calls.append(kwargs)
+            kwargs["intelligence_packet_out"]["packet"] = packet
+            return assessment
+
+        with (
+            mock.patch.dict(os.environ, flags, clear=False),
+            mock.patch.object(
+                bnl01_bot,
+                "get_user_profile",
+                return_value=("Member 1", ""),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "should_allow_greeting",
+                return_value=False,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "choose_response_style",
+                return_value=("balanced", "Respond naturally."),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_conversation_prompt_source_basis",
+                return_value=None,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_broadcast_memory_context",
+                return_value="",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_queue_artist_memory_context",
+                return_value="QUEUE OWNER SENTINEL",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_tiktok_show_evidence_context_for_turn",
+                return_value="SHOW OWNER SENTINEL",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "finalized_show_packet_owner_requested",
+                return_value=False,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_community_visual_basis",
+                return_value=visual_basis,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "render_community_visual_basis_for_prompt",
+                return_value="",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_unified_response_assessment_shadow",
+                side_effect=assessment_builder,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_ordinary_chat_basis",
+                return_value=ordinary_basis,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_shared_brain_synthesis_basis",
+                return_value=None,
+            ),
+        ):
+            metadata = {}
+            prompt, *_ = bnl01_bot.build_user_aware_prompt(
+                101,
+                1,
+                "Member 1",
+                text,
+                show_state_context="SHOW STATE OWNER SENTINEL",
+                channel_name="bnl-testing",
+                channel_id=303,
+                channel_policy="sealed_test",
+                route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+                is_direct_interaction=True,
+                website_read_model_context="WEBSITE QUEUE OWNER SENTINEL",
+                conversation_orchestration=orchestration,
+                prompt_metadata=metadata,
+            )
+
+        self.assertTrue(metadata["ordinary_chat_single_packet_applied"])
+        self.assertEqual(
+            metadata["ordinary_chat_single_packet_scope"].reason,
+            "eligible",
+        )
+        self.assertIs(
+            metadata["ordinary_chat_single_packet_basis"],
+            ordinary_basis,
+        )
+        self.assertEqual(len(assessment_calls), 1)
+        self.assertFalse(
+            assessment_calls[0]["website_read_model_present"]
+        )
+        self.assertFalse(assessment_calls[0]["show_state_present"])
+        self.assertNotIn(
+            "website_read_model",
+            assessment_calls[0]["prompt_lanes"],
+        )
+        self.assertNotIn(
+            "queue_artist_memory",
+            assessment_calls[0]["prompt_lanes"],
+        )
+        self.assertNotIn("WEBSITE QUEUE OWNER SENTINEL", prompt)
+        self.assertNotIn("SHOW STATE OWNER SENTINEL", prompt)
+        self.assertNotIn("QUEUE OWNER SENTINEL", prompt)
+        self.assertNotIn("SHOW OWNER SENTINEL", prompt)
+
     def test_bot_recorder_persists_only_aggregate_receipt(self):
         with mock.patch.object(
             bnl01_bot,


### PR DESCRIPTION
## What this fixes

This is the clean, product-aligned repair for the two publication-continuity failures observed in shared-brain acceptance:

- An eligible Journal/Relay publication could be selected correctly and then discarded because unrelated people elsewhere in the conversation made the global subject frame ambiguous.
- A natural Journal question whose topic mentioned the queue/show could build a valid publication packet, then be diverted into unrelated queue/show context and bypass the one-packet conversational path.

The result was that BNL had the eligible Journal context but failed to use it in the conversation.

## Behavior after this change

- A subject-free, packet-owned Journal/Relay retrieval task can retain its eligible publication context through unrelated multi-subject ambiguity.
- A Journal/Relay publication task owns the turn when queue/show words are merely the publication's topic.
- A real mixed request—such as asking what the Journal said *and* asking for current queue state—still uses the existing specialized owner path.
- An unresolved deictic such as “that Journal entry” remains ambiguous unless the conversation/reply context resolves the referent.

## Deliberate non-goals

- No Journal-title command or title/date punctuation grammar.
- No new memory store, retriever, brain, or canon authority.
- No changes to Journal generation, cadence, release ownership, Relay publication ownership, schemas, schedules, provider count, website, or queue behavior.
- No gate, environment, deployment, restart, or production change.

Journal/Relay content remains specialist-owned derived continuity that enters the existing Situation Frame → Unified Intelligence Packet → one conversational synthesis path.

## Verification

- Acceptance-focused shared-brain/publication/route slice: **183 tests passed**
- Full repository check: **2,532 tests passed**
- `git diff --check`: passed
- Published Git tree exactly matches the locally tested tree: `648bff3d175bd2ab06744383c601a874e1120ce8`
