### PR TITLE
Align Row 6 memory sources in one shared response

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -36187,16 +36187,18 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     ),
                 )
             )
-            batch_tiktok_show_episode_turn_contract = (
-                build_tiktok_show_episode_turn_contract(
-                    batch_tiktok_show_evidence_context
-                )
-            )
             batch_finalized_show_packet_owner = (
                 finalized_show_packet_owner_requested(
                     combined_text,
                     batch_tiktok_show_evidence_context,
                 )
+            )
+            batch_tiktok_show_episode_turn_contract = (
+                build_tiktok_show_episode_turn_contract(
+                    batch_tiktok_show_evidence_context
+                )
+                if batch_finalized_show_packet_owner
+                else ""
             )
             batch_source_context_available = bool(
                 batch_website_read_model_context
@@ -36261,7 +36263,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 has_media=bool(active_packet.get("media_present")),
                 specialized_owner_present=bool(
                     (
-                        batch_source_context_available
+                        batch_website_read_model_context
                         and not batch_publication_packet_owns_turn
                         and not batch_publication_queue_packet_ready
                     )
@@ -36734,14 +36736,17 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                         batch_attribution_contract
                         .third_party_attribution_requested
                     ),
-                    competing_factual_contexts=(
-                        (batch_memory_context,)
-                        if batch_memory_context
-                        else ()
+                    competing_factual_contexts=tuple(
+                        context
+                        for context in (
+                            batch_memory_context,
+                            batch_tiktok_show_evidence_prompt_block,
+                        )
+                        if context
                     ),
                 )
                 if len(unique_user_ids) == 1
-                and not batch_source_context_available
+                and not batch_website_read_model_context
                 and not batch_ordinary_chat_single_packet
                 else None
             )
@@ -37373,7 +37378,7 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                         batch_source_context_available
                     ),
                 )
