### PR TITLE
Repair Row 9 Batch A integration seams

### DIFF
--- a/bnl01_bot.py
+++ b/bnl01_bot.py
@@ -189,8 +189,10 @@ from bnl_shared_brain_synthesis import (
     evaluate_single_packet_response,
     finalize_run as finalize_shared_brain_synthesis_run,
     honest_empty_profile_response,
+    ordinary_chat_response_json_schema,
     ordinary_chat_configuration,
     ordinary_chat_route_scope_decision,
+    parse_ordinary_chat_response_contract,
     publication_packet_composes_current_queue,
     publication_packet_owns_turn,
     record_fallback as record_shared_brain_synthesis_fallback,
@@ -15748,6 +15750,8 @@ class BatchConversationTurn:
     user_id: int
     addressing: DiscordTurnAddressing
     attribution_target_user_ids: tuple[int, ...] = ()
+    planned_directness: str = ""
+    planned_direct_to_bnl: bool = False
 
     def __iter__(self):
         yield self.name
@@ -15767,8 +15771,10 @@ def build_batched_conversation_turn(
     *,
     direct_to_bnl: bool = False,
     addressing: DiscordTurnAddressing | None = None,
+    planned_directness: str = "",
+    planned_direct_to_bnl: bool = False,
 ) -> BatchConversationTurn:
-    """Build a batch item without flattening reply/tag routing into user prose."""
+    """Build a batch item without flattening typed routing into user prose."""
     addressing = addressing or resolve_discord_turn_addressing(
         message,
         direct_to_bnl=direct_to_bnl,
@@ -15784,6 +15790,8 @@ def build_batched_conversation_turn(
             if int(target_user_id or 0) > 0
             else ()
         ),
+        planned_directness=str(planned_directness or ""),
+        planned_direct_to_bnl=bool(planned_direct_to_bnl),
     )
 
 
@@ -29579,6 +29587,15 @@ def _generation_config_for_model(
     config_kwargs = {
         "max_output_tokens": policy.max_output_tokens,
     }
+    if str(route or "") == ORDINARY_CHAT_SINGLE_PACKET_ROUTE:
+        config_kwargs.update(
+            {
+                "response_mime_type": "application/json",
+                "response_json_schema": (
+                    ordinary_chat_response_json_schema()
+                ),
+            }
+        )
     normalized_model = str(model_name or "").lower()
     if "gemini-2.5" in normalized_model:
         legacy_budget = min(
@@ -34447,6 +34464,12 @@ def _collapse_consecutive_batch_fragments(items):
     current_attribution_targets = set(
         getattr(items[0], "attribution_target_user_ids", ()) or ()
     )
+    current_planned_directness = str(
+        getattr(items[0], "planned_directness", "") or ""
+    )
+    current_planned_direct_to_bnl = bool(
+        getattr(items[0], "planned_direct_to_bnl", False)
+    )
     fragments = [current_content]
 
     for item in items[1:]:
@@ -34457,6 +34480,15 @@ def _collapse_consecutive_batch_fragments(items):
             fragments.append(content)
             current_attribution_targets.update(
                 getattr(item, "attribution_target_user_ids", ()) or ()
+            )
+            item_planned_directness = str(
+                getattr(item, "planned_directness", "") or ""
+            )
+            if item_planned_directness:
+                current_planned_directness = item_planned_directness
+            current_planned_direct_to_bnl = bool(
+                current_planned_direct_to_bnl
+                or getattr(item, "planned_direct_to_bnl", False)
             )
             continue
 
@@ -34469,6 +34501,8 @@ def _collapse_consecutive_batch_fragments(items):
                     current_uid,
                     current_addressing,
                     tuple(sorted(current_attribution_targets)),
+                    current_planned_directness,
+                    current_planned_direct_to_bnl,
                 )
             )
         else:
@@ -34477,6 +34511,12 @@ def _collapse_consecutive_batch_fragments(items):
         current_addressing = addressing
         current_attribution_targets = set(
             getattr(item, "attribution_target_user_ids", ()) or ()
+        )
+        current_planned_directness = str(
+            getattr(item, "planned_directness", "") or ""
+        )
+        current_planned_direct_to_bnl = bool(
+            getattr(item, "planned_direct_to_bnl", False)
         )
         fragments = [current_content]
 
@@ -34489,6 +34529,8 @@ def _collapse_consecutive_batch_fragments(items):
                 current_uid,
                 current_addressing,
                 tuple(sorted(current_attribution_targets)),
+                current_planned_directness,
+                current_planned_direct_to_bnl,
             )
         )
     else:
