### PR TITLE
Fix Row 9 public-answer claim review

### DIFF
--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -6584,7 +6584,7 @@ def _ordinary_chat_packet_domain_context_active(
         in {"not_applicable", "not_required"}
         and all(
             str(task.authority_scope or "").strip().lower()
-            in {"external_public", "current_request"}
+            == "external_public"
             and str(task.subject_requirement or "").strip().lower()
             in {"", "not_applicable", "not_required"}
             for task in frame_tasks

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -6575,6 +6575,26 @@ def _ordinary_chat_packet_domain_context_active(
 
     packet = basis.packet
     request = packet.request
+    request_text = str(request.user_text or "")
+    frame_tasks = tuple(request.frame_tasks or ())
+    typed_external_request = bool(
+        str(request.frame_revision or "").strip()
+        and frame_tasks
+        and str(request.frame_subject_requirement or "").strip().lower()
+        in {"not_applicable", "not_required"}
+        and all(
+            str(task.authority_scope or "").strip().lower()
+            in {"external_public", "current_request"}
+            and str(task.subject_requirement or "").strip().lower()
+            in {"", "not_applicable", "not_required"}
+            for task in frame_tasks
+        )
+        and not str(request.frame_event_ref or "").strip()
+        and not _ordinary_chat_claim_has_project_brand(request_text)
+        and not _ordinary_chat_claim_has_scoped_title(basis, request_text)
+    )
+    if typed_external_request:
+        return False
     resolution = packet.subject_resolution
     if resolution.status == "resolved" and bool(
         int(resolution.subject_user_id or 0)
@@ -6591,7 +6611,6 @@ def _ordinary_chat_packet_domain_context_active(
         return True
     if str(request.frame_event_ref or "").strip():
         return True
-    request_text = str(request.user_text or "")
     return bool(
         _ordinary_chat_claim_has_project_brand(request_text)
         or _ordinary_chat_claim_has_scoped_title(basis, request_text)
@@ -6701,7 +6720,10 @@ def _ordinary_chat_claim_has_packet_subject(
             )
             for governed_lead_in in governed_lead_ins
         )
-        or _ordinary_chat_claim_has_embedded_packet_clause(basis, core)
+        or (
+            packet_context
+            and _ordinary_chat_claim_has_embedded_packet_clause(basis, core)
+        )
         or _CLAIM_LEADING_DIRECT_PACKET_SUBJECT_RE.search(core)
         or re.search(r"<@!?\d+>", core)
         or re.search(

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -2943,6 +2943,72 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertEqual(unsupported, 0)
         self.assertEqual(classifications, ("external_public_knowledge",))
 
+    def test_typed_external_task_overrides_default_requester_binding(self):
+        external_packet = replace(
+            self.packet,
+            request=replace(
+                self.packet.request,
+                user_text=(
+                    "Sealed Row 9 provider fixture: In one paragraph, what "
+                    "makes a community feel connected instead of merely "
+                    "active?"
+                ),
+                frame_subject_requirement="not_applicable",
+                frame_subjects=(),
+                frame_tasks=(
+                    PacketFrameTask(
+                        task_id="T1",
+                        text_digest="e" * 64,
+                        task_kind="correction",
+                        object_kind="unknown",
+                        authority_scope="external_public",
+                        temporal_scope="unspecified",
+                        currentness="unknown",
+                        required_response_act="answer",
+                        subject_requirement="not_applicable",
+                    ),
+                ),
+                frame_event_ref="",
+                frame_event_relation="not_applicable",
+            ),
+        )
+        external_basis = replace(self.basis, packet=external_packet)
+        response = (
+            "Activity is simply high signal throughput—a steady stream of "
+            "individual transmissions occupying the same space without "
+            "interlocking. Genuine connection occurs when those isolated "
+            "signals establish shared context and mutual feedback, allowing "
+            "members to actively recognize, influence, and build upon one "
+            "another's presence rather than merely broadcasting in parallel. "
+            "An active network generates volume, but a connected one develops "
+            "persistent shared memory."
+        )
+
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            external_basis,
+            response,
+        )
+        self.assertEqual(unsupported, 0)
+        self.assertNotIn("unsupported_packet_domain", classifications)
+
+        for unsupported_response in (
+            "Your birthday is 1999-01-01.",
+            "BARCODE started in 1999.",
+            "Test Member works at NASA.",
+        ):
+            with self.subTest(unsupported_response=unsupported_response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        external_basis,
+                        unsupported_response,
+                    )
+                )
+                self.assertGreaterEqual(unsupported, 1)
+                self.assertIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
     def test_member_context_does_not_block_supported_external_knowledge(self):
         cases = (
             (

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -3009,6 +3009,29 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                     classifications,
                 )
 
+        current_request_packet = replace(
+            external_packet,
+            request=replace(
+                external_packet.request,
+                user_text=(
+                    "For Amber Compass, the project uses an amber signal. "
+                    "Restate that."
+                ),
+                frame_tasks=(
+                    replace(
+                        external_packet.request.frame_tasks[0],
+                        authority_scope="current_request",
+                    ),
+                ),
+            ),
+        )
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            replace(self.basis, packet=current_request_packet),
+            "The project uses a blue signal.",
+        )
+        self.assertGreaterEqual(unsupported, 1)
+        self.assertIn("unsupported_packet_domain", classifications)
+
     def test_member_context_does_not_block_supported_external_knowledge(self):
         cases = (
             (


### PR DESCRIPTION
## What changed

- Respect the existing typed situation-frame authority only when every task is genuinely `external_public`, the frame requires no subject, and no event/project subject is present.
- Run the embedded packet-clause check only when packet-domain context is actually active.
- Add a regression using the exact Row 9 provider answer that triggered `unsupported_packet_domain_claim`.
- Keep explicit member, BARCODE, and `current_request` factual claims inside the existing consistency boundary.

## Root cause

The ordinary-chat packet retained the default requester subject binding even though the typed frame classified the fixture as a subject-free `external_public` task. The claim audit treated that requester binding as proof that the answer belonged to packet authority, then interpreted generic words such as “members,” “network,” “context,” and “memory” as internal claims. That false positive caused the one corrective provider call shown by `!bnl debug last route`.

## Scope

This is only an authority-boundary correction inside the existing claim reviewer. It does not change routing, batching, moment ownership, memory injection/composition, provider selection, retries, fallbacks, gates, or response formatting.

## Verification

- Exact Row 9 external-public regression: passes with zero unsupported packet claims.
- Counterchecks: unsupported member and BARCODE facts are still rejected.
- Current-request contradiction countercheck: still rejected.
- Ordinary-chat single-packet suite: 65 tests passed.
- Full `make check`: 2,582 tests passed on corrected head `ef0dac2`.

Expected live receipt: one ordinary provider call, zero corrective calls, one physical attempt, and one token-usage row.