-                if not batch_source_context_available
+                if not batch_website_read_model_context
                 else None
             )
         batch_synthesis_decision = (
@@ -39120,14 +39125,16 @@ def build_user_aware_prompt(
         if tiktok_show_evidence_context
         else ""
     )
+    finalized_show_packet_owner = finalized_show_packet_owner_requested(
+        clean_content,
+        tiktok_show_evidence_context,
+    )
     tiktok_show_episode_turn_contract = (
         build_tiktok_show_episode_turn_contract(
             tiktok_show_evidence_context
         )
-    )
-    finalized_show_packet_owner = finalized_show_packet_owner_requested(
-        clean_content,
-        tiktok_show_evidence_context,
+        if finalized_show_packet_owner
+        else ""
     )
     frozen_situation_frame = (
         conversation_orchestration.situation_frame
@@ -39431,8 +39438,13 @@ def build_user_aware_prompt(
         third_party_attribution_requested=(
             third_party_attribution_requested
         ),
-        competing_factual_contexts=(
-            (memory_context,) if memory_context else ()
+        competing_factual_contexts=tuple(
+            context
+            for context in (
+                memory_context,
+                tiktok_show_evidence_prompt_block,
+            )
+            if context
         ),
         )
     )

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -3103,8 +3103,12 @@ def render_packet_context(
         else "- Lead with the directly applicable approved identity "
         "relationship. Do not claim or imply a Discord activity history.\n"
         if identity_canon_only
-        else "- Lead with the requested show finding from the finalized show "
-        "evidence. Do not lead with data availability, routing, or lore.\n"
+        else "- When the current request specifically asks for a show finding, "
+        "lead with that finding from the finalized show evidence. For a member "
+        "profile or personal-recall question, treat the member's attributed "
+        "show evidence as one supporting part of the profile rather than the "
+        "answer's organizing frame. Do not lead with data availability, "
+        "routing, or lore.\n"
         if show_episode_present
         else "- Lead with member-specific substance. Relevant BARCODE canon "
         "may add one concise context anchor afterward, but can never "

--- a/bnl_tiktok_show_ledger.py
+++ b/bnl_tiktok_show_ledger.py
@@ -89,7 +89,9 @@ _COMMUNITY_BASELINE_QUERY_RE = re.compile(
 _SUBJECT_CONTINUITY_QUERY_RE = re.compile(
     r"\b(?:remember me|know me|about me|my history|my activity|my messages?|"
     r"what did i|when did i|did i|have i|was i|where was i|"
-    r"what do you think of me|your (?:read|opinion|impression) of me)\b",
+    r"what do you think of me|your (?:read|opinion|impression) of me|"
+    r"what (?:recurring )?(?:patterns?|themes?) (?:keep )?"
+    r"(?:coming up|recurring) for me)\b",
     re.IGNORECASE,
 )
 _RELATIVE_SHOW_DATE_SCOPE_RE = re.compile(
@@ -2068,6 +2070,12 @@ def _document_relevance(
             participant_matches.append(participant)
             evidence_query_overlap = True
             score += 90
+    if (
+        subject_ref
+        and _subject_continuity_requested(query)
+        and not direct_subject_candidates
+    ):
+        return 0, []
     for track in ledger.get("trackMoments") or ():
         if isinstance(track, Mapping) and _phrase_in_query(
             query,
@@ -2698,21 +2706,12 @@ def _dialogue_episode_context_item(
                 evidence_boosts={},
             ),
         )
-        if participant_refs:
-            authored = [
+        if participant_refs and _subject_continuity_requested(user_text):
+            return [
                 item
                 for item in ranked
                 if str(item.get("subjectRef") or "") in participant_refs
             ]
-            related = [
-                item
-                for item in ranked
-                if str(item.get("subjectRef") or "") not in participant_refs
-                and query_terms.intersection(
-                    _query_terms(str(item.get("text") or ""))
-                )
-            ]
-            return authored + related
         if query_terms:
             matches = [
                 item
@@ -2924,8 +2923,9 @@ def select_tiktok_show_episode_context_items(
     ]
     items: list[TikTokShowEpisodeContextItem] = []
     if (
-        _show_episode_scope_requested(user_text)
-        or participant_matches
+        _show_episode_scope_requested(user_text) or participant_matches
+    ) and not (
+        participant_matches and _subject_continuity_requested(user_text)
     ):
         items.append(
             _community_episode_context_item(
@@ -3172,8 +3172,13 @@ def build_tiktok_show_evidence_context(
                     topic.get("supportEventIds") or (),
                     (60 if topic_named else 42) + breadth_boost,
                 )
-        if topics and (wants_topics or not participant_matches):
-            lines.append("Recurring language/topics across retained public show chat:")
+        if topics and (wants_topics or not participant_matches) and not (
+            participant_matches and _subject_continuity_requested(user_text)
+        ):
+            lines.append(
+                "Repeated language/topics within this selected episode "
+                "(not independent recurrence):"
+            )
             for topic in topics[:8]:
                 lines.append(
                     f"- {json.dumps(str(topic.get('term') or ''), ensure_ascii=False)}: "
@@ -3298,19 +3303,12 @@ def build_tiktok_show_evidence_context(
                 evidence_boosts=evidence_boosts,
             ),
         )
-        if participant_refs:
-            authored = [
+        if participant_refs and _subject_continuity_requested(user_text):
+            relevant_messages = [
                 item
                 for item in relevant_messages
                 if str(item.get("subjectRef") or "") in participant_refs
             ]
-            other_relevant = [
-                item
-                for item in relevant_messages
-                if str(item.get("subjectRef") or "") not in participant_refs
-                and query_terms.intersection(_query_terms(str(item.get("text") or "")))
-            ]
-            relevant_messages = authored + other_relevant
         elif query_terms:
             query_matches = [
                 item
@@ -3379,7 +3377,14 @@ def build_tiktok_show_evidence_context(
             exchange_score += 10 * len(
                 query_terms.intersection(_query_terms(exchange_text))
             )
-            if exchange_score > 0 or _RECAP_QUERY_RE.search(user_text or ""):
+            if participant_refs and _subject_continuity_requested(user_text):
+                exchange_relevant = exchange_subject in participant_refs
+            else:
+                exchange_relevant = bool(
+                    exchange_score > 0
+                    or _RECAP_QUERY_RE.search(user_text or "")
+                )
+            if exchange_relevant:
                 relevant_exchanges.append((exchange_score, exchange))
         relevant_exchanges.sort(
             key=lambda item: (

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -2009,6 +2009,19 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
             ),
             mock.patch.object(
                 bnl01_bot,
+                "build_tiktok_show_evidence_context_for_turn",
+                return_value=(
+                    "Durable BARCODE Radio show episode memory:\n"
+                    "- REQUESTER SHOW EVIDENCE"
+                ),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "finalized_show_packet_owner_requested",
+                return_value=False,
+            ),
+            mock.patch.object(
+                bnl01_bot,
                 "build_unified_response_assessment_shadow",
                 return_value=object(),
             ),
@@ -2016,7 +2029,7 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
                 bnl01_bot,
                 "build_shared_brain_synthesis_basis",
                 return_value=object(),
-            ),
+            ) as build_basis,
             mock.patch.object(
                 bnl01_bot,
                 "maybe_generate_shared_brain_synthesis_canary",
@@ -2046,7 +2059,19 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
             await bnl01_bot._flush_channel_buffer(channel)
 
         deterministic_governance.assert_not_called()
+        competing_contexts = build_basis.call_args.kwargs[
+            "competing_factual_contexts"
+        ]
+        self.assertTrue(
+            any("Derived memory summaries" in item for item in competing_contexts)
+        )
+        self.assertTrue(
+            any("REQUESTER SHOW EVIDENCE" in item for item in competing_contexts)
+        )
         synthesize.assert_awaited_once()
+        self.assertTrue(
+            synthesize.await_args.kwargs["source_context_available"]
+        )
         guard.assert_awaited_once()
         self.assertFalse(
             guard.await_args.kwargs["regeneration_allowed"]
@@ -2056,6 +2081,149 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         finalized.assert_awaited_once()
         self.assertTrue(finalized.await_args.kwargs["response_sent"])
         self.assertTrue(finalized.await_args.kwargs["candidate_live"])
+
+    async def test_batched_personal_recurrence_composes_requester_show_evidence(self):
+        channel = self._channel(8146)
+        request = (
+            "Sealed acceptance fixture: based only on memory, what recurring "
+            "themes keep coming up for me?"
+        )
+        answer = (
+            "You repeatedly combine hands-on broadcast oversight with precise "
+            "identity and system corrections. Your retained show questions "
+            "add a concrete habit of checking the room signal and queue while "
+            "the broader memory shows the same calibration instinct elsewhere."
+        )
+        packet = object()
+        assessment = object()
+        basis = object()
+        memory_basis = object()
+        decision = SimpleNamespace(candidate_selected=True)
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=decision,
+            response=answer,
+            prompt="one composed requester-memory prompt",
+            prompt_source_bases=(memory_basis,),
+            candidate_active=True,
+            provider_call_count=1,
+            corrective_call_count=0,
+        )
+        scope_calls = []
+
+        def build_assessment(*_args, **kwargs):
+            kwargs["intelligence_packet_out"]["packet"] = packet
+            return assessment
+
+        def scope_decision(**kwargs):
+            scope_calls.append(kwargs)
+            return SimpleNamespace(
+                eligible=not kwargs.get("specialized_owner_present", False),
+                reason="eligible",
+            )
+
+        async def legacy_generation(*_args, **_kwargs):
+            raise AssertionError(
+                "requester show evidence must join the existing packet"
+            )
+
+        self._prime_flush(channel, request)
+        with (
+            self._flush_runtime(channel.id, legacy_generation),
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_build_bnl_read_model_context",
+                return_value="",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_tiktok_show_evidence_context_for_turn",
+                return_value=(
+                    "Durable BARCODE Radio show episode memory:\n"
+                    "- REQUESTER SHOW EVIDENCE"
+                ),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "finalized_show_packet_owner_requested",
+                return_value=False,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_tiktok_show_episode_turn_contract",
+            ) as show_owner_contract,
+            mock.patch.object(
+                bnl01_bot,
+                "build_user_memory_context",
+                return_value="DURABLE MEMBER MEMORY",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_memory_prompt_source_basis",
+                return_value=memory_basis,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "ordinary_chat_route_scope_decision",
+                side_effect=scope_decision,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_unified_response_assessment_shadow",
+                side_effect=build_assessment,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_ordinary_chat_basis",
+                return_value=basis,
+            ) as build_ordinary,
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_ordinary_chat_single_packet",
+                new=mock.AsyncMock(return_value=execution),
+            ) as generate_ordinary,
+            mock.patch.object(
+                bnl01_bot,
+                "build_shared_brain_synthesis_basis",
+            ) as build_shared,
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_shared_brain_synthesis_canary",
+                new=mock.AsyncMock(),
+            ) as generate_shared,
+            mock.patch.object(
+                bnl01_bot,
+                "prompt_source_basis_failure",
+                return_value="",
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "safely_finalize_shared_brain_synthesis",
+                new=mock.AsyncMock(return_value=True),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "record_unified_response_assessment_shadow_after_send",
+                new=mock.AsyncMock(),
+            ),
+        ):
+            await bnl01_bot._flush_channel_buffer(channel)
+
+        self.assertEqual(channel.sent, [answer])
+        self.assertTrue(scope_calls)
+        self.assertFalse(scope_calls[-1]["specialized_owner_present"])
+        show_owner_contract.assert_not_called()
+        competing_contexts = build_ordinary.call_args.kwargs[
+            "competing_factual_contexts"
+        ]
+        self.assertTrue(
+            any("DURABLE MEMBER MEMORY" in item for item in competing_contexts)
+        )
+        self.assertTrue(
+            any("REQUESTER SHOW EVIDENCE" in item for item in competing_contexts)
+        )
+        generate_ordinary.assert_awaited_once()
+        build_shared.assert_not_called()
+        generate_shared.assert_not_awaited()
 
     async def test_batched_packet_source_change_falls_back_to_normal_baseline(self):
         channel = self._channel(8127)

--- a/tests/test_tiktok_show_episode_response_guard.py
+++ b/tests/test_tiktok_show_episode_response_guard.py
@@ -331,15 +331,16 @@ class TikTokShowEpisodeResponseGuardTests(unittest.TestCase):
                         context,
                     )
                 )
-        for live_request in (
+        for non_historical_owner_request in (
             "What are people saying in TikTok chat right now?",
             "Is the queue open right now?",
             "What is currently in the BARCODE Radio queue?",
+            "Based only on memory, what recurring themes keep coming up for me?",
         ):
-            with self.subTest(live_request=live_request):
+            with self.subTest(request=non_historical_owner_request):
                 self.assertFalse(
                     bnl01_bot.finalized_show_packet_owner_requested(
-                        live_request,
+                        non_historical_owner_request,
                         context,
                     )
                 )

--- a/tests/test_tiktok_show_evidence_ledger.py
+++ b/tests/test_tiktok_show_evidence_ledger.py
@@ -1260,6 +1260,15 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             self.assertIn('"green visuals": 3 messages / 3 participants', broad)
             self.assertIn("Alex (@alex.signal)", broad)
             self.assertIn("queue/wheel", broad)
+            self.assertIn(
+                "Repeated language/topics within this selected episode "
+                "(not independent recurrence):",
+                broad,
+            )
+            self.assertNotIn(
+                "Recurring language/topics across retained public show chat:",
+                broad,
+            )
 
             personal_recurrence_query = (
                 "Sealed acceptance fixture: based only on memory, what "
@@ -1275,6 +1284,23 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
                 "Durable BARCODE Radio show episode memory:",
                 personal_recurrence_context,
             )
+            self.assertIn("Alex (@alex.signal)", personal_recurrence_context)
+            self.assertIn(
+                "BNL, the green visuals during this song are wild.",
+                personal_recurrence_context,
+            )
+            self.assertNotIn(
+                "Those green visuals changed again.",
+                personal_recurrence_context,
+            )
+            self.assertNotIn(
+                "The green visuals made that moment hit.",
+                personal_recurrence_context,
+            )
+            self.assertNotIn(
+                "Repeated language/topics within this selected episode",
+                personal_recurrence_context,
+            )
             conn = sqlite3.connect(db_file)
             personal_recurrence_items = select_tiktok_show_episode_context_items(
                 conn,
@@ -1285,9 +1311,36 @@ class TikTokShowEvidenceLedgerTests(unittest.TestCase):
             )
             conn.close()
             self.assertTrue(personal_recurrence_items)
-            self.assertIn(
-                "community",
+            self.assertEqual(
                 {item.kind for item in personal_recurrence_items},
+                {"dialogue"},
+            )
+            self.assertTrue(
+                all(
+                    item.subject_key == "discord_user:42"
+                    for item in personal_recurrence_items
+                )
+            )
+            personal_packet_text = " ".join(
+                item.text for item in personal_recurrence_items
+            )
+            self.assertIn("Alex", personal_packet_text)
+            self.assertNotIn(
+                "Those green visuals changed again.",
+                personal_packet_text,
+            )
+            self.assertNotIn(
+                "The green visuals made that moment hit.",
+                personal_packet_text,
+            )
+            self.assertEqual(
+                build_tiktok_show_evidence_context(
+                    db_file,
+                    guild_id=77,
+                    user_text=personal_recurrence_query,
+                    subject_user_id=999,
+                ),
+                "",
             )
 
             topic_excerpt = build_tiktok_show_evidence_context(


### PR DESCRIPTION
## What this fixes

The exact Row 6 acceptance wording was falling through a source-composition seam:

- finalized-show recall treated the personal question like a broad room/topic query, so it could supply whole-room show aggregates instead of requester-scoped show evidence;
- the batched route treated any show-evidence block as a specialized owner, which prevented the existing ordinary one-packet shared-brain route from composing it with durable member memory;
- the prompt applied finalized-show priority wording even though this was a personal-memory question, not a show-owned recap.

That left multiple valid memory blocks beside one another and allowed the response to lean on whichever block dominated the generation.

## Narrow change

- Recognize the sealed recurring-themes wording as the existing subject-continuity intent.
- For that self-continuity intent, select only episodes containing the requester, retain only requester-attributed examples/interactions, and omit unrelated room aggregates.
- Let finalized-show evidence participate in the existing ordinary shared-brain composition instead of marking it as a blocking specialized owner.
- Apply finalized-show priority wording only to requests that actually ask for a finalized-show finding.
- Tell the existing packet renderer to treat attributed show evidence as supporting evidence inside a personal read, not as the organizing frame.

Broad show/community questions keep their existing aggregate behavior.

## Explicit non-goals

This does **not** add or change a Moment owner, recurrence owner, memory store, persistence rule, gate, blocker, fallback, response template, style rule, or provider setting. PR #493 remains the base; none of PR #492's recurrence-denial mechanism is restored.

## Verification

- Focused show-ledger and batching regression suites: 71 tests passed.
- Show-owner guard suite: 14 tests passed.
- Full repository check: 2,581 tests passed.
- Diff check and tracked-tree privacy scan passed.