@@ -35274,8 +35316,15 @@ def _build_active_response_packet(channel_id: int, items, pending_state, pending
     should_generate = decision == "answer"
     request_action = _detect_request_action(combined_text)
     request_anchor_detected = bool(re.search(r"\b(these people|these things|this list|tell me|compare|rank|explain|describe|summarize|rewrite|respond to|answer)\b", combined_text.lower()))
-    addressed_to_bot = bool(
+    planned_direct_to_bnl = bool(
         any(
+            getattr(item, "planned_direct_to_bnl", False)
+            for item in original_items
+        )
+    )
+    addressed_to_bot = bool(
+        planned_direct_to_bnl
+        or any(
             getattr(item, "addressing", None)
             and (
                 getattr(item, "addressing").directly_targets_bnl
@@ -35290,7 +35339,8 @@ def _build_active_response_packet(channel_id: int, items, pending_state, pending
         )
     )
     response_obligation = bool(
-        any(
+        planned_direct_to_bnl
+        or any(
             getattr(item, "addressing", None)
             and getattr(item, "addressing").addresses_bnl
             for item in original_items
@@ -35303,7 +35353,14 @@ def _build_active_response_packet(channel_id: int, items, pending_state, pending
             if getattr(item, "addressing", None)
             and getattr(item, "addressing").addresses_bnl
         ),
-        "none",
+        next(
+            (
+                str(getattr(item, "planned_directness", "") or "")
+                for item in reversed(original_items)
+                if getattr(item, "planned_direct_to_bnl", False)
+            ),
+            "none",
+        ),
     )
     is_direct_question = "?" in combined_text
     has_structured_intent = _has_structured_intent(original_items, payload_items, pending_state=pending_request, pending_anchor=pending_anchor)
@@ -35322,6 +35379,7 @@ def _build_active_response_packet(channel_id: int, items, pending_state, pending
         "request_style": "list" if has_request_payload else "chat",
         "request_anchor_detected": request_anchor_detected,
         "has_structured_intent": has_structured_intent,
+        "planned_direct_to_bnl": planned_direct_to_bnl,
         "addressed_to_bot": addressed_to_bot,
         "response_obligation": response_obligation,
         "address_kind": address_kind,
@@ -37399,6 +37457,52 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             if batch_ordinary_chat_execution is not None
             else 0
         )
+        batch_typed_single_packet = bool(
+            batch_ordinary_chat_execution is not None
+            and batch_ordinary_chat_execution.typed_contract_required
+        )
+
+        async def _withhold_batch_typed_single_packet(
+            *,
+            reason: str,
+            guard_status: str,
+            frame_revalidation_status: str = "",
+            source_revalidation_status: str = "",
+        ) -> None:
+            """Finalize one-call batch output without exposing or rewriting it."""
+
+            nonlocal batch_synthesis_decision
+            batch_synthesis_decision = (
+                await safely_record_ordinary_chat_single_packet_review(
+                    batch_synthesis_decision,
+                    reason=reason,
+                    corrective_call_count=(
+                        batch_single_packet_corrective_call_count
+                    ),
+                    frame_revalidation_status=frame_revalidation_status,
+                    source_revalidation_status=source_revalidation_status,
+                )
+                or batch_synthesis_decision
+            )
+            await safely_finalize_shared_brain_synthesis(
+                batch_synthesis_decision,
+                final_response="",
+                response_sent=False,
+                candidate_live=False,
+                guard_status=guard_status,
+            )
+            logging.warning(
+                "ordinary_chat_typed_single_packet_withheld route=batch "
+                "reason=%s provider_calls=%s corrective_calls=%s",
+                reason,
+                (
+                    batch_ordinary_chat_execution.provider_call_count
+                    if batch_ordinary_chat_execution is not None
+                    else 0
+                ),
+                batch_single_packet_corrective_call_count,
+            )
+
         if batch_single_packet_cutover:
             response = batch_ordinary_chat_execution.response
             prompt = batch_ordinary_chat_execution.prompt
@@ -37423,6 +37527,14 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
             batch_review_reason = (
                 batch_ordinary_chat_execution.review_reason
             )
+            if batch_typed_single_packet:
+                await _withhold_batch_typed_single_packet(
+                    reason=batch_review_reason,
+                    guard_status=(
+                        "typed_batch_single_packet_candidate_rejected"
+                    ),
+                )
+                return
             review_diagnostics = {
                 "suppressed": True,
                 "suppression_reason": batch_review_reason,
@@ -37543,8 +37655,11 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 ),
                 prompt_source_bases=tuple(batch_prompt_source_bases),
                 regeneration_allowed=bool(
-                    batch_single_packet_cutover
-                    or not batch_synthesis_candidate_active
+                    not batch_typed_single_packet
+                    and (
+                        batch_single_packet_cutover
+                        or not batch_synthesis_candidate_active
+                    )
                 ),
                 situation_frame=(
                     orchestration_state["decision"].situation_frame
@@ -37559,6 +37674,14 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 guard_diagnostics.get("suppression_reason")
                 or "single_packet_guard_repair_required"
             )
+            if batch_typed_single_packet:
+                await _withhold_batch_typed_single_packet(
+                    reason=batch_single_packet_guard_reason,
+                    guard_status=(
+                        "typed_batch_single_packet_guard_rejected"
+                    ),
+                )
+                return
             (
                 response,
                 prompt,
@@ -37817,6 +37940,17 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                 )
             return
         if guard_diagnostics.get("suppressed"):
+            if batch_typed_single_packet:
+                await _withhold_batch_typed_single_packet(
+                    reason=str(
+                        guard_diagnostics.get("suppression_reason")
+                        or "typed_batch_single_packet_guard_rejected"
+                    ),
+                    guard_status=(
+                        "typed_batch_single_packet_guard_rejected"
+                    ),
+                )
+                return
             (
                 response,
                 prompt,
@@ -37894,6 +38028,14 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                             "exact_quote_guard_reason": presend_quote_failure,
                         }
                     )
+                    if batch_typed_single_packet:
+                        await _withhold_batch_typed_single_packet(
+                            reason=presend_quote_failure,
+                            guard_status=(
+                                "typed_batch_single_packet_quote_rejected"
+                            ),
+                        )
+                        return
                     (
                         response,
                         prompt,
@@ -38031,6 +38173,15 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                     "prompt_source_basis_changed": True,
                 }
             )
+            if batch_typed_single_packet:
+                await _withhold_batch_typed_single_packet(
+                    reason=batch_source_failure,
+                    guard_status=(
+                        "typed_batch_single_packet_source_changed"
+                    ),
+                    source_revalidation_status=batch_source_failure,
+                )
+                return
             (
                 response,
                 prompt,
@@ -38376,6 +38527,17 @@ async def _flush_channel_buffer(channel: discord.TextChannel, scheduler_wait_sta
                         "suppression_reason": frame_rewrite_reason,
                     }
                 )
+                if batch_typed_single_packet:
+                    await _withhold_batch_typed_single_packet(
+                        reason=frame_rewrite_reason,
+                        guard_status=(
+                            "typed_batch_single_packet_frame_changed"
+                        ),
+                        frame_revalidation_status=(
+                            batch_frame_revalidation.status
+                        ),
+                    )
+                    return
                 (
                     response,
                     prompt,
@@ -42778,6 +42940,7 @@ class OrdinaryChatSinglePacketExecution:
     provider_call_count: int
     corrective_call_count: int
     review_reason: str = ""
+    typed_contract_required: bool = False
 
 
 def _begin_ordinary_chat_single_packet_receipt(
@@ -43285,11 +43448,12 @@ async def maybe_generate_ordinary_chat_single_packet(
     source_context_available: bool,
     prompt_source_bases: tuple[PromptSourceBasis, ...] = (),
 ) -> OrdinaryChatSinglePacketExecution | None:
-    """Generate one natural response from the shared packet when available.
+    """Generate one typed, locally validated response from the shared packet.
 
-    Packet and receipt failures are diagnostic conditions, not response
-    authority. Returning ``None`` leaves the caller on the same normal BNL
-    generation path instead of substituting a canned block message.
+    A pre-provider packet failure may leave the caller on normal generation.
+    Once this route calls the provider, however, it owns the turn: malformed
+    or rejected output is recorded and withheld instead of triggering a
+    second physical call or exposing the non-visible response envelope.
     """
 
     if not scope_applied:
@@ -43353,6 +43517,7 @@ async def maybe_generate_ordinary_chat_single_packet(
     generation_started = time.monotonic()
     provider_call_count = 0
     tracked_generation = TrackedGenerationResponse("", 0)
+    response_contract = parse_ordinary_chat_response_contract("")
     try:
         tracked_generation = await get_tracked_gemini_response_with_optional_typing(
             channel,
@@ -43362,7 +43527,10 @@ async def maybe_generate_ordinary_chat_single_packet(
             route=ORDINARY_CHAT_SINGLE_PACKET_ROUTE,
             source_context_available=source_context_available,
         )
-        candidate = str(tracked_generation.text or "").strip()
+        response_contract = parse_ordinary_chat_response_contract(
+            tracked_generation.text
+        )
+        candidate = response_contract.response
         provider_call_count = tracked_generation.provider_call_count
     except Exception as exc:
         logging.warning(
@@ -43401,8 +43569,8 @@ async def maybe_generate_ordinary_chat_single_packet(
             provider_error_code=(
                 tracked_generation.provider_error_code
             ),
-            response_contract=None,
-            typed_contract_required=False,
+            response_contract=response_contract,
+            typed_contract_required=True,
         )
     except Exception as exc:
         logging.warning(
@@ -43431,27 +43599,36 @@ async def maybe_generate_ordinary_chat_single_packet(
             )
             or decision
         )
-    if candidate:
-        return OrdinaryChatSinglePacketExecution(
-            decision=decision,
-            response=candidate,
-            prompt=packet_prompt.prompt,
-            prompt_source_bases=(*tuple(prompt_source_bases or ()), basis),
-            candidate_active=bool(decision.candidate_selected),
-            provider_call_count=provider_call_count,
-            corrective_call_count=0,
-            review_reason=(
-                ""
-                if decision.candidate_selected
-                else str(decision.fallback_reason or "candidate_advisory")
-            ),
-        )
-    logging.warning(
-        "ordinary_chat_shared_brain_generation_empty reason=%s "
-        "response_path=normal_generation",
-        str(decision.fallback_reason or "generation_failed"),
+    review_reason = (
+        ""
+        if decision.candidate_selected
+        else str(decision.fallback_reason or "candidate_advisory")
     )
-    return None
+    execution = OrdinaryChatSinglePacketExecution(
+        decision=decision,
+        response=candidate,
+        prompt=packet_prompt.prompt,
+        prompt_source_bases=(*tuple(prompt_source_bases or ()), basis),
+        candidate_active=bool(decision.candidate_selected),
+        provider_call_count=provider_call_count,
+        corrective_call_count=0,
+        review_reason=review_reason,
+        typed_contract_required=True,
+    )
+    if not candidate:
+        logging.warning(
+            "ordinary_chat_shared_brain_generation_withheld reason=%s "
+            "response_path=no_second_call",
+            str(review_reason or "generation_failed"),
+        )
+        await safely_finalize_shared_brain_synthesis(
+            decision,
+            final_response="",
+            response_sent=False,
+            candidate_live=False,
+            guard_status="typed_single_packet_response_withheld",
+        )
+    return execution
 
 
 def build_ordinary_chat_response_repair_prompt(
@@ -43769,6 +43946,10 @@ async def send_planned_conversation_response(
         ordinary_chat_single_packet_execution is not None
     )
     single_packet_cutover = single_packet_receipt_present
+    typed_single_packet = bool(
+        ordinary_chat_single_packet_execution is not None
+        and ordinary_chat_single_packet_execution.typed_contract_required
+    )
     single_packet_corrective_call_count = int(
         ordinary_chat_single_packet_execution.corrective_call_count
         if ordinary_chat_single_packet_execution is not None
@@ -43821,12 +44002,57 @@ async def send_planned_conversation_response(
         prompt = baseline_prompt
         prompt_source_bases = baseline_prompt_source_bases
 
+    async def _withhold_typed_single_packet(
+        *,
+        reason: str,
+        guard_status: str,
+        frame_revalidation_status: str = "",
+        source_revalidation_status: str = "",
+    ) -> None:
+        """Finalize one-call output without exposing or regenerating it."""
+
+        nonlocal synthesis_decision
+        synthesis_decision = (
+            await safely_record_ordinary_chat_single_packet_review(
+                synthesis_decision,
+                reason=reason,
+                corrective_call_count=single_packet_corrective_call_count,
+                frame_revalidation_status=frame_revalidation_status,
+                source_revalidation_status=source_revalidation_status,
+            )
+            or synthesis_decision
+        )
+        await safely_finalize_shared_brain_synthesis(
+            synthesis_decision,
+            final_response="",
+            response_sent=False,
+            candidate_live=False,
+            guard_status=guard_status,
+        )
+        logging.warning(
+            "ordinary_chat_typed_single_packet_withheld reason=%s "
+            "provider_calls=%s corrective_calls=%s",
+            reason,
+            (
+                ordinary_chat_single_packet_execution.provider_call_count
+                if ordinary_chat_single_packet_execution is not None
+                else 0
+            ),
+            single_packet_corrective_call_count,
+        )
+
     if (
         single_packet_cutover
         and ordinary_chat_single_packet_execution is not None
         and ordinary_chat_single_packet_execution.review_reason
     ):
         review_reason = ordinary_chat_single_packet_execution.review_reason
+        if typed_single_packet:
+            await _withhold_typed_single_packet(
+                reason=review_reason,
+                guard_status="typed_single_packet_candidate_rejected",
+            )
+            return model_decision
         review_diagnostics = {
             "suppressed": True,
             "suppression_reason": review_reason,
@@ -43966,7 +44192,11 @@ async def send_planned_conversation_response(
         # evidence can require a grounded rewrite, but it cannot turn the
         # guard into a response veto.
         regeneration_allowed=bool(
-            single_packet_cutover or not synthesis_candidate_active
+            not typed_single_packet
+            and (
+                single_packet_cutover
+                or not synthesis_candidate_active
+            )
         ),
     )
     if (
@@ -43977,6 +44207,12 @@ async def send_planned_conversation_response(
             guard_diagnostics.get("suppression_reason")
             or "single_packet_guard_repair_required"
         )
+        if typed_single_packet:
+            await _withhold_typed_single_packet(
+                reason=reason,
+                guard_status="typed_single_packet_guard_rejected",
+            )
+            return model_decision
         (
             response,
             prompt,
@@ -44132,6 +44368,15 @@ async def send_planned_conversation_response(
         or guard_diagnostics.get("regenerated_for_register_mismatch")
     )
     if guard_diagnostics.get("suppressed"):
+        if typed_single_packet:
+            await _withhold_typed_single_packet(
+                reason=str(
+                    guard_diagnostics.get("suppression_reason")
+                    or "typed_single_packet_guard_rejected"
+                ),
+                guard_status="typed_single_packet_guard_rejected",
+            )
+            return model_decision
         (
             response,
             prompt,
@@ -44288,6 +44533,12 @@ async def send_planned_conversation_response(
                     "exact_quote_guard_reason": quote_presend_failure,
                 }
             )
+            if typed_single_packet:
+                await _withhold_typed_single_packet(
+                    reason=quote_presend_failure,
+                    guard_status="typed_single_packet_quote_rejected",
+                )
+                return model_decision
             (
                 response,
                 prompt,
@@ -44390,6 +44641,13 @@ async def send_planned_conversation_response(
                 "prompt_source_basis_changed": True,
             }
         )
+        if typed_single_packet:
+            await _withhold_typed_single_packet(
+                reason=direct_source_failure,
+                guard_status="typed_single_packet_source_changed",
+                source_revalidation_status=direct_source_failure,
+            )
+            return model_decision
         (
             response,
             prompt,
@@ -44603,6 +44861,15 @@ async def send_planned_conversation_response(
                     "suppression_reason": frame_rewrite_reason,
                 }
             )
+            if typed_single_packet:
+                await _withhold_typed_single_packet(
+                    reason=frame_rewrite_reason,
+                    guard_status="typed_single_packet_frame_changed",
+                    frame_revalidation_status=(
+                        final_frame_revalidation.status
+                    ),
+                )
+                return model_decision
             (
                 response,
                 prompt,
@@ -46161,6 +46428,10 @@ async def on_message(message: discord.Message):
                 conversation_content,
                 direct_to_bnl=real_direct_target,
                 addressing=turn_addressing,
+                planned_directness=conversation_plan.directness,
+                planned_direct_to_bnl=(
+                    conversation_plan_is_directed_to_bnl(conversation_plan)
+                ),
             )
         )
         _channel_last_message_at[message.channel.id] = datetime.now(PACIFIC_TZ)

--- a/bnl_shared_brain_synthesis.py
+++ b/bnl_shared_brain_synthesis.py
@@ -81,7 +81,7 @@ PUBLIC_HOME_OWNER_CHANNEL_IDS_ENV = (
 )
 ORDINARY_CHAT_CAPABILITY_NAME = "ordinary_chat_single_packet_canary"
 ORDINARY_CHAT_CAPABILITY_CONTRACT_VERSION = (
-    "ordinary_chat_single_packet_v6"
+    "ordinary_chat_single_packet_v7"
 )
 ORDINARY_CHAT_ENABLED_ENV = "BNL_ORDINARY_CHAT_SINGLE_PACKET_ENABLED"
 ORDINARY_CHAT_SCOPED_EXPANSION_ENABLED_ENV = (
@@ -552,8 +552,8 @@ _PACKET_EVENT_CLAIM_SUBJECT_RE = re.compile(
     r"show)\b|"
     r"^(?:(?:about|around|approximately|roughly|nearly|over|under|"
     r"more\s+than|fewer\s+than)\s+)?"
-    r"(?:\d+|[a-z]+(?:-[a-z]+)?)\s+"
-    r"(?:people|members|participants)\b",
+    r"(?:\d+|[a-z]+(?:-[a-z]+)?(?:\s+[a-z]+(?:-[a-z]+)?){0,5})\s+"
+    r"(?:humans?|people|members|participants)\b",
     re.I,
 )
 _PACKET_CLAUSE_TAIL_BOUNDARY_RE = re.compile(
@@ -3494,7 +3494,7 @@ def ordinary_chat_task_support_plan(
 def render_ordinary_chat_task_contract(
     basis: SharedBrainSynthesisBasis,
 ) -> str:
-    """Render ordered task/support guidance for one natural BNL response."""
+    """Render ordered task/support guidance for one typed provider result."""
 
     tasks = _ordinary_frame_tasks(basis)
     if not tasks:
@@ -3557,10 +3557,14 @@ def render_ordinary_chat_task_contract(
         + ("\n".join(evidence_lines) if evidence_lines else "- none")
         + "\n- PUBLIC may support stable general public knowledge only.\n"
         + "- REQUEST may support a non-factual conversational response only.\n"
-        + "VISIBLE RESPONSE CONTRACT:\n"
-        + "Write one natural BNL reply, not JSON. Answer every task in order "
-        + "and combine them coherently instead of treating one task as a "
-        + "reason to drop another. Use each task's listed packet support "
+        + "ONE-CALL RESPONSE ENVELOPE:\n"
+        + "Return the structured task result required by the provider response "
+        + "schema. Return one task object for every task above, in the same "
+        + "order. Copy its taskId, supportKind, and evidenceIds exactly from "
+        + "the corresponding TURN RESPONSE PLAN line. The text field is the "
+        + "only user-visible part. Make the ordered text fields combine into "
+        + "one natural, coherent BNL reply without repetition. Use each task's "
+        + "listed packet support "
         + "together with relevant authorized context already present in this "
         + "prompt for BARCODE, member, publication, history, or current-state "
         + "facts. "
@@ -3568,9 +3572,65 @@ def render_ordinary_chat_task_contract(
         + "verified and continue answering the remaining tasks. For "
         + "response=clarify, ask the natural clarification the task requires. "
         + "For response=refuse, answer naturally without revealing the "
-        + "protected values. Never mention task IDs, support kinds, evidence "
-        + "IDs, packets, lanes, contracts, validators, or internal controls."
+        + "protected values. Do not volunteer source availability, indexing, "
+        + "compilation, archive-status, or next-step notes unless the user "
+        + "asked for them. Never put task IDs, support kinds, evidence IDs, "
+        + "packets, lanes, schemas, contracts, validators, or internal controls "
+        + "inside a text field."
     )
+
+
+def ordinary_chat_response_json_schema() -> dict[str, Any]:
+    """Return the provider schema for the non-visible one-call envelope."""
+
+    return {
+        "type": "object",
+        "properties": {
+            "tasks": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 12,
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "taskId": {
+                            "type": "string",
+                            "enum": [f"T{index}" for index in range(1, 13)],
+                        },
+                        "text": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 2000,
+                        },
+                        "supportKind": {
+                            "type": "string",
+                            "enum": [
+                                "packet",
+                                "external_public",
+                                "current_request",
+                                "hold",
+                                "clarify",
+                            ],
+                        },
+                        "evidenceIds": {
+                            "type": "array",
+                            "maxItems": 8,
+                            "items": {"type": "string"},
+                        },
+                    },
+                    "required": [
+                        "taskId",
+                        "text",
+                        "supportKind",
+                        "evidenceIds",
+                    ],
+                    "additionalProperties": False,
+                },
+            }
+        },
+        "required": ["tasks"],
+        "additionalProperties": False,
+    }
 
 
 def parse_ordinary_chat_response_contract(

--- a/bnl_unified_intelligence_packet.py
+++ b/bnl_unified_intelligence_packet.py
@@ -81,6 +81,7 @@ from bnl_journal import (
 )
 from bnl_moment_engine import (
     SITUATION_EPISODE_READ_VERSION,
+    render_active_episode_canary_context,
     select_public_participant_moment_gists,
     select_situation_aware_episode_gists,
 )
@@ -100,6 +101,9 @@ from bnl_website_relay_state import (
 SCHEMA_VERSION = "unified_intelligence_packet_v12"
 SUBJECT_RESOLUTION_VERSION = "governed_packet_subject_resolution_v1"
 SOURCE_SNAPSHOT_VERSION = "unified_packet_source_snapshot_v2"
+SEALED_ACTIVE_EPISODE_PACKET_VERSION = (
+    "sealed_active_episode_packet_v1"
+)
 JOURNAL_PUBLICATION_SOURCE_CLASS = "journal_publication_projection"
 RELAY_PUBLICATION_SOURCE_CLASS = "relay_publication_projection"
 TABLE_NAME = "memory_governance_intelligence_packet_runs"
@@ -294,6 +298,9 @@ _EPISODE_QUERY_RE = re.compile(
     r"what\s+was\s+(?:retested|tested\s+again|completed|resolved)|"
     r"(?:correction|retest|retry|completion)\s+(?:history|result|status)|"
     r"(?:resume|continue|reopen|return\s+to)\s+(?:that|this|the)|"
+    r"(?:how\s+many\s+(?:humans?|people|members|participants)|who)\s+"
+    r"(?:attended|participated|joined|showed\s+up|took\s+part)|"
+    r"how\s+many\s+(?:humans?|people|members|participants)\s+were\s+there|"
     r"(?:moment|episode|open\s+loop|unresolved\s+thread)s?)\b",
     re.I,
 )
@@ -2862,6 +2869,88 @@ def _episode_projection_digest(
     )
 
 
+def _sealed_active_episode_projection(
+    conn: sqlite3.Connection,
+    request: IntelligencePacketRequest,
+    *,
+    expected_episode_id: str = "",
+) -> tuple[
+    str,
+    Any,
+    tuple[str, ...],
+    tuple[str, ...],
+    str,
+    str,
+] | None:
+    """Read one existing sealed aggregate and bind all source lineage."""
+
+    reference_out: dict[str, Any] = {}
+    context = render_active_episode_canary_context(
+        conn,
+        guild_id=int(request.guild_id or 0),
+        channel_id=int(request.channel_id or 0),
+        channel_policy=str(request.channel_policy or ""),
+        route_mode=str(request.route_mode or "unknown"),
+        topic_text=str(request.user_text or "")[:8000],
+        now=request.now or None,
+        expected_episode_id=str(expected_episode_id or ""),
+        reference_out=reference_out,
+    )
+    reference = reference_out.get("reference")
+    if not context or reference is None:
+        return None
+    roots: list[str] = []
+    occurrences: list[str] = []
+    for moment_id in tuple(reference.source_moment_ids or ()):
+        moment_roots, moment_occurrences = _moment_all_root_metadata(
+            conn,
+            moment_id=moment_id,
+        )
+        roots.extend(moment_roots)
+        occurrences.extend(moment_occurrences)
+    bound_roots = tuple(dict.fromkeys(roots))
+    bound_occurrences = tuple(dict.fromkeys(occurrences))
+    if not bound_roots or not bound_occurrences:
+        return None
+    episode_row = conn.execute(
+        """
+        SELECT last_activity_at
+        FROM memory_moment_episodes
+        WHERE episode_id=? AND guild_id=? AND channel_id=?
+          AND channel_policy='sealed_test' AND route_mode=?
+        """,
+        (
+            reference.episode_id,
+            int(request.guild_id or 0),
+            int(request.channel_id or 0),
+            str(request.route_mode or "unknown"),
+        ),
+    ).fetchone()
+    if not episode_row or not str(episode_row[0] or ""):
+        return None
+    source_digest = _digest(
+        SEALED_ACTIVE_EPISODE_PACKET_VERSION,
+        context,
+        reference.episode_id,
+        reference.lifecycle_status,
+        tuple(reference.source_moment_ids or ()),
+        int(reference.participant_count or 0),
+        int(reference.open_loop_count or 0),
+        tuple(reference.semantic_types or ()),
+        bound_roots,
+        bound_occurrences,
+        str(episode_row[0] or ""),
+    )
+    return (
+        context,
+        reference,
+        bound_roots,
+        bound_occurrences,
+        source_digest,
+        str(episode_row[0] or ""),
+    )
+
+
 def _episode_items(
     conn: sqlite3.Connection,
     request: IntelligencePacketRequest,
@@ -2878,6 +2967,69 @@ def _episode_items(
         str(request.frame_subject_requirement or "").strip().lower()
         == "required"
     )
+    if (
+        str(request.channel_policy or "").strip().lower()
+        == "sealed_test"
+        and not subject_required
+    ):
+        projection = _sealed_active_episode_projection(conn, request)
+        if projection is not None:
+            (
+                context,
+                reference,
+                roots,
+                occurrences,
+                source_digest,
+                observed_at,
+            ) = projection
+            event_ref = str(request.frame_event_ref or "").strip()
+            if event_ref not in reference.source_moment_ids:
+                event_ref = str(reference.source_moment_ids[-1] or "")
+            item = IntelligencePacketItem(
+                lane="episode",
+                source_class="moment_gist",
+                source_type="sealed_active_episode_aggregate",
+                source_ref="episode:%s:sealed-active"
+                % reference.episode_id,
+                source_digest=source_digest,
+                subject_key="event:%s" % reference.episode_id,
+                predicate_key="active_episode_aggregate",
+                text=context[:1200],
+                visibility="sealed_test",
+                confidence="high",
+                lifecycle=reference.lifecycle_status,
+                authority=_AUTHORITY_RANK["moment_gist"],
+                lineage=roots,
+                observed_at=observed_at,
+                usage="episode_aggregate",
+                score=94.0,
+                revalidation_kind="sealed_active_episode",
+                revalidation_key=reference.episode_id,
+                root_identities=roots,
+                occurrence_identities=occurrences,
+                event_ref=event_ref,
+                episode_ref=reference.episode_id,
+                event_relation=str(
+                    request.frame_event_relation or "same_event"
+                ),
+                phase=str(request.frame_phase or ""),
+                uncertainty_status="sealed_same_channel_aggregate",
+            )
+            diagnostics.episode_candidate_count = 1
+            if _route_allows_item(request, item):
+                diagnostics.episode_query_status = "selected"
+                diagnostics.candidates_by_lane["episode"] = (
+                    diagnostics.candidates_by_lane.get("episode", 0) + 1
+                )
+                return [item]
+            diagnostics.visibility_exclusions += 1
+            _add_exclusion(
+                diagnostics,
+                exclusions,
+                lane="episode",
+                reason="episode_visibility",
+                source_class=item.source_class,
+            )
     subject_key = str(subject_resolution.subject_key or "")
     if subject_required and not re.fullmatch(
         r"discord_user:[1-9]\d*",
@@ -5911,6 +6063,54 @@ def _episode_version(
     return ""
 
 
+def _sealed_active_episode_version(
+    conn: sqlite3.Connection,
+    packet: UnifiedIntelligencePacket,
+    item: IntelligencePacketItem,
+) -> str:
+    projection = _sealed_active_episode_projection(
+        conn,
+        packet.request,
+        expected_episode_id=str(item.revalidation_key or ""),
+    )
+    if projection is None:
+        return ""
+    (
+        context,
+        reference,
+        roots,
+        occurrences,
+        source_digest,
+        observed_at,
+    ) = projection
+    event_ref = str(packet.request.frame_event_ref or "").strip()
+    if event_ref not in reference.source_moment_ids:
+        event_ref = str(reference.source_moment_ids[-1] or "")
+    if not (
+        item.source_type == "sealed_active_episode_aggregate"
+        and item.source_ref
+        == "episode:%s:sealed-active" % reference.episode_id
+        and item.revalidation_key == reference.episode_id
+        and item.subject_key == "event:%s" % reference.episode_id
+        and item.predicate_key == "active_episode_aggregate"
+        and item.text == context[:1200]
+        and item.visibility == "sealed_test"
+        and item.lifecycle == reference.lifecycle_status
+        and item.lineage == roots
+        and item.observed_at == observed_at
+        and item.usage == "episode_aggregate"
+        and item.root_identities == roots
+        and item.occurrence_identities == occurrences
+        and item.event_ref == event_ref
+        and item.episode_ref == reference.episode_id
+        and item.event_relation
+        == str(packet.request.frame_event_relation or "same_event")
+        and item.uncertainty_status == "sealed_same_channel_aggregate"
+    ):
+        return ""
+    return source_digest
+
+
 def _show_episode_version(
     conn: sqlite3.Connection,
     packet: UnifiedIntelligencePacket,
@@ -6438,6 +6638,12 @@ def _revalidate_packet_in_snapshot(
                 current = _moment_version(conn, packet, item)
             elif item.revalidation_kind == "episode":
                 current = _episode_version(conn, packet, item)
+            elif item.revalidation_kind == "sealed_active_episode":
+                current = _sealed_active_episode_version(
+                    conn,
+                    packet,
+                    item,
+                )
             elif item.revalidation_kind == "show_episode":
                 current = _show_episode_version(
                     conn,

--- a/bnl_unified_response_assessment.py
+++ b/bnl_unified_response_assessment.py
@@ -415,6 +415,12 @@ _SITUATION_LEADING_ADDRESSEE_RE = re.compile(
     r"(?P<space>\s*)",
     re.I,
 )
+_SITUATION_TRAILING_BNL_ADDRESSEE_RE = re.compile(
+    r"(?P<body>[\s\S]*?)(?P<delimiter>[.,;:!?—–])\s*"
+    r"@?BNL(?:[- ]?0?1)?"
+    r"(?![- ]?0?1[a-z0-9_])(?![a-z0-9_])\s*[.!?]*\s*$",
+    re.I,
+)
 _SITUATION_LEADING_SUBJECT_PREDICATE_RE = re.compile(
     r"^(?:is|was|are|were|has|had|does|did|"
     r"(?:can|could|would|will|should)(?!\s+you\b)|"
@@ -479,7 +485,8 @@ _SITUATION_ENTITY_SUBJECT_QUESTION_RE = re.compile(
     re.I,
 )
 _SITUATION_ENTITY_SUBJECT_REQUEST_RE = re.compile(
-    r"\b(?:tell\s+me\s+about|what\s+do\s+you\s+"
+    r"\b(?:(?:who|what)\s+(?:created|built|made|founded|started)|"
+    r"tell\s+me\s+about|what\s+do\s+you\s+"
     r"(?:know|remember)\s+about|describe|summari[sz]e|explain)"
     r"\s+(?:the\s+)?$",
     re.I,
@@ -493,11 +500,12 @@ _SITUATION_EXPLICIT_EVENT_REFERENT_RE = re.compile(
 )
 _SITUATION_IMPLICIT_EVENT_QUERY_RE = re.compile(
     r"(?:"
-    r"(?:how\s+many\s+(?:people|members|participants)|who)\s+"
-    r"(?:attended|participated|joined|showed\s+up)"
+    r"(?:how\s+many\s+(?:humans?|people|members|participants)|who)\s+"
+    r"(?:attended|participated|joined|showed\s+up|took\s+part)"
     r"(?:\s+(?:it|this|that|there))?|"
-    r"how\s+many\s+(?:people|members|participants)\s+were\s+there|"
-    r"what\s+(?:happened|changed|failed|was\s+decided|got\s+fixed)|"
+    r"how\s+many\s+(?:humans?|people|members|participants)\s+were\s+there|"
+    r"what\s+(?:happened|changed|failed|was\s+decided|got\s+fixed|"
+    r"(?:are|were)\s+the\s+final\s+(?:settings|parameters|results))|"
     r"how\s+did\s+(?:it|this|that|the\s+(?:test|run|show|session))\s+go|"
     r"did\s+(?:it|this|that)\s+(?:work|pass|fail|finish|end|start)|"
     r"when\s+did\s+(?:it|this|that)\s+(?:start|end|happen|finish)"
@@ -838,15 +846,20 @@ def _situation_subject_text(value: str) -> str:
 
     text = _situation_plain_text(value).strip()
     match = _SITUATION_LEADING_ADDRESSEE_RE.match(text)
-    if match is None or match.group("possessive"):
-        return text
-    remainder = text[match.end() :].lstrip()
-    if (
-        not match.group("delimiter")
-        and _SITUATION_LEADING_SUBJECT_PREDICATE_RE.match(remainder)
-    ):
-        return text
-    return remainder
+    if match is not None and not match.group("possessive"):
+        remainder = text[match.end() :].lstrip()
+        if (
+            match.group("delimiter")
+            or not _SITUATION_LEADING_SUBJECT_PREDICATE_RE.match(remainder)
+        ):
+            text = remainder
+    trailing = _SITUATION_TRAILING_BNL_ADDRESSEE_RE.fullmatch(text)
+    if trailing is not None:
+        delimiter = trailing.group("delimiter")
+        text = trailing.group("body").rstrip()
+        if delimiter in ".!?":
+            text += delimiter
+    return text
 
 
 def _situation_bnl_self_subject_cue(value: str) -> bool:
@@ -1043,7 +1056,15 @@ def _situation_task_segments(text: str) -> Tuple[str, ...]:
     parts = tuple(part.strip(" ,;.!?") for part in value.split("\n"))
     parts = tuple(part for part in parts if part)
     explicit_tasks = tuple(
-        part for part in parts if _TASK_SEGMENT_START_RE.search(part)
+        part
+        for part in parts
+        if _TASK_SEGMENT_START_RE.search(part)
+        or re.search(
+            r":\s*(?:(?:briefly|please|quickly|first)\s+)*(?:%s)"
+            % _TASK_LEAD_RE.pattern,
+            part,
+            re.I,
+        )
     )
     if explicit_tasks and len(parts) > 1:
         return explicit_tasks
@@ -1482,6 +1503,17 @@ def build_situation_frame_v1(
         _EXTERNAL_ROLE_QUERY_RE.search(request_subject_text)
     )
 
+    event_label_context = bool(
+        str(moment_id or "").strip()
+        and (
+            _SITUATION_EXPLICIT_EVENT_REFERENT_RE.search(
+                request_subject_text
+            )
+            or _SITUATION_IMPLICIT_EVENT_QUERY_RE.search(
+                request_subject_text
+            )
+        )
+    )
     subjects = []
     if subject_ids:
         for index, user_id in enumerate(subject_ids):
@@ -1520,7 +1552,12 @@ def build_situation_frame_v1(
                     domain_hints=domains,
                 )
             )
-    elif not subject_ids and label_hints:
+    if (
+        not entity_refs
+        and not subject_ids
+        and label_hints
+        and not event_label_context
+    ):
         for label_hint in label_hints:
             subjects.append(
                 SituationSubjectReference(

--- a/tests/test_conversation_batching.py
+++ b/tests/test_conversation_batching.py
@@ -648,6 +648,70 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
             "prompt": generation.await_args.args[1],
         }
 
+    async def test_recent_followup_directness_survives_batch_buffer(self):
+        channel = self._channel(8146)
+        message = FakeMessage(
+            channel,
+            "How is he connected to Call'em Bini?",
+        )
+
+        with (
+            self._on_message_runtime(
+                channel.id,
+                followup_candidate=True,
+            ),
+            mock.patch.object(bnl01_bot, "_reset_debounce"),
+        ):
+            await bnl01_bot.on_message(message)
+
+        self.assertEqual(len(bnl01_bot._channel_buffers[channel.id]), 1)
+        turn = bnl01_bot._channel_buffers[channel.id][0]
+        self.assertEqual(turn.planned_directness, "recent_followup")
+        self.assertTrue(turn.planned_direct_to_bnl)
+
+        collapsed = bnl01_bot._collapse_consecutive_batch_fragments(
+            [turn, turn]
+        )
+        self.assertEqual(len(collapsed), 1)
+        self.assertTrue(collapsed[0].planned_direct_to_bnl)
+        self.assertEqual(collapsed[0].planned_directness, "recent_followup")
+
+        with mock.patch.object(
+            bnl01_bot,
+            "_should_force_free_speak_continuation_answer",
+            return_value=(True, "same_user_continuation_substantive"),
+        ):
+            packet = bnl01_bot._build_active_response_packet(
+                channel.id,
+                [turn],
+                None,
+                bot_user=SimpleNamespace(id=999, display_name="BNL-01"),
+                guild_id=channel.guild.id,
+                channel_policy="sealed_test",
+            )
+
+        self.assertTrue(packet["planned_direct_to_bnl"])
+        self.assertTrue(packet["addressed_to_bot"])
+        self.assertTrue(packet["response_obligation"])
+        self.assertEqual(packet["address_kind"], "recent_followup")
+
+    def test_passive_batch_turn_does_not_gain_planned_directness(self):
+        plan = bnl01_bot.plan_conversation_response(
+            "The beam looked narrow.",
+            "sealed_test",
+            route_mode=bnl01_bot.ROUTE_MODE_NORMAL_CHAT,
+            active_channel=True,
+            followup_candidate=False,
+            channel_allows_conversation=True,
+            batching_enabled=True,
+            conversation_surface=(
+                bnl01_bot.CONVERSATION_SURFACE_FREE_SPEAK_SEALED_MIRROR
+            ),
+        )
+
+        self.assertEqual(plan.directness, "free_speak_passive")
+        self.assertFalse(bnl01_bot.conversation_plan_is_directed_to_bnl(plan))
+
     def _assert_people_memory_contract(self, prompt):
         self.assertIn(
             "summarize another member's meaning in your own words by default",
@@ -3513,6 +3577,7 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
             candidate_active=True,
             provider_call_count=1,
             corrective_call_count=0,
+            typed_contract_required=True,
         )
         ordinary_generation = mock.AsyncMock(return_value=execution)
         shared_generation = mock.AsyncMock()
@@ -3606,6 +3671,233 @@ class ConversationBatchCoordinatorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             finalize.await_args.kwargs["guard_status"],
             "batch_single_packet_candidate_sent",
+        )
+
+    async def test_typed_batch_contract_rejection_withholds_without_second_call(
+        self,
+    ):
+        channel = self._channel(8137)
+        basis = object()
+        packet = object()
+        assessment = object()
+        decision = SimpleNamespace(
+            candidate_selected=False,
+            typed_contract_status="invalid",
+        )
+        review_reason = "typed_contract_packet_support_invalid"
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=decision,
+            response="Untrusted visible candidate.",
+            prompt="packet-owned prompt",
+            prompt_source_bases=(basis,),
+            candidate_active=False,
+            provider_call_count=1,
+            corrective_call_count=0,
+            review_reason=review_reason,
+            typed_contract_required=True,
+        )
+        ordinary_generation = mock.AsyncMock(return_value=execution)
+        shared_generation = mock.AsyncMock()
+        guarded = mock.AsyncMock()
+        resolve = mock.AsyncMock()
+        record_review = mock.AsyncMock(return_value=decision)
+        finalize = mock.AsyncMock(return_value=decision)
+
+        def build_assessment(*_args, **kwargs):
+            kwargs["intelligence_packet_out"]["packet"] = packet
+            return assessment
+
+        async def legacy_generation(*_args, **_kwargs):
+            raise AssertionError(
+                "a typed batch rejection must not call the legacy provider"
+            )
+
+        self._prime_flush(channel, "BNL, who is Cache Back?")
+        with (
+            self._flush_runtime(channel.id, legacy_generation),
+            mock.patch.object(
+                bnl01_bot,
+                "ordinary_chat_route_scope_decision",
+                return_value=SimpleNamespace(eligible=True, reason="canary"),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_unified_response_assessment_shadow",
+                side_effect=build_assessment,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_ordinary_chat_basis",
+                return_value=basis,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_ordinary_chat_single_packet",
+                new=ordinary_generation,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_shared_brain_synthesis_canary",
+                new=shared_generation,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "apply_guarded_response_regeneration",
+                new=guarded,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "resolve_guarded_response_obligation",
+                new=resolve,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "safely_record_ordinary_chat_single_packet_review",
+                new=record_review,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "safely_finalize_shared_brain_synthesis",
+                new=finalize,
+            ),
+        ):
+            await bnl01_bot._flush_channel_buffer(channel)
+
+        ordinary_generation.assert_awaited_once()
+        shared_generation.assert_not_awaited()
+        guarded.assert_not_awaited()
+        resolve.assert_not_awaited()
+        self.assertEqual(channel.sent, [])
+        record_review.assert_awaited_once()
+        self.assertEqual(record_review.await_args.kwargs["reason"], review_reason)
+        self.assertEqual(
+            record_review.await_args.kwargs["corrective_call_count"],
+            0,
+        )
+        finalize.assert_awaited_once()
+        self.assertEqual(finalize.await_args.kwargs["final_response"], "")
+        self.assertFalse(finalize.await_args.kwargs["response_sent"])
+        self.assertFalse(finalize.await_args.kwargs["candidate_live"])
+        self.assertEqual(
+            finalize.await_args.kwargs["guard_status"],
+            "typed_batch_single_packet_candidate_rejected",
+        )
+
+    async def test_typed_batch_guard_rejection_withholds_without_regeneration(
+        self,
+    ):
+        channel = self._channel(8138)
+        basis = object()
+        packet = object()
+        assessment = object()
+        decision = SimpleNamespace(
+            candidate_selected=True,
+            typed_contract_status="valid",
+        )
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=decision,
+            response="Packet-owned candidate.",
+            prompt="packet-owned prompt",
+            prompt_source_bases=(basis,),
+            candidate_active=True,
+            provider_call_count=1,
+            corrective_call_count=0,
+            typed_contract_required=True,
+        )
+        ordinary_generation = mock.AsyncMock(return_value=execution)
+        guard_reason = "current_payload_grounding_after_retry"
+        guarded = mock.AsyncMock(
+            return_value=(
+                execution.response,
+                {
+                    "suppressed": True,
+                    "suppression_reason": guard_reason,
+                },
+            )
+        )
+        resolve = mock.AsyncMock()
+        record_review = mock.AsyncMock(return_value=decision)
+        finalize = mock.AsyncMock(return_value=decision)
+
+        def build_assessment(*_args, **kwargs):
+            kwargs["intelligence_packet_out"]["packet"] = packet
+            return assessment
+
+        async def legacy_generation(*_args, **_kwargs):
+            raise AssertionError(
+                "a typed batch guard failure must not call the legacy provider"
+            )
+
+        self._prime_flush(channel, "BNL, who is Cache Back?")
+        with (
+            self._flush_runtime(channel.id, legacy_generation),
+            mock.patch.object(
+                bnl01_bot,
+                "ordinary_chat_route_scope_decision",
+                return_value=SimpleNamespace(eligible=True, reason="canary"),
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_unified_response_assessment_shadow",
+                side_effect=build_assessment,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "build_ordinary_chat_basis",
+                return_value=basis,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_ordinary_chat_single_packet",
+                new=ordinary_generation,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "maybe_generate_shared_brain_synthesis_canary",
+                new=mock.AsyncMock(),
+            ) as shared_generation,
+            mock.patch.object(
+                bnl01_bot,
+                "apply_guarded_response_regeneration",
+                new=guarded,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "resolve_guarded_response_obligation",
+                new=resolve,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "safely_record_ordinary_chat_single_packet_review",
+                new=record_review,
+            ),
+            mock.patch.object(
+                bnl01_bot,
+                "safely_finalize_shared_brain_synthesis",
+                new=finalize,
+            ),
+        ):
+            await bnl01_bot._flush_channel_buffer(channel)
+
+        ordinary_generation.assert_awaited_once()
+        shared_generation.assert_not_awaited()
+        guarded.assert_awaited_once()
+        self.assertFalse(guarded.await_args.kwargs["regeneration_allowed"])
+        resolve.assert_not_awaited()
+        self.assertEqual(channel.sent, [])
+        record_review.assert_awaited_once()
+        self.assertEqual(record_review.await_args.kwargs["reason"], guard_reason)
+        self.assertEqual(
+            record_review.await_args.kwargs["corrective_call_count"],
+            0,
+        )
+        finalize.assert_awaited_once()
+        self.assertEqual(finalize.await_args.kwargs["final_response"], "")
+        self.assertFalse(finalize.await_args.kwargs["response_sent"])
+        self.assertFalse(finalize.await_args.kwargs["candidate_live"])
+        self.assertEqual(
+            finalize.await_args.kwargs["guard_status"],
+            "typed_batch_single_packet_guard_rejected",
         )
 
     async def test_mixed_journal_and_current_queue_batch_uses_one_natural_packet(

--- a/tests/test_gemini_budget_enforcement.py
+++ b/tests/test_gemini_budget_enforcement.py
@@ -452,7 +452,12 @@ class GeminiBudgetEnforcementTests(unittest.TestCase):
                 )
             )
 
-        self.assertIsNone(execution)
+        self.assertIsNotNone(execution)
+        self.assertFalse(execution.candidate_active)
+        self.assertEqual(execution.response, "")
+        self.assertEqual(execution.provider_call_count, 0)
+        self.assertEqual(execution.corrective_call_count, 0)
+        self.assertTrue(execution.typed_contract_required)
         fake_client.models.generate_content.assert_not_called()
 
     def test_unknown_active_model_is_unpriced_and_never_called(self):

--- a/tests/test_ordinary_chat_single_packet_canary.py
+++ b/tests/test_ordinary_chat_single_packet_canary.py
@@ -24,6 +24,7 @@ from bnl_shared_brain_synthesis import (
     finalize_run,
     ordinary_chat_configuration,
     ordinary_chat_deterministic_response_act,
+    ordinary_chat_response_json_schema,
     ordinary_chat_route_scope_decision,
     ordinary_chat_task_support_plan,
     publication_packet_composes_current_queue,
@@ -735,7 +736,7 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertTrue(configured["effective"])
         self.assertEqual(
             configured["contract_version"],
-            "ordinary_chat_single_packet_v6",
+            "ordinary_chat_single_packet_v7",
         )
         self.assertEqual(configured["scope_mode"], "private_acceptance")
         self.assertFalse(
@@ -1034,8 +1035,9 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertTrue(owned.ready)
         self.assertIn("PACKET-OWNED RESPONSE CONTRACT", owned.prompt)
         self.assertIn("TURN RESPONSE PLAN", owned.prompt)
-        self.assertIn("VISIBLE RESPONSE CONTRACT", owned.prompt)
-        self.assertIn("Write one natural BNL reply, not JSON", owned.prompt)
+        self.assertIn("ONE-CALL RESPONSE ENVELOPE", owned.prompt)
+        self.assertIn("provider response schema", owned.prompt)
+        self.assertIn("only user-visible part", owned.prompt)
         self.assertNotIn("Return only this exact JSON template", owned.prompt)
         self.assertIn(self.basis.rendered_context, owned.prompt)
         self.assertEqual(owned.prompt.count(self.basis.rendered_context), 1)
@@ -1135,6 +1137,22 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         self.assertIn("one shared mind with filtered surfaces", owned.prompt)
 
     def test_typed_response_contract_accepts_only_applicable_packet_refs(self):
+        schema = ordinary_chat_response_json_schema()
+        self.assertEqual(schema["type"], "object")
+        self.assertEqual(schema["required"], ["tasks"])
+        task_schema = schema["properties"]["tasks"]["items"]
+        self.assertEqual(
+            task_schema["properties"]["supportKind"]["enum"],
+            [
+                "packet",
+                "external_public",
+                "current_request",
+                "hold",
+                "clarify",
+            ],
+        )
+        self.assertFalse(task_schema["additionalProperties"])
+
         contract = _contract_for_support_plan(
             self.basis,
             ("Your favorite movie is Arrival.",),
@@ -1637,7 +1655,7 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         )
         self.assertTrue(all(plan.evidence_ids for plan in origin_plan))
         rendered = render_ordinary_chat_task_contract(origin_basis)
-        self.assertIn("Write one natural BNL reply, not JSON", rendered)
+        self.assertIn("ONE-CALL RESPONSE ENVELOPE", rendered)
         self.assertIn(
             'request="Who is Cache Back"',
             rendered,
@@ -1651,7 +1669,7 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
             rendered,
         )
         self.assertIn(
-            "Answer every task in order",
+            "one task object for every task above",
             rendered,
         )
         for plan in origin_plan:
@@ -3403,6 +3421,8 @@ class OrdinaryChatSinglePacketCanaryTests(unittest.TestCase):
         for unsupported_response in (
             "Attendance reached 50 people.",
             "Fifty people attended.",
+            "Twenty five people attended.",
+            "One human took part.",
             "Around 50 people attended.",
             "The crowd reached 50 people.",
         ):

--- a/tests/test_shared_brain_synthesis_bot_path.py
+++ b/tests/test_shared_brain_synthesis_bot_path.py
@@ -1101,7 +1101,11 @@ class SharedBrainSynthesisBotPathTests(
         )
         provider = mock.AsyncMock(
             return_value=bnl01_bot.TrackedGenerationResponse(
-                text="One generated answer.",
+                text=(
+                    '{"tasks":[{"taskId":"T1","text":"One generated '
+                    'answer.","supportKind":"current_request",'
+                    '"evidenceIds":["REQUEST"]}]}'
+                ),
                 provider_call_count=1,
                 total_tokens=321,
                 prompt_tokens=200,
@@ -1194,7 +1198,12 @@ class SharedBrainSynthesisBotPathTests(
             123_456,
         )
         self.assertTrue(evaluate.call_args.kwargs["cost_priced"])
-        self.assertFalse(evaluate.call_args.kwargs["typed_contract_required"])
+        self.assertTrue(evaluate.call_args.kwargs["typed_contract_required"])
+        self.assertEqual(
+            evaluate.call_args.kwargs["response_contract"].status,
+            "parsed",
+        )
+        self.assertTrue(execution.typed_contract_required)
 
     async def test_single_packet_preprovider_exit_records_zero_calls(self):
         basis = SimpleNamespace(
@@ -1248,6 +1257,11 @@ class SharedBrainSynthesisBotPathTests(
                 "_evaluate_ordinary_chat_single_packet_receipt",
                 new=evaluate,
             ),
+            mock.patch.object(
+                bnl01_bot,
+                "safely_finalize_shared_brain_synthesis",
+                new=mock.AsyncMock(return_value=True),
+            ) as finalize,
         ):
             execution = (
                 await bnl01_bot.maybe_generate_ordinary_chat_single_packet(
@@ -1268,8 +1282,12 @@ class SharedBrainSynthesisBotPathTests(
                 )
             )
 
-        self.assertIsNone(execution)
+        self.assertIsNotNone(execution)
+        self.assertEqual(execution.response, "")
+        self.assertTrue(execution.typed_contract_required)
         provider.assert_awaited_once()
+        finalize.assert_awaited_once()
+        self.assertFalse(finalize.await_args.kwargs["response_sent"])
         self.assertEqual(evaluate.call_args.kwargs["provider_call_count"], 0)
         self.assertEqual(evaluate.call_args.kwargs["corrective_call_count"], 0)
 
@@ -1290,7 +1308,11 @@ class SharedBrainSynthesisBotPathTests(
         )
         provider = mock.AsyncMock(
             return_value=bnl01_bot.TrackedGenerationResponse(
-                text="Do you mean Mac Modem or Cache Back?",
+                text=(
+                    '{"tasks":[{"taskId":"T1","text":"Do you mean Mac '
+                    'Modem or Cache Back?","supportKind":"clarify",'
+                    '"evidenceIds":[]}]}'
+                ),
                 provider_call_count=1,
             )
         )
@@ -1391,7 +1413,10 @@ class SharedBrainSynthesisBotPathTests(
         )
         provider = mock.AsyncMock(
             return_value=bnl01_bot.TrackedGenerationResponse(
-                text=response,
+                text=(
+                    '{"tasks":[{"taskId":"T1","text":"%s",'
+                    '"supportKind":"hold","evidenceIds":[]}]}' % response
+                ),
                 provider_call_count=1,
             )
         )
@@ -1493,7 +1518,11 @@ class SharedBrainSynthesisBotPathTests(
         )
         provider = mock.AsyncMock(
             return_value=bnl01_bot.TrackedGenerationResponse(
-                text=response,
+                text=(
+                    '{"tasks":[{"taskId":"T1","text":"%s",'
+                    '"supportKind":"current_request",'
+                    '"evidenceIds":["REQUEST"]}]}' % response
+                ),
                 provider_call_count=1,
             )
         )
@@ -2070,6 +2099,163 @@ class SharedBrainSynthesisBotPathTests(
         finalize.assert_awaited_once()
         self.assertTrue(finalize.await_args.kwargs["response_sent"])
         self.assertFalse(finalize.await_args.kwargs["candidate_live"])
+
+    async def test_typed_single_packet_rejection_never_calls_rewriter(self):
+        message = FakeMessage()
+        run = SimpleNamespace(run_id="typed-rejected-run")
+        decision = SimpleNamespace(
+            run=run,
+            candidate_selected=False,
+            fallback_reason="typed_contract_packet_support_invalid",
+        )
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=decision,
+            response="Untrusted visible candidate.",
+            prompt="packet-owned prompt",
+            prompt_source_bases=(),
+            candidate_active=False,
+            provider_call_count=1,
+            corrective_call_count=0,
+            review_reason="typed_contract_packet_support_invalid",
+            typed_contract_required=True,
+        )
+        resolve = mock.AsyncMock()
+        review = mock.AsyncMock(return_value=decision)
+        finalize = mock.AsyncMock(return_value=True)
+        guard = mock.AsyncMock()
+        with ExitStack() as stack:
+            for patcher in self.common_patches():
+                stack.enter_context(patcher)
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "resolve_guarded_response_obligation",
+                    new=resolve,
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "safely_record_ordinary_chat_single_packet_review",
+                    new=review,
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "safely_finalize_shared_brain_synthesis",
+                    new=finalize,
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "apply_guarded_response_regeneration",
+                    new=guard,
+                )
+            )
+
+            await bnl01_bot.send_planned_conversation_response(
+                message,
+                "ignored baseline",
+                self.plan(),
+                prompt="ignored baseline prompt",
+                source_context_available=True,
+                allow_model_save=False,
+                mark_recent_direct=False,
+                ordinary_chat_single_packet_execution=execution,
+            )
+
+        self.assertEqual(message.replies, [])
+        resolve.assert_not_awaited()
+        guard.assert_not_awaited()
+        review.assert_awaited_once()
+        self.assertEqual(
+            review.await_args.kwargs["corrective_call_count"],
+            0,
+        )
+        finalize.assert_awaited_once()
+        self.assertFalse(finalize.await_args.kwargs["response_sent"])
+
+    async def test_typed_single_packet_guard_is_validation_only(self):
+        message = FakeMessage()
+        run = SimpleNamespace(run_id="typed-guard-run")
+        decision = SimpleNamespace(
+            run=run,
+            candidate_selected=True,
+            fallback_reason="",
+        )
+        execution = bnl01_bot.OrdinaryChatSinglePacketExecution(
+            decision=decision,
+            response="Packet-supported answer.",
+            prompt="packet-owned prompt",
+            prompt_source_bases=(),
+            candidate_active=True,
+            provider_call_count=1,
+            corrective_call_count=0,
+            typed_contract_required=True,
+        )
+        guard = mock.AsyncMock(
+            return_value=(
+                "",
+                {
+                    "suppressed": True,
+                    "suppression_reason": "generic_non_answer_validation_only",
+                },
+            )
+        )
+        resolve = mock.AsyncMock()
+        review = mock.AsyncMock(return_value=decision)
+        finalize = mock.AsyncMock(return_value=True)
+        with ExitStack() as stack:
+            for patcher in self.common_patches():
+                stack.enter_context(patcher)
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "apply_guarded_response_regeneration",
+                    new=guard,
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "resolve_guarded_response_obligation",
+                    new=resolve,
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "safely_record_ordinary_chat_single_packet_review",
+                    new=review,
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    bnl01_bot,
+                    "safely_finalize_shared_brain_synthesis",
+                    new=finalize,
+                )
+            )
+
+            await bnl01_bot.send_planned_conversation_response(
+                message,
+                "ignored baseline",
+                self.plan(),
+                prompt="ignored baseline prompt",
+                source_context_available=True,
+                allow_model_save=False,
+                mark_recent_direct=False,
+                ordinary_chat_single_packet_execution=execution,
+            )
+
+        self.assertEqual(message.replies, [])
+        self.assertFalse(guard.await_args.kwargs["regeneration_allowed"])
+        resolve.assert_not_awaited()
+        review.assert_awaited_once()
+        finalize.assert_awaited_once()
+        self.assertFalse(finalize.await_args.kwargs["response_sent"])
 
     async def test_natural_single_packet_candidate_uses_shared_guard(self):
         message = FakeMessage()

--- a/tests/test_situation_frame_v1.py
+++ b/tests/test_situation_frame_v1.py
@@ -211,6 +211,44 @@ class SituationFrameV1Tests(unittest.TestCase):
         self.assertEqual(live_weather.tasks[0].authority_scope, "external_current")
         self.assertEqual(live_weather.tasks[0].required_response_act, "hold")
 
+    def test_event_continuity_label_is_not_recast_as_a_person_subject(self):
+        frame = build_situation_frame_v1(
+            route_allowed=True,
+            route_mode="normal_chat",
+            conversation_surface="free_speak_sealed_mirror",
+            channel_policy="sealed_test",
+            current_text=(
+                "Back to Violet Lantern 499: what changed during this test, "
+                "what were the final settings, and how many humans took part?"
+            ),
+            current_speaker_user_ids=(101,),
+            current_speaker_labels=("Test Member",),
+            subject_label_hints=("Violet Lantern 499",),
+            moment_id="moment_violet_lantern",
+            moment_situation_state="recent_active",
+            moment_topic_coherent=True,
+            moment_participant_overlap=True,
+            referent_status="resolved",
+            response_act="answer",
+        )
+
+        self.assertEqual(frame.status, "resolved")
+        self.assertEqual(frame.subjects, ())
+        self.assertEqual(frame.subject_requirement, "not_applicable")
+        self.assertEqual(len(frame.tasks), 3)
+        self.assertTrue(
+            all(task.authority_scope == "packet" for task in frame.tasks)
+        )
+        self.assertTrue(
+            all(task.object_kind == "moment" for task in frame.tasks)
+        )
+        self.assertTrue(
+            all(
+                task.subject_requirement == "not_applicable"
+                for task in frame.tasks
+            )
+        )
+
     def test_barcode_radio_queue_is_one_packet_owned_queue_task(self):
         questions = (
             "is the Barcode Radio queue open right now?",

--- a/tests/test_token_budget_accounting.py
+++ b/tests/test_token_budget_accounting.py
@@ -478,6 +478,18 @@ class TokenBudgetAccountingTests(unittest.TestCase):
         )
         self.assertIsNone(config.thinking_config)
 
+    def test_single_packet_config_requires_structured_one_call_envelope(self):
+        config = bnl01_bot._generation_config_for_model(
+            "gemini-3.6-flash",
+            bnl01_bot.ORDINARY_CHAT_SINGLE_PACKET_ROUTE,
+        )
+
+        self.assertEqual(config.response_mime_type, "application/json")
+        schema = config.response_json_schema
+        self.assertEqual(schema["type"], "object")
+        self.assertEqual(schema["required"], ["tasks"])
+        self.assertFalse(schema["additionalProperties"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_unified_intelligence_packet.py
+++ b/tests/test_unified_intelligence_packet.py
@@ -344,6 +344,73 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
         self.assertIsNotNone(row)
         return row[0]
 
+    def add_sealed_violet_episode(self):
+        base = datetime(2026, 9, 5, 18, 55, tzinfo=timezone.utc)
+        exchanges = (
+            (
+                "Violet Lantern 499 starts amber with a slow pulse, and the "
+                "beam width is still open. What is settled?",
+                "Amber and slow are settled; beam width remains open.",
+            ),
+            (
+                "For Violet Lantern 499, change the signal to green, choose "
+                "a narrow beam, and keep the slow pulse. Recap the result.",
+                "Green signal, narrow beam, and slow pulse are final.",
+            ),
+            (
+                "Final Violet Lantern 499 check: what changed, and is any "
+                "setting still open?",
+                "Amber changed to green; narrow and slow are settled, with "
+                "no setting left open.",
+            ),
+        )
+        sources = []
+        row_id = 1200
+        for human_text, model_text in exchanges:
+            for role, user_id, name, text in (
+                ("user", 7, "Test Member", human_text),
+                ("model", 0, "BNL-01", model_text),
+            ):
+                result = ledger.shadow_conversation_row(
+                    self.conn,
+                    row_id=row_id,
+                    user_id=user_id,
+                    user_name=name,
+                    guild_id=1,
+                    role=role,
+                    content=text,
+                    channel_policy="sealed_test",
+                    channel_id=10,
+                    channel_name="bnl-testing",
+                    route_mode="normal_chat",
+                    observed_at=(
+                        base + timedelta(seconds=row_id - 1200)
+                    ).isoformat(),
+                )
+                moments.observe_ledger_entry(self.conn, result.entry_id)
+                if role == "user":
+                    sources.append(result.entry_id)
+                row_id += 1
+        moments.sweep_expired_windows(
+            self.conn,
+            now=(base + timedelta(minutes=3)).isoformat(),
+        )
+        row = self.conn.execute(
+            """
+            SELECT window.moment_id,link.episode_id
+            FROM memory_moment_windows window
+            JOIN memory_moment_episode_moments link
+              ON link.moment_id=window.moment_id
+            WHERE window.guild_id=1 AND window.channel_id=10
+              AND window.channel_policy='sealed_test'
+              AND window.lifecycle_status='finalized'
+            ORDER BY window.window_started_at DESC
+            LIMIT 1
+            """
+        ).fetchone()
+        self.assertIsNotNone(row)
+        return row[0], row[1], tuple(sources), base
+
     def add_followup_public_moment(self):
         base = datetime(2026, 7, 25, 12, 4, tzinfo=timezone.utc)
         messages = (
@@ -1753,6 +1820,110 @@ class UnifiedIntelligencePacketTests(unittest.TestCase):
         self.assertFalse(result.valid)
         self.assertEqual(result.status, "source_changed")
         self.assertGreaterEqual(result.changed_source_count, 1)
+
+    def test_sealed_event_query_uses_existing_active_episode_aggregate(self):
+        moment_id, episode_id, sources, base = (
+            self.add_sealed_violet_episode()
+        )
+        text = (
+            "Back to Violet Lantern 499: what changed during this test, "
+            "what were the final settings, and how many humans took part?"
+        )
+        tasks = tuple(
+            PacketFrameTask(
+                task_id="T%s" % index,
+                text_digest="%064x" % index,
+                task_kind="answer",
+                object_kind="moment",
+                authority_scope="packet",
+                temporal_scope="historical",
+                currentness="historical",
+                required_response_act="answer",
+                subject_requirement="not_applicable",
+            )
+            for index in range(1, 4)
+        )
+        request = IntelligencePacketRequest(
+            guild_id=1,
+            subject_user_id=7,
+            route_mode="normal_chat",
+            conversation_surface="free_speak_sealed_mirror",
+            channel_id=10,
+            channel_name="bnl-testing",
+            channel_policy="sealed_test",
+            visibility_allowance="sealed_test",
+            user_text=text,
+            participant_user_ids=(7,),
+            direct_state="direct",
+            budget_chars=6000,
+            conversation_evidence=(
+                PacketConversationEvidence(
+                    text=text,
+                    speaker_user_id=7,
+                    speaker_label="Test Member",
+                    current_turn=True,
+                ),
+            ),
+            now=(base + timedelta(minutes=4)).isoformat(),
+            frame_schema_version="situation_frame_v1",
+            frame_revision="sf_violet_lantern_final",
+            frame_input_evidence_digest="d" * 64,
+            frame_status="resolved",
+            frame_subject_requirement="not_applicable",
+            frame_tasks=tasks,
+            frame_event_ref=moment_id,
+            frame_event_relation="same_event",
+            frame_task_kind="multi_task",
+            frame_object_kind="moment",
+            frame_phase="completion",
+            frame_temporal_scope="historical",
+            frame_currentness="historical",
+        )
+
+        packet = build_packet(self.conn, request, environ=self.flags)
+
+        episode_items = tuple(
+            item for item in packet.items if item.lane == "episode"
+        )
+        self.assertEqual(len(episode_items), 1)
+        item = episode_items[0]
+        self.assertEqual(item.source_type, "sealed_active_episode_aggregate")
+        self.assertEqual(item.episode_ref, episode_id)
+        self.assertEqual(item.event_ref, moment_id)
+        self.assertEqual(item.visibility, "sealed_test")
+        self.assertIn("Shared human participants: 1", item.text)
+        self.assertNotIn("Test Member", item.text)
+        self.assertEqual(packet.diagnostics.episode_query_status, "selected")
+        self.assertTrue(revalidate_packet(self.conn, packet).valid)
+
+        public_packet = build_packet(
+            self.conn,
+            replace(
+                request,
+                channel_policy="public_home",
+                visibility_allowance="public_safe",
+            ),
+            persist=False,
+            environ=self.flags,
+        )
+        self.assertFalse(
+            any(
+                candidate.source_type == "sealed_active_episode_aggregate"
+                for candidate in public_packet.items
+            )
+        )
+
+        self.conn.execute(
+            """
+            UPDATE memory_ledger_entries
+            SET lifecycle_status='retracted'
+            WHERE entry_id=?
+            """,
+            (sources[0],),
+        )
+        changed = revalidate_packet(self.conn, packet, environ=self.flags)
+        self.assertFalse(changed.valid)
+        self.assertEqual(changed.status, "source_changed")
 
     def test_authorized_declared_member_claim_converges_as_subject_fact(self):
         self.add_conversation_context_row()

--- a/tests/test_unified_response_assessment_shadow.py
+++ b/tests/test_unified_response_assessment_shadow.py
@@ -51,6 +51,14 @@ class UnifiedResponseAssessmentShadowTests(unittest.TestCase):
                 "external_public",
             ),
             (
+                "When did Apollo 11 land? @BNL-01",
+                "external_public",
+            ),
+            (
+                "When did Apollo 11 land, @BNL-01?",
+                "external_public",
+            ),
+            (
                 "@BNL-01 can you explain when Apollo 11 landed?",
                 "current_request",
             ),
@@ -122,6 +130,7 @@ class UnifiedResponseAssessmentShadowTests(unittest.TestCase):
             ("@BNL-01 was created when?", "bnl_01"),
             ("@BNL-01 can explain its origin?", "bnl_01"),
             ("When was **@BNL-01** created?", "bnl_01"),
+            ("Who created @BNL-01?", "bnl_01"),
         )
         for text, expected_entity_ref in governed_cases:
             with self.subTest(text=text):


### PR DESCRIPTION
## Why

The Violet Lantern 499 Batch A live run produced plausible replies while exposing four connected architecture failures:

- ordinary-chat candidates were not using the typed response envelope and four turns made a corrective second provider call;
- the final event recap did not receive the active sealed Moment episode aggregate, so participant count was missed;
- event/task parsing treated the test label as a person-like subject and dropped a colon-prefaced task;
- the unmentioned same-user follow-up lost its already-approved `recent_followup` directness in the batch buffer, leaving only six Row 9 receipts for seven conversational turns.

## What changed

- wires the existing typed task contract into the Gemini response schema and exposes only validated task text;
- makes a provider-owned Row 9 turn strictly one physical call with zero corrective calls; invalid output is recorded and withheld;
- projects the existing same-channel sealed active-episode aggregate into the unified packet with source-root and occurrence lineage plus presend revalidation;
- aligns event count, final-settings, colon-preface, trailing addressee, and event-label classification across Frame, packet selection, and claim review;
- preserves the existing `recent_followup` decision through batch buffering and collapse without opting passive chatter into Row 9.

## Scope and safety

- remains restricted to the existing sealed `bnl-testing` Row 9 allowlist;
- does not enable any global live gate;
- extends existing Frame, Moment, packet, synthesis, batching, and guard owners; no parallel brain or authority path;
- final shared-brain acceptance remains contingent on the post-deploy messy-live receipt rerun.

## Verification

- affected-path suite: **286 tests passed**
- full repository gate: **2,593 tests passed**
- `git diff --check`: clean
- remote compare: one commit directly on PR499 merge commit `71b9389`, 12 expected files, zero unrelated history