### PR TITLE
Fix Row 6 recurrence persistence

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -36272,11 +36272,6 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 len(unique_user_ids) == 1
                 and batch_ordinary_chat_scope.eligible
             )
-            batch_source_no_store_reason = (
-                "finalized_show_evidence_no_store"
-                if batch_tiktok_show_evidence_context
-                else "website_read_model_no_store"
-            )
             batch_public_tiktok_memory_allowed = (
                 public_tiktok_interaction_memory_allowed(
                     combined_text,
@@ -36284,6 +36279,14 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     batch_website_read_model_context,
                 )
             )
+            batch_model_persistence_allowed = (
+                model_response_persistence_allowed_with_website_context(
+                    combined_text,
+                    channel_policy,
+                    batch_website_read_model_context,
+                )
+            )
+            batch_source_no_store_reason = "website_read_model_no_store"
             batch_website_read_model_prompt_block = ""
             if (
                 batch_website_read_model_context
@@ -37287,12 +37290,8 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 get_route_mode_contract(
                     ROUTE_MODE_NORMAL_CHAT
                 ).save_behavior
-                if batch_public_tiktok_memory_allowed
+                if batch_model_persistence_allowed
                 else "none"
-                if batch_source_context_available
-                else get_route_mode_contract(
-                    ROUTE_MODE_NORMAL_CHAT
-                ).save_behavior
             ),
             source_analysis_context_injected=(
                 batch_source_context_available
@@ -37308,6 +37307,9 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             save_policy_reason=(
                 "public_tiktok_interaction_normal_memory"
                 if batch_public_tiktok_memory_allowed
+                else "public_memory_sources_normal_memory"
+                if batch_model_persistence_allowed
+                and batch_source_context_available
                 else batch_source_no_store_reason
                 if batch_source_context_available
                 else "batch_model_save_pending"
@@ -38533,10 +38535,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 guard_status="batch_discord_send_failed",
             )
             return
-        if (
-            batch_source_context_available
-            and not batch_public_tiktok_memory_allowed
-        ):
+        if not batch_model_persistence_allowed:
             logging.info(
                 "batch_response_persistence_skipped "
                 "reason=%s channel_policy=%s",

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -381,7 +381,7 @@ _SELF_SUBJECT_CUE_RE = re.compile(
     r"\b(?:what\s+(?:am\s+i|do\s+you\s+(?:know|remember)\s+about\s+me)|"
     r"tell\s+me\s+(?:what|who)\s+i\s+am|about\s+me|my\s+(?:profile|"
     r"history|role|work|music|preferences?|goals?|memory|story)|"
-    r"remember\s+me|what\s+(?:patterns?|themes?)\s+(?:keep\s+)?"
+    r"remember\s+me|what\s+(?:recurring\s+)?(?:patterns?|themes?)\s+(?:keep\s+)?"
     r"(?:recurring|coming\s+up)\s+for\s+me|"
     r"what\s+keeps\s+(?:recurring|coming\s+up)\s+for\s+me)\b",
     re.I,

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -1070,6 +1070,90 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(save_model.call_args.args[2], channel.sent[0])
         self.assertEqual(save_model.call_args.kwargs["channel_policy"], "public_home")
 
+    async def test_sealed_generic_recurrence_with_public_show_context_commits_after_send(
+        self,
+    ):
+        channel = self._channel(8153)
+        request = (
+            "Sealed acceptance fixture: based only on memory, what recurring "
+            "themes keep coming up for me?"
+        )
+        answer = "There is not enough independent recurrence evidence yet."
+        generation_calls = []
+        show_evidence = (
+            "Durable BARCODE Radio show episode memory:\n"
+            "- Public finalized show evidence relevant to this request."
+        )
+        show_context = mock.Mock(return_value=show_evidence)
+        save_model = mock.Mock()
+        record_assessment = mock.AsyncMock()
+
+        async def generate(prompt, **kwargs):
+            generation_calls.append((prompt, kwargs))
+            return answer
+
+        self._prime_flush(channel, request)
+        with (
+            self._flush_runtime(channel.id, generate),
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_build_bnl_read_model_context",
+                return_value="",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_tiktok_show_evidence_context_for_turn",
+                new=show_context,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_user_memory_context",
+                return_value="",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "unified_response_assessment_shadow_enabled",
+                return_value=True,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "save_model_message",
+                new=save_model,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "record_unified_response_assessment_shadow_after_send",
+                new=record_assessment,
+            ),
+        ):
+            await bnl01_bot._flush_channel_buffer(channel)
+
+        show_context.assert_called_once_with(
+            guild_id=channel.guild.id,
+            user_text=request,
+            subject_user_id=100,
+            website_read_model_context="",
+        )
+        self.assertEqual(channel.sent, [answer])
+        self.assertEqual(len(generation_calls), 1)
+        self.assertTrue(generation_calls[0][1]["source_context_available"])
+        self.assertIn(show_evidence, generation_calls[0][0])
+        save_model.assert_called_once()
+        self.assertEqual(save_model.call_args.args[2], answer)
+        self.assertEqual(
+            save_model.call_args.kwargs["channel_policy"],
+            "sealed_test",
+        )
+        record_assessment.assert_awaited_once()
+        self.assertIsNotNone(record_assessment.await_args.args[0])
+        self.assertEqual(
+            record_assessment.await_args.kwargs["response"],
+            answer,
+        )
+        self.assertTrue(
+            record_assessment.await_args.kwargs["response_sent"]
+        )
+
     async def test_non_privileged_tester_queue_fragment_bypasses_reply_cooldown(self):
         channel = self._channel(8151)
         generation_calls = []

--- a/tests/test_situation_frame_v1.py
+++ b/tests/test_situation_frame_v1.py
@@ -118,6 +118,8 @@ class SituationFrameV1Tests(unittest.TestCase):
             "What do you know about me?",
             "Tell me who I am.",
             "What patterns keep recurring for me?",
+            "What recurring themes keep coming up for me?",
+            "Sealed acceptance fixture: based only on memory, what recurring themes keep coming up for me?",
         )
         for text in cases:
             with self.subTest(text=text):
@@ -143,6 +145,12 @@ class SituationFrameV1Tests(unittest.TestCase):
                     "third_party_subject_unresolved",
                     frame.ambiguity_reasons,
                 )
