### PR TITLE
Let BNL reason over Journal and Relay evidence

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -41963,11 +41963,45 @@ def _ordinary_chat_ambiguous_subject_labels(
     return labels if 2 <= len(labels) <= 4 else ()
 
 
+def _ordinary_chat_packet_publication_kind(
+    situation_frame: SituationFrameV1 | None,
+) -> str:
+    for task in tuple(getattr(situation_frame, "tasks", ()) or ()):
+        authority_scope = str(
+            getattr(task, "authority_scope", "") or ""
+        ).strip().lower()
+        object_kind = str(
+            getattr(task, "object_kind", "") or ""
+        ).strip().lower()
+        if authority_scope == "packet" and object_kind in {
+            "journal",
+            "relay",
+        }:
+            return object_kind
+    return ""
+
+
 def _ordinary_chat_single_packet_block_response(
     reason: str,
     situation_frame: SituationFrameV1 | None = None,
 ) -> str:
     value = str(reason or "").lower()
+    publication_kind = _ordinary_chat_packet_publication_kind(
+        situation_frame
+    )
+    if publication_kind and (
+        "deterministic_task_hold" in value
+        or "source" in value
+        or "packet" in value
+        or "control" in value
+        or "unavailable" in value
+    ):
+        label = publication_kind.capitalize()
+        return (
+            "I don’t have enough %s material to answer that honestly. I can "
+            "give you a general recap from other context, but I won’t pretend "
+            "it came from the %s." % (label, label)
+        )
     if "deterministic_task_hold" in value or "current_fact" in value:
         return (
             "I can’t verify that live or current fact from an authoritative "
@@ -42685,8 +42719,9 @@ def ordinary_chat_legacy_baseline_fallback_allowed(
     """Allow the established prompt only before a low-risk packet call.
 
     The packet route remains authoritative whenever it generated a candidate or
-    actually entered provider generation.  The legacy prompt is available only
-    for local packet/preflight failures, and never for typed live/current holds.
+    actually entered provider generation. The legacy prompt is available only
+    for local packet/preflight failures, never as a substitute publication
+    owner, and never for typed live/current holds.
     """
 
     if execution is None or execution.candidate_active:
@@ -42716,6 +42751,8 @@ def ordinary_chat_legacy_baseline_fallback_allowed(
         return False
 
     tasks = tuple(getattr(situation_frame, "tasks", ()) or ())
+    if _ordinary_chat_packet_publication_kind(situation_frame):
+        return False
     for task in tasks:
         authority_scope = str(
             getattr(task, "authority_scope", "") or ""

--- a/bnl_journal.py
+++ b/bnl_journal.py
@@ -844,18 +844,17 @@ def select_published_journal_entries_on_connection(
                         )
                     )
                     score = len(terms & candidate_terms)
-                    if score:
-                        scored.append(
-                            (
-                                score,
-                                str(
-                                    row.get("published_at")
-                                    or row.get("created_at")
-                                    or ""
-                                ),
-                                row,
-                            )
+                    scored.append(
+                        (
+                            score,
+                            str(
+                                row.get("published_at")
+                                or row.get("created_at")
+                                or ""
+                            ),
+                            row,
                         )
+                    )
                 scored.sort(
                     key=(
                         (lambda item: (item[1], item[0]))
@@ -864,6 +863,9 @@ def select_published_journal_entries_on_connection(
                     ),
                     reverse=True,
                 )
+                # Lexical overlap ranks the bounded public evidence window;
+                # it does not decide whether BNL is allowed to reason over
+                # otherwise eligible recent Journal publications.
                 rows = [row for _score, _timestamp, row in scored]
 
     candidate_count = len(rows)

--- a/bnl_website_relay_state.py
+++ b/bnl_website_relay_state.py
@@ -645,14 +645,13 @@ def select_accepted_relay_publications_on_connection(
                     if len(token) >= 4
                 }
                 score = len(terms & candidate_terms)
-                if score:
-                    scored.append(
-                        (
-                            score,
-                            str(row.get("published_timestamp") or ""),
-                            row,
-                        )
+                scored.append(
+                    (
+                        score,
+                        str(row.get("published_timestamp") or ""),
+                        row,
                     )
+                )
             scored.sort(
                 key=(
                     (lambda item: (item[1], item[0]))
@@ -661,6 +660,9 @@ def select_accepted_relay_publications_on_connection(
                 ),
                 reverse=True,
             )
+            # Lexical overlap is a ranking hint, not an authority gate. The
+            # one governed response model determines relevance from this
+            # bounded window of accepted public Relay evidence.
             rows = [row for _score, _timestamp, row in scored]
     candidate_count = len(rows)
     selected: list[AcceptedRelayPublication] = []

--- a/tests/test_publication_read_adapters.py
+++ b/tests/test_publication_read_adapters.py
@@ -278,6 +278,40 @@ class PublicationReadAdapterTests(unittest.TestCase):
             "journal_newer_light",
         )
 
+    def test_natural_journal_topic_preserves_recent_publications_for_reasoning(self):
+        self.add_journal(
+            "journal_broadcast_older",
+            title="August 21 Broadcast Notes",
+            excerpt="The broadcast ran long and the video feed stuttered.",
+            body="Several BARCODE Vol. 1 contributors visited the session.",
+            published_at="2026-08-22T01:00:00Z",
+        )
+        self.add_journal(
+            "journal_broadcast_newer",
+            title="August 28 Broadcast Notes",
+            excerpt="The broadcast logged 48 rostered tracks.",
+            body="Operational and community activity were recorded together.",
+            published_at="2026-08-29T01:00:00Z",
+        )
+
+        selected = journal.select_published_journal_entries_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text="What did the Journal say about the last show?",
+            control_snapshot=control_snapshot(),
+            now=NOW,
+        )
+
+        self.assertEqual("eligible", selected.status)
+        self.assertEqual("topic", selected.query_mode)
+        self.assertEqual(
+            (
+                "journal_broadcast_newer",
+                "journal_broadcast_older",
+            ),
+            tuple(item.entry_id for item in selected.publications),
+        )
+
     def test_journal_public_visibility_and_reuse_are_independent(self):
         entry_id = "journal_visibility_case"
         self.add_journal(entry_id, title="Public Ceramic Log")
@@ -455,6 +489,36 @@ class PublicationReadAdapterTests(unittest.TestCase):
         self.assertEqual(
             "bnl-relay-newer-light",
             selected.publications[0].relay_id,
+        )
+
+    def test_natural_relay_topic_preserves_recent_publications_for_reasoning(self):
+        self.add_relay(
+            "bnl-broadcast-older",
+            message=(
+                "The August 21 broadcast ran long and the video feed "
+                "stuttered."
+            ),
+            directive="Retain the preceding session as public context.",
+            published_at="2026-08-22T01:00:00Z",
+        )
+        self.add_relay(
+            "bnl-broadcast-newer",
+            message="The August 28 broadcast logged 48 rostered tracks.",
+            directive="Use the newest accepted session record first.",
+            published_at="2026-08-29T01:00:00Z",
+        )
+
+        selected = relay.select_accepted_relay_publications_on_connection(
+            self.conn,
+            guild_id=1,
+            user_text="What did the Relay say about the last show?",
+        )
+
+        self.assertEqual("eligible", selected.status)
+        self.assertEqual("topic", selected.query_mode)
+        self.assertEqual(
+            ("bnl-broadcast-newer", "bnl-broadcast-older"),
+            tuple(item.relay_id for item in selected.publications),
         )
 
     def test_relay_attempts_and_presence_are_not_accepted_speech(self):
@@ -639,6 +703,43 @@ class PublicationPacketIntegrationTests(PublicationReadAdapterTests):
         )
         self.assertFalse(changed.valid)
         self.assertEqual("source_changed", changed.status)
+
+    def test_natural_relay_question_reaches_the_publication_packet(self):
+        self.add_relay(
+            "bnl-live-acceptance-older",
+            message=(
+                "The August 21 broadcast ran long and the video feed "
+                "stuttered."
+            ),
+            published_at="2026-08-22T01:00:00Z",
+        )
+        self.add_relay(
+            "bnl-live-acceptance-newer",
+            message="The August 28 broadcast logged 48 rostered tracks.",
+            published_at="2026-08-29T01:00:00Z",
+        )
+
+        packet = build_packet(
+            self.conn,
+            self.request("What did the Relay say about the last show?"),
+            persist=False,
+            environ=self.flags,
+        )
+
+        self.assertEqual("eligible", packet.diagnostics.relay_query_status)
+        self.assertFalse(packet.diagnostics.invalid_invariants)
+        self.assertEqual(2, packet.diagnostics.publication_projection_count)
+        self.assertEqual(
+            {
+                "relay:bnl-live-acceptance-newer",
+                "relay:bnl-live-acceptance-older",
+            },
+            {
+                item.source_ref
+                for item in packet.items
+                if item.lane == "relay_publication"
+            },
+        )
 
     def test_latest_journal_revalidation_rejects_newer_matching_publication(self):
         snapshot = control_snapshot()

--- a/tests/test_shared_brain_synthesis_bot_path.py
+++ b/tests/test_shared_brain_synthesis_bot_path.py
@@ -1535,6 +1535,47 @@ class SharedBrainSynthesisBotPathTests(
             )
         )
 
+    def test_publication_hold_does_not_relabel_legacy_context(self):
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=SimpleNamespace(
+                run=SimpleNamespace(prompt_applied=False)
+            ),
+            response="publication hold",
+            prompt="packet-owned prompt",
+            prompt_source_bases=(),
+            candidate_active=False,
+            provider_call_count=0,
+            corrective_call_count=0,
+            block_reason="deterministic_task_hold",
+        )
+        frame = SimpleNamespace(
+            tasks=(
+                SimpleNamespace(
+                    authority_scope="packet",
+                    currentness="historical",
+                    required_response_act="answer",
+                    object_kind="relay",
+                ),
+            )
+        )
+
+        self.assertFalse(
+            bnl01_bot.ordinary_chat_legacy_baseline_fallback_allowed(
+                execution,
+                situation_frame=frame,
+                request_text=(
+                    "What did the Relay say about the last show?"
+                ),
+            )
+        )
+        self.assertIn(
+            "Relay",
+            bnl01_bot._ordinary_chat_single_packet_block_response(
+                "deterministic_task_hold",
+                frame,
+            ),
+        )
+
     def test_legacy_baseline_never_follows_live_or_started_packet(self):
         live_frame = SimpleNamespace(
             tasks=(


### PR DESCRIPTION
## What this fixes

The live Relay acceptance exposed a real convergence failure: a natural request such as “what did the Relay say about the last show?” could be reduced to a weak lexical token, discard all valid Relay publications, invalidate the packet, then fall back to general conversation/show context while sounding as though it came from the Relay.

This change restores the intended shared-brain behavior:

- Journal and Relay adapters keep eligible, governed publication evidence in the bounded scan and use lexical overlap for ranking instead of deleting zero-overlap evidence before BNL can reason over it.
- Ordinary-chat publication requests stay on the single governed packet/provider path.
- If that packet truly cannot provide Journal/Relay evidence, the legacy context-rich fallback cannot relabel unrelated context as publication evidence.
- Privacy, visibility, lifecycle, provenance, source validation, revalidation, packet limits, provider count, gates, schemas, and stores are unchanged.

## Acceptance coverage

- exact live Relay phrase: `what did the Relay say about the last show?`
- symmetric natural Journal phrase
- packet integration and publication-lane rendering
- no legacy show/conversation recap presented as Journal/Relay evidence

## Verification

- focused publication/bot path: 52 passed
- relevant architecture slice: 225 passed
- full `make check`: 2,538 passed
- `git diff --check`: clean

No deployment, restart, site, configuration, or gate changes are included.