### PR TITLE
Align shared-brain authority across Frame, Moment, and claim review

### DIFF
--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -52,6 +52,7 @@ from bnl_unified_response_assessment import (
     UnifiedResponseAssessment,
     assess_response_coherence,
     shadow_enabled as assessment_shadow_enabled,
+    situation_governed_dependency_kinds,
     situation_task_texts,
 )
 
@@ -542,6 +543,17 @@ _PACKET_REFERENT_RE = re.compile(
     r"you|your|yours)\b|"
     r"\b(?:he|she|they|him|his|her|hers|it|its|them|their|theirs)\b|"
     r"\b(?:the|this|that)\s+(?:event|member|project|requester|user)\b)",
+    re.I,
+)
+_PACKET_EVENT_CLAIM_SUBJECT_RE = re.compile(
+    r"^(?:(?:the|this|that|our)\s+)?"
+    r"(?:attendance|attendees?|participation|participants?|turnout|"
+    r"headcount|crowd|audience|event|moment|episode|session|test|run|"
+    r"show)\b|"
+    r"^(?:(?:about|around|approximately|roughly|nearly|over|under|"
+    r"more\s+than|fewer\s+than)\s+)?"
+    r"(?:\d+|[a-z]+(?:-[a-z]+)?)\s+"
+    r"(?:people|members|participants)\b",
     re.I,
 )
 _PACKET_CLAUSE_TAIL_BOUNDARY_RE = re.compile(
@@ -6577,6 +6589,10 @@ def _ordinary_chat_packet_domain_context_active(
     request = packet.request
     request_text = str(request.user_text or "")
     frame_tasks = tuple(request.frame_tasks or ())
+    governed_dependencies = situation_governed_dependency_kinds(
+        request_text,
+        event_ref=str(request.frame_event_ref or ""),
+    )
     typed_external_request = bool(
         str(request.frame_revision or "").strip()
         and frame_tasks
@@ -6589,9 +6605,12 @@ def _ordinary_chat_packet_domain_context_active(
             in {"", "not_applicable", "not_required"}
             for task in frame_tasks
         )
+        and not governed_dependencies
     )
     if typed_external_request:
         return False
+    if governed_dependencies:
+        return True
     resolution = packet.subject_resolution
     if resolution.status == "resolved" and bool(
         int(resolution.subject_user_id or 0)
@@ -6605,8 +6624,6 @@ def _ordinary_chat_packet_domain_context_active(
         not in {"", "none", "unresolved", "label_only"}
         for subject in tuple(request.frame_subjects or ())
     ):
-        return True
-    if str(request.frame_event_ref or "").strip():
         return True
     return bool(
         _ordinary_chat_claim_has_project_brand(request_text)
@@ -6697,6 +6714,13 @@ def _ordinary_chat_claim_has_packet_subject(
     attributive_member_at_start = bool(
         _PACKET_DOMAIN_ATTRIBUTIVE_MEMBER_RE.match(core)
     )
+    event_context = bool(
+        "event_referent"
+        in situation_governed_dependency_kinds(
+            basis.packet.request.user_text,
+            event_ref=basis.packet.request.frame_event_ref,
+        )
+    )
     return bool(
         _ordinary_chat_claim_has_project_brand(governed_without_links)
         or _ordinary_chat_claim_has_scoped_title(basis, governed_without_links)
@@ -6720,6 +6744,10 @@ def _ordinary_chat_claim_has_packet_subject(
         or (
             packet_context
             and _ordinary_chat_claim_has_embedded_packet_clause(basis, core)
+        )
+        or (
+            event_context
+            and _PACKET_EVENT_CLAIM_SUBJECT_RE.search(core)
         )
         or _CLAIM_LEADING_DIRECT_PACKET_SUBJECT_RE.search(core)
         or re.search(r"<@!?\d+>", core)

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -463,6 +463,27 @@ _SITUATION_BARCODE_PROJECT_RE = re.compile(
     r"\bbarcode\s+(?:collective|project)\b",
     re.I,
 )
+_SITUATION_ENTITY_SUBJECT_PREDICATE_RE = re.compile(
+    r"^\s*(?:['’]\s*s\b|(?:is|was|are|were|has|had|does|did|"
+    r"can|could|would|will|should|knows?|remembers?|works?|worked|"
+    r"owns?|owned|runs?|ran|hosts?|hosted|founds?|founded|starts?|"
+    r"started|joins?|joined|attends?|attended|creates?|created|"
+    r"builds?|built|launches?|launched)\b)",
+    re.I,
+)
+_SITUATION_ENTITY_SUBJECT_QUESTION_RE = re.compile(
+    r"\b(?:who|what|which|when|where|why|how)\b"
+    r"(?:\s+[a-z0-9'’-]+){0,4}\s+"
+    r"(?:is|was|are|were|do|does|did|has|have|had|"
+    r"can|could|would|will|should)\s+(?:the\s+)?$",
+    re.I,
+)
+_SITUATION_ENTITY_SUBJECT_REQUEST_RE = re.compile(
+    r"\b(?:tell\s+me\s+about|what\s+do\s+you\s+"
+    r"(?:know|remember)\s+about|describe|summari[sz]e|explain)"
+    r"\s+(?:the\s+)?$",
+    re.I,
+)
 _SITUATION_EXPLICIT_EVENT_REFERENT_RE = re.compile(
     r"\b(?:this|that|our|the)\s+"
     r"(?:(?:current|recent|last|previous|earlier|same|active|finalized)\s+)?"
@@ -838,6 +859,33 @@ def _situation_bnl_self_subject_cue(value: str) -> bool:
     )
 
 
+def _situation_entity_acts_as_subject(
+    subject_text: str,
+    entity_pattern: re.Pattern,
+) -> bool:
+    """Return whether one governed entity occupies a factual subject slot."""
+
+    for match in entity_pattern.finditer(str(subject_text or "")):
+        before = subject_text[: match.start()]
+        after = subject_text[match.end() :]
+        if _SITUATION_ENTITY_SUBJECT_PREDICATE_RE.match(after):
+            return True
+        if _SITUATION_ENTITY_SUBJECT_QUESTION_RE.search(before):
+            return True
+        if _SITUATION_ENTITY_SUBJECT_REQUEST_RE.search(before):
+            return True
+        if (
+            not before.strip()
+            and re.match(
+                r"^\s*[,;:—–-]+\s*(?:who|what|which|when|where|why|how)\b",
+                after,
+                re.I,
+            )
+        ):
+            return True
+    return False
+
+
 def _situation_governed_entity_refs(value: str) -> Tuple[str, ...]:
     """Return exact existing canon entities used as request subjects."""
 
@@ -846,17 +894,32 @@ def _situation_governed_entity_refs(value: str) -> Tuple[str, ...]:
     )
     refs = []
     if (
-        _SITUATION_BNL_ENTITY_RE.search(subject_text)
+        _situation_entity_acts_as_subject(
+            subject_text,
+            _SITUATION_BNL_ENTITY_RE,
+        )
         or _situation_bnl_self_subject_cue(value)
     ):
         refs.append(BNL01.key)
-    if _SITUATION_BARCODE_RADIO_RE.search(subject_text):
+    if _situation_entity_acts_as_subject(
+        subject_text,
+        _SITUATION_BARCODE_RADIO_RE,
+    ):
         refs.append("barcode_radio")
-    elif _SITUATION_BARCODE_NETWORK_RE.search(subject_text):
+    elif _situation_entity_acts_as_subject(
+        subject_text,
+        _SITUATION_BARCODE_NETWORK_RE,
+    ):
         refs.append("barcode_network")
     elif (
-        _SITUATION_BARCODE_EXACT_RE.search(subject_text)
-        or _SITUATION_BARCODE_PROJECT_RE.search(subject_text)
+        _situation_entity_acts_as_subject(
+            subject_text,
+            _SITUATION_BARCODE_EXACT_RE,
+        )
+        or _situation_entity_acts_as_subject(
+            subject_text,
+            _SITUATION_BARCODE_PROJECT_RE,
+        )
     ):
         refs.append("barcode")
     return tuple(dict.fromkeys(refs))
@@ -895,12 +958,16 @@ def situation_governed_dependency_kinds(
         _situation_subject_text(value)
     )
     dependencies = []
-    entity_refs = _situation_governed_entity_refs(value)
-    if BNL01.key in entity_refs:
+    if (
+        _SITUATION_BNL_ENTITY_RE.search(subject_text)
+        or _situation_bnl_self_subject_cue(value)
+    ):
         dependencies.append("bnl_subject")
-    if any(
-        entity_ref in {"barcode", "barcode_network", "barcode_radio"}
-        for entity_ref in entity_refs
+    if (
+        _SITUATION_BARCODE_RADIO_RE.search(subject_text)
+        or _SITUATION_BARCODE_NETWORK_RE.search(subject_text)
+        or _SITUATION_BARCODE_EXACT_RE.search(subject_text)
+        or _SITUATION_BARCODE_PROJECT_RE.search(subject_text)
     ):
         dependencies.append("project_subject")
     if _situation_governed_user_ids(value):
@@ -1093,6 +1160,14 @@ def _situation_tasks(
             event_ref=event_ref,
         )
         event_dependent = "event_referent" in dependency_kinds
+        governed_dependency = any(
+            dependency in {
+                "bnl_subject",
+                "project_subject",
+                "discord_subject",
+            }
+            for dependency in dependency_kinds
+        )
         phase = _situation_phase(segment)
         object_kind = _situation_object(segment)
         if event_dependent and object_kind == "unknown":
@@ -1143,14 +1218,6 @@ def _situation_tasks(
         subject_cue = bool(
             _situation_bnl_self_subject_cue(segment)
             or _SELF_SUBJECT_CUE_RE.search(subject_text)
-            or any(
-                dependency in {
-                    "bnl_subject",
-                    "project_subject",
-                    "discord_subject",
-                }
-                for dependency in dependency_kinds
-            )
             or (
                 _THIRD_PARTY_SUBJECT_CUE_RE.search(subject_text)
                 and not external_role_query
@@ -1183,6 +1250,7 @@ def _situation_tasks(
             subject_indexes = ()
         elif (
             subject_requirement == "required"
+            or governed_dependency
             or (
                 object_kind in _PACKET_AUTHORITY_OBJECTS
                 and not external_role_query

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -393,6 +393,96 @@ _BNL_SELF_SUBJECT_CUE_RE = re.compile(
     r"\bdescribe\s+yourself\b",
     re.I,
 )
+_SITUATION_PRESENTATION_RE = re.compile(
+    r"(?:\*\*|__|~~|(?<!\w)[*_]|[*_](?!\w)|"
+    r"[\u200b-\u200d\ufeff])"
+)
+_SITUATION_CODE_QUOTED_RE = re.compile(r"`+[^`\n]{1,240}`+")
+_SITUATION_DOUBLE_QUOTED_RE = re.compile(
+    r'(?:"[^"\n]{1,240}"|“[^”\n]{1,240}”)'
+)
+_SITUATION_SINGLE_QUOTED_RE = re.compile(
+    r"(?<!\w)(?:'[^'\n]{1,120}'|‘[^’\n]{1,120}’)(?!\w)"
+)
+_SITUATION_LEADING_ADDRESSEE_RE = re.compile(
+    r"^\s*(?:(?:hey|hi|hello|yo|please|okay|ok|so)\b"
+    r"[\s.,;:!?—–-]*)*"
+    r"(?P<addressee><@!?\d+>|@?BNL(?:[- ]?0?1)?)"
+    r"(?![- ]?0?1[a-z0-9_])"
+    r"(?![a-z0-9_])"
+    r"(?P<possessive>\s*['’]\s*s\b)?"
+    r"(?P<delimiter>\s*[.,;:!?—–-]+)?"
+    r"(?P<space>\s*)",
+    re.I,
+)
+_SITUATION_LEADING_SUBJECT_PREDICATE_RE = re.compile(
+    r"^(?:is|was|are|were|has|had|does|did|"
+    r"(?:can|could|would|will|should)(?!\s+you\b)|"
+    r"knows?|remembers?|works?|worked|owns?|owned|runs?|ran|"
+    r"hosts?|hosted|founds?|founded|starts?|started|"
+    r"joins?|joined|attends?|attended|creates?|created|"
+    r"builds?|built|launches?|launched)\b",
+    re.I,
+)
+_SITUATION_BNL_FACTUAL_SELF_RE = re.compile(
+    r"\b(?:when(?:['’]d|\s+did)\s+you\s+"
+    r"(?:start|begin|launch|join)\b|"
+    r"when\s+(?:were|was)\s+you\s+"
+    r"(?:created|built|founded|launched|started|born)|"
+    r"where\s+(?:are|were)\s+you\s+from|"
+    r"how\s+old\s+are\s+you|"
+    r"(?:who|what)\s+(?:created|built|made|founded|started)\s+you\b|"
+    r"you\s+(?:were|are)\s+(?:created|built|founded|launched|"
+    r"started|born)\b|"
+    r"(?:what(?:['’]s|\s+is)|when(?:['’]s|\s+is)|who(?:['’]s|\s+is))"
+    r"\s+your\s+(?:birthday|creator|creation|founder|founding|"
+    r"origin|history|identity|name|role|purpose|design|code|"
+    r"version|age|lore|canon|memory|project|network|radio)\b|"
+    r"your\s+(?:birthday|creator|creation|founder|founding|origin|"
+    r"history|identity|name|role|purpose|design|code|version|age|"
+    r"lore|canon|memory|project|network|radio)\b)",
+    re.I,
+)
+_SITUATION_BNL_ENTITY_RE = re.compile(
+    r"(?<![a-z0-9])@?B[\W_]*N[\W_]*L(?:[\W_]*0?1)?"
+    r"(?![\W_]*0?1[a-z0-9])(?![a-z0-9])",
+    re.I,
+)
+_SITUATION_BARCODE_EXACT_RE = re.compile(
+    r"(?<![A-Za-z0-9])BARCODE(?![A-Za-z0-9])"
+)
+_SITUATION_BARCODE_NETWORK_RE = re.compile(
+    r"\bbar[\W_]*code[\W_]*network\b",
+    re.I,
+)
+_SITUATION_BARCODE_RADIO_RE = re.compile(
+    r"\bbar[\W_]*code[\W_]*radio\b",
+    re.I,
+)
+_SITUATION_BARCODE_PROJECT_RE = re.compile(
+    r"\bbarcode\s+(?:collective|project)\b",
+    re.I,
+)
+_SITUATION_EXPLICIT_EVENT_REFERENT_RE = re.compile(
+    r"\b(?:this|that|our|the)\s+"
+    r"(?:(?:current|recent|last|previous|earlier|same|active|finalized)\s+)?"
+    r"(?:moment|episode|event|incident|attempt|run|session|test|"
+    r"rehearsal|show|discussion|thread)\b",
+    re.I,
+)
+_SITUATION_IMPLICIT_EVENT_QUERY_RE = re.compile(
+    r"(?:"
+    r"(?:how\s+many\s+(?:people|members|participants)|who)\s+"
+    r"(?:attended|participated|joined|showed\s+up)"
+    r"(?:\s+(?:it|this|that|there))?|"
+    r"how\s+many\s+(?:people|members|participants)\s+were\s+there|"
+    r"what\s+(?:happened|changed|failed|was\s+decided|got\s+fixed)|"
+    r"how\s+did\s+(?:it|this|that|the\s+(?:test|run|show|session))\s+go|"
+    r"did\s+(?:it|this|that)\s+(?:work|pass|fail|finish|end|start)|"
+    r"when\s+did\s+(?:it|this|that)\s+(?:start|end|happen|finish)"
+    r")\s*[?!.]*\s*$",
+    re.I,
+)
 _TASK_LEAD_RE = re.compile(
     r"(?:what|which|who|where|when|why|how|tell|explain|summari[sz]e|"
     r"restate|repeat|recap|paraphrase|recommend|suggest|list|"
@@ -697,6 +787,132 @@ def _situation_visibility(channel_policy: Any, route_allowed: bool) -> str:
     return "unknown"
 
 
+def _situation_plain_text(value: str) -> str:
+    """Remove presentation-only wrappers before request authority parsing."""
+
+    return _SITUATION_PRESENTATION_RE.sub(
+        "",
+        str(value or ""),
+    ).replace("\u00a0", " ")
+
+
+def _situation_unquoted_text(value: str) -> str:
+    """Hide quoted words so their pronouns cannot become live subjects."""
+
+    without_code = _SITUATION_CODE_QUOTED_RE.sub(" ", str(value or ""))
+    without_double_quotes = _SITUATION_DOUBLE_QUOTED_RE.sub(
+        " ",
+        without_code,
+    )
+    return _SITUATION_SINGLE_QUOTED_RE.sub(" ", without_double_quotes)
+
+
+def _situation_subject_text(value: str) -> str:
+    """Remove one true leading addressee while retaining factual subjects.
+
+    Discord addressing answers who should receive a response; it does not by
+    itself make the addressee the factual subject.  A possessive or an
+    immediate subject predicate keeps the leading name in the semantic text.
+    """
+
+    text = _situation_plain_text(value).strip()
+    match = _SITUATION_LEADING_ADDRESSEE_RE.match(text)
+    if match is None or match.group("possessive"):
+        return text
+    remainder = text[match.end() :].lstrip()
+    if (
+        not match.group("delimiter")
+        and _SITUATION_LEADING_SUBJECT_PREDICATE_RE.match(remainder)
+    ):
+        return text
+    return remainder
+
+
+def _situation_bnl_self_subject_cue(value: str) -> bool:
+    subject_text = _situation_unquoted_text(
+        _situation_subject_text(value)
+    )
+    return bool(
+        _BNL_SELF_SUBJECT_CUE_RE.search(subject_text)
+        or _SITUATION_BNL_FACTUAL_SELF_RE.search(subject_text)
+    )
+
+
+def _situation_governed_entity_refs(value: str) -> Tuple[str, ...]:
+    """Return exact existing canon entities used as request subjects."""
+
+    subject_text = _situation_unquoted_text(
+        _situation_subject_text(value)
+    )
+    refs = []
+    if (
+        _SITUATION_BNL_ENTITY_RE.search(subject_text)
+        or _situation_bnl_self_subject_cue(value)
+    ):
+        refs.append(BNL01.key)
+    if _SITUATION_BARCODE_RADIO_RE.search(subject_text):
+        refs.append("barcode_radio")
+    elif _SITUATION_BARCODE_NETWORK_RE.search(subject_text):
+        refs.append("barcode_network")
+    elif (
+        _SITUATION_BARCODE_EXACT_RE.search(subject_text)
+        or _SITUATION_BARCODE_PROJECT_RE.search(subject_text)
+    ):
+        refs.append("barcode")
+    return tuple(dict.fromkeys(refs))
+
+
+def _situation_governed_user_ids(value: str) -> Tuple[int, ...]:
+    """Return Discord mentions that remain after true vocative removal."""
+
+    subject_text = _situation_unquoted_text(
+        _situation_subject_text(value)
+    )
+    return tuple(
+        dict.fromkeys(
+            int(match.group("user_id"))
+            for match in re.finditer(
+                r"<@!?(?P<user_id>\d+)>",
+                subject_text,
+            )
+            if int(match.group("user_id") or 0) > 0
+        )
+    )
+
+
+def situation_governed_dependency_kinds(
+    value: str,
+    *,
+    event_ref: str = "",
+) -> Tuple[str, ...]:
+    """Classify request dependencies that require governed packet support.
+
+    This is an applicability boundary only.  It grants no facts and stores no
+    content; the packet's existing owners still select every usable source.
+    """
+
+    subject_text = _situation_unquoted_text(
+        _situation_subject_text(value)
+    )
+    dependencies = []
+    entity_refs = _situation_governed_entity_refs(value)
+    if BNL01.key in entity_refs:
+        dependencies.append("bnl_subject")
+    if any(
+        entity_ref in {"barcode", "barcode_network", "barcode_radio"}
+        for entity_ref in entity_refs
+    ):
+        dependencies.append("project_subject")
+    if _situation_governed_user_ids(value):
+        dependencies.append("discord_subject")
+    if str(event_ref or "").strip() and (
+        _SITUATION_EXPLICIT_EVENT_REFERENT_RE.search(subject_text)
+        or _SITUATION_IMPLICIT_EVENT_QUERY_RE.search(subject_text)
+    ):
+        dependencies.append("event_referent")
+    return tuple(dict.fromkeys(dependencies))
+
+
 def _situation_phase(text: str) -> str:
     for phase, pattern in _SITUATION_PHASE_PATTERNS:
         if pattern.search(text or ""):
@@ -801,14 +1017,17 @@ def _task_subject_indexes(
     segment: str,
     subjects: Sequence[SituationSubjectReference],
 ) -> Tuple[int, ...]:
-    bnl_self = bool(_BNL_SELF_SUBJECT_CUE_RE.search(segment or ""))
-    self_subject = bool(_SELF_SUBJECT_CUE_RE.search(segment or ""))
-    third_party = bool(_THIRD_PARTY_SUBJECT_CUE_RE.search(segment or ""))
+    subject_text = _situation_unquoted_text(
+        _situation_subject_text(segment)
+    )
+    bnl_self = _situation_bnl_self_subject_cue(segment)
+    self_subject = bool(_SELF_SUBJECT_CUE_RE.search(subject_text))
+    third_party = bool(_THIRD_PARTY_SUBJECT_CUE_RE.search(subject_text))
     matches = []
     for index, subject in enumerate(subjects):
         if int(subject.user_id or 0) > 0 and re.search(
             r"<@!?%s>" % int(subject.user_id),
-            segment or "",
+            subject_text,
         ):
             matches.append(index)
             continue
@@ -844,7 +1063,7 @@ def _task_subject_indexes(
         if any(
             re.search(
                 r"(?<![a-z0-9])%s(?![a-z0-9])" % re.escape(label),
-                segment or "",
+                subject_text,
                 re.I,
             )
             for label in labels
@@ -861,12 +1080,23 @@ def _situation_tasks(
     subjects: Sequence[SituationSubjectReference],
     response_act: str,
     exact_reply_resolved: bool = False,
+    event_ref: str = "",
 ) -> Tuple[SituationTaskReference, ...]:
     tasks = []
     prior_unique_subject_index = None
     for index, segment in enumerate(_situation_task_segments(text), start=1):
+        subject_text = _situation_unquoted_text(
+            _situation_subject_text(segment)
+        )
+        dependency_kinds = situation_governed_dependency_kinds(
+            segment,
+            event_ref=event_ref,
+        )
+        event_dependent = "event_referent" in dependency_kinds
         phase = _situation_phase(segment)
         object_kind = _situation_object(segment)
+        if event_dependent and object_kind == "unknown":
+            object_kind = "moment"
         temporal_scope, currentness = _situation_temporal_scope(segment)
         evidence = build_conversation_evidence_item(
             text=segment,
@@ -911,10 +1141,18 @@ def _situation_tasks(
                 )
         external_role_query = bool(_EXTERNAL_ROLE_QUERY_RE.search(segment))
         subject_cue = bool(
-            _BNL_SELF_SUBJECT_CUE_RE.search(segment)
-            or _SELF_SUBJECT_CUE_RE.search(segment)
+            _situation_bnl_self_subject_cue(segment)
+            or _SELF_SUBJECT_CUE_RE.search(subject_text)
+            or any(
+                dependency in {
+                    "bnl_subject",
+                    "project_subject",
+                    "discord_subject",
+                }
+                for dependency in dependency_kinds
+            )
             or (
-                _THIRD_PARTY_SUBJECT_CUE_RE.search(segment)
+                _THIRD_PARTY_SUBJECT_CUE_RE.search(subject_text)
                 and not external_role_query
             )
             or (object_kind == "person" and not external_role_query)
@@ -943,9 +1181,13 @@ def _situation_tasks(
             authority_scope = "current_request"
             subject_requirement = "not_applicable"
             subject_indexes = ()
-        elif subject_requirement == "required" or (
-            object_kind in _PACKET_AUTHORITY_OBJECTS
-            and not external_role_query
+        elif (
+            subject_requirement == "required"
+            or (
+                object_kind in _PACKET_AUTHORITY_OBJECTS
+                and not external_role_query
+            )
+            or event_dependent
         ):
             authority_scope = "packet"
         elif conversation_context_task:
@@ -1138,7 +1380,12 @@ def build_situation_frame_v1(
     target_ids = _unique_positive_ints(addressee_user_ids)
     subject_ids = _unique_positive_ints(subject_user_ids)
     label_hints = _unique_strings(subject_label_hints)[:8]
-    entity_refs = _unique_strings(subject_entity_refs)[:8]
+    entity_refs = _unique_strings(
+        (
+            *subject_entity_refs,
+            *_situation_governed_entity_refs(text),
+        )
+    )[:8]
     roles, domains = _situation_roles_domains(text)
     phase = _situation_phase(text)
     object_kind = _situation_object(text)
@@ -1153,10 +1400,19 @@ def build_situation_frame_v1(
         exact_quote_requested=False,
         evidence_items=(evidence,),
     )
-    third_party_cue = bool(_THIRD_PARTY_SUBJECT_CUE_RE.search(text))
-    self_subject_cue = bool(_SELF_SUBJECT_CUE_RE.search(text))
-    bnl_self_subject_cue = bool(_BNL_SELF_SUBJECT_CUE_RE.search(text))
-    external_role_query = bool(_EXTERNAL_ROLE_QUERY_RE.search(text))
+    request_subject_text = _situation_unquoted_text(
+        _situation_subject_text(text)
+    )
+    third_party_cue = bool(
+        _THIRD_PARTY_SUBJECT_CUE_RE.search(request_subject_text)
+    )
+    self_subject_cue = bool(
+        _SELF_SUBJECT_CUE_RE.search(request_subject_text)
+    )
+    bnl_self_subject_cue = _situation_bnl_self_subject_cue(text)
+    external_role_query = bool(
+        _EXTERNAL_ROLE_QUERY_RE.search(request_subject_text)
+    )
 
     subjects = []
     if subject_ids:
@@ -1262,6 +1518,7 @@ def build_situation_frame_v1(
         subjects=subjects,
         response_act=str(response_act or "observe"),
         exact_reply_resolved=exact_reply_resolved,
+        event_ref=str(moment_id or ""),
     )
 
     ambiguity = []
@@ -1335,6 +1592,8 @@ def build_situation_frame_v1(
             objective_kind=objective_kind,
         )
     )
+    if len(tasks) == 1:
+        object_kind = tasks[0].object_kind
     if len(tasks) > 1:
         object_kind = (
             tasks[0].object_kind

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -348,6 +348,123 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             environ=self.flags,
         )
 
+    def _basis_with_authority_frame(
+        self,
+        text,
+        *,
+        moment_id="",
+        subject_user_ids=(),
+    ):
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="free_speak_sealed_mirror",
+            channel_policy="sealed_test",
+            current_text=text,
+            current_speaker_user_ids=(7,),
+            current_speaker_labels=("Test Member",),
+            addressee_kinds=("discord_mention",),
+            addressee_user_ids=(99,),
+            source_message_ids=(301,),
+            explicit_mention_count=1,
+            subject_user_ids=subject_user_ids,
+            moment_id=moment_id,
+            moment_situation_state=(
+                "recent_active" if moment_id else "none"
+            ),
+            moment_topic_coherent=bool(moment_id),
+            moment_participant_overlap=bool(moment_id),
+            referent_status="not_requested",
+            response_act="answer",
+            packet_revision="turn_authority_boundary_fixture",
+        )
+        frame_subjects = tuple(
+            PacketFrameSubject(
+                user_id=subject.user_id,
+                entity_ref=subject.entity_ref,
+                label_hint=subject.label_hint,
+                binding_method=subject.binding_method,
+                confidence=subject.confidence,
+                role_hints=subject.role_hints,
+                domain_hints=subject.domain_hints,
+            )
+            for subject in frame.subjects
+        )
+        resolutions = tuple(
+            PacketSubjectResolution(
+                status="resolved",
+                subject_user_id=subject.user_id,
+                subject_key=(
+                    "discord_user:%s" % subject.user_id
+                    if subject.user_id
+                    else subject.entity_ref
+                ),
+                entity_ref=subject.entity_ref,
+                binding_method=subject.binding_method,
+                confidence=subject.confidence,
+                candidate_count=1,
+                reason_codes=("situation_frame_subject",),
+            )
+            for subject in frame.subjects
+        )
+        primary_resolution = (
+            resolutions[0]
+            if len(resolutions) == 1
+            else PacketSubjectResolution(
+                status=("multi_resolved" if resolutions else "not_applicable"),
+                candidate_count=len(resolutions),
+                reason_codes=(
+                    "situation_frame_subjects"
+                    if resolutions
+                    else "subject_not_required",
+                ),
+            )
+        )
+        request = replace(
+            self.packet.request,
+            subject_user_id=0,
+            subject_display_name="",
+            user_text=text,
+            frame_schema_version=frame.schema_version,
+            frame_revision=frame.frame_revision,
+            frame_input_evidence_digest=frame.input_evidence_digest,
+            frame_status=frame.status,
+            frame_ambiguity_reasons=frame.ambiguity_reasons,
+            frame_subject_requirement=frame.subject_requirement,
+            frame_subjects=frame_subjects,
+            frame_tasks=tuple(
+                PacketFrameTask(
+                    task_id=task.task_id,
+                    text_digest=task.text_digest,
+                    task_kind=task.task_kind,
+                    object_kind=task.object_kind,
+                    authority_scope=task.authority_scope,
+                    temporal_scope=task.temporal_scope,
+                    currentness=task.currentness,
+                    required_response_act=task.required_response_act,
+                    subject_requirement=task.subject_requirement,
+                    subject_indexes=task.subject_indexes,
+                )
+                for task in frame.tasks
+            ),
+            frame_role_hints=frame.role_hints,
+            frame_domain_hints=frame.domain_hints,
+            frame_event_ref=frame.event_ref,
+            frame_event_relation=frame.event_relation,
+            frame_task_kind=frame.task_kind,
+            frame_object_kind=frame.object_kind,
+            frame_phase=frame.phase,
+            frame_temporal_scope=frame.temporal_scope,
+            frame_currentness=frame.currentness,
+        )
+        packet = replace(
+            self.packet,
+            request=request,
+            subject_resolution=primary_resolution,
+            subject_resolutions=resolutions,
+        )
+        return frame, replace(self.basis, packet=packet)
+
     def _multi_subject_basis(self, text, subjects):
         frame = build_situation_frame_v1(
             route_allowed=True,
@@ -3118,6 +3235,218 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         )
         self.assertGreaterEqual(unsupported, 1)
         self.assertIn("unsupported_packet_domain", classifications)
+
+    def test_frame_and_claim_review_share_one_authority_boundary(self):
+        external_cases = (
+            (
+                "@BNL-01. When did Apollo 11 land?",
+                "It landed in 1969.",
+                "external_public",
+            ),
+            (
+                "Hey **@BNL-01**, when did Apollo 11 land?",
+                "It landed in 1969.",
+                "external_public",
+            ),
+            (
+                "Please @BNL-01 can you tell me when Apollo 11 landed?",
+                "It landed in 1969.",
+                "external_public",
+            ),
+            (
+                "@BNL-01 can you explain when Apollo 11 landed?",
+                "Apollo 11 landed in 1969.",
+                "current_request",
+            ),
+            (
+                "@BNL-01, what does the word 'you' mean?",
+                "It is a second-person pronoun.",
+                "external_public",
+            ),
+        )
+        for request_text, response, expected_authority in external_cases:
+            with self.subTest(request_text=request_text):
+                frame, basis = self._basis_with_authority_frame(request_text)
+
+                self.assertEqual(
+                    frame.tasks[0].authority_scope,
+                    expected_authority,
+                )
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(basis, response)
+                )
+                self.assertEqual(unsupported, 0)
+                self.assertNotIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
+        governed_cases = (
+            (
+                "@BNL-01 When was BARCODE founded?",
+                "It was founded in 1999.",
+                (),
+            ),
+            (
+                "@BNL-01, when were you created?",
+                "It was created in 1999.",
+                (),
+            ),
+            (
+                "@BNL-01, don't you know when you were created?",
+                "It was created in 1999.",
+                (),
+            ),
+            (
+                "@BNL-01's creator is who?",
+                "It was Test Creator.",
+                (),
+            ),
+            (
+                "@BNL-01 was created when?",
+                "It was created in 1999.",
+                (),
+            ),
+            (
+                "@BNL-01 can explain its origin?",
+                "It can explain its origin.",
+                (),
+            ),
+            (
+                "When was **@BNL-01** created?",
+                "It was created in 1999.",
+                (),
+            ),
+            (
+                "When did <@202> join?",
+                "They joined in 1999.",
+                (202,),
+            ),
+            (
+                "<@202>'s birthday is when?",
+                "It is January 1.",
+                (202,),
+            ),
+            (
+                "<@202> was created when?",
+                "They were created in 1999.",
+                (202,),
+            ),
+        )
+        for request_text, response, subject_user_ids in governed_cases:
+            with self.subTest(request_text=request_text):
+                frame, basis = self._basis_with_authority_frame(
+                    request_text,
+                    subject_user_ids=subject_user_ids,
+                )
+
+                self.assertEqual(frame.tasks[0].authority_scope, "packet")
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(basis, response)
+                )
+                self.assertGreaterEqual(unsupported, 1)
+                self.assertIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
+        ordinary_text = (
+            "@BNL-01 Sealed Row 9 provider fixture: In one paragraph, what "
+            "makes a community feel connected instead of merely active?"
+        )
+        frame, basis = self._basis_with_authority_frame(
+            ordinary_text,
+            moment_id="moment_prior_fixture",
+        )
+        self.assertEqual(frame.tasks[0].authority_scope, "external_public")
+        self.assertEqual(
+            ordinary_chat_task_support_plan(basis)[0].support_kind,
+            "external_public",
+        )
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            basis,
+            "Connection grows when members listen and build shared context.",
+        )
+        self.assertEqual(unsupported, 0)
+        self.assertNotIn("unsupported_packet_domain", classifications)
+
+        event_frame, event_basis = self._basis_with_authority_frame(
+            "How many people attended?",
+            moment_id="moment_prior_fixture",
+        )
+        self.assertEqual(event_frame.tasks[0].authority_scope, "packet")
+        self.assertEqual(event_frame.tasks[0].object_kind, "moment")
+        self.assertEqual(
+            ordinary_chat_task_support_plan(event_basis)[0].support_kind,
+            "hold",
+        )
+        for unsupported_response in (
+            "Attendance reached 50 people.",
+            "Fifty people attended.",
+            "Around 50 people attended.",
+            "The crowd reached 50 people.",
+        ):
+            with self.subTest(unsupported_response=unsupported_response):
+                classifications, unsupported = (
+                    audit_ordinary_chat_candidate_claims(
+                        event_basis,
+                        unsupported_response,
+                    )
+                )
+                self.assertGreaterEqual(unsupported, 1)
+                self.assertIn(
+                    "unsupported_packet_domain",
+                    classifications,
+                )
+
+        moment_digest = "f" * 64
+        moment_item = replace(
+            event_basis.packet.items[0],
+            lane="moment",
+            source_ref="moment:moment_prior_fixture",
+            source_digest=moment_digest,
+            text="Attendance reached 50 people.",
+            subject_key="",
+        )
+        supported_event_basis = replace(
+            event_basis,
+            packet=replace(event_basis.packet, items=(moment_item,)),
+            rendered_evidence_refs=(
+                ("E1", "moment", moment_digest, ()),
+            ),
+            rendered_source_digests=(moment_digest,),
+        )
+        support_plan = ordinary_chat_task_support_plan(
+            supported_event_basis
+        )
+        self.assertEqual(support_plan[0].support_kind, "packet")
+        self.assertEqual(support_plan[0].evidence_ids, ("E1",))
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            supported_event_basis,
+            "Attendance reached 50 people.",
+        )
+        self.assertEqual(unsupported, 0)
+        self.assertEqual(
+            classifications,
+            ("authorized_evidence_supported",),
+        )
+
+        named_event_frame, named_event_basis = (
+            self._basis_with_authority_frame(
+                "Who attended Woodstock?",
+                moment_id="moment_prior_fixture",
+            )
+        )
+        self.assertEqual(
+            named_event_frame.tasks[0].authority_scope,
+            "external_public",
+        )
+        classifications, unsupported = audit_ordinary_chat_candidate_claims(
+            named_event_basis,
+            "Jimi Hendrix performed at Woodstock.",
+        )
+        self.assertEqual(unsupported, 0)
+        self.assertNotIn("unsupported_packet_domain", classifications)
 
     def test_member_context_does_not_block_supported_external_knowledge(self):
         cases = (

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -3259,6 +3259,16 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                 "current_request",
             ),
             (
+                "@BNL-01, how do you boil an egg?",
+                "Place the egg in boiling water for about ten minutes.",
+                "external_public",
+            ),
+            (
+                "`<@99>`, when did Apollo 11 land?",
+                "It landed in 1969.",
+                "external_public",
+            ),
+            (
                 "@BNL-01, what does the word 'you' mean?",
                 "It is a second-person pronoun.",
                 "external_public",
@@ -3298,6 +3308,11 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
                 (),
             ),
             (
+                "@BNL-01, don't you know your birthday isn't January 1?",
+                "It is January 1.",
+                (),
+            ),
+            (
                 "@BNL-01's creator is who?",
                 "It was Test Creator.",
                 (),
@@ -3330,6 +3345,11 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             (
                 "<@202> was created when?",
                 "They were created in 1999.",
+                (202,),
+            ),
+            (
+                "<@202> has what birthday?",
+                "It is January 1.",
                 (202,),
             ),
         )

--- a/tests/test_unified_response_assessment_shadow.py
+++ b/tests/test_unified_response_assessment_shadow.py
@@ -55,6 +55,14 @@ class UnifiedResponseAssessmentShadowTests(unittest.TestCase):
                 "current_request",
             ),
             (
+                "@BNL-01, how do you boil an egg?",
+                "external_public",
+            ),
+            (
+                "`<@99>`, when did Apollo 11 land?",
+                "external_public",
+            ),
+            (
                 "@BNL-01, what does the word 'you' mean?",
                 "external_public",
             ),
@@ -95,6 +103,10 @@ class UnifiedResponseAssessmentShadowTests(unittest.TestCase):
             ("@BNL-01 When was BARCODE founded?", "barcode"),
             ("@BNL-01, when were you created?", "bnl_01"),
             ("@BNL-01, don't you know when you were created?", "bnl_01"),
+            (
+                "@BNL-01, don't you know your birthday isn't January 1?",
+                "bnl_01",
+            ),
             ("@BNL-01, when'd you launch?", "bnl_01"),
             ("@BNL-01, what's your origin?", "bnl_01"),
             ("@BNL-01's creator is who?", "bnl_01"),
@@ -137,6 +149,7 @@ class UnifiedResponseAssessmentShadowTests(unittest.TestCase):
             "<@202>'s birthday is when?",
             "<@202> 's birthday is when?",
             "<@202> was created when?",
+            "<@202> has what birthday?",
         ):
             with self.subTest(member_text=text):
                 frame = build_situation_frame_v1(

--- a/tests/test_unified_response_assessment_shadow.py
+++ b/tests/test_unified_response_assessment_shadow.py
@@ -30,6 +30,203 @@ FOUNDATION_SHADOWS = {
 
 
 class UnifiedResponseAssessmentShadowTests(unittest.TestCase):
+    def test_situation_frame_separates_addressing_from_governed_subjects(self):
+        external_cases = (
+            (
+                "@BNL-01 Sealed Row 9 provider fixture: In one paragraph, "
+                "what makes a community feel connected instead of merely "
+                "active?",
+                "external_public",
+            ),
+            (
+                "Hey **@BNL-01**. When did Apollo 11 land?",
+                "external_public",
+            ),
+            (
+                "Hey *<@99>*. When did Apollo 11 land?",
+                "external_public",
+            ),
+            (
+                "Please @BNL-01, can you tell me when Apollo 11 landed?",
+                "external_public",
+            ),
+            (
+                "@BNL-01 can you explain when Apollo 11 landed?",
+                "current_request",
+            ),
+            (
+                "@BNL-01, what does the word 'you' mean?",
+                "external_public",
+            ),
+            (
+                "@BNL-01, what does “your birthday” mean?",
+                "external_public",
+            ),
+            (
+                "@BNL-01, what does `your birthday` mean?",
+                "external_public",
+            ),
+            ("@BNL-01, how are you?", "current_request"),
+        )
+        for text, expected_authority in external_cases:
+            with self.subTest(text=text):
+                frame = build_situation_frame_v1(
+                    route_allowed=True,
+                    route_mode="normal_chat",
+                    conversation_surface="free_speak_sealed_mirror",
+                    channel_policy="sealed_test",
+                    current_text=text,
+                    current_speaker_user_ids=(101,),
+                    current_speaker_labels=("Test Member",),
+                    addressee_kinds=("discord_mention",),
+                    addressee_user_ids=(99,),
+                    explicit_mention_count=1,
+                    response_act="answer",
+                )
+
+                self.assertEqual(frame.subjects, ())
+                self.assertEqual(frame.subject_requirement, "not_applicable")
+                self.assertEqual(
+                    tuple(task.authority_scope for task in frame.tasks),
+                    (expected_authority,),
+                )
+
+        governed_cases = (
+            ("@BNL-01 When was BARCODE founded?", "barcode"),
+            ("@BNL-01, when were you created?", "bnl_01"),
+            ("@BNL-01, don't you know when you were created?", "bnl_01"),
+            ("@BNL-01, when'd you launch?", "bnl_01"),
+            ("@BNL-01, what's your origin?", "bnl_01"),
+            ("@BNL-01's creator is who?", "bnl_01"),
+            ("@BNL-01 's creator is who?", "bnl_01"),
+            ("@BNL-01 was created when?", "bnl_01"),
+            ("@BNL-01 can explain its origin?", "bnl_01"),
+            ("When was **@BNL-01** created?", "bnl_01"),
+        )
+        for text, expected_entity_ref in governed_cases:
+            with self.subTest(text=text):
+                frame = build_situation_frame_v1(
+                    route_allowed=True,
+                    route_mode="normal_chat",
+                    conversation_surface="free_speak_sealed_mirror",
+                    channel_policy="sealed_test",
+                    current_text=text,
+                    current_speaker_user_ids=(101,),
+                    current_speaker_labels=("Test Member",),
+                    addressee_kinds=("discord_mention",),
+                    addressee_user_ids=(99,),
+                    explicit_mention_count=1,
+                    response_act="answer",
+                )
+
+                self.assertEqual(frame.status, "resolved")
+                self.assertEqual(frame.subject_requirement, "required")
+                self.assertIn(
+                    expected_entity_ref,
+                    tuple(subject.entity_ref for subject in frame.subjects),
+                )
+                self.assertEqual(
+                    tuple(task.authority_scope for task in frame.tasks),
+                    ("packet",),
+                )
+                self.assertEqual(frame.tasks[0].subject_requirement, "required")
+                self.assertTrue(frame.tasks[0].subject_indexes)
+
+        for text in (
+            "When did <@202> join?",
+            "<@202>'s birthday is when?",
+            "<@202> 's birthday is when?",
+            "<@202> was created when?",
+        ):
+            with self.subTest(member_text=text):
+                frame = build_situation_frame_v1(
+                    route_allowed=True,
+                    route_mode="normal_chat",
+                    conversation_surface="free_speak_sealed_mirror",
+                    channel_policy="sealed_test",
+                    current_text=text,
+                    current_speaker_user_ids=(101,),
+                    current_speaker_labels=("Test Member",),
+                    subject_user_ids=(202,),
+                    subject_label_hints=("Second Member",),
+                    response_act="answer",
+                )
+
+                self.assertEqual(frame.subjects[0].user_id, 202)
+                self.assertEqual(frame.tasks[0].authority_scope, "packet")
+                self.assertEqual(frame.tasks[0].subject_indexes, (0,))
+
+    def test_situation_frame_requires_an_actual_event_referent(self):
+        ordinary_text = (
+            "Sealed Row 9 provider fixture: In one paragraph, what makes a "
+            "community feel connected instead of merely active?"
+        )
+        external_cases = (
+            ordinary_text,
+            "When did Apollo 11 land?",
+            "Who attended Woodstock?",
+        )
+        for moment_state in ("recent_active", "recent_finalized"):
+            for text in external_cases:
+                with self.subTest(moment_state=moment_state, text=text):
+                    frame = build_situation_frame_v1(
+                        route_allowed=True,
+                        route_mode="normal_chat",
+                        conversation_surface="free_speak_sealed_mirror",
+                        channel_policy="sealed_test",
+                        current_text=text,
+                        current_speaker_user_ids=(101,),
+                        current_speaker_labels=("Test Member",),
+                        moment_id="moment_prior_fixture",
+                        moment_situation_state=moment_state,
+                        moment_topic_coherent=True,
+                        moment_participant_overlap=True,
+                        response_act="answer",
+                    )
+
+                    self.assertTrue(frame.event_ref)
+                    self.assertEqual(frame.tasks[0].authority_scope, "external_public")
+
+        event_cases = (
+            "How many people attended?",
+            "Who participated?",
+            "What happened?",
+            "How did the test go?",
+            "Did it pass?",
+            "What changed in the recent event?",
+        )
+        for text in event_cases:
+            with self.subTest(text=text):
+                frame = build_situation_frame_v1(
+                    route_allowed=True,
+                    route_mode="normal_chat",
+                    conversation_surface="free_speak_sealed_mirror",
+                    channel_policy="sealed_test",
+                    current_text=text,
+                    current_speaker_user_ids=(101,),
+                    current_speaker_labels=("Test Member",),
+                    moment_id="moment_prior_fixture",
+                    moment_situation_state="recent_active",
+                    moment_topic_coherent=True,
+                    moment_participant_overlap=True,
+                    response_act="answer",
+                )
+
+                self.assertEqual(frame.tasks[0].authority_scope, "packet")
+                self.assertEqual(frame.tasks[0].object_kind, "moment")
+
+        no_event = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="free_speak_sealed_mirror",
+            channel_policy="sealed_test",
+            current_text="How many people attended?",
+            current_speaker_user_ids=(101,),
+            current_speaker_labels=("Test Member",),
+            response_act="answer",
+        )
+        self.assertEqual(no_event.tasks[0].authority_scope, "external_public")
+
     def shared_choice_assessment(self):
         final_question = (
             "Between Chrome Prophet and Null Basilica, which fits that "

--- a/tests/test_unified_response_assessment_shadow.py
+++ b/tests/test_unified_response_assessment_shadow.py
@@ -101,6 +101,14 @@ class UnifiedResponseAssessmentShadowTests(unittest.TestCase):
 
         governed_cases = (
             ("@BNL-01 When was BARCODE founded?", "barcode"),
+            (
+                "What do you know about BARCODE Radio?",
+                "barcode_radio",
+            ),
+            (
+                "What do you know about BARCODE Network?",
+                "barcode_network",
+            ),
             ("@BNL-01, when were you created?", "bnl_01"),
             ("@BNL-01, don't you know when you were created?", "bnl_01"),
             (
@@ -168,6 +176,47 @@ class UnifiedResponseAssessmentShadowTests(unittest.TestCase):
                 self.assertEqual(frame.subjects[0].user_id, 202)
                 self.assertEqual(frame.tasks[0].authority_scope, "packet")
                 self.assertEqual(frame.tasks[0].subject_indexes, (0,))
+
+    def test_project_context_does_not_expand_typed_subjects(self):
+        cases = (
+            (
+                "Who is DJ Floppydisc in BARCODE?",
+                ("dj_floppydisc",),
+            ),
+            (
+                "Tell me about Cache Back's work with BARCODE Radio.",
+                ("cache_back",),
+            ),
+            (
+                "Mac Modem and Cache Back are both part of BARCODE. "
+                "What is his role in the Network?",
+                ("mac_modem", "cache_back"),
+            ),
+        )
+        for text, typed_subjects in cases:
+            with self.subTest(text=text):
+                frame = build_situation_frame_v1(
+                    route_allowed=True,
+                    route_mode="normal_chat",
+                    conversation_surface="free_speak_sealed_mirror",
+                    channel_policy="sealed_test",
+                    current_text=text,
+                    current_speaker_user_ids=(101,),
+                    current_speaker_labels=("Test Member",),
+                    subject_entity_refs=typed_subjects,
+                    response_act="answer",
+                )
+
+                self.assertEqual(
+                    tuple(subject.entity_ref for subject in frame.subjects),
+                    typed_subjects,
+                )
+                self.assertTrue(
+                    all(
+                        task.authority_scope == "packet"
+                        for task in frame.tasks
+                    )
+                )
 
     def test_situation_frame_requires_an_actual_event_referent(self):
         ordinary_text = (


### PR DESCRIPTION
## Why

Row 9 proved the one-provider path, but two authority seams remained:

- an external-public Frame label could bypass packet review even when the request actually depended on BNL, BARCODE, a governed member, or a selected event;
- a recent Moment reference alone could affect claim authority even when the current public question did not refer to that event.

This PR closes those seams without adding another store, brain, gate, fallback, provider call, or site path.

## What changed

- Make the existing Situation Frame own one request-dependency classification.
- Separate a true leading vocative from factual subject grammar, including polite prefixes, punctuation, Markdown wrappers, possessives, second-person backreferences, contractions, quoted words, and leading-name predicates.
- Keep governed dependency routing separate from grammatical subject binding: contextual phrases may require packet authority without becoming extra subject identities.
- Bind explicit BNL/BARCODE subjects to their existing canon entities.
- Require an actual event referent before a selected Moment/episode owns the task.
- Reuse the Frame dependency decision in ordinary-chat claim review so a typed external-public task is trusted only when no governed dependency remains.
- Treat event-shaped answer subjects as packet-owned for event-dependent tasks, while allowing the same claim when selected Moment evidence supports it.

## Acceptance matrix

- Addressed Apollo/public-definition questions remain external-public.
- The exact live Row 9 community prompt remains external-public with a recent Moment attached.
- BNL creation/origin, BARCODE founding, and governed-member direct/possessive questions require packet support.
- Contextual phrases such as `DJ Floppydisc in BARCODE` and `Cache Back's work with BARCODE Radio` retain only the typed person as factual subject while still using packet authority.
- Recent Moment + unrelated public question does not activate event authority.
- Recent Moment + `How many people attended?` requires Moment/episode support.
- Unsupported attendance counts are rejected; the same count passes when its selected Moment evidence is present.
- Global Memory Governance, Relationship, Active Engagement, and Unified Moment live gates are untouched.

## Verification

- `make compile` — pass
- focused Frame/claim-review suites — 92/92 pass
- changed-owner integration sweep — 254/254 pass
- broad locally runnable subset — 1,118/1,118 pass (36 intentional skips)
- local `make check` remains dependency-limited because this scratch runtime lacks pinned `discord.py==2.7.1`
- pinned GitHub CI #373 — pass:
  - Python 3.9: 2,586/2,586
  - Python 3.12: 2,586/2,586
  - TikTok live transport contract: pass

CI #372 correctly exposed contextual BARCODE phrases being promoted into extra factual subjects. The follow-up commit separates dependency authority from subject identity and pins all three counterexamples.

Keep this PR draft for review. Do not merge or deploy without explicit approval.