### PR TITLE
Ground Row 6 recurrence answers in packet truth

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -193,6 +193,7 @@ from bnl_shared_brain_synthesis import (
     ordinary_chat_route_scope_decision,
     publication_packet_composes_current_queue,
     publication_packet_owns_turn,
+    render_recurrence_authority_contract,
     record_fallback as record_shared_brain_synthesis_fallback,
     record_single_packet_review,
     revalidate_basis as revalidate_shared_brain_synthesis_basis,
@@ -36791,6 +36792,13 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     "\n\n"
                     + batch_unified_moment_canary_basis.rendered_context
                 )
+            batch_recurrence_contract = (
+                render_recurrence_authority_contract(
+                    batch_intelligence_packet_out.get("packet")
+                )
+            )
+            if batch_recurrence_contract:
+                prompt += "\n\n" + batch_recurrence_contract
             if community_visual_prompt:
                 prompt += "\n\n" + community_visual_prompt + "\n"
             recent_media_prompt = ""
@@ -39634,6 +39642,9 @@ def build_user_aware_prompt(
         if ordinary_chat_single_packet
         else personal_recall_interpretation_contract(clean_content)
     )
+    recurrence_authority_contract = render_recurrence_authority_contract(
+        intelligence_packet_out.get("packet")
+    )
     if route_mode == ROUTE_MODE_NORMAL_CHAT and is_conversational_repair_intent(clean_content):
         prompt_contract += (
             "Correction-turn contract: use the visible prior exchange and make the corrected attempt now. "
@@ -39684,6 +39695,7 @@ def build_user_aware_prompt(
         f"{website_read_model_prompt_block}"
         f"{queue_artist_memory_prompt_block}"
         f"{tiktok_show_evidence_prompt_block}"
+        f"{recurrence_authority_contract}"
         f"{source_context_prompt_block}"
         f"{exact_quote_prompt_block}"
         f"{tiktok_show_analysis_turn_contract}"

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -3207,6 +3207,66 @@ def render_packet_context(
     )
 
 
+def render_recurrence_authority_contract(
+    packet: UnifiedIntelligencePacket | None,
+) -> str:
+    """Project the packet's existing recurrence verdict into response context."""
+
+    if packet is None:
+        return ""
+    diagnostics = getattr(packet, "diagnostics", None)
+    if diagnostics is None:
+        return ""
+    if (
+        getattr(diagnostics, "processing_errors", ())
+        or getattr(diagnostics, "invalid_invariants", ())
+        or not str(
+            getattr(diagnostics, "revalidation_status", "") or ""
+        ).startswith("passed")
+    ):
+        return ""
+    request = getattr(packet, "request", None)
+    object_kind = str(
+        getattr(request, "frame_object_kind", "") or ""
+    ).strip().lower()
+    subject_requirement = str(
+        getattr(request, "frame_subject_requirement", "") or ""
+    ).strip().lower()
+    if object_kind == "broadcast" or subject_requirement != "required":
+        return ""
+    status = str(
+        getattr(diagnostics, "theme_query_status", "not_requested")
+        or "not_requested"
+    ).strip().lower()
+    if status == "not_requested":
+        return ""
+    recurring_items = tuple(
+        item
+        for item in getattr(packet, "items", ())
+        if item.lane == "recurring_theme"
+    )
+    if status == "established" and recurring_items:
+        return (
+            "- Recurrence authority: only selected recurring-theme evidence "
+            "establishes a recurring pattern. Other eligible public, show, "
+            "and conversation memories remain additive context, not separate "
+            "proof of recurrence.\n"
+        )
+    if status == "provisional_single_occurrence":
+        return (
+            "- Recurrence authority: retained memory supports one occurrence "
+            "only, not a recurring theme. Say that plainly. Other eligible "
+            "public, show, and conversation memories remain additive examples, "
+            "but do not promote them into a pattern or habitual behavior.\n"
+        )
+    return (
+        "- Recurrence authority: retained memory does not establish a recurring "
+        "theme for this request. Say that plainly. Other eligible public, show, "
+        "and conversation memories remain additive examples, but do not promote "
+        "them into patterns or habitual behavior.\n"
+    )
+
+
 def _ordinary_packet_context(
     packet: UnifiedIntelligencePacket,
 ) -> tuple[str, tuple[tuple[str, int], ...], int, tuple[str, ...]]:
@@ -4136,6 +4196,9 @@ def build_packet_owned_prompt(
     """Add packet evidence to the already-authorized response context."""
 
     updated = str(prompt or "")
+    recurrence_contract = render_recurrence_authority_contract(
+        basis.packet
+    )
     if basis.ordinary_chat_single_packet:
         task_contract = render_ordinary_chat_task_contract(basis)
         if not updated.strip():
@@ -4149,6 +4212,12 @@ def build_packet_owned_prompt(
             additions.append(_ORDINARY_CHAT_FACTUAL_OWNER_CONTRACT)
         if basis.rendered_context and basis.rendered_context not in updated:
             additions.append(basis.rendered_context)
+        if (
+            recurrence_contract
+            and recurrence_contract not in updated
+            and recurrence_contract not in basis.rendered_context
+        ):
+            additions.append(recurrence_contract)
         if task_contract and task_contract not in updated:
             additions.append(task_contract)
         return PacketOwnedPrompt(
@@ -4199,11 +4268,14 @@ def build_packet_owned_prompt(
             + updated[start + len(value):]
         )
         replaced += 1
-    candidate_prompt = (
-        updated.rstrip()
-        + "\n\n"
-        + basis.rendered_context
-    )
+    additions = [basis.rendered_context]
+    if (
+        recurrence_contract
+        and recurrence_contract not in updated
+        and recurrence_contract not in basis.rendered_context
+    ):
+        additions.append(recurrence_contract)
+    candidate_prompt = "\n\n".join((updated.rstrip(), *additions))
     if any(
         context and context in candidate_prompt
         for context in basis.competing_factual_contexts

--- a/bnl_tiktok_show_ledger.py
+++ b/bnl_tiktok_show_ledger.py
@@ -3173,7 +3173,10 @@ def build_tiktok_show_evidence_context(
                     (60 if topic_named else 42) + breadth_boost,
                 )
         if topics and (wants_topics or not participant_matches):
-            lines.append("Recurring language/topics across retained public show chat:")
+            lines.append(
+                "Repeated language/topics within this selected episode "
+                "(not independent recurrence):"
+            )
             for topic in topics[:8]:
                 lines.append(
                     f"- {json.dumps(str(topic.get('term') or ''), ensure_ascii=False)}: "

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -1087,6 +1087,26 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         show_context = mock.Mock(return_value=show_evidence)
         save_model = mock.Mock()
         record_assessment = mock.AsyncMock()
+        build_assessment = (
+            bnl01_bot.build_unified_response_assessment_shadow
+        )
+
+        def build_with_recurrence_verdict(*args, **kwargs):
+            assessment = build_assessment(*args, **kwargs)
+            kwargs["intelligence_packet_out"]["packet"] = SimpleNamespace(
+                request=SimpleNamespace(
+                    frame_object_kind="memory",
+                    frame_subject_requirement="required",
+                ),
+                diagnostics=SimpleNamespace(
+                    processing_errors=(),
+                    invalid_invariants=(),
+                    revalidation_status="passed",
+                    theme_query_status="no_authoritative_theme",
+                ),
+                items=(),
+            )
+            return assessment
 
         async def generate(prompt, **kwargs):
             generation_calls.append((prompt, kwargs))
@@ -1117,6 +1137,11 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
             ),
             mock.patch.object(
                 bnl01_bot,
+                "build_unified_response_assessment_shadow",
+                side_effect=build_with_recurrence_verdict,
+            ),
+            mock.patch.object(
+                bnl01_bot,
                 "save_model_message",
                 new=save_model,
             ),
@@ -1138,6 +1163,14 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(generation_calls), 1)
         self.assertTrue(generation_calls[0][1]["source_context_available"])
         self.assertIn(show_evidence, generation_calls[0][0])
+        self.assertIn(
+            "retained memory does not establish a recurring theme",
+            generation_calls[0][0],
+        )
+        self.assertIn(
+            "public, show, and conversation memories remain additive examples",
+            generation_calls[0][0],
+        )
         save_model.assert_called_once()
         self.assertEqual(save_model.call_args.args[2], answer)
         self.assertEqual(

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -31,6 +31,7 @@ from bnl_shared_brain_synthesis import (
     parse_ordinary_chat_response_contract,
     record_single_packet_review,
     revalidate_basis,
+    render_recurrence_authority_contract,
     render_ordinary_chat_task_contract,
     render_packet_context,
     validate_ordinary_chat_response_contract,
@@ -981,6 +982,83 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         )
         self.assertTrue(valid)
         self.assertEqual(status, "passed")
+
+    def test_recurrence_verdict_keeps_public_examples_without_inventing_pattern(self):
+        recurrence_request = replace(
+            self.packet.request,
+            user_text="What recurring themes keep coming up for me?",
+            frame_object_kind="memory",
+            frame_subject_requirement="required",
+        )
+        packet = replace(self.packet, request=recurrence_request)
+        packet.diagnostics.theme_query_status = "no_authoritative_theme"
+
+        contract = render_recurrence_authority_contract(packet)
+        self.assertIn(
+            "retained memory does not establish a recurring theme",
+            contract,
+        )
+        self.assertIn(
+            "public, show, and conversation memories remain additive examples",
+            contract,
+        )
+
+        packet.diagnostics.theme_query_status = (
+            "provisional_single_occurrence"
+        )
+        provisional = render_recurrence_authority_contract(packet)
+        self.assertIn("one occurrence only", provisional)
+        self.assertIn("remain additive examples", provisional)
+
+        empty_packet = replace(packet, items=())
+        empty_basis = replace(
+            self.basis,
+            packet=empty_packet,
+            rendered_context=(
+                "SELECTED EVIDENCE:\n"
+                "- No stored evidence was selected for this turn."
+            ),
+        )
+        owned = build_packet_owned_prompt("Current request.", empty_basis)
+        self.assertTrue(owned.ready)
+        self.assertIn("one occurrence only", owned.prompt)
+
+        packet.diagnostics.theme_query_status = "no_authoritative_theme"
+        show_packet = replace(
+            packet,
+            request=replace(
+                recurrence_request,
+                user_text="What recurring topics came up throughout the show?",
+                frame_object_kind="broadcast",
+                frame_subject_requirement="required",
+            ),
+        )
+        self.assertEqual(
+            render_recurrence_authority_contract(show_packet),
+            "",
+        )
+
+        failed_packet = replace(packet)
+        failed_packet.diagnostics.revalidation_status = "failed_stale_source"
+        self.assertEqual(
+            render_recurrence_authority_contract(failed_packet),
+            "",
+        )
+        failed_packet.diagnostics.revalidation_status = "passed"
+
+        established_packet = replace(
+            packet,
+            items=(replace(packet.items[0], lane="recurring_theme"),),
+        )
+        established_packet.diagnostics.theme_query_status = "established"
+        established = render_recurrence_authority_contract(
+            established_packet
+        )
+        self.assertIn(
+            "only selected recurring-theme evidence establishes",
+            established,
+        )
+        self.assertNotIn("does not establish", established)
 
     def test_bnl_self_identity_prompt_keeps_subject_scoped_canon(self):
         basis = self._multi_subject_basis(

--- a/tests/test_tiktok_show_evidence_ledger.py
+++ b/tests/test_tiktok_show_evidence_ledger.py
@@ -1275,6 +1275,15 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 "Durable BARCODE Radio show episode memory:",
                 personal_recurrence_context,
             )
+            self.assertIn(
+                "Repeated language/topics within this selected episode "
+                "(not independent recurrence):",
+                personal_recurrence_context,
+            )
+            self.assertNotIn(
+                "Recurring language/topics across retained public show chat:",
+                personal_recurrence_context,
+            )
             conn = sqlite3.connect(db_file)
             personal_recurrence_items = select_tiktok_show_episode_context_items(
                 conn,


### PR DESCRIPTION
## Summary
- project the existing validated packet recurrence verdict into the visible response prompt
- keep authorized public, show, and conversation memory additive; do not treat one episode as independent recurrence
- leave broadcast-level recurring-topic questions unchanged
- clarify the single-episode show-evidence heading

This fixes the semantic gap where the Row 6 receipt correctly reported `no_authoritative_theme` but the visible reply still invented recurring personal patterns. It adds no post-generation guard, source exclusion, or phrase-by-phrase response blocker.

## Verification
- 2,581 repository tests pass
- 225 focused routing/synthesis tests pass
- exact Row 6 batch fixture covered with public show context retained
- tracked-tree private-identity scan passes
- `git diff --check` passes