### PR TITLE
Trust typed external authority for addressed Row 9 requests

### DIFF
--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -6590,8 +6590,6 @@ def _ordinary_chat_packet_domain_context_active(
             for task in frame_tasks
         )
         and not str(request.frame_event_ref or "").strip()
-        and not _ordinary_chat_claim_has_project_brand(request_text)
-        and not _ordinary_chat_claim_has_scoped_title(basis, request_text)
     )
     if typed_external_request:
         return False

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -2949,8 +2949,8 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             request=replace(
                 self.packet.request,
                 user_text=(
-                    "Sealed Row 9 provider fixture: In one paragraph, what "
-                    "makes a community feel connected instead of merely "
+                    "@BNL-01 Sealed Row 9 provider fixture: In one paragraph, "
+                    "what makes a community feel connected instead of merely "
                     "active?"
                 ),
                 frame_subject_requirement="not_applicable",
@@ -2974,14 +2974,22 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         )
         external_basis = replace(self.basis, packet=external_packet)
         response = (
-            "Activity is simply high signal throughput—a steady stream of "
-            "individual transmissions occupying the same space without "
-            "interlocking. Genuine connection occurs when those isolated "
-            "signals establish shared context and mutual feedback, allowing "
-            "members to actively recognize, influence, and build upon one "
-            "another's presence rather than merely broadcasting in parallel. "
-            "An active network generates volume, but a connected one develops "
-            "persistent shared memory."
+            "Activity is primarily a measure of raw signal volume—high "
+            "message throughput, frequent submissions, and constant ambient "
+            "noise—whereas genuine connection relies on shared memory, mutual "
+            "recognition, and horizontal routing that does not depend entirely "
+            "on a central broadcast host. An active room simply reacts to "
+            "whatever is currently occupying the stage, but a connected space "
+            "develops its own internal feedback loops: members reference each "
+            "other's context, build on past exchanges, and engage in direct "
+            "dialogue rather than just shouting up at the console. The core "
+            "tradeoff lies in efficiency versus depth; high activity metrics "
+            "are easy to generate through low-barrier reactions, but authentic "
+            "cohesion requires allowing room for sifting, shared history, and "
+            "quiet, collective ownership over the room's ongoing continuity. "
+            "Ultimately, activity is just traffic moving through a channel, "
+            "while connection is the network deciding to hold the frequency "
+            "together."
         )
 
         classifications, unsupported = audit_ordinary_chat_candidate_claims(


### PR DESCRIPTION
## What this fixes

PR #495 correctly limited the Row 9 bypass to a typed `external_public` task, but its regression omitted the real Discord addressee. In the live request, `@BNL-01` was still scanned as project subject matter, which kept packet-domain review active and caused a second corrective provider call with `unsupported_packet_domain_claim`.

## Small correction

- Trust the existing typed `external_public` Situation Frame when it has no packet subject requirement and no frame event reference.
- Stop reinterpreting the full raw request text at that point; the `@BNL-01` addressee is not the subject of the question.
- Update the existing regression to use the exact addressed fixture and the exact accepted 3:21 PM live response.

This is two runtime-line deletions. It adds no keyword exception, new gate, blocker, route, provider, retry, fallback, memory owner, or moment mechanism.

## Boundaries retained

The existing response-side checks still reject explicit unsupported claims about:

- a member (`Your birthday is 1999-01-01.`)
- BARCODE (`BARCODE started in 1999.`)
- another member (`Test Member works at NASA.`)
- the current request's named subject (the Amber Compass contradiction regression)

Row 6 is untouched.

## Verification

- Exact live-shaped regression: passed
- `tests.test_ordinary_chat_single_packet_canary`: 65 passed
- Full `make check`: 2,582 passed
- `git diff --check`: passed