+                self.assertEqual(frame.subject_requirement, "required")
+                self.assertEqual(
+                    frame.tasks[0].subject_requirement,
+                    "required",
+                )
+                self.assertEqual(frame.tasks[0].subject_indexes, (0,))
 
     def test_bnl_self_questions_bind_the_existing_canon_entity(self):
         cases = (

--- a/tests/test_tiktok_show_evidence_ledger.py
+++ b/tests/test_tiktok_show_evidence_ledger.py
@@ -1261,6 +1261,35 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             self.assertIn("Alex (@alex.signal)", broad)
             self.assertIn("queue/wheel", broad)
 
+            personal_recurrence_query = (
+                "Sealed acceptance fixture: based only on memory, what "
+                "recurring themes keep coming up for me?"
+            )
+            personal_recurrence_context = build_tiktok_show_evidence_context(
+                db_file,
+                guild_id=77,
+                user_text=personal_recurrence_query,
+                subject_user_id=42,
+            )
+            self.assertIn(
+                "Durable BARCODE Radio show episode memory:",
+                personal_recurrence_context,
+            )
+            conn = sqlite3.connect(db_file)
+            personal_recurrence_items = select_tiktok_show_episode_context_items(
+                conn,
+                guild_id=77,
+                user_text=personal_recurrence_query,
+                subject_user_id=42,
+                allow_subject_continuity=True,
+            )
+            conn.close()
+            self.assertTrue(personal_recurrence_items)
+            self.assertIn(
+                "community",
+                {item.kind for item in personal_recurrence_items},
+            )
+
             topic_excerpt = build_tiktok_show_evidence_context(
                 db_file,
                 guild_id=77,


### PR DESCRIPTION
## Summary
- bind the existing personal-recurrence frame for the Row 6 wording
- keep durable public show memory additive without suppressing normal model persistence
- preserve existing no-store handling for website read-model snapshots and turn-local Discord referents

## Verification
- focused recurrence, framing, show-ledger, batching, and packet tests pass
- `make check PYTHON=/tmp/bnl01-test-venv/bin/python` — 2,580 tests passed
- `git diff --check` passed