### PR TITLE
Preserve Row 9 project authority after bot mentions

### DIFF
--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -6576,6 +6576,13 @@ def _ordinary_chat_packet_domain_context_active(
     packet = basis.packet
     request = packet.request
     request_text = str(request.user_text or "")
+    request_subject_text = re.sub(
+        r"^\s*(?:<@!?\d+>|@BNL-01)\s*[,;:!?—–-]*\s*",
+        "",
+        request_text,
+        count=1,
+        flags=re.I,
+    )
     frame_tasks = tuple(request.frame_tasks or ())
     typed_external_request = bool(
         str(request.frame_revision or "").strip()
@@ -6590,6 +6597,11 @@ def _ordinary_chat_packet_domain_context_active(
             for task in frame_tasks
         )
         and not str(request.frame_event_ref or "").strip()
+        and not _ordinary_chat_claim_has_project_brand(request_subject_text)
+        and not _ordinary_chat_claim_has_scoped_title(
+            basis,
+            request_subject_text,
+        )
     )
     if typed_external_request:
         return False

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -6577,7 +6577,9 @@ def _ordinary_chat_packet_domain_context_active(
     request = packet.request
     request_text = str(request.user_text or "")
     request_subject_text = re.sub(
-        r"^\s*(?:<@!?\d+>|@BNL-01)\s*[,;:!?—–-]*\s*",
+        r"^\s*(?:(?:hey|hi|hello|yo|please|okay|ok|so)\b"
+        r"[\s,;:!?—–-]*)*(?:<@!?\d+>|@BNL-01)\s*"
+        r"[,;:!?—–-]*\s*",
         "",
         request_text,
         count=1,

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -6600,6 +6600,11 @@ def _ordinary_chat_packet_domain_context_active(
             for task in frame_tasks
         )
         and not str(request.frame_event_ref or "").strip()
+        and not re.search(
+            r"\b(?:you|your|yours|yourself)\b",
+            request_subject_text,
+            re.I,
+        )
         and not re.search(r"<@!?\d+>", request_subject_text)
         and not _ordinary_chat_claim_has_project_brand(request_subject_text)
         and not _ordinary_chat_claim_has_scoped_title(

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -6578,7 +6578,8 @@ def _ordinary_chat_packet_domain_context_active(
     request_text = str(request.user_text or "")
     request_subject_text = re.sub(
         r"^\s*(?:(?:hey|hi|hello|yo|please|okay|ok|so)\b"
-        r"[\s,;:!?—–-]*)*(?:<@!?\d+>|@BNL-01)\s*"
+        r"[\s,;:!?—–-]*)*(?:<@!?\d+>|@BNL-01)"
+        r"(?=\s|[,;:!?—–-]|$)\s*"
         r"[,;:!?—–-]*\s*",
         "",
         request_text,
@@ -6599,6 +6600,7 @@ def _ordinary_chat_packet_domain_context_active(
             for task in frame_tasks
         )
         and not str(request.frame_event_ref or "").strip()
+        and not re.search(r"<@!?\d+>", request_subject_text)
         and not _ordinary_chat_claim_has_project_brand(request_subject_text)
         and not _ordinary_chat_claim_has_scoped_title(
             basis,

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -6578,13 +6578,19 @@ def _ordinary_chat_packet_domain_context_active(
     request_text = str(request.user_text or "")
     request_subject_text = re.sub(
         r"^\s*(?:(?:hey|hi|hello|yo|please|okay|ok|so)\b"
-        r"[\s,;:!?—–-]*)*(?:<@!?\d+>|@BNL-01)"
-        r"(?=\s|[,;:!?—–-]|$)\s*"
-        r"[,;:!?—–-]*\s*",
+        r"[\s.,;:!?—–-]*)*(?:<@!?\d+>|@BNL-01)"
+        r"(?!\s*['’]s\b)(?=\s|[.,;:!?—–-]|$)\s*"
+        r"[.,;:!?—–-]*\s*",
         "",
         request_text,
         count=1,
         flags=re.I,
+    )
+    request_referent_text = re.sub(
+        r"(?:'[^'\n]{0,240}'|\"[^\"\n]{0,240}\"|"
+        r"“[^”\n]{0,240}”|‘[^’\n]{0,240}’)",
+        "",
+        request_subject_text,
     )
     frame_tasks = tuple(request.frame_tasks or ())
     typed_external_request = bool(
@@ -6602,7 +6608,7 @@ def _ordinary_chat_packet_domain_context_active(
         and not str(request.frame_event_ref or "").strip()
         and not re.search(
             r"\b(?:you|your|yours|yourself)\b",
-            request_subject_text,
+            request_referent_text,
             re.I,
         )
         and not re.search(r"<@!?\d+>", request_subject_text)

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -6587,10 +6587,13 @@ def _ordinary_chat_packet_domain_context_active(
         flags=re.I,
     )
     request_referent_text = re.sub(
-        r"(?:'[^'\n]{0,240}'|\"[^\"\n]{0,240}\"|"
-        r"“[^”\n]{0,240}”|‘[^’\n]{0,240}’)",
+        r"(?:'\s*(?:you|your|yours|yourself)\s*'|"
+        r"\"\s*(?:you|your|yours|yourself)\s*\"|"
+        r"“\s*(?:you|your|yours|yourself)\s*”|"
+        r"‘\s*(?:you|your|yours|yourself)\s*’)",
         "",
         request_subject_text,
+        flags=re.I,
     )
     frame_tasks = tuple(request.frame_tasks or ())
     typed_external_request = bool(

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -3082,6 +3082,8 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         for possessive_request in (
             "@BNL-01's creator is who?",
             "<@7>'s birthday is when?",
+            "@BNL-01 's creator is who?",
+            "<@7> 's birthday is when?",
         ):
             with self.subTest(possessive_request=possessive_request):
                 possessive_packet = replace(
@@ -3132,6 +3134,34 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                     "unsupported_packet_domain",
                     classifications,
                 )
+
+        quoted_word_packet = replace(
+            external_packet,
+            request=replace(
+                external_packet.request,
+                user_text="@BNL-01, what does the word 'you' mean?",
+            ),
+        )
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            replace(self.basis, packet=quoted_word_packet),
+            "It is a second-person pronoun.",
+        )
+        self.assertEqual(unsupported, 0)
+        self.assertNotIn("unsupported_packet_domain", classifications)
+
+        period_vocative_packet = replace(
+            external_packet,
+            request=replace(
+                external_packet.request,
+                user_text="@BNL-01. When did Apollo 11 land?",
+            ),
+        )
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            replace(self.basis, packet=period_vocative_packet),
+            "It landed in 1969.",
+        )
+        self.assertEqual(unsupported, 0)
+        self.assertNotIn("unsupported_packet_domain", classifications)
 
         current_request_packet = replace(
             external_packet,

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -3017,6 +3017,30 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                     classifications,
                 )
 
+        barcode_request_packet = replace(
+            external_packet,
+            request=replace(
+                external_packet.request,
+                user_text="@BNL-01 When was BARCODE founded?",
+            ),
+        )
+        for unsupported_response in (
+            "It was founded in 1999.",
+            "The project was founded in 1999.",
+        ):
+            with self.subTest(unsupported_response=unsupported_response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        replace(self.basis, packet=barcode_request_packet),
+                        unsupported_response,
+                    )
+                )
+                self.assertGreaterEqual(unsupported, 1)
+                self.assertIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
         current_request_packet = replace(
             external_packet,
             request=replace(

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -3114,6 +3114,10 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                 "<@7>, when is your birthday?",
                 "It is January 1.",
             ),
+            (
+                "@BNL-01, don't you know when you were created?",
+                "It was created in 1999.",
+            ),
         ):
             with self.subTest(second_person_request=second_person_request):
                 second_person_packet = replace(

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -2999,6 +2999,30 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertEqual(unsupported, 0)
         self.assertNotIn("unsupported_packet_domain", classifications)
 
+        for addressed_request in (
+            "Hey @BNL-01, when did Apollo 11 land?",
+            "Please, @BNL-01, when did Apollo 11 land?",
+        ):
+            with self.subTest(addressed_request=addressed_request):
+                addressed_packet = replace(
+                    external_packet,
+                    request=replace(
+                        external_packet.request,
+                        user_text=addressed_request,
+                    ),
+                )
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        replace(self.basis, packet=addressed_packet),
+                        "It landed in 1969.",
+                    )
+                )
+                self.assertEqual(unsupported, 0)
+                self.assertNotIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
         for unsupported_response in (
             "Your birthday is 1999-01-01.",
             "BARCODE started in 1999.",
@@ -3040,6 +3064,20 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                     "unsupported_packet_domain",
                     classifications,
                 )
+
+        bnl_subject_packet = replace(
+            external_packet,
+            request=replace(
+                external_packet.request,
+                user_text="When was @BNL-01 created?",
+            ),
+        )
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            replace(self.basis, packet=bnl_subject_packet),
+            "It was created in 1999.",
+        )
+        self.assertGreaterEqual(unsupported, 1)
+        self.assertIn("unsupported_packet_domain", classifications)
 
         current_request_packet = replace(
             external_packet,

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -3103,6 +3103,36 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                     classifications,
                 )
 
+        for second_person_request, indirect_response in (
+            (
+                "@BNL-01, when were you created?",
+                "It was created in 1999.",
+            ),
+            (
+                "<@7>, when is your birthday?",
+                "It is January 1.",
+            ),
+        ):
+            with self.subTest(second_person_request=second_person_request):
+                second_person_packet = replace(
+                    external_packet,
+                    request=replace(
+                        external_packet.request,
+                        user_text=second_person_request,
+                    ),
+                )
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        replace(self.basis, packet=second_person_packet),
+                        indirect_response,
+                    )
+                )
+                self.assertGreaterEqual(unsupported, 1)
+                self.assertIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
         current_request_packet = replace(
             external_packet,
             request=replace(

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -3079,6 +3079,30 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertGreaterEqual(unsupported, 1)
         self.assertIn("unsupported_packet_domain", classifications)
 
+        for possessive_request in (
+            "@BNL-01's creator is who?",
+            "<@7>'s birthday is when?",
+        ):
+            with self.subTest(possessive_request=possessive_request):
+                possessive_packet = replace(
+                    external_packet,
+                    request=replace(
+                        external_packet.request,
+                        user_text=possessive_request,
+                    ),
+                )
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        replace(self.basis, packet=possessive_packet),
+                        "It is January 1.",
+                    )
+                )
+                self.assertGreaterEqual(unsupported, 1)
+                self.assertIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
         current_request_packet = replace(
             external_packet,
             request=replace(


### PR DESCRIPTION
## Why this follow-up is required

A late automated review on #496 identified one real boundary regression before deployment: removing the raw request checks entirely could allow a BARCODE-scoped question to bypass packet review when the provider answered indirectly with `it` or `the project`.

## Small correction

- Normalize only a true leading bot vocative before classifying the request subject, including bounded common prefixes and normal sentence punctuation.
- Keep straight/curly possessives governed, including optional whitespace before the possessive suffix.
- Preserve packet authority when the remaining question refers back to the addressee through second-person language, while excluding quoted words from that check.
- Restore the existing BARCODE, raw Discord mention, and scoped-title request checks against the remaining question text.
- Add the exact fixture and every review counterexample.

The accepted community fixture remains typed external-public and needs no corrective call. BARCODE, member, possessive, or addressee-specific questions remain packet-governed even when an answer uses an indirect referent.

No route, provider, retry, fallback, gate, memory owner, moment mechanism, or Row 6 code is changed.

## Verification

- Exact fixture plus review counterexamples: passed
- `tests.test_ordinary_chat_single_packet_canary`: 65 passed
- Full venv-backed `make check`: 2,582 passed
- `git diff --check`: passed
