### PR TITLE
Fix Row 6 Copper acceptance receipts

### DIFF
--- a/bnl_moment_engine.py
+++ b/bnl_moment_engine.py
@@ -135,7 +135,7 @@ _EPISODE_NEGATED_CLOSE_RE = re.compile(
 _EPISODE_ACTION_RE = re.compile(
     r"\b(?:i|we|you|they|he|she)\s+(?:will|plan(?:ned)?\s+to|"
     r"intend(?:ed)?\s+to|need(?:ed)?\s+to|should|could)\b"
-    r"|\b(?:let(?:'|’)s|implement|build|fix|test|send|write|create|"
+    r"|\b(?:let(?:'|’)s|implement|perform|build|fix|test|send|write|create|"
     r"change|update|deploy|review|check|run)\b",
     re.I,
 )
@@ -2606,7 +2606,12 @@ def observe_ledger_entry(conn: sqlite3.Connection, ledger_entry_id: str) -> Mome
         if source.source_table != "conversations" or source.lifecycle_status not in {"active", "review_only"} or source.entry_type not in {"observation", "derived_summary"}:
             conn.execute("RELEASE moment_observe")
             return MomentObservationResult(reason_code="ineligible_source", ledger_entry_id=source.entry_id)
-        if _contains_sensitive_moment_source(
+        # Human-authored content remains the authority-bearing privacy
+        # boundary. Model turns are retained only as structural conversation
+        # evidence and never become public content authority; applying the
+        # opaque-code detector to them can drop BNL's intentional alphanumeric
+        # glitch markers and prevent an otherwise valid Moment from forming.
+        if source.is_human and _contains_sensitive_moment_source(
             source.normalized_value,
             source.predicate_key,
         ):

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -2477,7 +2477,19 @@ def build_unified_response_assessment(
     objective = _current_objective(current_text)
     current_options = _unique_strings(current_payload_anchors)[:8]
     resolved_thread_focus = _thread_focus_mode(thread_focus_mode)
-    criteria = _criterion_items(evidence_items)
+    criterion_evidence_items = evidence_items
+    if (
+        situation_frame is not None
+        and situation_frame.status == "resolved"
+        and situation_frame.event_relation == "new_event_same_participant"
+    ):
+        # A resolved explicit event boundary keeps nearby history available
+        # for attribution and audit, but criteria from the interrupted event
+        # must not be imposed on the new task.
+        criterion_evidence_items = tuple(
+            item for item in evidence_items if item.current_turn
+        )
+    criteria = _criterion_items(criterion_evidence_items)
     objective_kind = _objective_kind(
         objective=objective,
         current_options=current_options,

--- a/tests/test_moment_engine_v1.py
+++ b/tests/test_moment_engine_v1.py
@@ -603,6 +603,41 @@ class MomentEngineV1Tests(unittest.TestCase):
                 0,
             )
 
+    def test_model_glitch_marker_remains_structural_moment_evidence(self):
+        source = self.add(
+            450,
+            0,
+            "model",
+            (
+                "[BNL-01 // SIGNAL_STAGING_04] Antenna calibration is "
+                "current; archiving remains open."
+            ),
+            policy="sealed_test",
+            observe=False,
+        )
+
+        result = moments.observe_ledger_entry(self.conn, source.entry_id)
+
+        self.assertEqual(result.outcome, "observed")
+        self.assertEqual(result.reason_code, "ok")
+        self.assertEqual(
+            self.conn.execute(
+                "SELECT COUNT(*) FROM memory_moment_members "
+                "WHERE ledger_entry_id=?",
+                (source.entry_id,),
+            ).fetchone()[0],
+            1,
+        )
+        self.assertEqual(
+            self.conn.execute(
+                "SELECT COUNT(*) FROM memory_moment_diagnostics "
+                "WHERE ledger_entry_id=? AND "
+                "event_type='moment_processing_skipped'",
+                (source.entry_id,),
+            ).fetchone()[0],
+            0,
+        )
+
     def test_legacy_remembered_number_quarantine_is_complete_and_idempotent(self):
         raw=self.add(
             501,

--- a/tests/test_moment_episode_lifecycle_v2.py
+++ b/tests/test_moment_episode_lifecycle_v2.py
@@ -577,7 +577,10 @@ class MomentEpisodeLifecycleV2Tests(unittest.TestCase):
         copper_messages = (
             (
                 copper_prompt,
-                "Antenna calibration is current; archiving remains open.",
+                (
+                    "[BNL-01 // SIGNAL_STAGING_04] Antenna calibration is "
+                    "current; archiving remains open."
+                ),
             ),
             (
                 "This remains a separate task: Project Copper Kite. Commit "
@@ -620,6 +623,29 @@ class MomentEpisodeLifecycleV2Tests(unittest.TestCase):
         new = next(row for row in episodes if row[0] != glass_episode_id)
         self.assertEqual(old[1:], ("finalized", "topic_interruption"))
         self.assertEqual(new[1], "active")
+        self.assertGreaterEqual(
+            self.conn.execute(
+                "SELECT action_count FROM memory_moment_episodes "
+                "WHERE episode_id=?",
+                (new[0],),
+            ).fetchone()[0],
+            1,
+        )
+        copper_moment = self.conn.execute(
+            """
+            SELECT window.human_entry_count,window.model_entry_count,
+                   COUNT(member.ledger_entry_id)
+            FROM memory_moment_episode_moments AS link
+            JOIN memory_moment_windows AS window
+              ON window.moment_id=link.moment_id
+            JOIN memory_moment_members AS member
+              ON member.moment_id=window.moment_id
+            WHERE link.episode_id=?
+            GROUP BY window.moment_id
+            """,
+            (new[0],),
+        ).fetchone()
+        self.assertEqual(copper_moment, (2, 2, 4))
         self.assertEqual(
             self.conn.execute(
                 """

--- a/tests/test_unified_response_assessment_shadow.py
+++ b/tests/test_unified_response_assessment_shadow.py
@@ -7,6 +7,7 @@ from bnl_unified_response_assessment import (
     assess_response_coherence,
     build_conversation_evidence_item,
     build_evaluation_report,
+    build_situation_frame_v1,
     build_unified_response_assessment,
     ensure_schema,
     persist_shadow_run,
@@ -700,6 +701,98 @@ class UnifiedResponseAssessmentShadowTests(unittest.TestCase):
         self.assertEqual(coherent.status, "passed")
         self.assertEqual(coherent.conclusion_status, "consistent")
         self.assertEqual(coherent.criterion_status, "covered")
+
+    def test_resolved_new_event_does_not_inherit_interrupted_criteria(self):
+        glass_prompt = (
+            "Sealed acceptance fixture: Project Glass Harbor is in "
+            "rehearsal. The amber signal failed, and the open question is "
+            "whether to test the relay or the decoder first. Which should "
+            "we test first?"
+        )
+        copper_prompt = (
+            "Sealed acceptance fixture: this is a separate task. Project "
+            "Copper Kite has a stable blue indicator, and the antenna "
+            "calibration must be completed before its notes are archived. "
+            "What is the current task, and what remains open?"
+        )
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="sealed_test",
+            channel_policy="sealed_test",
+            current_text=copper_prompt,
+            current_speaker_user_ids=(101,),
+            subject_user_ids=(101,),
+            moment_id="glass-moment",
+            moment_situation_state="recent_active",
+            moment_topic_coherent=False,
+            moment_participant_overlap=True,
+            response_act="answer",
+        )
+        evidence = (
+            build_conversation_evidence_item(
+                text=glass_prompt,
+                source_id=1,
+                speaker_user_id=101,
+                speaker_label="Test Member",
+            ),
+            build_conversation_evidence_item(
+                text=copper_prompt,
+                source_id=2,
+                speaker_user_id=101,
+                speaker_label="Test Member",
+                current_turn=True,
+            ),
+        )
+
+        assessment = build_unified_response_assessment(
+            guild_id=1,
+            route_mode="normal_chat",
+            channel_policy="sealed_test",
+            conversation_surface="sealed_test",
+            current_speaker_user_ids=(101,),
+            participant_user_ids=(101,),
+            speaker_labels=("Test Member",),
+            current_exchange_source_ids=(2,),
+            prompt_lanes=("current_exchange", "conversation_context"),
+            continuity_required=True,
+            current_text=copper_prompt,
+            conversation_evidence_items=evidence,
+            situation_frame=frame,
+        )
+        response = (
+            "The current task is antenna calibration for Project "
+            "Copper Kite. Archiving the notes remains open."
+        )
+        coherence = assess_response_coherence(assessment, response)
+
+        self.assertEqual(frame.event_relation, "new_event_same_participant")
+        self.assertEqual(
+            tuple(
+                criterion.source_id
+                for criterion in assessment.attributed_criteria
+            ),
+            (2,),
+        )
+        self.assertEqual(len(assessment.conversation_evidence_items), 2)
+        self.assertEqual(coherence.status, "passed")
+        self.assertEqual(coherence.criterion_status, "covered")
+        self.assertNotIn(
+            "attributed_criterion_partial",
+            coherence.reason_codes,
+        )
+        conn = sqlite3.connect(":memory:")
+        try:
+            persist_shadow_run(conn, assessment, response=response)
+            self.assertEqual(
+                conn.execute(
+                    "SELECT response_alignment FROM "
+                    "unified_response_assessment_shadow_runs"
+                ).fetchone()[0],
+                "guard_clear",
+            )
+        finally:
+            conn.close()
 
     def test_semantic_frame_is_domain_neutral_across_conversation_shapes(self):
         cases = (


### PR DESCRIPTION
## Outcome

Repairs the three proven Row 6 Copper acceptance failures without changing the established shared-brain architecture, gates, schema, or deployment controls.

## Repairs

- Keep BNL model turns containing intentional opaque/glitch markers as structural Moment evidence while preserving the sensitive-source boundary for human-authored content.
- When the resolved Situation Frame says `new_event_same_participant`, derive response criteria from the current event only; historical evidence remains available for attribution and audit.
- Recognize explicit `perform` commitments as episode actions.

## Regression coverage

- Exact Copper glitch-marker model turn forms a four-member Moment.
- Explicit separate-task interruption finalizes Glass Harbor and creates the active Copper episode with an action.
- Resolved Copper event no longer inherits Glass Harbor's interrupted decision criterion and records `guard_clear`.

## Verification

- Full suite: **2,579 tests passed**
- Focused/adjacent suites: **75 + 29 + 24 tests passed**
- `git diff --check`: passed
- Python compilation: passed

No database writes, production restarts, feature-gate changes, or live-state mutations were performed by this repair.