### PR TITLE
Preserve transient Discord reply continuity

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -148,6 +148,7 @@ from bnl_conversation_context_v2 import (
     CONVERSATION_CONTEXT_VERSION,
     ConversationContextRequest,
     ConversationContextResult,
+    TransientDiscordReplySource,
     assess_payload_grounding,
     assess_reply_referent_grounding,
     assemble_conversation_context_v2,
@@ -3238,10 +3239,40 @@ def public_tiktok_interaction_memory_allowed(
     )
 
 
+def turn_local_discord_reply_requires_no_store(
+    prompt_source_bases=(),
+) -> bool:
+    """Keep replies derived from an unsaved Discord referent turn-local."""
+
+    return any(
+        bool(
+            tuple(
+                getattr(
+                    basis,
+                    "transient_referent_message_ids",
+                    (),
+                )
+                or ()
+            )
+            or tuple(
+                getattr(
+                    basis,
+                    "transient_referent_texts",
+                    (),
+                )
+                or ()
+            )
+        )
+        for basis in tuple(prompt_source_bases or ())
+    )
+
+
 def model_response_persistence_allowed_with_website_context(
     user_text: str,
     channel_policy: str,
     website_read_model_context: str,
+    *,
+    prompt_source_bases=(),
 ) -> bool:
     """Keep ordinary continuity while excluding injected website snapshots.
 
@@ -3252,6 +3283,8 @@ def model_response_persistence_allowed_with_website_context(
     writer.
     """
 
+    if turn_local_discord_reply_requires_no_store(prompt_source_bases):
+        return False
     context = str(website_read_model_context or "")
     return bool(
         not context
@@ -13293,6 +13326,8 @@ class DiscordTurnAddressing:
     source_message_id: int = 0
     reply_message_id: int = 0
     reply_conversation_row_id: int = 0
+    reply_source_text: str = ""
+    reply_source_channel_id: int = 0
     speaker_user_id: int = 0
     explicit_tag_user_ids: tuple[int, ...] = ()
     reply_target_user_id: int = 0
@@ -13328,6 +13363,35 @@ class DiscordTurnAddressing:
         if self.bnl_name_state not in {"", "none", "other_human", "denied"}:
             return "self_name_%s" % self.bnl_name_state
         return "none"
+
+
+def transient_discord_reply_sources(
+    addressings: tuple[DiscordTurnAddressing, ...],
+) -> tuple[TransientDiscordReplySource, ...]:
+    """Carry unsaved exact BNL replies through one prompt, never into storage."""
+
+    sources = []
+    seen_message_ids = set()
+    for addressing in addressings:
+        message_id = int(addressing.reply_message_id or 0)
+        content = str(addressing.reply_source_text or "").strip()
+        if (
+            not addressing.reply_targets_bnl
+            or int(addressing.reply_conversation_row_id or 0) > 0
+            or message_id <= 0
+            or message_id in seen_message_ids
+            or not content
+        ):
+            continue
+        seen_message_ids.add(message_id)
+        sources.append(
+            TransientDiscordReplySource(
+                message_id=message_id,
+                content=content,
+                channel_id=int(addressing.reply_source_channel_id or 0),
+            )
+        )
+    return tuple(sources)
 
 
 _CANONICAL_BNL_NAME_RE = re.compile(
@@ -14735,6 +14799,26 @@ def resolve_discord_turn_addressing(
         ),
         message_id=reply_message_id,
     )
+    resolved_reply_is_bnl = bool(
+        reply_author and bot_id and reply_author_id == bot_id
+    )
+    reply_source_text = (
+        str(getattr(resolved_reference, "content", "") or "").strip()[:4000]
+        if resolved_reply_is_bnl and reply_conversation_row_id <= 0
+        else ""
+    )
+    reply_source_channel_id = (
+        int(
+            getattr(
+                getattr(resolved_reference, "channel", None),
+                "id",
+                0,
+            )
+            or 0
+        )
+        if reply_source_text
+        else 0
+    )
     reply_target = "none"
     if reply_author:
         reply_target = "BNL-01" if bot_id and reply_author_id == bot_id else _safe_discord_display_name(reply_author)
@@ -14845,6 +14929,8 @@ def resolve_discord_turn_addressing(
         source_message_id=int(getattr(message, "id", 0) or 0),
         reply_message_id=reply_message_id,
         reply_conversation_row_id=reply_conversation_row_id,
+        reply_source_text=reply_source_text,
+        reply_source_channel_id=reply_source_channel_id,
         speaker_user_id=int(
             getattr(getattr(message, "author", None), "id", 0) or 0
         ),
@@ -21335,6 +21421,7 @@ def build_conversation_context_v2_for_prompt(
     current_participants: set[int] | None = None, is_direct_target: bool = False, is_reply_to_bnl: bool = False,
     referenced_message_ids: set[int] | None = None,
     referenced_conversation_row_ids: set[int] | None = None,
+    transient_reply_sources: tuple[TransientDiscordReplySource, ...] | None = None,
     is_batch: bool = False,
     is_deferred_payload_session: bool = False, now=None, route_allowed_sources=None,
     result_out: dict | None = None,
@@ -21369,6 +21456,7 @@ def build_conversation_context_v2_for_prompt(
             for x in (referenced_conversation_row_ids or set())
             if x
         ),
+        transient_reply_sources=tuple(transient_reply_sources or ()),
         is_direct_target=bool(is_direct_target), is_reply_to_bnl=bool(is_reply_to_bnl), is_batch=bool(is_batch),
         is_deferred_payload_session=bool(is_deferred_payload_session), now=now or datetime.now(timezone.utc),
         route_allowed_sources=frozenset(route_allowed_sources or getattr(get_route_mode_contract(route_mode), "allowed_context_sources", frozenset())),
@@ -21544,7 +21632,7 @@ def format_room_context_for_prompt(rows: list[dict], current_user_name: str = ""
     return "\n".join(rendered)
 
 
-def build_room_first_direct_context(guild_id: int, channel_id: int, channel_name: str, channel_policy: str, current_user_name: str, route: str = "direct", current_text: str = "", current_has_media: bool = False, *, current_user_id: int = 0, current_message_ids: set[int] | None = None, referenced_message_ids: set[int] | None = None, referenced_conversation_row_ids: set[int] | None = None, route_mode: str = ROUTE_MODE_NORMAL_CHAT, conversation_surface: str = "unknown", is_direct_target: bool = False, is_reply_to_bnl: bool = False, is_batch: bool = False, is_deferred_payload_session: bool = False, context_result_out: dict | None = None) -> str:
+def build_room_first_direct_context(guild_id: int, channel_id: int, channel_name: str, channel_policy: str, current_user_name: str, route: str = "direct", current_text: str = "", current_has_media: bool = False, *, current_user_id: int = 0, current_message_ids: set[int] | None = None, referenced_message_ids: set[int] | None = None, referenced_conversation_row_ids: set[int] | None = None, transient_reply_sources: tuple[TransientDiscordReplySource, ...] | None = None, route_mode: str = ROUTE_MODE_NORMAL_CHAT, conversation_surface: str = "unknown", is_direct_target: bool = False, is_reply_to_bnl: bool = False, is_batch: bool = False, is_deferred_payload_session: bool = False, context_result_out: dict | None = None) -> str:
     if conversation_context_v2_enabled():
         formatted = build_conversation_context_v2_for_prompt(
             guild_id=guild_id,
@@ -21561,6 +21649,7 @@ def build_room_first_direct_context(guild_id: int, channel_id: int, channel_name
             referenced_conversation_row_ids=(
                 referenced_conversation_row_ids or set()
             ),
+            transient_reply_sources=transient_reply_sources or (),
             is_direct_target=is_direct_target,
             is_reply_to_bnl=is_reply_to_bnl,
             is_batch=is_batch,
@@ -26342,6 +26431,8 @@ class ConversationPromptSourceBasis:
         ConversationEvidenceItem, ...
     ] = ()
     referent_scope_expanded: bool = False
+    transient_referent_message_ids: tuple[int, ...] = ()
+    transient_referent_texts: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -28451,6 +28542,39 @@ def build_memory_prompt_source_basis(
     )
 
 
+def _conversation_prompt_basis_digest(
+    source_digest: str,
+    transient_message_ids: tuple[int, ...],
+    transient_texts: tuple[str, ...],
+) -> str:
+    """Bind turn-local Discord referents into the immutable prompt basis."""
+
+    if not transient_message_ids and not transient_texts:
+        return source_digest
+    return _prompt_source_digest(
+        json.dumps(
+            {
+                "conversation_source_digest": source_digest,
+                "transient_discord_referents": [
+                    {
+                        "message_id": int(message_id or 0),
+                        "content_digest": hashlib.sha256(
+                            str(text or "").encode("utf-8")
+                        ).hexdigest(),
+                    }
+                    for message_id, text in zip(
+                        transient_message_ids,
+                        transient_texts,
+                    )
+                ],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+
+
 def build_conversation_prompt_source_basis(
     rendered_context: str,
     *,
@@ -28484,6 +28608,25 @@ def build_conversation_prompt_source_basis(
             getattr(context_result, "referent_competing_row_ids", ()) or ()
         )
         if int(row_id or 0) > 0
+    )
+    transient_referent_message_ids = tuple(
+        int(message_id or 0)
+        for message_id in (
+            getattr(
+                context_result,
+                "transient_referent_message_ids",
+                (),
+            )
+            or ()
+        )
+        if int(message_id or 0) > 0
+    )
+    transient_referent_texts = tuple(
+        str(text or "").strip()
+        for text in (
+            getattr(context_result, "transient_referent_texts", ()) or ()
+        )
+        if str(text or "").strip()
     )
     tracked_referent_row_ids = set(
         (*referent_source_row_ids, *referent_competing_row_ids)
@@ -28589,6 +28732,15 @@ def build_conversation_prompt_source_basis(
             for row_id in referent_source_row_ids
             for row in (rows_by_id.get(row_id),)
             if row is not None and str(row.get("content") or "").strip()
+        ) + tuple(
+            build_conversation_evidence_item(
+                text=text,
+                source_id=0,
+                speaker_user_id=0,
+                speaker_label="BNL-01",
+                current_turn=False,
+            )
+            for text in transient_referent_texts
         )
         referent_competing_evidence_items = tuple(
             build_conversation_evidence_item(
@@ -28613,7 +28765,7 @@ def build_conversation_prompt_source_basis(
         # Hand-built/test continuity blocks can lack resolvable rows. Preserve
         # the older conservative candidate digest for that compatibility path;
         # production-rendered v2 blocks carry exact source ids.
-        digest = (
+        source_digest = (
             _prompt_source_digest(
                 json.dumps(
                     [
@@ -28632,6 +28784,11 @@ def build_conversation_prompt_source_basis(
                 channel_name=channel_name,
                 channel_policy=channel_policy,
             )
+        )
+        digest = _conversation_prompt_basis_digest(
+            source_digest,
+            transient_referent_message_ids,
+            transient_referent_texts,
         )
     except sqlite3.Error:
         return None
@@ -28662,6 +28819,8 @@ def build_conversation_prompt_source_basis(
         referent_scope_expanded=bool(
             getattr(context_result, "referent_scope_expanded", False)
         ),
+        transient_referent_message_ids=transient_referent_message_ids,
+        transient_referent_texts=transient_referent_texts,
     )
 
 
@@ -28844,7 +29003,7 @@ def refresh_prompt_source_basis(
     tracked_conversation_row_ids = (
         basis.revalidation_row_ids or basis.source_row_ids
     )
-    fresh_digest = (
+    source_digest = (
         _conversation_prompt_selected_digest(
             guild_id=basis.guild_id,
             source_row_ids=tracked_conversation_row_ids,
@@ -28857,6 +29016,11 @@ def refresh_prompt_source_basis(
             channel_name=basis.channel_name,
             channel_policy=basis.channel_policy,
         )
+    )
+    fresh_digest = _conversation_prompt_basis_digest(
+        source_digest,
+        basis.transient_referent_message_ids,
+        basis.transient_referent_texts,
     )
     fresh = replace(basis, expected_digest=fresh_digest)
     return fresh, fresh.expected_digest != basis.expected_digest
@@ -35308,8 +35472,21 @@ def build_active_batch_conversation_context_v2_prompt(
                 or 0
             )
         },
+        transient_reply_sources=transient_discord_reply_sources(
+            tuple(
+                addressing
+                for item in current_items
+                for addressing in (getattr(item, "addressing", None),)
+                if isinstance(addressing, DiscordTurnAddressing)
+            )
+        ),
         is_batch=True,
         is_direct_target=bool(active_packet.get("addressed_to_bot")),
+        is_reply_to_bnl=any(
+            isinstance(getattr(item, "addressing", None), DiscordTurnAddressing)
+            and bool(item.addressing.reply_targets_bnl)
+            for item in current_items
+        ),
         is_deferred_payload_session=bool(pending_state or pending_anchor),
         result_out=result_out,
     )
@@ -38347,18 +38524,28 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
         if active_packet.get("media_present"):
             mark_recent_media_events_response_state(guild_id, channel_id, set(unique_user_ids), channel_policy, "responded")
 
-        await asyncio.to_thread(
-            save_model_message,
-            first_uid,
-            channel.guild.id,
-            response,
-            channel_name=getattr(channel, "name", ""),
-            channel_policy=channel_policy,
-            channel_id=channel_id,
-            route_mode=ROUTE_MODE_NORMAL_CHAT,
-            conversation_target_user_ids=tuple(unique_user_ids),
-            discord_message_ids=tuple(sent_message_ids),
-        )
+        if turn_local_discord_reply_requires_no_store(
+            batch_presend_source_bases
+        ):
+            logging.info(
+                "batch_response_persistence_skipped "
+                "reason=turn_local_discord_reply_no_store "
+                "channel_policy=%s",
+                channel_policy,
+            )
+        else:
+            await asyncio.to_thread(
+                save_model_message,
+                first_uid,
+                channel.guild.id,
+                response,
+                channel_name=getattr(channel, "name", ""),
+                channel_policy=channel_policy,
+                channel_id=channel_id,
+                route_mode=ROUTE_MODE_NORMAL_CHAT,
+                conversation_target_user_ids=tuple(unique_user_ids),
+                discord_message_ids=tuple(sent_message_ids),
+            )
         await persist_batch_bnl_self_name_decision_after_send_async(
             items,
             response=response,
@@ -40297,6 +40484,9 @@ async def _generate_direct_payload_session(session_key, reason: str):
         }
         if session_addressing.reply_conversation_row_id
         else set(),
+        transient_reply_sources=transient_discord_reply_sources(
+            (session_addressing,)
+        ),
         route_mode=ROUTE_MODE_DIRECT_PAYLOAD,
         is_direct_target=True,
         is_deferred_payload_session=True,
@@ -40723,6 +40913,7 @@ async def _generate_direct_payload_session(session_key, reason: str):
             direct_content,
             session.get("channel_policy", "unknown"),
             website_read_model_context,
+            prompt_source_bases=direct_payload_presend_source_bases,
         )
     )
     if direct_payload_model_persistence_allowed:
@@ -40737,10 +40928,22 @@ async def _generate_direct_payload_session(session_key, reason: str):
             route_mode=ROUTE_MODE_DIRECT_PAYLOAD,
             discord_message_ids=tuple(sent_message_ids),
         )
-    elif website_read_model_context:
+    elif (
+        website_read_model_context
+        or turn_local_discord_reply_requires_no_store(
+            direct_payload_presend_source_bases
+        )
+    ):
         logging.info(
             "direct_payload_response_persistence_skipped "
-            "reason=website_read_model_no_store channel_policy=%s",
+            "reason=%s channel_policy=%s",
+            (
+                "turn_local_discord_reply_no_store"
+                if turn_local_discord_reply_requires_no_store(
+                    direct_payload_presend_source_bases
+                )
+                else "website_read_model_no_store"
+            ),
             session.get("channel_policy", "unknown"),
         )
     await persist_bnl_self_name_decision_after_send_async(
@@ -44494,6 +44697,7 @@ async def send_planned_conversation_response(
             getattr(message, "content", ""),
             plan.channel_policy,
             website_read_model_context,
+            prompt_source_bases=prompt_source_bases,
         )
     )
     if direct_model_persistence_allowed:
@@ -44509,10 +44713,22 @@ async def send_planned_conversation_response(
             discord_message_ids=tuple(sent_message_ids),
         )
         logging.info("model_conversation_row_after_send route=%s channel_policy=%s saved=%s reason=%s", plan.route_mode, plan.channel_policy, int(bool(getattr(model_decision, "save_conversation", False))), getattr(model_decision, "reason", "unknown"))
-    elif allow_model_save and website_read_model_context:
+    elif allow_model_save and (
+        website_read_model_context
+        or turn_local_discord_reply_requires_no_store(
+            prompt_source_bases
+        )
+    ):
         logging.info(
             "direct_response_persistence_skipped "
-            "reason=website_read_model_no_store channel_policy=%s",
+            "reason=%s channel_policy=%s",
+            (
+                "turn_local_discord_reply_no_store"
+                if turn_local_discord_reply_requires_no_store(
+                    prompt_source_bases
+                )
+                else "website_read_model_no_store"
+            ),
             plan.channel_policy,
         )
     await persist_bnl_self_name_decision_after_send_async(
@@ -45556,6 +45772,9 @@ async def on_message(message: discord.Message):
                 }
                 if turn_addressing.reply_conversation_row_id
                 else set(),
+                transient_reply_sources=transient_discord_reply_sources(
+                    (turn_addressing,)
+                ),
                 route_mode=route_mode,
                 conversation_surface=conversation_surface,
                 is_direct_target=turn_addressing.addresses_bnl,
@@ -46075,6 +46294,9 @@ async def on_message(message: discord.Message):
             }
             if turn_addressing.reply_conversation_row_id
             else set(),
+            transient_reply_sources=transient_discord_reply_sources(
+                (turn_addressing,)
+            ),
             route_mode=route_mode,
             conversation_surface=conversation_surface,
             is_direct_target=turn_addressing.addresses_bnl,
@@ -46543,6 +46765,9 @@ async def on_message(message: discord.Message):
             }
             if turn_addressing.reply_conversation_row_id
             else set(),
+            transient_reply_sources=transient_discord_reply_sources(
+                (turn_addressing,)
+            ),
             route_mode=route_mode,
             conversation_surface=conversation_surface,
             is_direct_target=turn_addressing.addresses_bnl,

--- a/bnl_conversation_context_v2.py
+++ b/bnl_conversation_context_v2.py
@@ -209,6 +209,15 @@ WHEEL_STATE_RE = re.compile(r"\bwheel spins?\b|\bwheel\b(?=.*\b(?:owed|enabled|c
 UNSAFE_HISTORY_RE = re.compile(r"(?:\b(?:provider|host|preview|embed|media_buffer|media-storage|media storage|storage_diagnostic|storage diagnostic)\s*=|\bstored[- ]visual[- ]description\b|\binternal diagnostic\b|\bsource-mode\b|\bmode contamination\b)", re.I)
 
 @dataclass(frozen=True)
+class TransientDiscordReplySource:
+    """One resolved Discord reply target carried only for the current turn."""
+
+    message_id: int
+    content: str
+    channel_id: int = 0
+
+
+@dataclass(frozen=True)
 class ConversationContextRequest:
     guild_id: int
     current_user_id: int
@@ -224,6 +233,7 @@ class ConversationContextRequest:
     referenced_conversation_row_ids: frozenset[int] = field(
         default_factory=frozenset
     )
+    transient_reply_sources: tuple[TransientDiscordReplySource, ...] = ()
     is_direct_target: bool = False
     is_reply_to_bnl: bool = False
     is_batch: bool = False
@@ -256,6 +266,8 @@ class ConversationContextResult:
     referent_candidate_labels: tuple[str, ...] = ()
     referent_reason: str = ""
     referent_scope_expanded: bool = False
+    transient_referent_message_ids: tuple[int, ...] = ()
+    transient_referent_texts: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -1036,8 +1048,62 @@ def _unsafe_row(row: dict) -> bool:
     if UNSAFE_HISTORY_RE.search(content):
         return True
     if role in {"model", "assistant", "bnl"} and _unsafe_operational_state_assertion(content):
-        return True
+        # A resolved Discord reply to BNL may carry the exact visible wording of
+        # a no-store operational answer. It is eligible only as the structural
+        # referent for this turn; the rendered contract explicitly forbids using
+        # it as current-state evidence. Ordinary stored history remains blocked.
+        return not bool(row.get("_transient_exact_reply_source"))
     return False
+
+
+def _transient_exact_reply_rows(
+    req: ConversationContextRequest,
+) -> list[dict]:
+    """Normalize exact Discord reply targets without creating conversation rows."""
+
+    referenced_message_ids = {
+        int(message_id)
+        for message_id in req.referenced_message_ids
+        if int(message_id or 0) > 0
+    }
+    rows = []
+    seen_message_ids = set()
+    for source in req.transient_reply_sources:
+        if not isinstance(source, TransientDiscordReplySource):
+            continue
+        message_id = int(source.message_id or 0)
+        source_channel_id = int(source.channel_id or 0)
+        content = str(source.content or "").strip()
+        if (
+            message_id <= 0
+            or message_id not in referenced_message_ids
+            or message_id in seen_message_ids
+            or not content
+            or (
+                source_channel_id > 0
+                and int(req.channel_id or 0) > 0
+                and source_channel_id != int(req.channel_id or 0)
+            )
+        ):
+            continue
+        seen_message_ids.add(message_id)
+        rows.append(
+            {
+                "id": 0,
+                "role": "model",
+                "content": content,
+                "user_id": 0,
+                "user_name": "BNL-01",
+                "channel_id": int(req.channel_id or source_channel_id or 0),
+                "channel_name": str(req.channel_name or ""),
+                "channel_policy": str(req.channel_policy or "unknown"),
+                "timestamp": req.now.isoformat(),
+                "message_id": message_id,
+                "prompt_history_excluded": False,
+                "_transient_exact_reply_source": True,
+            }
+        )
+    return rows
 
 
 def nearby_contribution_referent_requested(text: str) -> bool:
@@ -1538,6 +1604,7 @@ def assemble_conversation_context_v2(rows: Iterable[dict], req: ConversationCont
     current_norms = {normalize_text(t) for t in req.current_texts if normalize_text(t)}
     current_text = " ".join(req.current_texts)
     source_rows = list(rows)
+    transient_reply_rows = _transient_exact_reply_rows(req)
     paired_all, unpaired_all, orphan_models = _pair_rows([dict(row) for row in source_rows])
     dupes, excluded = 0, 0
 
@@ -1655,6 +1722,9 @@ def assemble_conversation_context_v2(rows: Iterable[dict], req: ConversationCont
         ok, same = _eligible_row(row)
         if ok and same:
             referent_eligible_rows.append(dict(row, _same_room=True))
+    referent_eligible_rows.extend(
+        dict(row, _same_room=True) for row in transient_reply_rows
+    )
     excluded += len(orphan_models)
     scored_same, scored_cross = [], []
     for pair in pairs:
@@ -1922,7 +1992,8 @@ def assemble_conversation_context_v2(rows: Iterable[dict], req: ConversationCont
                 ("structural_referent", referent_resolution.reason),
             )
         )
-        candidate_row_ids.add(row_id)
+        if row_id > 0:
+            candidate_row_ids.add(row_id)
     for row in open_unpaired:
         reason = str(row.get("_unpaired_reason") or "open_loop_unpaired")
         if int(row.get("id") or 0) in candidate_row_ids:
@@ -1996,6 +2067,8 @@ def assemble_conversation_context_v2(rows: Iterable[dict], req: ConversationCont
     reasons: list[str] = [focus_reason] if focus_reason else []
     rendered_same = rendered_cross = rendered_unpaired = 0
     rendered_row_ids: set[int] = set()
+    rendered_transient_message_ids: set[int] = set()
+    rendered_transient_texts: list[str] = []
     if candidates:
         if not _append_block(lines, header, MAX_RENDERED_CHARS):
             lines = []
@@ -2085,7 +2158,18 @@ def assemble_conversation_context_v2(rows: Iterable[dict], req: ConversationCont
                 reasons.extend(why)
             elif kind in {"referent_user", "referent_model"}:
                 row_id = int(item.get("id") or 0)
-                if row_id in rendered_row_ids:
+                transient_exact_reply = bool(
+                    item.get("_transient_exact_reply_source")
+                )
+                transient_message_id = int(item.get("message_id") or 0)
+                if (
+                    (row_id > 0 and row_id in rendered_row_ids)
+                    or (
+                        transient_exact_reply
+                        and transient_message_id
+                        in rendered_transient_message_ids
+                    )
+                ):
                     continue
                 exact_discord_reply = (
                     referent_resolution.reason == "discord_reply_source"
@@ -2111,8 +2195,14 @@ def assemble_conversation_context_v2(rows: Iterable[dict], req: ConversationCont
                 ]
                 if not _append_block(lines, block, MAX_RENDERED_CHARS):
                     continue
-                row_ids.append(row_id)
-                rendered_row_ids.add(row_id)
+                if transient_exact_reply:
+                    rendered_transient_message_ids.add(transient_message_id)
+                    rendered_transient_texts.append(
+                        str(item.get("content") or "").strip()
+                    )
+                else:
+                    row_ids.append(row_id)
+                    rendered_row_ids.add(row_id)
                 rendered_unpaired += 1
                 reasons.extend(why)
     resolved_referent_ids = tuple(
@@ -2120,15 +2210,30 @@ def assemble_conversation_context_v2(rows: Iterable[dict], req: ConversationCont
         for row in referent_resolution.selected
         if int(row.get("id") or 0) > 0
     )
+    resolved_transient_message_ids = tuple(
+        int(row.get("message_id") or 0)
+        for row in referent_resolution.selected
+        if row.get("_transient_exact_reply_source")
+        and int(row.get("message_id") or 0) > 0
+    )
     final_referent_status = referent_resolution.status
     final_referent_reason = referent_resolution.reason
     if (
         final_referent_status == "resolved"
         and (
-            not resolved_referent_ids
-            or not all(
-                row_id in rendered_row_ids
-                for row_id in resolved_referent_ids
+            not (
+                resolved_referent_ids
+                and all(
+                    row_id in rendered_row_ids
+                    for row_id in resolved_referent_ids
+                )
+            )
+            and not (
+                resolved_transient_message_ids
+                and all(
+                    message_id in rendered_transient_message_ids
+                    for message_id in resolved_transient_message_ids
+                )
             )
         )
     ):
@@ -2183,4 +2288,8 @@ def assemble_conversation_context_v2(rows: Iterable[dict], req: ConversationCont
         ),
         referent_reason=final_referent_reason,
         referent_scope_expanded=exact_reply_scope_expanded,
+        transient_referent_message_ids=tuple(
+            sorted(rendered_transient_message_ids)
+        ),
+        transient_referent_texts=tuple(rendered_transient_texts),
     )

--- a/tests/test_conversation_context_v2.py
+++ b/tests/test_conversation_context_v2.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone, timedelta
 from bnl_conversation_context_v2 import (
     CONVERSATION_CONTEXT_VERSION,
     ConversationContextRequest,
+    TransientDiscordReplySource,
     assess_payload_grounding,
     assemble_conversation_context_v2,
     classify_thread_focus,
@@ -1472,6 +1473,50 @@ class ConversationContextV2QueueBoundaryExpandedTests(unittest.TestCase):
         ):
             with self.subTest(text=text):
                 self.assert_model_excluded(text)
+
+    def test_unsaved_exact_bnl_reply_is_transient_referent_only(self):
+        reply_text = (
+            "The Journal described the August 8 queue trial. "
+            "The queue is closed, and the August 28 session is archived."
+        )
+        res = assemble_conversation_context_v2(
+            [
+                row(900, "user", "queue status?", mid=8100),
+                row(
+                    901,
+                    "model",
+                    "The queue is open.",
+                    mid=8101,
+                ),
+            ],
+            req(
+                current_texts=(
+                    "What part came from the Journal, and what part is the "
+                    "current status?",
+                ),
+                referenced_message_ids=frozenset({9001}),
+                transient_reply_sources=(
+                    TransientDiscordReplySource(
+                        message_id=9001,
+                        content=reply_text,
+                        channel_id=10,
+                    ),
+                ),
+                is_reply_to_bnl=True,
+            ),
+        )
+
+        self.assertEqual(res.referent_status, "resolved")
+        self.assertEqual(res.referent_reason, "discord_reply_source")
+        self.assertEqual(res.thread_focus_mode, "exact_discord_reply")
+        self.assertEqual(res.selected_row_ids, ())
+        self.assertEqual(res.referent_selected_row_ids, ())
+        self.assertEqual(res.transient_referent_message_ids, (9001,))
+        self.assertEqual(res.transient_referent_texts, (reply_text,))
+        self.assertIn("exact Discord reply source", res.rendered_context)
+        self.assertIn("The queue is closed", res.rendered_context)
+        self.assertNotIn("The queue is open", res.rendered_context)
+        self.assertIn("not canon/current-state evidence", res.rendered_context)
 
     def test_ordinary_queue_discussion_is_allowed(self):
         for text in (

--- a/tests/test_conversation_orchestration.py
+++ b/tests/test_conversation_orchestration.py
@@ -3425,6 +3425,73 @@ class OrchestrationHardeningRegressionTests(unittest.TestCase):
             self.assertTrue(addressing.directly_targets_bnl)
             self.assertGreater(addressing.reply_conversation_row_id, 0)
 
+    def test_resolved_unsaved_bnl_reply_carries_turn_local_source_text(self):
+        reply_text = (
+            "The Journal described the queue trial. The queue is closed now."
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = os.path.join(temp_dir, "bnl.sqlite")
+            message = SimpleNamespace(
+                id=9100,
+                content=(
+                    "What part came from the Journal, and what part is the "
+                    "current status?"
+                ),
+                author=SimpleNamespace(id=44, display_name="Member"),
+                guild=SimpleNamespace(id=77, members=[]),
+                channel=SimpleNamespace(
+                    id=700,
+                    name="home",
+                    category=None,
+                    guild=SimpleNamespace(id=77),
+                ),
+                raw_mentions=[],
+                mentions=[],
+                reference=SimpleNamespace(
+                    resolved=SimpleNamespace(
+                        id=9001,
+                        content=reply_text,
+                        author=SimpleNamespace(
+                            id=999,
+                            display_name="BNL-01",
+                        ),
+                        channel=SimpleNamespace(id=700),
+                    ),
+                    message_id=9001,
+                ),
+            )
+            with (
+                mock.patch.object(bnl01_bot, "DB_FILE", db_path),
+                mock.patch.object(
+                    bnl01_bot,
+                    "_load_bnl_self_name_records",
+                    return_value=(),
+                ),
+                mock.patch.object(
+                    bnl01_bot.client._connection,
+                    "user",
+                    SimpleNamespace(id=999, display_name="BNL-01"),
+                ),
+            ):
+                addressing = bnl01_bot.resolve_discord_turn_addressing(
+                    message
+                )
+
+        self.assertTrue(addressing.reply_targets_bnl)
+        self.assertEqual(addressing.reply_conversation_row_id, 0)
+        self.assertEqual(addressing.reply_source_text, reply_text)
+        self.assertEqual(addressing.reply_source_channel_id, 700)
+        self.assertEqual(
+            bnl01_bot.transient_discord_reply_sources((addressing,)),
+            (
+                bnl01_bot.TransientDiscordReplySource(
+                    message_id=9001,
+                    content=reply_text,
+                    channel_id=700,
+                ),
+            ),
+        )
+
     def test_unresolved_discord_reference_to_member_stays_third_party_only(
         self,
     ):

--- a/tests/test_exact_discord_reply_packet_regression.py
+++ b/tests/test_exact_discord_reply_packet_regression.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 
@@ -360,6 +361,175 @@ class ExactDiscordReplyPacketRegressionTests(unittest.TestCase):
                 serialized_receipts = repr(receipt_rows).casefold()
                 self.assertNotIn("cobalt", serialized_receipts)
                 self.assertNotIn("amber", serialized_receipts)
+
+    def test_no_store_operational_reply_is_turn_local_exact_referent(self):
+        reply_text = (
+            "The Journal described the August 8 queue trial. "
+            "The queue is closed, and the August 28 session is archived."
+        )
+        result_out = {}
+        with sqlite3.connect(self.db_path) as conn:
+            rows_before = conn.execute(
+                "SELECT COUNT(*) FROM conversations"
+            ).fetchone()[0]
+
+        rendered_context = bnl01_bot.build_conversation_context_v2_for_prompt(
+            guild_id=1,
+            current_user_id=7,
+            channel_id=10,
+            channel_name="bnl-testing",
+            channel_policy="sealed_test",
+            route_mode="normal_chat",
+            conversation_surface="mention_or_reply",
+            current_texts=(
+                "What part came from the Journal, and what part is the "
+                "current status?",
+            ),
+            current_participants={7},
+            is_direct_target=True,
+            is_reply_to_bnl=True,
+            referenced_message_ids={9001},
+            transient_reply_sources=(
+                bnl01_bot.TransientDiscordReplySource(
+                    message_id=9001,
+                    content=reply_text,
+                    channel_id=10,
+                ),
+            ),
+            now=self.now,
+            route_allowed_sources={"conversation_continuity"},
+            result_out=result_out,
+        )
+        context_result = result_out["result"]
+
+        self.assertEqual(context_result.referent_status, "resolved")
+        self.assertEqual(context_result.selected_row_ids, ())
+        self.assertEqual(
+            context_result.transient_referent_message_ids,
+            (9001,),
+        )
+        self.assertIn(reply_text, rendered_context)
+
+        basis = bnl01_bot.build_conversation_prompt_source_basis(
+            rendered_context,
+            guild_id=1,
+            current_user_id=7,
+            channel_id=10,
+            channel_name="bnl-testing",
+            channel_policy="sealed_test",
+            context_result=context_result,
+        )
+        self.assertIsNotNone(basis)
+        self.assertEqual(basis.source_row_ids, ())
+        self.assertEqual(
+            basis.revalidation_row_ids,
+            tuple(
+                sorted(
+                    set(context_result.referent_selected_row_ids)
+                    | set(context_result.referent_competing_row_ids)
+                )
+            ),
+        )
+        self.assertNotIn(9001, basis.revalidation_row_ids)
+        self.assertEqual(basis.transient_referent_message_ids, (9001,))
+        self.assertEqual(
+            tuple(item.text for item in basis.referent_source_evidence_items),
+            (reply_text,),
+        )
+        refreshed, changed = bnl01_bot.refresh_prompt_source_basis(basis)
+        self.assertFalse(changed)
+        self.assertEqual(refreshed.expected_digest, basis.expected_digest)
+        self.assertTrue(
+            bnl01_bot.turn_local_discord_reply_requires_no_store((basis,))
+        )
+        self.assertFalse(
+            bnl01_bot.model_response_persistence_allowed_with_website_context(
+                "What part was the current status?",
+                "sealed_test",
+                "",
+                prompt_source_bases=(basis,),
+            )
+        )
+
+        delivered = "The first sentence was the Journal summary; the second was the status portion."
+        message = SimpleNamespace(
+            content="What part was the current status?",
+            author=SimpleNamespace(id=7, display_name="Test Member A"),
+            guild=SimpleNamespace(id=1),
+            channel=SimpleNamespace(id=10, name="bnl-testing"),
+            reply=mock.AsyncMock(return_value=SimpleNamespace(id=9002)),
+        )
+        plan = bnl01_bot.plan_conversation_response(
+            message.content,
+            "sealed_test",
+            route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            active_channel=True,
+            real_direct_target=True,
+            batching_enabled=True,
+            conversation_surface="mention_or_reply",
+        )
+        save_model = mock.Mock()
+        with (
+            mock.patch.object(
+                bnl01_bot,
+                "_apply_direct_response_pacing",
+                new=mock.AsyncMock(),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_shared_brain_synthesis_canary",
+                new=mock.AsyncMock(return_value=None),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "apply_guarded_response_regeneration",
+                new=mock.AsyncMock(
+                    return_value=(delivered, {"suppressed": False})
+                ),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_message_media_context",
+                return_value={"present": False},
+            ),
+            mock.patch.object(bnl01_bot, "update_last_route_debug"),
+            mock.patch.object(
+                bnl01_bot,
+                "save_model_message",
+                new=save_model,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "persist_bnl_self_name_decision_after_send_async",
+                new=mock.AsyncMock(),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "record_unified_response_assessment_shadow_after_send",
+                new=mock.AsyncMock(),
+            ),
+        ):
+            decision = asyncio.run(
+                bnl01_bot.send_planned_conversation_response(
+                    message,
+                    delivered,
+                    plan,
+                    prompt=rendered_context,
+                    source_context_available=True,
+                    prompt_source_bases=(basis,),
+                    mark_recent_direct=False,
+                )
+            )
+
+        message.reply.assert_awaited_once()
+        save_model.assert_not_called()
+        self.assertFalse(decision.save_conversation)
+
+        with sqlite3.connect(self.db_path) as conn:
+            rows_after = conn.execute(
+                "SELECT COUNT(*) FROM conversations"
+            ).fetchone()[0]
+        self.assertEqual(rows_after, rows_before)
 
     def test_exact_name_echo_delivery_becomes_pronoun_reply_source(self):
         seed = (


### PR DESCRIPTION
## Live failure reproduced

A mixed Journal/current-queue question was answered correctly, but the answer was intentionally not stored because it included live operational queue state. When the user used Discord's exact reply feature to ask which part came from the Journal and which part was current status, reply resolution found no persisted conversation row and asked the user to restate the excerpt.

## Repair

- Accept Discord's resolved reply text only when the referenced message is authored by the live BNL bot, has the exact referenced message ID, and belongs to the same channel when channel IDs are available.
- Inject that text as a synthetic, turn-local exact referent under an explicit continuity-only / not-current-state-evidence boundary.
- Keep it out of general conversation history, pairing, canon, and current operational-state evidence.
- Bind the transient message ID plus content digest into prompt-source revalidation.
- Prevent both the transient source and the response derived from it from being persisted.
- Preserve the existing exclusion of stale stored operational model assertions.

This lets BNL separate the historical Journal portion from the prior answer's current-status portion without treating that prior wording as proof that the queue is still in the same state.

## Verification

- Full repository gate: `make check PYTHON=python`
- Result: **2,566 tests passed**
- Focused conversation-context, orchestration, exact-reply, live-context bridge, and batching suites passed.
- `git diff --check` passed.
- Added-content privacy and architecture scans found no credentials, private owner identity, schema, gate, store, or authority changes.
- Remote tree SHA exactly matches the verified local tree.
- Barcode Network site repository is untouched.

## Deployment boundary

This PR does not merge, deploy, change VPS state, or enable any dormant gate. The live VPS remains on the previously deployed `a23a952a1ee976b717148de1868717b9a0fc6c14` until an explicit merge/deploy step.